### PR TITLE
Fix #97: Add Fingerprinting Protection

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		27658272217130D900754B2F /* GlobalSign_r3.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2765826F217130D900754B2F /* GlobalSign_r3.cer */; };
 		27658273217130D900754B2F /* DigiCertHighAssurance.cer in Resources */ = {isa = PBXBuildFile; fileRef = 27658270217130D900754B2F /* DigiCertHighAssurance.cer */; };
 		2798E01D213EFC3F003EDBB1 /* FavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */; };
+		279C756B219DDE3B001CD1CB /* FingerprintingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */; };
+		279C75C821A5B37D001CD1CB /* FingerprintingProtection.js in Resources */ = {isa = PBXBuildFile; fileRef = 279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */; };
 		27A586E1214C0DDD000CAE3C /* PreferencesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */; };
 		27C461DE211B76500088A441 /* ShieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C461DD211B76500088A441 /* ShieldsView.swift */; };
 		27C46201211CD8D20088A441 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
@@ -962,6 +964,8 @@
 		2765826F217130D900754B2F /* GlobalSign_r3.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = GlobalSign_r3.cer; sourceTree = "<group>"; };
 		27658270217130D900754B2F /* DigiCertHighAssurance.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = DigiCertHighAssurance.cer; sourceTree = "<group>"; };
 		2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteTests.swift; sourceTree = "<group>"; };
+		279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintingProtection.swift; sourceTree = "<group>"; };
+		279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = FingerprintingProtection.js; sourceTree = "<group>"; };
 		27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTest.swift; sourceTree = "<group>"; };
 		27C461DD211B76500088A441 /* ShieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsView.swift; sourceTree = "<group>"; };
 		27D87C2D2152B50200FB55C6 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
@@ -2348,6 +2352,7 @@
 		D0FCF7E71FE44CA9004A7995 /* UserScripts */ = {
 			isa = PBXGroup;
 			children = (
+				279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */,
 				D0FCF7E81FE44D8F004A7995 /* AllFrames */,
 				D0FCF7E91FE44DA2004A7995 /* MainFrame */,
 			);
@@ -2586,6 +2591,7 @@
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				D0FCF7F41FE45842004A7995 /* UserScriptManager.swift */,
+				279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */,
 			);
 			indentWidth = 4;
 			path = Browser;
@@ -3816,6 +3822,7 @@
 				E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */,
 				2F44FB2D1A9D5D8500FD20CC /* FiraSans-BoldItalic.ttf in Resources */,
 				D03F8F23200EAC1F003C2224 /* AllFramesAtDocumentStart.js in Resources */,
+				279C75C821A5B37D001CD1CB /* FingerprintingProtection.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4403,6 +4410,7 @@
 				28EADE5D1AFC3A78007FB2FB /* UIImageViewExtensions.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
+				279C756B219DDE3B001CD1CB /* FingerprintingProtection.swift in Sources */,
 				E650755F1E37F756006961AC /* Try.m in Sources */,
 				3B6889C51D66950E002AC85E /* UIImageColors.swift in Sources */,
 				0A1E84402190A57F0042F782 /* SyncSelectDeviceTypeViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		27658271217130D900754B2F /* GlobalSign_r1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2765826E217130D900754B2F /* GlobalSign_r1.cer */; };
 		27658272217130D900754B2F /* GlobalSign_r3.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2765826F217130D900754B2F /* GlobalSign_r3.cer */; };
 		27658273217130D900754B2F /* DigiCertHighAssurance.cer in Resources */ = {isa = PBXBuildFile; fileRef = 27658270217130D900754B2F /* DigiCertHighAssurance.cer */; };
+		2795274A21A890EB00921AA1 /* FingerprintingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */; };
 		2798E01D213EFC3F003EDBB1 /* FavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */; };
 		279C756B219DDE3B001CD1CB /* FingerprintingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */; };
 		279C75C821A5B37D001CD1CB /* FingerprintingProtection.js in Resources */ = {isa = PBXBuildFile; fileRef = 279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */; };
@@ -963,6 +964,7 @@
 		2765826E217130D900754B2F /* GlobalSign_r1.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = GlobalSign_r1.cer; sourceTree = "<group>"; };
 		2765826F217130D900754B2F /* GlobalSign_r3.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = GlobalSign_r3.cer; sourceTree = "<group>"; };
 		27658270217130D900754B2F /* DigiCertHighAssurance.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = DigiCertHighAssurance.cer; sourceTree = "<group>"; };
+		2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintingProtectionTests.swift; sourceTree = "<group>"; };
 		2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteTests.swift; sourceTree = "<group>"; };
 		279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintingProtection.swift; sourceTree = "<group>"; };
 		279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = FingerprintingProtection.js; sourceTree = "<group>"; };
@@ -2942,6 +2944,7 @@
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
 				39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */,
 				D8EFFA251FF702A8001D3A09 /* NavigationRouterTests.swift */,
+				2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -4483,6 +4486,7 @@
 				3BFCBF201E04B1C50070C042 /* UIImageViewExtensionsTests.swift in Sources */,
 				E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,
+				2795274A21A890EB00921AA1 /* FingerprintingProtectionTests.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -77,6 +77,8 @@ extension Preferences {
         static let clearPrivateDataToggles = Option<[Bool]>(key: "privacy.clear-data-toggles", default: [])
     }
     final class Shields {
+        static let allShields = [blockAdsAndTracking, httpsEverywhere, blockPhishingAndMalware, blockScripts, fingerprintingProtection, blockImages]
+        
         /// Shields will block ads and tracking if enabled
         static let blockAdsAndTracking = Option<Bool>(key: "shields.block-ads-and-tracking", default: true)
         /// Websites will be upgraded to HTTPS if a loaded page attempts to use HTTP

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -177,7 +177,7 @@ class BrowserViewController: UIViewController {
         Preferences.Privacy.privateBrowsingOnly.observe(from: self)
         Preferences.Privacy.cookieAcceptPolicy.observe(from: self)
         Preferences.General.tabBarVisibility.observe(from: self)
-        Preferences.Shields.fingerprintingProtection.observe(from: self)
+        Preferences.Shields.allShields.forEach { $0.observe(from: self) }
         
         // Lists need to be compiled before attempting tab restoration
         contentBlockListDeferred = ContentBlockerHelper.compileLists()
@@ -1765,6 +1765,8 @@ extension BrowserViewController: TabDelegate {
         tab.addContentScript(tab.contentBlocker, name: ContentBlockerHelper.name())
 
         tab.addContentScript(FocusHelper(tab: tab), name: FocusHelper.name())
+        
+        tab.addContentScript(FingerprintingProtection(tab: tab), name: FingerprintingProtection.name())
     }
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {
@@ -2779,9 +2781,13 @@ extension BrowserViewController: PreferencesObserver {
                 tabManager.addTabAndSelect(nil, isPrivate: isPrivate)
             }
             updateTabsBarVisibility()
-        case Preferences.Shields.fingerprintingProtection.key:
-            // TODO: Update fingerprinting protection based on `Preferences.Shields.fingerprintingProtection` once fingerprinting protection is added back
-            break
+        case Preferences.Shields.blockAdsAndTracking.key,
+             Preferences.Shields.httpsEverywhere.key,
+             Preferences.Shields.blockScripts.key,
+             Preferences.Shields.blockPhishingAndMalware.key,
+             Preferences.Shields.blockImages.key,
+             Preferences.Shields.fingerprintingProtection.key:
+            tabManager.allTabs.forEach { $0.webView?.reload() }
         default:
             log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
             break

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -6,6 +6,7 @@ import Foundation
 import WebKit
 import Shared
 import Data
+import BraveShared
 
 private let log = Logger.browserLogger
 
@@ -152,6 +153,11 @@ extension BrowserViewController: WKNavigationDelegate {
                 // Grab all lists that have valid rules and add/remove them as necessary
                 on.compactMap { $0.rule }.forEach(controller.add)
                 off.compactMap { $0.rule }.forEach(controller.remove)
+                
+                if let tab = tabManager[webView] {
+                    let isFPEnabled = domainForShields.shield_fpProtection?.boolValue ?? Preferences.Shields.fingerprintingProtection.value
+                    tab.userScriptManager?.isFingerprintingProtectionEnabled = isFPEnabled
+                }
             }
             
             decisionHandler(.allow)

--- a/Client/Frontend/Browser/FingerprintingProtection.swift
+++ b/Client/Frontend/Browser/FingerprintingProtection.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import WebKit
+import Data
+import BraveShared
+
+class FingerprintingProtection: TabContentScript {
+    fileprivate weak var tab: Tab?
+    
+    init(tab: Tab) {
+        self.tab = tab
+    }
+    
+    static func name() -> String {
+        return "FingerprintingProtection"
+    }
+    
+    func scriptMessageHandlerName() -> String? {
+        return "fingerprintingProtection"
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        if let stats = self.tab?.contentBlocker.stats {
+            self.tab?.contentBlocker.stats = stats.addingFingerprintingBlock()
+            BraveGlobalShieldStats.shared.fpProtection += 1
+        }
+    }
+}

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -6,6 +6,7 @@ import Foundation
 import WebKit
 import Storage
 import Shared
+import BraveShared
 import SwiftyJSON
 import XCGLogger
 import Data
@@ -208,7 +209,7 @@ class Tab: NSObject {
 
             self.webView = webView
             self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
-            self.userScriptManager = UserScriptManager(tab: self)
+            self.userScriptManager = UserScriptManager(tab: self, isFingerprintingProtectionEnabled: Preferences.Shields.fingerprintingProtection.value)
             tabDelegate?.tab?(self, didCreateWebView: webView)
         }
     }

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -3,24 +3,65 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import WebKit
+import Shared
+
+private let log = Logger.browserLogger
 
 class UserScriptManager {
 
     // Scripts can use this to verify the app –not js on the page– is calling into them.
     public static let securityToken = UUID()
 
-    init(tab: Tab) {
+    private weak var tab: Tab?
+    
+    // Whether or not the fingerprinting protection
+    var isFingerprintingProtectionEnabled: Bool {
+        didSet {
+            if oldValue == isFingerprintingProtectionEnabled { return }
+            reloadUserScripts()
+        }
+    }
+    
+    init(tab: Tab, isFingerprintingProtectionEnabled: Bool) {
+        self.tab = tab
+        self.isFingerprintingProtectionEnabled = isFingerprintingProtectionEnabled
+        
+        reloadUserScripts()
+    }
+    
+    // MARK: -
+    
+    private let packedUserScripts: [WKUserScript] = {
         [(WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: false),
          (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: false),
          (WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: true),
-         (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: true)].forEach { arg in
+         (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: true)].compactMap { arg in
             let (injectionTime, mainFrameOnly) = arg
             let name = (mainFrameOnly ? "MainFrame" : "AllFrames") + "AtDocument" + (injectionTime == .atDocumentStart ? "Start" : "End")
             if let path = Bundle.main.path(forResource: name, ofType: "js"),
-               let source = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String {
+                let source = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String {
                 let wrappedSource = "(function() { const SECURITY_TOKEN = '\(UserScriptManager.securityToken)'; \(source) })()"
-                let userScript = WKUserScript(source: wrappedSource, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
-                tab.webView?.configuration.userContentController.addUserScript(userScript)
+                return WKUserScript(source: wrappedSource, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
+            }
+            return nil
+        }
+    }()
+    
+    private let fingerprintingProtectionUserScript: WKUserScript? = {
+        guard let path = Bundle.main.path(forResource: "FingerprintingProtection", ofType: "js"), let source = try? String(contentsOfFile: path) else {
+            log.error("Failed to load fingerprinting protection user script")
+            return nil
+        }
+        return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+    }()
+    
+    private func reloadUserScripts() {
+        tab?.webView?.configuration.userContentController.do {
+            $0.removeAllUserScripts()
+            self.packedUserScripts.forEach($0.addUserScript)
+            
+            if isFingerprintingProtectionEnabled, let script = fingerprintingProtectionUserScript {
+                $0.addUserScript(script)
             }
         }
     }

--- a/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerHelper.swift
@@ -189,8 +189,11 @@ class ContentBlockerHelper {
             if stats.total <= 1 {
                 TabEvent.post(.didChangeContentBlocking, for: tab)
             }
+            statsDidChange?(stats)
         }
     }
+    
+    var statsDidChange: ((TPPageStats) -> Void)?
 
     static private var blockImagesRule: WKContentRuleList?
     static var heavyInitHasRunOnce = false

--- a/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/Frontend/ContentBlocker/TrackingProtectionPageStats.swift
@@ -13,20 +13,26 @@ struct TPPageStats {
     let adCount: Int
     let trackerCount: Int
     let scriptCount: Int
+    let fingerprintingCount: Int
 
-    var total: Int { return adCount + trackerCount + scriptCount }
+    var total: Int { return adCount + trackerCount + scriptCount + fingerprintingCount }
     
-    init(adCount: Int = 0, trackerCount: Int = 0, scriptCount: Int = 0) {
+    init(adCount: Int = 0, trackerCount: Int = 0, scriptCount: Int = 0, fingerprintingCount: Int = 0) {
         self.adCount = adCount
         self.trackerCount = trackerCount
         self.scriptCount = scriptCount
+        self.fingerprintingCount = fingerprintingCount
+    }
+    
+    func addingFingerprintingBlock() -> TPPageStats {
+        return TPPageStats(adCount: adCount, trackerCount: trackerCount, scriptCount: scriptCount, fingerprintingCount: fingerprintingCount + 1)
     }
 
     func create(byAddingListItem listItem: BlocklistName) -> TPPageStats {
         switch listItem {
-        case .ad: return TPPageStats(adCount: adCount + 1, trackerCount: trackerCount, scriptCount: scriptCount)
-        case .tracker: return TPPageStats(adCount: adCount, trackerCount: trackerCount + 1, scriptCount: scriptCount)
-        case .script: return TPPageStats(adCount: adCount, trackerCount: trackerCount, scriptCount: scriptCount + 1)
+        case .ad: return TPPageStats(adCount: adCount + 1, trackerCount: trackerCount, scriptCount: scriptCount, fingerprintingCount: fingerprintingCount)
+        case .tracker: return TPPageStats(adCount: adCount, trackerCount: trackerCount + 1, scriptCount: scriptCount, fingerprintingCount: fingerprintingCount)
+        case .script: return TPPageStats(adCount: adCount, trackerCount: trackerCount, scriptCount: scriptCount + 1, fingerprintingCount: fingerprintingCount)
         default:
             break
         }

--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -27,8 +27,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
         updateToggleStatus()
         updateShieldBlockStats()
         
-        let name = Notification.Name(rawValue: BraveGlobalShieldStats.DidUpdateNotification)
-        self.statsUpdateObservable = NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+        tab.contentBlocker.statsDidChange = { [weak self] _ in
             self?.updateShieldBlockStats()
         }
     }
@@ -67,7 +66,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
     private func updateShieldBlockStats() {
         shieldsView.shieldsContainerStackView.adsTrackersStatView.valueLabel.text = String(tab.contentBlocker.stats.adCount)
         shieldsView.shieldsContainerStackView.scriptsBlockedStatView.valueLabel.text = String(tab.contentBlocker.stats.scriptCount)
-//        shieldsView.shieldsContainerStackView.fingerprintingStatView.valueLabel.text = String(shieldBlockStats.fingerprintCount)
+        shieldsView.shieldsContainerStackView.fingerprintingStatView.valueLabel.text = String(tab.contentBlocker.stats.fingerprintingCount)
     }
     
     private func updateBraveShieldState(shield: BraveShieldState.Shield, on: Bool, option: Preferences.Option<Bool>?) {

--- a/Client/Frontend/UserContent/UserScripts/FingerprintingProtection.js
+++ b/Client/Frontend/UserContent/UserScripts/FingerprintingProtection.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+if (webkit.messageHandlers.fingerprintingProtection) {
+    install();
+}
+
+function install() {
+    function sendMessage(msg) {
+        if (msg) {
+            webkit.messageHandlers.fingerprintingProtection.postMessage(msg);
+        }
+    }
+
+    function installIFrameMethodTrap(obj, method) {
+        let orig = obj[method];
+        obj[method] = function () {
+            var last = arguments[arguments.length - 1]
+            if (last && last.toLowerCase() === 'canvas') {
+                // Prevent fingerprinting using contentDocument.createElement('canvas'),
+                // which evades trapInstanceMethod when the iframe is sandboxed
+                sendMessage({ obj: `${obj}`, method: method })
+            } else {
+                // Otherwise apply the original method
+                return orig.apply(this, arguments)
+            }
+        };
+        return orig;
+    }
+
+    let hooks = [
+        {
+            obj: window.CanvasRenderingContext2D.prototype,
+            methods: ['getImageData', 'getLineDash', 'measureText']
+        },
+        {
+            obj: window.HTMLCanvasElement.prototype,
+            methods: ['toDataURL', 'toBlob']
+        },
+        {
+            obj: window.WebGLRenderingContext.prototype,
+            methods: ['getSupportedExtensions', 'getParameter', 'getContextAttributes', 'getShaderPrecisionFormat', 'getExtension']
+        },
+        {
+            obj: window.AudioBuffer.prototype,
+            methods: ['copyFromChannel', 'getChannelData']
+        },
+        {
+            obj: window.AnalyserNode.prototype,
+            methods: ['getFloatFrequencyData', 'getByteFrequencyData', 'getFloatTimeDomainData', 'getByteTimeDomainData']
+        }
+    ];
+
+    // Install Method Hooks
+    hooks.forEach(function (hook) {
+        hook.methods.forEach(function (method) {
+            hook.obj[method] = function () {
+                sendMessage({ obj: `${hook.obj}`, method: method });
+            }
+        });
+    });
+
+    // Install iframe Document Hooks
+    if (window.frameElement) {
+        installIFrameMethodTrap(document, 'createElement');
+        installIFrameMethodTrap(document, 'createElementNS');
+    }
+}

--- a/ClientTests/FingerprintingProtectionTests.swift
+++ b/ClientTests/FingerprintingProtectionTests.swift
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import XCTest
+@testable import Client
+import BraveShared
+import Data
+import WebKit
+
+class FingerprintProtectionTest: XCTestCase {
+    
+    override func setUp() {
+        DataController.shared = DataController()
+    }
+    
+    func testFingerprintProtection() {
+        // Let the app startup, prevents the tab from not being selected
+        wait(2)
+        
+        let url = URL(string: "https://panopticlick.eff.org/results")!
+        
+        // Enable fingerprinting protection for the domain
+        let domain = Domain.getOrCreateForUrl(url, context: DataController.viewContext)
+        domain.shield_fpProtection = true as NSNumber
+        DataController.save(context: DataController.viewContext)
+        
+        // Create the web page load delegate/expectation
+        let navExpectation = expectation(description: "Navigation")
+        let navDelegate = FingerprintProtectionNavDelegate(completed: { error in
+            if let error = error {
+                XCTFail("Failed to load the web page: \(error.localizedDescription)")
+            }
+            navExpectation.fulfill()
+        })
+        
+        // Grab the tab manager
+        let tabManager = (UIApplication.shared.delegate as! AppDelegate).browserViewController.tabManager
+        tabManager.addNavigationDelegate(navDelegate)
+        
+        // Add the tab
+        let tab = tabManager.addTabAndSelect(URLRequest(url: url))
+        
+        // Wait until the tabs fully loaded the page and give some buffer on completion
+        wait(for: [navExpectation], timeout: 10.0)
+        wait(3)
+        
+        // Expand the details
+        tab.webView?.evaluateJavaScript("document.getElementById('showFingerprintLink2').click()", completionHandler: nil)
+        
+        wait(1)
+        
+        // Check the hash of the canvas fingerprint
+        let innerHTMLCheck = expectation(description: "Hash of Canvas Fingerprint")
+        tab.webView?.evaluateJavaScript("document.body.innerHTML", completionHandler: { (value, error) in
+            defer { innerHTMLCheck.fulfill() }
+            XCTAssertNil(error)
+            guard let innerHTML = value as? String else {
+                XCTFail("Incorrect type found")
+                return
+            }
+            XCTAssert(innerHTML.contains("891f3debe00dbd3d1f0457a70d2f5213"))
+        })
+        
+        let matchCheck = expectation(description: "Match Check")
+        tab.webView?.evaluateJavaScript("/webgl fingerprint.*(\\n.+)*undetermined/gim.exec(document.body.innerHTML)[0]", completionHandler: { (value, error) in
+            defer { matchCheck.fulfill() }
+            XCTAssertNil(error)
+            guard let match = value as? String else {
+                XCTFail("Incorrect type found")
+                return
+            }
+            XCTAssert(match.count > 50 && match.count < 300)
+        })
+        
+        wait(for: [innerHTMLCheck, matchCheck], timeout: 10)
+    }
+}
+
+private class FingerprintProtectionNavDelegate: NSObject, WKNavigationDelegate {
+    
+    let completed: (Error?) -> Void
+    
+    init(completed: @escaping (Error?) -> Void) {
+        self.completed = completed
+        super.init()
+    }
+    
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        completed(nil)
+    }
+    
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        completed(error)
+    }
+}

--- a/ClientTests/XCTestCaseExtensions.swift
+++ b/ClientTests/XCTestCaseExtensions.swift
@@ -8,10 +8,7 @@ import XCTest
 extension XCTestCase {
     func wait(_ time: TimeInterval) {
         let expectation = self.expectation(description: "Wait")
-        let delayTime = DispatchTime.now() + Double(Int64(time * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-        DispatchQueue.main.asyncAfter(deadline: delayTime) {
-            expectation.fulfill()
-        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + time, execute: { expectation.fulfill() })
         waitForExpectations(timeout: time + 1, handler: nil)
     }
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

AdBlocking stats can be ignored since 1.7 currently uses different adblocking/tracking filters.

| Test | 1.6 | 1.7 |
| --- | --- | --- |
| [browserleaks.com](https://browserleaks.com/canvas) | ![img_0093](https://user-images.githubusercontent.com/529104/48865913-05577200-ed9f-11e8-912f-ac987875ac5a.png) | ![img_0092](https://user-images.githubusercontent.com/529104/48865924-0be5e980-ed9f-11e8-8610-a0abe4218c37.png) |
| [amiunique.org](https://amiunique.org/fp) | ![img_0094](https://user-images.githubusercontent.com/529104/48865965-28822180-ed9f-11e8-95eb-97233c2fad56.png) | ![img_0090](https://user-images.githubusercontent.com/529104/48865976-2f109900-ed9f-11e8-8db3-b4ff12294a04.png) |
| [panopticlick.eff.org](https://panopticlick.eff.org) | ![img_0095](https://user-images.githubusercontent.com/529104/48866002-494a7700-ed9f-11e8-8c6a-047d9ea48b4d.png) | ![img_0091](https://user-images.githubusercontent.com/529104/48866007-4cddfe00-ed9f-11e8-8c21-a182382fd6ae.png) |