### PR TITLE
Sync improvements

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -348,6 +348,8 @@ public extension Strings {
     public static let NotEnoughWordsTitle = NSLocalizedString("NotEnoughWordsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Not Enough Words", comment: "Sync Alert")
     public static let NotEnoughWordsDescription = NSLocalizedString("NotEnoughWordsDescription", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Please enter all of the words and try again.", comment: "Sync Alert")
     public static let RemoveDevice = NSLocalizedString("RemoveDevice", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Remove", comment: "Action button for removing sync device.")
+    public static let SyncInitErrorTitle = NSLocalizedString("SyncInitErrorTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Brave Sync Communication Error", comment: "Title for sync initialization error alert")
+    public static let SyncInitErrorMessage = NSLocalizedString("SyncInitErrorMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "The Brave Sync Agent is currently offline or not reachable. Please try again later.", comment: "Message for sync initialization error alert")
 }
 
 public extension Strings {

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -296,7 +296,7 @@ extension FavoritesViewController: FavoriteCellDelegate {
         let actionSheet = UIAlertController(title: fav.displayTitle, message: nil, preferredStyle: .actionSheet)
         
         let deleteAction = UIAlertAction(title: Strings.Remove_Favorite, style: .destructive) { _ in
-            fav.remove(save: true)
+            fav.remove()
             
             // Remove cached icon.
             if let urlString = fav.url, let url = URL(string: urlString) {

--- a/Client/Frontend/Menu/BookmarksViewController.swift
+++ b/Client/Frontend/Menu/BookmarksViewController.swift
@@ -64,7 +64,7 @@ class BookmarkEditingViewController: FormViewController {
       block(self)
     }
     
-    self.bookmark.update(customTitle: self.titleRow?.value, url: self.urlRow?.value?.absoluteString, save: true)
+    self.bookmark.update(customTitle: self.titleRow?.value, url: self.urlRow?.value?.absoluteString, save: true, sendToSync: true)
   }
   
   var isEditingFolder: Bool {

--- a/Client/Frontend/Menu/BookmarksViewController.swift
+++ b/Client/Frontend/Menu/BookmarksViewController.swift
@@ -247,7 +247,7 @@ class BookmarksViewController: SiteTableViewController {
     }
     
     // TODO: Needs to be recursive
-    currentFolder.remove(save: true)
+    currentFolder.remove()
     
     self.navigationController?.popViewController(animated: true)
   }
@@ -428,22 +428,19 @@ class BookmarksViewController: SiteTableViewController {
   func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
     guard let item = bookmarksFRC?.object(at: indexPath) else { return nil }
     
-    let deleteAction = UITableViewRowAction(style: UITableViewRowActionStyle.destructive, title: Strings.Delete, handler: { (action, indexPath) in
-      
-      func delete() {
-        item.remove(save: true)
-      }
+    let deleteAction = UITableViewRowAction(style: UITableViewRowActionStyle.destructive, title: Strings.Delete,
+                                            handler: { action, indexPath in
       
       if let children = item.children, !children.isEmpty {
         let alert = UIAlertController(title: Strings.DeleteBookmarksFolderAlertTitle, message: Strings.DeleteBookmarksFolderAlertMessage, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel))
         alert.addAction(UIAlertAction(title: Strings.YesDeleteButtonTitle, style: .destructive) { _ in
-          delete()
+          item.remove()
         })
         
         self.present(alert, animated: true, completion: nil)
       } else {
-        delete()
+        item.remove()
       }
     })
     

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -200,7 +200,7 @@ class SyncSettingsTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
         
         guard let deviceToDelete = frc?.object(at: indexPath), editingStyle == .delete else { return }
-        deviceToDelete.remove(save: true)
+        deviceToDelete.remove()
     }
 }
 

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -126,6 +126,26 @@ class SyncWelcomeViewController: SyncViewController {
         buttonsStackView.addArrangedSubview(existingUserButton)
         buttonsStackView.addArrangedSubview(newToSyncButton)
         mainStackView.addArrangedSubview(buttonsStackView)
+        
+        handleSyncSetupFailure()
+    }
+    
+    /// Sync setup failure is handled here because it can happen from few places in children VCs(new chain, qr code, codewords)
+    /// This makes all presented Sync View Controllers to dismiss, cleans up any sync setup and shows user a friendly message.
+    private func handleSyncSetupFailure() {
+        let sync = Sync.shared
+        sync.syncSetupFailureCallback = { [weak self] in
+            self?.dismiss(animated: true)
+            sync.leaveSyncGroup()
+            
+            let bvc = (UIApplication.shared.delegate as? AppDelegate)?.browserViewController
+            
+            let title = Strings.SyncInitErrorTitle
+            let message = Strings.SyncInitErrorMessage
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+            bvc?.present(alert, animated: true)
+        }
     }
     
     @objc func newToSyncAction() {

--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -360,6 +360,40 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         
         return self.add(rootObject: bookmark, save: true)
     }
+    
+    public func remove(sendToSync: Bool = true) {
+        if isFavorite { delete() }
+        
+        // Before we delete a folder and its children, we need to grab all children bookmarks
+        // and send them to sync with `delete` action.
+        if isFolder && sendToSync {
+            removeFolderAndSendSyncRecords(uuid: syncUUID)
+            return
+        }
+        
+        if sendToSync {
+            Sync.shared.sendSyncRecords(action: .delete, records: [self])
+        }
+        
+        delete()
+    }
+    
+    private func removeFolderAndSendSyncRecords(uuid: [Int]?) {
+        if !isFolder { return }
+        
+        var allBookmarks = [Bookmark]()
+        allBookmarks.append(self)
+        
+        if let allNestedBookmarks = Bookmark.getRecursiveChildren(forFolderUUID: syncUUID) {
+            log.warning("All nested bookmarks of :\(String(describing: title)) folder is nil")
+            
+            allBookmarks.append(contentsOf: allNestedBookmarks)
+        }
+        
+        Sync.shared.sendSyncRecords(action: .delete, records: allBookmarks)
+        
+        delete()
+    }
 }
 
 // TODO: Document well
@@ -423,6 +457,34 @@ extension Bookmark {
         
         let record = first(where: predicate, context: context)
         record?.delete()
+    }
+    
+    /// Gets all nested bookmarks recursively.
+    public static func getRecursiveChildren(forFolderUUID syncUUID: [Int]?,
+                                            context: NSManagedObjectContext = DataController.viewContext) -> [Bookmark]? {
+        guard let searchableUUID = SyncHelpers.syncDisplay(fromUUID: syncUUID) else {
+            return nil
+        }
+        
+        let syncParentDisplayUUIDKeyPath = #keyPath(Bookmark.syncParentDisplayUUID)
+        
+        let predicate = NSPredicate(format: "\(syncParentDisplayUUIDKeyPath) == %@", searchableUUID)
+        
+        var allBookmarks = [Bookmark]()
+        
+        let result = all(where: predicate, context: context)
+        
+        result?.forEach {
+            allBookmarks.append($0)
+            
+            if $0.isFolder {
+                if let nestedBookmarks = getRecursiveChildren(forFolderUUID: $0.syncUUID) {
+                    allBookmarks.append(contentsOf: nestedBookmarks)
+                }
+            }
+        }
+        
+        return allBookmarks
     }
     
     public class func frecencyQuery(context: NSManagedObjectContext, containing: String?) -> [Bookmark] {

--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -67,7 +67,6 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
     
     override public func awakeFromInsert() {
         super.awakeFromInsert()
-        created = Date()
         lastVisited = created
     }
     
@@ -100,6 +99,7 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         update(customTitle: site.customTitle, url: site.location, newSyncOrder: bookmark.syncOrder)
         lastVisited = Date(timeIntervalSince1970: (Double(site.lastAccessedTime ?? 0) / 1000.0))
         syncParentUUID = bookmark.parentFolderObjectId
+        created = record?.syncNativeTimestamp
         // No auto-save, must be handled by caller if desired
     }
     
@@ -196,6 +196,7 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         bk.isFavorite = bookmark?.isFavorite ?? bk.isFavorite
         bk.isFolder = bookmark?.isFolder ?? bk.isFolder
         bk.syncUUID = root?.objectId ?? bk.syncUUID ?? SyncCrypto.uniqueSerialBytes(count: 16)
+        bk.created = root?.syncNativeTimestamp ?? Date()
         
         if let location = site?.location, let url = URL(string: location) {
             bk.domain = Domain.getOrCreateForUrl(url, context: context, save: false)

--- a/Data/models/Device.swift
+++ b/Data/models/Device.swift
@@ -79,6 +79,7 @@ public final class Device: NSManagedObject, Syncable, CRUD {
         guard let root = record as? SyncDevice else { return }
         self.name = root.name
         self.deviceId = root.deviceId
+        created = record?.syncNativeTimestamp
         
         // No save currently
     }

--- a/Data/models/Syncable.swift
+++ b/Data/models/Syncable.swift
@@ -95,22 +95,19 @@ extension Syncable {
 }
 
 extension Syncable /* where Self: NSManagedObject */ {
-    public func remove(save: Bool) {
+    public func remove(sendToSync: Bool = true) {
         
         // This is r annoying, and can be fixed in Swift 4, but since objects can't be cast to a class & protocol,
         //  but given extension on Syncable, if this passes the object is both Syncable and an NSManagedObject subclass
         guard let s = self as? NSManagedObject, let context = s.managedObjectContext else { return }
         
-        // Must happen before, otherwise bookmark is gone
-        
-        Sync.shared.sendSyncRecords(action: .delete, records: [self])
+        if sendToSync {
+            Sync.shared.sendSyncRecords(action: .delete, records: [self])
+        }
         
         // Should actually delay, and wait for server to refetch records to confirm deletion.
         // Force a sync resync instead, should not be slow
         context.delete(s)
-        if save {
-            DataController.save(context: context)
-        }
     }
 }
 

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -96,6 +96,10 @@ public class Sync: JSInjector {
     
     fileprivate var fetchTimer: Timer?
     
+    /// If sync initialization fails, we should inform user and remove all partial sync setup that happened.
+    /// Please note that sync initialization also happens on app launch, not only on first connection to Sync.
+    public var syncSetupFailureCallback: (() -> Void)?
+    
     var baseSyncOrder: String? {
         get {
             return UserDefaults.standard.string(forKey: prefBaseOrder)
@@ -630,6 +634,10 @@ extension Sync {
         
     }
     
+    func syncSetupError() {
+        syncSetupFailureCallback?()
+    }
+    
     func getBookmarkOrder(previousOrder: String?, nextOrder: String?) -> String? {
         
         // Empty string as a parameter means next/previous bookmark doesn't exist
@@ -692,6 +700,8 @@ extension Sync: WKScriptMessageHandler {
             self.isSyncFullyInitialized.deleteSiteSettingsReady = true
         case "delete-sync-category":
             self.isSyncFullyInitialized.deleteCategoryReady = true
+        case "sync-setup-error":
+            self.syncSetupError()
         default:
             print("\(messageName) not handled yet")
         }

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -459,12 +459,20 @@ extension Sync {
         guard var fetchedRecords = recordType.fetchedModelType?.syncRecords(recordJSON) else { return }
         
         // Currently only prefs are device related
-        if recordType == .prefs, let data = fetchedRecords as? [SyncDevice] {
+        if recordType == .prefs {
             // Devices have really bad data filtering, so need to manually process more of it
             // Sort to not rely on API - Reverse sort, so unique pulls the `latest` not just the `first`
-            fetchedRecords = data.sorted { device1, device2 in
+            fetchedRecords = fetchedRecords.sorted { device1, device2 in
                 device1.syncTimestamp ?? -1 > device2.syncTimestamp ?? -1 }.unique { $0.objectId ?? [] == $1.objectId ?? [] }
             
+        } else if recordType == .bookmark {
+            // Bookmarks are sorted to have the oldest bookmark to come in first, so it can be added before it's children.
+            fetchedRecords = fetchedRecords.sorted(by: {
+                let firstTimestamp = $0.syncTimestamp ?? 0
+                let secondTimestamp = $1.syncTimestamp ?? 0
+                
+                return firstTimestamp < secondTimestamp
+            })
         }
         
         let context = DataController.newBackgroundContext()

--- a/Data/sync/SyncDevice.swift
+++ b/Data/sync/SyncDevice.swift
@@ -9,17 +9,10 @@ class SyncDevice: SyncRecord {
     // MARK: Declaration for string constants to be used to decode and also serialize.
     private struct SerializationKeys {
         static let name = "name"
-        static let syncTimestamp = "syncTimestamp"
     }
     
     // MARK: Properties
     var name: String?
-    // Not on 'device' object
-    var syncTimestamp: Int?
-    
-    var syncNativeTimestamp: Date? {
-        return Date.fromTimestamp(Timestamp(syncTimestamp ?? 0))
-    }
     
     required init(record: Syncable?, deviceId: [Int]?, action: Int?) {
         super.init(record: record, deviceId: deviceId, action: action)
@@ -35,8 +28,7 @@ class SyncDevice: SyncRecord {
         super.init(json: json)
 
         self.name = json?[SyncObjectDataType.Device.rawValue][SerializationKeys.name].string
-        self.syncTimestamp = json?[SerializationKeys.syncTimestamp].int
-        
+
         // Preference
         self.objectData = nil
     }
@@ -54,7 +46,6 @@ class SyncDevice: SyncRecord {
 
         var dictionary = super.dictionaryRepresentation()
         dictionary[SyncObjectDataType.Device.rawValue] = deviceDict
-        if let value = self.syncTimestamp { dictionary[SerializationKeys.syncTimestamp] = value }
         
         return dictionary
     }


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->
This PR fixes a lot of problems with sync.
- threading issues in `get-existing-objects`
- sending updated records(did not work at all previously)
- adding `syncTimestamp` to Bookmark
- removing nested bookmarks
- adding nested bookmarks from sync server in correct order
- deleting a device from sync seems to work more reliable too
- leave sync group when user initialized sync for the first time and `sync-setup-error` happens


## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
