### PR TITLE
Fix #459: New non-selected tabs will correctly show https padlock

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -913,7 +913,7 @@ class BrowserViewController: UIViewController {
             
             navigationToolbar.updateForwardStatus(canGoForward)
         case .hasOnlySecureContent:
-            guard let tab = tabManager[webView], tab === tabManager.selectedTab else {
+            guard let tab = tabManager[webView] else {
                 break
             }
             
@@ -921,14 +921,18 @@ class BrowserViewController: UIViewController {
                 tab.contentIsSecure = false
             }
             
-            updateURLBar(forTab: tab)
+            if tab === tabManager.selectedTab {
+                updateURLBar(forTab: tab)
+            }
         case .serverTrust:
-            guard let tab = tabManager[webView], tab === tabManager.selectedTab else {
+            guard let tab = tabManager[webView] else {
                 break
             }
 
             tab.contentIsSecure = false
-            updateURLBar(forTab: tab)
+            if tab === tabManager.selectedTab {
+                updateURLBar(forTab: tab)
+            }
 
             guard let serverTrust = tab.webView?.serverTrust else {
                 break
@@ -943,7 +947,9 @@ class BrowserViewController: UIViewController {
                 }
 
                 DispatchQueue.main.async {
-                    self.updateURLBar(forTab: tab)
+                    if tab === self.tabManager.selectedTab {
+                        self.updateURLBar(forTab: tab)
+                    }
                 }
             }
         default:

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -236,7 +236,7 @@ class BrowserViewController: UIViewController {
 
         if let tab = tabManager.selectedTab,
                let webView = tab.webView {
-            updateURLBar(forTab: tab)
+            updateURLBar()
             navigationToolbar.updateBackStatus(webView.canGoBack)
             navigationToolbar.updateForwardStatus(webView.canGoForward)
             urlBar.locationView.loading = tab.loading
@@ -921,18 +921,14 @@ class BrowserViewController: UIViewController {
                 tab.contentIsSecure = false
             }
             
-            if tab === tabManager.selectedTab {
-                updateURLBar(forTab: tab)
-            }
+            updateURLBar()
         case .serverTrust:
             guard let tab = tabManager[webView] else {
                 break
             }
 
             tab.contentIsSecure = false
-            if tab === tabManager.selectedTab {
-                updateURLBar(forTab: tab)
-            }
+            updateURLBar()
 
             guard let serverTrust = tab.webView?.serverTrust else {
                 break
@@ -947,9 +943,7 @@ class BrowserViewController: UIViewController {
                 }
 
                 DispatchQueue.main.async {
-                    if tab === self.tabManager.selectedTab {
-                        self.updateURLBar(forTab: tab)
-                    }
+                    self.updateURLBar()
                 }
             }
         default:
@@ -967,7 +961,7 @@ class BrowserViewController: UIViewController {
     }
 
     func updateUIForReaderHomeStateForTab(_ tab: Tab) {
-        updateURLBar(forTab: tab)
+        updateURLBar()
         scrollController.showToolbars(animated: false)
 
         if let url = tab.url {
@@ -984,7 +978,9 @@ class BrowserViewController: UIViewController {
     }
 
     /// Updates the URL bar security, text and button states.
-    fileprivate func updateURLBar(forTab tab: Tab) {
+    fileprivate func updateURLBar() {
+        guard let tab = tabManager.selectedTab else { return }
+        
         urlBar.currentURL = tab.url?.displayURL
         
         urlBar.contentIsSecure = tab.contentIsSecure
@@ -1879,7 +1875,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         if let tab = selected, let webView = tab.webView {
-            updateURLBar(forTab: tab)
+            updateURLBar()
 
             if tab.type != previous?.type {
                 let theme = Theme.of(tab)


### PR DESCRIPTION
Problem was that the two observed properties of the `Tab`'s webview (`hasOnlySecureContent` and `serverTrust`) only set the `Tab.contentIsSecure` if the tab's webView was the selected tab, where it should only be _updating the url bar_ if its the selected tab.

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_