### PR TITLE
Fix #221: Respect current tab type when toggling display of the tab bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -757,7 +757,7 @@ class BrowserViewController: UIViewController {
     
     func updateTabsBarVisibility() {
         func shouldShowTabBar() -> Bool {
-            let tabCount = tabManager.tabs.count
+            let tabCount = tabManager.tabs(withType: TabType.of(tabManager.selectedTab)).count
             guard let tabBarVisibility = TabBarVisibility(rawValue: Preferences.General.tabBarVisibility.value) else {
                 // This should never happen
                 assertionFailure("Invalid tab bar visibility preference: \(Preferences.General.tabBarVisibility.value).")


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_none included_

## Notes for testing this patch

_none included_