### PR TITLE
Fix #196: This fixes tab bars showing while collapsed on iPhone X

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -234,6 +234,8 @@ private extension TabScrollingController {
 
         let alpha = 1 - abs(headerTopOffset / topScrollHeight)
         urlBar?.updateAlphaForSubviews(alpha)
+        let tabsAlpha = 1 - abs((headerTopOffset - tabsBarOffset) / topScrollHeight)
+        tabsBar?.view.alpha = tabsAlpha
     }
 
     func isHeaderDisplayedForGivenOffset(_ offset: CGFloat) -> Bool {
@@ -265,6 +267,7 @@ private extension TabScrollingController {
             self.headerTopOffset = headerOffset + self.tabsBarOffset
             self.footerBottomOffset = footerOffset
             self.urlBar?.updateAlphaForSubviews(alpha)
+            self.tabsBar?.view.alpha = alpha
             self.header?.superview?.layoutIfNeeded()
         }
 


### PR DESCRIPTION
## Changes

To fix bug #196, I added alpha animations to the tab bar in a similar fashion to the url bar. Technically, the tab bar is still in the wrong position, but the alpha animations make for a better UX.

The changes have no effect on non-iPhone X devices

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![demo](https://user-images.githubusercontent.com/1043281/45055812-ee866680-b05e-11e8-899c-5d048505cd4e.gif)


## Notes for testing this patch

Repeating steps in #196 (copied below) shows that the issue does not persist.

### Steps to Reproduce

1. Set tab bar visibility to always in Settings if not already set
2. Create at least 2 tabs, one of which is a website that can be scrolled (i.e. reddit.com)
3. Scroll the tab up (slowly), it will get stuck at the very top or, scroll quickly (via a quick swipe), tab bar will get stuck much lower