### PR TITLE
Fix #168: Only add url to history if the tab is not private

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1116,7 +1116,9 @@ class BrowserViewController: UIViewController {
                 runScriptsOnWebView(webView)
                 
                 // Only add history of a url which is not a localhost url
-                History.add(tab.title ?? "", url: url)
+                if !tab.isPrivate {
+                    History.add(tab.title ?? "", url: url)
+                }
             }
 
             TabEvent.post(.didChangeURL(url), for: tab)


### PR DESCRIPTION
## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

Fix #168

## Notes for testing this patch

With this change, any URLs visited in private browsing should not appear in the browsing history.

1. Open a new (normal) tab and go to any site.
2. Open Menu > History and make sure the current tab info **is** in the history.
3. Open a new private tab and go to any site.
4. Open Menu > History and make sure the current tab info is **not** in the history.
