### PR TITLE
Fix #445: Add toolbar swiping to switch tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1692,6 +1692,15 @@ extension BrowserViewController: TabToolbarDelegate {
             self.present(backForwardViewController, animated: true, completion: nil)
         }
     }
+    
+    func tabToolbarDidSwipeToChangeTabs(_ tabToolbar: TabToolbarProtocol, direction: UISwipeGestureRecognizer.Direction) {
+        let tabs = tabManager.tabsForCurrentMode
+        guard let selectedTab = tabManager.selectedTab, let index = tabs.firstIndex(where: { $0 === selectedTab }) else { return }
+        let newTabIndex = index + (direction == .left ? -1 : 1)
+        if newTabIndex >= 0 && newTabIndex < tabs.count {
+            tabManager.selectTab(tabs[newTabIndex])
+        }
+    }
 }
 
 extension BrowserViewController: TabsBarViewControllerDelegate {


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

It should perform exactly as 1.6 (continued panning will move more than 1 tab, switching direction will go back to previous tabs.)