### PR TITLE
Tab Restore Fixes

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -117,7 +117,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         browserViewController.restorationIdentifier = NSStringFromClass(BrowserViewController.self)
         browserViewController.restorationClass = AppDelegate.self
-        browserViewController.crashedLastSession = crashedLastSession
+        // Don't track crashes if we're building the local Fennec environment due to the fact that terminating/stopping
+        // the simulator via Xcode will count as a "crash" and lead to restore popups in the subsequent launch
+        #if !MOZ_CHANNEL_FENNEC
+            browserViewController.crashedLastSession = crashedLastSession
+        #endif
 
         let navigationController = UINavigationController(rootViewController: browserViewController)
         navigationController.delegate = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1796,11 +1796,11 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     fileprivate func updateTabCountUsingTabManager(_ tabManager: TabManager, animated: Bool = true) {
-        if let selectedTab = tabManager.selectedTab {
-            let count = selectedTab.isPrivate ? tabManager.privateTabs.count : tabManager.normalTabs.count
-            toolbar?.updateTabCount(count, animated: animated)
-            urlBar.updateTabCount(count, animated: !urlBar.inOverlayMode)
-        }
+        // BRAVE TODO: When we port PrivateBrowsing we need to update this to count the number of tabs correctly
+        // in private mode
+        let count = tabManager.tabs.count
+        toolbar?.updateTabCount(count, animated: animated)
+        urlBar.updateTabCount(count, animated: !urlBar.inOverlayMode)
     }
 }
 


### PR DESCRIPTION
- [QOL] No longer attempts to track crashes when building the `Fennec` environment.
- [Bug Fix] Updates the tab count properly after restoring

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_