### PR TITLE
Fix #153, Fix #155: Data should not be persisted while private browsing

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		C615FAE5212AC5E000A8168C /* PrivacyProtectionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C615FAE4212AC5E000A8168C /* PrivacyProtectionProtocol.swift */; };
 		C615FAED212ACAD200A8168C /* BraveWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C615FAEC212ACAD200A8168C /* BraveWebView.swift */; };
 		C6345ECB2113B3A000CFB983 /* SearchPlugins in Resources */ = {isa = PBXBuildFile; fileRef = C6345ECA2113B3A000CFB983 /* SearchPlugins */; };
+		C6620BBB213BCEC6009FE75A /* TabType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6620BB3213BCEC6009FE75A /* TabType.swift */; };
 		C690C208212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C690C207212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift */; };
 		C690C2142130121E00E6EEE9 /* WebImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C690C2132130121E00E6EEE9 /* WebImageCacheManager.swift */; };
 		C6B81B81212D6C1100996084 /* NoPrivacyProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B81B80212D6C1100996084 /* NoPrivacyProtection.swift */; };
@@ -1215,6 +1216,7 @@
 		C615FAE4212AC5E000A8168C /* PrivacyProtectionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionProtocol.swift; sourceTree = "<group>"; };
 		C615FAEC212ACAD200A8168C /* BraveWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveWebView.swift; sourceTree = "<group>"; };
 		C6345ECA2113B3A000CFB983 /* SearchPlugins */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SearchPlugins; sourceTree = "<group>"; };
+		C6620BB3213BCEC6009FE75A /* TabType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabType.swift; sourceTree = "<group>"; };
 		C690C207212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebImageCacheWithNoPrivacyProtectionManager.swift; sourceTree = "<group>"; };
 		C690C2132130121E00E6EEE9 /* WebImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebImageCacheManager.swift; sourceTree = "<group>"; };
 		C6B81B80212D6C1100996084 /* NoPrivacyProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoPrivacyProtection.swift; sourceTree = "<group>"; };
@@ -2516,6 +2518,7 @@
 				3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */,
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				D3A994961A3686BD008AD1AC /* Tab.swift */,
+				C6620BB3213BCEC6009FE75A /* TabType.swift */,
 				E4CD9F2C1A6DC91200318571 /* TabLocationView.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */,
@@ -4343,6 +4346,7 @@
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
 				E689C7301E0C7617008BAADB /* NSAttributedStringExtensions.swift in Sources */,
 				D0C95E0E200FD3B200E4E51C /* PrintHelper.swift in Sources */,
+				C6620BBB213BCEC6009FE75A /* TabType.swift in Sources */,
 				E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */,
 				A16DC67F20E585D90069C8E1 /* PasscodeSettingsViewController.swift in Sources */,
 				A1D8420320BC44F800BDAFF7 /* PopoverContainerView.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -283,7 +283,6 @@
 		A134B88A20DA98BB00A581D0 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A134B88920DA98BB00A581D0 /* Preferences.swift */; };
 		A13AC72520EC12360040D4BB /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13AC72420EC12360040D4BB /* Migration.swift */; };
 		A1510DA120E409E9008BF1F4 /* URLCacheExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1510DA020E409E9008BF1F4 /* URLCacheExtensions.swift */; };
-		A1510DAA20E425EA008BF1F4 /* BraveWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1510DA920E425EA008BF1F4 /* BraveWebView.swift */; };
 		A1510DDF20E51EF4008BF1F4 /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1510DDE20E51EF4008BF1F4 /* UIDeviceExtensions.swift */; };
 		A16DC67F20E585D90069C8E1 /* PasscodeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16DC67E20E585D90069C8E1 /* PasscodeSettingsViewController.swift */; };
 		A1704D732110A1DC00717321 /* HTTPCookieStorageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1704D722110A1DC00717321 /* HTTPCookieStorageExtensions.swift */; };
@@ -322,7 +321,18 @@
 		C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */; };
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
+		C615FACF2129FBD000A8168C /* ImageCacheProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C615FACE2129FBD000A8168C /* ImageCacheProtocol.swift */; };
+		C615FAD9212A1E2600A8168C /* WebImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C615FAD8212A1E2600A8168C /* WebImageCache.swift */; };
+		C615FADF212A319C00A8168C /* PrivacyProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C615FADE212A319C00A8168C /* PrivacyProtection.swift */; };
+		C615FAE5212AC5E000A8168C /* PrivacyProtectionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C615FAE4212AC5E000A8168C /* PrivacyProtectionProtocol.swift */; };
+		C615FAED212ACAD200A8168C /* BraveWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C615FAEC212ACAD200A8168C /* BraveWebView.swift */; };
 		C6345ECB2113B3A000CFB983 /* SearchPlugins in Resources */ = {isa = PBXBuildFile; fileRef = C6345ECA2113B3A000CFB983 /* SearchPlugins */; };
+		C690C208212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C690C207212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift */; };
+		C690C2142130121E00E6EEE9 /* WebImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C690C2132130121E00E6EEE9 /* WebImageCacheManager.swift */; };
+		C6B81B81212D6C1100996084 /* NoPrivacyProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B81B80212D6C1100996084 /* NoPrivacyProtection.swift */; };
+		C6B81B8A212D84BD00996084 /* ImageCacheType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B81B89212D84BD00996084 /* ImageCacheType.swift */; };
+		C6B81B8C212D989200996084 /* ImageCacheOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B81B8B212D989200996084 /* ImageCacheOptions.swift */; };
+		C6D267522136800100465DFA /* PrivateBrowsingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D267512136800100465DFA /* PrivateBrowsingManager.swift */; };
 		C817B34D1FC609500086018E /* UIScrollViewSwizzled.swift in Sources */ = {isa = PBXBuildFile; fileRef = C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */; };
 		C8611C8E1F71904C00C3DE7D /* DiskImageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */; };
 		C8611CB01F71AEBA00C3DE7D /* NoImageModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */; };
@@ -1166,7 +1176,6 @@
 		A134B88920DA98BB00A581D0 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		A13AC72420EC12360040D4BB /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
 		A1510DA020E409E9008BF1F4 /* URLCacheExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCacheExtensions.swift; sourceTree = "<group>"; };
-		A1510DA920E425EA008BF1F4 /* BraveWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveWebView.swift; sourceTree = "<group>"; };
 		A1510DDE20E51EF4008BF1F4 /* UIDeviceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtensions.swift; sourceTree = "<group>"; };
 		A16DC67E20E585D90069C8E1 /* PasscodeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeSettingsViewController.swift; sourceTree = "<group>"; };
 		A1704D722110A1DC00717321 /* HTTPCookieStorageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPCookieStorageExtensions.swift; sourceTree = "<group>"; };
@@ -1200,7 +1209,18 @@
 		C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabTrayButtonExtensions.swift; path = ../Browser/TabTrayButtonExtensions.swift; sourceTree = "<group>"; };
 		C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardTableViewCell.swift; sourceTree = "<group>"; };
 		C4F3B2991CFCF93A00966259 /* ButtonToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonToast.swift; sourceTree = "<group>"; };
+		C615FACE2129FBD000A8168C /* ImageCacheProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheProtocol.swift; sourceTree = "<group>"; };
+		C615FAD8212A1E2600A8168C /* WebImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebImageCache.swift; sourceTree = "<group>"; };
+		C615FADE212A319C00A8168C /* PrivacyProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtection.swift; sourceTree = "<group>"; };
+		C615FAE4212AC5E000A8168C /* PrivacyProtectionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionProtocol.swift; sourceTree = "<group>"; };
+		C615FAEC212ACAD200A8168C /* BraveWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveWebView.swift; sourceTree = "<group>"; };
 		C6345ECA2113B3A000CFB983 /* SearchPlugins */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SearchPlugins; sourceTree = "<group>"; };
+		C690C207212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebImageCacheWithNoPrivacyProtectionManager.swift; sourceTree = "<group>"; };
+		C690C2132130121E00E6EEE9 /* WebImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebImageCacheManager.swift; sourceTree = "<group>"; };
+		C6B81B80212D6C1100996084 /* NoPrivacyProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoPrivacyProtection.swift; sourceTree = "<group>"; };
+		C6B81B89212D84BD00996084 /* ImageCacheType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheType.swift; sourceTree = "<group>"; };
+		C6B81B8B212D989200996084 /* ImageCacheOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheOptions.swift; sourceTree = "<group>"; };
+		C6D267512136800100465DFA /* PrivateBrowsingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingManager.swift; sourceTree = "<group>"; };
 		C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSwizzled.swift; sourceTree = "<group>"; };
 		C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeTests.swift; sourceTree = "<group>"; };
 		C8EB60C31F1FB12500F9B5B3 /* navigationDelegate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = navigationDelegate.html; sourceTree = "<group>"; };
@@ -2220,6 +2240,30 @@
 			tabWidth = 4;
 			usesTabs = 0;
 		};
+		C6D267592137E39A00465DFA /* ImageCache */ = {
+			isa = PBXGroup;
+			children = (
+				C615FACE2129FBD000A8168C /* ImageCacheProtocol.swift */,
+				C6B81B8B212D989200996084 /* ImageCacheOptions.swift */,
+				C6B81B89212D84BD00996084 /* ImageCacheType.swift */,
+				C615FAD8212A1E2600A8168C /* WebImageCache.swift */,
+				C690C207212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift */,
+				C690C2132130121E00E6EEE9 /* WebImageCacheManager.swift */,
+			);
+			path = ImageCache;
+			sourceTree = "<group>";
+		};
+		C6D267612137E45D00465DFA /* PrivacyProtection */ = {
+			isa = PBXGroup;
+			children = (
+				C615FAE4212AC5E000A8168C /* PrivacyProtectionProtocol.swift */,
+				C615FADE212A319C00A8168C /* PrivacyProtection.swift */,
+				C6B81B80212D6C1100996084 /* NoPrivacyProtection.swift */,
+				C6D267512136800100465DFA /* PrivateBrowsingManager.swift */,
+			);
+			path = PrivacyProtection;
+			sourceTree = "<group>";
+		};
 		C8F457A61F1FD75A000CB895 /* BrowserViewController */ = {
 			isa = PBXGroup;
 			children = (
@@ -2416,6 +2460,8 @@
 		D3A994941A368691008AD1AC /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				C6D267612137E45D00465DFA /* PrivacyProtection */,
+				C6D267592137E39A00465DFA /* ImageCache */,
 				0AADC4BB20D2A4F700FDE368 /* HomePanel */,
 				0A4B011620D02DAC004D4011 /* TabsBar */,
 				0B3E7D931B27A7CE00E2E84D /* AboutHomeHandler.swift */,
@@ -2423,6 +2469,7 @@
 				C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */,
 				C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */,
 				C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */,
+				C615FAEC212ACAD200A8168C /* BraveWebView.swift */,
 				E653422C1C5944F90039DD9E /* BrowserPrompts.swift */,
 				E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */,
 				C8F457A61F1FD75A000CB895 /* BrowserViewController */,
@@ -2483,7 +2530,6 @@
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				D0FCF7F41FE45842004A7995 /* UserScriptManager.swift */,
-				A1510DA920E425EA008BF1F4 /* BraveWebView.swift */,
 			);
 			indentWidth = 4;
 			path = Browser;
@@ -4214,6 +4260,7 @@
 				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,
 				E68E7ADC1CAC208200FDCA76 /* SetupPasscodeViewController.swift in Sources */,
 				7B3631EA1C244FEE00D12AF9 /* Theme.swift in Sources */,
+				C690C208212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift in Sources */,
 				E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				D0FCF7F51FE45842004A7995 /* UserScriptManager.swift in Sources */,
@@ -4233,6 +4280,8 @@
 				3BCE6D3C1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift in Sources */,
 				745DAB301CDAAFAA00D44181 /* RecentlyClosedTabsPanel.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
+				C615FAD9212A1E2600A8168C /* WebImageCache.swift in Sources */,
+				C615FAED212ACAD200A8168C /* BraveWebView.swift in Sources */,
 				C817B34D1FC609500086018E /* UIScrollViewSwizzled.swift in Sources */,
 				39F819C61FD70F5D009E31E4 /* TabEventHandlers.swift in Sources */,
 				E65607611C08B4E200534B02 /* SearchInputView.swift in Sources */,
@@ -4251,10 +4300,12 @@
 				DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */,
 				E4CD9E911A6897FB00318571 /* ReaderMode.swift in Sources */,
 				A1FEEE0320BEE6BF00298DA2 /* HomeMenuController.swift in Sources */,
+				C615FAE5212AC5E000A8168C /* PrivacyProtectionProtocol.swift in Sources */,
 				E68E7ADE1CAC208A00FDCA76 /* RemovePasscodeViewController.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,
 				EB11A1062044A90E0018F749 /* ContentBlockerHelper+TabContentScript.swift in Sources */,
 				3B0943811D6CC4FC004F24E1 /* FilledPageControl.swift in Sources */,
+				C615FADF212A319C00A8168C /* PrivacyProtection.swift in Sources */,
 				FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */,
 				E6108FF91C84E91C005D25E8 /* BasePasscodeViewController.swift in Sources */,
 				39F4C10A2045DB2E00746155 /* FocusHelper.swift in Sources */,
@@ -4273,6 +4324,7 @@
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				74821F8E1DAD8F1400EEEA72 /* ActivityStreamHighlightCell.swift in Sources */,
 				0AADC4D220D2A6A200FDE368 /* FavoritesHelper.swift in Sources */,
+				C690C2142130121E00E6EEE9 /* WebImageCacheManager.swift in Sources */,
 				A104E199210A384400D2323E /* ShieldsViewController.swift in Sources */,
 				D0E89A2920910917001CE5C7 /* DownloadsPanel.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
@@ -4308,12 +4360,14 @@
 				C8F457A81F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift in Sources */,
 				E6927EC01C7B6FB800D03F75 /* ErrorToast.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
+				C6B81B81212D6C1100996084 /* NoPrivacyProtection.swift in Sources */,
 				D8C75DF3207584C400BB8AD0 /* UIImageViewAligned.m in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
 				39DD030D1CD53E1900BC09B3 /* HomePageHelper.swift in Sources */,
 				C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				A83E5AB71C1D993D0026D912 /* UIPasteboardExtensions.swift in Sources */,
+				C6B81B8A212D84BD00996084 /* ImageCacheType.swift in Sources */,
 				D8EFFA0C1FF5B1FA001D3A09 /* NavigationRouter.swift in Sources */,
 				D0E55C4F1FB4FD23006DC274 /* FormPostHelper.swift in Sources */,
 				E650754E1E37F6AE006961AC /* GeometryExtensions.swift in Sources */,
@@ -4324,6 +4378,7 @@
 				DDA24A431FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */,
 				E65075611E37F77D006961AC /* MenuHelper.swift in Sources */,
 				E63ED7D81BFCD9990097D08E /* LoginTableViewCell.swift in Sources */,
+				C615FACF2129FBD000A8168C /* ImageCacheProtocol.swift in Sources */,
 				3BB50E201D627539004B33DF /* ActivityStreamPanel.swift in Sources */,
 				39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */,
 				0AADC4D520D2A6A200FDE368 /* PreloadedFavorites.swift in Sources */,
@@ -4338,6 +4393,7 @@
 				0AADC4D420D2A6A200FDE368 /* FavoritesDataSource.swift in Sources */,
 				E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
+				C6B81B8C212D989200996084 /* ImageCacheOptions.swift in Sources */,
 				D02816C21ECA5E2A00240CAA /* HistoryStateHelper.swift in Sources */,
 				E68E7ACB1CAC1D4500FDCA76 /* PagingPasscodeViewController.swift in Sources */,
 				D04D1B92209790B60074B35F /* Toast.swift in Sources */,
@@ -4390,7 +4446,6 @@
 				A1FEEE2020BF28D900298DA2 /* Then.swift in Sources */,
 				A1CA29C420E1746A00CB9126 /* OptionSelectionViewController.swift in Sources */,
 				0A4B012420D0321A004D4011 /* UX.swift in Sources */,
-				A1510DAA20E425EA008BF1F4 /* BraveWebView.swift in Sources */,
 				E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */,
 				E6327A641BF6438E008D12E0 /* DebugSettingsBundleOptions.swift in Sources */,
 				D3E8EF101B97BE69001900FB /* ClearPrivateDataTableViewController.swift in Sources */,
@@ -4398,6 +4453,7 @@
 				E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */,
 				59A68D66379CFA85C4EAF00B /* TwoLineCell.swift in Sources */,
 				A1AD4BE320C0861D007A6EA1 /* UIBarButtonItemExtensions.swift in Sources */,
+				C6D267522136800100465DFA /* PrivateBrowsingManager.swift in Sources */,
 				0A4B012220D02F26004D4011 /* TabBarCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -474,11 +474,3 @@ extension AppDelegate: MFMailComposeViewControllerDelegate {
         startApplication(application!, withLaunchOptions: self.launchOptions)
     }
 }
-
-extension UIApplication {
-  
-    static var isInPrivateMode: Bool {
-        let appDelegate = UIApplication.shared.delegate as? AppDelegate
-        return appDelegate?.browserViewController.tabManager.selectedTab?.isPrivate ?? false
-    }
-}

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import SDWebImage
 import XCGLogger
 
 private let log = Logger.browserLogger
@@ -83,8 +82,11 @@ class TestAppDelegate: AppDelegate {
         log.debug("Wiping everything for a clean start.")
 
         // Clear image cache
-        SDImageCache.shared().clearDisk()
-        SDImageCache.shared().clearMemory()
+        WebImageCacheManager.shared.clearMemoryCache()
+        WebImageCacheManager.shared.clearDiskCache()
+        
+        WebImageCacheWithNoPrivacyProtectionManager.shared.clearMemoryCache()
+        WebImageCacheWithNoPrivacyProtectionManager.shared.clearDiskCache()
 
         // Clear the cookie/url cache
         URLCache.shared.removeAllCachedResponses()

--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 import Storage
-import SDWebImage
 import Shared
 
 public extension UIImageView {
@@ -67,16 +66,3 @@ public extension UIImageView {
         }
     }
 }
-
-open class ImageOperation: NSObject, SDWebImageOperation {
-    open var cacheOperation: Operation?
-
-    var cancelled: Bool {
-        return cacheOperation?.isCancelled ?? false
-    }
-
-    @objc open func cancel() {
-        cacheOperation?.cancel()
-    }
-}
-

--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -1,9 +1,24 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
 import WebKit
-import Shared
-import JavaScriptCore
 
-class BraveWebView: TabWebView {    
+class BraveWebView: WKWebView {
+    
+    init(frame: CGRect, configuration: WKWebViewConfiguration = WKWebViewConfiguration(), privacyProtection: PrivacyProtectionProtocol = PrivacyProtection()) {
+        if privacyProtection.nonPersistent {
+            configuration.processPool = WKProcessPool()
+            configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        }
+        
+        super.init(frame: frame, configuration: configuration)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+    
 }

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -24,7 +24,7 @@ private extension TrayToBrowserAnimator {
         guard let selectedTab = bvc.tabManager.selectedTab else { return }
 
         let tabManager = bvc.tabManager
-        let displayedTabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        let displayedTabs = tabManager.tabs(withType: selectedTab.type)
         guard let expandFromIndex = displayedTabs.index(of: selectedTab) else { return }
 
         bvc.view.frame = transitionContext.finalFrame(for: bvc)
@@ -115,7 +115,7 @@ private extension BrowserToTrayAnimator {
         guard let selectedTab = bvc.tabManager.selectedTab else { return }
 
         let tabManager = bvc.tabManager
-        let displayedTabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        let displayedTabs = tabManager.tabs(withType: selectedTab.type)
         guard let scrollToIndex = displayedTabs.index(of: selectedTab) else { return }
 
         tabTray.view.frame = transitionContext.finalFrame(for: tabTray)
@@ -304,20 +304,25 @@ private func createTransitionCellFromTab(_ tab: Tab?, withFrame frame: CGRect) -
     cell.screenshotView.image = tab?.screenshot
     cell.titleText.text = tab?.displayTitle
 
-    if let tab = tab, tab.isPrivate {
+    let tabType = TabType.of(tab)
+    
+    switch tabType {
+    case .regular: break
+    case .private:
         cell.style = .dark
     }
 
     if let favIcon = tab?.displayFavicon {
         cell.favicon.sd_setImage(with: URL(string: favIcon.url)!)
     } else {
-        let defaultFavicon = #imageLiteral(resourceName: "defaultFavicon")
-        if tab?.isPrivate ?? false {
-            cell.favicon.image = defaultFavicon
-            cell.favicon.tintColor = (tab?.isPrivate ?? false) ? UIColor.Photon.White100 : UIColor.Photon.Grey60
-        } else {
-            cell.favicon.image = defaultFavicon
+        cell.favicon.image = #imageLiteral(resourceName: "defaultFavicon")
+
+        switch tabType {
+        case .regular: break
+        case .private:
+            cell.favicon.tintColor = UIColor.Photon.White100
         }
     }
+
     return cell
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -12,7 +12,6 @@ import SnapKit
 import XCGLogger
 import Alamofire
 import MobileCoreServices
-import SDWebImage
 import SwiftyJSON
 import Deferred
 import Data
@@ -2441,7 +2440,8 @@ extension BrowserViewController {
         let alert = ThirdPartySearchAlerts.addThirdPartySearchEngine { alert in
             self.customSearchEngineButton.tintColor = UIColor.Photon.Grey50
             self.customSearchEngineButton.isUserInteractionEnabled = false
-            SDWebImageManager.shared().loadImage(with: iconURL, options: .continueInBackground, progress: nil) { (image, _, _, _, _, _) in
+
+            WebImageCacheManager.shared.load(from: iconURL) { (image, _, _, _, _) in
                 guard let image = image else {
                     let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
                     self.present(alert, animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1510,13 +1510,13 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
     
     func tabToolbarDidPressAddTab(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        self.openBlankNewTab(focusLocationField: true, isPrivate: UIApplication.isInPrivateMode)
+        self.openBlankNewTab(focusLocationField: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
     }
 
     func tabToolbarDidLongPressAddTab(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.addAction(UIAlertAction(title: Strings.Cancel, style: .cancel, handler: nil))
-        if !UIApplication.isInPrivateMode {
+        if !PrivateBrowsingManager.shared.isPrivateBrowsing {
             let newPrivateTabAction = UIAlertAction(title: Strings.NewPrivateTabTitle, style: .default, handler: { [unowned self] _ in
                 // BRAVE TODO: Add check for DuckDuckGo popup (and based on 1.6, whether the browser lock is enabled?)
                 // before focusing on the url bar
@@ -1525,7 +1525,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             alertController.addAction(newPrivateTabAction)
         }
         alertController.addAction(UIAlertAction(title: Strings.NewTabTitle, style: .default, handler: { [unowned self] _ in
-            self.openBlankNewTab(focusLocationField: true, isPrivate: UIApplication.isInPrivateMode)
+            self.openBlankNewTab(focusLocationField: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
         }))
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -51,7 +51,8 @@ extension BrowserViewController: DownloadQueueDelegate {
             if error == nil {
                 let downloadCompleteToast = ButtonToast(labelText: download.filename, imageName: "check", buttonText: Strings.DownloadsButtonTitle, completion: { buttonPressed in
                     if buttonPressed {
-                        self.openURLInNewTab(HomePanelType.downloads.localhostURL, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false, isPrivileged: true)
+                        let tabIsPrivate = TabType.of(self.tabManager.selectedTab).isPrivate
+                        self.openURLInNewTab(HomePanelType.downloads.localhostURL, isPrivate: tabIsPrivate, isPrivileged: true)
                     }
                 })
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -58,7 +58,7 @@ extension BrowserViewController {
             return
         }
 
-        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        let tabs = tabManager.tabs(withType: currentTab.type)
         if let index = tabs.index(of: currentTab), index + 1 < tabs.count {
             tabManager.selectTab(tabs[index + 1])
         } else if let firstTab = tabs.first {
@@ -71,7 +71,7 @@ extension BrowserViewController {
             return
         }
 
-        let tabs = currentTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
+        let tabs = tabManager.tabs(withType: currentTab.type)
         if let index = tabs.index(of: currentTab), index - 1 < tabs.count && index != 0 {
             tabManager.selectTab(tabs[index - 1])
         } else if let lastTab = tabs.last {

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -46,7 +46,7 @@ class FaviconHandler {
             guard let tab = tab else { return }
             
             tab.favicons.append(favicon)
-            if tab.type == .regular {
+            if !tab.isPrivate {
                 FaviconMO.add(favicon, forSiteUrl: currentURL)
             }
         }
@@ -97,7 +97,7 @@ extension FaviconHandler: TabEventHandler {
         guard let faviconURL = metadata.faviconURL else {
             return
         }
-        
+
         loadFaviconURL(faviconURL, forTab: tab) >>== { (favicon, data) in
             TabEvent.post(.didLoadFavicon(favicon, with: data), for: tab)
         }

--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -36,7 +36,7 @@ class BraveShieldStatsView: UIView, Themeable {
     lazy var timeStatView: StatView = {
         let statView = StatView(frame: CGRect.zero)
         statView.title = Strings.ShieldsTimeStats
-        statView.color = UIApplication.isInPrivateMode ? UX.GreyA : UX.GreyJ
+        statView.color = PrivateBrowsingManager.shared.isPrivateBrowsing ? UX.GreyA : UX.GreyJ
         return statView
     }()
     

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 import Shared
 import XCGLogger
 import Storage
-import SDWebImage
 import Deferred
 import Data
 

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -30,7 +30,7 @@ class FavoritesViewController: UIViewController {
         layout.minimumLineSpacing = 6
         
         let view = UICollectionView(frame: self.view.frame, collectionViewLayout: layout).then {
-            $0.backgroundColor = UIApplication.isInPrivateMode ? UX.HomePanel.BackgroundColorPBM : UX.HomePanel.BackgroundColor
+            $0.backgroundColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UX.HomePanel.BackgroundColorPBM : UX.HomePanel.BackgroundColor
             $0.delegate = self
         
             let cellIdentifier = FavoriteCell.identifier
@@ -49,7 +49,7 @@ class FavoritesViewController: UIViewController {
     // MARK: - Views initialization
     private let privateTabMessageContainer = UIView().then {
         $0.isUserInteractionEnabled = true
-        $0.isHidden = !UIApplication.isInPrivateMode
+        $0.isHidden = !PrivateBrowsingManager.shared.isPrivateBrowsing
     }
     
     private let privateTabTitleLabel = UILabel().then {
@@ -136,13 +136,13 @@ class FavoritesViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = UIApplication.isInPrivateMode ? UX.HomePanel.BackgroundColorPBM : UX.HomePanel.BackgroundColor
+        view.backgroundColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UX.HomePanel.BackgroundColorPBM : UX.HomePanel.BackgroundColor
         
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongGesture(gesture:)))
         collection.addGestureRecognizer(longPressGesture)
         
         view.addSubview(collection)
-        collection.dataSource = UIApplication.isInPrivateMode ? nil : dataSource
+        collection.dataSource = PrivateBrowsingManager.shared.isPrivateBrowsing ? nil : dataSource
         dataSource.collectionView = collection
         
         // Could setup as section header but would need to use flow layout,
@@ -351,7 +351,7 @@ class FavoritesViewController: UIViewController {
     
     // MARK: - Private browsing modde
     @objc func privateBrowsingModeChanged() {
-        let isPrivateBrowsing = UIApplication.isInPrivateMode
+        let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
         
         // TODO: This entire blockshould be abstracted
         //  to make code in this class DRY (duplicates from elsewhere)

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoriteCell.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoriteCell.swift
@@ -163,7 +163,7 @@ class FavoriteCell: UICollectionViewCell {
         backgroundColor = UIColor.clear
         textLabel.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
         textLabel.textColor = 
-            UIApplication.isInPrivateMode ? UX.Favorites.cellLabelColorPrivate : UX.Favorites.cellLabelColorNormal
+            PrivateBrowsingManager.shared.isPrivateBrowsing ? UX.Favorites.cellLabelColorPrivate : UX.Favorites.cellLabelColorNormal
         imageView.backgroundColor = UIColor.clear
         imageView.image = nil
     }

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesTileDecorator.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesTileDecorator.swift
@@ -71,7 +71,7 @@ class FavoritesTileDecorator {
             cell.imageView.backgroundColor = website.backgroundColor
             cell.imageView.contentMode = .scaleAspectFit
             cell.imageView.layer.minificationFilter = kCAFilterTrilinear
-            cell.showBorder(!UIApplication.isInPrivateMode)
+            cell.showBorder(!PrivateBrowsingManager.shared.isPrivateBrowsing)
             
             let size = CGSize(width: image.size.width - 6, height: image.size.height - 6)
             cell.imageView.image = image.scale(toSize: size)

--- a/Client/Frontend/Browser/ImageCache/ImageCacheOptions.swift
+++ b/Client/Frontend/Browser/ImageCache/ImageCacheOptions.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+struct ImageCacheOptions: OptionSet {
+    
+    let rawValue: Int
+    
+    /*
+     * Low priority download.
+     */
+    static let lowPriority = ImageCacheOptions(rawValue: 1 << 0)
+    
+}

--- a/Client/Frontend/Browser/ImageCache/ImageCacheProtocol.swift
+++ b/Client/Frontend/Browser/ImageCache/ImageCacheProtocol.swift
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// ImageCacheProgress A block called while the image is downloading.
+///
+/// The first parameter is the received image size.
+///
+/// The second parameter is the
+///
+/// The last parameter is the original image URL.
+
+typealias ImageCacheProgress = ((Int, Int, URL) -> Void)?
+
+/// ImageCacheCompletion A block called when the operation has completed.
+///
+/// This block takes the requested UIImage as first parameter and the NSData representation as second
+/// parameter. In case of an error the image parameter will be nil and the third parameter may contain an
+/// Error.
+///
+/// The fourth parameter is an `ImageCacheType` enum indicating if the image was retrieved from the web,
+/// memory cache or disk cache.
+///
+/// The last parameter is the original image URL.
+
+typealias ImageCacheCompletion = ((UIImage?, Data?, Error?, ImageCacheType, URL) -> Void)?
+
+protocol ImageCacheProtocol {
+    
+    associatedtype ReturnAssociatedType
+    
+    /// Initialize an image cache with privacy protection.
+    ///
+    /// - parameter privacyProtection: An object representing privacy protection for this cache store.
+    /// - parameter sandbox: The sandbox for this cache store.
+    init(withPrivacyProtection privacyProtection: PrivacyProtectionProtocol, sandbox: String?)
+    
+    /// Downloads the image at the given URL if not present in the cache otherwise returns the cached version.
+    ///
+    /// - parameter url: URL to the image.
+    /// - parameter options: A mask to specify ImageCacheOptions options.
+    /// - parameter progress: An ImageCacheProgress block called while the image is downloading.
+    /// - parameter completion: An ImageCacheCompletion block called when the operation has completed.
+    /// - returns: ReturnAssociatedType customized using typealias.
+    @discardableResult func load(from url: URL, options: ImageCacheOptions, progress: ImageCacheProgress, completion: ImageCacheCompletion) -> ReturnAssociatedType?
+    
+    /// Returns whether the image at the given URL is cached in memory or not.
+    ///
+    /// - parameter url: URL to image.
+    /// - returns: true if the image is cached in memory, otherwise false.
+    func isCached(_ url: URL) -> Bool
+    
+    /// Returns whether the image at the given URL is cached on disk or not.
+    ///
+    /// - parameter url: URL to image.
+    /// - returns: true if the image is cached on disk, otherwise false.
+    func isPersisted(_ url: URL) -> Bool
+    
+    /// Remove image at the given URL from the cache.
+    ///
+    /// - parameter url: URL to image.
+    func remove(fromCache url: URL)
+    
+    /// Clears the memory cache.
+    func clearMemoryCache()
+    
+    /// Clears the disk cache.
+    func clearDiskCache()
+    
+}

--- a/Client/Frontend/Browser/ImageCache/ImageCacheType.swift
+++ b/Client/Frontend/Browser/ImageCache/ImageCacheType.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+enum ImageCacheType: Int, CustomDebugStringConvertible {
+
+    /// The image was not available in the cache, but was downloaded from the web.
+    case none
+
+    /// The image was obtained from the memory cache.
+    case memory
+
+    /// The image was obtained from the disk cache.
+    case disk
+
+    var debugDescription: String {
+        switch self {
+        case .none:
+            return "Image was not available in the cache, but was downloaded from the web"
+            
+        case .memory:
+            return "Image was obtained from the memory cache"
+            
+        case .disk:
+            return "Image was obtained from the disk cache"
+        }
+    }
+
+}

--- a/Client/Frontend/Browser/ImageCache/WebImageCache.swift
+++ b/Client/Frontend/Browser/ImageCache/WebImageCache.swift
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SDWebImage
+
+final class WebImageCache: ImageCacheProtocol {
+    
+    private let webImageManager: SDWebImageManager
+    
+    private let privacyProtection: PrivacyProtectionProtocol
+    
+    typealias ReturnAssociatedType = SDWebImageOperation
+    
+    deinit {
+        clearMemoryCache()
+        clearDiskCache()
+    }
+    
+    init(withPrivacyProtection privacyProtection: PrivacyProtectionProtocol, sandbox: String? = nil) {
+        self.privacyProtection = privacyProtection
+        
+        var imageCache: SDImageCache
+        
+        if let sandbox = sandbox {
+            imageCache = SDImageCache(namespace: sandbox, diskCacheDirectory: sandbox)
+        } else {
+            imageCache = SDImageCache.shared()
+        }
+        
+        let imageDownloader = SDWebImageDownloader.shared()
+        
+        webImageManager = SDWebImageManager(cache: imageCache, downloader: imageDownloader)
+    }
+    
+    @discardableResult
+    func load(from url: URL, options: ImageCacheOptions = [], progress: ImageCacheProgress = nil,
+              completion: ImageCacheCompletion = nil) -> SDWebImageOperation? {
+        let progressBlock: SDWebImageDownloaderProgressBlock = { receivedSize, expectedSize, url in
+            guard let url = url else {
+                return
+            }
+            
+            progress?(receivedSize, expectedSize, url)
+        }
+        
+        var webImageOptions = self.webImageOptions
+        
+        if options.contains(.lowPriority) {
+            webImageOptions.append(.lowPriority)
+        }
+
+        let imageOperation = webImageManager.loadImage(with: url, options: SDWebImageOptions(webImageOptions), progress: progressBlock) { image, data, error, webImageCacheType, _, imageURL in
+            if let image = image, !self.privacyProtection.nonPersistent {
+                self.webImageManager.saveImage(toCache: image, for: url)
+            }
+            
+            let cacheType = self.mapImageCacheType(from: webImageCacheType)
+            completion?(image, data, error, cacheType, url)
+        }
+        
+        return imageOperation
+    }
+    
+    func isCached(_ url: URL) -> Bool {
+        return webImageManager.cacheKey(for: url) != nil
+    }
+    
+    func isPersisted(_ url: URL) -> Bool {
+        let key = webImageManager.cacheKey(for: url)
+        let exists = webImageManager.imageCache?.diskImageDataExists(withKey: key) ?? false
+        return exists
+    }
+    
+    func remove(fromCache url: URL) {
+        let key = webImageManager.cacheKey(for: url)
+        webImageManager.imageCache?.removeImage(forKey: key)
+    }
+    
+    func clearMemoryCache() {
+        webImageManager.imageCache?.clearMemory()
+    }
+    
+    func clearDiskCache() {
+        if privacyProtection.nonPersistent {
+            return
+        }
+        
+        webImageManager.imageCache?.clearDisk()
+    }
+    
+}
+
+extension WebImageCache {
+    
+    private var webImageOptions: [SDWebImageOptions] {
+        var options: [SDWebImageOptions] = [.retryFailed, .continueInBackground]
+        
+        if privacyProtection.nonPersistent {
+            options.append(.cacheMemoryOnly)
+        }
+        
+        return options
+    }
+    
+    private func mapImageCacheType(from imageCacheType: SDImageCacheType) -> ImageCacheType {
+        switch imageCacheType {
+        case .none:
+            return ImageCacheType.none
+            
+        case .memory:
+            return ImageCacheType.memory
+            
+        case .disk:
+            return ImageCacheType.disk
+        }
+    }
+    
+}

--- a/Client/Frontend/Browser/ImageCache/WebImageCacheManager.swift
+++ b/Client/Frontend/Browser/ImageCache/WebImageCacheManager.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+final class WebImageCacheManager {
+
+    private let webImageCache: WebImageCache
+
+    static let shared: WebImageCache = {
+        let privacyProtection = PrivacyProtection()
+
+        let webImageCacheManager = WebImageCacheManager(withPrivacyProtection: privacyProtection)
+        return webImageCacheManager.webImageCache
+    }()
+
+    private init(withPrivacyProtection privacyProtection: PrivacyProtectionProtocol) {
+        let webImageCache = WebImageCache(withPrivacyProtection: privacyProtection)
+        self.webImageCache = webImageCache
+    }
+    
+}

--- a/Client/Frontend/Browser/ImageCache/WebImageCacheWithNoPrivacyProtectionManager.swift
+++ b/Client/Frontend/Browser/ImageCache/WebImageCacheWithNoPrivacyProtectionManager.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+final class WebImageCacheWithNoPrivacyProtectionManager {
+
+    private let webImageCache: WebImageCache
+
+    static let shared: WebImageCache = {
+        let privacyProtection = NoPrivacyProtection()
+
+        let webImageCacheManager = WebImageCacheWithNoPrivacyProtectionManager(withPrivacyProtection: privacyProtection)
+        return webImageCacheManager.webImageCache
+    }()
+
+    private init(withPrivacyProtection privacyProtection: PrivacyProtectionProtocol) {
+        let webImageCache = WebImageCache(withPrivacyProtection: privacyProtection)
+        self.webImageCache = webImageCache
+    }
+
+}

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -47,7 +47,7 @@ class MetadataParserHelper: TabEventHandler {
             TabEvent.post(.didLoadPageMetadata(pageMetadata), for: tab)
 
             let userInfo: [String: Any] = [
-                "isPrivate": tab.isPrivate,
+                "tabType": tab.type,
                 "pageMetadata": pageMetadata,
                 "tabURL": pageURL
             ]

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
-import SDWebImage
 import Shared
 import Storage
 import XCGLogger
@@ -73,32 +72,18 @@ class MediaImageLoader: TabEventHandler {
     }
 
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
-        let cacheImages = !NoImageModeHelper.isActivated
-        if let urlString = metadata.mediaURL,
-            let mediaURL = URL(string: urlString), cacheImages {
-            prepareCache(mediaURL)
+        if let mediaURL = metadata.mediaURL, let url = URL(string: mediaURL) {
+            loadImage(from: url)
         }
     }
 
-    fileprivate func prepareCache(_ url: URL) {
-        let manager = SDWebImageManager.shared()
-        manager.cachedImageExists(for: url) { exists in
-            if !exists {
-                self.downloadAndCache(fromURL: url)
-            }
+    fileprivate func loadImage(from url: URL) {
+        let shouldCacheImages = !NoImageModeHelper.isActivated
+        if !shouldCacheImages {
+            return
         }
+
+        WebImageCacheManager.shared.load(from: url)
     }
 
-    fileprivate func downloadAndCache(fromURL webUrl: URL) {
-        let manager = SDWebImageManager.shared()
-        manager.loadImage(with: webUrl, options: .continueInBackground, progress: nil) { (image, _, _, _, _, _) in
-            if let image = image {
-                self.cache(image: image, forURL: webUrl)
-            }
-        }
-    }
-
-    fileprivate func cache(image: UIImage, forURL url: URL) {
-        SDWebImageManager.shared().saveImage(toCache: image, for: url)
-    }
 }

--- a/Client/Frontend/Browser/PrivacyProtection/NoPrivacyProtection.swift
+++ b/Client/Frontend/Browser/PrivacyProtection/NoPrivacyProtection.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+final class NoPrivacyProtection: PrivacyProtectionProtocol {
+    
+    var nonPersistent: Bool {
+        return false
+    }
+    
+}

--- a/Client/Frontend/Browser/PrivacyProtection/PrivacyProtection.swift
+++ b/Client/Frontend/Browser/PrivacyProtection/PrivacyProtection.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+
+final class PrivacyProtection: PrivacyProtectionProtocol {
+
+    var nonPersistent: Bool {
+        let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
+        return isPrivateBrowsing
+    }
+
+}

--- a/Client/Frontend/Browser/PrivacyProtection/PrivacyProtectionProtocol.swift
+++ b/Client/Frontend/Browser/PrivacyProtection/PrivacyProtectionProtocol.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+protocol PrivacyProtectionProtocol {
+
+    /**
+     Return whether data should be persisted. This is useful for implementing "private browsing".
+     */
+    var nonPersistent: Bool { get }
+
+}

--- a/Client/Frontend/Browser/PrivacyProtection/PrivateBrowsingManager.swift
+++ b/Client/Frontend/Browser/PrivacyProtection/PrivateBrowsingManager.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+final class PrivateBrowsingManager {
+    
+    var isPrivateBrowsing = false
+    
+    static let shared = PrivateBrowsingManager()
+    
+}

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -50,7 +50,7 @@ protocol SearchViewControllerDelegate: class {
 class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {
     var searchDelegate: SearchViewControllerDelegate?
 
-    fileprivate let isPrivate: Bool
+    fileprivate let tabType: TabType
     fileprivate var suggestClient: SearchSuggestClient?
 
     // Views for displaying the bottom scrollable search engine list. searchEngineScrollView is the
@@ -68,8 +68,8 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     static var userAgent: String?
 
-    init(isPrivate: Bool) {
-        self.isPrivate = isPrivate
+    init(forTabType tabType: TabType) {
+        self.tabType = tabType
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -143,7 +143,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             make.bottom.equalTo(self.view).offset(-keyboardHeight)
         }
     }
-
+    
     var searchEngines: SearchEngines! {
         didSet {
             suggestClient?.cancelPendingRequest()
@@ -152,7 +152,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             querySuggestClient()
 
             // Show the default search engine first.
-            if !isPrivate {
+            if !tabType.isPrivate {
                 let ua = SearchViewController.userAgent ?? "FxSearch"
                 suggestClient = SearchSuggestClient(searchEngine: searchEngines.defaultEngine, userAgent: ua)
             }
@@ -167,7 +167,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
         // If we're not showing search suggestions, the default search engine won't be visible
         // at the top of the table. Show it with the others in the bottom search bar.
-        if isPrivate || !searchEngines.shouldShowSearchSuggestions {
+        if tabType.isPrivate || !searchEngines.shouldShowSearchSuggestions {
             engines?.insert(searchEngines.defaultEngine, at: 0)
         }
 
@@ -407,7 +407,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch SearchListSection(rawValue: section)! {
         case .searchSuggestions:
-            return searchEngines.shouldShowSearchSuggestions && !searchQuery.looksLikeAURL() && !isPrivate ? 1 : 0
+            return searchEngines.shouldShowSearchSuggestions && !searchQuery.looksLikeAURL() && !tabType.isPrivate ? 1 : 0
         case .bookmarksAndHistory:
             return data.count
         }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -33,7 +33,7 @@ protocol URLChangeDelegate {
 }
 
 struct TabState {
-    var isPrivate: Bool = false
+    var type: TabType = .regular
     var desktopSite: Bool = false
     var url: URL?
     var title: String?
@@ -43,20 +43,14 @@ struct TabState {
 class Tab: NSObject {
     var id: String?
     
-    fileprivate var _isPrivate: Bool = false
-    internal fileprivate(set) var isPrivate: Bool {
-        get {
-            return _isPrivate
-        }
-        set {
-            if _isPrivate != newValue {
-                _isPrivate = newValue
-            }
-        }
+    private(set) var type: TabType = .regular
+    
+    var isPrivate: Bool {
+        return type.isPrivate
     }
 
     var tabState: TabState {
-        return TabState(isPrivate: _isPrivate, desktopSite: desktopSite, url: url, title: displayTitle, favicon: displayFavicon)
+        return TabState(type: type, desktopSite: desktopSite, url: url, title: displayTitle, favicon: displayFavicon)
     }
 
     // PageMetadata is derived from the page content itself, and as such lags behind the
@@ -149,10 +143,10 @@ class Tab: NSObject {
     /// tab instance, queue it for later until we become foregrounded.
     fileprivate var alertQueue = [JSAlertInfo]()
 
-    init(configuration: WKWebViewConfiguration, isPrivate: Bool = false) {
+    init(configuration: WKWebViewConfiguration, type: TabType = .regular) {
         self.configuration = configuration
         super.init()
-        self.isPrivate = isPrivate
+        self.type = type
 
         if let appDelegate = UIApplication.shared.delegate as? AppDelegate, let profile = appDelegate.profile {
             contentBlocker = ContentBlockerHelper(tab: self, profile: profile)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -67,7 +67,7 @@ class Tab: NSObject {
 
     var userActivity: NSUserActivity?
 
-    var webView: WKWebView?
+    var webView: BraveWebView?
     var tabDelegate: TabDelegate?
     weak var urlDidChangeDelegate: URLChangeDelegate?     // TODO: generalize this.
     var bars = [SnackBar]()
@@ -192,7 +192,7 @@ class Tab: NSObject {
             configuration!.preferences = WKPreferences()
             configuration!.preferences.javaScriptCanOpenWindowsAutomatically = false
             configuration!.allowsInlineMediaPlayback = true
-            let webView = BraveWebView(frame: .zero, configuration: configuration!)
+            let webView = TabWebView(frame: .zero, configuration: configuration!)
             webView.delegate = self
             configuration = nil
 
@@ -465,7 +465,7 @@ class Tab: NSObject {
     }
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-        guard let webView = object as? WKWebView, webView == self.webView,
+        guard let webView = object as? BraveWebView, webView == self.webView,
             let path = keyPath, path == KVOConstants.URL.rawValue else {
             return assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
@@ -552,7 +552,7 @@ private protocol TabWebViewDelegate: class {
     func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String)
 }
 
-class TabWebView: WKWebView, MenuHelperInterface {
+class TabWebView: BraveWebView, MenuHelperInterface {
     fileprivate weak var delegate: TabWebViewDelegate?
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -358,7 +358,13 @@ extension TabLocationView: AccessibilityActionsSource {
 
 extension TabLocationView: Themeable {
     func applyTheme(_ theme: Theme) {
-        backgroundColor = theme == .Normal ? BraveUX.LocationBarBackgroundColor : BraveUX.LocationBarBackgroundColor_PrivateMode
+        switch theme {
+        case .regular:
+            backgroundColor = BraveUX.LocationBarBackgroundColor
+        case .private:
+            backgroundColor = BraveUX.LocationBarBackgroundColor_PrivateMode
+        }
+
         urlTextField.textColor = UIColor.Browser.Tint.colorFor(theme)
         readerModeButton.selectedTintColor = UIColor.TextField.ReaderModeButtonSelected.colorFor(theme)
         readerModeButton.unselectedTintColor = UIColor.TextField.ReaderModeButtonUnselected.colorFor(theme)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -81,7 +81,6 @@ class TabManager: NSObject {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !(self.prefs.boolForKey("blockPopups") ?? true)
-        configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
         return configuration
     }()
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -91,17 +91,6 @@ class TabManager: NSObject {
     var selectedIndex: Int { return _selectedIndex }
     var tempTabs: [Tab]?
 
-    var normalTabs: [Tab] {
-        assert(Thread.isMainThread)
-
-        return tabs.filter { !$0.isPrivate }
-    }
-
-    var privateTabs: [Tab] {
-        assert(Thread.isMainThread)
-        return tabs.filter { $0.isPrivate }
-    }
-
     init(prefs: Prefs, imageStore: DiskImageStore?) {
         assert(Thread.isMainThread)
 
@@ -170,7 +159,13 @@ class TabManager: NSObject {
     
     // What the users sees displayed based on current private browsing mode
     var displayedTabsForCurrentPrivateMode: [Tab] {
-        return UIApplication.isInPrivateMode ? privateTabs : normalTabs
+        let tabType: TabType = PrivateBrowsingManager.shared.isPrivateBrowsing ? .private : .regular
+        return tabs(withType: tabType)
+    }
+
+    func tabs(withType type: TabType) -> [Tab] {
+        assert(Thread.isMainThread)
+        return tabs.filter { $0.type == type }
     }
 
     func getTabFor(_ url: URL) -> Tab? {
@@ -201,7 +196,7 @@ class TabManager: NSObject {
         }
 
         // Make sure to wipe the private tabs if the user has the pref turned on
-        if shouldClearPrivateTabs(), !(tab?.isPrivate ?? false) {
+        if shouldClearPrivateTabs() && !TabType.of(tab).isPrivate {
             removeAllPrivateTabs()
         }
 
@@ -228,7 +223,13 @@ class TabManager: NSObject {
         }
         if let tab = selectedTab {
             TabEvent.post(.didGainFocus, for: tab)
-            UITextField.appearance().keyboardAppearance = tab.isPrivate ? .dark : .light
+            
+            switch tab.type {
+            case .regular:
+                UITextField.appearance().keyboardAppearance = .light
+            case .private:
+                UITextField.appearance().keyboardAppearance = .dark
+            }
         }
     }
 
@@ -254,7 +255,7 @@ class TabManager: NSObject {
     }
 
     func addPopupForParentTab(_ parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
-        let popup = Tab(configuration: configuration, isPrivate: parentTab.isPrivate)
+        let popup = Tab(configuration: configuration, type: parentTab.type)
         configureTab(popup, request: nil, afterTab: parentTab, flushToDisk: true, zombie: false, isPopup: true)
 
         // Wait momentarily before selecting the new tab, otherwise the parent tab
@@ -313,7 +314,8 @@ class TabManager: NSObject {
         // Take the given configuration. Or if it was nil, take our default configuration for the current browsing mode.
         let configuration: WKWebViewConfiguration = configuration ?? (isPrivate ? privateConfiguration : self.configuration)
 
-        let tab = Tab(configuration: configuration, isPrivate: isPrivate)
+        let type: TabType = isPrivate ? .private : .regular
+        let tab = Tab(configuration: configuration, type: type)
         if !isPrivate {
             tab.id = id ?? TabMO.create().syncUUID
         }
@@ -331,20 +333,22 @@ class TabManager: NSObject {
         return tab
     }
     
-    func moveTab(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
+    func moveTab(fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
         assert(Thread.isMainThread)
+        
+        let tabType: TabType = PrivateBrowsingManager.shared.isPrivateBrowsing ? .private : .regular
+        let currentTabs = tabs(withType: tabType)
 
-        let currentTabs = privateMode ? privateTabs : normalTabs
+        let fromTab = currentTabs[visibleFromIndex]
+        let toTab = currentTabs[visibleToIndex]
 
-        guard visibleFromIndex < currentTabs.count, visibleToIndex < currentTabs.count else {
+        guard let fromIndex = tabs.index(of: fromTab), let toIndex = tabs.index(of: toTab) else {
             return
         }
 
-        let previouslySelectedTab = selectedTab
+        tabs.swapAt(fromIndex, toIndex)
 
-        tabs.insert(tabs.remove(at: visibleFromIndex), at: visibleToIndex)
-
-        if let previouslySelectedTab = previouslySelectedTab, let previousSelectedIndex = tabs.index(of: previouslySelectedTab) {
+        if let previouslySelectedTab = selectedTab, let previousSelectedIndex = tabs.index(of: previouslySelectedTab) {
             _selectedIndex = previousSelectedIndex
         }
 
@@ -371,7 +375,7 @@ class TabManager: NSObject {
 
         delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }
 
-        if parent == nil || parent?.isPrivate != tab.isPrivate {
+        if parent == nil || parent?.type != tab.type {
             tabs.append(tab)
         } else if let parent = parent, var insertIndex = tabs.index(of: parent) {
             insertIndex += 1
@@ -505,9 +509,11 @@ class TabManager: NSObject {
         delegates.forEach { $0.get()?.tabManager(self, willRemoveTab: tab) }
 
         // The index of the tab in its respective tab grouping. Used to figure out which tab is next
+        let viableTabs = tabs(withType: tab.type)
+
         var tabIndex: Int = -1
         if let oldTab = oldSelectedTab {
-            tabIndex = (tab.isPrivate ? privateTabs.index(of: oldTab) : normalTabs.index(of: oldTab)) ?? -1
+            tabIndex = viableTabs.index(of: oldTab) ?? -1
         }
 
         let prevCount = count
@@ -517,8 +523,6 @@ class TabManager: NSObject {
         if let tab = TabMO.get(fromId: tab.id, context: context) {
             DataController.remove(object: tab, context: context)
         }
-
-        let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
 
         // Let's select the tab to be selected next.
         if let oldTab = oldSelectedTab, tab !== oldTab {
@@ -560,7 +564,7 @@ class TabManager: NSObject {
         delegates.forEach { $0.get()?.tabManager(self, didRemoveTab: tab) }
         TabEvent.post(.didClose, for: tab)
 
-        if !tab.isPrivate && viableTabs.isEmpty {
+        if tab.isPrivate && viableTabs.isEmpty {
             addTab()
         }
 
@@ -575,9 +579,10 @@ class TabManager: NSObject {
     /// Removes all private tabs from the manager without notifying delegates.
     private func removeAllPrivateTabs() {
         // reset the selectedTabIndex if we are on a private tab because we will be removing it.
-        if selectedTab?.isPrivate ?? false {
+        if TabType.of(selectedTab).isPrivate {
             _selectedIndex = -1
         }
+
         tabs.forEach { tab in
             if tab.isPrivate {
                 tab.webView?.removeFromSuperview()
@@ -585,7 +590,7 @@ class TabManager: NSObject {
             }
         }
 
-        tabs = tabs.filter { !$0.isPrivate }
+        tabs = tabs(withType: .regular)
     }
 
     func removeAllBrowsingDataForTab(_ tab: Tab, completionHandler: @escaping () -> Void = {}) {
@@ -636,16 +641,22 @@ class TabManager: NSObject {
         guard let tempTabs = self.tempTabs, tempTabs.count > 0 else {
             return
         }
-        let tabsCopy = normalTabs
+
+        let tabsCopy = tabs(withType: .regular)
+
         restoreTabs(tempTabs)
         self.isRestoring = true
+
         for tab in tempTabs {
             tab.showContent(true)
         }
-        if !tempTabs[0].isPrivate {
+
+        let tab = tempTabs.first
+        if !TabType.of(tab).isPrivate {
             removeTabs(tabsCopy)
         }
-        selectTab(tempTabs.first)
+        selectTab(tab)
+
         self.isRestoring = false
         delegates.forEach { $0.get()?.tabManagerDidRestoreTabs(self) }
         self.tempTabs?.removeAll()
@@ -857,7 +868,8 @@ extension TabManager {
         isRestoring = false
 
         // Always make sure there is a single normal tab.
-        if normalTabs.isEmpty {
+        let tabs = self.tabs(withType: .regular)
+        if tabs.isEmpty {
             let tab = addTab()
             if selectedTab == nil {
                 selectTab(tab)

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -93,7 +93,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
         screenShot?.accessibilityLabel = previewAccessibilityLabel
     }
 
-    fileprivate func setupWebView(_ webView: WKWebView?) {
+    fileprivate func setupWebView(_ webView: BraveWebView?) {
         guard let webView = webView, let url = webView.url, !isIgnoredURL(url) else { return }
         let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
         clonedWebView.allowsLinkPreview = false

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -71,7 +71,7 @@ open class TabToolbarHelper: NSObject {
         toolbar.addTabButton.addTarget(self, action: #selector(didClickAddTab), for: UIControlEvents.touchUpInside)
         toolbar.addTabButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressAddTab(_:))))
 
-        setTheme(theme: .Normal, forButtons: toolbar.actionButtons)
+        setTheme(theme: .regular, forButtons: toolbar.actionButtons)
     }
 
     func didClickBack() {
@@ -251,7 +251,13 @@ extension TabToolbar: TabToolbarProtocol {
 
 extension TabToolbar: Themeable {
     func applyTheme(_ theme: Theme) {
-        backgroundColor = theme == .Normal ? BraveUX.ToolbarsBackgroundSolidColor : BraveUX.DarkToolbarsBackgroundSolidColor
+        switch theme {
+        case .regular:
+            backgroundColor = BraveUX.ToolbarsBackgroundSolidColor
+        case .private:
+            backgroundColor = BraveUX.DarkToolbarsBackgroundSolidColor
+        }
+
         helper?.setTheme(theme: theme, forButtons: actionButtons)
     }
 }

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -22,7 +22,7 @@ class PrivateModeButton: ToggleButton, Themeable {
     func applyTheme(_ theme: Theme) {
         tintColor = UIColor.Browser.Tint.colorFor(theme)
         imageView?.tintColor = tintColor
-        isSelected = theme == .Private
+        isSelected = theme.isPrivate
         accessibilityValue = isSelected ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
     }
 }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -253,6 +253,8 @@ class TabTrayController: UIViewController {
 
     fileprivate(set) internal var privateMode: Bool = false {
         didSet {
+            PrivateBrowsingManager.shared.isPrivateBrowsing = privateMode
+            
             tabDataSource.tabs = tabsToDisplay
             toolbar.applyTheme(privateMode ? .private : .regular)
             collectionView?.reloadData()

--- a/Client/Frontend/Browser/TabType.swift
+++ b/Client/Frontend/Browser/TabType.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+enum TabType: Int, CustomDebugStringConvertible {
+    
+    /// Regular browsing.
+    case regular
+    
+    /// Private browsing.
+    case `private`
+    
+    /// Textual representation suitable for debugging.
+    var debugDescription: String {
+        switch self {
+        case .regular:
+            return "Regular tab"
+        case .private:
+            return "Private tab"
+        }
+    }
+    
+    /// Returns whether the tab is private or not.
+    var isPrivate: Bool {
+        switch self {
+        case .regular:
+            return false
+        case .private:
+            return true
+        }
+    }
+    
+    /// Returns the type of the given Tab, if the tab is nil returns a regular tab type.
+    ///
+    /// - parameter tab: An object representing a Tab.
+    /// - returns: A Tab type.
+    static func of(_ tab: Tab?) -> TabType {
+        return tab?.type ?? .regular
+    }
+    
+}

--- a/Client/Frontend/Browser/TabsBar/TabBarCell.swift
+++ b/Client/Frontend/Browser/TabsBar/TabBarCell.swift
@@ -17,7 +17,7 @@ class TabBarCell: UICollectionViewCell {
         let button = UIButton()
         button.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
         button.setImage(#imageLiteral(resourceName: "close_tab_bar").template, for: .normal)
-        button.tintColor = UIApplication.isInPrivateMode ? UIColor.white : UIColor.black
+        button.tintColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UIColor.white : UIColor.black
         // Close button is a bit wider to increase tap area, this aligns the 'X' image closer to the right.
         button.imageEdgeInsets.left = 6
         return button
@@ -90,17 +90,17 @@ class TabBarCell: UICollectionViewCell {
     
     override var isSelected: Bool {
         didSet(selected) {
-            closeButton.tintColor = UIApplication.isInPrivateMode ? UIColor.white : UIColor.black
+            closeButton.tintColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UIColor.white : UIColor.black
             if selected {
                 titleLabel.font = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.semibold)
                 closeButton.isHidden = false
-                titleLabel.textColor = UIApplication.isInPrivateMode ? UIColor.white : UIColor.black
-                backgroundColor = UIApplication.isInPrivateMode ? BraveUX.DarkToolbarsBackgroundSolidColor : BraveUX.ToolbarsBackgroundSolidColor
+                titleLabel.textColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UIColor.white : UIColor.black
+                backgroundColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? BraveUX.DarkToolbarsBackgroundSolidColor : BraveUX.ToolbarsBackgroundSolidColor
             }
                 // Prevent swipe and release outside- deselects cell.
             else if currentIndex != tabManager?.currentDisplayedIndex {
                 titleLabel.font = UIFont.systemFont(ofSize: 12)
-                titleLabel.textColor = UIApplication.isInPrivateMode ? UIColor(white: 1.0, alpha: 0.4) : UIColor(white: 0.0, alpha: 0.4)
+                titleLabel.textColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UIColor(white: 1.0, alpha: 0.4) : UIColor(white: 0.0, alpha: 0.4)
                 closeButton.isHidden = true
                 backgroundColor = .clear
             }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -28,13 +28,13 @@ class TabsBarViewController: UIViewController {
         button.backgroundColor = .clear
         return button
     }()
-    
+
     fileprivate lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.minimumInteritemSpacing = 0
         layout.minimumLineSpacing = 0
-        
+
         let view = UICollectionView(frame: CGRect.zero, collectionViewLayout: layout)
         view.showsHorizontalScrollIndicator = false
         view.bounces = false
@@ -50,35 +50,35 @@ class TabsBarViewController: UIViewController {
     
     fileprivate weak var tabManager: TabManager?
     fileprivate var tabList = WeakList<Tab>()
-    
+
     init(tabManager: TabManager) {
         self.tabManager = tabManager
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         tabManager?.addDelegate(self)
-        
+
         // Can't get view.frame inside of lazy property, need to put this code here.
         collectionView.frame = view.frame
         (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize = CGSize(width: UX.TabsBar.minimumWidth, height: view.frame.height)
         view.addSubview(collectionView)
-        
+
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongGesture(gesture:)))
         longPressGesture.minimumPressDuration = 0.2
         collectionView.addGestureRecognizer(longPressGesture)
-        
+
         NotificationCenter.default.addObserver(self, selector: #selector(orientationChanged), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
-        
+
         if UIDevice.current.userInterfaceIdiom == .pad {
             view.addSubview(plusButton)
-            
+
             plusButton.snp.makeConstraints { make in
                 make.right.top.bottom.equalTo(view)
                 make.width.equalTo(UX.TabsBar.buttonWidth)
@@ -98,19 +98,19 @@ class TabsBarViewController: UIViewController {
             make.left.right.equalTo(view)
         }
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         // Updating tabs here is especially handy when tabs are reordered from the tab tray.
         updateData()
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        
+
         // ensure the selected tab is visible after rotations
         if let index = tabManager?.currentDisplayedIndex {
             let indexPath = IndexPath(item: index, section: 0)
@@ -118,34 +118,34 @@ class TabsBarViewController: UIViewController {
             // will not overshoot the edges for the bookend tabs
             collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.reloadDataAndRestoreSelectedTab()
         }
     }
-    
+
     @objc func orientationChanged() {
         overflowIndicators()
     }
-    
+
     @objc func addTabPressed() {
         tabManager?.addTabAndSelect(isPrivate: UIApplication.isInPrivateMode)
     }
-    
+
     func updateData() {
         tabList = WeakList<Tab>()
-        
+
         tabManager?.displayedTabsForCurrentPrivateMode.forEach {
             tabList.insert($0)
         }
-        
+
         overflowIndicators()
         reloadDataAndRestoreSelectedTab()
     }
-    
+
     func reloadDataAndRestoreSelectedTab() {
         collectionView.reloadData()
-        
+
         if let tabManager = tabManager, let selectedTab = tabManager.selectedTab {
             let selectedIndex = tabList.index(of: selectedTab) ?? 0
             if selectedIndex < tabList.count() {
@@ -153,7 +153,7 @@ class TabsBarViewController: UIViewController {
             }
         }
     }
-    
+
     @objc func handleLongGesture(gesture: UILongPressGestureRecognizer) {
         switch(gesture.state) {
         case .began:
@@ -173,34 +173,34 @@ class TabsBarViewController: UIViewController {
             collectionView.cancelInteractiveMovement()
         }
     }
-    
+
     private func tabOverflowWidth(_ tabCount: Int) -> CGFloat {
         let overflow = CGFloat(tabCount) * UX.TabsBar.minimumWidth - collectionView.frame.width
         return max(overflow, 0)
     }
-    
+
     fileprivate func overflowIndicators() {
         addScrollHint(for: .leftSide, maskLayer: leftOverflowIndicator)
         addScrollHint(for: .rightSide, maskLayer: rightOverflowIndicator)
-        
+
         let offset = Float(collectionView.contentOffset.x)
         let startFade = Float(30)
         leftOverflowIndicator.opacity = min(1, offset / startFade)
-        
+
         // all the way scrolled right
         let offsetFromRight = collectionView.contentSize.width - CGFloat(offset) - collectionView.frame.width
         rightOverflowIndicator.opacity = min(1, Float(offsetFromRight) / startFade)
     }
-    
+
     private enum HintSide { case leftSide, rightSide }
-    
+
     private func addScrollHint(for side: HintSide, maskLayer: CAGradientLayer) {
         maskLayer.removeFromSuperlayer()
-        
+
         let barsColor = UIApplication.isInPrivateMode ?
             UX.barsDarkBackgroundSolidColor : UX.barsBackgroundSolidColor
         let colors = [barsColor.withAlphaComponent(0).cgColor, barsColor.cgColor]
-        
+
         let locations = [0.9, 1.0]
         maskLayer.startPoint = CGPoint(x: side == .rightSide ? 0 : 1.0, y: 0.5)
         maskLayer.endPoint = CGPoint(x: side == .rightSide ? 1.0 : 0, y: 0.5)
@@ -234,7 +234,7 @@ extension TabsBarViewController: UICollectionViewDelegate {
 extension TabsBarViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let tabCount = CGFloat(tabList.count())
-        
+
         if tabCount < 1 { return CGSize.zero }
         if tabCount == 1 { return collectionView.frame.size }
         
@@ -243,59 +243,59 @@ extension TabsBarViewController: UICollectionViewDelegateFlowLayout {
             let maxWidth = collectionView.frame.width / tabCount
             return CGSize(width: maxWidth, height: view.frame.height)
         }
-        
+
         return CGSize(width: UX.TabsBar.minimumWidth, height: view.frame.height)
     }
 }
 
 // MARK: - UICollectionViewDataSource
 extension TabsBarViewController: UICollectionViewDataSource {
-    
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return tabList.count()
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
         return true
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TabCell", for: indexPath) as? TabBarCell
             else { return UICollectionViewCell() }
         guard let tab = tabList[indexPath.row] else { return cell }
-        
+
         cell.tabManager = tabManager
         cell.tab = tab
         cell.titleLabel.text = tab.displayTitle
         cell.currentIndex = indexPath.row
         cell.separatorLineRight.isHidden = (indexPath.row != tabList.count() - 1)
-        
+
         cell.closeTabCallback = { [weak self] tab in
             guard let strongSelf = self, let tabManager = strongSelf.tabManager, let previousIndex = strongSelf.tabList.index(of: tab) else { return }
-            
+
             tabManager.removeTab(tab)
             strongSelf.updateData()
-            
+
             let previousOrNext = max(0, previousIndex - 1)
             tabManager.selectTab(strongSelf.tabList[previousOrNext])
-            
+
             strongSelf.collectionView.selectItem(at: IndexPath(row: previousOrNext, section: 0), animated: true, scrollPosition: .centeredHorizontally)
         }
-        
+
         return cell
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         guard let manager = tabManager, let fromTab = tabList[sourceIndexPath.row],
             let toTab = tabList[destinationIndexPath.row] else { return }
-        
+
         // Find original from/to index... we need to target the full list not partial.
         guard let from = manager.tabs.index(where: {$0 === fromTab}),
             let to = manager.tabs.index(where: {$0 === toTab}) else { return }
-        
-        manager.moveTab(isPrivate: UIApplication.isInPrivateMode, fromIndex: from, toIndex: to)
+
+        manager.moveTab(fromIndex: from, toIndex: to)
         updateData()
-        
+
         guard let selectedTab = tabList[destinationIndexPath.row] else { return }
         manager.selectTab(selectedTab)
     }
@@ -307,16 +307,16 @@ extension TabsBarViewController: TabManagerDelegate {
         assert(Thread.current.isMainThread)
         updateData()
     }
-    
+
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {
         updateData()
     }
-    
+
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab) {
         assert(Thread.current.isMainThread)
         updateData()
     }
-    
+
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
         assert(Thread.current.isMainThread)
         updateData()
@@ -325,9 +325,17 @@ extension TabsBarViewController: TabManagerDelegate {
 
 extension TabsBarViewController: Themeable {
     func applyTheme(_ theme: Theme) {
-        view.backgroundColor = theme == .Private ? BraveUX.Black : BraveUX.GreyB
-        plusButton.tintColor = theme == .Private ? UIColor.white : BraveUX.GreyI
+        switch theme {
+        case .regular:
+            view.backgroundColor = BraveUX.GreyB
+            plusButton.tintColor = BraveUX.GreyI
+            bottomLine.backgroundColor = UIColor(white: 0.0, alpha: 0.2)
+        case .private:
+            view.backgroundColor = BraveUX.Black
+            plusButton.tintColor = UIColor.white
+            bottomLine.backgroundColor = UIColor(white: 1.0, alpha: 0.2)
+        }
+
         collectionView.backgroundColor = view.backgroundColor
-        bottomLine.backgroundColor = theme == .Private ? UIColor(white: 1.0, alpha: 0.2) : UIColor(white: 0.0, alpha: 0.2)
     }
 }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -14,7 +14,7 @@ private struct URLBarViewUX {
     static let LocationContentOffset: CGFloat = 8
     static let TextFieldCornerRadius: CGFloat = 8
     static let ProgressBarHeight: CGFloat = 3
-
+    
     static let TabsButtonRotationOffset: CGFloat = 1.5
     static let TabsButtonHeight: CGFloat = 18.0
     static let ToolbarButtonInsets = UIEdgeInsets(equalInset: Padding)
@@ -57,19 +57,19 @@ class URLBarView: UIView {
             }
         }
     }
-
-    fileprivate var currentTheme: Theme = .Normal
-
+    
+    fileprivate var currentTheme: Theme = .regular
+    
     var toolbarIsShowing = false
-
+    
     fileprivate var locationTextField: ToolbarTextField?
-
+    
     /// Overlay mode is the state where the lock/reader icons are hidden, the home panels are shown,
     /// and the Cancel button is visible (allowing the user to leave overlay mode). Overlay mode
     /// is *not* tied to the location text field's editing state; for instance, when selecting
     /// a panel, the first responder will be resigned, yet the overlay mode UI is still active.
     var inOverlayMode = false
-
+    
     lazy var locationView: TabLocationView = {
         let locationView = TabLocationView()
         locationView.translatesAutoresizingMaskIntoConstraints = false
@@ -77,7 +77,7 @@ class URLBarView: UIView {
         locationView.delegate = self
         return locationView
     }()
-
+    
     lazy var locationContainer: UIView = {
         let locationContainer = TabLocationContainerView()
         locationContainer.translatesAutoresizingMaskIntoConstraints = false
@@ -86,19 +86,19 @@ class URLBarView: UIView {
     }()
     
     let line = UIView()
-
+    
     lazy var tabsButton: TabsButton = {
         let tabsButton = TabsButton.tabTrayButton()
         tabsButton.accessibilityIdentifier = "URLBarView.tabsButton"
         return tabsButton
     }()
-
+    
     fileprivate lazy var progressBar: GradientProgressBar = {
         let progressBar = GradientProgressBar()
         progressBar.clipsToBounds = false
         return progressBar
     }()
-
+    
     fileprivate lazy var cancelButton: UIButton = {
         let cancelButton = InsetButton()
         cancelButton.setTitle(Strings.Cancel, for: .normal)
@@ -121,7 +121,7 @@ class URLBarView: UIView {
         button.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .horizontal)
         return button
     }()
-
+    
     fileprivate lazy var scrollToTopButton: UIButton = {
         let button = UIButton()
         button.addTarget(self, action: #selector(tappedScrollToTopArea), for: .touchUpInside)
@@ -162,7 +162,7 @@ class URLBarView: UIView {
         get {
             return locationView.url as URL?
         }
-
+        
         set(newURL) {
             locationView.url = newURL
             refreshShieldsStatus()
@@ -178,7 +178,7 @@ class URLBarView: UIView {
             shieldsButton.setImage(UIImage(imageLiteralResourceName: "shields-menu-icon"), for: .normal)
         }
     }
-
+    
     var hasOnlySecureContent: Bool {
         get {
             return locationView.hasOnlySecureContent
@@ -187,17 +187,17 @@ class URLBarView: UIView {
             locationView.hasOnlySecureContent = newValue
         }
     }
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         commonInit()
     }
-
+    
     fileprivate func commonInit() {
         locationContainer.addSubview(locationView)
     
@@ -206,11 +206,11 @@ class URLBarView: UIView {
         
         helper = TabToolbarHelper(toolbar: self)
         setupConstraints()
-
+        
         // Make sure we hide any views that shouldn't be showing in non-overlay mode.
         updateViewsForOverlayModeAndToolbarChanges()
     }
-
+    
     fileprivate func setupConstraints() {
         
         line.snp.makeConstraints { make in
@@ -222,13 +222,13 @@ class URLBarView: UIView {
             make.top.equalTo(self)
             make.left.right.equalTo(self.locationContainer)
         }
-
+        
         progressBar.snp.makeConstraints { make in
             make.top.equalTo(self.snp.bottom).inset(URLBarViewUX.ProgressBarHeight / 2)
             make.height.equalTo(URLBarViewUX.ProgressBarHeight)
             make.left.right.equalTo(self)
         }
-
+        
         locationView.snp.makeConstraints { make in
             make.edges.equalTo(self.locationContainer)
         }
@@ -244,7 +244,7 @@ class URLBarView: UIView {
             make.centerY.equalTo(self)
             make.size.equalTo(URLBarViewUX.ButtonHeight)
         }
-
+        
         forwardButton.snp.makeConstraints { make in
             make.leading.equalTo(self.backButton.snp.trailing)
             make.centerY.equalTo(self)
@@ -277,7 +277,7 @@ class URLBarView: UIView {
         }
          */
     }
-
+    
     override func updateConstraints() {
         super.updateConstraints()
         if inOverlayMode {
@@ -336,18 +336,18 @@ class URLBarView: UIView {
                 make.edges.equalTo(self.locationContainer)
             }
         }
-
+        
     }
     
     @objc func showQRScanner() {
         self.delegate?.urlBarDidPressQRButton(self)
     }
-
+    
     func createLocationTextField() {
         guard locationTextField == nil else { return }
-
+        
         locationTextField = ToolbarTextField()
-
+        
         guard let locationTextField = locationTextField else { return }
         
         locationTextField.translatesAutoresizingMaskIntoConstraints = false
@@ -369,16 +369,16 @@ class URLBarView: UIView {
         
         locationTextField.applyTheme(currentTheme)
     }
-
+    
     override func becomeFirstResponder() -> Bool {
         return self.locationTextField?.becomeFirstResponder() ?? false
     }
-
+    
     func removeLocationTextField() {
         locationTextField?.removeFromSuperview()
         locationTextField = nil
     }
-
+    
     // Ideally we'd split this implementation in two, one URLBarView with a toolbar and one without
     // However, switching views dynamically at runtime is a difficult. For now, we just use one view
     // that can show in either mode.
@@ -392,31 +392,31 @@ class URLBarView: UIView {
         }
         updateViewsForOverlayModeAndToolbarChanges()
     }
-
+    
     func updateAlphaForSubviews(_ alpha: CGFloat) {
         locationContainer.alpha = alpha
         self.alpha = alpha
     }
-
+    
     func updateProgressBar(_ progress: Float) {
         progressBar.alpha = 1
         progressBar.isHidden = false
         progressBar.setProgress(progress, animated: !isTransitioning)
     }
-
+    
     func hideProgressBar() {
         progressBar.isHidden = true
         progressBar.setProgress(0, animated: false)
     }
-
+    
     func updateReaderModeState(_ state: ReaderModeState) {
         locationView.readerModeState = state
     }
-
+    
     func setAutocompleteSuggestion(_ suggestion: String?) {
         locationTextField?.setAutocompleteSuggestion(suggestion)
     }
-
+    
     func setLocation(_ location: String?, search: Bool) {
         guard let text = location, !text.isEmpty else {
             locationTextField?.text = location
@@ -430,16 +430,16 @@ class URLBarView: UIView {
             locationTextField?.setTextWithoutSearching(text)
         }
     }
-
+    
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
         createLocationTextField()
-
+        
         // Show the overlay mode UI, which includes hiding the locationView and replacing it
         // with the editable locationTextField.
         animateToOverlayState(overlayMode: true)
-
+        
         delegate?.urlBarDidEnterOverlayMode(self)
-
+        
         // Bug 1193755 Workaround - Calling becomeFirstResponder before the animation happens
         // won't take the initial frame of the label into consideration, which makes the label
         // look squished at the start of the animation and expand to be correct. As a workaround,
@@ -461,13 +461,13 @@ class URLBarView: UIView {
             }
         }
     }
-
+    
     func leaveOverlayMode(didCancel cancel: Bool = false) {
         locationTextField?.resignFirstResponder()
         animateToOverlayState(overlayMode: false, didCancel: cancel)
         delegate?.urlBarDidLeaveOverlayMode(self)
     }
-
+    
     func prepareOverlayAnimation() {
         // Make sure everything is showing during the transition (we'll hide it afterwards).
         bringSubview(toFront: self.locationContainer)
@@ -480,7 +480,7 @@ class URLBarView: UIView {
         shareButton.isHidden = !toolbarIsShowing
         locationView.contentView.isHidden = false
     }
-
+    
     func transitionToOverlay(_ didCancel: Bool = false) {
         cancelButton.alpha = inOverlayMode ? 1 : 0
         showQRScannerButton.alpha = inOverlayMode ? 1 : 0
@@ -504,7 +504,7 @@ class URLBarView: UIView {
             }
         }
     }
-
+    
     func updateViewsForOverlayModeAndToolbarChanges() {
         cancelButton.isHidden = !inOverlayMode
         showQRScannerButton.isHidden = !inOverlayMode
@@ -515,17 +515,17 @@ class URLBarView: UIView {
         shareButton.isHidden = !toolbarIsShowing || inOverlayMode
         locationView.contentView.isHidden = inOverlayMode
     }
-
+    
     func animateToOverlayState(overlayMode overlay: Bool, didCancel cancel: Bool = false) {
         prepareOverlayAnimation()
         layoutIfNeeded()
-
+        
         inOverlayMode = overlay
-
+        
         if !overlay {
             removeLocationTextField()
         }
-
+        
         UIView.animate(withDuration: 0.3, delay: 0.0, usingSpringWithDamping: 0.85, initialSpringVelocity: 0.0, options: [], animations: {
             self.transitionToOverlay(cancel)
             self.setNeedsUpdateConstraints()
@@ -534,15 +534,15 @@ class URLBarView: UIView {
             self.updateViewsForOverlayModeAndToolbarChanges()
         })
     }
-
+    
     func didClickAddTab() {
         delegate?.urlBarDidPressTabs(self)
     }
-
+    
     @objc func didClickCancel() {
         leaveOverlayMode(didCancel: true)
     }
-
+    
     @objc func tappedScrollToTopArea() {
         delegate?.urlBarDidPressScrollToTop(self)
     }
@@ -561,11 +561,11 @@ extension URLBarView: TabToolbarProtocol {
     func updateBackStatus(_ canGoBack: Bool) {
         backButton.isEnabled = canGoBack
     }
-
+    
     func updateForwardStatus(_ canGoForward: Bool) {
         forwardButton.isEnabled = canGoForward
     }
-
+    
     func updateTabCount(_ count: Int, animated: Bool = true) {
         tabsButton.updateTabCount(count, animated: animated)
     }
@@ -574,7 +574,7 @@ extension URLBarView: TabToolbarProtocol {
         locationView.reloadButton.isEnabled = isWebPage
         shareButton.isEnabled = isWebPage
     }
-
+    
     var access: [Any]? {
         get {
             if inOverlayMode {
@@ -598,10 +598,10 @@ extension URLBarView: TabLocationViewDelegate {
     func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool {
         return delegate?.urlBarDidLongPressReaderMode(self) ?? false
     }
-
+    
     func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {
         guard let (locationText, isSearchQuery) = delegate?.urlBarDisplayTextForURL(locationView.url as URL?) else { return }
-
+        
         var overlayText = locationText
         // Make sure to use the result from urlBarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
         if let text = locationText, let url = URL(string: text), let host = url.host, AppConstants.MOZ_PUNYCODE {
@@ -609,11 +609,11 @@ extension URLBarView: TabLocationViewDelegate {
         }
         enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)
     }
-
+    
     func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {
         delegate?.urlBarDidLongPressLocation(self)
     }
-
+    
     func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView) {
         delegate?.urlBarDidPressReload(self)
     }
@@ -637,7 +637,7 @@ extension URLBarView: TabLocationViewDelegate {
     func tabLocationViewLocationAccessibilityActions(_ tabLocationView: TabLocationView) -> [UIAccessibilityCustomAction]? {
         return delegate?.urlBarLocationAccessibilityActions(self)
     }
-
+    
     func tabLocationViewDidBeginDragInteraction(_ tabLocationView: TabLocationView) {
         delegate?.urlBarDidBeginDragInteraction(self)
     }
@@ -653,20 +653,20 @@ extension URLBarView: AutocompleteTextFieldDelegate {
             return false
         }
     }
-
+    
     func autocompleteTextField(_ autocompleteTextField: AutocompleteTextField, didEnterText text: String) {
         delegate?.urlBar(self, didEnterText: text)
     }
-
+    
     func autocompleteTextFieldDidBeginEditing(_ autocompleteTextField: AutocompleteTextField) {
         autocompleteTextField.highlightAll()
     }
-
+    
     func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool {
         delegate?.urlBar(self, didEnterText: "")
         return true
     }
-
+    
     func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField) {
         leaveOverlayMode(didCancel: true)
     }
@@ -674,7 +674,7 @@ extension URLBarView: AutocompleteTextFieldDelegate {
 
 // MARK: UIAppearance
 extension URLBarView {
-
+    
     @objc dynamic var cancelTintColor: UIColor? {
         get { return cancelButton.tintColor }
         set { return cancelButton.tintColor = newValue }
@@ -684,22 +684,27 @@ extension URLBarView {
         get { return showQRScannerButton.tintColor }
         set { return showQRScannerButton.tintColor = newValue }
     }
-
+    
 }
 
 extension URLBarView: Themeable {
-
+    
     func applyTheme(_ theme: Theme) {
         locationView.applyTheme(theme)
         locationTextField?.applyTheme(theme)
         actionButtons.forEach { $0.applyTheme(theme) }
         tabsButton.applyTheme(theme)
-
+        
         progressBar.setGradientColors(startColor: UIColor.LoadingBar.Start.colorFor(theme), endColor: UIColor.LoadingBar.End.colorFor(theme))
         currentTheme = theme
         cancelTintColor = UIColor.Browser.Tint.colorFor(theme)
         showQRButtonTintColor = UIColor.Browser.Tint.colorFor(theme)
-        backgroundColor = theme == .Normal ? BraveUX.ToolbarsBackgroundSolidColor : BraveUX.DarkToolbarsBackgroundSolidColor
+        switch theme {
+        case .regular:
+            backgroundColor = BraveUX.ToolbarsBackgroundSolidColor
+        case .private:
+            backgroundColor = BraveUX.DarkToolbarsBackgroundSolidColor
+        }
         line.backgroundColor = UIColor.Browser.URLBarDivider.colorFor(theme)
     }
 }
@@ -725,7 +730,7 @@ class TabLocationContainerView: UIView {
 }
 
 class ToolbarTextField: AutocompleteTextField {
-
+    
     @objc dynamic var clearButtonTintColor: UIColor? {
         didSet {
             // Clear previous tinted image that's cache and ask for a relayout
@@ -733,20 +738,20 @@ class ToolbarTextField: AutocompleteTextField {
             setNeedsLayout()
         }
     }
-
+    
     fileprivate var tintedClearImage: UIImage?
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     override func layoutSubviews() {
         super.layoutSubviews()
-
+        
         // Since we're unable to change the tint color of the clear image, we need to iterate through the
         // subviews, find the clear button, and tint it ourselves. Thanks to Mikael Hellman for the tip:
         // http://stackoverflow.com/questions/27944781/how-to-change-the-tint-color-of-the-clear-button-on-a-uitextfield
@@ -756,7 +761,7 @@ class ToolbarTextField: AutocompleteTextField {
                     if tintedClearImage == nil {
                         tintedClearImage = tintImage(image, color: clearButtonTintColor)
                     }
-
+                    
                     if button.imageView?.image != tintedClearImage {
                         button.setImage(tintedClearImage, for: [])
                     }
@@ -764,20 +769,20 @@ class ToolbarTextField: AutocompleteTextField {
             }
         }
     }
-
+    
     fileprivate func tintImage(_ image: UIImage, color: UIColor?) -> UIImage {
         guard let color = color else { return image }
-
+        
         let size = image.size
-
+        
         UIGraphicsBeginImageContextWithOptions(size, false, 2)
         let context = UIGraphicsGetCurrentContext()!
         image.draw(at: .zero, blendMode: .normal, alpha: 1.0)
-
+        
         context.setFillColor(color.cgColor)
         context.setBlendMode(.sourceIn)
         context.setAlpha(1.0)
-
+        
         let rect = CGRect(size: image.size)
         context.fill(rect)
         let tintedImage = UIGraphicsGetImageFromCurrentImageContext()!
@@ -788,9 +793,15 @@ class ToolbarTextField: AutocompleteTextField {
 }
 
 extension ToolbarTextField: Themeable {
-
+    
     func applyTheme(_ theme: Theme) {
-        backgroundColor = theme == .Normal ? BraveUX.LocationBarBackgroundColor : BraveUX.LocationBarBackgroundColor_PrivateMode
+        switch theme {
+        case .regular:
+            backgroundColor = BraveUX.LocationBarBackgroundColor
+        case .private:
+            backgroundColor = BraveUX.LocationBarBackgroundColor_PrivateMode
+        }
+
         textColor = UIColor.TextField.TextAndTint.colorFor(theme)
         clearButtonTintColor = textColor
         highlightColor = UIColor.TextField.Highlight.colorFor(theme)

--- a/Client/Frontend/Home/ActivityStreamPanel.swift
+++ b/Client/Frontend/Home/ActivityStreamPanel.swift
@@ -6,7 +6,6 @@ import Shared
 import UIKit
 import Deferred
 import Storage
-import SDWebImage
 import XCGLogger
 import SnapKit
 

--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import SDWebImage
 import Storage
 
 private struct TopSiteCellUX {

--- a/Client/Frontend/Menu/BookmarksViewController.swift
+++ b/Client/Frontend/Menu/BookmarksViewController.swift
@@ -662,7 +662,7 @@ extension BookmarksViewController {
       actionsForFolder(bookmark).forEach { alert.addAction($0) }
     } else {
       alert.title = bookmark.url?.replacingOccurrences(of: "mailto:", with: "").ellipsize(maxLength: ActionSheetTitleMaxLength)
-      actionsForBookmark(bookmark, currentTabIsPrivate: tabState.isPrivate).forEach { alert.addAction($0) }
+      actionsForBookmark(bookmark, currentTabIsPrivate: tabState.type.isPrivate).forEach { alert.addAction($0) }
     }
     
     let cancelAction = UIAlertAction(title: Strings.Cancel, style: .cancel, handler: nil)

--- a/Client/Frontend/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Menu/HistoryViewController.swift
@@ -278,7 +278,7 @@ extension HistoryViewController {
     let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
     
     alert.title = history.url?.replacingOccurrences(of: "mailto:", with: "").ellipsize(maxLength: ActionSheetTitleMaxLength)
-    actionsForHistory(history, currentTabIsPrivate: tabState.isPrivate).forEach { alert.addAction($0) }
+    actionsForHistory(history, currentTabIsPrivate: tabState.type.isPrivate).forEach { alert.addAction($0) }
     
     let cancelAction = UIAlertAction(title: Strings.Cancel, style: .cancel, handler: nil)
     alert.addAction(cancelAction)

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -288,4 +288,14 @@ class ReaderMode: TabContentScript {
             }
         }
     }
+
+    static func cache(for tab: Tab?) -> ReaderModeCache {
+        switch TabType.of(tab) {
+        case .regular:
+            return DiskReaderModeCache.sharedInstance
+        case .private:
+            return MemoryReaderModeCache.sharedInstance
+        }
+    }
+
 }

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
-import SDWebImage
 import Shared
 
 protocol SearchEnginePickerDelegate: class {

--- a/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -55,7 +55,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
     fileprivate var interstitialErrorView: UILabel!
 
     // The web view that displays content.
-    var webView: WKWebView!
+    var webView: BraveWebView!
 
     fileprivate func startLoading(_ timeout: Double = DefaultTimeoutTimeInterval) {
         if self.isLoaded {
@@ -106,12 +106,9 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
         startLoading()
     }
 
-    func makeWebView() -> WKWebView {
-        let config = WKWebViewConfiguration()
-        let webView = WKWebView(
-            frame: CGRect(width: 1, height: 1),
-            configuration: config
-        )
+    func makeWebView() -> BraveWebView {
+        let frame = CGRect(width: 1, height: 1)
+        let webView = BraveWebView(frame: frame)
         webView.allowsLinkPreview = false
         webView.navigationDelegate = self
         return webView

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -25,7 +25,7 @@ struct BrowserColor {
     }
 
     func colorFor(_ theme: Theme) -> UIColor {
-        return color(isPBM: theme == .Private)
+        return color(isPBM: theme.isPrivate)
     }
 }
 

--- a/Client/Frontend/Widgets/Theme.swift
+++ b/Client/Frontend/Widgets/Theme.swift
@@ -1,13 +1,54 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import Foundation
 
 protocol Themeable {
+    
     func applyTheme(_ theme: Theme)
+    
 }
 
 enum Theme: String {
-    case Private
-    case Normal
+    
+    /// Regular browsing.
+    case regular
+
+    /// Private browsing.
+    case `private`
+    
+    /// Textual representation suitable for debugging.
+    var debugDescription: String {
+        switch self {
+        case .regular:
+            return "Regular theme"
+        case .private:
+            return "Private theme"
+        }
+    }
+
+    /// Returns whether the theme is private or not.
+    var isPrivate: Bool {
+        switch self {
+        case .regular:
+            return false
+        case .private:
+            return true
+        }
+    }
+    
+    /// Returns the theme of the given Tab, if the tab is nil returns a regular theme.
+    ///
+    /// - parameter tab: An object representing a Tab.
+    /// - returns: A Tab theme.
+    static func of(_ tab: Tab?) -> Theme {
+        switch TabType.of(tab) {
+        case .regular:
+            return .regular
+        case .private:
+            return .private
+        }
+    }
+    
 }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -29,12 +29,12 @@ open class MockTabManagerStateDelegate: TabManagerStateDelegate {
 struct MethodSpy {
     let functionName: String
     let method: ((_ tabs: [Tab?]) -> Void)?
-
+    
     init(functionName: String) {
         self.functionName = functionName
         self.method = nil
     }
-
+    
     init(functionName: String, method: ((_ tabs: [Tab?]) -> Void)?) {
         self.functionName = functionName
         self.method = method
@@ -42,20 +42,20 @@ struct MethodSpy {
 }
 
 open class MockTabManagerDelegate: TabManagerDelegate {
-
+    
     //this array represents the order in which delegate methods should be called.
     //each delegate method will pop the first struct from the array. If the method name doesn't match the struct then the order is incorrect
     //Then it evaluates the method closure which will return true/false depending on if the tabs are correct
     var methodCatchers: [MethodSpy] = []
-
+    
     func expect(_ methods: [MethodSpy]) {
         self.methodCatchers = methods
     }
-
+    
     func verify(_ message: String) {
         XCTAssertTrue(methodCatchers.isEmpty, message)
     }
-
+    
     func testDelegateMethodWithName(_ name: String, tabs: [Tab?]) {
         guard let spy = self.methodCatchers.first else {
             XCTAssert(false, "No method was availible in the queue. For the delegate method \(name) to use")
@@ -67,77 +67,77 @@ open class MockTabManagerDelegate: TabManagerDelegate {
         }
         methodCatchers.removeFirst()
     }
-
+    
     public func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
         testDelegateMethodWithName(#function, tabs: [selected, previous])
     }
-
+    
     public func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {
         testDelegateMethodWithName(#function, tabs: [tab])
     }
-
+    
     public func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab) {
         testDelegateMethodWithName(#function, tabs: [tab])
     }
-
+    
     public func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
         testDelegateMethodWithName(#function, tabs: [])
     }
-
+    
     public func tabManager(_ tabManager: TabManager, willRemoveTab tab: Tab) {
         testDelegateMethodWithName(#function, tabs: [tab])
     }
-
+    
     public func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {
         testDelegateMethodWithName(#function, tabs: [tab])
     }
-
+    
     public func tabManagerDidAddTabs(_ tabManager: TabManager) {
         testDelegateMethodWithName(#function, tabs: [])
     }
-
+    
     public func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
         testDelegateMethodWithName(#function, tabs: [])
     }
 }
 
 class TabManagerTests: XCTestCase {
-
+    
     let willRemove = MethodSpy(functionName: "tabManager(_:willRemoveTab:)")
     let didRemove = MethodSpy(functionName: "tabManager(_:didRemoveTab:)")
     let willAdd = MethodSpy(functionName: "tabManager(_:willAddTab:)")
     let didAdd = MethodSpy(functionName: "tabManager(_:didAddTab:)")
-
+    
     override func setUp() {
         super.setUp()
     }
-
+    
     override func tearDown() {
         super.tearDown()
     }
-
+    
     // BRAVE TODO: We no longer "store tabs", happens async from CoreData, so this test has to reflect CD instead
     /*
-    func testTabManagerCallsTabManagerStateDelegateOnStoreChangesWithNormalTabs() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        let stateDelegate = MockTabManagerStateDelegate()
-        manager.stateDelegate = stateDelegate
-        let configuration = WKWebViewConfiguration()
-        configuration.processPool = WKProcessPool()
-
-        // test that non-private tabs are saved to the db
-        // add some non-private tabs to the tab manager
-        for _ in 0..<3 {
-            let tab = Tab(configuration: configuration)
-            tab.url = URL(string: "http://yahoo.com")!
-            manager.configureTab(tab, request: URLRequest(url: tab.url!), flushToDisk: false, zombie: false)
-        }
-        
-        XCTAssertEqual(stateDelegate.numberOfTabsStored, 3, "Expected state delegate to have been called with 3 tabs, but called with \(stateDelegate.numberOfTabsStored)")
-    }
+     func testTabManagerCallsTabManagerStateDelegateOnStoreChangesWithNormalTabs() {
+     let profile = TabManagerMockProfile()
+     let manager = TabManager(prefs: profile.prefs, imageStore: nil)
+     let stateDelegate = MockTabManagerStateDelegate()
+     manager.stateDelegate = stateDelegate
+     let configuration = WKWebViewConfiguration()
+     configuration.processPool = WKProcessPool()
+     
+     // test that non-private tabs are saved to the db
+     // add some non-private tabs to the tab manager
+     for _ in 0..<3 {
+     let tab = Tab(configuration: configuration)
+     tab.url = URL(string: "http://yahoo.com")!
+     manager.configureTab(tab, request: URLRequest(url: tab.url!), flushToDisk: false, zombie: false)
+     }
+     
+     XCTAssertEqual(stateDelegate.numberOfTabsStored, 3, "Expected state delegate to have been called with 3 tabs, but called with \(stateDelegate.numberOfTabsStored)")
+     }
      */
-
+    
     func testTabManagerDoesNotCallTabManagerStateDelegateOnStoreChangesWithPrivateTabs() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
@@ -145,39 +145,39 @@ class TabManagerTests: XCTestCase {
         manager.stateDelegate = stateDelegate
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
-
+        
         // test that non-private tabs are saved to the db
         // add some non-private tabs to the tab manager
         for _ in 0..<3 {
-            let tab = Tab(configuration: configuration, isPrivate: true)
+            let tab = Tab(configuration: configuration, type: .private)
             tab.url = URL(string: "http://yahoo.com")!
             manager.configureTab(tab, request: URLRequest(url: tab.url!), flushToDisk: false, zombie: false)
         }
-
+        
         XCTAssertEqual(stateDelegate.numberOfTabsStored, 0, "Expected state delegate to have been called with 3 tabs, but called with \(stateDelegate.numberOfTabsStored)")
     }
-
+    
     func testAddTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
-
+        
         delegate.expect([willAdd, didAdd])
         manager.addTab()
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     func testDidDeleteLastTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         let tab = manager.addTab()
         manager.selectTab(tab)
         manager.addDelegate(delegate)
-
+        
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
@@ -189,19 +189,19 @@ class TabManagerTests: XCTestCase {
         manager.removeTab(tab)
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     func testDidDeleteLastPrivateTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         let tab = manager.addTab()
         manager.selectTab(tab)
         let privateTab = manager.addTab(isPrivate: true)
         manager.selectTab(privateTab)
         manager.addDelegate(delegate)
-
+        
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
@@ -215,85 +215,85 @@ class TabManagerTests: XCTestCase {
         manager.removeTab(privateTab)
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     func testDeletePrivateTabsOnExit() {
         //setup
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
-
+        
         // create one private and one normal tab
         let tab = manager.addTab()
         manager.selectTab(tab)
         manager.selectTab(manager.addTab(isPrivate: true))
-
-        XCTAssertEqual(manager.selectedTab?.isPrivate, true, "The selected tab should be the private tab")
-        XCTAssertEqual(manager.privateTabs.count, 1, "There should only be one private tab")
-
+        
+        XCTAssertEqual(TabType.of(manager.selectedTab).isPrivate, true, "The selected tab should be the private tab")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 1, "There should only be one private tab")
+        
         manager.selectTab(tab)
-        XCTAssertEqual(manager.privateTabs.count, 0, "If the normal tab is selected the private tab should have been deleted")
-        XCTAssertEqual(manager.normalTabs.count, 1, "The regular tab should stil be around")
-
+        XCTAssertEqual(manager.tabs(withType: .private).count, 0, "If the normal tab is selected the private tab should have been deleted")
+        XCTAssertEqual(manager.tabs(withType: .regular).count, 1, "The regular tab should stil be around")
+        
         manager.selectTab(manager.addTab(isPrivate: true))
-        XCTAssertEqual(manager.privateTabs.count, 1, "There should be one new private tab")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 1, "There should be one new private tab")
         manager.willSwitchTabMode(leavingPBM: true)
-        XCTAssertEqual(manager.privateTabs.count, 0, "After willSwitchTabMode there should be no more private tabs")
-
+        XCTAssertEqual(manager.tabs(withType: .private).count, 0, "After willSwitchTabMode there should be no more private tabs")
+        
         manager.selectTab(manager.addTab(isPrivate: true))
         manager.selectTab(manager.addTab(isPrivate: true))
-        XCTAssertEqual(manager.privateTabs.count, 2, "Private tabs should not be deleted when another one is added")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 2, "Private tabs should not be deleted when another one is added")
         manager.selectTab(manager.addTab())
-        XCTAssertEqual(manager.privateTabs.count, 0, "But once we add a normal tab we've switched out of private mode. Private tabs should be deleted")
-        XCTAssertEqual(manager.normalTabs.count, 2, "The original normal tab and the new one should both still exist")
-
+        XCTAssertEqual(manager.tabs(withType: .private).count, 0, "But once we add a normal tab we've switched out of private mode. Private tabs should be deleted")
+        XCTAssertEqual(manager.tabs(withType: .regular).count, 2, "The original normal tab and the new one should both still exist")
+        
         profile.prefs.setBool(false, forKey: "settings.closePrivateTabs")
         manager.selectTab(manager.addTab(isPrivate: true))
         manager.selectTab(tab)
-        XCTAssertEqual(manager.selectedTab?.isPrivate, false, "The selected tab should not be private")
-        XCTAssertEqual(manager.privateTabs.count, 1, "If the flag is false then private tabs should still exist")
+        XCTAssertEqual(TabType.of(manager.selectedTab).isPrivate, false, "The selected tab should not be private")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 1, "If the flag is false then private tabs should still exist")
     }
-
+    
     func testTogglePBMDelete() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
-
+        
         let tab = manager.addTab()
         manager.selectTab(tab)
         manager.selectTab(manager.addTab())
         manager.selectTab(manager.addTab(isPrivate: true))
-
+        
         manager.willSwitchTabMode(leavingPBM: false)
-        XCTAssertEqual(manager.privateTabs.count, 1, "There should be 1 private tab")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 1, "There should be 1 private tab")
         manager.willSwitchTabMode(leavingPBM: true)
-        XCTAssertEqual(manager.privateTabs.count, 0, "There should be 0 private tab")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 0, "There should be 0 private tab")
         manager.removeTab(tab)
-        XCTAssertEqual(manager.normalTabs.count, 1, "There should be 1 normal tab")
+        XCTAssertEqual(manager.tabs(withType: .regular).count, 1, "There should be 1 normal tab")
     }
-
+    
     func testDeleteNonSelectedTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         let tab = manager.addTab()
         manager.selectTab(tab)
         manager.addTab()
         let deleteTab = manager.addTab()
         manager.addDelegate(delegate)
-
+        
         delegate.expect([willRemove, didRemove])
         manager.removeTab(deleteTab)
-
+        
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     func testDeleteSelectedTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         func addTab(_ visit: Bool) -> Tab {
             let tab = manager.addTab()
             if visit {
@@ -301,47 +301,47 @@ class TabManagerTests: XCTestCase {
             }
             return tab
         }
-
+        
         let tab0 = addTab(false) // not visited
         let tab1 = addTab(true)
         let tab2 = addTab(true)
         let tab3 = addTab(true)
         let tab4 = addTab(false) // not visited
-
+        
         // starting at tab1, we should be selecting
         // [ tab3, tab4, tab2, tab0 ]
-
+        
         manager.selectTab(tab1)
         tab1.parent = tab3
         manager.removeTab(manager.selectedTab!)
         // Rule: parent tab if it was the most recently visited
         XCTAssertEqual(manager.selectedTab, tab3)
-
+        
         manager.removeTab(manager.selectedTab!)
         // Rule: next to the right.
         XCTAssertEqual(manager.selectedTab, tab4)
-
+        
         manager.removeTab(manager.selectedTab!)
         // Rule: next to the left, when none to the right
         XCTAssertEqual(manager.selectedTab, tab2)
-
+        
         manager.removeTab(manager.selectedTab!)
         // Rule: last one left.
         XCTAssertEqual(manager.selectedTab, tab0)
     }
-
+    
     func testDeleteLastTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         (0..<10).forEach {_ in manager.addTab() }
         manager.selectTab(manager.tabs.last)
         let deleteTab = manager.tabs.last
         let newSelectedTab = manager.tabs[8]
         manager.addDelegate(delegate)
-
+        
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
@@ -350,64 +350,64 @@ class TabManagerTests: XCTestCase {
         }
         delegate.expect([willRemove, didRemove, didSelect])
         manager.removeTab(manager.tabs.last!)
-
+        
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     func testDelegatesCalledWhenRemovingPrivateTabs() {
         //setup
         let profile = TabManagerMockProfile()
         let delegate = MockTabManagerDelegate()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
-
+        
         // create one private and one normal tab
         let tab = manager.addTab()
         let newTab = manager.addTab()
         manager.selectTab(tab)
         manager.selectTab(manager.addTab(isPrivate: true))
         manager.addDelegate(delegate)
-
+        
         // Double check a few things
-        XCTAssertEqual(manager.selectedTab?.isPrivate, true, "The selected tab should be the private tab")
-        XCTAssertEqual(manager.privateTabs.count, 1, "There should only be one private tab")
-
+        XCTAssertEqual(TabType.of(manager.selectedTab).isPrivate, true, "The selected tab should be the private tab")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 1, "There should only be one private tab")
+        
         // switch to normal mode. Which should delete the private tabs
         manager.willSwitchTabMode(leavingPBM: true)
-
+        
         //make sure tabs are cleared properly and indexes are reset
-        XCTAssertEqual(manager.privateTabs.count, 0, "Private tab should have been deleted")
+        XCTAssertEqual(manager.tabs(withType: .private).count, 0, "Private tab should have been deleted")
         XCTAssertEqual(manager.selectedIndex, -1, "The selected index should have been reset")
-
+        
         // didSelect should still be called when switching between a nil tab
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             XCTAssertNil(tabs[1], "there should be no previous tab")
             let next = tabs[0]!
             XCTAssertFalse(next.isPrivate)
         }
-
+        
         // make sure delegate method is actually called
         delegate.expect([didSelect])
-
+        
         // select the new tab to trigger the delegate methods
         manager.selectTab(newTab)
-
+        
         // check
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     func testDeleteFirstTab() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         (0..<10).forEach {_ in manager.addTab() }
         manager.selectTab(manager.tabs.first)
         let deleteTab = manager.tabs.first
         let newSelectedTab = manager.tabs[1]
         manager.addDelegate(delegate)
-
+        
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
@@ -418,14 +418,14 @@ class TabManagerTests: XCTestCase {
         manager.removeTab(manager.tabs.first!)
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     // Private tabs and regular tabs are in the same tabs array.
     // Make sure that when a private tab is added inbetween regular tabs it isnt accidently selected when removing a regular tab
     func testTabsIndex() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         // We add 2 tabs. Then a private one before adding another normal tab and selecting it.
         // Make sure that when the last one is deleted we dont switch to the private tab
         manager.addTab()
@@ -434,7 +434,7 @@ class TabManagerTests: XCTestCase {
         let deleted = manager.addTab()
         manager.selectTab(manager.tabs.last)
         manager.addDelegate(delegate)
-
+        
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
@@ -443,15 +443,15 @@ class TabManagerTests: XCTestCase {
         }
         delegate.expect([willRemove, didRemove, didSelect])
         manager.removeTab(manager.tabs.last!)
-
+        
         delegate.verify("Not all delegate methods were called")
     }
-
+    
     func testTabsIndexClosingFirst() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
-
+        
         // We add 2 tabs. Then a private one before adding another normal tab and selecting the first.
         // Make sure that when the last one is deleted we dont switch to the private tab
         let deleted = manager.addTab()
@@ -460,7 +460,7 @@ class TabManagerTests: XCTestCase {
         manager.addTab()
         manager.selectTab(manager.tabs.first)
         manager.addDelegate(delegate)
-
+        
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
@@ -471,5 +471,5 @@ class TabManagerTests: XCTestCase {
         manager.removeTab(manager.tabs.first!)
         delegate.verify("Not all delegate methods were called")
     }
-
+    
 }

--- a/ClientTests/TestFavicons.swift
+++ b/ClientTests/TestFavicons.swift
@@ -5,7 +5,6 @@
 import Foundation
 import XCTest
 import Storage
-import SDWebImage
 @testable import Client
 import Shared
 
@@ -34,15 +33,15 @@ class TestFavicons: ProfileTest {
                 return expectation.fulfill()
             }
             XCTAssertEqual(favicons.count, 1, "Instagram should have a Favicon.")
-            SDWebImageManager.shared().loadImage(with: url, options: .retryFailed, progress: nil, completed: { (img, _, _, _, _, _) in
-                guard let image = img else {
+
+            WebImageCacheWithNoPrivacyProtection.shared.load(from: url) { (image, _, _, _, _, _) in
+                guard let image = image else {
                     XCTFail("Not a valid URL provided for a favicon.")
                     return expectation.fulfill()
                 }
                 XCTAssertNotEqual(image.size, .zero)
                 expectation.fulfill()
-            })
-
+            }
         }
         self.waitForExpectations(timeout: 3000, handler: nil)
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -216,9 +216,10 @@ open class BrowserProfile: Profile {
            let visitType = VisitType(rawValue: v),
            let url = notification.userInfo!["url"] as? URL, !isIgnoredURL(url),
            let title = notification.userInfo!["title"] as? NSString {
+
             // Only record local vists if the change notification originated from a non-private tab
-            if !(notification.userInfo!["isPrivate"] as? Bool ?? false) {
-                // We don't record a visit if no type was specified -- that means "ignore me".
+            let tabType: TabType = notification.userInfo!["tabType"] as? TabType ?? .regular
+            if !tabType.isPrivate {
                 let site = Site(url: url.absoluteString, title: title as String)
                 let visit = SiteVisit(site: site, date: Date.nowMicroseconds(), type: visitType)
                 history.addLocalVisit(visit)
@@ -232,8 +233,8 @@ open class BrowserProfile: Profile {
 
     @objc
     func onPageMetadataFetched(notification: NSNotification) {
-        let isPrivate = notification.userInfo?["isPrivate"] as? Bool ?? true
-        guard !isPrivate else {
+        let tabType = notification.userInfo?["tabType"] as? TabType ?? .regular
+        guard !tabType.isPrivate else {
             log.debug("Private mode - Ignoring page metadata.")
             return
         }


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

Private browsing mode has been removed from `UIApplication` into it's own singleton as a temporary measure until we move to mixed tabs.

`BraveWebView` is protected with PrivacyProtection so that data is not persisted while using private browsing mode. `BraveWebView` is a subclass of WKWebView and should be used instead of `WKWebView` so that cookies, disk and memory caches, and persistent data such as WebSQL, IndexedDB databases, and local storage are not persisted in private browsing mode.

`WebImageCache` has been added with privacy protection and should replace calls to `SDWebImage` so that images are not persisted in private browsing mode.

Singleton's for `WebImageCache` have been added for convenience as a temporary measure until we move to mixed tabs where we can then instantiate a sandboxed `WebImageCache` object for each tab.

Changed browsing mode flag from a `Bool` to a `TabType` currently supporting `.regular` and `.private` browsing modes, so that `.tor` can be added at a future date.