### PR TITLE
Fix #103: Add unit tests for favourited Bookmarks

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */; };
 		0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
+		2798E01D213EFC3F003EDBB1 /* FavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */; };
 		27C461DE211B76500088A441 /* ShieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C461DD211B76500088A441 /* ShieldsView.swift */; };
 		27C46201211CD8D20088A441 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
 		27F4439F2135E11200296C58 /* BraveShareTo.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 27F443952135E11200296C58 /* BraveShareTo.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -932,6 +933,7 @@
 		0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsetButton.swift; sourceTree = "<group>"; };
 		0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFavicons.swift; sourceTree = "<group>"; };
 		0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = noTitle.html; sourceTree = "<group>"; };
+		2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteTests.swift; sourceTree = "<group>"; };
 		27C461DD211B76500088A441 /* ShieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsView.swift; sourceTree = "<group>"; };
 		27F443952135E11200296C58 /* BraveShareTo.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BraveShareTo.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		27F4439C2135E11200296C58 /* BraveShareToInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BraveShareToInfo.plist; sourceTree = "<group>"; };
@@ -2049,6 +2051,7 @@
 				0AF3B4E8213D8E3200695962 /* FaviconMOTests.swift */,
 				0AF3B4E6213D8E3200695962 /* HistoryTests.swift */,
 				0AF3B4EC213D8E3300695962 /* TabMOTests.swift */,
+				2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */,
 				5D1DC52420AC9AFB00905E5A /* Info.plist */,
 			);
 			path = DataTests;
@@ -4104,6 +4107,7 @@
 			files = (
 				0AF3B4F0213D8E3300695962 /* FaviconMOTests.swift in Sources */,
 				A176323B20CF2AF800126F25 /* DeferredTestUtils.swift in Sources */,
+				2798E01D213EFC3F003EDBB1 /* FavoriteTests.swift in Sources */,
 				0AF3B4ED213D8E3300695962 /* CoreDataTestCase.swift in Sources */,
 				0AF3B4EF213D8E3300695962 /* DomainTests.swift in Sources */,
 				0AF3B4EE213D8E3300695962 /* HistoryTests.swift in Sources */,

--- a/DataTests/FavoriteTests.swift
+++ b/DataTests/FavoriteTests.swift
@@ -1,0 +1,227 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+import XCTest
+@testable import Data
+
+class FavoriteTests: CoreDataTestCase {
+    
+    private let fetchRequest: NSFetchRequest<Bookmark> = {
+        let fetchRequest = NSFetchRequest<Bookmark>(entityName: String(describing: Bookmark.self))
+        // We always want favorites folder to be on top, in the first section.
+        fetchRequest.sortDescriptors = [
+            NSSortDescriptor(key: "order", ascending: true),
+            NSSortDescriptor(key: "created", ascending: false)
+        ]
+        fetchRequest.predicate = NSPredicate(format: "isFavorite == true")
+        return fetchRequest
+    }()
+    
+    private lazy var fetchController = NSFetchedResultsController<Bookmark>(
+        fetchRequest: fetchRequest,
+        managedObjectContext: DataController.mainThreadContext,
+        sectionNameKeyPath: nil,
+        cacheName: nil
+    )
+    
+    private func entity(for context: NSManagedObjectContext) -> NSEntityDescription {
+        return NSEntityDescription.entity(forEntityName: String(describing: Bookmark.self), in: context)!
+    }
+    
+    // MARK: - Adding
+    
+    func testAddFavorite() {
+        let url = "http://brave.com"
+        let title = "Brave"
+        
+        let favoritedBookmark = createAndWait(url: URL(string: url), title: title)
+        XCTAssertEqual(try! DataController.mainThreadContext.count(for: fetchRequest), 1)
+        
+        XCTAssertEqual(favoritedBookmark.url, url)
+        XCTAssertEqual(favoritedBookmark.title, title)
+    }
+    
+    // MARK: - Editing
+    
+    func testEditFavoriteURL() {
+        let url = "http://brave.com"
+        let newUrl = "http://updated.example.com"
+        
+        let object = createAndWait(url: URL(string: url), title: "title")
+        
+        XCTAssertEqual(object.displayTitle, "title")
+        XCTAssertEqual(object.url, url)
+        
+        backgroundSaveAndWaitForExpectation {
+            object.update(customTitle: nil, url: newUrl, save: true)
+        }
+        // Make sure only one record was added to DB
+        XCTAssertEqual(try! DataController.mainThreadContext.count(for: fetchRequest), 1)
+        
+        XCTAssertNotEqual(object.url, url)
+        XCTAssertEqual(object.url, newUrl)
+    }
+    
+    func testEditFavoriteName() {
+        let url = "http://brave.com"
+        let customTitle = "Brave"
+        let newTitle = "Updated Title"
+        
+        let object = createAndWait(url: URL(string: url), title: "title", customTitle: customTitle)
+        
+        XCTAssertEqual(object.displayTitle, customTitle)
+        XCTAssertEqual(object.url, url)
+        
+        backgroundSaveAndWaitForExpectation {
+            object.update(customTitle: newTitle, url: nil, save: true)
+        }
+        // Make sure only one record was added to DB
+        XCTAssertEqual(try! DataController.mainThreadContext.count(for: fetchRequest), 1)
+        
+        XCTAssertNotEqual(object.displayTitle, customTitle)
+        XCTAssertEqual(object.displayTitle, newTitle)
+    }
+    
+    // MARK: - Deleting
+    
+    func testDeleteFavorite() {
+        let bookmarks = makeFavorites(5)
+        
+        DataController.mainThreadContext.delete(bookmarks.first!)
+        XCTAssertEqual(try! DataController.mainThreadContext.count(for: fetchRequest), bookmarks.count - 1)
+    }
+    
+    func testDeleteAllFavorites() {
+        let bookmarks = makeFavorites(5)
+        
+        // Delete them all
+        bookmarks.forEach { DataController.mainThreadContext.delete($0) }
+        XCTAssertEqual(try! DataController.mainThreadContext.count(for: fetchRequest), 0)
+    }
+    
+    // MARK: - Reordering
+    
+    private func reorder(_ index: Int, toIndex: Int) {
+        backgroundSaveAndWaitForExpectation {
+            Bookmark.reorderBookmarks(
+                frc: fetchController as? NSFetchedResultsController<NSFetchRequestResult>,
+                sourceIndexPath: IndexPath(row: index, section: 0),
+                destinationIndexPath: IndexPath(row: toIndex, section: 0)
+            )
+        }
+    }
+    
+    func testCorrectOrder() {
+        makeFavorites(5)
+        
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        // Fetched objects starts un-ordered (all have 0 order)
+        fetchController.fetchedObjects!.forEach {
+            XCTAssertEqual($0.order, 0)
+        }
+        
+        // Upon re-order, each now has a given order
+        reorder(0, toIndex: 2)
+        // Check to see if an order (2) has been given to fetchedObjects index 0
+        XCTAssertEqual(fetchController.fetchedObjects![0].order, 2)
+        
+        // Verify that order is now taken into account by refetching
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        // Fetched objects should be sorted by order
+        for (i, obj) in fetchController.fetchedObjects!.enumerated() {
+            XCTAssertEqual(obj.order, Int16(i))
+        }
+    }
+    
+    func testReorderFavorites() {
+        makeFavorites(5)
+        
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        let first = fetchController.fetchedObjects![0]
+        let second = fetchController.fetchedObjects![1]
+        
+        reorder(0, toIndex: 2)
+        // Check to see if an order (2) has been given to fetchedObjects index 0
+        XCTAssertEqual(first.order, 2)
+        // The second favorite should have been pushed backwards to 0 since we moved the original 0 to 2
+        XCTAssertEqual(second.order, 0)
+        
+        // Order is now taken into account by refetching
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        // Verify that the object is at index 2 in list of fetched objects
+        XCTAssertEqual(fetchController.fetchedObjects![2], first)
+        // Verify that the first object at index 0 is the original pushed back one
+        XCTAssertEqual(fetchController.fetchedObjects![0], second)
+        // Verify that the object at index 1 was pushed back
+        XCTAssertEqual(fetchController.fetchedObjects![1].order, 1)
+    }
+    
+    func testMoveToStart() {
+        makeFavorites(5)
+        
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        let object = fetchController.fetchedObjects![3]
+        let startIndex = fetchController.fetchedObjects!.startIndex
+        
+        reorder(3, toIndex: startIndex)
+        XCTAssertEqual(object.order, Int16(startIndex))
+        
+        // Order is now taken into account by refetching
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        XCTAssertEqual(fetchController.fetchedObjects?.first, object)
+    }
+    
+    func testMoveToEnd() {
+        makeFavorites(5)
+        
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        let first = fetchController.fetchedObjects!.first!
+        let endIndex = fetchController.fetchedObjects!.endIndex - 1
+        
+        reorder(0, toIndex: endIndex)
+        XCTAssertEqual(first.order, Int16(endIndex))
+        
+        // Order is now taken into account by refetching
+        try! fetchController.performFetch()
+        XCTAssertNotNil(fetchController.fetchedObjects)
+        
+        XCTAssertEqual(fetchController.fetchedObjects?.last, first)
+    }
+    
+    // MARK: - Utility
+    
+    @discardableResult
+    private func makeFavorites(_ count: Int) -> [Bookmark] {
+        let bookmarks = (0..<count).map { createAndWait(url: URL(string: "http://brave.com/\($0)"), title: "brave") }
+        XCTAssertEqual(bookmarks.count, count)
+        XCTAssertEqual(try! DataController.mainThreadContext.count(for: fetchRequest), bookmarks.count)
+        return bookmarks
+    }
+    
+    @discardableResult
+    private func createAndWait(url: URL?, title: String, customTitle: String? = nil) -> Bookmark {
+        backgroundSaveAndWaitForExpectation {
+            Bookmark.add(url: url, title: title, customTitle: customTitle, isFavorite: true)
+        }
+        let bookmark = try! DataController.mainThreadContext.fetch(fetchRequest).first!
+        XCTAssertTrue(bookmark.isFavorite)
+        return bookmark
+    }
+}


### PR DESCRIPTION
Preloaded favourites (YouTube, Amazon, CoinMarketCap, etc.) are actually not done by the `Data` framework or `Bookmark` functions, therefore they were omitted from tests. 

If we want to move this from [PreloadedFavourites.swift](https://github.com/brave/brave-ios/blob/e31fabcf50d73374f10111f017c5cd21cfc6e99b/Client/Frontend/Browser/HomePanel/favorites/PreloadedFavorites.swift), let me know.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`
 