### PR TITLE
Fix #523: Passcode is reset if database is destroyed (e.g. new install).

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -13,6 +13,7 @@ import LocalAuthentication
 import CoreSpotlight
 import UserNotifications
 import BraveShared
+import Data
 
 private let log = Logger.browserLogger
 
@@ -55,6 +56,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.window!.backgroundColor = UIColor.Photon.White100
+        
+        // Passcode checking, must happen on immediate launch
+        if !DataController.shared.storeExists() {
+            // Since passcode is stored in keychain it persists between installations.
+            //  If there is no database (either fresh install, or deleted in file system), there is no real reason
+            //  to passcode the browser (no data to protect).
+            // Main concern is user installs Brave after a long period of time, cannot recall passcode, and can
+            //  literally never use Brave. This bypasses this situation, while not using a modifiable pref.
+            KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(nil)
+        }
 
         // Short circuit the app if we want to email logs from the debug menu
         if DebugSettingsBundleOptions.launchIntoEmailComposer {

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -8,14 +8,14 @@ import XCGLogger
 private let log = Logger.browserLogger
 
 public class DataController: NSObject {
-    private let databaseName = "Brave.sqlite"
+    private static let databaseName = "Brave.sqlite"
     
     public static var shared: DataController = DataController()
     
     private lazy var container: NSPersistentContainer = {
+        
         let modelName = "Model"
-        guard let modelURL =
-            Bundle(for: DataController.self).url(forResource: modelName, withExtension: "momd") else {
+        guard let modelURL = Bundle(for: DataController.self).url(forResource: modelName, withExtension: "momd") else {
             fatalError("Error loading model from bundle")
         }
         guard let mom = NSManagedObjectModel(contentsOf: modelURL) else {
@@ -81,13 +81,6 @@ public class DataController: NSObject {
             return
         }
         
-        let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
-        guard let docURL = urls.last else {
-            log.error("Could not load url at document directory")
-            fatalError()
-        }
-        let storeURL = docURL.appendingPathComponent(databaseName)
-        
         let storeDescription = NSPersistentStoreDescription(url: storeURL)
         
         // This makes the database file encrypted until device is unlocked.
@@ -95,6 +88,19 @@ public class DataController: NSObject {
         storeDescription.setOption(completeProtection, forKey: NSPersistentStoreFileProtectionKey)
         
         container.persistentStoreDescriptions = [storeDescription]
+    }
+    
+    let storeURL: URL = {
+        let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        guard let docURL = urls.last else {
+            log.error("Could not load url at document directory")
+            fatalError()
+        }
+        return docURL.appendingPathComponent(DataController.databaseName)
+    }()
+    
+    public func storeExists() -> Bool {
+        return FileManager.default.fileExists(atPath: storeURL.path)
     }
 }
 


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
