### PR TITLE
Make `tabs(withType:)` private to prevent UI from relying on it

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -24,7 +24,7 @@ private extension TrayToBrowserAnimator {
         guard let selectedTab = bvc.tabManager.selectedTab else { return }
 
         let tabManager = bvc.tabManager
-        let displayedTabs = tabManager.tabs(withType: selectedTab.type)
+        let displayedTabs = tabManager.tabsForCurrentMode
         guard let expandFromIndex = displayedTabs.index(of: selectedTab) else { return }
 
         bvc.view.frame = transitionContext.finalFrame(for: bvc)
@@ -117,7 +117,7 @@ private extension BrowserToTrayAnimator {
         guard let selectedTab = bvc.tabManager.selectedTab else { return }
 
         let tabManager = bvc.tabManager
-        let displayedTabs = tabManager.tabs(withType: selectedTab.type)
+        let displayedTabs = tabManager.tabsForCurrentMode
         guard let scrollToIndex = displayedTabs.index(of: selectedTab) else { return }
 
         tabTray.view.frame = transitionContext.finalFrame(for: tabTray)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -58,7 +58,7 @@ extension BrowserViewController {
             return
         }
 
-        let tabs = tabManager.tabs(withType: currentTab.type)
+        let tabs = tabManager.tabsForCurrentMode
         if let index = tabs.index(of: currentTab), index + 1 < tabs.count {
             tabManager.selectTab(tabs[index + 1])
         } else if let firstTab = tabs.first {
@@ -71,7 +71,7 @@ extension BrowserViewController {
             return
         }
 
-        let tabs = tabManager.tabs(withType: currentTab.type)
+        let tabs = tabManager.tabsForCurrentMode
         if let index = tabs.index(of: currentTab), index - 1 < tabs.count && index != 0 {
             tabManager.selectTab(tabs[index - 1])
         } else if let lastTab = tabs.last {

--- a/Client/Frontend/Browser/NightModeHelper.swift
+++ b/Client/Frontend/Browser/NightModeHelper.swift
@@ -33,7 +33,7 @@ class NightModeHelper: TabContentScript {
     
     static func setNightMode(tabManager: TabManager, enabled: Bool) {
         Preferences.General.nightMode.value = enabled
-        for tab in tabManager.tabs {
+        for tab in tabManager.allTabs {
             tab.setNightMode(enabled)
         }
     }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -135,7 +135,7 @@ class TabsBarViewController: UIViewController {
     func updateData() {
         tabList = WeakList<Tab>()
         
-        tabManager?.displayedTabsForCurrentPrivateMode.forEach {
+        tabManager?.tabsForCurrentMode.forEach {
             tabList.insert($0)
         }
         
@@ -290,7 +290,7 @@ extension TabsBarViewController: UICollectionViewDataSource {
             let toTab = tabList[destinationIndexPath.row] else { return }
         
         // Find original from/to index... we need to target the full list not partial.
-        let tabs = manager.tabs(withType: fromTab.type)
+        let tabs = manager.tabsForCurrentMode
         guard let to = tabs.index(where: {$0 === toTab}) else { return }
         
         manager.moveTab(fromTab, toIndex: to)

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -192,7 +192,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
             self.tabManager.removeAll()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
                 if !self.gotNotificationDeathOfAllWebViews {
-                    self.tabManager.tabs.forEach { $0.deleteWebView() }
+                    self.tabManager.allTabs.forEach { $0.deleteWebView() }
                     self.allWebViewsKilled()
                 }
             })

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -300,7 +300,7 @@ class SettingsViewController: TableViewController {
                 Row(text: "View URP Logs", selection: {
                     self.navigationController?.pushViewController(UrpLogsViewController(), animated: true)
                 }, accessory: .disclosureIndicator),
-                Row(text: "URP Code: \(UserReferralProgram.getReferralCode(prefs: nil) ?? "--")"),
+                Row(text: "URP Code: \(UserReferralProgram.getReferralCode() ?? "--")"),
                 Row(text: "Load all QA Links", selection: {
                     let url = URL(string: "https://raw.githubusercontent.com/brave/qa-resources/master/testlinks.json")!
                     let string = try? String(contentsOf: url)

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -26,6 +26,13 @@ open class MockTabManagerStateDelegate: TabManagerStateDelegate {
     }
 }
 
+extension TabManager {
+    func tabs(withType type: TabType) -> [Tab] {
+        assert(Thread.isMainThread)
+        return allTabs.filter { $0.type == type }
+    }
+}
+
 struct MethodSpy {
     let functionName: String
     let method: ((_ tabs: [Tab?]) -> Void)?
@@ -309,9 +316,9 @@ class TabManagerTests: XCTestCase {
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         (0..<10).forEach {_ in manager.addTab() }
-        manager.selectTab(manager.tabs.last)
-        let deleteTab = manager.tabs.last
-        let newSelectedTab = manager.tabs[8]
+        manager.selectTab(manager.allTabs.last)
+        let deleteTab = manager.allTabs.last
+        let newSelectedTab = manager.allTabs[8]
         manager.addDelegate(delegate)
         
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
@@ -321,7 +328,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(next, newSelectedTab)
         }
         delegate.expect([willRemove, didRemove, didSelect])
-        manager.removeTab(manager.tabs.last!)
+        manager.removeTab(manager.allTabs.last!)
         
         delegate.verify("Not all delegate methods were called")
     }
@@ -370,9 +377,9 @@ class TabManagerTests: XCTestCase {
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
         (0..<10).forEach {_ in manager.addTab() }
-        manager.selectTab(manager.tabs.first)
-        let deleteTab = manager.tabs.first
-        let newSelectedTab = manager.tabs[1]
+        manager.selectTab(manager.allTabs.first)
+        let deleteTab = manager.allTabs.first
+        let newSelectedTab = manager.allTabs[1]
         manager.addDelegate(delegate)
         
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
@@ -382,7 +389,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(next, newSelectedTab)
         }
         delegate.expect([willRemove, didRemove, didSelect])
-        manager.removeTab(manager.tabs.first!)
+        manager.removeTab(manager.allTabs.first!)
         delegate.verify("Not all delegate methods were called")
     }
     
@@ -397,7 +404,7 @@ class TabManagerTests: XCTestCase {
         let newSelected = manager.addTab()
         manager.addTab(isPrivate: true)
         let deleted = manager.addTab()
-        manager.selectTab(manager.tabs.last)
+        manager.selectTab(manager.allTabs.last)
         manager.addDelegate(delegate)
         
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
@@ -407,7 +414,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(next, newSelected)
         }
         delegate.expect([willRemove, didRemove, didSelect])
-        manager.removeTab(manager.tabs.last!)
+        manager.removeTab(manager.allTabs.last!)
         
         delegate.verify("Not all delegate methods were called")
     }
@@ -421,7 +428,7 @@ class TabManagerTests: XCTestCase {
         let newSelected = manager.addTab()
         manager.addTab(isPrivate: true)
         manager.addTab()
-        manager.selectTab(manager.tabs.first)
+        manager.selectTab(manager.allTabs.first)
         manager.addDelegate(delegate)
         
         let didSelect = MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)") { tabs in
@@ -431,7 +438,7 @@ class TabManagerTests: XCTestCase {
             XCTAssertEqual(next, newSelected)
         }
         delegate.expect([willRemove, didRemove, didSelect])
-        manager.removeTab(manager.tabs.first!)
+        manager.removeTab(manager.allTabs.first!)
         delegate.verify("Not all delegate methods were called")
     }
     


### PR DESCRIPTION
Fixes #352 (Fixes the number, doesn't remove the number)

## Pull Request Checklist

- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

Sanity check needed