### PR TITLE
Fix #147: Don't show `localhost` url's in the tab title after data clear

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -303,7 +303,7 @@ class Tab: NSObject {
         if let title = webView?.title, !title.isEmpty {
             return title.contains("localhost") ? "" : title
         }
-        else if let url = webView?.url, url.isAboutHomeURL {
+        else if let url = webView?.url ?? self.url, url.isAboutHomeURL {
             return Strings.NewTabTitle
         }
         


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_