### PR TITLE
Fix #165: Remove all redundant iOS 11 version checks

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -100,10 +100,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let imageStore = DiskImageStore(files: profile.files, namespace: "TabManagerScreenshots", quality: UIConstants.ScreenshotQuality)
 
         // Temporary fix for Bug 1390871 - NSInvalidArgumentException: -[WKContentView menuHelperFindInPage]: unrecognized selector
-        if #available(iOS 11, *) {
-            if let clazz = NSClassFromString("WKCont" + "ent" + "View"), let swizzledMethod = class_getInstanceMethod(TabWebViewMenuHelper.self, #selector(TabWebViewMenuHelper.swizzledMenuHelperFindInPage)) {
-                class_addMethod(clazz, MenuHelper.SelectorFindInPage, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
-            }
+        if let clazz = NSClassFromString("WKCont" + "ent" + "View"), let swizzledMethod = class_getInstanceMethod(TabWebViewMenuHelper.self, #selector(TabWebViewMenuHelper.swizzledMenuHelperFindInPage)) {
+            class_addMethod(clazz, MenuHelper.SelectorFindInPage, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
         }
 
         self.tabManager = TabManager(prefs: profile.prefs, imageStore: imageStore)

--- a/Client/Extensions/SnapKitExtensions.swift
+++ b/Client/Extensions/SnapKitExtensions.swift
@@ -8,9 +8,6 @@ import SnapKit
 extension UIView {
 
     var safeArea: ConstraintBasicAttributesDSL {
-        if #available(iOS 11.0, *) {
-            return self.safeAreaLayoutGuide.snp
-        }
-        return self.snp
+        return self.safeAreaLayoutGuide.snp
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -375,10 +375,8 @@ class BrowserViewController: UIViewController {
 
         // Setup UIDropInteraction to handle dragging and dropping
         // links into the view from other apps.
-        if #available(iOS 11, *) {
-            let dropInteraction = UIDropInteraction(delegate: self)
-            view.addInteraction(dropInteraction)
-        }
+        let dropInteraction = UIDropInteraction(delegate: self)
+        view.addInteraction(dropInteraction)
     }
 
     fileprivate func setupConstraints() {
@@ -888,10 +886,8 @@ class BrowserViewController: UIViewController {
         guard let url = webView.url, url.isWebPage(), !url.isLocal else {
             return
         }
-        if #available(iOS 11, *) {
-            if NoImageModeHelper.isActivated {
-                webView.evaluateJavaScript("__firefox__.NoImageMode.setEnabled(true)", completionHandler: nil)
-            }
+        if NoImageModeHelper.isActivated {
+            webView.evaluateJavaScript("__firefox__.NoImageMode.setEnabled(true)", completionHandler: nil)
         }
     }
 
@@ -1259,7 +1255,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidTapShield(_ urlBar: URLBarView, from button: UIButton) {
-        if #available(iOS 11.0, *), let tab = self.tabManager.selectedTab {
+        if let tab = self.tabManager.selectedTab {
             let trackingProtectionMenu = self.getTrackingSubMenu(for: tab)
             guard !trackingProtectionMenu.isEmpty else { return }
             self.presentSheetWith(actions: trackingProtectionMenu, on: self, from: urlBar)
@@ -1319,7 +1315,7 @@ extension BrowserViewController: URLBarDelegate {
         let urlActions = self.getLongPressLocationBarActions(with: urlBar)
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
-        if #available(iOS 11.0, *), let tab = self.tabManager.selectedTab {
+        if let tab = self.tabManager.selectedTab {
             let trackingProtectionMenu = self.getTrackingMenu(for: tab, presentingOn: urlBar)
             self.presentSheetWith(actions: [urlActions, trackingProtectionMenu], on: self, from: urlBar)
         } else {
@@ -1594,11 +1590,9 @@ extension BrowserViewController: TabDelegate {
         historyStateHelper.delegate = self
         tab.addContentScript(historyStateHelper, name: HistoryStateHelper.name())
 
-        if #available(iOS 11, *) {
-            if let blocker = tab.contentBlocker as? ContentBlockerHelper {
-                blocker.setupTabTrackingProtection()
-                tab.addContentScript(blocker, name: ContentBlockerHelper.name())
-            }
+        if let blocker = tab.contentBlocker as? ContentBlockerHelper {
+            blocker.setupTabTrackingProtection()
+            tab.addContentScript(blocker, name: ContentBlockerHelper.name())
         }
 
         tab.addContentScript(FocusHelper(tab: tab), name: FocusHelper.name())

--- a/Client/Frontend/Browser/HomePanel/TopSitesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/TopSitesViewController.swift
@@ -211,11 +211,7 @@ class TopSitesViewController: UIViewController {
     // MARK: - Constraints setup
     fileprivate func makeConstraints() {
         collection.snp.makeConstraints { make in
-            if #available(iOS 11.0, *) {
-                make.edges.equalTo(self.view.safeAreaLayoutGuide.snp.edges)
-            } else {
-                make.edges.equalTo(self.view)
-            }
+            make.edges.equalTo(self.view.safeAreaLayoutGuide.snp.edges)
         }
         
         privateTabMessageContainer.snp.makeConstraints { make in

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -154,10 +154,8 @@ class Tab: NSObject {
         super.init()
         self.isPrivate = isPrivate
 
-        if #available(iOS 11, *) {
-            if let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile {
-                contentBlocker = ContentBlockerHelper(tab: self, profile: profile)
-            }
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile {
+            contentBlocker = ContentBlockerHelper(tab: self, profile: profile)
         }
     }
 

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -124,10 +124,8 @@ class TabLocationView: UIView {
 
         // Remove the default drop interaction from the URL text field so that our
         // custom drop interaction on the BVC can accept dropped URLs.
-        if #available(iOS 11, *) {
-            if let dropInteraction = urlTextField.textDropInteraction {
-                urlTextField.removeInteraction(dropInteraction)
-            }
+        if let dropInteraction = urlTextField.textDropInteraction {
+            urlTextField.removeInteraction(dropInteraction)
         }
 
         return urlTextField
@@ -260,11 +258,9 @@ class TabLocationView: UIView {
 
         // Setup UIDragInteraction to handle dragging the location
         // bar for dropping its URL into other apps.
-        if #available(iOS 11, *) {
-            let dragInteraction = UIDragInteraction(delegate: self)
-            dragInteraction.allowsSimultaneousRecognitionDuringLift = true
-            self.addInteraction(dragInteraction)
-        }
+        let dragInteraction = UIDragInteraction(delegate: self)
+        dragInteraction.allowsSimultaneousRecognitionDuringLift = true
+        self.addInteraction(dragInteraction)
     }
 
     required init(coder: NSCoder) {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -888,7 +888,7 @@ extension TabManager: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
 
-        if #available(iOS 11, *), let tab = self[webView], let blocker = tab.contentBlocker as? ContentBlockerHelper {
+        if let tab = self[webView], let blocker = tab.contentBlocker as? ContentBlockerHelper {
             blocker.clearPageStats()
         }
     }
@@ -900,13 +900,11 @@ extension TabManager: WKNavigationDelegate {
         let isNightMode = NightModeAccessors.isNightMode(self.prefs)
         tab.setNightMode(isNightMode)
 
-        if #available(iOS 11, *) {
-            let isNoImageMode = self.prefs.boolForKey(PrefsKeys.KeyNoImageModeStatus) ?? false
-            tab.noImageMode = isNoImageMode
-
-            if let tpHelper = tab.contentBlocker as? ContentBlockerHelper, !tpHelper.isEnabled {
-                webView.evaluateJavaScript("window.__firefox__.TrackingProtectionStats.setEnabled(false, \(UserScriptManager.securityToken))", completionHandler: nil)
-            }
+        let isNoImageMode = self.prefs.boolForKey(PrefsKeys.KeyNoImageModeStatus) ?? false
+        tab.noImageMode = isNoImageMode
+        
+        if let tpHelper = tab.contentBlocker as? ContentBlockerHelper, !tpHelper.isEnabled {
+            webView.evaluateJavaScript("window.__firefox__.TrackingProtectionStats.setEnabled(false, \(UserScriptManager.securityToken))", completionHandler: nil)
         }
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -323,11 +323,9 @@ class TabTrayController: UIViewController {
         collectionView.register(TabCell.self, forCellWithReuseIdentifier: TabCell.Identifier)
         collectionView.backgroundColor = TabTrayControllerUX.BackgroundColor
 
-        if #available(iOS 11.0, *) {
-            collectionView.dragInteractionEnabled = true
-            collectionView.dragDelegate = tabDataSource
-            collectionView.dropDelegate = tabDataSource
-        }
+        collectionView.dragInteractionEnabled = true
+        collectionView.dragDelegate = tabDataSource
+        collectionView.dropDelegate = tabDataSource
 
         view.addSubview(collectionView)
         view.addSubview(toolbar)

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -104,12 +104,7 @@ public struct UIConstants {
     static var ToolbarHeight: CGFloat = 46
     static var BottomToolbarHeight: CGFloat {
         get {
-            var bottomInset: CGFloat = 0.0
-            if #available(iOS 11, *) {
-                if let window = UIApplication.shared.keyWindow {
-                    bottomInset = window.safeAreaInsets.bottom
-                }
-            }
+            let bottomInset: CGFloat = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0
             return ToolbarHeight + bottomInset
         }
     }

--- a/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheetProtocol.swift
@@ -80,13 +80,11 @@ extension PhotonActionSheetProtocol {
     func getOtherPanelActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
         var items: [PhotonActionSheetItem] = []
 
-        if #available(iOS 11, *) {
-            let trackingProtectionEnabled = ContentBlockerHelper.isTrackingProtectionActive(tabManager: self.tabManager)
-            let trackingProtection = PhotonActionSheetItem(title: Strings.TPMenuTitle, iconString: "menu-TrackingProtection", isEnabled: trackingProtectionEnabled, accessory: .Switch) { action in
-                ContentBlockerHelper.toggleTrackingProtectionMode(for: self.profile.prefs, tabManager: self.tabManager)
-            }
-            items.append(contentsOf: [trackingProtection])
+        let trackingProtectionEnabled = ContentBlockerHelper.isTrackingProtectionActive(tabManager: self.tabManager)
+        let trackingProtection = PhotonActionSheetItem(title: Strings.TPMenuTitle, iconString: "menu-TrackingProtection", isEnabled: trackingProtectionEnabled, accessory: .Switch) { action in
+            ContentBlockerHelper.toggleTrackingProtectionMode(for: self.profile.prefs, tabManager: self.tabManager)
         }
+        items.append(contentsOf: [trackingProtection])
 
         let nightModeEnabled = NightModeHelper.isActivated(profile.prefs)
         let nightMode = PhotonActionSheetItem(title: Strings.AppMenuNightMode, iconString: "menu-NightMode", isEnabled: nightModeEnabled, accessory: .Switch) { action in
@@ -388,7 +386,7 @@ extension PhotonActionSheetProtocol {
             tab.toggleDesktopSite()
         }
 
-        if #available(iOS 11, *), let helper = tab.contentBlocker as? ContentBlockerHelper {
+        if let helper = tab.contentBlocker as? ContentBlockerHelper {
             let title = helper.isEnabled ? Strings.TrackingProtectionReloadWithout : Strings.TrackingProtectionReloadWith
             let imageName = helper.isEnabled ? "menu-TrackingProtection-Off" : "menu-TrackingProtection"
             let toggleTP = PhotonActionSheetItem(title: title, iconString: imageName) { action in

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -104,7 +104,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
         // Set an empty footer to prevent empty cells from appearing in the list.
         tableView.tableFooterView = UIView()
 
-        if #available(iOS 11.0, *), let _ = self as? HomePanelContextMenu {
+        if let _ = self as? HomePanelContextMenu {
             tableView.dragDelegate = self
         }
     }


### PR DESCRIPTION
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_