### PR TITLE
Fix #290: Leave URL bar overlay mode when deleting tabs/opening new URLs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -975,6 +975,8 @@ class BrowserViewController: UIViewController {
     }
 
     func openURLInNewTab(_ url: URL?, isPrivate: Bool = false, isPrivileged: Bool) {
+        urlBar.leaveOverlayMode(didCancel: true)
+
         if let selectedTab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(selectedTab)
         }
@@ -1664,10 +1666,7 @@ extension BrowserViewController: TabToolbarDelegate {
 extension BrowserViewController: TabsBarViewControllerDelegate {
     func tabsBarDidSelectTab(_ tabsBarController: TabsBarViewController, _ tab: Tab) {
         if tab == tabManager.selectedTab { return }
-        if urlBar.inOverlayMode {
-            // Lose focus
-            urlBar.leaveOverlayMode(didCancel: true)
-        }
+        urlBar.leaveOverlayMode(didCancel: true)
         tabManager.selectTab(tab)
     }
 }
@@ -1904,7 +1903,7 @@ extension BrowserViewController: TabManagerDelegate {
         updateTabCountUsingTabManager(tabManager)
         // tabDelegate is a weak ref (and the tab's webView may not be destroyed yet)
         // so we don't expcitly unset it.
-
+        urlBar.leaveOverlayMode(didCancel: true)
         if let url = tab.url, !url.isAboutURL && !tab.isPrivate {
             profile.recentlyClosedTabs.addTab(url as URL, title: tab.title, faviconURL: tab.displayFavicon?.url)
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -462,6 +462,7 @@ class URLBarView: UIView {
     }
     
     func leaveOverlayMode(didCancel cancel: Bool = false) {
+        if !inOverlayMode { return }
         locationTextField?.resignFirstResponder()
         animateToOverlayState(overlayMode: false, didCancel: cancel)
         delegate?.urlBarDidLeaveOverlayMode(self)


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

Prelude tests with creating a new tab or entering URL bar overlay