### PR TITLE
Port History

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		7BF5A1EE1B429B3100EA9DD8 /* SyncCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvanceAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvanceAccountSettingViewController.swift */; };
 		8DCD3BCD1ED5B7FA00446D38 /* FxADeepLinkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */; };
+		A198E75120C701ED00334C11 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A198E75020C701ED00334C11 /* HistoryViewController.swift */; };
 		A1AD4BCF20BF3E8C007A6EA1 /* BookmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1AD4BCE20BF3E8C007A6EA1 /* BookmarksViewController.swift */; };
 		A1AD4BD120BF3F4D007A6EA1 /* Eureka.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1AD4BD020BF3F4D007A6EA1 /* Eureka.framework */; };
 		A1AD4BD420BF4757007A6EA1 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1AD4BD220BF4712007A6EA1 /* ImageCache.swift */; };
@@ -1621,6 +1622,7 @@
 		7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTests.swift; sourceTree = "<group>"; };
 		8D8251721F4DE67E00780643 /* AdvanceAccountSettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdvanceAccountSettingViewController.swift; sourceTree = "<group>"; };
 		8DCD3BCC1ED5B7FA00446D38 /* FxADeepLinkingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxADeepLinkingTests.swift; sourceTree = "<group>"; };
+		A198E75020C701ED00334C11 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		A1AD4BCE20BF3E8C007A6EA1 /* BookmarksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksViewController.swift; sourceTree = "<group>"; };
 		A1AD4BD020BF3F4D007A6EA1 /* Eureka.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Eureka.framework; path = Carthage/Build/iOS/Eureka.framework; sourceTree = "<group>"; };
 		A1AD4BD220BF4712007A6EA1 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
@@ -3791,6 +3793,7 @@
 				3BB50E101D6274CD004B33DF /* ActivityStreamTopSitesCell.swift */,
 				59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */,
 				A1AD4BCE20BF3E8C007A6EA1 /* BookmarksViewController.swift */,
+				A198E75020C701ED00334C11 /* HistoryViewController.swift */,
 				D0E89A2820910917001CE5C7 /* DownloadsPanel.swift */,
 				59A6825233896FC846499289 /* HistoryPanel.swift */,
 				D30B101D1AA7F9C600C01CA3 /* HomePanels.swift */,
@@ -5534,6 +5537,7 @@
 				D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */,
 				0B3E7D951B27A7CE00E2E84D /* AboutHomeHandler.swift in Sources */,
 				D331DFCA1CB6E9EE009B5DA2 /* OldStrings.swift in Sources */,
+				A198E75120C701ED00334C11 /* HistoryViewController.swift in Sources */,
 				D3BE7B461B054F8600641031 /* TestAppDelegate.swift in Sources */,
 				3BB50E111D6274CD004B33DF /* ActivityStreamTopSitesCell.swift in Sources */,
 				0B62EFD21AD63CD100ACB9CD /* Clearables.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -18,6 +18,7 @@ import SwiftyJSON
 import Telemetry
 import Sentry
 import Deferred
+import Data
 
 private let KVOs: [KVOConstants] = [
     .estimatedProgress,
@@ -1134,6 +1135,7 @@ class BrowserViewController: UIViewController {
             }
 
             TabEvent.post(.didChangeURL(url), for: tab)
+            History.add(tab.title ?? "", url: url)
         }
 
         if tab === tabManager.selectedTab {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1132,10 +1132,12 @@ class BrowserViewController: UIViewController {
 
                 // Re-run additional scripts in webView to extract updated favicons and metadata.
                 runScriptsOnWebView(webView)
+                
+                // Only add history of a url which is not a localhost url
+                History.add(tab.title ?? "", url: url)
             }
 
             TabEvent.post(.didChangeURL(url), for: tab)
-            History.add(tab.title ?? "", url: url)
         }
 
         if tab === tabManager.selectedTab {

--- a/Client/Frontend/Home/HistoryViewController.swift
+++ b/Client/Frontend/Home/HistoryViewController.swift
@@ -188,10 +188,8 @@ class HistoryViewController: SiteTableViewController, HomePanel {
     tableView.deselectRow(at: indexPath, animated: true)
   }
   
-  // Minimum of 1 section
-  func numberOfSectionsInTableView(_ tableView: UITableView) -> Int {
-    let count = frc?.sections?.count ?? 0
-    return count
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return frc?.sections?.count ?? 0
   }
   
   func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/Client/Frontend/Home/HistoryViewController.swift
+++ b/Client/Frontend/Home/HistoryViewController.swift
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import BraveShared
+import Storage
+import Data
+import CoreData
+
+private struct HistoryViewControllerUX {
+  static let WelcomeScreenPadding: CGFloat = 15
+  static let WelcomeScreenItemTextColor = UIColor.gray
+  static let WelcomeScreenItemWidth = 170
+}
+
+class HistoryViewController: SiteTableViewController, HomePanel {
+  weak var homePanelDelegate: HomePanelDelegate? = nil
+  fileprivate lazy var emptyStateOverlayView: UIView = self.createEmptyStateOverview()
+  fileprivate var kvoContext: UInt8 = 1
+  var frc: NSFetchedResultsController<NSFetchRequestResult>?
+  
+  init() {
+    super.init(nibName: nil, bundle: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(HistoryViewController.notificationReceived(_:)), name: .DynamicFontChanged, object: nil)
+  }
+  
+  override func viewDidLoad() {
+    frc = History.frc()
+    frc!.delegate = self
+    super.viewDidLoad()
+    self.tableView.accessibilityIdentifier = "History List"
+    
+    reloadData()
+  }
+  
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  deinit {
+    NotificationCenter.default.removeObserver(self, name: .DynamicFontChanged, object: nil)
+  }
+  
+  @objc func notificationReceived(_ notification: Notification) {
+    switch notification.name {
+    case .DynamicFontChanged:
+      if emptyStateOverlayView.superview != nil {
+        emptyStateOverlayView.removeFromSuperview()
+      }
+      emptyStateOverlayView = createEmptyStateOverview()
+    default:
+      // no need to do anything at all
+      break
+    }
+  }
+  
+  override func reloadData() {
+    guard let frc = frc else {
+      return
+    }
+    
+    do {
+      try frc.performFetch()
+    } catch let error as NSError {
+      print(error.description)
+    }
+    
+    tableView.reloadData()
+    updateEmptyPanelState()
+  }
+  
+  fileprivate func updateEmptyPanelState() {
+    if frc?.fetchedObjects?.count == 0 {
+      if self.emptyStateOverlayView.superview == nil {
+        self.tableView.addSubview(self.emptyStateOverlayView)
+        self.emptyStateOverlayView.snp.makeConstraints { make -> Void in
+          make.edges.equalTo(self.tableView)
+          make.size.equalTo(self.view)
+        }
+      }
+    } else {
+      self.emptyStateOverlayView.removeFromSuperview()
+    }
+  }
+  
+  fileprivate func createEmptyStateOverview() -> UIView {
+    let overlayView = UIView()
+    overlayView.backgroundColor = UIColor.white
+    
+    return overlayView
+  }
+  
+  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = super.tableView(tableView, cellForRowAt: indexPath)
+    configureCell(cell, atIndexPath: indexPath)
+    return cell
+  }
+  
+  func configureCell(_ _cell: UITableViewCell, atIndexPath indexPath: IndexPath) {
+    guard let cell = _cell as? TwoLineTableViewCell else { return }
+    let site = frc!.object(at: indexPath) as! History
+    cell.backgroundColor = UIColor.clear
+    cell.setLines(site.title, detailText: site.url)
+    
+    cell.imageView?.contentMode = .center
+    cell.imageView?.image = FaviconFetcher.defaultFavicon
+    cell.imageView?.layer.cornerRadius = 6
+    cell.imageView?.layer.masksToBounds = true
+    
+    if let faviconMO = site.domain?.favicon, let urlString = faviconMO.url, let url = URL(string: urlString) {
+      ImageCache.shared.image(url, type: .square, callback: { (image) in
+        if image == nil {
+          DispatchQueue.main.async {
+            cell.imageView?.contentMode = .scaleAspectFit
+            cell.imageView?.sd_setImage(with: url, completed: { (img, err, type, url) in
+              if let img = img, let url = url {
+                ImageCache.shared.cache(img, url: url, type: .square, callback: nil)
+              }
+            })
+          }
+        }
+        else {
+          DispatchQueue.main.async {
+            cell.imageView?.contentMode = .scaleAspectFit
+            cell.imageView?.image = image
+          }
+        }
+      })
+    }
+  }
+  
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    let site = frc?.object(at: indexPath) as! History
+    
+    if let u = site.url, let url = URL(string: u) {
+      homePanelDelegate?.homePanel(self, didSelectURL: url, visitType: .typed)
+    }
+    tableView.deselectRow(at: indexPath, animated: true)
+  }
+  
+  // Minimum of 1 section
+  func numberOfSectionsInTableView(_ tableView: UITableView) -> Int {
+    let count = frc?.sections?.count ?? 0
+    return count
+  }
+  
+  func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    guard let sections = frc?.sections else { return nil }
+    return sections.indices ~= section ? sections[section].name : nil
+  }
+  
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    guard let sections = frc?.sections else { return 0 }
+    return sections.indices ~= section ? sections[section].numberOfObjects : 0
+  }
+  
+  func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+    return true
+  }
+  
+  func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+    if (editingStyle == UITableViewCellEditingStyle.delete) {
+      if let obj = self.frc?.object(at: indexPath) as? History {
+        obj.remove(save: true)
+      }
+    }
+  }
+  
+//  override func getLongPressUrl(forIndexPath indexPath: IndexPath) -> (URL?, [Int]?) {
+//    guard let obj = frc?.object(at: indexPath) as? History else { return (nil, nil) }
+//    return (obj.url != nil ? URL(string: obj.url!) : nil, nil)
+//  }
+}
+
+extension HistoryViewController : NSFetchedResultsControllerDelegate {
+  func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+    tableView.beginUpdates()
+  }
+  
+  func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+    tableView.endUpdates()
+  }
+  
+  func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange sectionInfo: NSFetchedResultsSectionInfo, atSectionIndex sectionIndex: Int, for type: NSFetchedResultsChangeType) {
+    switch type {
+    case .insert:
+      let sectionIndexSet = IndexSet(integer: sectionIndex)
+      self.tableView.insertSections(sectionIndexSet, with: .fade)
+    case .delete:
+      let sectionIndexSet = IndexSet(integer: sectionIndex)
+      self.tableView.deleteSections(sectionIndexSet, with: .fade)
+    default: break;
+    }
+  }
+  
+  func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+    switch (type) {
+    case .insert:
+      if let indexPath = newIndexPath {
+        tableView.insertRows(at: [indexPath], with: .automatic)
+      }
+    case .delete:
+      if let indexPath = indexPath {
+        tableView.deleteRows(at: [indexPath], with: .automatic)
+      }
+    case .update:
+      if let indexPath = indexPath, let cell = tableView.cellForRow(at: indexPath) {
+        configureCell(cell, atIndexPath: indexPath)
+      }
+    case .move:
+      if let indexPath = indexPath {
+        tableView.deleteRows(at: [indexPath], with: .automatic)
+      }
+      
+      if let newIndexPath = newIndexPath {
+        tableView.insertRows(at: [newIndexPath], with: .automatic)
+      }
+    }
+    updateEmptyPanelState()
+  }
+}

--- a/Client/Frontend/Menu/HomeMenuController.swift
+++ b/Client/Frontend/Menu/HomeMenuController.swift
@@ -33,10 +33,10 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
   
   weak var delegate: HomeMenuControllerDelegate?
   
-  let bookmarksPanel: BookmarksViewController
+  let bookmarksController: BookmarksViewController
   fileprivate var bookmarksNavController: UINavigationController!
   
-  let history = HistoryViewController()
+  let historyController: HistoryViewController
   
   var bookmarksButton = UIButton()
   var historyButton = UIButton()
@@ -53,7 +53,7 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
   var isPanToDismissEnabled: Bool {
     if visibleController === bookmarksNavController {
       // Don't break reordering bookmarks
-      return !bookmarksPanel.tableView.isEditing
+      return !bookmarksController.tableView.isEditing
     }
     return true
   }
@@ -62,7 +62,7 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
   var pageButtons: [UIButton: UIViewController] {
     return [
       bookmarksButton: bookmarksNavController,
-      historyButton: history,
+      historyButton: historyController,
     ]
   }
   
@@ -73,18 +73,19 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
   init(profile: Profile, tabState: TabState) {
     self.profile = profile
     self.tabState = tabState
-    self.bookmarksPanel = BookmarksViewController(folder: nil, tabState: tabState)
+    self.bookmarksController = BookmarksViewController(folder: nil, tabState: tabState)
+    self.historyController = HistoryViewController(tabState: tabState)
     
     super.init(nibName: nil, bundle: nil)
-    bookmarksPanel.profile = profile
-    history.profile = profile
+    bookmarksController.profile = profile
+    historyController.profile = profile
     
-    bookmarksPanel.homePanelDelegate = self
-    bookmarksPanel.bookmarksDidChange = { [weak self] in
+    bookmarksController.homePanelDelegate = self
+    bookmarksController.bookmarksDidChange = { [weak self] in
       self?.updateBookmarkStatus()
     }
     
-    history.homePanelDelegate = self
+    historyController.homePanelDelegate = self
   }
   
   @available(*, unavailable)
@@ -95,7 +96,7 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    bookmarksNavController = UINavigationController(rootViewController: bookmarksPanel)
+    bookmarksNavController = UINavigationController(rootViewController: bookmarksController)
     bookmarksNavController.view.backgroundColor = UIColor.white
     view.addSubview(topButtonsView)
     
@@ -131,7 +132,7 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
     settingsButton.tintColor = BraveUX.ActionButtonTintColor
     addBookmarkButton.tintColor = BraveUX.ActionButtonTintColor
     
-    view.addSubview(history.view)
+    view.addSubview(historyController.view)
     view.addSubview(bookmarksNavController.view)
     
     // Setup the bookmarks button as default
@@ -178,7 +179,7 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
     if Bookmark.contains(url: url, context: DataController.shared.mainThreadContext) {
       Bookmark.remove(forUrl: url, context: DataController.shared.mainThreadContext)
     } else {
-      Bookmark.add(url: url, title: tabState.title, parentFolder: bookmarksPanel.currentBookmarksPanel().currentFolder)
+      Bookmark.add(url: url, title: tabState.title, parentFolder: bookmarksController.currentBookmarksPanel().currentFolder)
     }
   }
   
@@ -228,7 +229,7 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
       make.top.equalTo(topButtonsView.snp.bottom)
     }
     
-    history.view.snp.remakeConstraints { make in
+    historyController.view.snp.remakeConstraints { make in
       make.left.right.bottom.equalTo(self.view)
       make.top.equalTo(topButtonsView.snp.bottom)
     }

--- a/Client/Frontend/Menu/HomeMenuController.swift
+++ b/Client/Frontend/Menu/HomeMenuController.swift
@@ -36,7 +36,7 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
   let bookmarksPanel: BookmarksViewController
   fileprivate var bookmarksNavController: UINavigationController!
   
-  let history = HistoryPanel()
+  let history = HistoryViewController()
   
   var bookmarksButton = UIButton()
   var historyButton = UIButton()
@@ -83,6 +83,8 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
     bookmarksPanel.bookmarksDidChange = { [weak self] in
       self?.updateBookmarkStatus()
     }
+    
+    history.homePanelDelegate = self
   }
   
   @available(*, unavailable)
@@ -248,16 +250,6 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
     sender.tintColor = BraveUX.ActionButtonSelectedTintColor
     
     visibleController = vc
-  }
-  
-  func setHomePanelDelegate(_ delegate: HomePanelDelegate?) {
-    bookmarksPanel.homePanelDelegate = delegate
-    history.homePanelDelegate = delegate
-
-    if (delegate != nil) {
-      bookmarksPanel.reloadData()
-      history.reloadData()
-    }
   }
   
   func updateBookmarkStatus() {

--- a/Data/models/History.swift
+++ b/Data/models/History.swift
@@ -36,14 +36,14 @@ public func isIgnoredURL(_ url: String) -> Bool {
     return false
 }
 
-class History: NSManagedObject, WebsitePresentable {
+public class History: NSManagedObject, WebsitePresentable {
 
-    @NSManaged var title: String?
-    @NSManaged var url: String?
-    @NSManaged var visitedOn: Date?
-    @NSManaged var syncUUID: UUID?
-    @NSManaged var domain: Domain?
-    @NSManaged var sectionIdentifier: String?
+    @NSManaged public var title: String?
+    @NSManaged public var url: String?
+    @NSManaged public var visitedOn: Date?
+    @NSManaged public var syncUUID: UUID?
+    @NSManaged public var domain: Domain?
+    @NSManaged public var sectionIdentifier: String?
     
     static let Today = getDate(0)
     static let Yesterday = getDate(-1)
@@ -55,7 +55,7 @@ class History: NSManagedObject, WebsitePresentable {
         return NSEntityDescription.entity(forEntityName: "History", in: context)!
     }
 
-    class func add(_ title: String, url: URL) {
+    public class func add(_ title: String, url: URL) {
         let context = DataController.shared.workerContext
         context.perform {
             var item = History.getExisting(url, context: context)
@@ -74,7 +74,7 @@ class History: NSManagedObject, WebsitePresentable {
         }
     }
 
-    class func frc() -> NSFetchedResultsController<NSFetchRequestResult> {
+    public class func frc() -> NSFetchedResultsController<NSFetchRequestResult> {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>()
         let context = DataController.shared.mainThreadContext
         
@@ -87,7 +87,7 @@ class History: NSManagedObject, WebsitePresentable {
         return NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext:context, sectionNameKeyPath: "sectionIdentifier", cacheName: nil)
     }
 
-    override func awakeFromFetch() {
+    public override func awakeFromFetch() {
         if sectionIdentifier != nil {
             return
         }
@@ -145,6 +145,15 @@ class History: NSManagedObject, WebsitePresentable {
             print(fetchError)
         }
         return []
+    }
+    
+    public func remove(save: Bool) {
+        guard let context = managedObjectContext else { return }
+        context.delete(self)
+        
+        if save {
+            DataController.saveContext(context: context)
+        }
     }
     
     class func deleteAll(_ completionOnMain: @escaping ()->()) {


### PR DESCRIPTION
Porting `HistoryPanel` → `HistoryViewController` is mostly the same w/ some adjustments:

- Fixed Swift 4 table view signatures
- Fixed favicon loading
- Different long press implementation (same as bookmarks)

One caveat: FF's table header's changed, not sure if we want to bring back old one (new one is a bit taller, grey background instead of white, and bolder font)