### PR TITLE
Fix #176: Always show the tab bar despite only having 1 tab on iPad

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -761,7 +761,7 @@ class BrowserViewController: UIViewController {
             }
             switch tabBarVisibility {
             case .always:
-                return tabCount > 1
+                return tabCount > 1 || UIDevice.current.userInterfaceIdiom == .pad
             case .landscapeOnly:
                 return tabCount > 1 && UIDevice.current.orientation.isLandscape
             case .never:


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

Verify that the tab bar is visible when the setting `Shows Tab Bar` is on
