### PR TITLE
Fix #336: No longer crashes when removing the last private tab on iPad

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -567,8 +567,8 @@ class TabManager: NSObject {
         delegates.forEach { $0.get()?.tabManager(self, didRemoveTab: tab) }
         TabEvent.post(.didClose, for: tab)
 
-        if !tab.isPrivate && currentTabs.isEmpty {
-            addTab()
+        if currentTabs.isEmpty {
+            addTab(isPrivate: tab.isPrivate)
         }
 
         // If the removed tab was selected, find the new tab to select.

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -196,23 +196,19 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: true)
         manager.selectTab(tab)
-        let privateTab = manager.addTab(isPrivate: true)
-        manager.selectTab(privateTab)
         manager.addDelegate(delegate)
         
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
             let next = tabs[0]!
             let previous = tabs[1]!
             XCTAssertTrue(previous != next)
-            XCTAssertTrue(previous == privateTab)
-            XCTAssertTrue(next == tab)
-            XCTAssertTrue(previous.isPrivate)
-            XCTAssertTrue(manager.selectedTab == next)
+            XCTAssertTrue(previous == tab)
+            XCTAssertTrue(next.isPrivate)
         }
-        delegate.expect([willRemove, didRemove, didSelect])
-        manager.removeTab(privateTab)
+        delegate.expect([willRemove, didRemove, willAdd, didAdd, didSelect])
+        manager.removeTab(tab)
         delegate.verify("Not all delegate methods were called")
     }
     


### PR DESCRIPTION
When you delete the last private tab it will now open a new private tab like regular mode does

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_