### PR TITLE
Fix package.json version semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-ios",
-  "version": "2.0",
+  "version": "2.0.0",
   "description": "Brave for iOS",
   "scripts": {
     "build": "webpack --config webpack.config.js"


### PR DESCRIPTION
Fixes running `./bootstrap.sh` (when npm is ran)
