### PR TITLE
Fix #89: Prevent loading home panel while restoring tabs.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -720,7 +720,7 @@ class BrowserViewController: SensitiveViewController {
                 hideHomePanelController()
                 return
             }
-            if url.isAboutHomeURL {
+            if url.isAboutHomeURL && !url.isErrorPageURL {
                 showHomePanelController(inline: true)
             } else if !url.isLocalUtility || url.isReaderModeURL {
                 hideHomePanelController()


### PR DESCRIPTION
Check for error page may seem weird but it is used by session restore to trigger a redirect when loaded.