### PR TITLE
Fix #271: Update cancel button color in private mode

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -670,11 +670,6 @@ extension URLBarView: AutocompleteTextFieldDelegate {
 // MARK: UIAppearance
 extension URLBarView {
     
-    @objc dynamic var cancelTintColor: UIColor? {
-        get { return cancelButton.tintColor }
-        set { return cancelButton.tintColor = newValue }
-    }
-    
     @objc dynamic var showQRButtonTintColor: UIColor? {
         get { return showQRScannerButton.tintColor }
         set { return showQRScannerButton.tintColor = newValue }
@@ -692,7 +687,7 @@ extension URLBarView: Themeable {
         
         progressBar.setGradientColors(startColor: UIColor.LoadingBar.Start.colorFor(theme), endColor: UIColor.LoadingBar.End.colorFor(theme))
         currentTheme = theme
-        cancelTintColor = UIColor.Browser.Tint.colorFor(theme)
+        cancelButton.setTitleColor(UIColor.Browser.Tint.colorFor(theme), for: .normal)
         showQRButtonTintColor = UIColor.Browser.Tint.colorFor(theme)
         switch theme {
         case .regular:


### PR DESCRIPTION
Removes `cancelTintColor` since `cancelButton` is not a `system` typed UIButton, therefore `tintColor` does not affect it.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![simulator screen shot - iphone 8 - 2018-09-20 at 10 26 25](https://user-images.githubusercontent.com/529104/45825177-a783ac80-bcbf-11e8-8594-4f47297a60b0.png)

## Notes for testing this patch

_None included_