### PR TITLE
Fixed crash #464, by removing redundant deletewebview call.

### DIFF
--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -192,7 +192,6 @@ class ClearPrivateDataTableViewController: UITableViewController {
             self.tabManager.removeAll()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
                 if !self.gotNotificationDeathOfAllWebViews {
-                    self.tabManager.allTabs.forEach { $0.deleteWebView() }
                     self.allWebViewsKilled()
                 }
             })

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -174,6 +174,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
              } else {*/
             ClearPrivateDataTableViewController.clearPrivateData(clear).uponQueue(DispatchQueue.main) { _ in
                 // TODO: add API to avoid add/remove
+                // @Brave-devs: Why is this done in the next line? 
                 self.tabManager.removeTab(self.tabManager.addTab())
             }
             //      }

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -174,7 +174,6 @@ class ClearPrivateDataTableViewController: UITableViewController {
              } else {*/
             ClearPrivateDataTableViewController.clearPrivateData(clear).uponQueue(DispatchQueue.main) { _ in
                 // TODO: add API to avoid add/remove
-                // @Brave-devs: Why is this done in the next line? 
                 self.tabManager.removeTab(self.tabManager.addTab())
             }
             //      }


### PR DESCRIPTION
The app used to crash when removing a tab after any private data is cleared. 
This happens because of the behaviour below:
1. After data is cleared all tabs are removed including their webviews (deinit).
2. When all tabs are removed a new default tab is created with its own webview.
3. The redundant deleteWebView call used to delete this webview.
4. The current implementation of TabManager tries to rebuild the webview (Which it should not, though there is a check for webview is nil) of the new tab to be displayed, post any internal operation like remove or add.
5. In this case if the new tab to be displayed is the one created after data clear, it crashes.

Another bug is Clear all data, goto fav screen, tap on any link
Result: Nothing happens. 
Reason: Same as above.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
