### PR TITLE
Fix #262, Fix #263: Add "reset to default value" functionality to Preferences

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -42,7 +42,7 @@ extension Preferences {
         /// The list of observers for this option
         private let observers = WeakList<PreferencesObserver>()
         /// The UserDefaults container that you wish to save to
-        private let container: UserDefaults
+        public let container: UserDefaults
         /// The current value of this preference
         ///
         /// Upon setting this value, UserDefaults will be updated and any observers will be called

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -79,10 +79,18 @@ extension Preferences {
         }
         /// The key used for getting/setting the value in `UserDefaults`
         public let key: String
+        /// The default value of this preference
+        private let defaultValue: ValueType
+        /// Reset's the preference to its original default value
+        public func reset() {
+            value = defaultValue
+        }
+        
         /// Creates a preference
         public init(key: String, default: ValueType, container: UserDefaults = Preferences.defaultContainer) {
             self.key = key
             self.container = container
+            self.defaultValue = `default`
             value = (container.value(forKey: key) as? ValueType) ?? `default`
         }
     }

--- a/BraveSharedTests/PreferencesTest.swift
+++ b/BraveSharedTests/PreferencesTest.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import BraveShared
+
+private let optionalStringDefault: String? = nil
+private let intDefault: Int = 1
+
+extension Preferences {
+    // Test preferences
+    fileprivate static let optionalStringOption = Option<String?>(key: "option-one", default: optionalStringDefault)
+    fileprivate static let intOption = Option<Int>(key: "option-two", default: intDefault)
+}
+
+class PreferencesTest: XCTestCase {
+
+    override func setUp() {
+        Preferences.optionalStringOption.reset()
+        Preferences.intOption.reset()
+        
+        XCTAssertEqual(optionalStringDefault, Preferences.optionalStringOption.value)
+        XCTAssertEqual(intDefault, Preferences.intOption.value)
+    }
+
+    func testSettingPreference() {
+        let newString = "test"
+        let optionalStringOption = Preferences.optionalStringOption
+        optionalStringOption.value = newString
+        XCTAssertEqual(newString, optionalStringOption.value)
+        XCTAssertEqual(newString, optionalStringOption.container.string(forKey: optionalStringOption.key))
+        
+        let newInt = 2
+        let intOption = Preferences.intOption
+        intOption.value = newInt
+        XCTAssertEqual(newInt, intOption.value)
+        XCTAssertEqual(newInt, intOption.container.integer(forKey: Preferences.intOption.key))
+    }
+
+    func testResetPreference() {
+        Preferences.optionalStringOption.value = "test"
+        Preferences.intOption.value = 2
+        XCTAssertEqual("test", Preferences.optionalStringOption.value)
+        XCTAssertEqual(2, Preferences.intOption.value)
+        
+        Preferences.optionalStringOption.reset()
+        XCTAssertEqual(optionalStringDefault, Preferences.optionalStringOption.value)
+        XCTAssertNil(Preferences.optionalStringOption.container.string(forKey: Preferences.optionalStringOption.key))
+        Preferences.intOption.reset()
+        XCTAssertEqual(intDefault, Preferences.intOption.value)
+    }
+
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
 		2798E01D213EFC3F003EDBB1 /* FavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */; };
+		27A586E1214C0DDD000CAE3C /* PreferencesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */; };
 		27C461DE211B76500088A441 /* ShieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C461DD211B76500088A441 /* ShieldsView.swift */; };
 		27C46201211CD8D20088A441 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
 		27F4439F2135E11200296C58 /* BraveShareTo.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 27F443952135E11200296C58 /* BraveShareTo.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -946,6 +947,7 @@
 		0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFavicons.swift; sourceTree = "<group>"; };
 		0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = noTitle.html; sourceTree = "<group>"; };
 		2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteTests.swift; sourceTree = "<group>"; };
+		27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTest.swift; sourceTree = "<group>"; };
 		27C461DD211B76500088A441 /* ShieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsView.swift; sourceTree = "<group>"; };
 		27F443952135E11200296C58 /* BraveShareTo.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BraveShareTo.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		27F4439C2135E11200296C58 /* BraveShareToInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BraveShareToInfo.plist; sourceTree = "<group>"; };
@@ -2146,6 +2148,7 @@
 			children = (
 				5DE7689320B3456E00FF5533 /* BraveSharedTests.swift */,
 				5D6DDEFF21428CF0001FF0AE /* DAUTests.swift */,
+				27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */,
 				5DE7689520B3456E00FF5533 /* Info.plist */,
 			);
 			path = BraveSharedTests;
@@ -4199,6 +4202,7 @@
 			files = (
 				A176323C20CF2AF900126F25 /* DeferredTestUtils.swift in Sources */,
 				5DE7689420B3456E00FF5533 /* BraveSharedTests.swift in Sources */,
+				27A586E1214C0DDD000CAE3C /* PreferencesTest.swift in Sources */,
 				5D6DDF0021428CF0001FF0AE /* DAUTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
@iccub Brought up that we needed a way to reset defaults (or have mock defaults as per FF), for unit tests that rely on `Preferences`.

This made me realize there was a bug that caused a crash/exception when you set any optional preference back to `nil`.

Also adds unit tests for `Preferences`.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`