### PR TITLE
Fix #132: Update Cookie Accept Policy when updated from preferences

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		A1510DAA20E425EA008BF1F4 /* BraveWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1510DA920E425EA008BF1F4 /* BraveWebView.swift */; };
 		A1510DDF20E51EF4008BF1F4 /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1510DDE20E51EF4008BF1F4 /* UIDeviceExtensions.swift */; };
 		A16DC67F20E585D90069C8E1 /* PasscodeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16DC67E20E585D90069C8E1 /* PasscodeSettingsViewController.swift */; };
+		A1704D732110A1DC00717321 /* HTTPCookieStorageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1704D722110A1DC00717321 /* HTTPCookieStorageExtensions.swift */; };
 		A176323820CF2A6000126F25 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
 		A176323920CF2AF200126F25 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
 		A176323A20CF2AF600126F25 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
@@ -1154,6 +1155,7 @@
 		A1510DA920E425EA008BF1F4 /* BraveWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveWebView.swift; sourceTree = "<group>"; };
 		A1510DDE20E51EF4008BF1F4 /* UIDeviceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtensions.swift; sourceTree = "<group>"; };
 		A16DC67E20E585D90069C8E1 /* PasscodeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeSettingsViewController.swift; sourceTree = "<group>"; };
+		A1704D722110A1DC00717321 /* HTTPCookieStorageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPCookieStorageExtensions.swift; sourceTree = "<group>"; };
 		A176323020CF2A6000126F25 /* DeferredTestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeferredTestUtils.swift; sourceTree = "<group>"; };
 		A198E75020C701ED00334C11 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		A1AD4BCE20BF3E8C007A6EA1 /* BookmarksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksViewController.swift; sourceTree = "<group>"; };
@@ -1756,6 +1758,7 @@
 				C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */,
 				A1AD4BE020C082EF007A6EA1 /* UIGestureRecognizerExtensions.swift */,
 				A1AD4BE220C0861D007A6EA1 /* UIBarButtonItemExtensions.swift */,
+				A1704D722110A1DC00717321 /* HTTPCookieStorageExtensions.swift */,
 			);
 			indentWidth = 4;
 			name = Extensions;
@@ -4272,6 +4275,7 @@
 				F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */,
 				744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */,
 				D04D1B862097859B0074B35F /* DownloadToast.swift in Sources */,
+				A1704D732110A1DC00717321 /* HTTPCookieStorageExtensions.swift in Sources */,
 				7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */,
 				3BE7275D1CCFE8B60099189F /* CustomSearchHandler.swift in Sources */,
 				A1FEEE2020BF28D900298DA2 /* Then.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -214,7 +214,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             $0.onTintColor = BraveUX.BraveOrange
         }
       
-        HTTPCookieStorage.shared.cookieAcceptPolicy = HTTPCookie.AcceptPolicy(rawValue: Preferences.Privacy.cookieAcceptPolicy.value) ?? .onlyFromMainDocumentDomain
+        HTTPCookieStorage.shared.updateCookieAcceptPolicy(to: HTTPCookie.AcceptPolicy(rawValue: Preferences.Privacy.cookieAcceptPolicy.value))
       
         return shouldPerformAdditionalDelegateHandling
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -164,6 +164,7 @@ class BrowserViewController: UIViewController {
         tabManager.addDelegate(self)
         tabManager.addNavigationDelegate(self)
         downloadQueue.delegate = self
+        Preferences.Privacy.cookieAcceptPolicy.observe(from: self)
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -2596,6 +2597,7 @@ extension BrowserViewController: TopSitesDelegate {
 
 extension BrowserViewController: PreferencesObserver {
     func preferencesDidChange(for key: String) {
+        HTTPCookieStorage.shared.updateCookieAcceptPolicy(to: HTTPCookie.AcceptPolicy(rawValue: Preferences.Privacy.cookieAcceptPolicy.value))
         // TODO: Update tab bar visiblity based on `Preferences.tabBarVisibility` once BraveURLBarView is back
         // TODO: Update fingerprinting protection based on `Preferences.Shields.fingerprintingProtection` once fingerprinting protection is added back
         if Preferences.Privacy.privateBrowsingOnly.value {

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -23,9 +23,9 @@ extension HTTPCookie.AcceptPolicy: RepresentableOptionType {
     
     public var displayString: String {
         switch self {
-        case .always: return Strings.Block_all_cookies
+        case .always: return Strings.Dont_block_cookies
         case .onlyFromMainDocumentDomain: return Strings.Block_3rd_party_cookies
-        case .never: return Strings.Dont_block_cookies
+        case .never: return Strings.Block_all_cookies
         }
     }
 }
@@ -218,7 +218,7 @@ class SettingsViewController: TableViewController {
         cookieControlRow.selection = { [unowned self] in
             // Show Options for cookie control
             let optionsViewController = OptionSelectionViewController<HTTPCookie.AcceptPolicy>(
-                options: [.onlyFromMainDocumentDomain, .always, .never],
+                options: [.onlyFromMainDocumentDomain, .never, .always],
                 selectedOption: HTTPCookie.AcceptPolicy(rawValue:  Preferences.Privacy.cookieAcceptPolicy.value),
                 optionChanged: { [unowned self] _, option in
                     Preferences.Privacy.cookieAcceptPolicy.value = option.rawValue

--- a/Client/HTTPCookieStorageExtensions.swift
+++ b/Client/HTTPCookieStorageExtensions.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+extension HTTPCookieStorage {
+    /// The default cookie accept policy in Brave
+    static let defaultBraveAcceptPolicy: HTTPCookie.AcceptPolicy = .onlyFromMainDocumentDomain
+    
+    /// Updates the cookie accept policy on this HTTPCookieStorage to a given policy. If nil is provided then it will
+    /// set the accept policy to `defaultBraveAcceptPolicy`
+    func updateCookieAcceptPolicy(to policy: HTTPCookie.AcceptPolicy?) {
+        cookieAcceptPolicy = policy ?? HTTPCookieStorage.defaultBraveAcceptPolicy
+    }
+}


### PR DESCRIPTION
Also fixes accidental-swapped-display strings of cookie controls in settings

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_