### PR TITLE
Fix #322: Adjust height for popup when if it clips off screen

### DIFF
--- a/Client/Frontend/Popup/AlertPopupView.swift
+++ b/Client/Frontend/Popup/AlertPopupView.swift
@@ -14,7 +14,6 @@ class AlertPopupView: PopupView {
     
     fileprivate let kAlertPopupScreenFraction: CGFloat = 0.8
     fileprivate let kPadding: CGFloat = 20.0
-    fileprivate var resizePercentage: CGFloat = 1.0
     
     init(image: UIImage?, title: String, message: String) {
         super.init(frame: CGRect.zero)
@@ -57,6 +56,25 @@ class AlertPopupView: PopupView {
     }
     
     func updateSubviews() {
+        titleLabel.adjustsFontSizeToFitWidth = false
+        messageLabel.adjustsFontSizeToFitWidth = false
+
+        _updateSubviews()
+        
+        let paddingHeight: CGFloat = padding * 3.0
+        let externalContentHeight: CGFloat = dialogButtons.count == 0 ? paddingHeight
+            : kPopupDialogButtonHeight + paddingHeight
+        
+        if containerView.frame.height + externalContentHeight > UIScreen.main.bounds.height {
+            let desiredHeight: CGFloat = UIScreen.main.bounds.height - externalContentHeight
+            let resizePercentage = desiredHeight / containerView.frame.height
+            titleLabel.adjustsFontSizeToFitWidth = true
+            messageLabel.adjustsFontSizeToFitWidth = true
+            _updateSubviews(resizePercentage)
+        }
+    }
+    
+    fileprivate func _updateSubviews(_ resizePercentage: CGFloat = 1.0) {
         let width: CGFloat = dialogWidth
         
         var imageFrame: CGRect = dialogImage?.frame ?? CGRect.zero
@@ -87,16 +105,6 @@ class AlertPopupView: PopupView {
         containerViewFrame.size.width = width
         containerViewFrame.size.height = rint(messageLabelFrame.maxY + kPadding * 1.5 * resizePercentage)
         containerView.frame = containerViewFrame
-        
-        let externalContentHeight: CGFloat = dialogButtons.count == 0 ? padding * 3.0 : kPopupDialogButtonHeight + padding * 3.0
-        resizePercentage = 1.0
-        if containerViewFrame.height + externalContentHeight > UIScreen.main.bounds.height {
-            let desiredHeight: CGFloat = UIScreen.main.bounds.height - externalContentHeight
-            resizePercentage = desiredHeight / containerViewFrame.height
-            titleLabel.adjustsFontSizeToFitWidth = true
-            messageLabel.adjustsFontSizeToFitWidth = true
-            updateSubviews()
-        }
     }
     
     override func layoutSubviews() {

--- a/Client/Frontend/Popup/AlertPopupView.swift
+++ b/Client/Frontend/Popup/AlertPopupView.swift
@@ -59,27 +59,26 @@ class AlertPopupView: PopupView {
         titleLabel.adjustsFontSizeToFitWidth = false
         messageLabel.adjustsFontSizeToFitWidth = false
 
-        _updateSubviews()
+        updateSubviews(resizePercentage: 1.0)
         
-        let paddingHeight: CGFloat = padding * 3.0
-        let externalContentHeight: CGFloat = dialogButtons.count == 0 ? paddingHeight
-            : kPopupDialogButtonHeight + paddingHeight
+        let paddingHeight = padding * 3.0
+        let externalContentHeight = dialogButtons.count == 0 ? paddingHeight : kPopupDialogButtonHeight + paddingHeight
+        let desiredHeight = UIScreen.main.bounds.height - externalContentHeight
         
-        if containerView.frame.height + externalContentHeight > UIScreen.main.bounds.height {
-            let desiredHeight: CGFloat = UIScreen.main.bounds.height - externalContentHeight
+        if containerView.frame.height > desiredHeight {
             let resizePercentage = desiredHeight / containerView.frame.height
             titleLabel.adjustsFontSizeToFitWidth = true
             messageLabel.adjustsFontSizeToFitWidth = true
-            _updateSubviews(resizePercentage)
+            updateSubviews(resizePercentage: resizePercentage)
         }
     }
     
-    fileprivate func _updateSubviews(_ resizePercentage: CGFloat = 1.0) {
+    fileprivate func updateSubviews(resizePercentage: CGFloat) {
         let width: CGFloat = dialogWidth
         
         var imageFrame: CGRect = dialogImage?.frame ?? CGRect.zero
-        if let dialogImage = dialogImage {
-            imageFrame.size = CGSize(width: dialogImage.image!.size.width * resizePercentage, height: dialogImage.image!.size.height * resizePercentage)
+        if let dialogImage = dialogImage, let dialogImageSize = dialogImage.image?.size {
+            imageFrame.size = CGSize(width: dialogImageSize.width * resizePercentage, height: dialogImageSize.height * resizePercentage)
             imageFrame.origin.x = (width - imageFrame.width) / 2.0
             imageFrame.origin.y = kPadding * 2.0 * resizePercentage
             dialogImage.frame = imageFrame

--- a/Client/Frontend/Popup/AlertPopupView.swift
+++ b/Client/Frontend/Popup/AlertPopupView.swift
@@ -14,6 +14,7 @@ class AlertPopupView: PopupView {
     
     fileprivate let kAlertPopupScreenFraction: CGFloat = 0.8
     fileprivate let kPadding: CGFloat = 20.0
+    fileprivate var resizePercentage: CGFloat = 1.0
     
     init(image: UIImage?, title: String, message: String) {
         super.init(frame: CGRect.zero)
@@ -60,29 +61,42 @@ class AlertPopupView: PopupView {
         
         var imageFrame: CGRect = dialogImage?.frame ?? CGRect.zero
         if let dialogImage = dialogImage {
+            imageFrame.size = CGSize(width: dialogImage.image!.size.width * resizePercentage, height: dialogImage.image!.size.height * resizePercentage)
             imageFrame.origin.x = (width - imageFrame.width) / 2.0
-            imageFrame.origin.y = kPadding * 2.0
+            imageFrame.origin.y = kPadding * 2.0 * resizePercentage
             dialogImage.frame = imageFrame
         }
         
-        let titleLabelSize: CGSize = titleLabel.sizeThatFits(CGSize(width: width - kPadding * 3.0, height: CGFloat.greatestFiniteMagnitude))
+        var titleLabelSize: CGSize = titleLabel.sizeThatFits(CGSize(width: width - kPadding * 3.0, height: CGFloat.greatestFiniteMagnitude))
+        titleLabelSize.height = titleLabelSize.height * resizePercentage
         var titleLabelFrame: CGRect = titleLabel.frame
         titleLabelFrame.size = titleLabelSize
         titleLabelFrame.origin.x = rint((width - titleLabelSize.width) / 2.0)
-        titleLabelFrame.origin.y = imageFrame.maxY + kPadding
+        titleLabelFrame.origin.y = imageFrame.maxY + kPadding * resizePercentage
         titleLabel.frame = titleLabelFrame
         
-        let messageLabelSize: CGSize = messageLabel.sizeThatFits(CGSize(width: width - kPadding * 4.0, height: CGFloat.greatestFiniteMagnitude))
+        var messageLabelSize: CGSize = messageLabel.sizeThatFits(CGSize(width: width - kPadding * 4.0, height: CGFloat.greatestFiniteMagnitude))
+        messageLabelSize.height = messageLabelSize.height * resizePercentage
         var messageLabelFrame: CGRect = messageLabel.frame
         messageLabelFrame.size = messageLabelSize
         messageLabelFrame.origin.x = rint((width - messageLabelSize.width) / 2.0)
-        messageLabelFrame.origin.y = rint(titleLabelFrame.maxY + kPadding * 1.5 / 2.0)
+        messageLabelFrame.origin.y = rint(titleLabelFrame.maxY + kPadding * 1.5 / 2.0 * resizePercentage)
         messageLabel.frame = messageLabelFrame
         
         var containerViewFrame: CGRect = containerView.frame
         containerViewFrame.size.width = width
-        containerViewFrame.size.height = messageLabelFrame.maxY + kPadding * 1.5
+        containerViewFrame.size.height = rint(messageLabelFrame.maxY + kPadding * 1.5 * resizePercentage)
         containerView.frame = containerViewFrame
+        
+        let externalContentHeight: CGFloat = dialogButtons.count == 0 ? padding * 3.0 : kPopupDialogButtonHeight + padding * 3.0
+        resizePercentage = 1.0
+        if containerViewFrame.height + externalContentHeight > UIScreen.main.bounds.height {
+            let desiredHeight: CGFloat = UIScreen.main.bounds.height - externalContentHeight
+            resizePercentage = desiredHeight / containerViewFrame.height
+            titleLabel.adjustsFontSizeToFitWidth = true
+            messageLabel.adjustsFontSizeToFitWidth = true
+            updateSubviews()
+        }
     }
     
     override func layoutSubviews() {

--- a/Client/Frontend/Popup/PopupView.swift
+++ b/Client/Frontend/Popup/PopupView.swift
@@ -467,6 +467,7 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
         buttonData.isDefault = true
         buttonData.handler = tapped
         dialogButtons.append(buttonData)
+        layoutSubviews()
     }
     
     func addButton(title: String, tapped: (() -> PopupViewDismissType)?) {

--- a/Client/Frontend/Popup/PopupView.swift
+++ b/Client/Frontend/Popup/PopupView.swift
@@ -467,7 +467,7 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
         buttonData.isDefault = true
         buttonData.handler = tapped
         dialogButtons.append(buttonData)
-        layoutSubviews()
+        layoutIfNeeded()
     }
     
     func addButton(title: String, tapped: (() -> PopupViewDismissType)?) {


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

Fixes [issue 322](https://github.com/brave/brave-ios/issues/322)

Opening a popup in landscape mode would clip the popup off the bottom of the screen for smaller devices. This happened because the height of the popup is set based on the contents of the popup without adjusting for the screen's height.

## Pull Request Checklist

- [x] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

<img width="801" alt="screen shot 2018-10-23 at 12 46 01 am" src="https://user-images.githubusercontent.com/18453121/47336329-3f790b00-d65d-11e8-9a05-0bf944d885f9.png">
