### PR TITLE
Update state of edit bookmarks button on bookmarks count change

### DIFF
--- a/Client/Frontend/Menu/BookmarksViewController.swift
+++ b/Client/Frontend/Menu/BookmarksViewController.swift
@@ -182,6 +182,8 @@ class BookmarksViewController: SiteTableViewController, HomePanel {
       print(error.description)
     }
     
+    editBookmarksButton?.isEnabled = (self.bookmarksFRC?.fetchedObjects?.count ?? 0) > 0
+    
     super.reloadData()
   }
   
@@ -230,6 +232,7 @@ class BookmarksViewController: SiteTableViewController, HomePanel {
     items.append(UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil))
     
     editBookmarksButton = UIBarButtonItem(image: UIImage(named: "edit")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: #selector(onEditBookmarksButton))
+    editBookmarksButton.isEnabled = false
     items.append(editBookmarksButton)
     items.append(UIBarButtonItem.fixedSpace(5))
     
@@ -633,11 +636,18 @@ extension BookmarksViewController : NSFetchedResultsControllerDelegate {
         return
       }
       tableView.insertRows(at: [path], with: .automatic)
+      editBookmarksButton.isEnabled = true
     case .delete:
       guard let indexPath = indexPath else {
         return
       }
       tableView.deleteRows(at: [indexPath], with: .automatic)
+      let foldersCount = controller.fetchedObjects?.count ?? 0
+      if foldersCount == 0 {
+        editBookmarksButton.isEnabled = false
+        switchTableEditingMode(true)
+      }
+      
     case .move:
       break
     }


### PR DESCRIPTION
## What?

- [x] The edit button in the bookmarks screen will be enabled only when there are bookmarks.
- [x] The editing mode will be switched off when all the bookmarks are deleted.

## Why?

The edit button was confusing me when the bookmarks were empty. So I thought we can just disable it when there are no bookmarks, for a minor UX improvement.
