### PR TITLE
Fix #150: New Tab favourites list is now scrollable again on iPad

### DIFF
--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -224,7 +224,7 @@ class FavoritesViewController: UIViewController {
                 make.leftMargin.equalTo(collection).offset(8)
                 make.rightMargin.equalTo(collection).offset(-8)
             }
-            make.bottom.equalTo(collection)
+            make.bottom.equalTo(collection.frameLayoutGuide)
         }
         
         if UIDevice.current.userInterfaceIdiom == .pad {


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_