### PR TITLE
Fixed #446 by blocking  popups completely in private mode.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1989,7 +1989,8 @@ private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "
 
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        guard let parentTab = tabManager[webView] else { return nil }
+        // Fix for #446, when in private mode the WKProcessPoll of the configuration is changed, this leads to a crash for popups ie window.open where the configuration is craeted by parent wkwebview. To handle this for now we are stopping popup when in private mode. The fix is done in guard statement below.
+        guard let parentTab = tabManager[webView], !parentTab.isPrivate else { return nil }
 
         guard navigationAction.isAllowed, shouldRequestBeOpenedAsPopup(navigationAction.request) else {
             print("Denying popup from request: \(navigationAction.request)")

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1989,7 +1989,11 @@ private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "
 
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        // Fix for #446, when in private mode the WKProcessPoll of the configuration is changed, this leads to a crash for popups ie window.open where the configuration is craeted by parent wkwebview. To handle this for now we are stopping popup when in private mode. The fix is done in guard statement below.
+        /* Fix for #446, when in private mode the WKProcessPool of the configuration is changed,
+         this leads to a crash for popups ie window.open where the configuration is created by parent wkwebview.
+         To handle this for now we are stopping popup when in private mode.
+         The fix is done in guard statement below.
+         */
         guard let parentTab = tabManager[webView], !parentTab.isPrivate else { return nil }
 
         guard navigationAction.isAllowed, shouldRequestBeOpenedAsPopup(navigationAction.request) else {


### PR DESCRIPTION
Fix for #446, when in private mode the WKProcessPoll of the configuration is changed, this leads to a crash for popups ie window.open where the configuration is craeted by parent wkwebview. To handle this for now we are stopping popup when in private mode. The fix is done in guard statement below.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
