### PR TITLE
Fix #201: Tab reordering now respects tab type & selects the correct tab

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -346,7 +346,8 @@ class TabManager: NSObject {
             return
         }
 
-        tabs.swapAt(fromIndex, toIndex)
+        let tab = tabs.remove(at: fromIndex)
+        tabs.insert(tab, at: toIndex)
 
         if let previouslySelectedTab = selectedTab, let previousSelectedIndex = tabs.index(of: previouslySelectedTab) {
             _selectedIndex = previousSelectedIndex

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -290,8 +290,9 @@ extension TabsBarViewController: UICollectionViewDataSource {
             let toTab = tabList[destinationIndexPath.row] else { return }
         
         // Find original from/to index... we need to target the full list not partial.
-        guard let from = manager.tabs.index(where: {$0 === fromTab}),
-            let to = manager.tabs.index(where: {$0 === toTab}) else { return }
+        let tabs = manager.tabs(withType: fromTab.type)
+        guard let from = tabs.index(where: {$0 === fromTab}),
+            let to = tabs.index(where: {$0 === toTab}) else { return }
         
         manager.moveTab(fromIndex: from, toIndex: to)
         updateData()


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_none included_

## Notes for testing this patch

_none included_