### PR TITLE
Fix #203: Tapping a favourite site's edit button now works correctly

### DIFF
--- a/Client/Frontend/Browser/HomePanel/favorites/FavoriteCell.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoriteCell.swift
@@ -86,7 +86,6 @@ class FavoriteCell: UICollectionViewCell {
         $0.isExclusiveTouch = true
         let removeButtonImage = #imageLiteral(resourceName: "edit-small").template
         $0.setImage(removeButtonImage, for: .normal)
-        $0.addTarget(self, action: #selector(FavoriteCell.editButtonTapped), for: UIControlEvents.touchUpInside)
         $0.accessibilityLabel = Strings.Edit_Bookmark
         $0.isHidden = true
         $0.backgroundColor = UX.GreyC
@@ -134,6 +133,8 @@ class FavoriteCell: UICollectionViewCell {
         
         // Prevents the textLabel from getting squished in relation to other view priorities.
         textLabel.setContentCompressionResistancePriority(UILayoutPriority.defaultHigh, for: UILayoutConstraintAxis.vertical)
+        
+        editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
         
         NotificationCenter.default.addObserver(self, selector: #selector(showEditMode), name: Notification.Name.ThumbnailEditOn, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(hideEditMode), name: Notification.Name.ThumbnailEditOff, object: nil)


### PR DESCRIPTION
Turns out the edit functionality did exist, however the edit button was not actually adding a target because `self` is `nil` at that point and Xcode doesn't report it as an error for some dumb reason.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_