### PR TITLE
Fix README: added hint for installing swiftlint first

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Getting involved
 
 We encourage you to participate in this open source project. We love Pull Requests, Bug Reports, ideas, (security) code reviews or any kind of positive contribution.
 
-* [Discord](https://discord.gg/cR3gmq5): 
+* [Discord](https://discord.gg/cR3gmq5):
     -  `#ios` channel for general conversing.
     - `#developers-ios` channel for development discussion.
 * Bugs:           [File a new bug](https://github.com/brave/brave-ios/issues/new) • [Existing bugs](https://github.com/brave/brave-ios/issues)
@@ -34,6 +34,10 @@ Building the code
     ```shell
     brew update
     brew install carthage
+    ```
+1. Install SwiftLint:
+    ```shell
+    brew install swiftlint
     ```
 1. Clone the repository:
     ```shell
@@ -93,4 +97,4 @@ The entire `Local` directory is included in the `.gitignore`, so these changes a
 The easiest known way to find your team ID is to log into your [Apple Developer](https://developer.apple.com) account. After logging in, the team ID is currently shown at the end of the URL:
 <br>`https://developer.apple.com/account/<TEAM ID>`
 
-Use this string literal in the above, `DevTeam.xcconfig` file to code sign 
+Use this string literal in the above, `DevTeam.xcconfig` file to code sign


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

This PR is adding a note in README that `swiftlint` should be installed before `bootstrap.sh` can be executed. 
Currently it is not mentioned, but setting up this project for development for the very first time, will end up like this:

```
$ sh ./bootstrap.sh
Brave requires the command: swiftlint
Please install it via Homebrew or directly from https://github.com/realm/SwiftLint/releases
```

Therefor i have added a specific lint, that swiftlint needs to be installed first.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Notes for testing this patch

No testing required as no code was added, removed or modified.