### PR TITLE
Fix #104: Add more TabManager unit tests

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -328,23 +328,24 @@ class TabManager: NSObject {
         return tab
     }
     
-    func moveTab(fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
+    func moveTab(_ tab: Tab, toIndex visibleToIndex: Int) {
         assert(Thread.isMainThread)
         
-        let tabType: TabType = PrivateBrowsingManager.shared.isPrivateBrowsing ? .private : .regular
-        let currentTabs = tabs(withType: tabType)
+        let currentTabs = tabs(withType: tab.type)
 
-        let fromTab = currentTabs[visibleFromIndex]
         let toTab = currentTabs[visibleToIndex]
 
-        guard let fromIndex = tabs.index(of: fromTab), let toIndex = tabs.index(of: toTab) else {
+        guard let fromIndex = tabs.index(of: tab), let toIndex = tabs.index(of: toTab) else {
             return
         }
+        
+        // Make sure to save the selected tab before updating the tabs list
+        let previouslySelectedTab = selectedTab
 
         let tab = tabs.remove(at: fromIndex)
         tabs.insert(tab, at: toIndex)
 
-        if let previouslySelectedTab = selectedTab, let previousSelectedIndex = tabs.index(of: previouslySelectedTab) {
+        if let previouslySelectedTab = previouslySelectedTab, let previousSelectedIndex = tabs.index(of: previouslySelectedTab) {
             _selectedIndex = previousSelectedIndex
         }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -870,7 +870,7 @@ extension TabManagerDataSource: UICollectionViewDropDelegate {
         isDragging = false
 
         let destinationIndex = destinationIndexPath.item
-        tabManager.moveTab(fromIndex: sourceIndex, toIndex: destinationIndex)
+        tabManager.moveTab(tab, toIndex: destinationIndex)
         tabs.insert(tabs.remove(at: sourceIndex), at: destinationIndex)
         collectionView.moveItem(at: IndexPath(item: sourceIndex, section: 0), to: destinationIndexPath)
     }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -291,10 +291,9 @@ extension TabsBarViewController: UICollectionViewDataSource {
         
         // Find original from/to index... we need to target the full list not partial.
         let tabs = manager.tabs(withType: fromTab.type)
-        guard let from = tabs.index(where: {$0 === fromTab}),
-            let to = tabs.index(where: {$0 === toTab}) else { return }
+        guard let to = tabs.index(where: {$0 === toTab}) else { return }
         
-        manager.moveTab(fromIndex: from, toIndex: to)
+        manager.moveTab(fromTab, toIndex: to)
         updateData()
         
         guard let selectedTab = tabList[destinationIndexPath.row] else { return }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -108,8 +108,13 @@ class TabManagerTests: XCTestCase {
     let willAdd = MethodSpy(functionName: "tabManager(_:willAddTab:)")
     let didAdd = MethodSpy(functionName: "tabManager(_:didAddTab:)")
     
+    var manager: TabManager!
+    
     override func setUp() {
         super.setUp()
+        
+        let profile = TabManagerMockProfile()
+        manager = TabManager(prefs: profile.prefs, imageStore: nil)
     }
     
     override func tearDown() {
@@ -139,8 +144,6 @@ class TabManagerTests: XCTestCase {
      */
     
     func testTabManagerDoesNotCallTabManagerStateDelegateOnStoreChangesWithPrivateTabs() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let stateDelegate = MockTabManagerStateDelegate()
         manager.stateDelegate = stateDelegate
         let configuration = WKWebViewConfiguration()
@@ -158,8 +161,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testAddTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
         
@@ -169,8 +170,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testDidDeleteLastTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -191,8 +190,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testDidDeleteLastPrivateTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -213,10 +210,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testDeletePrivateTabsOnExit() {
-        //setup
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        
         // create one private and one normal tab
         let tab = manager.addTab()
         manager.selectTab(tab)
@@ -243,9 +236,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testTogglePBMDelete() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        
         let tab = manager.addTab()
         manager.selectTab(tab)
         manager.selectTab(manager.addTab())
@@ -260,8 +250,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testDeleteNonSelectedTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -278,8 +266,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testDeleteSelectedTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         func addTab(_ visit: Bool) -> Tab {
@@ -319,8 +305,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testDeleteLastTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -344,9 +328,7 @@ class TabManagerTests: XCTestCase {
     
     func testDelegatesCalledWhenRemovingPrivateTabs() {
         //setup
-        let profile = TabManagerMockProfile()
         let delegate = MockTabManagerDelegate()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         
         // create one private and one normal tab
         let tab = manager.addTab()
@@ -384,8 +366,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testDeleteFirstTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
@@ -409,8 +389,6 @@ class TabManagerTests: XCTestCase {
     // Private tabs and regular tabs are in the same tabs array.
     // Make sure that when a private tab is added inbetween regular tabs it isnt accidently selected when removing a regular tab
     func testTabsIndex() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         // We add 2 tabs. Then a private one before adding another normal tab and selecting it.
@@ -435,8 +413,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testTabsIndexClosingFirst() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         // We add 2 tabs. Then a private one before adding another normal tab and selecting the first.
@@ -460,8 +436,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testRemoveOnlyTab() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         
         let tab = manager.addTab()
@@ -477,9 +451,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testRemoveAllTabs() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        
         (0..<10).forEach { _ in manager.addTab() }
         manager.removeAll()
         
@@ -488,9 +459,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testMoveTabToEnd() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        
         let firstTab = manager.addTabAndSelect()
         let secondTab = manager.addTab()
         manager.addTab(isPrivate: true)
@@ -505,9 +473,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testMoveTabToStart() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        
         let firstTab = manager.addTabAndSelect()
         let secondTab = manager.addTab()
         manager.addTab(isPrivate: true)
@@ -522,9 +487,6 @@ class TabManagerTests: XCTestCase {
     }
     
     func testMoveTabToMiddle() {
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
-        
         let firstTab = manager.addTab()
         let secondTab = manager.addTab()
         manager.addTab(isPrivate: true)
@@ -542,8 +504,6 @@ class TabManagerTests: XCTestCase {
     func testQueryAddedTabs() {
         TabMO.deleteAll()
         
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
         
@@ -559,8 +519,6 @@ class TabManagerTests: XCTestCase {
     func testQueryAddedPrivateTabs() {
         TabMO.deleteAll()
         
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
         
@@ -576,8 +534,6 @@ class TabManagerTests: XCTestCase {
     func testQueryAddedMixedTabs() {
         TabMO.deleteAll()
         
-        let profile = TabManagerMockProfile()
-        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
         


### PR DESCRIPTION
- [x] `testRemoveOnlyTab`
- [x] `testRemoveAllTabs`
- [x] `testMoveTabToEnd`
- [x] `testMoveTabToStart`
- [x] `testMoveTabToMiddle`
- [x] `testQueryAddedTabs`
- [x] `testQueryAddedPrivateTabs`
- [x] `testQueryAddedMixedTabs`

Also refactors `moveTab` method to have a tab passed in rather than a from index removing the need to check `PrivateBrowsingManager`

Note: Conflicts with #367 (rebases will be needed depending on which branch is merged first)

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_