### PR TITLE
Fix #465: Standard search engine change no longer updates private mode's

### DIFF
--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -94,6 +94,11 @@ class SearchEngines {
         
         // When re-sorting engines only look at default search for standard browsing.
         if type == .standard {
+            // Make sure we don't alter the private mode's default since it relies on order when its not set
+            if Preferences.Search.defaultPrivateEngineName.value == nil, let firstEngine = orderedEngines.first {
+                // So set the default engine for private mode to whatever the default was before we changed the standard
+                setDefaultEngine(firstEngine.shortName, forType: .privateMode)
+            }
             // The default engine is always first in the list.
             var newlyOrderedEngines =
                 orderedEngines.filter { engine in engine.shortName != defaultEngine(forType: type).shortName }


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`
