### PR TITLE
Fix #308: Notification is now posted upon private mode change

### DIFF
--- a/Client/Frontend/Browser/PrivacyProtection/PrivateBrowsingManager.swift
+++ b/Client/Frontend/Browser/PrivacyProtection/PrivateBrowsingManager.swift
@@ -6,7 +6,13 @@ import Foundation
 
 final class PrivateBrowsingManager {
     
-    var isPrivateBrowsing = false
+    var isPrivateBrowsing = false {
+        didSet {
+            if oldValue != isPrivateBrowsing {
+                NotificationCenter.default.post(name: .PrivacyModeChanged, object: nil)
+            }
+        }
+    }
     
     static let shared = PrivateBrowsingManager()
     


### PR DESCRIPTION
The ported `FavoritesViewController` (`TopSitesPanel` in 1.6) relied on the private browsing changed notification to update its theme.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_