### PR TITLE
Add sync classes and rest of Bookmark's methods

### DIFF
--- a/BraveSync/Sync.swift
+++ b/BraveSync/Sync.swift
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import WebKit
+import Shared
+import CoreData
+import SwiftKeychainWrapper
+import SwiftyJSON
+import Storage
+
+/*
+ module.exports.categories = {
+ BOOKMARKS: '0',
+ HISTORY_SITES: '1',
+ PREFERENCES: '2'
+ }
+ 
+ module.exports.actions = {
+ CREATE: 0,
+ UPDATE: 1,
+ DELETE: 2
+ }
+ */
+
+let NotificationSyncReady = "NotificationSyncReady"
+
+// TODO: Make capitals - pluralize - call 'categories' not 'type'
+public enum SyncRecordType : String {
+    case bookmark = "BOOKMARKS"
+    case history = "HISTORY_SITES"
+    case prefs = "PREFERENCES"
+    
+    // Please note, this is not a general fetch record string, sync Devices are part of the Preferences
+    case devices = "DEVICES"
+    //
+    
+    
+    // These are 'static', and do not change, would make actually lazy/static, but not allow for enums
+    var fetchedModelType: SyncRecord.Type? {
+        let map: [SyncRecordType : SyncRecord.Type] = [.bookmark : SyncBookmark.self, .prefs : SyncDevice.self]
+        return map[self]
+    }
+    
+    var coredataModelType: Syncable.Type? {
+        let map: [SyncRecordType : Syncable.Type] = [.bookmark : BookmarkMO.self, .prefs : Device.self]
+        return map[self]
+    }
+    
+    var syncFetchMethod: String {
+        return self == .devices ? "fetch-sync-devices" : "fetch-sync-records"
+    }
+}
+
+public enum SyncObjectDataType : String {
+    case Bookmark = "bookmark"
+    case Prefs = "preference" // Remove
+    
+    // Device is considered part of preferences, this is to just be used internally for tracking a constant.
+    //  At some point if Sync migrates to further abstracting Device to its own record type, this will be super close
+    //  to just working out of the box
+    case Device = "device"
+}
+
+enum SyncActions: Int {
+    case create = 0
+    case update = 1
+    case delete = 2
+    
+}
+
+// TODO: Add rest of Sync.swift implementation from Brave 1.x

--- a/BraveSync/fetched_models/SyncBookmark.swift
+++ b/BraveSync/fetched_models/SyncBookmark.swift
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftyJSON
+import Shared
+
+final public class SyncBookmark: SyncRecord {
+    
+    // MARK: Declaration for string constants to be used to decode and also serialize.
+    fileprivate struct SerializationKeys {
+        static let isFolder = "isFolder"
+        static let parentFolderObjectId = "parentFolderObjectId"
+        static let site = "site"
+    }
+    
+    // MARK: Properties
+    var isFavorite: Bool = false
+    var isFolder: Bool? = false
+    var parentFolderObjectId: [Int]?
+    var site: SyncSite?
+    
+    convenience init() {
+        self.init(json: nil)
+    }
+    
+    /// Initiates the instance based on the object.
+    ///
+    /// - parameter object: The object of either Dictionary or Array kind that was passed.
+    /// - returns: An initialized instance of the class.
+    convenience init(object: [String: AnyObject]) {
+        self.init(json: JSON(object))
+    }
+    
+    required public init(record: Syncable?, deviceId: [Int]?, action: Int?) {
+        super.init(record: record, deviceId: deviceId, action: action)
+        
+        let bm = record as? BookmarkMO
+        
+        
+        let unixCreated = Int(bm?.created?.toTimestamp() ?? 0)
+        let unixAccessed = Int(bm?.lastVisited?.toTimestamp() ?? 0)
+        
+        let site = SyncSite()
+        site.title = bm?.title
+        site.customTitle = bm?.customTitle
+        site.location = bm?.url
+        site.creationTime = unixCreated
+        site.lastAccessedTime = unixAccessed
+        // TODO: Does this work?
+        site.favicon = bm?.domain?.favicon?.url
+
+        self.isFavorite = bm?.isFavorite ?? false
+        self.isFolder = bm?.isFolder
+        // FIXME: Sync
+        // self.parentFolderObjectId = bm?.syncParentUUID
+        self.site = site
+    }
+
+    
+    /// Initiates the instance based on the JSON that was passed.
+    ///
+    /// - parameter json: JSON object from SwiftyJSON.
+    required public init(json: JSON?) {
+        super.init(json: json)
+        
+        guard let objectData = self.objectData else { return }
+        
+        let bookmark = json?[objectData.rawValue]
+        isFolder = bookmark?[SerializationKeys.isFolder].bool
+        if let items = bookmark?[SerializationKeys.parentFolderObjectId].array { parentFolderObjectId = items.map { $0.intValue } }
+        site = SyncSite(json: bookmark?[SerializationKeys.site])
+    }
+    
+    /// Generates description of the object in the form of a NSDictionary.
+    ///
+    /// - returns: A Key value pair containing all valid values in the object.
+    override func dictionaryRepresentation() -> [String: Any] {
+        guard let objectData = self.objectData else { return [:] }
+
+        // Create nested bookmark dictionary
+        var bookmarkDict = [String: Any]()
+        bookmarkDict[SerializationKeys.isFolder] = isFolder
+        if let value = parentFolderObjectId { bookmarkDict[SerializationKeys.parentFolderObjectId] = value }
+        if let value = site { bookmarkDict[SerializationKeys.site] = value.dictionaryRepresentation() }
+        
+        // Fetch parent, and assign bookmark
+        var dictionary = super.dictionaryRepresentation()
+        dictionary[objectData.rawValue] = bookmarkDict
+
+        return dictionary
+    }
+    
+}

--- a/BraveSync/fetched_models/SyncDevice.swift
+++ b/BraveSync/fetched_models/SyncDevice.swift
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Shared
+import SwiftyJSON
+
+class SyncDevice: SyncRecord {
+    
+    // MARK: Declaration for string constants to be used to decode and also serialize.
+    private struct SerializationKeys {
+        static let name = "name"
+        static let syncTimestamp = "syncTimestamp"
+    }
+    
+    // MARK: Properties
+    var name: String?
+    // Not on 'device' object
+    var syncTimestamp: Int?
+    
+    var syncNativeTimestamp: Date? {
+        return Date.fromTimestamp(Timestamp(syncTimestamp ?? 0))
+    }
+    
+    required init(record: Syncable?, deviceId: [Int]?, action: Int?) {
+        super.init(record: record, deviceId: deviceId, action: action)
+        
+        let device = record as? Device
+        self.name = device?.name
+        
+        // Preference
+        self.objectData = nil
+    }
+    
+    required init(json: JSON?) {
+        super.init(json: json)
+
+        self.name = json?[SyncObjectDataType.Device.rawValue][SerializationKeys.name].string
+        self.syncTimestamp = json?[SerializationKeys.syncTimestamp].int
+        
+        // Preference
+        self.objectData = nil
+    }
+    
+    /// Generates description of the object in the form of a NSDictionary.
+    ///
+    /// - returns: A Key value pair containing all valid values in the object.
+    override func dictionaryRepresentation() -> [String: Any] {
+        
+        // Notice there is no objectData type, this is technically part of Preferences, which does not use that key/value pair
+        
+        // Device specific
+        var deviceDict = [String: Any]()
+        if let value = self.name { deviceDict[SerializationKeys.name] = value }
+
+        var dictionary = super.dictionaryRepresentation()
+        dictionary[SyncObjectDataType.Device.rawValue] = deviceDict
+        if let value = self.syncTimestamp { dictionary[SerializationKeys.syncTimestamp] = value }
+        
+        return dictionary
+    }
+
+}

--- a/BraveSync/fetched_models/SyncRecord.swift
+++ b/BraveSync/fetched_models/SyncRecord.swift
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import CoreData
+import SwiftyJSON
+
+protocol SyncRecordProtocol {
+    associatedtype CoreDataParallel: Syncable
+//    var CoredataParallel: NSManagedObject.Type?
+    
+}
+
+public class SyncRecord: SyncRecordProtocol {
+    
+    // MARK: Declaration for string constants to be used to decode and also serialize.
+    fileprivate struct SerializationKeys {
+        static let objectId = "objectId"
+        static let deviceId = "deviceId"
+        static let action = "action"
+        static let objectData = "objectData"
+        // TODO: Add sync timestamp
+    }
+    
+    // MARK: Properties
+    var objectId: [Int]?
+    var deviceId: [Int]?
+    var action: Int?
+    var objectData: SyncObjectDataType?
+    
+//    var CoredataParallel: Syncable.Type?
+    typealias CoreDataParallel = Device
+    
+    convenience init() {
+        self.init(json: nil)
+    }
+    
+    /// Initiates the instance based on the object.
+    ///
+    /// - parameter object: The object of either Dictionary or Array kind that was passed.
+    /// - returns: An initialized instance of the class.
+    convenience init(object: [String: AnyObject]) {
+        self.init(json: JSON(object))
+    }
+    
+    // Would be nice to make this type specific to class
+    required public init(record: Syncable?, deviceId: [Int]?, action: Int?) {
+        
+        self.objectId = record?.syncUUID
+        self.deviceId = deviceId
+        self.action = action
+        
+        // TODO: Move to SyncObjectDataType enum
+//        self.objectData = [Syncable.Type: SyncObjectDataType] = [Bookmark.self: .Bookmark][self.Type]
+        self.objectData = .Bookmark
+        
+        // TODO: Need object type!!
+        
+        // TOOD: Add sync timestmap
+    }
+    
+    /// Initiates the instance based on the JSON that was passed.
+    ///
+    /// - parameter json: JSON object from SwiftyJSON.
+    required public init(json: JSON?) {
+        // objectId can come in two different formats
+        if let items = json?[SerializationKeys.objectId].array { objectId = items.map { $0.intValue } }
+        if let items = json?[SerializationKeys.deviceId].array { deviceId = items.map { $0.intValue } }
+        action = json?[SerializationKeys.action].int
+        if let item = json?[SerializationKeys.objectData].string { objectData = SyncObjectDataType(rawValue: item) }
+        // TODO: Add sync timestamp
+    }
+    
+    /// Generates description of the object in the form of a NSDictionary.
+    ///
+    /// - returns: A Key value pair containing all valid values in the object.
+    func dictionaryRepresentation() -> [String: Any] {
+        var dictionary: [String: Any] = [:]
+        // Override to use string value instead of array, to be uniform to CD
+        if let value = objectId { dictionary[SerializationKeys.objectId] = value }
+        if let value = deviceId { dictionary[SerializationKeys.deviceId] = value }
+        if let value = action { dictionary[SerializationKeys.action] = value }
+        if let value = objectData { dictionary[SerializationKeys.objectData] = value.rawValue }
+        // TODO: Add sync timestamp
+        return dictionary
+    }
+}
+
+// Uses same mappings above, but for arrays
+extension SyncRecordProtocol where Self: SyncRecord {
+    
+    static func syncRecords(_ rootJSON: [JSON]?) -> [Self]? {
+        return rootJSON?.map {
+            return self.init(json: $0)
+        }
+    }
+    
+    static func syncRecords(_ rootJSON: JSON) -> [Self]? {
+        return self.syncRecords(rootJSON.array)
+    }
+}
+
+

--- a/BraveSync/fetched_models/SyncResponse.swift
+++ b/BraveSync/fetched_models/SyncResponse.swift
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftyJSON
+
+/*
+ * Due to sync's 'callbacks' running through the same function, parameters are reused
+ * for ever single function call, resulting in a complex web of peculiar naming.
+ *
+ * Direct key mappings are using to pluck the variable names from the data, and an attempt
+ * to make them more native feeling (e.g. descriptive names) has been made. In some cases
+ * variable names are still generic due to the extreme usage of them (i.e. no nice way to make non-generic)
+ *
+ * At some point a switch to fullblown generic names may need necessary, but this hybrid approach seemed best
+ * at the time of building it
+ */
+
+typealias SyncDefaultResponseType = SyncRecord
+final class SyncResponse {
+    
+    // MARK: Declaration for string constants to be used to decode and also serialize.
+    fileprivate struct SerializationKeys {
+        static let arg2 = "arg2"
+        static let message = "message"
+        static let arg1 = "arg1"
+        static let arg3 = "arg3"
+        static let arg4 = "arg4" // isTruncated
+    }
+    
+    // MARK: Properties
+    // TODO: rename this property
+    var rootElements: JSON? // arg2
+    var message: String?
+    var arg1: String?
+    var lastFetchedTimestamp: Int? // arg3
+    var isTruncated: Bool? // arg4
+    
+    /// Initiates the instance based on the object.
+    ///
+    /// - parameter object: The object of either Dictionary or Array kind that was passed.
+    /// - returns: An initialized instance of the class.
+    convenience init(object: String) {
+        self.init(json: JSON(parseJSON: object))
+    }
+    
+    /// Initiates the instance based on the JSON that was passed.
+    ///
+    /// - parameter json: JSON object from SwiftyJSON.
+    required init(json: JSON?) {
+        rootElements = json?[SerializationKeys.arg2]
+        
+        message = json?[SerializationKeys.message].string
+        arg1 = json?[SerializationKeys.arg1].string
+        lastFetchedTimestamp = json?[SerializationKeys.arg3].int
+        isTruncated = json?[SerializationKeys.arg4].bool
+    }
+}

--- a/BraveSync/fetched_models/SyncSite.swift
+++ b/BraveSync/fetched_models/SyncSite.swift
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftyJSON
+
+public final class SyncSite {
+    
+    // MARK: Declaration for string constants to be used to decode and also serialize.
+    fileprivate struct SerializationKeys {
+        static let customTitle = "customTitle"
+        static let title = "title"
+        static let favicon = "favicon"
+        static let location = "location"
+        static let creationTime = "creationTime"
+        static let lastAccessedTime = "lastAccessedTime"
+    }
+    
+    // MARK: Properties
+    public var customTitle: String?
+    public var title: String?
+    public var favicon: String?
+    public var location: String?
+    public var creationTime: Int?
+    public var lastAccessedTime: Int?
+    
+    public var creationNativeDate: Date? {
+        return Date.fromTimestamp(Timestamp(creationTime ?? 0))
+    }
+    
+    public var lastAccessedNativeDate: Date? {
+        return Date.fromTimestamp(Timestamp(lastAccessedTime ?? 0))
+    }
+    
+    public convenience init() {
+        self.init(json: nil)
+    }
+    
+    /// Initiates the instance based on the object.
+    ///
+    /// - parameter object: The object of either Dictionary or Array kind that was passed.
+    /// - returns: An initialized instance of the class.
+    public convenience init(object: [String: AnyObject]) {
+        self.init(json: JSON(object))
+    }
+    
+    /// Initiates the instance based on the JSON that was passed.
+    ///
+    /// - parameter json: JSON object from SwiftyJSON.
+    public required init(json: JSON?) {
+        customTitle = json?[SerializationKeys.customTitle].string
+        title = json?[SerializationKeys.title].string
+        favicon = json?[SerializationKeys.favicon].string
+        location = json?[SerializationKeys.location].string
+        creationTime = json?[SerializationKeys.creationTime].int
+        lastAccessedTime = json?[SerializationKeys.lastAccessedTime].int
+    }
+    
+    /// Generates description of the object in the form of a NSDictionary.
+    ///
+    /// - returns: A Key value pair containing all valid values in the object.
+    public func dictionaryRepresentation() -> [String: AnyObject] {
+        var dictionary: [String: AnyObject] = [:]
+        if let value = customTitle { dictionary[SerializationKeys.customTitle] = value as AnyObject }
+        if let value = title { dictionary[SerializationKeys.title] = value as AnyObject }
+        if let value = favicon { dictionary[SerializationKeys.favicon] = value as AnyObject }
+        if let value = location { dictionary[SerializationKeys.location] = value as AnyObject }
+        if let value = creationTime { dictionary[SerializationKeys.creationTime] = value as AnyObject }
+        if let value = lastAccessedTime { dictionary[SerializationKeys.lastAccessedTime] = value as AnyObject }
+        return dictionary
+    }
+    
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -8,6 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */; };
+		0A1E466E20A059A7004CDE5A /* Syncable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E466C20A059A6004CDE5A /* Syncable.swift */; };
+		0A1E466F20A059A7004CDE5A /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E466D20A059A7004CDE5A /* Device.swift */; };
+		0A1E467620A059D2004CDE5A /* SyncResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E467120A059D1004CDE5A /* SyncResponse.swift */; };
+		0A1E467720A059D2004CDE5A /* SyncSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E467220A059D2004CDE5A /* SyncSite.swift */; };
+		0A1E467820A059D2004CDE5A /* SyncDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E467320A059D2004CDE5A /* SyncDevice.swift */; };
+		0A1E467920A059D2004CDE5A /* SyncBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E467420A059D2004CDE5A /* SyncBookmark.swift */; };
+		0A1E467A20A059D2004CDE5A /* SyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E467520A059D2004CDE5A /* SyncRecord.swift */; };
+		0A1E467C20A059F0004CDE5A /* Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E467B20A059F0004CDE5A /* Sync.swift */; };
 		0B1C05D71A798B1F004C78B0 /* UIImageViewAligned.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1C05D61A798B1F004C78B0 /* UIImageViewAligned.m */; };
 		0B21E8061E26CCB7000C8779 /* EarlGrey.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0B21E8051E26CCB7000C8779 /* EarlGrey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		0B305E1B1E3A98A900BE0767 /* BookmarkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B305E1A1E3A98A900BE0767 /* BookmarkingTests.swift */; };
@@ -108,7 +116,7 @@
 		289A4C141C4EB90600A460E3 /* StorageTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289A4C121C4EB90600A460E3 /* StorageTestUtils.swift */; };
 		28A17B671BEC727500BC14ED /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A17B661BEC727500BC14ED /* Downloader.swift */; };
 		28AA941D1B97DCA800703DC6 /* BookmarkPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AA941C1B97DCA800703DC6 /* BookmarkPayload.swift */; };
-		28B62ACE1BC745E7004A585A /* Syncable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B62ACD1BC745E7004A585A /* Syncable.swift */; };
+		28B62ACE1BC745E7004A585A /* FFSyncable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B62ACD1BC745E7004A585A /* FFSyncable.swift */; };
 		28C28BFD1C51A3B900D5460E /* Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C28BFC1C51A3B900D5460E /* Merging.swift */; };
 		28C4AB721AD42D4300D9ACE3 /* Clients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C4AB711AD42D4300D9ACE3 /* Clients.swift */; };
 		28C8B7851C852535006D8318 /* BookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C8B7841C852535006D8318 /* BookmarksPanelTests.swift */; };
@@ -1394,6 +1402,14 @@
 
 /* Begin PBXFileReference section */
 		03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelativeDatesTests.swift; sourceTree = "<group>"; };
+		0A1E466C20A059A6004CDE5A /* Syncable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Syncable.swift; sourceTree = "<group>"; };
+		0A1E466D20A059A7004CDE5A /* Device.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		0A1E467120A059D1004CDE5A /* SyncResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncResponse.swift; sourceTree = "<group>"; };
+		0A1E467220A059D2004CDE5A /* SyncSite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncSite.swift; sourceTree = "<group>"; };
+		0A1E467320A059D2004CDE5A /* SyncDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncDevice.swift; sourceTree = "<group>"; };
+		0A1E467420A059D2004CDE5A /* SyncBookmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncBookmark.swift; sourceTree = "<group>"; };
+		0A1E467520A059D2004CDE5A /* SyncRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncRecord.swift; sourceTree = "<group>"; };
+		0A1E467B20A059F0004CDE5A /* Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sync.swift; sourceTree = "<group>"; };
 		0B1C05D51A798B1F004C78B0 /* UIImageViewAligned.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIImageViewAligned.h; sourceTree = "<group>"; };
 		0B1C05D61A798B1F004C78B0 /* UIImageViewAligned.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIImageViewAligned.m; sourceTree = "<group>"; };
 		0B21E8051E26CCB7000C8779 /* EarlGrey.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EarlGrey.framework; path = Carthage/Build/iOS/EarlGrey.framework; sourceTree = "<group>"; };
@@ -1480,7 +1496,7 @@
 		28A17B661BEC727500BC14ED /* Downloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Downloader.swift; path = Synchronizers/Downloader.swift; sourceTree = "<group>"; };
 		28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
 		28AA941C1B97DCA800703DC6 /* BookmarkPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkPayload.swift; sourceTree = "<group>"; };
-		28B62ACD1BC745E7004A585A /* Syncable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Syncable.swift; sourceTree = "<group>"; };
+		28B62ACD1BC745E7004A585A /* FFSyncable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FFSyncable.swift; sourceTree = "<group>"; };
 		28C077971A3B064000834FE5 /* CryptoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoTests.swift; path = SyncTests/CryptoTests.swift; sourceTree = "<group>"; };
 		28C0779D1A3B066000834FE5 /* RecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecordTests.swift; path = SyncTests/RecordTests.swift; sourceTree = "<group>"; };
 		28C28BFC1C51A3B900D5460E /* Merging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Merging.swift; sourceTree = "<group>"; };
@@ -2374,6 +2390,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0A1E465920A05941004CDE5A /* BraveSync */ = {
+			isa = PBXGroup;
+			children = (
+				0A1E467020A059BE004CDE5A /* fetched_models */,
+				0A1E467B20A059F0004CDE5A /* Sync.swift */,
+			);
+			path = BraveSync;
+			sourceTree = "<group>";
+		};
+		0A1E467020A059BE004CDE5A /* fetched_models */ = {
+			isa = PBXGroup;
+			children = (
+				0A1E467420A059D2004CDE5A /* SyncBookmark.swift */,
+				0A1E467320A059D2004CDE5A /* SyncDevice.swift */,
+				0A1E467520A059D2004CDE5A /* SyncRecord.swift */,
+				0A1E467120A059D1004CDE5A /* SyncResponse.swift */,
+				0A1E467220A059D2004CDE5A /* SyncSite.swift */,
+			);
+			path = fetched_models;
+			sourceTree = "<group>";
+		};
 		0B1C05D41A798B1F004C78B0 /* UIImageViewAligned */ = {
 			isa = PBXGroup;
 			children = (
@@ -2685,6 +2722,8 @@
 			isa = PBXGroup;
 			children = (
 				5C56FF4A202E4018009FF126 /* CoreData */,
+				0A1E466D20A059A7004CDE5A /* Device.swift */,
+				0A1E466C20A059A6004CDE5A /* Syncable.swift */,
 				74B195431CF503FC007F36EF /* RecentlyClosedTabs.swift */,
 				2FCAE33D1ABB5F1800877008 /* Storage-Bridging-Header.h */,
 				D37DE2821CA2047500A5EC69 /* CertStore.swift */,
@@ -2706,7 +2745,7 @@
 				2829D39F1C2F0AD400DCF931 /* Sharing.swift */,
 				2FCAE2481ABB531100877008 /* Site.swift */,
 				0B54BD181B698B7C004C822C /* SuggestedSites.swift */,
-				28B62ACD1BC745E7004A585A /* Syncable.swift */,
+				28B62ACD1BC745E7004A585A /* FFSyncable.swift */,
 				7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */,
 				2FCAE25C1ABB531100877008 /* Visit.swift */,
 				28532D301C483DEB000072D9 /* Bookmarks */,
@@ -3585,6 +3624,7 @@
 				E6C191D51E38F7B7000A213B /* Cartfile.resolved */,
 				2FA435FC1ABB83B4008031D1 /* Account */,
 				2FA4360B1ABB83B4008031D1 /* AccountTests */,
+				0A1E465920A05941004CDE5A /* BraveSync */,
 				F84B21C01A090F8100AAB793 /* Client */,
 				F84B21D61A090F8100AAB793 /* ClientTests */,
 				F8708D1E1A0970990051AB07 /* Extensions */,
@@ -5320,6 +5360,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A1E467920A059D2004CDE5A /* SyncBookmark.swift in Sources */,
 				5CA9770C2035FB4C00181058 /* HistoryMO.swift in Sources */,
 				2FCAE2621ABB531100877008 /* History.swift in Sources */,
 				28126F6E1C2F94F9006466CC /* SQLiteBookmarksModel.swift in Sources */,
@@ -5334,17 +5375,20 @@
 				28C4AB721AD42D4300D9ACE3 /* Clients.swift in Sources */,
 				D0131B4D1F3CF7D8000CDE86 /* SQLiteFavicons.swift in Sources */,
 				28126F741C2F96F1006466CC /* SQLiteBookmarksResetting.swift in Sources */,
-				28B62ACE1BC745E7004A585A /* Syncable.swift in Sources */,
+				28B62ACE1BC745E7004A585A /* FFSyncable.swift in Sources */,
 				74B195441CF503FC007F36EF /* RecentlyClosedTabs.swift in Sources */,
 				E65075C21E37F956006961AC /* ExtensionUtils.swift in Sources */,
 				7BF5A1EA1B41640500EA9DD8 /* SyncQueue.swift in Sources */,
 				2852B8441C51996B00591EAC /* Trees.swift in Sources */,
+				0A1E466E20A059A7004CDE5A /* Syncable.swift in Sources */,
 				E677F0541D94247300ECF1FB /* Metadata.swift in Sources */,
 				28E08C991AF44EF9009BA2FA /* SQLiteHistory.swift in Sources */,
 				285D3B901B4386520035FD22 /* SQLiteQueue.swift in Sources */,
+				0A1E467720A059D2004CDE5A /* SyncSite.swift in Sources */,
 				28532D321C483E3D000072D9 /* CompletionOps.swift in Sources */,
 				2FCAE25D1ABB531100877008 /* Bookmarks.swift in Sources */,
 				394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */,
+				0A1E467C20A059F0004CDE5A /* Sync.swift in Sources */,
 				5CA977552037857B00181058 /* TabMO.swift in Sources */,
 				2FCAE2781ABB531100877008 /* Visit.swift in Sources */,
 				5CA9770B2035FB4C00181058 /* BookmarkMO.swift in Sources */,
@@ -5366,14 +5410,18 @@
 				2FCAE2681ABB531100877008 /* BrowserDB.swift in Sources */,
 				283586FD1C73F18E00A55435 /* CachingItemSource.swift in Sources */,
 				5CA977542037857B00181058 /* TopSiteMO.swift in Sources */,
+				0A1E466F20A059A7004CDE5A /* Device.swift in Sources */,
 				D0B29EE01F460BDF00C7CEFC /* LoginsSchema.swift in Sources */,
 				2FCAE2651ABB531100877008 /* RemoteTabs.swift in Sources */,
 				2FCAE2601ABB531100877008 /* Favicons.swift in Sources */,
 				28126F771C2F9833006466CC /* SQLiteBookmarksBase.swift in Sources */,
 				2FCAE2771ABB531100877008 /* SwiftData.swift in Sources */,
+				0A1E467620A059D2004CDE5A /* SyncResponse.swift in Sources */,
 				5C3787CB20321DB1009E6BCB /* Model.xcdatamodeld in Sources */,
 				2FCAE25F1ABB531100877008 /* Cursor.swift in Sources */,
+				0A1E467820A059D2004CDE5A /* SyncDevice.swift in Sources */,
 				28302E401AF0747800521E2E /* DatabaseError.swift in Sources */,
+				0A1E467A20A059D2004CDE5A /* SyncRecord.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -7,6 +7,7 @@ import Shared
 import Account
 import SwiftKeychainWrapper
 import LocalAuthentication
+import Storage
 
 // This file contains all of the settings available in the main settings screen of the app.
 
@@ -26,6 +27,34 @@ class HiddenSetting: Setting {
         return !ShowDebugSettings
     }
 }
+
+// FIXME: Sync
+/*
+class SyncDeviceSetting: Setting {
+    let profile: Profile
+    
+    var onTap: (()->Void)?
+    internal var device: Device
+    
+    internal var displayTitle: String {
+        return device.name ?? ""
+    }
+    
+    override var accessoryType: UITableViewCellAccessoryType { return .none }
+    
+    override var accessibilityIdentifier: String? { return "SyncDevice" }
+    
+    init(profile: Profile, device: Device) {
+        self.profile = profile
+        self.device = device
+        super.init(title: NSAttributedString(string: device.name ?? "", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+    }
+    
+    override func onClick(_ navigationController: UINavigationController?) {
+        onTap?()
+    }
+}
+*/
 
 // Sync setting for connecting a Firefox Account.  Shown when we don't have an account.
 class ConnectSetting: WithoutAccountSetting {
@@ -707,7 +736,7 @@ class SendAnonymousUsageDataSetting: BoolSetting {
         super.init(
             prefs: prefs, prefKey: AppConstants.PrefSendUsageData, defaultValue: true,
             attributedTitleText: NSAttributedString(string: Strings.SendUsageSettingTitle),
-            attributedStatusText: createStatusText(),
+            attributedStatusText: SendAnonymousUsageDataSetting.createStatusText(),
             settingDidChange: {
                 AdjustIntegration.setEnabled($0)
                 LeanPlumClient.shared.set(attributes: [LPAttributeKey.telemetryOptIn: $0])
@@ -716,7 +745,7 @@ class SendAnonymousUsageDataSetting: BoolSetting {
         )
     }
 
-    private func createStatusText() -> NSAttributedString {
+    private static func createStatusText() -> NSAttributedString {
         let statusText = NSMutableAttributedString()
         statusText.append(NSAttributedString(string: Strings.SendUsageSettingMessage, attributes: [NSForegroundColorAttributeName: SettingsUX.TableViewHeaderTextColor]))
         statusText.append(NSAttributedString(string: " "))

--- a/Shared/TimeConstants.swift
+++ b/Shared/TimeConstants.swift
@@ -98,6 +98,10 @@ extension Date {
     public func toRFC822String() -> String {
         return rfc822DateFormatter.string(from: self)
     }
+    
+    public func toTimestamp() -> Timestamp {
+        return UInt64(self.timeIntervalSince1970 * 1000)
+    }
 }
 
 let MaxTimestampAsDouble: Double = Double(UInt64.max)

--- a/Storage/Device.swift
+++ b/Storage/Device.swift
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+import UIKit
+import CoreData
+import Foundation
+import Shared
+
+public class Device: NSManagedObject, Syncable {
+    
+    // Check if this can be nested inside the method
+    private static var sharedCurrentDevice: Device?
+    
+    // Assign on parent model via CD
+    @NSManaged var isSynced: Bool
+    
+    @NSManaged public var created: Date?
+    @NSManaged public var isCurrentDevice: Bool
+    @NSManaged public var deviceDisplayId: String?
+    @NSManaged public var syncDisplayUUID: String?
+    @NSManaged public var name: String?
+    
+    // Device is subtype of prefs 🤢
+    public var recordType: SyncRecordType = .prefs
+
+    // Just a facade around the displayId, for easier access and better CD storage
+    var deviceId: [Int]? {
+        get { return SyncHelpers.syncUUID(fromString: deviceDisplayId) }
+        set(value) { deviceDisplayId = SyncHelpers.syncDisplay(fromUUID: value) }
+    }
+    
+    // FIXME: Sync
+    /*
+    public class func deviceSettings(profile: Profile) -> [SyncDeviceSetting]? {
+        // Building settings off of device objects
+        let deviceSettings: [SyncDeviceSetting]? = (Device.get(predicate: nil, context: DataController.shared.workerContext) as? [Device])?.map {
+            // Even if no 'real' title, still want it to show up in list
+            return SyncDeviceSetting(profile: profile, device: $0)
+        }
+        return deviceSettings
+    }
+    */
+    
+    // This should be abstractable
+    public func asDictionary(deviceId: [Int]?, action: Int?) -> [String: Any] {
+        return SyncDevice(record: self, deviceId: deviceId, action: action).dictionaryRepresentation()
+    }
+    
+    public static func add(rootObject root: SyncRecord?, save: Bool, sendToSync: Bool, context: NSManagedObjectContext) -> Syncable? {
+        
+        // No guard, let bleed through to allow 'empty' devices (e.g. local)
+        let root = root as? SyncDevice
+
+        let device = Device(entity: Device.entity(context: context), insertInto: context)
+        
+        device.created = root?.syncNativeTimestamp ?? Date()
+        // FIXME: Sync
+        // device.syncUUID = root?.objectId ?? SyncCrypto.shared.uniqueSerialBytes(count: 16)
+
+        device.update(syncRecord: root)
+        
+        if save {
+            DataManager.saveContext(context: context)
+        }
+        
+        return device
+    }
+    
+    class func add(save: Bool = false, context: NSManagedObjectContext) -> Device? {
+        return add(rootObject: nil, save: save, sendToSync: false, context: context) as? Device
+    }
+    
+    public func update(syncRecord record: SyncRecord?) {
+        guard let root = record as? SyncDevice else { return }
+        self.name = root.name
+        self.deviceId = root.deviceId
+        
+        // No save currently
+    }
+    
+    static func currentDevice() -> Device? {
+        
+        if sharedCurrentDevice == nil {
+            let context = DataManager.shared.workerContext
+            // Create device
+            let predicate = NSPredicate(format: "isCurrentDevice = YES")
+            // Should only ever be one current device!
+            var localDevice: Device? = get(predicate: predicate, context: context)?.first
+            
+            if localDevice == nil {
+                // Create
+                localDevice = add(context: context)
+                localDevice?.isCurrentDevice = true
+                DataManager.saveContext(context: context)
+            }
+            
+            sharedCurrentDevice = localDevice
+        }
+        return sharedCurrentDevice
+    }
+    
+    class func deleteAll(completionOnMain: ()->()) {
+        let context = DataManager.shared.workerContext
+        context.perform {
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>()
+            fetchRequest.entity = Device.entity(context: context)
+            fetchRequest.includesPropertyValues = false
+            do {
+                let results = try context.fetch(fetchRequest)
+                for result in results {
+                    context.delete(result as! NSManagedObject)
+                }
+                
+            } catch {
+                let fetchError = error as NSError
+                print(fetchError)
+            }
+
+            // Destroy handle to local device instance, otherwise it is locally retained and will throw console errors
+            sharedCurrentDevice = nil
+            
+            DataManager.saveContext(context: context)
+        }
+    }
+    
+}

--- a/Storage/FFSyncable.swift
+++ b/Storage/FFSyncable.swift
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Shared
+
+/**
+ * This exists to allow resets after meta/global or crypto/key changes.
+ *
+ * 'Reset' in this case means that timestamps and progress tracking are
+ * discarded: this storage is reconfigured such that all data will be
+ * reuploaded, and all data will be re-merged as necessary.
+ *
+ * This protocol is primarily consumed by `ResettableSynchronizer`, and
+ * is invoked when a significant server change is observed — changed keys,
+ * changed engine elections or syncIDs, or a node reassignment.
+ */
+public protocol ResettableSyncStorage {
+    func resetClient() -> Success
+}
+
+public protocol AccountRemovalDelegate {
+    func onRemovedAccount() -> Success
+}

--- a/Storage/Syncable.swift
+++ b/Storage/Syncable.swift
@@ -1,24 +1,135 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Foundation
 import Shared
+import CoreData
+import SwiftyJSON
 
-/**
- * This exists to allow resets after meta/global or crypto/key changes.
- *
- * 'Reset' in this case means that timestamps and progress tracking are
- * discarded: this storage is reconfigured such that all data will be
- * reuploaded, and all data will be re-merged as necessary.
- *
- * This protocol is primarily consumed by `ResettableSynchronizer`, and
- * is invoked when a significant server change is observed — changed keys,
- * changed engine elections or syncIDs, or a node reassignment.
- */
-public protocol ResettableSyncStorage {
-    func resetClient() -> Success
+public protocol Syncable: class /* where Self: NSManagedObject */ {
+    // Used to enforce CD conformity
+    /* @NSManaged */ var syncDisplayUUID: String? { get set }
+    /* @NSManaged */ var created: Date? { get set }
+    
+    // Primarily used for generic record deletion
+    var recordType: SyncRecordType { get }
+    
+    static func entity(context:NSManagedObjectContext) -> NSEntityDescription
+    
+    func asDictionary(deviceId: [Int]?, action: Int?) -> [String: Any]
+    
+    func update(syncRecord record: SyncRecord?)
+    
+    @discardableResult static func add(rootObject root: SyncRecord?, save: Bool, sendToSync: Bool, context: NSManagedObjectContext) -> Syncable?
 }
 
-public protocol AccountRemovalDelegate {
-    func onRemovedAccount() -> Success
+extension Syncable {
+    public static func entity(context:NSManagedObjectContext) -> NSEntityDescription {
+        // Swift 4 version
+        // let className = String(describing: type(of: self))
+        let className = String(describing: self)
+        return NSEntityDescription.entity(forEntityName: className, in: context)!
+    }
+    
+    public static func get(syncUUIDs: [[Int]]?, context: NSManagedObjectContext) -> [NSManagedObject]? {
+        
+        guard let syncUUIDs = syncUUIDs else {
+            return nil
+        }
+        
+        // TODO: filter a unique set of syncUUIDs
+        
+        let searchableUUIDs = syncUUIDs.map { SyncHelpers.syncDisplay(fromUUID: $0) }.flatMap { $0 }
+        return get(predicate: NSPredicate(format: "syncDisplayUUID IN %@", searchableUUIDs), context: context)
+    }
+    
+    public static func get(predicate: NSPredicate?, context: NSManagedObjectContext) -> [NSManagedObject]? {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>()
+        
+        fetchRequest.entity = Self.entity(context: context)
+        fetchRequest.predicate = predicate
+        
+        var result: [NSManagedObject]? = nil
+        context.performAndWait {
+            
+            
+            do {
+                result = try context.fetch(fetchRequest) as? [NSManagedObject]
+            } catch {
+                let fetchError = error as NSError
+                print(fetchError)
+            }
+        }
+        
+        return result
+    }
+}
+
+//extension Syncable where Self: NSManagedObject {
+extension Syncable {
+    
+    // Is conveted to better store in CD
+    var syncUUID: [Int]? {
+        get { return SyncHelpers.syncUUID(fromString: syncDisplayUUID) }
+        set(value) { syncDisplayUUID = SyncHelpers.syncDisplay(fromUUID: value) }
+    }
+    
+    // Maybe use 'self'?
+    static func get<T: Syncable>(predicate: NSPredicate?, context: NSManagedObjectContext?) -> [T]? {
+        guard let context = context else {
+            // error
+            return nil
+        }
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>()
+        
+        fetchRequest.entity = T.entity(context: context)
+        fetchRequest.predicate = predicate
+        
+        do {
+            return try context.fetch(fetchRequest) as? [T]
+        } catch {
+            let fetchError = error as NSError
+            print(fetchError)
+        }
+        
+        return nil
+    }
+}
+
+extension Syncable /* where Self: NSManagedObject */ {
+    func remove(save: Bool) {
+        
+        // This is r annoying, and can be fixed in Swift 4, but since objects can't be cast to a class & protocol,
+        //  but given extension on Syncable, if this passes the object is both Syncable and an NSManagedObject subclass
+        guard let s = self as? NSManagedObject, let context = s.managedObjectContext else { return }
+        
+        // Must happen before, otherwise bookmark is gone
+        
+        // FIXME: Sync
+        // Sync.shared.sendSyncRecords(action: .delete, records: [self])
+        
+        // Should actually delay, and wait for server to refetch records to confirm deletion.
+        // Force a sync resync instead, should not be slow
+        context.delete(s)
+        if save {
+            DataManager.saveContext(context: context)
+        }
+    }
+}
+
+class SyncHelpers {
+    // Converters
+    
+    /// UUID -> DisplayUUID
+    static func syncDisplay(fromUUID uuid: [Int]?) -> String? {
+        return uuid?.map{ $0.description }.joined(separator: ",")
+    }
+    
+    /// DisplayUUID -> UUID
+    static func syncUUID(fromString string: String?) -> [Int]? {
+        return string?.components(separatedBy: ",").flatMap { Int($0) }
+    }
+    
+    static func syncUUID(fromJSON json: JSON?) -> [Int]? {
+        return json?.array?.flatMap { $0.int }
+    }
 }


### PR DESCRIPTION
In order to add `add()` and `update()` methods for unit tests, few of sync classes had to be imported.

I wanted to move it to `Sync` framework but sourceKit crashed a lot and couldn't make it, after few file imports Xcode was telling me that there's no Sync module or `Could not build Objective-C module 'Sync'`. Maybe we could create new Sync framework instead of adding to the existing one.

`Sync.swift` was not fully migrated, only enums are needed for now.
Some parts of code needed to be commented out in order to work, those are marked with `// FIXME: Sync` comments.