### PR TITLE
Fix #342: Removed iOS 11 deprecation warnings

### DIFF
--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -41,6 +41,8 @@ class BasePasscodeViewController: UIViewController {
         updateRightBarButtonItem()
         if #available(iOS 11.0, *) {
             scrollView?.contentInsetAdjustmentBehavior = .never
+        } else {
+            automaticallyAdjustsScrollViewInsets = false
         }
     }
 

--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -10,7 +10,7 @@ import SwiftKeychainWrapper
 /// for the various Passcode configuration screens.
 class BasePasscodeViewController: UIViewController {
     var authenticationInfo: AuthenticationKeychainInfo?
-
+    var scrollView: UIScrollView?
     var errorToast: ErrorToast?
     let errorPadding: CGFloat = 10
 
@@ -39,7 +39,9 @@ class BasePasscodeViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
         updateRightBarButtonItem()
-        automaticallyAdjustsScrollViewInsets = false
+        if #available(iOS 11.0, *) {
+            scrollView?.contentInsetAdjustmentBehavior = .never
+        }
     }
 
     @objc func dismissAnimated() {

--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -10,7 +10,6 @@ import SwiftKeychainWrapper
 /// for the various Passcode configuration screens.
 class BasePasscodeViewController: UIViewController {
     var authenticationInfo: AuthenticationKeychainInfo?
-    var scrollView: UIScrollView?
     var errorToast: ErrorToast?
     let errorPadding: CGFloat = 10
 
@@ -39,11 +38,6 @@ class BasePasscodeViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = SettingsUX.TableViewHeaderBackgroundColor
         updateRightBarButtonItem()
-        if #available(iOS 11.0, *) {
-            scrollView?.contentInsetAdjustmentBehavior = .never
-        } else {
-            automaticallyAdjustsScrollViewInsets = false
-        }
     }
 
     @objc func dismissAnimated() {

--- a/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
@@ -13,6 +13,7 @@ class PagingPasscodeViewController: BasePasscodeViewController {
         scrollView.isUserInteractionEnabled = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
+        scrollView.contentInsetAdjustmentBehavior = .never
         return scrollView
     }()
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -70,6 +70,8 @@ class LoginListViewController: UIViewController {
     fileprivate var selectedIndexPaths = [IndexPath]()
 
     fileprivate let tableView = UITableView()
+    
+    fileprivate var scrollView = UIScrollView()
 
     weak var settingsDelegate: SettingsDelegate?
 
@@ -89,7 +91,9 @@ class LoginListViewController: UIViewController {
         notificationCenter.addObserver(self, selector: #selector(remoteLoginsDidChange), name: .DataRemoteLoginChangesWereApplied, object: nil)
         notificationCenter.addObserver(self, selector: #selector(dismissAlertController), name: .UIApplicationDidEnterBackground, object: nil)
 
-        automaticallyAdjustsScrollViewInsets = false
+        if #available(iOS 11.0, *) {
+            scrollView.contentInsetAdjustmentBehavior = .never
+        }
         self.view.backgroundColor = UIColor.Photon.White100
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(beginEditing))
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -71,8 +71,6 @@ class LoginListViewController: UIViewController {
 
     fileprivate let tableView = UITableView()
     
-    fileprivate var scrollView = UIScrollView()
-
     weak var settingsDelegate: SettingsDelegate?
 
     init(profile: Profile) {
@@ -91,12 +89,8 @@ class LoginListViewController: UIViewController {
         notificationCenter.addObserver(self, selector: #selector(remoteLoginsDidChange), name: .DataRemoteLoginChangesWereApplied, object: nil)
         notificationCenter.addObserver(self, selector: #selector(dismissAlertController), name: .UIApplicationDidEnterBackground, object: nil)
 
-        if #available(iOS 11.0, *) {
-            scrollView.contentInsetAdjustmentBehavior = .never
-        } else {
-            automaticallyAdjustsScrollViewInsets = false
-        }
-        
+        tableView.contentInsetAdjustmentBehavior = .never
+
         self.view.backgroundColor = UIColor.Photon.White100
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(beginEditing))
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -93,7 +93,10 @@ class LoginListViewController: UIViewController {
 
         if #available(iOS 11.0, *) {
             scrollView.contentInsetAdjustmentBehavior = .never
+        } else {
+            automaticallyAdjustsScrollViewInsets = false
         }
+        
         self.view.backgroundColor = UIColor.Photon.White100
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(beginEditing))
 


### PR DESCRIPTION
This PR contains fix for this warning: 
`'automaticallyAdjustsScrollViewInsets' was deprecated in iOS 11.0: Use UIScrollView's contentInsetAdjustmentBehavior instead`

Warnings related to touchID weren't fixed as it is a Swift compiler bug. Look at discussion in the issue #342.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] Tests had passed
- [ ] I have marked the bug with `[needsuplift]`
