### PR TITLE
Switch from loading images by name to image literals

### DIFF
--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -54,7 +54,7 @@ class BackForwardTableViewCell: UITableViewCell {
             if let s = site {
                 faviconView.setFavicon(forSite: s, onCompletion: { [weak self] (color, url) in
                     if s.tileURL.isLocal {
-                        self?.faviconView.image = UIImage(named: "faviconFox")
+                        self?.faviconView.image = #imageLiteral(resourceName: "faviconFox")
                         self?.faviconView.image = self?.faviconView.image?.createScaled(CGSize(width: BackForwardViewCellUX.IconSize, height: BackForwardViewCellUX.IconSize))
                         self?.faviconView.backgroundColor = UIColor.Photon.White100
                         return

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -311,7 +311,7 @@ private func createTransitionCellFromTab(_ tab: Tab?, withFrame frame: CGRect) -
     if let favIcon = tab?.displayFavicon {
         cell.favicon.sd_setImage(with: URL(string: favIcon.url)!)
     } else {
-        let defaultFavicon = UIImage(named: "defaultFavicon")
+        let defaultFavicon = #imageLiteral(resourceName: "defaultFavicon")
         if tab?.isPrivate ?? false {
             cell.favicon.image = defaultFavicon
             cell.favicon.tintColor = (tab?.isPrivate ?? false) ? UIColor.Photon.White100 : UIColor.Photon.Grey60

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -59,7 +59,7 @@ class BrowserViewController: UIViewController {
 
     lazy fileprivate var customSearchEngineButton: UIButton = {
         let searchButton = UIButton()
-        searchButton.setImage(UIImage(named: "AddSearch")?.withRenderingMode(.alwaysTemplate), for: [])
+        searchButton.setImage(#imageLiteral(resourceName: "AddSearch").template, for: [])
         searchButton.addTarget(self, action: #selector(addCustomSearchEngineForFocusedElement), for: .touchUpInside)
         searchButton.accessibilityIdentifier = "BrowserViewController.customSearchEngineButton"
         return searchButton

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -83,14 +83,14 @@ class FindInPageBar: UIView {
         matchCountView.accessibilityIdentifier = "FindInPage.matchCount"
         addSubview(matchCountView)
 
-        previousButton.setImage(UIImage(named: "find_previous"), for: [])
+        previousButton.setImage(#imageLiteral(resourceName: "find_previous"), for: [])
         previousButton.setTitleColor(FindInPageUX.ButtonColor, for: [])
         previousButton.accessibilityLabel = NSLocalizedString("Previous in-page result", tableName: "FindInPage", comment: "Accessibility label for previous result button in Find in Page Toolbar.")
         previousButton.addTarget(self, action: #selector(didFindPrevious), for: .touchUpInside)
         previousButton.accessibilityIdentifier = "FindInPage.find_previous"
         addSubview(previousButton)
 
-        nextButton.setImage(UIImage(named: "find_next"), for: [])
+        nextButton.setImage(#imageLiteral(resourceName: "find_next"), for: [])
         nextButton.setTitleColor(FindInPageUX.ButtonColor, for: [])
         nextButton.accessibilityLabel = NSLocalizedString("Next in-page result", tableName: "FindInPage", comment: "Accessibility label for next result button in Find in Page Toolbar.")
         nextButton.addTarget(self, action: #selector(didFindNext), for: .touchUpInside)
@@ -98,7 +98,7 @@ class FindInPageBar: UIView {
         addSubview(nextButton)
 
         let closeButton = UIButton()
-        closeButton.setImage(UIImage(named: "find_close"), for: [])
+        closeButton.setImage(#imageLiteral(resourceName: "find_close"), for: [])
         closeButton.setTitleColor(FindInPageUX.ButtonColor, for: [])
         closeButton.accessibilityLabel = NSLocalizedString("Done", tableName: "FindInPage", comment: "Done button in Find in Page Toolbar.")
         closeButton.addTarget(self, action: #selector(didPressClose), for: .touchUpInside)

--- a/Client/Frontend/Browser/HomePanel/TopSitesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/TopSitesViewController.swift
@@ -82,7 +82,7 @@ class TopSitesViewController: UIViewController {
         $0.addTarget(self, action: #selector(showPrivateTabInfo), for: .touchUpInside)
     }
     
-    private let ddgLogo = UIImageView(image: UIImage(named: "duckduckgo"))
+    private let ddgLogo = UIImageView(image: #imageLiteral(resourceName: "duckduckgo"))
     
     private let ddgLabel = UILabel().then {
         $0.numberOfLines = 0

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoriteCell.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoriteCell.swift
@@ -84,7 +84,7 @@ class FavoriteCell: UICollectionViewCell {
     
     let editButton = UIButton().then {
         $0.isExclusiveTouch = true
-        let removeButtonImage = UIImage(named: "edit-small")?.withRenderingMode(.alwaysTemplate)
+        let removeButtonImage = #imageLiteral(resourceName: "edit-small").template
         $0.setImage(removeButtonImage, for: .normal)
         $0.addTarget(self, action: #selector(FavoriteCell.editButtonTapped), for: UIControlEvents.touchUpInside)
         $0.accessibilityLabel = Strings.Edit_Bookmark

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -148,7 +148,7 @@ class LoginsHelper: TabContentScript {
             tab?.removeSnackbar(existingPrompt)
         }
 
-        snackBar = TimerSnackBar(text: promptMessage, img: UIImage(named: "key"))
+        snackBar = TimerSnackBar(text: promptMessage, img: #imageLiteral(resourceName: "key"))
         let dontSave = SnackButton(title: Strings.LoginsHelperDontSaveButtonTitle, accessibilityIdentifier: "SaveLoginPrompt.dontSaveButton") { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil
@@ -182,7 +182,7 @@ class LoginsHelper: TabContentScript {
             tab?.removeSnackbar(existingPrompt)
         }
 
-        snackBar = TimerSnackBar(text: formatted, img: UIImage(named: "key"))
+        snackBar = TimerSnackBar(text: formatted, img: #imageLiteral(resourceName: "key"))
         let dontSave = SnackButton(title: Strings.LoginsHelperDontUpdateButtonTitle, accessibilityIdentifier: "UpdateLoginPrompt.donttUpdateButton") { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -35,8 +35,8 @@ class QRCodeViewController: UIViewController {
     }()
 
     private var videoPreviewLayer: AVCaptureVideoPreviewLayer?
-    private let scanLine: UIImageView = UIImageView(image: UIImage(named: "qrcode-scanLine"))
-    private let scanBorder: UIImageView = UIImageView(image: UIImage(named: "qrcode-scanBorder"))
+    private let scanLine: UIImageView = UIImageView(image: #imageLiteral(resourceName: "qrcode-scanLine"))
+    private let scanBorder: UIImageView = UIImageView(image: #imageLiteral(resourceName: "qrcode-scanBorder"))
     private lazy var instructionsLabel: UILabel = {
         let label = UILabel()
         label.text = Strings.ScanQRCodeInstructionsLabel
@@ -79,10 +79,10 @@ class QRCodeViewController: UIViewController {
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: QRCodeViewControllerUX.navigationBarTitleColor]
 
         // Setup the NavigationItem
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "qrcode-goBack"), style: .plain, target: self, action: #selector(goBack))
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: #imageLiteral(resourceName: "qrcode-goBack"), style: .plain, target: self, action: #selector(goBack))
         self.navigationItem.leftBarButtonItem?.tintColor = UIColor.Photon.White100
 
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "qrcode-light"), style: .plain, target: self, action: #selector(openLight))
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: #imageLiteral(resourceName: "qrcode-light"), style: .plain, target: self, action: #selector(openLight))
         if captureDevice.hasTorch {
             self.navigationItem.rightBarButtonItem?.tintColor = UIColor.Photon.White100
         } else {
@@ -186,7 +186,7 @@ class QRCodeViewController: UIViewController {
                 try captureDevice.lockForConfiguration()
                 captureDevice.torchMode = AVCaptureDevice.TorchMode.off
                 captureDevice.unlockForConfiguration()
-                navigationItem.rightBarButtonItem?.image = UIImage(named: "qrcode-light")
+                navigationItem.rightBarButtonItem?.image = #imageLiteral(resourceName: "qrcode-light")
                 navigationItem.rightBarButtonItem?.tintColor = UIColor.Photon.White100
             } catch {
                 print(error)
@@ -196,7 +196,7 @@ class QRCodeViewController: UIViewController {
                 try captureDevice.lockForConfiguration()
                 captureDevice.torchMode = AVCaptureDevice.TorchMode.on
                 captureDevice.unlockForConfiguration()
-                navigationItem.rightBarButtonItem?.image = UIImage(named: "qrcode-isLighting")
+                navigationItem.rightBarButtonItem?.image = #imageLiteral(resourceName: "qrcode-isLighting")
                 navigationItem.rightBarButtonItem?.tintColor = QRCodeViewControllerUX.isLightingNavigationItemColor
             } catch {
                 print(error)

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -25,7 +25,7 @@ enum ReaderModeBarButtonType {
     }
 
     fileprivate var image: UIImage? {
-        let image = UIImage(named: imageName)
+        let image = UIImage(imageLiteralResourceName: imageName)
         image?.accessibilityLabel = localizedDescription
         return image
     }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -21,7 +21,6 @@ private struct SearchViewControllerUX {
     static let EngineButtonWidth = EngineButtonHeight * 1.4
     static let EngineButtonBackgroundColor = UIColor.clear.cgColor
 
-    static let SearchImage = "search"
     static let SearchEngineTopBorderWidth = 0.5
     static let SearchImageHeight: Float = 44
     static let SearchImageWidth: Float = 24
@@ -60,7 +59,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     fileprivate let searchEngineScrollViewContent = UIView()
 
     fileprivate lazy var bookmarkedBadge: UIImage = {
-        return UIImage(named: "bookmarked_passive")!
+        return #imageLiteral(resourceName: "bookmarked_passive")
     }()
 
     // Cell for the suggestion flow layout. Since heightForHeaderInSection is called *before*
@@ -200,7 +199,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
         //search settings icon
         let searchButton = UIButton()
-        searchButton.setImage(UIImage(named: "quickSearch"), for: [])
+        searchButton.setImage(#imageLiteral(resourceName: "quickSearch"), for: [])
         searchButton.imageView?.contentMode = .center
         searchButton.layer.backgroundColor = SearchViewControllerUX.EngineButtonBackgroundColor
         searchButton.addTarget(self, action: #selector(didClickSearchButton), for: .touchUpInside)
@@ -576,8 +575,7 @@ fileprivate class SuggestionCell: UITableViewCell {
 
                 // If this is the first image, add the search icon.
                 if container.subviews.isEmpty {
-                    let image = UIImage(named: SearchViewControllerUX.SearchImage)
-                    button.setImage(image, for: [])
+                    button.setImage(#imageLiteral(resourceName: "search"), for: [])
                     if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
                         button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
                     } else {

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -64,10 +64,10 @@ class TabLocationView: UIView {
     var loading: Bool = false {
         didSet {
             if loading {
-                reloadButton.setImage(#imageLiteral(resourceName: "nav-stop").withRenderingMode(.alwaysTemplate), for: .normal)
+                reloadButton.setImage(#imageLiteral(resourceName: "nav-stop").template, for: .normal)
                 reloadButton.accessibilityLabel = NSLocalizedString("Stop", comment: "Accessibility Label for the tab toolbar Stop button")
             } else {
-                reloadButton.setImage(#imageLiteral(resourceName: "nav-refresh").withRenderingMode(.alwaysTemplate), for: .normal)
+                reloadButton.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
                 reloadButton.accessibilityLabel = NSLocalizedString("Reload", comment: "Accessibility Label for the tab toolbar Reload button")
             }
         }
@@ -176,7 +176,7 @@ class TabLocationView: UIView {
     lazy var reloadButton = ToolbarButton().then {
         $0.accessibilityIdentifier = "TabToolbar.stopReloadButton"
         $0.accessibilityLabel = NSLocalizedString("Reload", comment: "Accessibility Label for the tab toolbar Reload button")
-        $0.setImage(#imageLiteral(resourceName: "nav-refresh").withRenderingMode(.alwaysTemplate), for: .normal)
+        $0.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
         let longPressGestureStopReloadButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressStopReload(_:)))
         $0.addGestureRecognizer(longPressGestureStopReloadButton)
         $0.addTarget(self, action: #selector(didClickStopReload), for: .touchUpInside)

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -62,11 +62,11 @@ open class TabToolbarHelper: NSObject {
         let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTabs))
         toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
         
-        toolbar.shareButton.setImage(UIImage(named: "nav-share"), for: .normal)
+        toolbar.shareButton.setImage(#imageLiteral(resourceName: "nav-share"), for: .normal)
         toolbar.shareButton.accessibilityLabel = Strings.Share
         toolbar.shareButton.addTarget(self, action: #selector(didClickShare), for: UIControlEvents.touchUpInside)
         
-        toolbar.addTabButton.setImage(UIImage(named: "add_tab"), for: .normal)
+        toolbar.addTabButton.setImage(#imageLiteral(resourceName: "add_tab"), for: .normal)
         toolbar.addTabButton.accessibilityLabel = Strings.Add_Tab
         toolbar.addTabButton.addTarget(self, action: #selector(didClickAddTab), for: UIControlEvents.touchUpInside)
         toolbar.addTabButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressAddTab(_:))))

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -11,7 +11,7 @@ class PrivateModeButton: ToggleButton, Themeable {
         super.init(frame: frame)
         accessibilityLabel = PrivateModeStrings.toggleAccessibilityLabel
         accessibilityHint = PrivateModeStrings.toggleAccessibilityHint
-        let maskImage = UIImage(named: "smallPrivateMask")?.withRenderingMode(.alwaysTemplate)
+        let maskImage = #imageLiteral(resourceName: "smallPrivateMask").template
         setImage(maskImage, for: [])
     }
     

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -770,9 +770,9 @@ fileprivate class TabManagerDataSource: NSObject, UICollectionViewDataSource {
         tabCell.accessibilityHint = NSLocalizedString("Swipe right or left with three fingers to close the tab.", comment: "Accessibility hint for tab tray's displayed tab.")
 
         if let favIcon = tab.displayFavicon, let url = URL(string: favIcon.url) {
-            tabCell.favicon.sd_setImage(with: url, placeholderImage: UIImage(named: "defaultFavicon"), options: [], completed: nil)
+            tabCell.favicon.sd_setImage(with: url, placeholderImage: #imageLiteral(resourceName: "defaultFavicon"), options: [], completed: nil)
         } else {
-            let defaultFavicon = UIImage(named: "defaultFavicon")
+            let defaultFavicon = #imageLiteral(resourceName: "defaultFavicon")
             if tab.isPrivate {
                 tabCell.favicon.image = defaultFavicon
                 tabCell.favicon.tintColor = UIColor.Photon.White100
@@ -965,7 +965,7 @@ fileprivate class EmptyPrivateTabsView: UIView {
     }()
 
     fileprivate var iconImageView: UIImageView = {
-        let imageView = UIImageView(image: UIImage(named: "largePrivateMask"))
+        let imageView = UIImageView(image: #imageLiteral(resourceName: "largePrivateMask"))
         return imageView
     }()
 

--- a/Client/Frontend/Browser/TabsBar/TabBarCell.swift
+++ b/Client/Frontend/Browser/TabsBar/TabBarCell.swift
@@ -16,7 +16,7 @@ class TabBarCell: UICollectionViewCell {
     private lazy var closeButton: UIButton = {
         let button = UIButton()
         button.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
-        button.setImage(UIImage(named: "close_tab_bar")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.setImage(#imageLiteral(resourceName: "close_tab_bar").template, for: .normal)
         button.tintColor = UIApplication.isInPrivateMode ? UIColor.white : UIColor.black
         // Close button is a bit wider to increase tap area, this aligns the 'X' image closer to the right.
         button.imageEdgeInsets.left = 6

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -20,7 +20,7 @@ class TabsBarViewController: UIViewController {
     
     private lazy var plusButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: "add_tab")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.setImage(#imageLiteral(resourceName: "add_tab").template, for: .normal)
         button.imageEdgeInsets = UIEdgeInsetsMake(6, 10, 6, 10)
         button.tintColor = UIColor.black
         button.contentMode = .scaleAspectFit

--- a/Client/Frontend/Home/DownloadsPanel.swift
+++ b/Client/Frontend/Home/DownloadsPanel.swift
@@ -301,7 +301,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         let overlayView = UIView()
         overlayView.backgroundColor = UIColor.white
 
-        let logoImageView = UIImageView(image: UIImage(named: "emptyDownloads"))
+        let logoImageView = UIImageView(image: #imageLiteral(resourceName: "emptyDownloads"))
         overlayView.addSubview(logoImageView)
         logoImageView.snp.makeConstraints { make in
             make.centerX.equalTo(overlayView)

--- a/Client/Frontend/Menu/BookmarksViewController.swift
+++ b/Client/Frontend/Menu/BookmarksViewController.swift
@@ -224,12 +224,12 @@ class BookmarksViewController: SiteTableViewController, HomePanel {
     
     items.append(UIBarButtonItem.fixedSpace(5))
     
-    addFolderButton = UIBarButtonItem(image: UIImage(named: "bookmarks_newfolder_icon")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: #selector(onAddBookmarksFolderButton))
+    addFolderButton = UIBarButtonItem(image: #imageLiteral(resourceName: "bookmarks_newfolder_icon").template, style: .plain, target: self, action: #selector(onAddBookmarksFolderButton))
     items.append(addFolderButton!)
     
     items.append(UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil))
     
-    editBookmarksButton = UIBarButtonItem(image: UIImage(named: "edit")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: #selector(onEditBookmarksButton))
+    editBookmarksButton = UIBarButtonItem(image: #imageLiteral(resourceName: "edit").template, style: .plain, target: self, action: #selector(onEditBookmarksButton))
     items.append(editBookmarksButton)
     items.append(UIBarButtonItem.fixedSpace(5))
     
@@ -379,7 +379,7 @@ class BookmarksViewController: SiteTableViewController, HomePanel {
       cell.textLabel?.font = UIFont.systemFont(ofSize: fontSize)
       cell.accessoryType = .none
     } else {
-      configCell(image: UIImage(named: "bookmarks_folder_hollow"))
+      configCell(image: #imageLiteral(resourceName: "bookmarks_folder_hollow"))
       cell.textLabel?.font = UIFont.boldSystemFont(ofSize: fontSize)
       cell.accessoryType = .disclosureIndicator
       if let twoLineCell = cell as? TwoLineTableViewCell {

--- a/Client/Frontend/Menu/HomeMenuController.swift
+++ b/Client/Frontend/Menu/HomeMenuController.swift
@@ -109,22 +109,22 @@ class HomeMenuController: UIViewController, PopoverContentComponent {
     
     divider.backgroundColor = BraveUX.ColorForSidebarLineSeparators
     
-    settingsButton.setImage(UIImage(named: "menu-settings")?.withRenderingMode(.alwaysTemplate), for: .normal)
+    settingsButton.setImage(#imageLiteral(resourceName: "menu-settings").template, for: .normal)
     settingsButton.addTarget(self, action: #selector(onClickSettingsButton), for: .touchUpInside)
     settingsButton.contentEdgeInsets = UIEdgeInsetsMake(5, 10, 5, 10)
     settingsButton.accessibilityLabel = Strings.Settings
     
-    bookmarksButton.setImage(UIImage(named: "menu-bookmark-list")?.withRenderingMode(.alwaysTemplate), for: .normal)
+    bookmarksButton.setImage(#imageLiteral(resourceName: "menu-bookmark-list").template, for: .normal)
     bookmarksButton.contentEdgeInsets = UIEdgeInsetsMake(5, 10, 5, 10)
     bookmarksButton.accessibilityLabel = Strings.Show_Bookmarks
     
-    historyButton.setImage(UIImage(named: "menu-history")?.withRenderingMode(.alwaysTemplate), for: .normal)
+    historyButton.setImage(#imageLiteral(resourceName: "menu-history").template, for: .normal)
     historyButton.contentEdgeInsets = UIEdgeInsetsMake(5, 10, 5, 10)
     historyButton.accessibilityLabel = Strings.Show_History
     
     addBookmarkButton.addTarget(self, action: #selector(onClickBookmarksButton), for: .touchUpInside)
-    addBookmarkButton.setImage(UIImage(named: "menu-add-bookmark")?.withRenderingMode(.alwaysTemplate), for: .normal)
-    addBookmarkButton.setImage(UIImage(named: "menu-marked-bookmark")?.withRenderingMode(.alwaysTemplate), for: .selected)
+    addBookmarkButton.setImage(#imageLiteral(resourceName: "menu-add-bookmark").template, for: .normal)
+    addBookmarkButton.setImage(#imageLiteral(resourceName: "menu-marked-bookmark").template, for: .selected)
     addBookmarkButton.contentEdgeInsets = UIEdgeInsetsMake(5, 10, 5, 10)
     addBookmarkButton.accessibilityLabel = Strings.Add_Bookmark
     

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -149,7 +149,7 @@ class ReaderModeStyleViewController: UIViewController {
             make.width.equalTo(ReaderModeStyleViewControllerUX.BrightnessSliderWidth)
         }
 
-        let brightnessMinImageView = UIImageView(image: UIImage(named: "brightnessMin"))
+        let brightnessMinImageView = UIImageView(image: #imageLiteral(resourceName: "brightnessMin"))
         brightnessRow.addSubview(brightnessMinImageView)
 
         brightnessMinImageView.snp.makeConstraints { (make) -> Void in
@@ -157,7 +157,7 @@ class ReaderModeStyleViewController: UIViewController {
             make.right.equalTo(slider.snp.left).offset(-ReaderModeStyleViewControllerUX.BrightnessIconOffset)
         }
 
-        let brightnessMaxImageView = UIImageView(image: UIImage(named: "brightnessMax"))
+        let brightnessMaxImageView = UIImageView(image: #imageLiteral(resourceName: "brightnessMax"))
         brightnessRow.addSubview(brightnessMaxImageView)
 
         brightnessMaxImageView.snp.makeConstraints { (make) -> Void in

--- a/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
+++ b/Client/Frontend/Widgets/ActivityStreamHighlightCell.swift
@@ -184,10 +184,10 @@ class ActivityStreamHighlightCell: UICollectionViewCell {
 
         if let bookmarked = site.bookmarked, bookmarked {
             self.descriptionLabel.text = Strings.HighlightBookmarkText
-            self.statusIcon.image = UIImage(named: "context_bookmark")
+            self.statusIcon.image = #imageLiteral(resourceName: "context_bookmark")
         } else {
             self.descriptionLabel.text = Strings.HighlightVistedText
-            self.statusIcon.image = UIImage(named: "context_viewed")
+            self.statusIcon.image = #imageLiteral(resourceName: "context_viewed")
         }
     }
 }

--- a/Client/Frontend/Widgets/LoginTableViewCell.swift
+++ b/Client/Frontend/Widgets/LoginTableViewCell.swift
@@ -108,7 +108,7 @@ class LoginTableViewCell: UITableViewCell {
 
     fileprivate var customIndentView = UIView()
 
-    fileprivate var customCheckmarkIcon = UIImageView(image: UIImage(named: "loginUnselected"))
+    fileprivate var customCheckmarkIcon = UIImageView(image: #imageLiteral(resourceName: "loginUnselected"))
 
     /// Override the default accessibility label since it won't include the description by default
     /// since it's a UITextField acting as a label.
@@ -328,7 +328,7 @@ class LoginTableViewCell: UITableViewCell {
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-        customCheckmarkIcon.image = UIImage(named: selected ? "loginSelected" : "loginUnselected")
+        customCheckmarkIcon.image = selected ? #imageLiteral(resourceName: "loginSelected") : #imageLiteral(resourceName: "loginUnselected")
     }
 }
 
@@ -358,7 +358,7 @@ extension LoginTableViewCell {
     func updateCellWithLogin(_ login: LoginData) {
         descriptionLabel.text = login.hostname
         highlightedLabel.text = login.username
-        iconImageView.image = UIImage(named: "faviconFox")
+        iconImageView.image = #imageLiteral(resourceName: "faviconFox")
     }
 }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet.swift
@@ -550,7 +550,7 @@ private class PhotonActionSheetCell: UITableViewCell {
     }()
 
     lazy var toggleSwitch: UIImageView = {
-        let toggle = UIImageView(image: UIImage(named: "menu-Toggle-Off"))
+        let toggle = UIImageView(image: #imageLiteral(resourceName: "menu-Toggle-Off"))
         toggle.contentMode = .scaleAspectFit
         return toggle
     }()
@@ -563,7 +563,7 @@ private class PhotonActionSheetCell: UITableViewCell {
     }()
 
     lazy var disclosureIndicator: UIImageView = {
-        let disclosureIndicator = UIImageView(image: UIImage(named: "menu-Disclosure"))
+        let disclosureIndicator = UIImageView(image: #imageLiteral(resourceName: "menu-Disclosure"))
         disclosureIndicator.contentMode = .scaleAspectFit
         disclosureIndicator.layer.cornerRadius = PhotonActionSheetCellUX.CornerRadius
         disclosureIndicator.setContentHuggingPriority(.required, for: .horizontal)
@@ -637,7 +637,8 @@ private class PhotonActionSheetCell: UITableViewCell {
         accessibilityLabel = action.title
         selectionStyle = action.handler != nil ? .default : .none
 
-        if let iconName = action.iconString, let image = UIImage(named: iconName)?.withRenderingMode(.alwaysTemplate) {
+        if let iconName = action.iconString {
+            let image = UIImage(imageLiteralResourceName: iconName).template
             statusIcon.sd_setImage(with: action.iconURL, placeholderImage: image, options: []) { (img, err, _, _) in
                 if let img = img {
                     self.statusIcon.image = img.createScaled(PhotonActionSheetUX.IconSize)
@@ -677,7 +678,7 @@ private class PhotonActionSheetCell: UITableViewCell {
         case .Disclosure:
             stackView.addArrangedSubview(disclosureIndicator)
         case .Switch:
-            let image = action.isEnabled ? UIImage(named: "menu-Toggle-On") : UIImage(named: "menu-Toggle-Off")
+            let image = action.isEnabled ? #imageLiteral(resourceName: "menu-Toggle-On") : #imageLiteral(resourceName: "menu-Toggle-Off")
             toggleSwitch.isAccessibilityElement = true
             toggleSwitch.accessibilityIdentifier = action.isEnabled ? "enabled" : "disabled"
             toggleSwitch.image = image

--- a/Client/Frontend/Widgets/SearchInputView.swift
+++ b/Client/Frontend/Widgets/SearchInputView.swift
@@ -56,13 +56,13 @@ class SearchInputView: UIView {
     }()
 
     lazy var searchIcon: UIImageView = {
-        return UIImageView(image: UIImage(named: "quickSearch"))
+        return UIImageView(image: #imageLiteral(resourceName: "quickSearch"))
     }()
 
     fileprivate lazy var closeButton: UIButton = {
         let button = UIButton()
         button.addTarget(self, action: #selector(tappedClose), for: .touchUpInside)
-        button.setImage(UIImage(named: "clear"), for: [])
+        button.setImage(#imageLiteral(resourceName: "clear"), for: [])
         button.accessibilityLabel = NSLocalizedString("Clear Search", tableName: "LoginManager",
             comment: "Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode")
         return button

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -110,7 +110,7 @@ class SnackBar: UIView {
     init(text: String, img: UIImage?) {
         super.init(frame: .zero)
 
-        imageView.image = img ?? UIImage(named: "defaultFavicon")
+        imageView.image = img ?? #imageLiteral(resourceName: "defaultFavicon")
         textLabel.text = text
         setup()
     }
@@ -217,7 +217,7 @@ class TimerSnackBar: SnackBar {
     }
 
     static func showAppStoreConfirmationBar(forTab tab: Tab, appStoreURL: URL) {
-        let bar = TimerSnackBar(text: Strings.ExternalLinkAppStoreConfirmationTitle, img: UIImage(named: "defaultFavicon"))
+        let bar = TimerSnackBar(text: Strings.ExternalLinkAppStoreConfirmationTitle, img: #imageLiteral(resourceName: "defaultFavicon"))
         let openAppStore = SnackButton(title: Strings.OKString, accessibilityIdentifier: "ConfirmOpenInAppStore") { bar in
             tab.removeSnackbar(bar)
             UIApplication.shared.open(appStoreURL)

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -31,7 +31,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
     static let ExpirationTime = TimeInterval(60*60*24*7) // Only check for icons once a week
     fileprivate static var characterToFaviconCache = [String: UIImage]()
     static var defaultFavicon: UIImage = {
-        return UIImage(named: "defaultFavicon")!
+        return #imageLiteral(resourceName: "defaultFavicon")
     }()
 
     static var colors: [String: UIColor] = [:] //An in-Memory data store that stores background colors domains. Stored using url.baseDomain.

--- a/ClientTests/UIImageViewExtensionsTests.swift
+++ b/ClientTests/UIImageViewExtensionsTests.swift
@@ -35,7 +35,7 @@ class UIImageViewExtensionsTests: XCTestCase {
     }
 
     func testAsyncSetIcon() {
-        let originalImage = UIImage(named: "fxLogo")!
+        let originalImage = #imageLiteral(resourceName: "fxLogo")
 
         WebServer.sharedInstance.registerHandlerForMethod("GET", module: "favicon", resource: "icon") { (request) -> GCDWebServerResponse! in
             return GCDWebServerDataResponse(data: UIImagePNGRepresentation(originalImage)!, contentType: "image/png")

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -39,8 +39,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
 
         let button = imageButton.button
 
-        button.setImage(UIImage(named: "new_tab_button_normal")?.withRenderingMode(.alwaysTemplate), for: .normal)
-        button.setImage(UIImage(named: "new_tab_button_highlight")?.withRenderingMode(.alwaysTemplate), for: .highlighted)
+        button.setImage(#imageLiteral(resourceName: "new_tab_button_normal").template, for: .normal)
+        button.setImage(#imageLiteral(resourceName: "new_tab_button_highlight").template, for: .highlighted)
 
         let label = imageButton.label
         label.font = UIFont.systemFont(ofSize: TodayUX.imageButtonTextSize)
@@ -55,8 +55,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         imageButton.label.text = TodayStrings.NewPrivateTabButtonLabel
 
         let button = imageButton.button
-        button.setImage(UIImage(named: "new_private_tab_button_normal"), for: .normal)
-        button.setImage(UIImage(named: "new_private_tab_button_highlight"), for: .highlighted)
+        button.setImage(#imageLiteral(resourceName: "new_private_tab_button_normal"), for: .normal)
+        button.setImage(#imageLiteral(resourceName: "new_private_tab_button_highlight"), for: .highlighted)
 
         let label = imageButton.label
         label.tintColor = TodayUX.privateBrowsingColor
@@ -76,7 +76,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         button.setBackgroundColor(UIColor.clear, forState: .normal)
         button.setBackgroundColor(TodayUX.backgroundHightlightColor, forState: .highlighted)
 
-        button.setImage(UIImage(named: "copy_link_icon")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.setImage(#imageLiteral(resourceName: "copy_link_icon").template, for: .normal)
 
         button.label.font = UIFont.systemFont(ofSize: TodayUX.labelTextSize)
         button.subtitleLabel.font = UIFont.systemFont(ofSize: TodayUX.linkTextSize)

--- a/Shared/Extensions/UIImageExtensions.swift
+++ b/Shared/Extensions/UIImageExtensions.swift
@@ -91,7 +91,7 @@ extension UIImage {
     // this function ensures that.
     //
     // This can be verified with this code:
-    //    let image = UIImage(named: "fxLogo")!
+    //    let image = #imageLiteral(resourceName: "fxLogo")
     //    let data = UIImagePNGRepresentation(image)!
     //    assert(data != UIImagePNGRepresentation(UIImage(data: data)!))
     @available(*, deprecated, message: "use only in testing code")

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -424,7 +424,7 @@ class SimplePageServer {
         let webServer: GCDWebServer = GCDWebServer()
 
         webServer.addHandler(forMethod: "GET", path: "/image.png", request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse? in
-            let img = UIImagePNGRepresentation(UIImage(named: "goBack")!)
+            let img = UIImagePNGRepresentation(#imageLiteral(resourceName: "goBack"))
             return GCDWebServerDataResponse(data: img, contentType: "image/png")
         }
 


### PR DESCRIPTION
Largely a find & replace for using `#imageLiteral` in place of `UIImage(named:)` and the new `template` getter.

Any `UIImage(named:)` that couldn't be replaced with a direct image literal (and image is in an asset catalog) is now using `UIImage(imageLiteralResourceName:)` to avoid failing to load a resource.

