### PR TITLE
Fix #109: Only show green lock for fully secure sites

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -26,6 +26,7 @@ private let KVOs: [KVOConstants] = [
     .canGoForward,
     .URL,
     .title,
+    .hasOnlySecureContent,
 ]
 
 private let ActionSheetTitleMaxLength = 120
@@ -879,6 +880,9 @@ class BrowserViewController: UIViewController {
                 let canGoForward = change?[.newKey] as? Bool else { break }
 
             navigationToolbar.updateForwardStatus(canGoForward)
+        case .hasOnlySecureContent:
+            guard let tab = tabManager[webView], tab === tabManager.selectedTab else { break }
+            urlBar.hasOnlySecureContent = webView.hasOnlySecureContent
         default:
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
@@ -916,6 +920,7 @@ class BrowserViewController: UIViewController {
     /// Call this whenever the page URL changes.
     fileprivate func updateURLBarDisplayURL(_ tab: Tab) {
         urlBar.currentURL = tab.url?.displayURL
+        urlBar.hasOnlySecureContent = tab.webView?.hasOnlySecureContent ?? false
 
         let isPage = tab.url?.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isPage)

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -46,17 +46,28 @@ class TabLocationView: UIView {
 
     var url: URL? {
         didSet {
-            let wasHidden = lockImageView.isHidden
-            lockImageView.isHidden = url?.scheme != "https"
-            if wasHidden != lockImageView.isHidden {
-                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
-            }
+            updateLockImageView()
             updateTextWithURL()
             pageOptionsButton.isHidden = (url == nil)
             if url == nil {
                 trackingProtectionButton.isHidden = true
             }
             setNeedsUpdateConstraints()
+        }
+    }
+
+    var hasOnlySecureContent = false {
+        didSet {
+            updateLockImageView()
+        }
+    }
+
+    private func updateLockImageView() {
+        let wasHidden = lockImageView.isHidden
+        let isFullySecure = (url?.scheme == "https" && hasOnlySecureContent)
+        lockImageView.isHidden = !isFullySecure
+        if wasHidden != lockImageView.isHidden {
+            UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
         }
     }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -171,6 +171,15 @@ class URLBarView: UIView {
         }
     }
 
+    var hasOnlySecureContent: Bool {
+        get {
+            return locationView.hasOnlySecureContent
+        }
+        set {
+            locationView.hasOnlySecureContent = newValue
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -18,6 +18,7 @@ public enum KVOConstants: String {
     case canGoBack = "canGoBack"
     case canGoForward = "canGoForward"
     case contentSize = "contentSize"
+    case hasOnlySecureContent = "hasOnlySecureContent"
 }
 
 public struct AppConstants {


### PR DESCRIPTION
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

Fully secure HTTPS site (behavior unchanged) https://badssl.com/
![](https://user-images.githubusercontent.com/19424103/43982262-c527bbd4-9cba-11e8-9579-4fcac7fc4d77.png)

HTTPS site with certificate error (green lock is now hidden) https://expired.badssl.com/
![](https://user-images.githubusercontent.com/19424103/43982299-dffbb4b0-9cba-11e8-9082-765d40aca061.png)

HTTPS site with mixed content (green lock is now hidden) https://www.bennish.net/mixed-content.html
![](https://user-images.githubusercontent.com/19424103/43982329-fb5ec742-9cba-11e8-8b2d-9c20b9b01a30.png)

HTTP unsecure site (behavior unchanged) http://neverssl.com/
![](https://user-images.githubusercontent.com/19424103/43982371-35c53b82-9cbb-11e8-9d46-487cd900e52c.png)

## Notes for testing this patch

Previously, all sites with URLs that begin with `https` had the green lock icon in the url bar. This change hides the green lock when browsing sites with certificate errors or mixed content.

Note that sites with certificate errors or mixed content are now treated the same as unsecure HTTP sites. This matches iOS Safari's behavior.

QA Steps:

1. Create a new tab and navigate to https://badssl.com/. The green lock should be visible.
2. Tap the "expired" link, which goes to https://expired.badssl.com/. The green lock should be hidden.
3. Create a new tab and navigate to https://www.bennish.net/mixed-content.html. The green lock should be hidden.
4. Create a new tab and navigate to http://neverssl.com/. The green lock should be hidden.
