### PR TITLE
Fix #62, Fix #314: Integrate DuckDuckGo search engine callout and popup & minor UI issue

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -373,6 +373,11 @@ public extension Strings {
     public static let Browser_lock_callout_message = NSLocalizedString("With Browser Lock, you will need to enter a PIN in order to access Brave.", comment: "Browser Lock feature callout message.")
     public static let Browser_lock_callout_not_now = NSLocalizedString("Not Now", comment: "Browser Lock feature callout not now action.")
     public static let Browser_lock_callout_enable = NSLocalizedString("Enable", comment: "Browser Lock feature callout enable action.")
+    public static let DDG_callout_title = NSLocalizedString("Private search with DuckDuckGo?", comment: "DuckDuckGo callout title.")
+    public static let DDG_callout_message = NSLocalizedString("With private search, Brave will use DuckDuckGo to answer your searches while you are in this private tab. DuckDuckGo is a search engine that does not track your search history, enabling you to search privately.", comment: "DuckDuckGo message.")
+    public static let DDG_callout_no = NSLocalizedString("No", comment: "DuckDuckGo callout no action.")
+    public static let DDG_callout_enable = NSLocalizedString("Yes", comment: "DuckDuckGo callout enable action.")
+    public static let DDG_promotion = NSLocalizedString("Learn about private search \rwith DuckDuckGo", comment: "DuckDuckGo promotion label.")
 }
 
 // SYNC.

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */; };
 		0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
+		27187808216526090006036E /* AlertPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27187807216526090006036E /* AlertPopupView.swift */; };
+		2718780A216526240006036E /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27187809216526240006036E /* PopupView.swift */; };
 		2760D2BF215ACCE20068E131 /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2760D2BE215ACCE20068E131 /* BundleExtensions.swift */; };
 		2798E01D213EFC3F003EDBB1 /* FavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */; };
 		27A586E1214C0DDD000CAE3C /* PreferencesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */; };
@@ -920,6 +922,8 @@
 		0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsetButton.swift; sourceTree = "<group>"; };
 		0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFavicons.swift; sourceTree = "<group>"; };
 		0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = noTitle.html; sourceTree = "<group>"; };
+		27187807216526090006036E /* AlertPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPopupView.swift; sourceTree = "<group>"; };
+		27187809216526240006036E /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		2760D2BE215ACCE20068E131 /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
 		2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteTests.swift; sourceTree = "<group>"; };
 		27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTest.swift; sourceTree = "<group>"; };
@@ -1713,6 +1717,15 @@
 				0B742CCC1B32491400EE9264 /* libsqlcipher.a */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		271877FF216525FB0006036E /* Popup */ = {
+			isa = PBXGroup;
+			children = (
+				27187809216526240006036E /* PopupView.swift */,
+				27187807216526090006036E /* AlertPopupView.swift */,
+			);
+			path = Popup;
 			sourceTree = "<group>";
 		};
 		27F443962135E11200296C58 /* BraveShareTo */ = {
@@ -2930,6 +2943,7 @@
 				2F44FC551A9E83E200FD20CC /* Settings */,
 				D3972BF01C22412B00035B87 /* Share */,
 				A1D841FE20BC44E400BDAFF7 /* Popover */,
+				271877FF216525FB0006036E /* Popup */,
 				D0FCF7EE1FE44E15004A7995 /* UserContent */,
 				D38A1BEB1A9FA2CA00F6A386 /* Widgets */,
 				2C49854D206173C800893DAE /* photon-colors.swift */,
@@ -4316,8 +4330,10 @@
 				E65075511E37F6D1006961AC /* NSURLExtensionsMailTo.swift in Sources */,
 				D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */,
 				D03F8EB22004014E003C2224 /* FaviconHandler.swift in Sources */,
+				27187808216526090006036E /* AlertPopupView.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift in Sources */,
 				A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */,
+				2718780A216526240006036E /* PopupView.swift in Sources */,
 				0AADC4D420D2A6A200FDE368 /* FavoritesDataSource.swift in Sources */,
 				E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -28,10 +28,10 @@ enum PasswordManagerShortcutBehavior: Int {
 // MARK: - Other Preferences
 extension Preferences {
     final class Popups {
-        /// Whether or not the user has opted-in for using DuckDuckGo during a Private Browsing session
+        /// Whether or not the user has seen the DuckDuckGo popup at least once
         ///
-        /// Defaults to nil, meaning the user has not been given the choice yet
-        static let duckDuckGoPrivateSearch = Option<Bool?>(key: "popups.ddg-private-search", default: nil)
+        /// Defaults to false, meaning the user has not been given the choice yet
+        static let duckDuckGoPrivateSearch = Option<Bool>(key: "popups.ddg-private-search", default: false)
     }
     final class AppState {
         /// A flag for determining if the app exited with user interaction in the previous session

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -11,7 +11,11 @@ private let TypeSuggest = "application/x-suggestions+json"
 
 class OpenSearchEngine: NSObject, NSCoding {
     static let PreferredIconSize = 30
-
+    
+    struct EngineNames {
+        static let duckDuckGo = "DuckDuckGo"
+    }
+    
     let shortName: String
     let engineID: String?
     let image: UIImage

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1091,13 +1091,13 @@ class TrayToolbar: UIView {
         }
 
         doneButton.snp.makeConstraints { make in
-            make.centerY.equalTo(self)
+            make.centerY.equalTo(safeArea.centerY)
             make.trailing.equalTo(self).offset(-sideOffset)
         }
 
         addSubview(privateModeButton)
         privateModeButton.snp.makeConstraints { make in
-            make.centerY.equalTo(self)
+            make.centerY.equalTo(safeArea.centerY)
             make.leading.equalTo(self).offset(sideOffset)
         }
     }

--- a/Client/Frontend/Popup/AlertPopupView.swift
+++ b/Client/Frontend/Popup/AlertPopupView.swift
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import BraveShared
+
+class AlertPopupView: PopupView {
+    
+    fileprivate var dialogImage: UIImageView?
+    fileprivate var titleLabel: UILabel!
+    fileprivate var messageLabel: UILabel!
+    fileprivate var containerView: UIView!
+    
+    fileprivate let kAlertPopupScreenFraction: CGFloat = 0.8
+    fileprivate let kPadding: CGFloat = 20.0
+    
+    init(image: UIImage?, title: String, message: String) {
+        super.init(frame: CGRect.zero)
+        
+        overlayDismisses = false
+        defaultShowType = .normal
+        defaultDismissType = .noAnimation
+        presentsOverWindow = true
+        
+        containerView = UIView(frame: CGRect.zero)
+        containerView.autoresizingMask = [.flexibleWidth]
+        
+        if let image = image {
+            let di = UIImageView(image: image)
+            containerView.addSubview(di)
+            dialogImage = di
+        }
+        
+        titleLabel = UILabel(frame: CGRect.zero)
+        titleLabel.textColor = BraveUX.GreyJ
+        titleLabel.textAlignment = .center
+        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: UIFont.Weight.bold)
+        titleLabel.text = title
+        titleLabel.numberOfLines = 0
+        containerView.addSubview(titleLabel)
+        
+        messageLabel = UILabel(frame: CGRect.zero)
+        messageLabel.textColor = BraveUX.GreyH
+        messageLabel.textAlignment = .center
+        messageLabel.font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.regular)
+        messageLabel.text = message
+        messageLabel.numberOfLines = 0
+        containerView.addSubview(messageLabel)
+        
+        updateSubviews()
+        
+        setPopupContentView(view: containerView)
+        setStyle(popupStyle: .dialog)
+        setDialogColor(color: BraveUX.PopupDialogColorLight)
+    }
+    
+    func updateSubviews() {
+        let width: CGFloat = dialogWidth
+        
+        var imageFrame: CGRect = dialogImage?.frame ?? CGRect.zero
+        if let dialogImage = dialogImage {
+            imageFrame.origin.x = (width - imageFrame.width) / 2.0
+            imageFrame.origin.y = kPadding * 2.0
+            dialogImage.frame = imageFrame
+        }
+        
+        let titleLabelSize: CGSize = titleLabel.sizeThatFits(CGSize(width: width - kPadding * 3.0, height: CGFloat.greatestFiniteMagnitude))
+        var titleLabelFrame: CGRect = titleLabel.frame
+        titleLabelFrame.size = titleLabelSize
+        titleLabelFrame.origin.x = rint((width - titleLabelSize.width) / 2.0)
+        titleLabelFrame.origin.y = imageFrame.maxY + kPadding
+        titleLabel.frame = titleLabelFrame
+        
+        let messageLabelSize: CGSize = messageLabel.sizeThatFits(CGSize(width: width - kPadding * 4.0, height: CGFloat.greatestFiniteMagnitude))
+        var messageLabelFrame: CGRect = messageLabel.frame
+        messageLabelFrame.size = messageLabelSize
+        messageLabelFrame.origin.x = rint((width - messageLabelSize.width) / 2.0)
+        messageLabelFrame.origin.y = rint(titleLabelFrame.maxY + kPadding * 1.5 / 2.0)
+        messageLabel.frame = messageLabelFrame
+        
+        var containerViewFrame: CGRect = containerView.frame
+        containerViewFrame.size.width = width
+        containerViewFrame.size.height = messageLabelFrame.maxY + kPadding * 1.5
+        containerView.frame = containerViewFrame
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        updateSubviews()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Client/Frontend/Popup/PopupView.swift
+++ b/Client/Frontend/Popup/PopupView.swift
@@ -1,0 +1,581 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Shared
+import BraveShared
+
+enum PopupViewDismissType: Int {
+    case dont
+    case deny
+    case noAnimation
+    case normal
+    case flyUp
+    case flyDown
+    case scaleDown
+}
+
+enum PopupViewShowType: Int {
+    case normal
+    case flyUp
+    case flyDown
+}
+
+enum PopupViewAlignment: Int {
+    case top
+    case middle
+    case bottom
+}
+
+enum PopupViewStyle: Int {
+    case dialog
+    case sheet
+}
+
+protocol PopupViewDelegate {
+    func popupViewDidShow(_ popupView: PopupView)
+    func popupViewShouldDismiss(_ popupView: PopupView) -> Bool
+    func popupViewDidDismiss(_ popupView: PopupView)
+}
+
+class ButtonData: NSObject {
+    var title: String = ""
+    var isDefault: Bool = true
+    var button: UIButton?
+    var handler: (() -> PopupViewDismissType)?
+}
+
+class PopupView: UIView, UIGestureRecognizerDelegate {
+    static let popupView = PopupView()
+    
+    fileprivate var keyboardState: KeyboardState?
+    
+    let kPopupDialogPadding: CGFloat = 20.0
+    let kPopupDialogButtonHeight: CGFloat = 50.0
+    let kPopupDialogMaxWidth: CGFloat = 390.0
+    
+    fileprivate let kPopupBackgroundAlpha: CGFloat = 0.6
+    fileprivate let kPopupBackgroundDismissTouchDuration: Double = 0.005
+    fileprivate let kPopupDialogShakeAngle: CGFloat = 0.2
+    fileprivate let kPopupDialogCornerRadius: CGFloat = 12.0
+    fileprivate let kPopupDialogButtonRadius: CGFloat = 0.0
+    fileprivate let kPopupDialogButtonPadding: CGFloat = 16.0
+    fileprivate let kPopupDialogButtonSpacing: CGFloat = 16.0
+    fileprivate let kPopupDialogButtonTextSize: CGFloat = 17.0
+    
+    var showHandler: (() -> Void)?
+    var dismissHandler: (() -> Void)?
+    
+    var dialogWidth: CGFloat {
+        get {
+            return min(UIScreen.main.bounds.width - padding * 2.0, kPopupDialogMaxWidth)
+        }
+    }
+    
+    var dialogView: UIView!
+    var overlayView: UIView!
+    var contentView: UIView!
+    
+    var style: PopupViewStyle!
+    var verticalAlignment: PopupViewAlignment = .middle
+    var defaultShowType: PopupViewShowType = .normal
+    var defaultDismissType: PopupViewDismissType = .normal
+    var overlayDismisses: Bool = true
+    var overlayDismissHandler: (() -> Bool)?
+    var presentsOverWindow: Bool = true
+    var automaticallyMovesWithKeyboard: Bool = true
+    var padding: CGFloat = 20.0 {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    
+    var dialogButtons: Array<ButtonData> = []
+    var dialogButtonsContainer: UIView!
+    var dialogButtonDefaultTextColor: UIColor = UIColor.white
+    var dialogButtonDefaultBackgroundColor: UIColor = BraveUX.Blue
+    var dialogButtonTextColor: UIColor = UIColor.white
+    var dialogButtonBackgroundColor: UIColor = BraveUX.GreyE
+    
+    var delegate: PopupViewDelegate?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = UIColor.clear
+        autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        
+        let touchRecognizer: UILongPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(backgroundTapped(recognizer:)))
+        touchRecognizer.minimumPressDuration = kPopupBackgroundDismissTouchDuration
+        touchRecognizer.delegate = self
+        
+        overlayView = UIView(frame: bounds)
+        overlayView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        overlayView.backgroundColor = BraveUX.GreyJ
+        overlayView.alpha = kPopupBackgroundAlpha
+        overlayView.addGestureRecognizer(touchRecognizer)
+        addSubview(overlayView)
+        
+        dialogButtonsContainer = UIView(frame: CGRect.zero)
+        dialogButtonsContainer.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        
+        dialogView = UIView(frame: CGRect.zero)
+        dialogView.clipsToBounds = true
+        dialogView.autoresizingMask = [.flexibleWidth, .flexibleTopMargin, .flexibleBottomMargin]
+        dialogView.backgroundColor = UIColor.white
+        
+        setStyle(popupStyle: .dialog)
+        
+        KeyboardHelper.defaultHelper.addDelegate(self)
+    }
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)!
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: Layout
+    
+    private var applicationWindow: UIWindow? {
+        return (UIApplication.shared.delegate as? AppDelegate)?.window
+    }
+    
+    override func layoutSubviews() {
+        let contentSize: CGSize = contentView.frame.size
+        let keyboardHeight = keyboardState?.intersectionHeightForView(applicationWindow ?? self) ?? 0
+        
+        dialogView.frame = _dialogFrameWithKeyboardHeight(height: keyboardHeight)
+        contentView.frame = CGRect(x: 0.0, y: 0.0, width: dialogView.bounds.size.width, height: contentSize.height)
+        
+        // Add and create buttons as necessary.
+        if dialogButtons.count > 0 {
+            var buttonWidth: CGFloat = 0.0
+            
+            dialogButtonsContainer.frame = CGRect(x: 0.0, y: contentSize.height, width: dialogView.frame.size.width, height: kPopupDialogButtonHeight)
+            
+            buttonWidth = dialogView.frame.width - (kPopupDialogButtonPadding * 2.0)
+            buttonWidth -= CGFloat((dialogButtons.count-1)) * kPopupDialogButtonSpacing
+            buttonWidth = buttonWidth / CGFloat(dialogButtons.count)
+            buttonWidth = rint(buttonWidth)
+            
+            var buttonFrame: CGRect = CGRect(x: kPopupDialogButtonPadding, y: 0, width: buttonWidth, height: kPopupDialogButtonHeight)
+            let defaultButtonFont: UIFont = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.semibold)
+            let normalButtonFont: UIFont = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.semibold)
+            
+            for buttonData in dialogButtons {
+                var button: UIButton? = buttonData.button
+                if button == nil {
+                    let defaultButton: Bool = buttonData.isDefault
+                    button = UIButton(type: .system)
+                    button!.titleLabel!.font = defaultButton ? defaultButtonFont : normalButtonFont
+                    button!.layer.cornerRadius = buttonFrame.height / 2.0 //kPopupDialogButtonRadius
+                    button!.backgroundColor = defaultButton ? dialogButtonDefaultBackgroundColor : dialogButtonBackgroundColor
+                    button!.setTitle(buttonData.title, for: .normal)
+                    button!.setTitleColor(defaultButton ? dialogButtonDefaultTextColor : dialogButtonTextColor, for: .normal)
+                    button!.addTarget(self, action: #selector(dialogButtonTapped(button:)), for: .touchUpInside)
+                    buttonData.button = button
+                    dialogButtonsContainer.addSubview(button!)
+                }
+                
+                button?.frame = buttonFrame
+                buttonFrame.origin.x += buttonFrame.size.width + kPopupDialogButtonSpacing
+            }
+            
+            dialogView.addSubview(dialogButtonsContainer)
+        }
+    }
+    
+    @discardableResult fileprivate func _dialogFrameWithKeyboardHeight(height: CGFloat) -> CGRect {
+        var visibleFrame: CGRect = bounds
+        var dialogFrame: CGRect = CGRect.zero
+        let contentSize: CGSize = contentView.frame.size
+        var dialogSize: CGSize = CGSize(width: dialogWidth, height: contentSize.height)
+        
+        if dialogButtons.count > 0 {
+            dialogSize.height += kPopupDialogButtonHeight
+            dialogSize.height += kPopupDialogButtonPadding
+        }
+        
+        if automaticallyMovesWithKeyboard && height > 0 {
+            visibleFrame = CGRect(x: 0.0, y: 0.0, width: bounds.size.width, height: UIScreen.main.bounds.height - height)
+        }
+        
+        if !dialogView.transform.isIdentity {
+            dialogSize = dialogSize.applying(dialogView.transform)
+        }
+        
+        dialogFrame = CGRect(x: rint(visibleFrame.midX - (dialogSize.width / 2.0)), y: rint(visibleFrame.midY - (dialogSize.height / 2.0)), width: dialogSize.width, height: dialogSize.height)
+        dialogFrame.origin.y = max(dialogFrame.origin.y, padding)
+        
+        if verticalAlignment == .top {
+            dialogFrame.origin.y = visibleFrame.origin.y
+        } else if verticalAlignment == .bottom {
+            dialogFrame.origin.y = visibleFrame.size.height - dialogFrame.size.height
+        }
+        
+        return dialogFrame
+    }
+    
+    // MARK: Presentation
+    
+    func show() {
+        showWithType(showType: defaultShowType)
+    }
+    
+    func showWithType(showType: PopupViewShowType) {
+        if superview != nil { return }
+        
+        dialogView.removeFromSuperview()
+        
+        frame = UIScreen.main.bounds
+        addSubview(dialogView)
+        setNeedsLayout()
+        layoutIfNeeded()
+        
+        if showType == .flyUp {
+            let finalFrame: CGRect = dialogView.frame
+            var startFrame: CGRect = dialogView.frame
+            startFrame.origin.y = frame.maxY
+            dialogView.frame = startFrame
+            
+            // For subclasses.
+            willShowWithType(showType: showType)
+            
+            UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 0.85, initialSpringVelocity: 0, options: [], animations: {
+                self.dialogView.frame = finalFrame
+            }, completion: nil)
+        } else if showType == .flyDown {
+            let finalFrame: CGRect = dialogView.frame
+            var startFrame: CGRect = dialogView.frame
+            startFrame.origin.y = -dialogView.frame.height
+            dialogView.frame = startFrame
+            
+            willShowWithType(showType: showType)
+            
+            UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 0.85, initialSpringVelocity: 0, options: [], animations: {
+                self.dialogView.frame = finalFrame
+            }, completion: nil)
+        }
+        
+        overlayView.alpha = 0.0
+        
+        if presentsOverWindow {
+            UIApplication.shared.keyWindow?.addSubview(self)
+        } else {
+            let currentViewController: AnyObject = (applicationWindow?.rootViewController)!
+            if currentViewController is UINavigationController {
+                let navigationController: UINavigationController? = currentViewController as? UINavigationController
+                navigationController?.visibleViewController?.view.addSubview(self)
+            } else if currentViewController is UIViewController {
+                let viewController: UIViewController? = currentViewController as? UIViewController
+                viewController?.view.addSubview(self)
+            }
+        }
+        
+        UIView.animate(withDuration: 0.2, delay: 0.0, options: [.curveEaseOut], animations: {
+            self.overlayView.alpha = self.kPopupBackgroundAlpha
+        }, completion: nil)
+        
+        didShowWithType(showType: showType)
+        
+        showHandler?()
+        
+        delegate?.popupViewDidShow(self)
+    }
+    
+    func dismiss() {
+        dismissWithType(dismissType: defaultDismissType)
+    }
+    
+    func dismissWithType(dismissType: PopupViewDismissType) {
+        if dismissType == .dont {
+            return
+        }
+        
+        if delegate?.popupViewShouldDismiss(self) == false {
+            return
+        }
+        
+        if dismissType != .deny {
+            self.endEditing(true)
+        }
+        
+        switch dismissType {
+        case .dont:
+            break
+        case .deny:
+            let animation: CAKeyframeAnimation = CAKeyframeAnimation(keyPath: "transform")
+            animation.duration = 0.06
+            animation.repeatCount = 2
+            animation.autoreverses = true
+            animation.isRemovedOnCompletion = true
+            animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+            animation.values = [NSValue(caTransform3D: CATransform3DMakeRotation(kPopupDialogShakeAngle, 0.0, 0.0, 1.0)), NSValue(caTransform3D: CATransform3DMakeRotation(-kPopupDialogShakeAngle, 0.0, 0.0, 1.0))]
+            dialogView.layer.add(animation, forKey: "dialog.shake")
+        case .noAnimation:
+            willDismissWithType(dismissType: dismissType)
+            removeFromSuperview()
+            didDismissWithType(dismissType: dismissType)
+            delegate?.popupViewDidDismiss(self)
+            dismissHandler?()
+        case .normal:
+            willDismissWithType(dismissType: dismissType)
+            
+            UIView.animate(withDuration: 0.2, delay: 0.0, options: [.beginFromCurrentState, .curveEaseIn], animations: {
+                self.alpha = 0.0
+            }, completion: { (finished) in
+                self.removeFromSuperview()
+                self.alpha = 1.0
+                self.didDismissWithType(dismissType: dismissType)
+                self.delegate?.popupViewDidDismiss(self)
+                self.dismissHandler?()
+            })
+        case .scaleDown:
+            willDismissWithType(dismissType: dismissType)
+            
+            UIView.animate(withDuration: 0.2, delay: 0.0, options: [.beginFromCurrentState, .curveEaseIn], animations: {
+                self.alpha = 0.0
+                self.dialogView.transform = self.dialogView.transform.scaledBy(x: 0.9, y: 0.9)
+            }, completion: { (finished) in
+                self.removeFromSuperview()
+                self.alpha = 1.0
+                self.dialogView.transform = CGAffineTransform.identity
+                self.didDismissWithType(dismissType: dismissType)
+                self.delegate?.popupViewDidDismiss(self)
+                self.dismissHandler?()
+            })
+        case .flyUp:
+            willDismissWithType(dismissType: dismissType)
+            
+            overlayView.alpha = kPopupBackgroundAlpha
+            UIView.animate(withDuration: 0.2, delay: 0.0, options: [.beginFromCurrentState, .curveEaseIn], animations: {
+                var flyawayFrame: CGRect = self.dialogView.frame
+                flyawayFrame.origin.y = -flyawayFrame.height
+                flyawayFrame.origin.y -= 20.0
+                self.dialogView.frame = flyawayFrame
+                self.overlayView.alpha = 0.0
+            }, completion: { (finished) in
+                self.removeFromSuperview()
+                self.overlayView.alpha = self.kPopupBackgroundAlpha
+                self.didDismissWithType(dismissType: dismissType)
+                self.delegate?.popupViewDidDismiss(self)
+                self.dismissHandler?()
+            })
+        case .flyDown:
+            willDismissWithType(dismissType: dismissType)
+            
+            overlayView.alpha = kPopupBackgroundAlpha
+            UIView.animate(withDuration: 0.2, delay: 0.0, options: [.beginFromCurrentState, .curveEaseIn], animations: {
+                var flyawayFrame: CGRect = self.dialogView.frame
+                flyawayFrame.origin.y = self.overlayView.bounds.height
+                flyawayFrame.origin.y += 20.0
+                self.dialogView.frame = flyawayFrame
+                self.overlayView.alpha = 0.0
+            }, completion: { (finished) in
+                self.removeFromSuperview()
+                self.overlayView.alpha = self.kPopupBackgroundAlpha
+                self.didDismissWithType(dismissType: dismissType)
+                self.delegate?.popupViewDidDismiss(self)
+                self.dismissHandler?()
+            })
+        }
+    }
+    
+    // MARK: Options
+    
+    func setStyle(popupStyle: PopupViewStyle) {
+        style = popupStyle
+        
+        switch popupStyle {
+        case .dialog:
+            dialogView.layer.cornerRadius = kPopupDialogCornerRadius
+            defaultShowType = .flyUp
+            defaultDismissType = .flyDown
+            verticalAlignment = .middle
+            padding = kPopupDialogPadding
+        case .sheet:
+            dialogView.layer.cornerRadius = 0.0
+            defaultShowType = .flyUp
+            defaultDismissType = .flyDown
+            verticalAlignment = .bottom
+            padding = 0.0
+        }
+        
+        setNeedsLayout()
+    }
+    
+    func setVerticalAlignment(alignment: PopupViewAlignment) {
+        verticalAlignment = alignment
+        setNeedsLayout()
+    }
+    
+    func setDialogColor(color: UIColor) {
+        dialogView.backgroundColor = color
+    }
+    
+    func setOverlayColor(color: UIColor, animate: Bool) {
+        if !animate {
+            overlayView.backgroundColor = color
+        } else {
+            UIView.animate(withDuration: 0.35, delay: 0.0, options: [.beginFromCurrentState], animations: {
+                self.overlayView.backgroundColor = color
+            }, completion: nil)
+        }
+    }
+    
+    func setButtonTextColor(color: UIColor) {
+        dialogButtonTextColor = color
+        
+        for buttonData in dialogButtons {
+            if let button: UIButton = buttonData.button {
+                button.setTitleColor(color, for: .normal)
+            }
+        }
+    }
+    
+    func setButtonBackgroundColor(color: UIColor) {
+        dialogButtonBackgroundColor = color
+        
+        let fadeTransition: CATransition = CATransition()
+        fadeTransition.type = kCATransitionFade
+        fadeTransition.duration = 0.2
+        dialogButtonsContainer.layer.add(fadeTransition, forKey: kCATransition)
+        
+        for buttonData in dialogButtons {
+            if let button: UIButton = buttonData.button {
+                button.layer.add(fadeTransition, forKey: kCATransition)
+                button.backgroundColor = color
+            }
+        }
+    }
+    
+    func setPopupContentView(view: UIView) {
+        contentView?.removeFromSuperview()
+        contentView = view
+        contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        dialogView.addSubview(contentView)
+        setNeedsLayout()
+    }
+    
+    func addDefaultButton(title: String, tapped: (() -> PopupViewDismissType)?) {
+        let buttonData: ButtonData = ButtonData()
+        buttonData.title = title
+        buttonData.isDefault = true
+        buttonData.handler = tapped
+        dialogButtons.append(buttonData)
+    }
+    
+    func addButton(title: String, tapped: (() -> PopupViewDismissType)?) {
+        let buttonData: ButtonData = ButtonData()
+        buttonData.title = title
+        buttonData.isDefault = false
+        buttonData.handler = tapped
+        dialogButtons.append(buttonData)
+        setNeedsLayout()
+    }
+    
+    func setTitle(title: String, buttonIndex: Int) {
+        if buttonIndex >= dialogButtons.count {
+            return
+        }
+        
+        let buttonData: ButtonData = dialogButtons[buttonIndex]
+        buttonData.title = title
+        
+        if let button = buttonData.button {
+            button.setTitle(title, for: .normal)
+        }
+    }
+    
+    func removeButtonAtIndex(buttonIndex: Int) {
+        if buttonIndex >= dialogButtons.count {
+            return
+        }
+        
+        let buttonData: ButtonData = dialogButtons[buttonIndex]
+        if let button = buttonData.button {
+            button.removeFromSuperview()
+        }
+        
+        dialogButtons.remove(at: buttonIndex)
+        setNeedsLayout()
+    }
+    
+    func numberOfButtons() -> Int {
+        return dialogButtons.count
+    }
+    
+    // MARK: Actions
+    
+    @objc func dialogButtonTapped(button: UIButton) {
+        var dismissType = defaultDismissType
+        
+        for buttonData in dialogButtons {
+            if let target = buttonData.button {
+                if target == button {
+                    if let handler = buttonData.handler {
+                        dismissType = handler()
+                        break
+                    }
+                }
+            }
+        }
+        
+        dismissWithType(dismissType: dismissType)
+    }
+    
+    // MARK: Background
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        let point: CGPoint = touch.location(in: dialogView)
+        return dialogView.point(inside: point, with: nil) == false
+    }
+    
+    @objc func backgroundTapped(recognizer: AnyObject?) {
+        if overlayDismisses == false {
+            return
+        }
+        
+        guard let recognizer = recognizer else { return }
+        
+        if recognizer.state == .began {
+            if let overlayDismissHandler = overlayDismissHandler, overlayDismissHandler() {
+                dismiss()
+            }
+        }
+    }
+    
+    // MARK: Subclass Hooks
+    
+    func willShowWithType(showType: PopupViewShowType) {}
+    func didShowWithType(showType: PopupViewShowType) {}
+    func willDismissWithType(dismissType: PopupViewDismissType) {}
+    func didDismissWithType(dismissType: PopupViewDismissType) {}
+}
+
+extension PopupView: KeyboardHelperDelegate {
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
+        keyboardState = state
+        if !automaticallyMovesWithKeyboard {
+            return
+        }
+        let keyboardHeight = keyboardState?.intersectionHeightForView(applicationWindow ?? self) ?? 0
+        _dialogFrameWithKeyboardHeight(height: keyboardHeight)
+    }
+    
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
+    }
+    
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
+        keyboardState = nil
+        if !automaticallyMovesWithKeyboard {
+            return
+        }
+        let keyboardHeight = keyboardState?.intersectionHeightForView(applicationWindow ?? self) ?? 0
+        _dialogFrameWithKeyboardHeight(height: keyboardHeight)
+    }
+}


### PR DESCRIPTION
One thing to note, we do not focus the url bar when we create a new private tab at the moment. If we decide to change this, we will need to add the necessary checks to assure focus is not done when a popup is going to be shown.

Also: `PopupView` and `AlertPopupView` are almost 100% ported aside from the need to replace all instances of `getApp()` with a new local convenience getter `applicationWindow`

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_
