### PR TITLE
Fix #319: Update tab title copy to be more sense in its new location

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -959,7 +959,7 @@ fileprivate class EmptyPrivateTabsView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        titleLabel.text =  Strings.Private_Tab_Title
+        titleLabel.text =  Strings.Private_Browsing
         descriptionLabel.text = Strings.Private_Tab_Body
 
         addSubview(titleLabel)


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_none included_

## Notes for testing this patch

_none included_
