### PR TITLE
Fix #353: Change copy of new tab page in back/forward list

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -58,6 +58,7 @@ public extension Strings {
 //    public static let SelectLocationBarTitle = NSLocalizedString("Select Location Bar", comment: "")
 //    public static let NewTabTitle = NSLocalizedString("New Tab", comment: "")
 //    public static let NewPrivateTabTitle = NSLocalizedString("New Private Tab", comment: "")
+    public static let Home = NSLocalizedString("Home", comment: "")
     public static let SearchNewTabTitle = NSLocalizedString("Search in New Tab", comment: "")
     public static let SearchNewPrivateTabTitle = NSLocalizedString("Search in New Private Tab", comment: "")
     public static let CloseAllTabsTitle = NSLocalizedString("Close All %i Tabs", comment: "")

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Shared
+import BraveShared
 import WebKit
 import Storage
 import SnapKit
@@ -229,7 +230,7 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
         cell.connectingForwards = indexPath.item != 0
 
         guard let url = urlString, !item.url.isAboutHomeURL else {
-            cell.site = Site(url: item.url.absoluteString, title: Strings.FirefoxHomePage)
+            cell.site = Site(url: item.url.absoluteString, title: Strings.Home)
             return cell
         }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -103,7 +103,6 @@ extension Strings {
     public static let HistoryPanelEmptyStateTitle = NSLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you’ve visited recently will show up here.", comment: "Title for the History Panel empty state.")
     public static let RecentlyClosedTabsButtonTitle = NSLocalizedString("HistoryPanel.RecentlyClosedTabsButton.Title", value: "Recently Closed", comment: "Title for the Recently Closed button in the History Panel")
     public static let RecentlyClosedTabsPanelTitle = NSLocalizedString("RecentlyClosedTabsPanel.Title", value: "Recently Closed", comment: "Title for the Recently Closed Tabs Panel")
-    public static let FirefoxHomePage = NSLocalizedString("Firefox.HomePage.Title", value: "Firefox Home Page", comment: "Title for firefox about:home page in tab history list")
 }
 
 // Syncing


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![simulator screen shot - iphone x - 2018-10-26 at 16 37 14](https://user-images.githubusercontent.com/529104/47591426-915fb080-d93d-11e8-9c2f-98aa1723d378.png)

## Notes for testing this patch

_None included_
