### PR TITLE
Fix #170: Always show shields menu button even on new tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1432,8 +1432,7 @@ extension BrowserViewController: URLBarDelegate {
     
     func urlBarDidTapBraveShieldsButton(_ urlBar: URLBarView) {
         // BRAVE TODO: Insert shield block stats here
-        guard let url = tabManager.selectedTab?.url else { return }
-        let shields = ShieldsViewController(url: url, shieldBlockStats: nil)
+        let shields = ShieldsViewController(url: tabManager.selectedTab?.url, shieldBlockStats: nil)
         shields.shieldsSettingsChanged = { [unowned self] _ in
             // Reload this tab. This will also trigger an update of the brave icon in `TabLocationView` if
             // the setting changed is the global `.AllOff` shield

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -55,12 +55,6 @@ class TabLocationView: UIView {
             }
             updateTextWithURL()
             pageOptionsButton.isHidden = (url == nil)
-            if let url = url {
-                shieldsButton.isHidden = url.isLocal
-            } else {
-                trackingProtectionButton.isHidden = true
-                shieldsButton.isHidden = true
-            }
             refreshShieldsStatus()
             setNeedsUpdateConstraints()
         }


### PR DESCRIPTION
Displays just the copy when you view on a new tab.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

| New Tab | Shields On | Shields Off |
| --- | --- | --- |
| ![simulator screen shot - iphone 8 - 2018-08-21 at 11 16 51](https://user-images.githubusercontent.com/529104/44411124-d0cfe200-a533-11e8-8534-79393dde4bd2.png) | ![simulator screen shot - iphone 8 - 2018-08-21 at 11 16 44](https://user-images.githubusercontent.com/529104/44411106-c9a8d400-a533-11e8-8601-636dc23e3d85.png) | ![simulator screen shot - iphone 8 - 2018-08-21 at 11 19 02](https://user-images.githubusercontent.com/529104/44411236-0b397f00-a534-11e8-9963-b8604e64b589.png) |

## Notes for testing this patch

_None included_