### PR TITLE
Fix #488: Remove Trackers + Script blocking from global stats view

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -371,6 +371,7 @@ public extension Strings {
     public static let Security = NSLocalizedString("Security", tableName: "BraveShared", value: "Security", comment: "Settings security section title")
     public static let Save_Logins = NSLocalizedString("SaveLogins", tableName: "BraveShared", value: "Save Logins", comment: "Setting to enable the built-in password manager")
     public static let ShieldsAdStats = NSLocalizedString("AdsrBlocked", tableName: "BraveShared", value: "Ads \rBlocked", comment: "Shields Ads Stat")
+    public static let ShieldsAdAndTrackerStats = NSLocalizedString("AdsAndTrackersrBlocked", tableName: "BraveShared", value: "Ads & Trackers \rBlocked", comment: "Shields Ads Stat")
     public static let ShieldsTrackerStats = NSLocalizedString("TrackersrBlocked", tableName: "BraveShared", value: "Trackers \rBlocked", comment: "Shields Trackers Stat")
     public static let ShieldsHttpsStats = NSLocalizedString("HTTPSrUpgrades", tableName: "BraveShared", value: "HTTPS \rUpgrades", comment: "Shields Https Stat")
     public static let ShieldsTimeStats = NSLocalizedString("EstTimerSaved", tableName: "BraveShared", value: "Est. Time \rSaved", comment: "Shields Time Saved Stat")

--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -15,22 +15,8 @@ class BraveShieldStatsView: UIView, Themeable {
     
     lazy var adsStatView: StatView = {
         let statView = StatView(frame: CGRect.zero)
-        statView.title = Strings.ShieldsAdStats
+        statView.title = Strings.ShieldsAdAndTrackerStats
         statView.color = UX.BraveOrange
-        return statView
-    }()
-
-    lazy var trackersStatView: StatView = {
-        let statView = StatView(frame: CGRect.zero)
-        statView.title = Strings.ShieldsTrackerStats
-        statView.color = UX.Purple
-        return statView
-    }()
-
-    lazy var scriptsStatView: StatView = {
-        let statView = StatView(frame: CGRect.zero)
-        statView.color = UX.Green
-        statView.title = Strings.Scripts_Blocked
         return statView
     }()
 
@@ -42,7 +28,7 @@ class BraveShieldStatsView: UIView, Themeable {
     }()
     
     lazy var stats: [StatView] = {
-        return [self.trackersStatView, self.adsStatView, self.scriptsStatView, self.timeStatView]
+        return [self.adsStatView, self.timeStatView]
     }()
     
     override init(frame: CGRect) {
@@ -78,9 +64,7 @@ class BraveShieldStatsView: UIView, Themeable {
     }
     
     @objc private func update() {
-        adsStatView.stat = "\(BraveGlobalShieldStats.shared.adblock)"
-        trackersStatView.stat = "\(BraveGlobalShieldStats.shared.trackingProtection)"
-        scriptsStatView.stat = "\(BraveGlobalShieldStats.shared.scripts)"
+        adsStatView.stat = "\(BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection)"
         timeStatView.stat = timeSaved
     }
     

--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -73,7 +73,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
     }
     
     private func updateShieldBlockStats() {
-        shieldsView.shieldsContainerStackView.adsTrackersStatView.valueLabel.text = String(tab.contentBlocker.stats.adCount)
+        shieldsView.shieldsContainerStackView.adsTrackersStatView.valueLabel.text = String(tab.contentBlocker.stats.adCount + tab.contentBlocker.stats.trackerCount)
         shieldsView.shieldsContainerStackView.scriptsBlockedStatView.valueLabel.text = String(tab.contentBlocker.stats.scriptCount)
         shieldsView.shieldsContainerStackView.fingerprintingStatView.valueLabel.text = String(tab.contentBlocker.stats.fingerprintingCount)
     }


### PR DESCRIPTION
- Also fixes ads + trackers count in domain-specific shield stats not including trackers count

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![simulator screen shot - iphone x - 2018-11-30 at 10 24 11](https://user-images.githubusercontent.com/529104/49298112-8e029c00-f48a-11e8-8ba7-fb39ea7189a0.png)

## Notes for testing this patch

_None included_