### PR TITLE
Fix #214, Fix #215: Secure connection security indicator should not be shown for insecure sites

### DIFF
--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -7,6 +7,8 @@ import WebKit
 
 class BraveWebView: WKWebView {
     
+    var isSecure = false
+    
     init(frame: CGRect, configuration: WKWebViewConfiguration = WKWebViewConfiguration(), privacyProtection: PrivacyProtectionProtocol = PrivacyProtection()) {
         if privacyProtection.nonPersistent {
             configuration.processPool = WKProcessPool()

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -572,6 +572,15 @@ class TabWebView: BraveWebView, MenuHelperInterface {
 
         return super.hitTest(point, with: event)
     }
+    
+    // rdar://33283179 Apple bug where `serverTrust` is not defined as KVO when it should be
+    override func value(forUndefinedKey key: String) -> Any? {
+        if key == #keyPath(WKWebView.serverTrust) {
+            return serverTrust
+        }
+
+        return super.value(forUndefinedKey: key)
+    }
 }
 
 ///

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -53,7 +53,7 @@ class TabLocationView: UIView {
         }
     }
 
-    var hasOnlySecureContent = false {
+    var isSecure = false {
         didSet {
             updateLockImageView()
         }
@@ -73,8 +73,8 @@ class TabLocationView: UIView {
     
     private func updateLockImageView() {
         let wasHidden = lockImageView.isHidden
-        let isFullySecure = (url?.scheme == "https" && hasOnlySecureContent)
-        lockImageView.isHidden = !isFullySecure
+        lockImageView.isHidden = !isSecure
+
         if wasHidden != lockImageView.isHidden {
             UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -178,12 +178,12 @@ class URLBarView: UIView {
         }
     }
     
-    var hasOnlySecureContent: Bool {
+    var isSecure: Bool {
         get {
-            return locationView.hasOnlySecureContent
+            return locationView.isSecure
         }
         set {
-            locationView.hasOnlySecureContent = newValue
+            locationView.isSecure = newValue
         }
     }
     

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -23,6 +23,7 @@ public enum KVOConstants: String {
     case canGoForward = "canGoForward"
     case contentSize = "contentSize"
     case hasOnlySecureContent = "hasOnlySecureContent"
+    case serverTrust = "serverTrust"
 }
 
 public struct AppConstants {


### PR DESCRIPTION


<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
