### PR TITLE
Fix #268: Use correct Brave error page copy

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -33,13 +33,13 @@ public extension Strings {
 
 // Error pages.
 public extension Strings {
-//    public static let ErrorPagesAdvancedButton = NSLocalizedString("Advanced", comment: "Label for button to perform advanced actions on the error page")
-//    public static let ErrorPagesAdvancedWarning1 = NSLocalizedString("Warning: we can't confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages")
-//    public static let ErrorPagesAdvancedWarning2 = NSLocalizedString("It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages")
-//    public static let ErrorPagesCertWarningDescription = NSLocalizedString("The owner of %@ has configured their website improperly. To protect your information from being stolen, Brave has not connected to this website.", comment: "Warning text on the certificate error page")
-//    public static let ErrorPagesCertWarningTitle = NSLocalizedString("Your connection is not private", comment: "Title on the certificate error page")
-//    public static let ErrorPagesGoBackButton = NSLocalizedString("Go Back", comment: "Label for button to go back from the error page")
-//    public static let ErrorPagesVisitOnceButton = NSLocalizedString("Visit site anyway", comment: "Button label to temporarily continue to the site from the certificate error page")
+    public static let ErrorPagesAdvancedButton = NSLocalizedString("Advanced", comment: "Label for button to perform advanced actions on the error page")
+    public static let ErrorPagesAdvancedWarning1 = NSLocalizedString("Warning: we can't confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages")
+    public static let ErrorPagesAdvancedWarning2 = NSLocalizedString("It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages")
+    public static let ErrorPagesCertWarningDescription = NSLocalizedString("The owner of %@ has configured their website improperly. To protect your information from being stolen, Brave has not connected to this website.", comment: "Warning text on the certificate error page")
+    public static let ErrorPagesCertWarningTitle = NSLocalizedString("Your connection is not private", comment: "Title on the certificate error page")
+    public static let ErrorPagesGoBackButton = NSLocalizedString("Go Back", comment: "Label for button to go back from the error page")
+    public static let ErrorPagesVisitOnceButton = NSLocalizedString("Visit site anyway", comment: "Button label to temporarily continue to the site from the certificate error page")
 }
 
 // Logins Helper.

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -83,17 +83,6 @@ extension Strings {
     public static let UseFaceID = NSLocalizedString("Use Face ID", comment: "List section title for when to use Face ID")
 }
 
-// Error pages.
-extension Strings {
-    public static let ErrorPagesAdvancedButton = NSLocalizedString("ErrorPages.Advanced.Button", value: "Advanced", comment: "Label for button to perform advanced actions on the error page")
-    public static let ErrorPagesAdvancedWarning1 = NSLocalizedString("ErrorPages.AdvancedWarning1.Text", value: "Warning: we can’t confirm your connection to this website is secure.", comment: "Warning text when clicking the Advanced button on error pages")
-    public static let ErrorPagesAdvancedWarning2 = NSLocalizedString("ErrorPages.AdvancedWarning2.Text", value: "It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.", comment: "Additional warning text when clicking the Advanced button on error pages")
-    public static let ErrorPagesCertWarningDescription = NSLocalizedString("ErrorPages.CertWarning.Description", value: "The owner of %@ has configured their website improperly. To protect your information from being stolen, Firefox has not connected to this website.", comment: "Warning text on the certificate error page")
-    public static let ErrorPagesCertWarningTitle = NSLocalizedString("ErrorPages.CertWarning.Title", value: "This Connection is Untrusted", comment: "Title on the certificate error page")
-    public static let ErrorPagesGoBackButton = NSLocalizedString("ErrorPages.GoBack.Button", value: "Go Back", comment: "Label for button to go back from the error page")
-    public static let ErrorPagesVisitOnceButton = NSLocalizedString("ErrorPages.VisitOnce.Button", value: "Visit site anyway", comment: "Button label to temporarily continue to the site from the certificate error page")
-}
-
 // Logins Helper.
 extension Strings {
     public static let LoginsHelperSaveLoginButtonTitle = NSLocalizedString("LoginsHelper.SaveLogin.Button", value: "Save Login", comment: "Button to save the user's password")


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_