### PR TITLE
Fix #380: Remove progress bar animation when you change tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1887,10 +1887,7 @@ extension BrowserViewController: TabManagerDelegate {
         urlBar.locationView.loading = selected?.loading ?? false
         navigationToolbar.updateBackStatus(selected?.canGoBack ?? false)
         navigationToolbar.updateForwardStatus(selected?.canGoForward ?? false)
-        if !(selected?.webView?.url?.isLocalUtility ?? false) {
-            self.urlBar.updateProgressBar(Float(selected?.estimatedProgress ?? 0))
-        }
-
+        
         if let readerMode = selected?.getContentScript(name: ReaderMode.name()) as? ReaderMode {
             urlBar.updateReaderModeState(readerMode.state)
             if readerMode.state == .active {


### PR DESCRIPTION
The progress bar is already automatically updated when `WKWebView.estimatedProgress` changes (based on KVO) so updating when the user changes tabs seems pointless.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_none included_

## Notes for testing this patch

_none included_