### PR TITLE
Fix #291: Remove 3D Touch quick actions that don't exist in 1.6

### DIFF
--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -10,9 +10,6 @@ import XCGLogger
 
 enum ShortcutType: String {
     case newTab = "NewTab"
-    case newPrivateTab = "NewPrivateTab"
-    case openLastBookmark = "OpenLastBookmark"
-    case qrCode = "QRCode"
 
     init?(fullType: String) {
         guard let last = fullType.components(separatedBy: ".").last else { return nil }
@@ -46,49 +43,6 @@ class QuickActions: NSObject {
 
     var launchedShortcutItem: UIApplicationShortcutItem?
 
-    // MARK: Administering Quick Actions
-    func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType, fromShareItem shareItem: ShareItem, toApplication application: UIApplication) {
-            var userData = [QuickActions.TabURLKey: shareItem.url]
-            if let title = shareItem.title {
-                userData[QuickActions.TabTitleKey] = title
-            }
-            QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(type, withUserData: userData, toApplication: application)
-    }
-
-    @discardableResult func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType, withUserData userData: [AnyHashable: Any] = [AnyHashable: Any](), toApplication application: UIApplication) -> Bool {
-        // add the quick actions version so that it is always in the user info
-        var userData: [AnyHashable: Any] = userData
-        userData[QuickActions.QuickActionsVersionKey] = QuickActions.QuickActionsVersion
-        var dynamicShortcutItems = application.shortcutItems ?? [UIApplicationShortcutItem]()
-        switch type {
-        case .openLastBookmark:
-            let openLastBookmarkShortcut = UIMutableApplicationShortcutItem(type: ShortcutType.openLastBookmark.type,
-                localizedTitle: lastBookmarkTitle,
-                localizedSubtitle: userData[QuickActions.TabTitleKey] as? String,
-                icon: UIApplicationShortcutIcon(templateImageName: "quick_action_last_bookmark"),
-                userInfo: userData
-            )
-            if let index = (dynamicShortcutItems.index { $0.type == ShortcutType.openLastBookmark.type }) {
-                dynamicShortcutItems[index] = openLastBookmarkShortcut
-            } else {
-                dynamicShortcutItems.append(openLastBookmarkShortcut)
-            }
-        default:
-            log.warning("Cannot add static shortcut item of type \(type)")
-            return false
-        }
-        application.shortcutItems = dynamicShortcutItems
-        return true
-    }
-
-    func removeDynamicApplicationShortcutItemOfType(_ type: ShortcutType, fromApplication application: UIApplication) {
-        guard var dynamicShortcutItems = application.shortcutItems,
-            let index = (dynamicShortcutItems.index { $0.type == type.type }) else { return }
-
-        dynamicShortcutItems.remove(at: index)
-        application.shortcutItems = dynamicShortcutItems
-    }
-
     // MARK: Handling Quick Actions
     @discardableResult func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem, withBrowserViewController bvc: BrowserViewController ) -> Bool {
 
@@ -106,37 +60,10 @@ class QuickActions: NSObject {
         switch type {
         case .newTab:
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
-        case .newPrivateTab:
-            handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
-        // even though we're removing OpenLastTab, it's possible that someone will use an existing last tab quick action to open the app
-        // the first time after upgrading, so we should still handle it
-        case .openLastBookmark:
-            if let urlToOpen = (userData?[QuickActions.TabURLKey] as? String)?.asURL {
-                handleOpenURL(withBrowserViewController: browserViewController, urlToOpen: urlToOpen)
-            }
-        case .qrCode:
-            handleQRCode(with: browserViewController)
         }
     }
 
     fileprivate func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController, isPrivate: Bool) {
         bvc.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
-    }
-
-    fileprivate func handleOpenURL(withBrowserViewController bvc: BrowserViewController, urlToOpen: URL) {
-        // open bookmark in a non-private browsing tab
-        bvc.switchToPrivacyMode(isPrivate: false)
-
-        // find out if bookmarked URL is currently open
-        // if so, open to that tab,
-        // otherwise, create a new tab with the bookmarked URL
-        bvc.switchToTabForURLOrOpen(urlToOpen, isPrivileged: true)
-    }
-    
-    fileprivate func handleQRCode(with vc: QRCodeViewControllerDelegate & UIViewController) {
-        let qrCodeViewController = QRCodeViewController()
-        qrCodeViewController.qrCodeDelegate = vc
-        let controller = UINavigationController(rootViewController: qrCodeViewController)
-        vc.present(controller, animated: true, completion: nil)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -819,13 +819,6 @@ class BrowserViewController: UIViewController {
         let absoluteString = url.absoluteString
         let shareItem = ShareItem(url: absoluteString, title: tabState.title, favicon: tabState.favicon)
         _ = profile.bookmarks.shareItem(shareItem)
-        var userData = [QuickActions.TabURLKey: shareItem.url]
-        if let title = shareItem.title {
-            userData[QuickActions.TabTitleKey] = title
-        }
-        QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
-            withUserData: userData,
-            toApplication: UIApplication.shared)
     }
 
     override func accessibilityPerformEscape() -> Bool {

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -115,22 +115,6 @@
 			<key>UIApplicationShortcutItemType</key>
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER).NewTab</string>
 		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemIconFile</key>
-			<string>quick_action_new_private_tab</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>ShortcutItemTitleNewPrivateTab</string>
-			<key>UIApplicationShortcutItemType</key>
-			<string>$(PRODUCT_BUNDLE_IDENTIFIER).NewPrivateTab</string>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemIconFile</key>
-			<string>menu-ScanQRCode</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>ShortcutItemTitleQRCode</string>
-			<key>UIApplicationShortcutItemType</key>
-			<string>$(PRODUCT_BUNDLE_IDENTIFIER).QRCode</string>
-		</dict>
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>


### PR DESCRIPTION
Note: We were actually _missing_ the icon in 1.6, where as in 1.7 we do have the add icon.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

| 1.6 | 1.7 | 
| --- | --- |
| ![img_4eb37f2f57b1-1](https://user-images.githubusercontent.com/529104/46098596-d05de300-c192-11e8-8509-d3c1561194b7.jpeg) | ![img_44bb50b3c890-1](https://user-images.githubusercontent.com/529104/46158385-bb915600-c24b-11e8-815d-acdd4ce09b09.jpeg) |


## Notes for testing this patch

Requires a 3D touch enabled device