### PR TITLE
Fix #26: Add global "Hide Images" toggle in Settings

### DIFF
--- a/Client/Application/Preferences.swift
+++ b/Client/Application/Preferences.swift
@@ -92,6 +92,8 @@ extension Preferences {
         static let blockScripts = Option<Bool>(key: "shields.block-scripts", default: false)
         /// Enforces fingerprinting protection on the users session
         static let fingerprintingProtection = Option<Bool>(key: "shields.fingerprinting-protection", default: false)
+        /// Disables image loading in the browser
+        static let blockImages = Option<Bool>(key: "shields.block-images", default: false)
         ///
         static let useRegionAdBlock = Option<Bool>(key: "shields.regional-adblock", default: false)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -889,7 +889,7 @@ class BrowserViewController: UIViewController {
             return
         }
         if #available(iOS 11, *) {
-            if NoImageModeHelper.isActivated(profile.prefs) {
+            if NoImageModeHelper.isActivated {
                 webView.evaluateJavaScript("__firefox__.NoImageMode.setEnabled(true)", completionHandler: nil)
             }
         }

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -73,7 +73,7 @@ class MediaImageLoader: TabEventHandler {
     }
 
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
-        let cacheImages = !NoImageModeHelper.isActivated(prefs)
+        let cacheImages = !NoImageModeHelper.isActivated
         if let urlString = metadata.mediaURL,
             let mediaURL = URL(string: urlString), cacheImages {
             prepareCache(mediaURL)

--- a/Client/Frontend/Browser/NoImageModeHelper.swift
+++ b/Client/Frontend/Browser/NoImageModeHelper.swift
@@ -29,15 +29,7 @@ class NoImageModeHelper: TabContentScript {
         // Do nothing.
     }
 
-    static func isActivated(_ prefs: Prefs) -> Bool {
-        return prefs.boolForKey(NoImageModePrefsKey.NoImageModeStatus) ?? false
-    }
-
-    static func toggle(profile: Profile, tabManager: TabManager) {
-        if #available(iOS 11, *) {
-            let enabled = !isActivated(profile.prefs)
-            profile.prefs.setBool(enabled, forKey: PrefsKeys.KeyNoImageModeStatus)
-            tabManager.tabs.forEach { $0.noImageMode = enabled }
-        }
+    static var isActivated: Bool {
+        return Preferences.Shields.blockImages.value
     }
 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -114,6 +114,8 @@ class TabManager: NSObject {
         addNavigationDelegate(self)
 
         NotificationCenter.default.addObserver(self, selector: #selector(prefsDidChange), name: UserDefaults.didChangeNotification, object: nil)
+        
+        Preferences.Shields.blockImages.observe(from: self)
     }
 
     func addNavigationDelegate(_ delegate: WKNavigationDelegate) {
@@ -1060,4 +1062,11 @@ extension TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {}
     func tabManagerDidAddTabs(_ tabManager: TabManager) {}
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {}
+}
+
+extension TabManager: PreferencesObserver {
+    func preferencesDidChange(for key: String) {
+        // Update Block images
+        tabs.forEach { $0.noImageMode = Preferences.Shields.blockImages.value }
+    }
 }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -271,6 +271,7 @@ class SettingsViewController: TableViewController {
                 BoolRow(title: Strings.Block_Phishing_and_Malware, option: Preferences.Shields.blockPhishingAndMalware),
                 BoolRow(title: Strings.Block_Scripts, option: Preferences.Shields.blockScripts),
                 BoolRow(title: Strings.Fingerprinting_Protection, option: Preferences.Shields.fingerprintingProtection),
+                BoolRow(title: Strings.AppMenuNoImageMode, option: Preferences.Shields.blockImages),
             ]
         )
         // TODO: Add regional adblock

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -81,16 +81,11 @@ extension PhotonActionSheetProtocol {
         var items: [PhotonActionSheetItem] = []
 
         if #available(iOS 11, *) {
-            let noImageEnabled = NoImageModeHelper.isActivated(profile.prefs)
-            let noImageMode = PhotonActionSheetItem(title: Strings.AppMenuNoImageMode, iconString: "menu-NoImageMode", isEnabled: noImageEnabled, accessory: .Switch) { action in
-                NoImageModeHelper.toggle(profile: self.profile, tabManager: self.tabManager)
-            }
-
             let trackingProtectionEnabled = ContentBlockerHelper.isTrackingProtectionActive(tabManager: self.tabManager)
             let trackingProtection = PhotonActionSheetItem(title: Strings.TPMenuTitle, iconString: "menu-TrackingProtection", isEnabled: trackingProtectionEnabled, accessory: .Switch) { action in
                 ContentBlockerHelper.toggleTrackingProtectionMode(for: self.profile.prefs, tabManager: self.tabManager)
             }
-            items.append(contentsOf: [trackingProtection, noImageMode])
+            items.append(contentsOf: [trackingProtection])
         }
 
         let nightModeEnabled = NightModeHelper.isActivated(profile.prefs)


### PR DESCRIPTION
Simply integrates with the Firefox "Hide Images" feature for the time being

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_