### PR TITLE
Fix #468: Unlock webkit directories that may have been locked in 1.6

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -58,6 +58,16 @@ extension Preferences {
         migrate(key: "privateBrowsingAlwaysOn", to: Preferences.Privacy.privateBrowsingOnly)
         migrate(key: "clearprivatedata.toggles", to: Preferences.Privacy.clearPrivateDataToggles)
         
+        // Make sure to unlock all directories that may have been locked in 1.6 private mode
+        let baseDir = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)[0]
+        [baseDir + "/WebKit", baseDir + "/Caches"].forEach {
+            do {
+                try FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755 as Int16)], ofItemAtPath: $0)
+            } catch {
+                log.error("Failed setting the directory attributes for \($0)")
+            }
+        }
+        
         // Security
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
         if let pinLockInfo = KeychainWrapper.standard.object(forKey: "pinLockInfo") as? AuthenticationKeychainInfo {


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_
