### PR TITLE
Fix #513, share correct item from history/bookmark panels.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2779,10 +2779,8 @@ extension BrowserViewController: HomeMenuControllerDelegate {
             UIPasteboard.general.url = url
         case .share:
             menu.dismiss(animated: true) {
-                guard let url = self.tabManager.selectedTab?.url else { return }
                 self.presentActivityViewController(
                     url,
-                    tab: self.tabManager.selectedTab,
                     sourceView: self.view,
                     sourceRect: self.view.convert(self.urlBar.shareButton.frame, from: self.urlBar.shareButton.superview),
                     arrowDirection: [.up]

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -33,10 +33,10 @@ class ShareExtensionHelper: NSObject {
         if let tab = selectedTab {
             activityItems.append(TabPrintPageRenderer(tab: tab))
         }
+        
+        let title = selectedTab?.title ?? absoluteString
+        activityItems.append(TitleActivityItemProvider(title: title))
 
-        if let title = selectedTab?.title {
-            activityItems.append(TitleActivityItemProvider(title: title))
-        }
         activityItems.append(self)
 
         let activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: activities)


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

The previous implementation shared url of selected tab rather than the link we tapped in history/bookmark panels. Now it should all work

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
