### PR TITLE
Fix #266: Hide favourites if an error page is showing

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -719,7 +719,7 @@ class BrowserViewController: UIViewController {
             }
             if url.isAboutHomeURL && !url.isErrorPageURL {
                 showHomePanelController(inline: true)
-            } else if !url.isLocalUtility || url.isReaderModeURL {
+            } else if !url.isLocalUtility || url.isReaderModeURL || url.isErrorPageURL {
                 hideHomePanelController()
             }
         }


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_