### PR TITLE
Fix #461. Tab count will changed to correct value

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1991,8 +1991,9 @@ extension BrowserViewController: TabManagerDelegate {
 
     fileprivate func updateTabCountUsingTabManager(_ tabManager: TabManager, animated: Bool = true) {
         let count = tabManager.tabsForCurrentMode.count
-        toolbar?.updateTabCount(count, animated: animated)
-        urlBar.updateTabCount(count, animated: !urlBar.inOverlayMode)
+        // The window check insures that the view is visible and hence can be animated
+        toolbar?.updateTabCount(count, animated: self.view.window != nil ? animated : false)
+        urlBar.updateTabCount(count, animated: self.view.window != nil ? !urlBar.inOverlayMode : false)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -509,7 +509,7 @@ class BrowserViewController: UIViewController {
 
         checkCrashRestoration()
         
-        updateTabCountUsingTabManager(tabManager, animated: false)
+        updateTabCountUsingTabManager(tabManager)
         clipboardBarDisplayHandler?.checkIfShouldDisplayBar()
         favoritesViewController?.updateDuckDuckGoVisibility()
     }
@@ -1989,11 +1989,10 @@ extension BrowserViewController: TabManagerDelegate {
         show(toast: toast, afterWaiting: ButtonToastUX.ToastDelay)
     }
 
-    fileprivate func updateTabCountUsingTabManager(_ tabManager: TabManager, animated: Bool = true) {
+    fileprivate func updateTabCountUsingTabManager(_ tabManager: TabManager) {
         let count = tabManager.tabsForCurrentMode.count
-        // The window check insures that the view is visible and hence can be animated
-        toolbar?.updateTabCount(count, animated: self.view.window != nil ? animated : false)
-        urlBar.updateTabCount(count, animated: self.view.window != nil ? !urlBar.inOverlayMode : false)
+        toolbar?.updateTabCount(count)
+        urlBar.updateTabCount(count)
     }
 }
 

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -19,7 +19,7 @@ protocol TabToolbarProtocol: class {
     func updateBackStatus(_ canGoBack: Bool)
     func updateForwardStatus(_ canGoForward: Bool)
     func updatePageStatus(_ isWebPage: Bool)
-    func updateTabCount(_ count: Int, animated: Bool)
+    func updateTabCount(_ count: Int)
 }
 
 protocol TabToolbarDelegate: class {
@@ -272,8 +272,8 @@ extension TabToolbar: TabToolbarProtocol {
         shareButton.isEnabled = isWebPage
     }
 
-    func updateTabCount(_ count: Int, animated: Bool) {
-        tabsButton.updateTabCount(count, animated: animated)
+    func updateTabCount(_ count: Int) {
+        tabsButton.updateTabCount(count)
     }
 }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -570,8 +570,8 @@ extension URLBarView: TabToolbarProtocol {
         forwardButton.isEnabled = canGoForward
     }
     
-    func updateTabCount(_ count: Int, animated: Bool = true) {
-        tabsButton.updateTabCount(count, animated: animated)
+    func updateTabCount(_ count: Int) {
+        tabsButton.updateTabCount(count)
     }
 
     func updatePageStatus(_ isWebPage: Bool) {

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -45,12 +45,6 @@ class TabsButton: UIButton {
             }
         }
     }
-    
-    override var transform: CGAffineTransform {
-        didSet {
-            clonedTabsButton?.transform = transform
-        }
-    }
 
     lazy var countLabel: UILabel = {
         let label = UILabel()
@@ -82,9 +76,6 @@ class TabsButton: UIButton {
         border.isUserInteractionEnabled = false
         return border
     }()
-    
-    // Used to temporarily store the cloned button so we can respond to layout changes during animation
-    fileprivate weak var clonedTabsButton: TabsButton?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -116,107 +107,16 @@ class TabsButton: UIButton {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    func clone() -> UIView {
-        let button = TabsButton()
-
-        button.accessibilityLabel = accessibilityLabel
-        button.countLabel.text = countLabel.text
-
-        // Copy all of the styable properties over to the new TabsButton
-        button.countLabel.font = countLabel.font
-        button.countLabel.textColor = countLabel.textColor
-        button.countLabel.layer.cornerRadius = countLabel.layer.cornerRadius
-
-        button.labelBackground.backgroundColor = labelBackground.backgroundColor
-        button.labelBackground.layer.cornerRadius = labelBackground.layer.cornerRadius
-
-        button.borderView.strokeWidth = borderView.strokeWidth
-        button.borderView.color = borderView.color
-        button.borderView.cornerRadius = borderView.cornerRadius
-
-        return button
-    }
     
-    var countToBe: String {
-        let infinity = "\u{221E}"
-        let count = currentCount ?? 0
-        return (count < 100) ? "\(count)" : infinity
-    }
-    
-    func updateTabCount(_ count: Int, animated: Bool = true) {
+    func updateTabCount(_ count: Int) {
         let count = max(count, 1)
-
-        // only animate a tab count change if the tab count has actually changed
-        if currentCount != count {
-            currentCount = count
-            
-            if let _ = self.clonedTabsButton {
-                self.clonedTabsButton?.layer.removeAllAnimations()
-                self.clonedTabsButton?.removeFromSuperview()
-                insideButton.layer.removeAllAnimations()
-            }
-            if !animated {
-                self.accessibilityLabel = Strings.Show_Tabs
-                self.countLabel.text = countToBe
-                self.accessibilityValue = countToBe
-                return
-            }
-            // make a 'clone' of the tabs button
-            let newTabsButton = clone() as! TabsButton // swiftlint:disable:this force_cast
-
-            self.clonedTabsButton = newTabsButton
-            newTabsButton.frame = self.bounds
-            newTabsButton.addTarget(self, action: #selector(cloneDidClickTabs), for: .touchUpInside)
-            newTabsButton.countLabel.text = countToBe
-            newTabsButton.accessibilityValue = countToBe
-            newTabsButton.insideButton.frame = self.insideButton.frame
-            newTabsButton.snp.removeConstraints()
-            self.addSubview(newTabsButton)
-            newTabsButton.snp.makeConstraints { make  in
-                make.center.equalTo(self)
-            }
-
-            // Instead of changing the anchorPoint of the CALayer, lets alter the rotation matrix math to be
-            // a rotation around a non-origin point
-            let frame = self.insideButton.frame
-            let halfTitleHeight = frame.height / 2
-            var newFlipTransform = CATransform3DIdentity
-            newFlipTransform = CATransform3DTranslate(newFlipTransform, 0, halfTitleHeight, 0)
-            newFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            newFlipTransform = CATransform3DRotate(newFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
-            newTabsButton.insideButton.layer.transform = newFlipTransform
-
-            var oldFlipTransform = CATransform3DIdentity
-            oldFlipTransform = CATransform3DTranslate(oldFlipTransform, 0, halfTitleHeight, 0)
-            oldFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            oldFlipTransform = CATransform3DRotate(oldFlipTransform, CGFloat(-(Double.pi / 2)), 1.0, 0.0, 0.0)
-            
-            let animate = {
-                newTabsButton.insideButton.layer.transform = CATransform3DIdentity
-                self.insideButton.layer.transform = oldFlipTransform
-                self.insideButton.layer.opacity = 0
-            }
-            
-            let completion: (Bool) -> Void = {[weak self] completed in
-                guard let `self` = self else {
-                    return
-                }
-                let noActiveAnimations = self.insideButton.layer.animationKeys()?.isEmpty ?? true
-                if completed || noActiveAnimations {
-                    newTabsButton.removeFromSuperview()
-                    self.insideButton.layer.opacity = 1
-                    self.insideButton.layer.transform = CATransform3DIdentity
-                }
-                self.accessibilityLabel = Strings.Show_Tabs
-                self.countLabel.text = self.countToBe
-                self.accessibilityValue = self.countToBe
-            }
-            UIView.animate(withDuration: 1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: [], animations: animate, completion: completion)
-        }
-    }
-    @objc func cloneDidClickTabs() {
-        sendActions(for: .touchUpInside)
+        // Sometimes tabs count state is held in the cloned tabs button.
+        let infinity = "\u{221E}"
+        let countToBe = (count < 100) ? "\(count)" : infinity
+        currentCount = count
+        self.accessibilityLabel = Strings.Show_Tabs
+        self.countLabel.text = countToBe
+        self.accessibilityValue = countToBe
     }
 }
 

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -201,11 +201,7 @@ class TabsButton: UIButton {
                 self.countLabel.text = countToBe
                 self.accessibilityValue = countToBe
             }
-            if animated {
-                UIView.animate(withDuration: 1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: [], animations: animate, completion: completion)
-            } else {
-                completion(true)
-            }
+            UIView.animate(withDuration: animated ? 1.5 : 0, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: [], animations: animate, completion: completion)
         }
     }
     @objc func cloneDidClickTabs() {

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -85,6 +85,7 @@ class TabsButton: UIButton {
         addSubview(insideButton)
         isAccessibilityElement = true
         accessibilityTraits |= UIAccessibilityTraitButton
+        self.accessibilityLabel = Strings.Show_Tabs
     }
 
     override func updateConstraints() {
@@ -114,7 +115,6 @@ class TabsButton: UIButton {
         let infinity = "\u{221E}"
         let countToBe = (count < 100) ? "\(count)" : infinity
         currentCount = count
-        self.accessibilityLabel = Strings.Show_Tabs
         self.countLabel.text = countToBe
         self.accessibilityValue = countToBe
     }


### PR DESCRIPTION
Fix #461. Tab count change was animated even when not visible, this when combined with ViewController Transition occasionally resulted in wrong tab count (The transform applied was never removed.)
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
