### PR TITLE
Fix #362: Private tabs are now removed when exiting private mode

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -195,7 +195,7 @@ class TabManager: NSObject {
         }
 
         // Make sure to wipe the private tabs if the user has the pref turned on
-        if shouldClearPrivateTabs() && !TabType.of(tab).isPrivate {
+        if !TabType.of(tab).isPrivate {
             removeAllPrivateTabs()
         }
 
@@ -232,15 +232,11 @@ class TabManager: NSObject {
         }
     }
 
-    func shouldClearPrivateTabs() -> Bool {
-        return prefs.boolForKey("settings.closePrivateTabs") ?? false
-    }
-
     //Called by other classes to signal that they are entering/exiting private mode
     //This is called by TabTrayVC when the private mode button is pressed and BEFORE we've switched to the new mode
     //we only want to remove all private tabs when leaving PBM and not when entering.
     func willSwitchTabMode(leavingPBM: Bool) {
-        if shouldClearPrivateTabs() && leavingPBM {
+        if leavingPBM {
             removeAllPrivateTabs()
         }
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -465,17 +465,16 @@ class TabTrayController: UIViewController, Themeable {
             fromView = emptyPrivateTabsView
         }
 
-        tabManager.willSwitchTabMode(leavingPBM: privateMode)
-        privateMode = !privateMode
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs
-        let exitingPrivateMode = !privateMode && tabManager.shouldClearPrivateTabs()
+        tabManager.willSwitchTabMode(leavingPBM: privateMode)
+        privateMode = !privateMode
 
         toolbar.privateModeButton.isSelected = privateMode
         collectionView.layoutSubviews()
 
         let toView: UIView
-        if !privateTabsAreEmpty(), let newSnapshot = collectionView.snapshotView(afterScreenUpdates: !exitingPrivateMode) {
+        if !privateTabsAreEmpty(), let newSnapshot = collectionView.snapshotView(afterScreenUpdates: true) {
             emptyPrivateTabsView.isHidden = true
             //when exiting private mode don't screenshot the collectionview (causes the UI to hang)
             newSnapshot.frame = collectionView.frame

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -216,7 +216,6 @@ class TabManagerTests: XCTestCase {
         //setup
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
         
         // create one private and one normal tab
         let tab = manager.addTab()
@@ -241,18 +240,11 @@ class TabManagerTests: XCTestCase {
         manager.selectTab(manager.addTab())
         XCTAssertEqual(manager.tabs(withType: .private).count, 0, "But once we add a normal tab we've switched out of private mode. Private tabs should be deleted")
         XCTAssertEqual(manager.tabs(withType: .regular).count, 2, "The original normal tab and the new one should both still exist")
-        
-        profile.prefs.setBool(false, forKey: "settings.closePrivateTabs")
-        manager.selectTab(manager.addTab(isPrivate: true))
-        manager.selectTab(tab)
-        XCTAssertEqual(TabType.of(manager.selectedTab).isPrivate, false, "The selected tab should not be private")
-        XCTAssertEqual(manager.tabs(withType: .private).count, 1, "If the flag is false then private tabs should still exist")
     }
     
     func testTogglePBMDelete() {
         let profile = TabManagerMockProfile()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
         
         let tab = manager.addTab()
         manager.selectTab(tab)
@@ -355,7 +347,6 @@ class TabManagerTests: XCTestCase {
         let profile = TabManagerMockProfile()
         let delegate = MockTabManagerDelegate()
         let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        profile.prefs.setBool(true, forKey: "settings.closePrivateTabs")
         
         // create one private and one normal tab
         let tab = manager.addTab()


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_
