### PR TITLE
Fix #298: Remove password manager button setting & related UI

### DIFF
--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -14,17 +14,6 @@ enum TabBarVisibility: Int {
     static let allCases: [TabBarVisibility] = [.never, .always, .landscapeOnly]
 }
 
-enum PasswordManagerShortcutBehavior: Int {
-    case showPicker
-    case onePassword
-    case lastPass
-    case bitwarden
-    case trueKey
-    
-    // TODO: Remove when we can use Swift 4.2/`CaseIterable`
-    static let allCases: [PasswordManagerShortcutBehavior] = [.showPicker, .onePassword, .lastPass, .bitwarden, .trueKey]
-}
-
 // MARK: - Other Preferences
 extension Preferences {
     final class Popups {
@@ -55,8 +44,6 @@ extension Preferences {
         static let blockPopups = Option<Bool>(key: "general.block-popups", default: true)
         /// Controls how the tab bar should be shown (or not shown)
         static let tabBarVisibility = Option<Int>(key: "general.tab-bar-visiblity", default: TabBarVisibility.always.rawValue)
-        /// The behavior when the password manager button is tapped
-        static let passwordManagerShortcutBehavior = Option<Int>(key: "general.pm-button-behavior", default: PasswordManagerShortcutBehavior.showPicker.rawValue)
     }
     final class Search {
         /// Whether or not to show suggestions while the user types

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -34,7 +34,6 @@ extension Preferences {
         migrate(key: "saveLogins", to: Preferences.General.saveLogins)
         migrate(key: "blockPopups", to: Preferences.General.blockPopups)
         migrate(key: "kPrefKeyTabsBarShowPolicy", to: Preferences.General.tabBarVisibility)
-        migrate(key: "thirdPartyPasswordShortcutEnabled", to: Preferences.General.passwordManagerShortcutBehavior)
         
         // Privacy
         migrate(key: "braveAcceptCookiesPref", to: Preferences.Privacy.cookieAcceptPolicy)

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -30,30 +30,6 @@ extension HTTPCookie.AcceptPolicy: RepresentableOptionType {
     }
 }
 
-extension PasswordManagerShortcutBehavior: RepresentableOptionType {
-    public var displayString: String {
-        switch self {
-        case .showPicker: return Strings.ShowPicker
-        case .onePassword: return "1Password"
-        case .lastPass: return "LastPass"
-        case .bitwarden: return "Bitwarden"
-        case .trueKey: return "True Key"
-        }
-    }
-    
-    /* v1.6 doesn't show images despite the code/assets existing to support it
-    public var image: UIImage? {
-        switch self {
-            case .showPicker: return UIImage(imageLiteralResourceName: "key")
-            case .onePassword: return UIImage(imageLiteralResourceName: "passhelper_1pwd")
-            case .lastPass: return UIImage(imageLiteralResourceName: "passhelper_lastpass")
-            case .bitwarden: return UIImage(imageLiteralResourceName: "passhelper_bitwarden")
-            case .trueKey: return UIImage(imageLiteralResourceName: "passhelper_truekey")
-        }
-    }
-    */
-}
-
 /// Just creates a switch toggle `Row` which updates a `Preferences.Option<Bool>`
 private func BoolRow(title: String, option: Preferences.Option<Bool>) -> Row {
     return Row(
@@ -170,31 +146,6 @@ class SettingsViewController: TableViewController {
             }
             general.rows.append(row)
         }
-        
-        // TODO: Check if Password Managers exist before showing this row
-        var pmRow = Row(
-            text: Strings.Password_manager_button,
-            detailText: PasswordManagerShortcutBehavior(rawValue: Preferences.General.passwordManagerShortcutBehavior.value)?.displayString,
-            accessory: .disclosureIndicator
-        )
-        pmRow.selection = { [unowned self] in
-            // Show options for password manager button
-            let optionsViewController = OptionSelectionViewController<PasswordManagerShortcutBehavior>(
-                options: PasswordManagerShortcutBehavior.allCases,
-                selectedOption: PasswordManagerShortcutBehavior(rawValue: Preferences.General.passwordManagerShortcutBehavior.value),
-                optionChanged: { [unowned self] _, option in
-                    Preferences.General.passwordManagerShortcutBehavior.value = option.rawValue
-                    
-                    if let indexPath = self.dataSource.indexPath(rowUUID: pmRow.uuid, sectionUUID: general.uuid) {
-                        self.dataSource.sections[indexPath.section].rows[indexPath.row].detailText = option.displayString
-                    }
-                }
-            )
-            optionsViewController.headerText = Strings.Password_manager_button
-            optionsViewController.footerText = Strings.Password_manager_button_settings_footer
-            self.navigationController?.pushViewController(optionsViewController, animated: true)
-        }
-        general.rows.append(pmRow)
         
         return general
     }()


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_