### PR TITLE
Fix #239: Browser URL bar height now respects tab bar visibility

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -91,6 +91,7 @@ private extension TrayToBrowserAnimator {
             bvc.webViewContainerBackdrop.isHidden = false
             bvc.favoritesViewController?.view.isHidden = false
             bvc.urlBar.isTransitioning = false
+            bvc.updateTabsBarVisibility()
             transitionContext.completeTransition(true)
         })
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -84,12 +84,11 @@ class BrowserViewController: UIViewController {
     let tabManager: TabManager
 
     // These views wrap the urlbar and toolbar to provide background effects on them
-    var header: UIView!
+    var header: UIStackView!
     var footer: UIView!
     fileprivate var topTouchArea: UIButton!
     
     // These constraints allow to show/hide tabs bar
-    var headerHeightConstraint: Constraint?
     var webViewContainerTopOffset: Constraint?
     
     // Backdrop used for displaying greyed background for private tabs
@@ -325,18 +324,20 @@ class BrowserViewController: UIViewController {
         urlBar.translatesAutoresizingMaskIntoConstraints = false
         urlBar.delegate = self
         urlBar.tabToolbarDelegate = self
-        header = UIView(frame: CGRect.zero)
-        header.addSubview(urlBar)
+        header = UIStackView().then {
+            $0.axis = .vertical
+            $0.clipsToBounds = true
+        }
+        header.addArrangedSubview(urlBar)
         
         tabsBar = TabsBarViewController(tabManager: tabManager)
         tabsBar.delegate = self
-        header.addSubview(tabsBar.view)
+        header.addArrangedSubview(tabsBar.view)
         
         view.addSubview(header)
         
         addChildViewController(tabsBar)
         tabsBar.didMove(toParentViewController: self)
-        tabsBar.view.isHidden = true
 
         // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work, thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need to make them "persistent" e.g. by being stored in BVC
         pasteGoAction = AccessibleAction(name: Strings.PasteAndGoTitle, handler: { () -> Bool in
@@ -391,24 +392,14 @@ class BrowserViewController: UIViewController {
         header.snp.makeConstraints { make in
             scrollController.headerTopConstraint = make.top.equalTo(view.safeArea.top).constraint
             make.left.right.equalTo(self.view)
-            
-            if let headerHeightConstraint = headerHeightConstraint {
-                headerHeightConstraint.update(offset: UX.UrlBar.height)
-            } else {
-                headerHeightConstraint = make.height.equalTo(UX.UrlBar.height).constraint
-            }
         }
         
         urlBar.snp.makeConstraints { make in
-            make.leading.trailing.equalTo(header)
             make.height.equalTo(UIConstants.TopToolbarHeight)
-            make.top.equalTo(header.snp.top)
         }
         
         tabsBar.view.snp.makeConstraints { make in
-            make.leading.trailing.bottom.equalTo(header)
             make.height.equalTo(UX.TabsBar.height)
-            make.top.equalTo(urlBar.snp.bottom)
         }
 
         webViewContainerBackdrop.snp.makeConstraints { make in
@@ -607,8 +598,7 @@ class BrowserViewController: UIViewController {
         webViewContainer.snp.remakeConstraints { make in
             make.left.right.equalTo(self.view)
             
-            let tabsBarOffset = tabsBar.view.isHidden ? UX.TabsBar.height : 0
-            webViewContainerTopOffset = make.top.equalTo(readerModeBar?.snp.bottom ?? self.header.snp.bottom).inset(tabsBarOffset).constraint
+            webViewContainerTopOffset = make.top.equalTo(readerModeBar?.snp.bottom ?? self.header.snp.bottom).constraint
 
             let findInPageHeight = (findInPageBar == nil) ? 0 : UIConstants.ToolbarHeight
             if let toolbar = self.toolbar {
@@ -630,13 +620,11 @@ class BrowserViewController: UIViewController {
         }
 
         urlBar.setNeedsUpdateConstraints()
-        updateTabsBarVisibility()
 
         // Remake constraints even if we're already showing the home controller.
         // The home controller may change sizes if we tap the URL bar while on about:home.
         favoritesViewController?.view.snp.remakeConstraints { make in
-            let tabsBarOffset = tabsBar.view.isHidden ? UX.TabsBar.height : 0
-            webViewContainerTopOffset = make.top.equalTo(readerModeBar?.snp.bottom ?? self.header.snp.bottom).inset(tabsBarOffset).constraint
+            webViewContainerTopOffset = make.top.equalTo(readerModeBar?.snp.bottom ?? self.header.snp.bottom).constraint
             
             make.left.right.equalTo(self.view)
             if self.homePanelIsInline {
@@ -753,6 +741,11 @@ class BrowserViewController: UIViewController {
     }
     
     func updateTabsBarVisibility() {
+        if tabManager.selectedTab == nil {
+            tabsBar.view.isHidden = true
+            return
+        }
+        
         func shouldShowTabBar() -> Bool {
             let tabCount = tabManager.tabs(withType: TabType.of(tabManager.selectedTab)).count
             guard let tabBarVisibility = TabBarVisibility(rawValue: Preferences.General.tabBarVisibility.value) else {
@@ -776,10 +769,9 @@ class BrowserViewController: UIViewController {
         if isShowing != shouldShow {
             UIView.animate(withDuration: 0.1) {
                 self.tabsBar.view.isHidden = !shouldShow
-                self.headerHeightConstraint?.update(offset: UX.UrlBar.height)
-                self.webViewContainerTopOffset?.update(inset: shouldShow ? 0 : UX.TabsBar.height)
-                self.view.layoutIfNeeded()
             }
+        } else {
+            tabsBar.view.isHidden = !shouldShow
         }
     }
 
@@ -1843,6 +1835,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         updateFindInPageVisibility(visible: false, tab: previous)
+        updateTabsBarVisibility()
 
         urlBar.locationView.loading = selected?.loading ?? false
         navigationToolbar.updateBackStatus(selected?.canGoBack ?? false)

--- a/Client/Frontend/UX.swift
+++ b/Client/Frontend/UX.swift
@@ -15,7 +15,7 @@ struct UX {
     }
     
     struct UrlBar {
-        static let height: CGFloat = UIConstants.TopToolbarHeight + UX.TabsBar.height
+        static let height: CGFloat = UIConstants.TopToolbarHeight
     }
     
     struct HomePanel {


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_