### PR TITLE
Fix #376: Remove the block images shield toggle

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -230,7 +230,6 @@ class SettingsViewController: TableViewController {
                 BoolRow(title: Strings.Block_Phishing_and_Malware, option: Preferences.Shields.blockPhishingAndMalware),
                 BoolRow(title: Strings.Block_Scripts, option: Preferences.Shields.blockScripts),
                 BoolRow(title: Strings.Fingerprinting_Protection, option: Preferences.Shields.fingerprintingProtection),
-                BoolRow(title: Strings.AppMenuNoImageMode, option: Preferences.Shields.blockImages),
             ]
         )
         // TODO: Add regional adblock


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_
