### PR TITLE
Fixed #304 by removing 'Preferences' folder from clearing.

### DIFF
--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -127,7 +127,10 @@ class CacheClearable: Clearable {
             URLCache.shared.removeAllCachedResponses()
             
             var err: Error?
-            for item in ["Caches", "Preferences", "Cookies", "WebKit"] {
+            /* Please note that this is a hack. If possible please use a public api.
+             Removed Preferences from the list as it used to delete UserDefaults
+             */
+            for item in ["Caches", "Cookies", "WebKit"] {
                 do {
                     try deleteLibraryFolderContents(item, validateClearedExceptFor: ["Snapshots"])
                 } catch {

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -127,9 +127,6 @@ class CacheClearable: Clearable {
             URLCache.shared.removeAllCachedResponses()
             
             var err: Error?
-            /* Please note that this is a hack. If possible please use a public api.
-             Removed Preferences from the list as it used to delete UserDefaults
-             */
             for item in ["Caches", "Cookies", "WebKit"] {
                 do {
                     try deleteLibraryFolderContents(item, validateClearedExceptFor: ["Snapshots"])


### PR DESCRIPTION
This fixes #304. While clearing cache and data the iOS **Preferences** folder was deleted. This folder is also used to store UserDefaults. Since the UserDefaults was destroyed all preferences were lost.

p.s You will not notice this till relaunch as the Userdefaults is cached in memory.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
