### PR TITLE
Fix #232, open url compile error on Xcode 9.

### DIFF
--- a/BraveShareTo/ShareToBraveViewController.swift
+++ b/BraveShareTo/ShareToBraveViewController.swift
@@ -57,7 +57,7 @@ class ShareToBraveViewController: SLComposeServiceViewController {
         // From http://stackoverflow.com/questions/24297273/openurl-not-work-in-action-extension
         var responder = self as UIResponder?
         while let strongResponder = responder {
-            let selector = #selector(UIApplication.openURL(_:))
+            let selector = sel_registerName("openURL:")
             if strongResponder.responds(to: selector) {
                 strongResponder.callSelector(selector, object: url as NSURL, delay: 0)
             }


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

Now it works on both Xcode 9 & 10

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
