### PR TITLE
Fix #337: Implement `Private Browsing Only` mode

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -116,6 +116,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         // Add restoration class, the factory that will return the ViewController we
         // will restore with.
+        
+        // Make sure current private browsing flag respects the private browsing only user preference
+        PrivateBrowsingManager.shared.isPrivateBrowsing = Preferences.Privacy.privateBrowsingOnly.value
 
         browserViewController = BrowserViewController(profile: self.profile!, tabManager: self.tabManager)
         browserViewController.edgesForExtendedLayout = []

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -17,7 +17,7 @@ protocol TopSitesDelegate: class {
     func didTapDuckDuckGoCallout()
 }
 
-class FavoritesViewController: UIViewController {
+class FavoritesViewController: UIViewController, Themeable {
     private struct UI {
         static let statsHeight: CGFloat = 110.0
         static let statsBottomMargin: CGFloat = 5
@@ -198,14 +198,13 @@ class FavoritesViewController: UIViewController {
     
     // MARK: - Private browsing modde
     @objc func privateBrowsingModeChanged() {
-        let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
-        
-        // TODO: This entire blockshould be abstracted
-        //  to make code in this class DRY (duplicates from elsewhere)
-        view.backgroundColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UX.HomePanel.BackgroundColorPBM : UX.HomePanel.BackgroundColor
-        braveShieldStatsView.timeStatView.color = isPrivateBrowsing ? UX.GreyA : UX.GreyJ
-        collection.reloadData()
         updateDuckDuckGoVisibility()
+    }
+    
+    func applyTheme(_ theme: Theme) {
+        let isPrivate = theme == .private
+        view.backgroundColor = isPrivate ? UX.HomePanel.BackgroundColorPBM : UX.HomePanel.BackgroundColor
+        braveShieldStatsView.timeStatView.color = isPrivate ? UX.GreyA : UX.GreyJ
     }
     
     @objc func showPrivateTabInfo() {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -871,10 +871,12 @@ extension TabManager {
         }
         isRestoring = false
 
+        let isPrivateBrowsingOnly = Preferences.Privacy.privateBrowsingOnly.value
+        
         // Always make sure there is a single normal tab.
-        let tabs = self.tabs(withType: .regular)
+        let tabs = self.tabs(withType: isPrivateBrowsingOnly ? .private : .regular)
         if tabs.isEmpty {
-            let tab = addTab()
+            let tab = addTab(isPrivate: isPrivateBrowsingOnly)
             if selectedTab == nil {
                 selectTab(tab)
             }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -280,6 +280,8 @@ class TabTrayController: UIViewController, Themeable {
         super.init(nibName: nil, bundle: nil)
 
         tabManager.addDelegate(self)
+        
+        Preferences.Privacy.privateBrowsingOnly.observe(from: self)
     }
 
     convenience init(tabManager: TabManager, profile: Profile, tabTrayDelegate: TabTrayDelegate) {
@@ -320,6 +322,8 @@ class TabTrayController: UIViewController, Themeable {
 
         view.addSubview(collectionView)
         view.addSubview(toolbar)
+        
+        updatePrivateModeButtonVisibility()
 
         makeConstraints()
 
@@ -528,6 +532,18 @@ class TabTrayController: UIViewController, Themeable {
     func closeTabsForCurrentTray() {
         tabManager.removeTabsWithUndoToast(tabsToDisplay)
         self.collectionView.reloadData()
+    }
+    
+    func updatePrivateModeButtonVisibility() {
+        toolbar.privateModeButton.isHidden = Preferences.Privacy.privateBrowsingOnly.value
+    }
+}
+
+extension TabTrayController: PreferencesObserver {
+    func preferencesDidChange(for key: String) {
+        if key == Preferences.Privacy.privateBrowsingOnly.key {
+            updatePrivateModeButtonVisibility()
+        }
     }
 }
 

--- a/Client/Frontend/Widgets/Theme.swift
+++ b/Client/Frontend/Widgets/Theme.swift
@@ -43,12 +43,15 @@ enum Theme: String {
     /// - parameter tab: An object representing a Tab.
     /// - returns: A Tab theme.
     static func of(_ tab: Tab?) -> Theme {
-        switch TabType.of(tab) {
-        case .regular:
-            return .regular
-        case .private:
-            return .private
+        if let tab = tab {
+            switch TabType.of(tab) {
+            case .regular:
+                return .regular
+            case .private:
+                return .private
+            }
         }
+        return PrivateBrowsingManager.shared.isPrivateBrowsing ? .private : .regular
     }
     
 }


### PR DESCRIPTION
Flow matches 1.6 behaviour. Turning private only browsing mode on switches to private browsing, turning it off while in private mode switches back to regular mode.

## Pull Request Checklist

- [X] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_