### PR TITLE
Fix #467, dau first ping param conversion.

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -29,16 +29,10 @@ extension Preferences {
     final class DAU {
         static let lastLaunchInfo = Option<[Int?]?>(key: "dau.last-launch-info", default: nil)
         static let weekOfInstallation = Option<String?>(key: "dau.week-of-installation", default: nil)
-        static let firstPingParam: Option<Bool> = {
-            var defaultValue = true
-            // On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
-            // We need to translate that to use the new `firstPingParam` preference.
-            if Preferences.DAU.lastLaunchInfo.value != nil {
-                defaultValue = false
-            }
-            
-            return Option<Bool>(key: "dau.first-ping", default: defaultValue)
-        }()
+        // On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
+        // We need to translate that to use the new `firstPingParam` preference.
+        static let firstPingParam: Option<Bool> =
+            Option<Bool>(key: "dau.first-ping", default: Preferences.DAU.lastLaunchInfo.value == nil)
         
         /// We use this to properly calculate `week` parameter of the DAU ping.
         static let lastPingFirstMonday = Option<String?>(key: "dau.last-ping-first-monday", default: nil)

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -29,7 +29,17 @@ extension Preferences {
     final class DAU {
         static let lastLaunchInfo = Option<[Int?]?>(key: "dau.last-launch-info", default: nil)
         static let weekOfInstallation = Option<String?>(key: "dau.week-of-installation", default: nil)
-        static let firstPingParam = Option<Bool>(key: "dau.first-ping", default: true)
+        static let firstPingParam: Option<Bool> = {
+            var defaultValue = true
+            // On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
+            // We need to translate that to use the new `firstPingParam` preference.
+            if Preferences.DAU.lastLaunchInfo.value != nil {
+                defaultValue = false
+            }
+            
+            return Option<Bool>(key: "dau.first-ping", default: defaultValue)
+        }()
+        
         /// We use this to properly calculate `week` parameter of the DAU ping.
         static let lastPingFirstMonday = Option<String?>(key: "dau.last-ping-first-monday", default: nil)
     }
@@ -147,11 +157,6 @@ extension Preferences {
     public class func migrateBraveShared(keyPrefix: String) {
         // DAU
         migrate(keyPrefix: keyPrefix, key: "dau_stat", to: Preferences.DAU.lastLaunchInfo)
-        // On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
-        // We need to translate that to use the new `firstPingParam` preference.
-        if Preferences.DAU.lastLaunchInfo.value != nil {
-            Preferences.DAU.firstPingParam.value = false
-        }
         migrate(keyPrefix: keyPrefix, key: "week_of_installation", to: Preferences.DAU.weekOfInstallation)
         migrate(keyPrefix: keyPrefix, key: "lastPingFirstMondayKey", to: Preferences.DAU.lastPingFirstMonday)
         

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -147,6 +147,11 @@ extension Preferences {
     public class func migrateBraveShared(keyPrefix: String) {
         // DAU
         migrate(keyPrefix: keyPrefix, key: "dau_stat", to: Preferences.DAU.lastLaunchInfo)
+        // On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
+        // We need to translate that to use the new `firstPingParam` preference.
+        if Preferences.DAU.lastLaunchInfo.value != nil {
+            Preferences.DAU.firstPingParam.value = false
+        }
         migrate(keyPrefix: keyPrefix, key: "week_of_installation", to: Preferences.DAU.weekOfInstallation)
         migrate(keyPrefix: keyPrefix, key: "lastPingFirstMondayKey", to: Preferences.DAU.lastPingFirstMonday)
         


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
We need to translate that to use the new `firstPingParam` preference.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
