### PR TITLE
Ref #20: Cleanup warnings part 2

### DIFF
--- a/Client/Application/AdjustIntegration.swift
+++ b/Client/Application/AdjustIntegration.swift
@@ -164,10 +164,12 @@ extension AdjustIntegration: AdjustDelegate {
     ///
     /// Here we also disable Adjust based on the Send Anonymous Usage Data setting.
 
-    func adjustAttributionChanged(_ attribution: ADJAttribution!) {
+    func adjustAttributionChanged(_ attribution: ADJAttribution?) {
         do {
             Logger.browserLogger.info("Adjust - Saving attribution info to disk")
-            try saveAttribution(attribution)
+            if let attribution = attribution {
+                try saveAttribution(attribution)
+            }
         } catch let error {
             Logger.browserLogger.error("Adjust - Failed to save attribution: \(error)")
         }

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -146,7 +146,7 @@ extension AppAuthenticator {
                 
                 DispatchQueue.main.async {
                     switch code {
-                    case .userFallback, .touchIDNotEnrolled, .touchIDNotAvailable, .touchIDLockout:
+                    case .userFallback, .biometryNotEnrolled, .biometryNotAvailable, .biometryLockout:
                         fallback?()
                     case .userCancel:
                         cancel?()

--- a/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
@@ -25,7 +25,7 @@ class PagingPasscodeViewController: BasePasscodeViewController {
         panes.forEach { pager.addSubview($0) }
         pager.snp.makeConstraints { make in
             make.bottom.left.right.equalTo(self.view)
-            make.top.equalTo(self.topLayoutGuide.snp.bottom)
+            make.top.equalTo(view.safeArea.top)
         }
     }
 

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -35,7 +35,7 @@ class PasscodeEntryViewController: BasePasscodeViewController {
         view.addSubview(passcodePane)
         passcodePane.snp.makeConstraints { make in
             make.bottom.left.right.equalTo(self.view)
-            make.top.equalTo(self.topLayoutGuide.snp.bottom)
+            make.top.equalTo(view.safeArea.top)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -383,7 +383,7 @@ class BrowserViewController: UIViewController {
 
     fileprivate func setupConstraints() {
         header.snp.makeConstraints { make in
-            scrollController.headerTopConstraint = make.top.equalTo(self.topLayoutGuide.snp.bottom).constraint
+            scrollController.headerTopConstraint = make.top.equalTo(view.safeArea.top).constraint
             make.left.right.equalTo(self.view)
             
             if let headerHeightConstraint = headerHeightConstraint {
@@ -414,7 +414,7 @@ class BrowserViewController: UIViewController {
         super.viewDidLayoutSubviews()
         statusBarOverlay.snp.remakeConstraints { make in
             make.top.left.right.equalTo(self.view)
-            make.height.equalTo(self.topLayoutGuide.length)
+            make.bottom.equalTo(view.safeArea.top)
         }
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -397,7 +397,7 @@ class TabTrayController: UIViewController {
             make.left.equalTo(view.safeArea.left)
             make.right.equalTo(view.safeArea.right)
             make.bottom.equalTo(view.safeArea.bottom)
-            make.top.equalTo(self.topLayoutGuide.snp.bottom)
+            make.top.equalTo(view.safeArea.top)
         }
 
         toolbar.snp.makeConstraints { make in

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -106,7 +106,7 @@ class LoginListViewController: UIViewController {
         loadingStateView.isHidden = true
 
         searchView.snp.makeConstraints { make in
-            make.top.equalTo(self.topLayoutGuide.snp.bottom)
+            make.top.equalTo(view.safeArea.top)
             make.leading.trailing.equalTo(self.view)
             make.height.equalTo(LoginListUX.SearchHeight)
         }

--- a/Client/Utils/Try.h
+++ b/Client/Utils/Try.h
@@ -5,5 +5,5 @@
 #import <Foundation/Foundation.h>
 
 @interface Try : NSObject
-- (id) initWithTry: (void(^)()) tryBlock catch: (void(^)(NSException *exception)) catchBlock;
+- (id) initWithTry: (void(^)(void)) tryBlock catch: (void(^)(NSException *exception)) catchBlock;
 @end

--- a/Client/Utils/Try.m
+++ b/Client/Utils/Try.m
@@ -6,7 +6,7 @@
 
 @implementation Try
 
-- (id) initWithTry: (void(^)()) tryBlock catch: (void(^)(NSException *exception)) catchBlock {
+- (id) initWithTry: (void(^)(void)) tryBlock catch: (void(^)(NSException *exception)) catchBlock {
     if (self = [super init]) {
         @try {
             tryBlock();

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -207,7 +207,7 @@ class Sync: JSInjector {
         get {
             if !UserDefaults.standard.bool(forKey: prefNameSeed) {
                 // This must be true to stay in sync group
-                KeychainWrapper.standard.remove(key: prefNameSeed)
+                KeychainWrapper.standard.removeObject(forKey: prefNameSeed)
                 return nil
             }
             
@@ -250,7 +250,7 @@ class Sync: JSInjector {
             fetchTimer?.invalidate()
             fetchTimer = nil
             
-            KeychainWrapper.standard.remove(key: prefNameSeed)
+            KeychainWrapper.standard.removeObject(forKey: prefNameSeed)
         }
     }
     


### PR DESCRIPTION
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Notes

Part 2 of #20

This includes replacements for APIs deprecated in iOS 11.0, as well as a few other changes. Summary of changes:
- Adjust method implementation to match protocol definition (AdjustIntegration.swift)
- Replace deprecated `LAError.Code.touchID`… with `LAError.Code.biometry`… (AppAuthenticator.swift)
- Replace deprecated `topLayoutGuide` with `safeArea` (several view controllers)
- Add `void` to empty block parameter lists (Try.h and Try.m)
- Replace deprecated `KeychainWrapper.remove(key:)` with `KeychainWrapper.removeObject(forKey:)` (Sync.swift)