### PR TITLE
Fix #417: Don't dismiss a popover when going from flat to portrait

### DIFF
--- a/Client/Frontend/Popover/PopoverController.swift
+++ b/Client/Frontend/Popover/PopoverController.swift
@@ -83,8 +83,6 @@ class PopoverController: UIViewController {
         
         self.modalPresentationStyle = .overFullScreen
         self.transitioningDelegate = self
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(orientationChanged), name: .UIDeviceOrientationDidChange, object: nil)
     }
     
     deinit {
@@ -242,7 +240,9 @@ class PopoverController: UIViewController {
         viewController.present(self, animated: true)
     }
     
-    @objc private func orientationChanged() {
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
         if dismissesOnOrientationChanged {
             dismiss(animated: true)
         }


### PR DESCRIPTION
I couldn't reproduce the sizing difference based on flat vs portrait but I fixed the dismissal at least :)

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
