### PR TITLE
Fix #200: Use the correct copy in settings: `Save Login` → `Save Logins`

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -139,7 +139,7 @@ class SettingsViewController: TableViewController {
                 Row(text: Strings.DefaultSearchEngine, selection: {
                     // Show default engines
                 }, accessory: .disclosureIndicator),
-                BoolRow(title: Strings.SaveLogin, option: Preferences.General.saveLogins),
+                BoolRow(title: Strings.Save_Logins, option: Preferences.General.saveLogins),
                 BoolRow(title: Strings.Block_Popups, option: Preferences.General.blockPopups),
             ]
         )


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`