### PR TITLE
Ref #20: Cleanup warnings part 1

### DIFF
--- a/Client/Application/AdjustIntegration.swift
+++ b/Client/Application/AdjustIntegration.swift
@@ -192,8 +192,8 @@ extension AdjustIntegration: AdjustDelegate {
     /// with launching the deeplink. We let the interstial view decide what to do with deeplink.
     /// Ref: https://github.com/adjust/ios_sdk#deferred-deep-linking-scenario
     
-    func adjustDeeplinkResponse(_ deeplink: URL!) -> Bool {
-        profile.prefs.setString("\(deeplink)", forKey: "AdjustDeeplinkKey")
+    func adjustDeeplinkResponse(_ deeplink: URL?) -> Bool {
+        profile.prefs.setString("\(String(describing: deeplink))", forKey: "AdjustDeeplinkKey")
         return true
     }
 

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -47,7 +47,7 @@ class WebServer {
     }
 
     /// Convenience method to register a dynamic handler. Will be mounted at $base/$module/$resource
-    func registerHandlerForMethod(_ method: String, module: String, resource: String, handler: @escaping (_ request: GCDWebServerRequest?) -> GCDWebServerResponse!) {
+    func registerHandlerForMethod(_ method: String, module: String, resource: String, handler: @escaping (_ request: GCDWebServerRequest?) -> GCDWebServerResponse?) {
         // Prevent serving content if the requested host isn't a whitelisted local host.
         let wrappedHandler = {(request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             guard let request = request, request.url.isLocal else {

--- a/Client/Extensions/GeometryExtensions.swift
+++ b/Client/Extensions/GeometryExtensions.swift
@@ -17,6 +17,7 @@ extension CGRect {
 
 extension UIEdgeInsets {
     init(equalInset inset: CGFloat) {
+        self.init()
         top = inset
         left = inset
         right = inset

--- a/Client/Extensions/NSURLExtensionsMailTo.swift
+++ b/Client/Extensions/NSURLExtensionsMailTo.swift
@@ -29,14 +29,14 @@ public extension URL {
         let toStart = urlString.index(urlString.startIndex, offsetBy: "mailto:".count)
         let toEnd = urlString.index(of: "?") ?? urlString.endIndex
 
-        let to = urlString.substring(with: toStart..<toEnd)
+        let to = String(urlString[toStart..<toEnd])
 
         guard toEnd != urlString.endIndex else {
             return MailToMetadata(to: to, headers: [String: String]())
         }
 
         // Extract headers
-        let headersString = urlString.substring(with: urlString.index(toEnd, offsetBy: 1)..<urlString.endIndex)
+        let headersString = String(urlString[urlString.index(toEnd, offsetBy: 1)..<urlString.endIndex])
         var headers = [String: String]()
         let headerComponents = headersString.components(separatedBy: "&")
 

--- a/Client/Frontend/Browser/AboutHomeHandler.swift
+++ b/Client/Frontend/Browser/AboutHomeHandler.swift
@@ -9,7 +9,7 @@ import GCDWebServers
 
 struct AboutHomeHandler {
     static func register(_ webServer: WebServer) {
-        webServer.registerHandlerForMethod("GET", module: "about", resource: "home") { (request: GCDWebServerRequest?) -> GCDWebServerResponse! in
+        webServer.registerHandlerForMethod("GET", module: "about", resource: "home") { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             return GCDWebServerResponse(statusCode: 200)
         }
     }
@@ -17,7 +17,7 @@ struct AboutHomeHandler {
 
 struct AboutLicenseHandler {
     static func register(_ webServer: WebServer) {
-        webServer.registerHandlerForMethod("GET", module: "about", resource: "license") { (request: GCDWebServerRequest?) -> GCDWebServerResponse! in
+        webServer.registerHandlerForMethod("GET", module: "about", resource: "license") { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             let path = Bundle.main.path(forResource: "Licenses", ofType: "html")
             do {
                 let html = try String(contentsOfFile: path!, encoding: .utf8)

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -134,7 +134,7 @@ class ErrorPageHelper {
     class func register(_ server: WebServer, certStore: CertStore?) {
         self.certStore = certStore
 
-        server.registerHandlerForMethod("GET", module: "errors", resource: "error.html", handler: { (request) -> GCDWebServerResponse! in
+        server.registerHandlerForMethod("GET", module: "errors", resource: "error.html", handler: { (request) -> GCDWebServerResponse? in
             guard let url = request?.url.originalURLFromErrorURL else {
                 return GCDWebServerResponse(statusCode: 404)
             }
@@ -209,7 +209,7 @@ class ErrorPageHelper {
             return response
         })
 
-        server.registerHandlerForMethod("GET", module: "errors", resource: "NetError.css", handler: { (request) -> GCDWebServerResponse! in
+        server.registerHandlerForMethod("GET", module: "errors", resource: "NetError.css", handler: { (request) -> GCDWebServerResponse? in
             let path = Bundle(for: self).path(forResource: "NetError", ofType: "css")!
             guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
                 log.error("NetError data is nil")
@@ -219,7 +219,7 @@ class ErrorPageHelper {
             return GCDWebServerDataResponse(data: data, contentType: "text/css")
         })
 
-        server.registerHandlerForMethod("GET", module: "errors", resource: "CertError.css", handler: { (request) -> GCDWebServerResponse! in
+        server.registerHandlerForMethod("GET", module: "errors", resource: "CertError.css", handler: { (request) -> GCDWebServerResponse? in
             let path = Bundle(for: self).path(forResource: "CertError", ofType: "css")!
             
             guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -100,7 +100,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
         // Extract the pre-path substring from the URL. This should be more efficient than parsing via
         // NSURL since we need to only look at the beginning of the string.
         // Note that we won't match non-HTTP(S) URLs.
-        guard let match = URLBeforePathRegex.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.characters.count)) else {
+        guard let match = URLBeforePathRegex.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.count)) else {
             return nil
         }
 
@@ -127,7 +127,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
         if let range = domainWithDotPrefix.range(of: ".\(query)", options: .caseInsensitive, range: nil, locale: nil) {
             // We don't actually want to match the top-level domain ("com", "org", etc.) by itself, so
             // so make sure the result includes at least one ".".
-            let matchedDomain: String = domainWithDotPrefix.substring(from: domainWithDotPrefix.index(range.lowerBound, offsetBy: 1))
+            let matchedDomain = String(domainWithDotPrefix.suffix(from: domainWithDotPrefix.index(range.lowerBound, offsetBy: 1)))
             if matchedDomain.contains(".") {
                 return matchedDomain
             }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -154,7 +154,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
             // Show the default search engine first.
             if !isPrivate {
-                let ua = SearchViewController.userAgent as String! ?? "FxSearch"
+                let ua = SearchViewController.userAgent ?? "FxSearch"
                 suggestClient = SearchSuggestClient(searchEngine: searchEngines.defaultEngine, userAgent: ua)
             }
 

--- a/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/Client/Frontend/Browser/SwipeAnimator.swift
@@ -148,7 +148,7 @@ extension SwipeAnimator {
 
 extension SwipeAnimator: UIGestureRecognizerDelegate {
     @objc func gestureRecognizerShouldBegin(_ recognizer: UIGestureRecognizer) -> Bool {
-        let cellView = recognizer.view as UIView!
+        let cellView = recognizer.view
         let panGesture = recognizer as! UIPanGestureRecognizer
         let translation = panGesture.translation(in: cellView?.superview)
         return fabs(translation.x) > fabs(translation.y)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -260,7 +260,7 @@ class Tab: NSObject {
         } else if let request = lastRequest {
             webView.load(request)
         } else {
-            log.warning("creating webview with no lastRequest and no session data: \(self.url)")
+            log.warning("creating webview with no lastRequest and no session data: \(String(describing: self.url))")
         }
         
     }

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -7,7 +7,7 @@ import SnapKit
 import Shared
 
 protocol TabToolbarProtocol: class {
-    weak var tabToolbarDelegate: TabToolbarDelegate? { get set }
+    var tabToolbarDelegate: TabToolbarDelegate? { get set }
     var tabsButton: TabsButton { get }
     var menuButton: ToolbarButton { get }
     var forwardButton: ToolbarButton { get }

--- a/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/Client/Frontend/Browser/TemporaryDocument.swift
@@ -83,7 +83,7 @@ extension TemporaryDocument: URLSessionTaskDelegate, URLSessionDownloadDelegate 
             localFileURL = url
             pendingResult?.fill(url)
             pendingResult = nil
-        } catch let error {
+        } catch {
             // If we encounter an error downloading the temp file, just return with the
             // original remote URL so it can still be shared as a web URL.
             if let remoteURL = request.url {

--- a/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
@@ -164,7 +164,7 @@ fileprivate class TPStatsBlocklists {
                     assert(false, "url-filter code needs updating for new list format")
                     return
                 }
-                let baseDomain = filter.substring(from: loc.upperBound).replacingOccurrences(of: "\\.", with: ".")
+                let baseDomain = String(filter.suffix(from: loc.upperBound)).replacingOccurrences(of: "\\.", with: ".")
                 assert(!baseDomain.isEmpty)
 
                 // Sanity check for the lists.

--- a/Client/Frontend/Home/HomePanelDelegates.swift
+++ b/Client/Frontend/Home/HomePanelDelegates.swift
@@ -17,7 +17,7 @@ private struct HomePanelViewControllerUX {
 }
 
 protocol HomePanel: class {
-    weak var homePanelDelegate: HomePanelDelegate? { get set }
+    var homePanelDelegate: HomePanelDelegate? { get set }
 }
 
 struct HomePanelUX {

--- a/Client/Frontend/Home/PanelDataObservers.swift
+++ b/Client/Frontend/Home/PanelDataObservers.swift
@@ -12,7 +12,7 @@ private let log = Logger.browserLogger
 
 protocol DataObserver {
     var profile: Profile { get }
-    weak var delegate: DataObserverDelegate? { get set }
+    var delegate: DataObserverDelegate? { get set }
 
     func refreshIfNeeded(forceHighlights highlights: Bool, forceTopSites topSites: Bool)
 }

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -18,7 +18,7 @@ struct ReaderModeHandlers {
         // Register a handler that simply lets us know if a document is in the cache or not. This is called from the
         // reader view interstitial page to find out when it can stop showing the 'Loading...' page and instead load
         // the readerized content.
-        webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page-exists") { (request: GCDWebServerRequest?) -> GCDWebServerResponse! in
+        webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page-exists") { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             guard let query = request?.query, let stringURL = query["url"] as? String,
                   let url = URL(string: stringURL) else {
                 return GCDWebServerResponse(statusCode: 500)
@@ -29,7 +29,7 @@ struct ReaderModeHandlers {
         }
 
         // Register the handler that accepts /reader-mode/page?url=http://www.example.com requests.
-        webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page") { (request: GCDWebServerRequest?) -> GCDWebServerResponse! in
+        webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page") { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             if let query = request?.query, let url = query["url"] as? String {
                 if let url = URL(string: url), url.isWebPage() {
                     do {

--- a/Client/Frontend/Reader/ReaderModeUtils.swift
+++ b/Client/Frontend/Reader/ReaderModeUtils.swift
@@ -10,7 +10,7 @@ struct ReaderModeUtils {
 
     static func simplifyDomain(_ domain: String) -> String {
         return DomainPrefixesToSimplify.first { domain.hasPrefix($0) }.map {
-            $0.substring(from: $0.index($0.startIndex, offsetBy: $0.count))
+            String($0.suffix(from: $0.index($0.startIndex, offsetBy: $0.count)))
         } ?? domain
     }
 

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -186,7 +186,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             return
         }
 
-        let suggestionText = suggestion.substring(from: suggestion.index(suggestion.startIndex, offsetBy: normalized.count))
+        let suggestionText = String(suggestion.suffix(from: suggestion.index(suggestion.startIndex, offsetBy: normalized.count)))
         let autocompleteText = NSMutableAttributedString(string: suggestionText)
         autocompleteText.addAttribute(NSAttributedStringKey.backgroundColor, value: highlightColor, range: NSRange(location: 0, length: suggestionText.count))
         autocompleteTextLabel?.removeFromSuperview() // should be nil. But just in case

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -220,7 +220,7 @@ class TimerSnackBar: SnackBar {
         let bar = TimerSnackBar(text: Strings.ExternalLinkAppStoreConfirmationTitle, img: UIImage(named: "defaultFavicon"))
         let openAppStore = SnackButton(title: Strings.OKString, accessibilityIdentifier: "ConfirmOpenInAppStore") { bar in
             tab.removeSnackbar(bar)
-            UIApplication.shared.openURL(appStoreURL)
+            UIApplication.shared.open(appStoreURL)
         }
         let cancelButton = SnackButton(title: Strings.CancelString, accessibilityIdentifier: "CancelOpenInAppStore") { bar in
             tab.removeSnackbar(bar)

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -139,7 +139,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
                 if let refresh = meta["http-equiv"], refresh == "Refresh",
                     let content = meta["content"],
                     let index = content.range(of: "URL="),
-                    let url = NSURL(string: content.substring(from: index.upperBound)) {
+                    let url = NSURL(string: String(content.suffix(from: index.upperBound))) {
                     reloadUrl = url as URL
                 }
             }

--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -133,7 +133,7 @@ public class Bookmark: NSManagedObject, WebsitePresentable, Syncable {
         }
     }
 
-    public static func add(rootObject root: SyncRecord?, save: Bool, sendToSync: Bool, context: NSManagedObjectContext) -> Syncable? {
+    @discardableResult public static func add(rootObject root: SyncRecord?, save: Bool, sendToSync: Bool, context: NSManagedObjectContext) -> Syncable? {
         // Explicit parentFolder to force method decision
         return add(rootObject: root as? SyncBookmark, save: save, sendToSync: sendToSync, parentFolder: nil, context: context)
     }

--- a/Data/models/Device.swift
+++ b/Data/models/Device.swift
@@ -34,7 +34,7 @@ class Device: NSManagedObject, Syncable {
         return SyncDevice(record: self, deviceId: deviceId, action: action).dictionaryRepresentation()
     }
     
-    static func add(rootObject root: SyncRecord?, save: Bool, sendToSync: Bool, context: NSManagedObjectContext) -> Syncable? {
+    @discardableResult static func add(rootObject root: SyncRecord?, save: Bool, sendToSync: Bool, context: NSManagedObjectContext) -> Syncable? {
         
         // No guard, let bleed through to allow 'empty' devices (e.g. local)
         let root = root as? SyncDevice

--- a/Data/models/Syncable.swift
+++ b/Data/models/Syncable.swift
@@ -38,7 +38,7 @@ extension Syncable {
         
         // TODO: filter a unique set of syncUUIDs
         
-        let searchableUUIDs = syncUUIDs.map { SyncHelpers.syncDisplay(fromUUID: $0) }.flatMap { $0 }
+        let searchableUUIDs = syncUUIDs.compactMap { SyncHelpers.syncDisplay(fromUUID: $0) }
         return get(predicate: NSPredicate(format: "syncDisplayUUID IN %@", searchableUUIDs), context: context)
     }
     
@@ -125,10 +125,10 @@ class SyncHelpers {
     
     /// DisplayUUID -> UUID
     static func syncUUID(fromString string: String?) -> [Int]? {
-        return string?.components(separatedBy: ",").flatMap { Int($0) }
+        return string?.components(separatedBy: ",").compactMap { Int($0) }
     }
     
     static func syncUUID(fromJSON json: JSON?) -> [Int]? {
-        return json?.array?.flatMap { $0.int }
+        return json?.array?.compactMap { $0.int }
     }
 }

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -256,7 +256,7 @@ class Sync: JSInjector {
     
     var syncSeedArray: [Int]? {
         let splitBytes = syncSeed?.components(separatedBy: CharacterSet(charactersIn: "[], ")).filter { !$0.isEmpty }
-        let seed = splitBytes?.map{ Int($0) }.flatMap{ $0 }
+        let seed = splitBytes?.compactMap { Int($0) }
         return seed?.count == Sync.SeedByteLength ? seed : nil
     }
     
@@ -508,7 +508,7 @@ extension Sync {
 
         guard let fetchedRecords = recordType.fetchedModelType?.syncRecords(recordJSON) else { return }
 
-        let ids = fetchedRecords.map { $0.objectId }.flatMap { $0 }
+        let ids = fetchedRecords.compactMap { $0.objectId }
         let localbookmarks = recordType.coredataModelType?.get(syncUUIDs: ids, context: DataController.shared.workerContext) as? [Bookmark]
         
         
@@ -550,7 +550,7 @@ extension Sync {
     func saveInitData(_ data: JSON) {
         // Sync Seed
         if let seedJSON = data["arg1"].array {
-            let seed = seedJSON.map({ $0.int }).flatMap({ $0 })
+            let seed = seedJSON.compactMap { $0.int }
             
             // TODO: Move to constant
             if seed.count < Sync.SeedByteLength {

--- a/Data/sync/SyncCrypto.swift
+++ b/Data/sync/SyncCrypto.swift
@@ -100,7 +100,7 @@ class SyncCrypto: JSInjector {
     /// fromJoinedBytes: a single string of hex data (even # of chars required): 897a6f0219fd2950
     /// return: integer values split into 8 bit groupings [0x98, 0x7a, 0x6f, ...]
     func splitBytes(fromJoinedBytes bytes: String) -> [Int]? {
-        var chars = bytes.characters.map { String($0) }
+        var chars = bytes.map { String($0) }
         
         if chars.count % 2 == 1 {
             // Must be an even array
@@ -131,7 +131,7 @@ class SyncCrypto: JSInjector {
         let hex = bytes.map { String($0, radix: 16, uppercase: false) }
         
         // Sync hex must be 2 chars, with optional leading 0
-        let fullHex = hex.map { $0.characters.count == 2 ? $0 : "0" + $0 }
+        let fullHex = hex.map { $0.count == 2 ? $0 : "0" + $0 }
         let combinedHex = fullHex.joined(separator: "")
         return combinedHex
     }

--- a/Shared/Accessibility.swift
+++ b/Shared/Accessibility.swift
@@ -29,8 +29,8 @@ extension AccessibleAction { // UIAccessibilityCustomAction
 }
 
 extension AccessibleAction { // UIAlertAction
-    private var alertActionHandler: (UIAlertAction!) -> Void {
-        return { (_: UIAlertAction!) -> Void in
+    private var alertActionHandler: (UIAlertAction?) -> Void {
+        return { (_: UIAlertAction?) -> Void in
             _ = self.handler()
         }
     }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -397,7 +397,7 @@ extension URL {
             return nil
         }
         if scheme == "http" && host == "localhost" && path.hasPrefix(aboutPath) {
-            return path.substring(from: aboutPath.endIndex)
+            return String(path.suffix(from: aboutPath.endIndex))
         }
         return nil
     }

--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -83,7 +83,7 @@ open class DiskImageStore {
     }
 
     /// Clears all images from the cache, excluding the given set of keys.
-    open func clearExcluding(_ keys: Set<String>) -> Success {
+    @discardableResult open func clearExcluding(_ keys: Set<String>) -> Success {
         return deferDispatchAsync(queue) { () -> Success in
             let keysToDelete = self.keys.subtracting(keys)
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Notes

Part 1 of #20

This cleans up a few dozen of the warnings that are easiest to fix. Summary of changes:

- Change `flatMap` (deprecated) to `compactMap`
- Change `!` to `?` in method signatures
- Add `String(describing:)` for string interpolation of optionals
- Convert `string.substring` (deprecated) to modern subscripts or `string.suffix(with:)`
- Remove unnecessary casting
- Remove `weak` from variables in protocol declarations
- Add `@discardableResult` where needed
- Change from `string.characters` (deprecated) to just `string`
- Remove unused `let error` in `catch`
- Change `UIApplication.shared.openURL()` (deprecated in iOS 10.0) to `UIApplication.shared.open()`
- Include `self.init()` in UIEdgeInsets initializer
