### PR TITLE
Fix #300: Change Bitwarden to upper case B

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -36,7 +36,7 @@ extension PasswordManagerShortcutBehavior: RepresentableOptionType {
         case .showPicker: return Strings.ShowPicker
         case .onePassword: return "1Password"
         case .lastPass: return "LastPass"
-        case .bitwarden: return "bitwarden"
+        case .bitwarden: return "Bitwarden"
         case .trueKey: return "True Key"
         }
     }


### PR DESCRIPTION
This basically does the same thing as 
https://github.com/brave/browser-ios/pull/1743 since Bitwarden uses uppper case B nowadays and only lower as win their logos...