### PR TITLE
Fix #439: URL bar no longer shows search queries for unselected engines

### DIFF
--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -171,11 +171,7 @@ class SearchEngines {
     }
 
     func queryForSearchURL(_ url: URL?) -> String? {
-        for engine in orderedEngines {
-            guard let searchTerm = engine.queryForSearchURL(url) else { continue }
-            return searchTerm
-        }
-        return nil
+        return defaultEngine().queryForSearchURL(url)
     }
 
     fileprivate func getDisabledEngineNames() -> [String: Bool] {


### PR DESCRIPTION
No longer shows "is:issue is:open" when you are on a GitHub issues page when GitHub is not your selected search engine.

Perhaps we can revisit this to change the default search engine temporarily for this tab's session on this page but not sure if it's a good idea -- needs discussion.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![simulator screen shot - iphone x - 2018-11-26 at 16 59 19](https://user-images.githubusercontent.com/529104/49044731-a7f76280-f19c-11e8-87a8-ed6f2a771ae1.png)

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.