### PR TITLE
Update TabManagerTests to reflect `tabs` rename.

### DIFF
--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -453,16 +453,16 @@ class TabManagerTests: XCTestCase {
         
         delegate.verify("Not all delegate methods were called")
         
-        XCTAssertFalse(manager.tabs.isEmpty, "Should create a new tab when all others are removed")
-        XCTAssertFalse(manager.tabs.first!.isPrivate, "The new tab should be a regular tab")
+        XCTAssertFalse(manager.allTabs.isEmpty, "Should create a new tab when all others are removed")
+        XCTAssertFalse(manager.allTabs.first!.isPrivate, "The new tab should be a regular tab")
     }
     
     func testRemoveAllTabs() {
         (0..<10).forEach { _ in manager.addTab() }
         manager.removeAll()
         
-        XCTAssertFalse(manager.tabs.isEmpty, "Should create a new tab when all others are removed")
-        XCTAssertFalse(manager.tabs.first!.isPrivate, "The new tab should be a regular tab")
+        XCTAssertFalse(manager.allTabs.isEmpty, "Should create a new tab when all others are removed")
+        XCTAssertFalse(manager.allTabs.first!.isPrivate, "The new tab should be a regular tab")
     }
     
     func testMoveTabToEnd() {


### PR DESCRIPTION
We forgot to change it once `TabManager.tabs` got renamed to `allTabs`