### PR TITLE
Fix #371: Add release fastlane that sets the URP API key

### DIFF
--- a/Client/Configuration/Fennec.enterprise.xcconfig
+++ b/Client/Configuration/Fennec.enterprise.xcconfig
@@ -6,6 +6,8 @@
 
 MOZ_BUNDLE_DISPLAY_NAME = BraveNight
 
+BRAVE_API_KEY = key
+
 // Bundle Identifier
 MOZ_BUNDLE_ID = $(BASE_BUNDLE_ID).BrowserEnterprise
 

--- a/Client/Configuration/Fennec.xcconfig
+++ b/Client/Configuration/Fennec.xcconfig
@@ -7,6 +7,8 @@
 
 MOZ_BUNDLE_DISPLAY_NAME = Brave ($(USER))
 
+BRAVE_API_KEY = key
+
 // Bundle Identifier
 // MOZ_BUNDLE_ID = set in Local.xconfig
 

--- a/Client/Configuration/FirefoxBeta.xcconfig
+++ b/Client/Configuration/FirefoxBeta.xcconfig
@@ -6,6 +6,8 @@
 
 MOZ_BUNDLE_DISPLAY_NAME = BraveBeta
 
+BRAVE_API_KEY = key
+
 // Bundle Identifier
 MOZ_BUNDLE_ID = $(BASE_BUNDLE_ID).BrowserBeta
 

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>key</string>
+	<string>$(BRAVE_API_KEY)</string>
 	<key>AdjustAppToken</key>
 	<string>$(ADJUST_APP_TOKEN)</string>
 	<key>AdjustEnvironment</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,7 +98,7 @@ platform :ios do
       sdk: "iphoneos",
       clean: true,
       skip_package_ipa: true,
-      xcargs: "-allowProvisioningUpdates BRAVE_API_KEY=\"#{sh("head", "-1", "#{LOCAL_PATH}/brave-api-key")}\"",
+      xcargs: "-allowProvisioningUpdates BRAVE_API_KEY=\"#{sh("head", "-1", "#{ENV['HOME']}/brave-api-key")}\"",
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,7 +98,7 @@ platform :ios do
       sdk: "iphoneos",
       clean: true,
       skip_package_ipa: true,
-      xcargs: "-allowProvisioningUpdates BRAVE_API_KEY=\"#{sh("head", "-1", "#{ENV['HOME']}/brave-api-key")}\"",
+      xcargs: "-allowProvisioningUpdates BRAVE_API_KEY=\"#{sh("head", "-1", "#{ENV['HOME']}/.brave-api-key")}\"",
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,6 +83,25 @@ platform :ios do
     )
   end
 
+  desc "Create an archive to be uploaded to the App Store"
+  lane :release do |options|
+    set_build_number(options)
+
+    carthage(
+      platform: "iOS",
+      cache_builds: true,
+      configuration: "Release",
+    )
+
+    gym(
+      scheme: "Firefox",
+      sdk: "iphoneos",
+      clean: true,
+      skip_package_ipa: true,
+      xcargs: "-allowProvisioningUpdates BRAVE_API_KEY=\"#{sh("head", "-1", "#{LOCAL_PATH}/brave-api-key")}\"",
+    )
+  end
+
   # Private helper methods ---------------------------------------
 
   desc "Adds the version/build tag on top of the AppIcon. Takes the following arguments: \"


### PR DESCRIPTION
Fixes #371

[Like 1.6](https://github.com/brave/browser-ios/blob/development/brave/setup.sh), the file `brave-api-key` is needed in the `Client/Configurations/Local` directory (similar to `AppleId` file).

## Pull Request Checklist

- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`