### PR TITLE
Fix #84: Load saved tab's favicons upon tab restoration

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -783,15 +783,11 @@ extension TabManager {
             // Since this is a restored tab, reset the URL to be loaded as that will be handled by the SessionRestoreHandler
             tab.url = nil
 
-            // BRAVE TODO: restore favicon
-            /*
-            if let faviconURL = savedTab.favicon.url {
+            if let urlString = savedTab.url, let url = URL(string: urlString), let faviconURL = Domain.getOrCreateForUrl(url, context: DataController.shared.workerContext)?.favicon?.url {
                 let icon = Favicon(url: faviconURL, date: Date())
                 icon.width = 1
                 tab.favicons.append(icon)
             }
-             */
-
             
             // Set the UUID for the tab, asynchronously fetch the UIImage, then store
             // the screenshot in the tab as long as long as a newer one hasn't been taken.

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -10,6 +10,7 @@ import Deferred
 import SDWebImage
 import Fuzi
 import SwiftyJSON
+import class Data.FaviconMO 
 
 private let log = Logger.browserLogger
 private let queue = DispatchQueue(label: "FaviconFetcher", attributes: DispatchQueue.Attributes.concurrent)
@@ -195,7 +196,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
                     if let img = img {
                         fav.width = Int(img.size.width)
                         fav.height = Int(img.size.height)
-                        profile.favicons.addFavicon(fav, forSite: site)
+                        FaviconMO.add(fav, forSiteUrl: siteUrl)
                     } else {
                         fav.width = 0
                         fav.height = 0


### PR DESCRIPTION
Also switches favicon metadata storage to `FaviconMO`

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_