### PR TITLE
Fix #492, fix #491, don't apply adblock rules on session restore htmls.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -146,9 +146,12 @@ extension BrowserViewController: WKNavigationDelegate {
             // Weird behavior here with `targetFram` and `sourceFrame`, on refreshing page `sourceFrame` is not nil (it is non-optional)
             //  however, it is still an uninitialized object, making it an unreliable source to compare `isMainFrame` against.
             //  Rather than using `sourceFrame.isMainFrame` or even comparing `sourceFrame == targetFrame`, a simple URL check is used.
+            // No adblocking logic is be used on session restore urls. It uses javascript to retrieve the
+            // request then the page is reloaded with a proper url and adblocking rules are applied.
             if
                 let mainDocumentURL = navigationAction.request.mainDocumentURL,
                 mainDocumentURL == url,
+                !url.isSessionRestoreURL,
                 navigationAction.sourceFrame.isMainFrame || navigationAction.targetFrame?.isMainFrame == true {
                 
                 // Identify specific block lists that need to be applied to the requesting domain

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -366,6 +366,10 @@ extension URL {
     public var safeBrowsingErrorURL: Bool {
         return scheme == "http" && host == "localhost" && path.contains("/errors/SafeBrowsingError.html")
     }
+    
+    public var isSessionRestoreURL: Bool {
+        return scheme == "http" && host == "localhost" && path.contains("/about/sessionrestore")
+    }
 
     public var originalURLFromErrorURL: URL? {
         let components = URLComponents(url: self, resolvingAgainstBaseURL: false)

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -359,16 +359,20 @@ extension URL {
 // Helpers to deal with ErrorPage URLs
 
 extension URL {
+    private var isLocalhost: Bool {
+        return scheme == "http" && host == "localhost"
+    }
+    
     public var isErrorPageURL: Bool {
-        return scheme == "http" && host == "localhost" && path.contains("/errors/")
+        return isLocalhost && path.contains("/errors/")
     }
     
     public var safeBrowsingErrorURL: Bool {
-        return scheme == "http" && host == "localhost" && path.contains("/errors/SafeBrowsingError.html")
+        return isLocalhost && path.contains("/errors/SafeBrowsingError.html")
     }
     
     public var isSessionRestoreURL: Bool {
-        return scheme == "http" && host == "localhost" && path.contains("/about/sessionrestore")
+        return isLocalhost && path.contains("/about/sessionrestore")
     }
 
     public var originalURLFromErrorURL: URL? {


### PR DESCRIPTION
No adblock rules should be used on session restore urls. It uses javascript to retrieve the
request then the page is reloaded with a proper url and adblocking rules are applied.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
