### PR TITLE
Fix #542, adblock stats counting improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ scripts/
 BuildId.xcconfig
 
 Client/Configuration/Local/
+
+ABPFilterParserData.dat
+adblock-regions.txt

--- a/Client-Bridging-Header.h
+++ b/Client-Bridging-Header.h
@@ -14,4 +14,6 @@
 #import "Shared-Bridging-Header.h"
 #import "Storage-Bridging-Header.h"
 
+#import "ABPFilterLibWrapper.h"
+
 #endif

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		0A43293B21B1C8D10041625B /* FifoDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A43293A21B1C8D10041625B /* FifoDict.swift */; };
 		0A43293E21B1CA910041625B /* ABPFilterLibWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0A43293C21B1CA910041625B /* ABPFilterLibWrapper.mm */; };
 		0A43294021B1CB8C0041625B /* ABPFilterLibWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A43293D21B1CA910041625B /* ABPFilterLibWrapper.h */; };
-		0A43294421B2E8DD0041625B /* adblock-regions.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0A43294321B2E8DC0041625B /* adblock-regions.txt */; };
 		0A4B012020D02EC4004D4011 /* TabsBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4B011F20D02EC4004D4011 /* TabsBarViewController.swift */; };
 		0A4B012220D02F26004D4011 /* TabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4B012120D02F26004D4011 /* TabBarCell.swift */; };
 		0A4B012420D0321A004D4011 /* UX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4B012320D0321A004D4011 /* UX.swift */; };
@@ -964,7 +963,6 @@
 		0A43293A21B1C8D10041625B /* FifoDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FifoDict.swift; sourceTree = "<group>"; };
 		0A43293C21B1CA910041625B /* ABPFilterLibWrapper.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ABPFilterLibWrapper.mm; sourceTree = "<group>"; };
 		0A43293D21B1CA910041625B /* ABPFilterLibWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ABPFilterLibWrapper.h; sourceTree = "<group>"; };
-		0A43294321B2E8DC0041625B /* adblock-regions.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "adblock-regions.txt"; sourceTree = SOURCE_ROOT; };
 		0A4B011F20D02EC4004D4011 /* TabsBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsBarViewController.swift; sourceTree = "<group>"; };
 		0A4B012120D02F26004D4011 /* TabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCell.swift; sourceTree = "<group>"; };
 		0A4B012320D0321A004D4011 /* UX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UX.swift; sourceTree = "<group>"; };
@@ -2031,7 +2029,6 @@
 				0A4319B621B1C5470041625B /* bloom-filter-cpp */,
 				0A43210321B1C5840041625B /* hashset-cpp */,
 				0A43216721B1C5D30041625B /* ad-block */,
-				0A43294321B2E8DC0041625B /* adblock-regions.txt */,
 			);
 			path = Dependencies;
 			sourceTree = "<group>";
@@ -4172,7 +4169,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D38A1EE01CB458EC0080C842 /* CertError.html in Resources */,
-				0A43294421B2E8DD0041625B /* adblock-regions.txt in Resources */,
 				0BA1E0301B051A07007675AF /* NetError.css in Resources */,
 				3BC659491E5BA4AE006D560F /* TopSites in Resources */,
 				E4B7B77E1A793CF20022C5E0 /* FiraSans-SemiBold.ttf in Resources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -31,6 +31,20 @@
 		0A4214FF21AC0D6C006B8E39 /* TimeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4214F621AC0AFF006B8E39 /* TimeExtensions.swift */; };
 		0A42150121AC0E8E006B8E39 /* TimeExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A42150021AC0E8E006B8E39 /* TimeExtensionTests.swift */; };
 		0A4214E921A6EBCF006B8E39 /* SafeBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4214E821A6EBCF006B8E39 /* SafeBrowsingTests.swift */; };
+		0A431D9721B1C54A0041625B /* BloomFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A4319C221B1C5470041625B /* BloomFilter.cpp */; };
+		0A43214921B1C5850041625B /* hash_set.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A43211121B1C5840041625B /* hash_set.cc */; };
+		0A4325A721B1C5D70041625B /* ad_block_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A43219121B1C5D40041625B /* ad_block_client.cc */; };
+		0A4325A821B1C5D70041625B /* filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A43219321B1C5D40041625B /* filter.cc */; };
+		0A4325AC21B1C5D70041625B /* protocol.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A43219A21B1C5D40041625B /* protocol.cc */; };
+		0A4325AD21B1C5D70041625B /* cosmetic_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A43219B21B1C5D40041625B /* cosmetic_filter.cc */; };
+		0A4325AE21B1C5D70041625B /* no_fingerprint_domain.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A43219C21B1C5D40041625B /* no_fingerprint_domain.cc */; };
+		0A43292C21B1C6DD0041625B /* hashFn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A43292B21B1C6DD0041625B /* hashFn.cpp */; };
+		0A43293021B1C7F50041625B /* AdBlockStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A43292F21B1C7F50041625B /* AdBlockStats.swift */; };
+		0A43293921B1C8120041625B /* NetworkDataFileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A43293821B1C8120041625B /* NetworkDataFileLoader.swift */; };
+		0A43293B21B1C8D10041625B /* FifoDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A43293A21B1C8D10041625B /* FifoDict.swift */; };
+		0A43293E21B1CA910041625B /* ABPFilterLibWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0A43293C21B1CA910041625B /* ABPFilterLibWrapper.mm */; };
+		0A43294021B1CB8C0041625B /* ABPFilterLibWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A43293D21B1CA910041625B /* ABPFilterLibWrapper.h */; };
+		0A43294421B2E8DD0041625B /* adblock-regions.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0A43294321B2E8DC0041625B /* adblock-regions.txt */; };
 		0A4B012020D02EC4004D4011 /* TabsBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4B011F20D02EC4004D4011 /* TabsBarViewController.swift */; };
 		0A4B012220D02F26004D4011 /* TabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4B012120D02F26004D4011 /* TabBarCell.swift */; };
 		0A4B012420D0321A004D4011 /* UX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4B012320D0321A004D4011 /* UX.swift */; };
@@ -930,6 +944,27 @@
 		0A4214E821A6EBCF006B8E39 /* SafeBrowsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeBrowsingTests.swift; sourceTree = "<group>"; };
 		0A4214F621AC0AFF006B8E39 /* TimeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeExtensions.swift; sourceTree = "<group>"; };
 		0A42150021AC0E8E006B8E39 /* TimeExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeExtensionTests.swift; sourceTree = "<group>"; };
+		0A4319B521B1C4F40041625B /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		0A4319C221B1C5470041625B /* BloomFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BloomFilter.cpp; sourceTree = "<group>"; };
+		0A43211121B1C5840041625B /* hash_set.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hash_set.cc; sourceTree = "<group>"; };
+		0A43216921B1C5D30041625B /* protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = protocol.h; sourceTree = "<group>"; };
+		0A43219121B1C5D40041625B /* ad_block_client.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ad_block_client.cc; sourceTree = "<group>"; };
+		0A43219221B1C5D40041625B /* no_fingerprint_domain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = no_fingerprint_domain.h; sourceTree = "<group>"; };
+		0A43219321B1C5D40041625B /* filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = filter.cc; sourceTree = "<group>"; };
+		0A43219A21B1C5D40041625B /* protocol.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = protocol.cc; sourceTree = "<group>"; };
+		0A43219B21B1C5D40041625B /* cosmetic_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cosmetic_filter.cc; sourceTree = "<group>"; };
+		0A43219C21B1C5D40041625B /* no_fingerprint_domain.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = no_fingerprint_domain.cc; sourceTree = "<group>"; };
+		0A4321B221B1C5D40041625B /* cosmetic_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cosmetic_filter.h; sourceTree = "<group>"; };
+		0A4321E621B1C5D40041625B /* filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter.h; sourceTree = "<group>"; };
+		0A4321EB21B1C5D40041625B /* ad_block_client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ad_block_client.h; sourceTree = "<group>"; };
+		0A43258621B1C5D60041625B /* base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
+		0A43292B21B1C6DD0041625B /* hashFn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hashFn.cpp; sourceTree = "<group>"; };
+		0A43292F21B1C7F50041625B /* AdBlockStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdBlockStats.swift; sourceTree = "<group>"; };
+		0A43293821B1C8120041625B /* NetworkDataFileLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDataFileLoader.swift; sourceTree = "<group>"; };
+		0A43293A21B1C8D10041625B /* FifoDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FifoDict.swift; sourceTree = "<group>"; };
+		0A43293C21B1CA910041625B /* ABPFilterLibWrapper.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ABPFilterLibWrapper.mm; sourceTree = "<group>"; };
+		0A43293D21B1CA910041625B /* ABPFilterLibWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ABPFilterLibWrapper.h; sourceTree = "<group>"; };
+		0A43294321B2E8DC0041625B /* adblock-regions.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "adblock-regions.txt"; sourceTree = SOURCE_ROOT; };
 		0A4B011F20D02EC4004D4011 /* TabsBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsBarViewController.swift; sourceTree = "<group>"; };
 		0A4B012120D02F26004D4011 /* TabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCell.swift; sourceTree = "<group>"; };
 		0A4B012320D0321A004D4011 /* UX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UX.swift; sourceTree = "<group>"; };
@@ -1921,6 +1956,7 @@
 		0A0D3D2F21A4BC1F00BEE65B /* WebFilters */ = {
 			isa = PBXGroup;
 			children = (
+				0A4319B321B1C4D60041625B /* AdblockStats */,
 				0A0D3D3721A4BCF100BEE65B /* SafeBrowsing */,
 			);
 			path = WebFilters;
@@ -1974,6 +2010,69 @@
 			);
 			path = Sync;
 			sourceTree = "<group>";
+		};
+		0A4319B321B1C4D60041625B /* AdblockStats */ = {
+			isa = PBXGroup;
+			children = (
+				0A4319B421B1C4E30041625B /* Dependencies */,
+				0A43292F21B1C7F50041625B /* AdBlockStats.swift */,
+				0A43293821B1C8120041625B /* NetworkDataFileLoader.swift */,
+				0A43293A21B1C8D10041625B /* FifoDict.swift */,
+				0A43293D21B1CA910041625B /* ABPFilterLibWrapper.h */,
+				0A43293C21B1CA910041625B /* ABPFilterLibWrapper.mm */,
+			);
+			path = AdblockStats;
+			sourceTree = "<group>";
+		};
+		0A4319B421B1C4E30041625B /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				0A4319B521B1C4F40041625B /* README.md */,
+				0A4319B621B1C5470041625B /* bloom-filter-cpp */,
+				0A43210321B1C5840041625B /* hashset-cpp */,
+				0A43216721B1C5D30041625B /* ad-block */,
+				0A43294321B2E8DC0041625B /* adblock-regions.txt */,
+			);
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
+		0A4319B621B1C5470041625B /* bloom-filter-cpp */ = {
+			isa = PBXGroup;
+			children = (
+				0A4319C221B1C5470041625B /* BloomFilter.cpp */,
+				0A43292B21B1C6DD0041625B /* hashFn.cpp */,
+			);
+			name = "bloom-filter-cpp";
+			path = "node_modules/bloom-filter-cpp";
+			sourceTree = SOURCE_ROOT;
+		};
+		0A43210321B1C5840041625B /* hashset-cpp */ = {
+			isa = PBXGroup;
+			children = (
+				0A43211121B1C5840041625B /* hash_set.cc */,
+			);
+			name = "hashset-cpp";
+			path = "node_modules/hashset-cpp";
+			sourceTree = SOURCE_ROOT;
+		};
+		0A43216721B1C5D30041625B /* ad-block */ = {
+			isa = PBXGroup;
+			children = (
+				0A43216921B1C5D30041625B /* protocol.h */,
+				0A43219121B1C5D40041625B /* ad_block_client.cc */,
+				0A43219221B1C5D40041625B /* no_fingerprint_domain.h */,
+				0A43219321B1C5D40041625B /* filter.cc */,
+				0A43219A21B1C5D40041625B /* protocol.cc */,
+				0A43219B21B1C5D40041625B /* cosmetic_filter.cc */,
+				0A43219C21B1C5D40041625B /* no_fingerprint_domain.cc */,
+				0A4321B221B1C5D40041625B /* cosmetic_filter.h */,
+				0A4321E621B1C5D40041625B /* filter.h */,
+				0A4321EB21B1C5D40041625B /* ad_block_client.h */,
+				0A43258621B1C5D60041625B /* base.h */,
+			);
+			name = "ad-block";
+			path = "node_modules/ad-block";
+			sourceTree = SOURCE_ROOT;
 		};
 		0A4B011620D02DAC004D4011 /* TabsBar */ = {
 			isa = PBXGroup;
@@ -3348,6 +3447,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		0A43293F21B1CB810041625B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A43294021B1CB8C0041625B /* ABPFilterLibWrapper.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		288A2D831AB8B3260023ABC3 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -3671,6 +3778,7 @@
 				7B604F8F1C494AAA006EEEC3 /* Copy Carthage Dependencies */,
 				2779B7052159297D0044A102 /* Run SwiftLint */,
 				F84B21BA1A090F8100AAB793 /* Sources */,
+				0A43293F21B1CB810041625B /* Headers */,
 				F84B21BC1A090F8100AAB793 /* Resources */,
 				28CE83DE1A1D1E7C00576538 /* Frameworks */,
 				F84B22531A0920C600AAB793 /* Embed App Extensions */,
@@ -4064,6 +4172,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D38A1EE01CB458EC0080C842 /* CertError.html in Resources */,
+				0A43294421B2E8DD0041625B /* adblock-regions.txt in Resources */,
 				0BA1E0301B051A07007675AF /* NetError.css in Resources */,
 				3BC659491E5BA4AE006D560F /* TopSites in Resources */,
 				E4B7B77E1A793CF20022C5E0 /* FiraSans-SemiBold.ttf in Resources */,
@@ -4564,6 +4673,7 @@
 				E68F36981EA694000048CF44 /* PanelDataObservers.swift in Sources */,
 				31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */,
 				0A4B012020D02EC4004D4011 /* TabsBarViewController.swift in Sources */,
+				0A4325A721B1C5D70041625B /* ad_block_client.cc in Sources */,
 				A1D8420420BC44F800BDAFF7 /* PopoverContentComponent.swift in Sources */,
 				A1D8420220BC44F800BDAFF7 /* PopoverController.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
@@ -4583,8 +4693,10 @@
 				E65607611C08B4E200534B02 /* SearchInputView.swift in Sources */,
 				0A0D3D6121A596BE00BEE65B /* MalwareList.swift in Sources */,
 				EB2A63341F3B49A7004EF8B0 /* ContentBlockerHelper.swift in Sources */,
+				0A43293B21B1C8D10041625B /* FifoDict.swift in Sources */,
 				FA6B2AC21D41F02D00429414 /* Punycode.swift in Sources */,
 				D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */,
+				0A4325AD21B1C5D70041625B /* cosmetic_filter.cc in Sources */,
 				0B3E7D951B27A7CE00E2E84D /* AboutHomeHandler.swift in Sources */,
 				0AADC4CA20D2A66E00FDE368 /* FavoriteCell.swift in Sources */,
 				A198E75120C701ED00334C11 /* HistoryViewController.swift in Sources */,
@@ -4635,9 +4747,11 @@
 				74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
+				0A43293E21B1CA910041625B /* ABPFilterLibWrapper.mm in Sources */,
 				E689C7301E0C7617008BAADB /* NSAttributedStringExtensions.swift in Sources */,
 				D0C95E0E200FD3B200E4E51C /* PrintHelper.swift in Sources */,
 				C6620BBB213BCEC6009FE75A /* TabType.swift in Sources */,
+				0A4325AE21B1C5D70041625B /* no_fingerprint_domain.cc in Sources */,
 				E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */,
 				2743464A21AC4AB200003B1F /* DomainShieldExtensions.swift in Sources */,
 				A16DC67F20E585D90069C8E1 /* PasscodeSettingsViewController.swift in Sources */,
@@ -4648,6 +4762,7 @@
 				E63ED8E11BFD25580097D08E /* LoginListViewController.swift in Sources */,
 				D0625CA8208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
+				0A43214921B1C5850041625B /* hash_set.cc in Sources */,
 				39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */,
 				E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
@@ -4667,13 +4782,16 @@
 				D8EFFA0C1FF5B1FA001D3A09 /* NavigationRouter.swift in Sources */,
 				D0E55C4F1FB4FD23006DC274 /* FormPostHelper.swift in Sources */,
 				E650754E1E37F6AE006961AC /* GeometryExtensions.swift in Sources */,
+				0A43293921B1C8120041625B /* NetworkDataFileLoader.swift in Sources */,
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */,
+				0A4325AC21B1C5D70041625B /* protocol.cc in Sources */,
 				E6D8D5E71B569D70009E5A58 /* BrowserTrayAnimators.swift in Sources */,
 				DDA24A431FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */,
 				E65075611E37F77D006961AC /* MenuHelper.swift in Sources */,
 				E63ED7D81BFCD9990097D08E /* LoginTableViewCell.swift in Sources */,
+				0A431D9721B1C54A0041625B /* BloomFilter.cpp in Sources */,
 				C615FACF2129FBD000A8168C /* ImageCacheProtocol.swift in Sources */,
 				39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */,
 				0AADC4D520D2A6A200FDE368 /* PreloadedFavorites.swift in Sources */,
@@ -4714,6 +4832,7 @@
 				A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */,
 				0A1E84412190A57F0042F782 /* SyncViewController.swift in Sources */,
 				0AADC4C820D2A55A00FDE368 /* FavoritesViewController.swift in Sources */,
+				0A43293021B1C7F50041625B /* AdBlockStats.swift in Sources */,
 				E65075571E37F714006961AC /* FaviconFetcher.swift in Sources */,
 				D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */,
 				D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */,
@@ -4729,6 +4848,8 @@
 				E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */,
 				A1AD4BD420BF4757007A6EA1 /* ImageCache.swift in Sources */,
 				0A1E84462190A57F0042F782 /* SyncAddDeviceViewController.swift in Sources */,
+				0A43292C21B1C6DD0041625B /* hashFn.cpp in Sources */,
+				0A4325A821B1C5D70041625B /* filter.cc in Sources */,
 				D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */,
 				EB11A1052044A90E0018F749 /* TrackingProtectionPageStats.swift in Sources */,
 				E633E2DA1C21EAF8001FFF6C /* LoginDetailViewController.swift in Sources */,
@@ -7243,6 +7364,8 @@
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/node_modules/bloom-filter-cpp",
+					"$(SRCROOT)/node_modules/hashset-cpp",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -7637,6 +7760,8 @@
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/node_modules/bloom-filter-cpp",
+					"$(SRCROOT)/node_modules/hashset-cpp",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -8037,6 +8162,8 @@
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/node_modules/bloom-filter-cpp",
+					"$(SRCROOT)/node_modules/hashset-cpp",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -8258,6 +8385,8 @@
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/node_modules/bloom-filter-cpp",
+					"$(SRCROOT)/node_modules/hashset-cpp",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -56,6 +56,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.window!.backgroundColor = UIColor.Photon.White100
+
+        AdBlockStats.shared.startLoading()
         
         // Passcode checking, must happen on immediate launch
         if !DataController.shared.storeExists() {

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -91,6 +91,8 @@ extension Preferences {
         static let blockImages = Option<Bool>(key: "shields.block-images", default: false)
         ///
         static let useRegionAdBlock = Option<Bool>(key: "shields.regional-adblock", default: false)
+        /// Version of downloaded data file for adblock stats.
+        static let adblockStatsDataVersion = Option<Int?>(key: "stats.adblock-data-version", default: nil)
     }
 }
 

--- a/Client/Frontend/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
+++ b/Client/Frontend/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
@@ -46,8 +46,11 @@ extension ContentBlockerHelper: TabContentScript {
             BraveGlobalShieldStats.shared.scripts += 1
             return
         }
+        
+        var req = URLRequest(url: url)
+        req.mainDocumentURL = mainDocumentUrl
 
-        TPStatsBlocklistChecker.shared.isBlocked(url: url, domain: domain, resourceType: resourceType).uponQueue(.main) { listItem in
+        TPStatsBlocklistChecker.shared.isBlocked(request: req, domain: domain, resourceType: resourceType).uponQueue(.main) { listItem in
             if let listItem = listItem {
                 self.stats = self.stats.create(byAddingListItem: listItem)
                 

--- a/Client/WebFilters/AdblockStats/ABPFilterLibWrapper.h
+++ b/Client/WebFilters/AdblockStats/ABPFilterLibWrapper.h
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import <Foundation/Foundation.h>
+
+@interface ABPFilterLibWrapper : NSObject
+- (void)setDataFile:(NSData *)data;
+- (BOOL)hasDataFile;
+- (BOOL)isBlockedConsideringType:(NSString *)url mainDocumentUrl:(NSString *)mainDoc acceptHTTPHeader:(NSString *)acceptHeader;
+- (BOOL)isBlockedIgnoringType:(NSString *)url mainDocumentUrl:(NSString *)mainDoc;
+@end

--- a/Client/WebFilters/AdblockStats/ABPFilterLibWrapper.mm
+++ b/Client/WebFilters/AdblockStats/ABPFilterLibWrapper.mm
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import "ABPFilterLibWrapper.h"
+#include "ad_block_client.h"
+
+
+@interface ABPFilterLibWrapper() {
+    AdBlockClient parser;
+}
+@property (nonatomic, retain) NSData *data;
+@end
+
+@implementation ABPFilterLibWrapper
+
+-(void)setDataFile:(NSData *)data
+{
+    @synchronized(self) {
+        self.data = data;
+        parser.deserialize((char *)self.data.bytes);
+    }
+}
+
+-(BOOL)hasDataFile
+{
+    @synchronized(self) {
+        return self.data != nil;
+    }
+}
+
+-(BOOL)_isBlockedCommonSetup:(NSString **)mainDoc
+{
+    if (![self hasDataFile]) {
+        return false;
+    }
+
+    if (*mainDoc) {
+        *mainDoc = [*mainDoc stringByReplacingOccurrencesOfString:@"http://" withString:@""];
+        *mainDoc = [*mainDoc stringByReplacingOccurrencesOfString:@"https://" withString:@""];
+    }
+    return true;
+}
+
+// Ignore the type (.html, .js, .css) of the requested resource
+- (BOOL)isBlockedIgnoringType:(NSString *)url
+                          mainDocumentUrl:(NSString *)mainDoc
+{
+    @synchronized(self) {
+        if (![self _isBlockedCommonSetup:&mainDoc]) {
+            return false;
+        }
+
+        FilterOption option = FONoFilterOption;
+        return parser.matches(url.UTF8String, option, mainDoc.UTF8String);
+    }
+}
+
+
+- (BOOL)isBlockedConsideringType:(NSString *)url
+              mainDocumentUrl:(NSString *)mainDoc
+             acceptHTTPHeader:(NSString *)acceptHeader
+{
+    @synchronized(self) {
+        if (![self _isBlockedCommonSetup:&mainDoc]) {
+            return false;
+        }
+
+        FilterOption option = FONoFilterOption;
+        if (acceptHeader) {
+            if ([acceptHeader rangeOfString:@"/css"].location != NSNotFound) {
+                option  = FOStylesheet;
+            }
+            else if ([acceptHeader rangeOfString:@"image/"].location != NSNotFound) {
+                option  = FOImage;
+            }
+            else if ([acceptHeader rangeOfString:@"javascript"].location != NSNotFound) {
+                option  = FOScript;
+            }
+        }
+        if (option == FONoFilterOption) {
+            if ([url hasSuffix:@".js"]) {
+                option = FOScript;
+            }
+            else if ([url hasSuffix:@".png"] || [url hasSuffix:@".jpg"] || [url hasSuffix:@".jpeg"] || [url hasSuffix:@".gif"]) {
+                option = FOImage;
+            }
+            else if ([url hasSuffix:@".css"]) {
+                option = FOStylesheet;
+            }
+        }
+
+        return parser.matches(url.UTF8String, option, mainDoc.UTF8String);
+    }
+}
+
+@end

--- a/Client/WebFilters/AdblockStats/AdBlockStats.swift
+++ b/Client/WebFilters/AdblockStats/AdBlockStats.swift
@@ -1,0 +1,241 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import BraveShared
+
+private let log = Logger.browserLogger
+
+class AdBlockStats {
+    static let shared = AdBlockStats()
+    
+    typealias LocaleCode = String
+    
+    class AdblockNetworkDataFileLoader: NetworkDataFileLoader {
+        var lang = AdBlockStats.defaultLocale
+    }
+    
+    static let prefKey = "braveBlockAdsAndTracking"
+    static let prefKeyDefaultValue = true
+    static let prefKeyUseRegional = "braveAdblockUseRegional"
+    static let prefKeyUseRegionalDefaultValue = true
+    static let dataVersion = 4
+    
+    static let dataVersionPrefKey = "dataVersionPrefKey"
+    static let defaultLocale = "en"
+    
+    let adBlockDataFolderName = "abp-data"
+    let adBlockRegionFilePath = Bundle.main.path(forResource: "adblock-regions", ofType: "txt")
+    let adBlockDataUrlPath = "https://adblock-data.s3.brave.com/"
+    
+    var isNSPrefEnabled = true
+    fileprivate var fifoCacheOfUrlsChecked = FifoDict()
+    fileprivate var regionToS3FileName = [LocaleCode: String]()
+    
+    fileprivate var networkLoaders = [LocaleCode: AdblockNetworkDataFileLoader]()
+    fileprivate lazy var abpFilterLibWrappers: [LocaleCode: ABPFilterLibWrapper] = {
+        return [AdBlockStats.defaultLocale: ABPFilterLibWrapper()]
+    }()
+    var currentLocaleCode: LocaleCode = defaultLocale {
+        didSet {
+            updateRegionalAdblockEnabledState()
+        }
+    }
+    fileprivate var isRegionalAdblockEnabled = prefKeyUseRegionalDefaultValue
+    
+    fileprivate init() {
+        setDataVersionPreference()
+        updateEnabledState()
+        networkLoaders[AdBlockStats.defaultLocale] = getNetworkLoader(forLocale: AdBlockStats.defaultLocale, name: "ABPFilterParserData")
+        parseAdblockRegionsFile()
+        
+        // so that didSet is called from init
+        defer { currentLocaleCode = Locale.current.languageCode ?? AdBlockStats.defaultLocale }
+    }
+    
+    private func parseAdblockRegionsFile() {
+        guard let filePath = adBlockRegionFilePath,
+            let regional = try? String(contentsOfFile: filePath, encoding: String.Encoding.utf8) else {
+                log.error("Could not find adblock regions file")
+                return
+        }
+        
+        regional.components(separatedBy: "\n").forEach {
+            let parts = $0.components(separatedBy: ",")
+            guard let filename = parts.last, parts.count > 1 else {
+                return
+            }
+            
+            for locale in parts {
+                if regionToS3FileName[locale] != nil { log.info("Duplicate regions not handled yet \(locale)") }
+                
+                if locale.count > 2 {
+                    log.info("Only 2 letter locale codes are handled.")
+                    let firstTwoLocaleCharacters = String(locale.prefix(2))
+                    regionToS3FileName[firstTwoLocaleCharacters] = filename
+                } else {
+                    regionToS3FileName[locale] = filename
+                }
+            }
+        }
+    }
+    
+    /// We want to avoid situations in which user still has downloaded old abp data version.
+    /// We remove all abp data after data version is updated, then the newest data is downloaded.
+    private func setDataVersionPreference() {
+        
+        guard let dataVersioPref = Preferences.Shields.adblockStatsDataVersion.value, dataVersioPref == AdBlockStats.dataVersion else {
+            cleanDatFiles()
+            Preferences.Shields.adblockStatsDataVersion.value = AdBlockStats.dataVersion
+            return
+        }
+    }
+    
+    private func cleanDatFiles() {
+        guard let dir = NetworkDataFileLoader.directoryPath else { return }
+        
+        let fm = FileManager.default
+        do {
+            let folderPath = dir + "/\(adBlockDataFolderName)"
+            let paths = try fm.contentsOfDirectory(atPath: folderPath)
+            for path in paths {
+                try fm.removeItem(atPath: "\(folderPath)/\(path)")
+            }
+        } catch {
+            log.error(error.localizedDescription)
+        }
+    }
+    
+    fileprivate func getNetworkLoader(forLocale locale: LocaleCode, name: String) -> AdblockNetworkDataFileLoader {
+        let dataUrl = URL(string: "\(adBlockDataUrlPath)\(AdBlockStats.dataVersion)/\(name).dat")!
+        let dataFile = "abp-data-\(AdBlockStats.dataVersion)-\(locale).dat"
+        let loader = AdblockNetworkDataFileLoader(url: dataUrl, file: dataFile, localDirName: adBlockDataFolderName)
+        loader.lang = locale
+        loader.delegate = self
+        return loader
+    }
+    
+    func startLoading() {
+        networkLoaders.forEach { $0.1.loadData() }
+    }
+    
+    func isRegionalAdblockPossible() -> (hasRegionalFile: Bool, isDefaultSettingOn: Bool) {
+        return (hasRegionalFile: currentLocaleCode != AdBlockStats.defaultLocale && regionToS3FileName[currentLocaleCode] != nil,
+                isDefaultSettingOn: isRegionalAdblockEnabled)
+    }
+    
+    func updateEnabledState() {
+        isNSPrefEnabled = Preferences.Shields.blockAdsAndTracking.value
+    }
+    
+    fileprivate func updateRegionalAdblockEnabledState() {
+        // TODO: Enable regional filters once it's supported.
+        
+//        isRegionalAdblockEnabled = BraveApp.getPrefs()?.boolForKey(AdBlocker.prefKeyUseRegional) ?? AdBlocker.prefKeyUseRegionalDefaultValue
+        isRegionalAdblockEnabled = false
+        
+        if currentLocaleCode != AdBlockStats.defaultLocale && isRegionalAdblockEnabled {
+            if let file = regionToS3FileName[currentLocaleCode] {
+                if networkLoaders[currentLocaleCode] == nil {
+                    networkLoaders[currentLocaleCode] = getNetworkLoader(forLocale: currentLocaleCode, name: file)
+                    abpFilterLibWrappers[currentLocaleCode] = ABPFilterLibWrapper()
+                    
+                }
+            } else {
+                log.warning("No custom adblock file for \(self.currentLocaleCode)")
+            }
+        }
+    }
+    
+    func shouldBlock(_ request: URLRequest) -> Bool {
+        // synchronize code from this point on.
+        objc_sync_enter(self)
+        defer { objc_sync_exit(self) }
+        
+        guard let url = request.url else {
+            return false
+        }
+        
+        var currentTabUrl: URL?
+        
+        DispatchQueue.main.async {
+            guard let delegate = UIApplication.shared.delegate as? AppDelegate else { return }
+            currentTabUrl = delegate.browserViewController.tabManager.selectedTab?.url
+        }
+        
+        // Do not block main frame urls
+        // e.g. user clicked on an ad intentionally (adblock could block redirect to requested site)
+        if url == currentTabUrl { return false }
+        
+        let mainDocDomain = stripLocalhostWebServer(request.mainDocumentURL?.host ?? "")
+        
+        // A cache entry is like: fifoOfCachedUrlChunks[0]["www.microsoft.com_http://some.url"] = true/false for blocking
+        let key = "\(mainDocDomain)_" + stripLocalhostWebServer(url.absoluteString)
+        
+        if let checkedItem = fifoCacheOfUrlsChecked.getItem(key) {
+            if checkedItem === NSNull() {
+                return false
+            } else {
+                if let checkedItem = checkedItem as? Bool {
+                    return checkedItem
+                } else {
+                    log.error("Can't cast checkedItem to Bool")
+                    return false
+                }
+            }
+        }
+        
+        var isBlocked = false
+        let header = "*/*"
+        
+        for (_, adblocker) in abpFilterLibWrappers {
+            isBlocked = adblocker.isBlockedConsideringType(url.absoluteString,
+                                                           mainDocumentUrl: mainDocDomain,
+                                                           acceptHTTPHeader: header)
+          
+            if isBlocked {
+                break
+            }
+        }
+        fifoCacheOfUrlsChecked.addItem(key, value: isBlocked as AnyObject)
+        
+        return isBlocked
+    }
+    
+    // Firefox has uses urls of the form  http://localhost:6571/errors/error.html?url=http%3A//news.google.ca/ to populate the browser history, and load+redirect using GCDWebServer
+    func stripLocalhostWebServer(_ url: String?) -> String {
+        guard let url = url else { return "" }
+    
+        // I think the ones prefixed with the following are the only ones of concern. There is also about/sessionrestore urls, not sure if we need to look at those
+        let token = "?url="
+        
+        if let range = url.range(of: token) {
+            return url[range.upperBound..<url.endIndex].removingPercentEncoding ?? ""
+        } else {
+            return url
+        }
+    }
+}
+
+extension AdBlockStats: NetworkDataFileLoaderDelegate {
+    
+    func fileLoader(_ loader: NetworkDataFileLoader, setDataFile data: Data?) {
+        guard let loader = loader as? AdblockNetworkDataFileLoader, let adblocker = abpFilterLibWrappers[loader.lang] else {
+            assertionFailure()
+            return
+        }
+        adblocker.setDataFile(data)
+    }
+    
+    func fileLoaderHasDataFile(_ loader: NetworkDataFileLoader) -> Bool {
+        guard let loader = loader as? AdblockNetworkDataFileLoader, let adblocker = abpFilterLibWrappers[loader.lang] else {
+            assertionFailure()
+            return false
+        }
+        return adblocker.hasDataFile()
+    }
+    
+    func fileLoaderDelegateWillHandleInitialRead(_ loader: NetworkDataFileLoader) -> Bool {
+        return false
+    }
+}

--- a/Client/WebFilters/AdblockStats/Dependencies/README.md
+++ b/Client/WebFilters/AdblockStats/Dependencies/README.md
@@ -1,0 +1,7 @@
+## Adblock Stats dependencies folder.
+
+A `.bootstrap.sh` script must be run in order to link the containing files properly.
+Visit `https://github.com/brave/brave-ios#building-the-code` for detailed install instructions.
+
+All files put here are only references of files inside of node_modules(soft links).
+Please do not add hard linked files here, and use parent folder instead.

--- a/Client/WebFilters/AdblockStats/FifoDict.swift
+++ b/Client/WebFilters/AdblockStats/FifoDict.swift
@@ -1,0 +1,35 @@
+// Lookup time is O(maxDicts)
+// Very basic implementation of a recent item collection class, stored as groups of items in dictionaries, oldest items are deleted as blocks of items since their entire containing dictionary is deleted.
+class FifoDict {
+    var fifoArrayOfDicts: [NSMutableDictionary] = []
+    let maxDicts = 5
+    let maxItemsPerDict = 50
+    
+    // the url key is a combination of urls, the main doc url, and the url being checked
+    func addItem(_ key: String, value: AnyObject?) {
+        if fifoArrayOfDicts.count > maxItemsPerDict {
+            fifoArrayOfDicts.removeFirst()
+        }
+        
+        if fifoArrayOfDicts.last == nil || (fifoArrayOfDicts.last?.count ?? 0) > maxItemsPerDict {
+            fifoArrayOfDicts.append(NSMutableDictionary())
+        }
+        
+        if let lastDict = fifoArrayOfDicts.last {
+            if value == nil {
+                lastDict[key] = NSNull()
+            } else {
+                lastDict[key] = value
+            }
+        }
+    }
+    
+    func getItem(_ key: String) -> AnyObject?? {
+        for dict in fifoArrayOfDicts {
+            if let item = dict[key] {
+                return item as AnyObject
+            }
+        }
+        return nil
+    }
+}

--- a/Client/WebFilters/AdblockStats/NetworkDataFileLoader.swift
+++ b/Client/WebFilters/AdblockStats/NetworkDataFileLoader.swift
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import Alamofire
+
+private let log = Logger.browserLogger
+
+protocol NetworkDataFileLoaderDelegate: class {
+    func fileLoader(_: NetworkDataFileLoader, setDataFile data: Data?)
+    func fileLoaderHasDataFile(_: NetworkDataFileLoader) -> Bool
+    func fileLoaderDelegateWillHandleInitialRead(_: NetworkDataFileLoader) -> Bool
+}
+
+class NetworkDataFileLoader {
+    let dataUrl: URL
+    let dataFile: String
+    let nameOfDataDir: String
+    
+    static let directoryPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first
+    
+    weak var delegate: NetworkDataFileLoaderDelegate?
+    
+    init(url: URL, file: String, localDirName: String) {
+        dataUrl = url
+        dataFile = file
+        nameOfDataDir = localDirName
+    }
+    
+    // return the dir and a bool if the dir was created
+    func createAndGetDataDirPath() -> (String, Bool) {
+        if let dir = NetworkDataFileLoader.directoryPath {
+            let path = dir + "/" + nameOfDataDir
+            var wasCreated = false
+            if !FileManager.default.fileExists(atPath: path) {
+                do {
+                    try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+                } catch {
+                    log.error("NetworkDataFileLoader error: \(error)")
+                }
+                wasCreated = true
+            }
+            return (path, wasCreated)
+        } else {
+            log.error("Can't get documents dir.")
+            return ("", false)
+        }
+    }
+    
+    func etagFileNameFromDataFile(_ dataFileName: String) -> String {
+        return dataFileName + ".etag"
+    }
+    
+    func readDataEtag() -> String? {
+        let (dir, _) = createAndGetDataDirPath()
+        let path = etagFileNameFromDataFile(dir + "/" + dataFile)
+        if !FileManager.default.fileExists(atPath: path) {
+            return nil
+        }
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
+        return NSString(data: data, encoding: String.Encoding.utf8.rawValue) as String?
+    }
+    
+    fileprivate func finishWritingToDisk(_ data: Data, etag: String?) {
+        let (dir, _) = createAndGetDataDirPath()
+        let path = dir + "/" + dataFile
+        if !((try? data.write(to: URL(fileURLWithPath: path), options: [.atomic])) != nil) { // will overwrite
+            log.error("Failed to write data to \(path)")
+        }
+        
+        addSkipBackupAttributeToItemAtURL(URL(fileURLWithPath: dir, isDirectory: true))
+        
+        if let etagData = etag?.data(using: String.Encoding.utf8) {
+            let etagPath = etagFileNameFromDataFile(path)
+            if !((try? etagData.write(to: URL(fileURLWithPath: etagPath), options: [.atomic])) != nil) {
+                log.error("Failed to write data to \(etagPath)")
+            }
+        }
+        
+        delegate?.fileLoader(self, setDataFile: data)
+    }
+    
+    func addSkipBackupAttributeToItemAtURL(_ url: URL) {
+        do {
+            try (url as NSURL).setResourceValue(true, forKey: URLResourceKey.isExcludedFromBackupKey)
+        } catch {
+            log.error("Error excluding \(url.lastPathComponent) from backup \(error)")
+        }
+    }
+    
+    fileprivate func networkRequest() {
+        let session = URLSession.shared
+        let task = session.dataTask(with: dataUrl, completionHandler: {
+            (data, response, error) -> Void in
+            if let err = error {
+                print(err.localizedDescription)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 60) {
+                    self.networkRequest()
+                }
+            } else {
+                if let data = data, let response = response as? HTTPURLResponse {
+                    if 400...499 ~= response.statusCode { // error
+                        log.error("Failed to download, error: \(response.statusCode), URL:\(String(describing: response.url))")
+                    } else {
+                        let etag = response.allHeaderFields["Etag"] as? String
+                        self.finishWritingToDisk(data, etag: etag)
+                    }
+                }
+            }
+        })
+        task.resume()
+    }
+    
+    func pathToExistingDataOnDisk() -> String? {
+        let (dir, _) = createAndGetDataDirPath()
+        let path = dir + "/" + dataFile
+        return FileManager.default.fileExists(atPath: path) ? path : nil
+    }
+    
+    fileprivate func checkForUpdatedFileAfterDelay() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { // a few seconds after startup, check to see if a new file is available
+            Alamofire.request(self.dataUrl, method: .head, encoding: JSONEncoding.default).response { response in
+                if let err = response.error {
+                    print("\(err)")
+                } else {
+                    guard let etag = response.response?.allHeaderFields["Etag"] as? String else { return }
+                    let etagOnDisk = self.readDataEtag()
+                    if etagOnDisk != etag {
+                        self.networkRequest()
+                    }
+                }
+            }
+        }
+    }
+    
+    func loadData() {
+        guard let delegate = delegate else { return }
+        checkForUpdatedFileAfterDelay()
+        
+        if !delegate.fileLoaderHasDataFile(self) {
+            networkRequest()
+        } else if !delegate.fileLoaderDelegateWillHandleInitialRead(self) {
+            func readData() -> Data? {
+                guard let path = pathToExistingDataOnDisk() else { return nil }
+                return FileManager.default.contents(atPath: path)
+            }
+            
+            if let data = readData() {
+                delegate.fileLoader(self, setDataFile: data)
+            } else {
+                networkRequest()
+            }
+        }
+    }
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,21 +46,6 @@ npm run build:sync
 echo "Building adblock library"
 npm run build:adblock
 
-# Set up adblock regional filters
-
-echo "Compiling adblock regional filters"
-if ! g++ get_adblock_regions.cpp -Inode_modules/ad-block/ -std=c++11 -o get_adblock_regions; then
-    echo "Error: could not setup adblock region file."
-    exit 1
-fi
-
-./get_adblock_regions && rm get_adblock_regions
-
-if [ ! -e adblock-regions.txt ]; then
-    echo "Error: adblock region file does not exist."
-    exit 1
-fi
-
 # Sets up local configurations from the tracked .template files
 
 # Checking the `Local` Directory

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -41,8 +41,25 @@ SWIFT_VERSION=4.0 carthage bootstrap $CARTHAGE_VERBOSE --platform ios --color au
 
 npm install
 npm run build
-echo "Building Brave's sync"
+echo "Building sync"
 npm run build:sync
+echo "Building adblock library"
+npm run build:adblock
+
+# Set up adblock regional filters
+
+echo "Compiling adblock regional filters"
+if ! g++ get_adblock_regions.cpp -Inode_modules/ad-block/ -std=c++11 -o get_adblock_regions; then
+    echo "Error: could not setup adblock region file."
+    exit 1
+fi
+
+./get_adblock_regions && rm get_adblock_regions
+
+if [ ! -e adblock-regions.txt ]; then
+    echo "Error: adblock region file does not exist."
+    exit 1
+fi
 
 # Sets up local configurations from the tracked .template files
 

--- a/get_adblock_regions.cpp
+++ b/get_adblock_regions.cpp
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <iostream>
+#include <fstream>
+#include "filter_list.cc"
+#include "lists/regions.h"
+
+// Gets regions from regions.h file and parses it to a format supported by iOS app.
+int main(int argc, const char * argv[]) {
+    std::string regionListTxt;
+
+    for (int i = 0; i < region_lists.size(); i++) {
+        std::string regionLine;
+
+        FilterList region = region_lists[i];
+
+        if(region.langs.size() == 0) {
+            continue;
+        }
+
+        for(int j = 0; j < region.langs.size(); j++) {
+            std::string language = region.langs[j];
+            regionLine.append(language);
+            regionLine.append(",");
+        }
+
+        regionLine.append(region.uuid);
+        regionListTxt.append(regionLine);
+        regionListTxt.append("\n");
+    }
+
+    std::ofstream file("adblock-regions.txt");
+    file << regionListTxt;
+
+    return 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,23 @@
         }
       }
     },
+    "ad-block": {
+      "version": "github:brave/ad-block#b933cf5168c5284dc159735d8bcefb415d0cfc00",
+      "from": "github:brave/ad-block#b933cf5168c5284dc159735d8bcefb415d0cfc00",
+      "requires": {
+        "bloom-filter-cpp": "^1.2.0",
+        "cppunitlite": "^1.0.0",
+        "hashset-cpp": "^2.1.0",
+        "nan": "^2.10.0"
+      },
+      "dependencies": {
+        "cppunitlite": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cppunitlite/-/cppunitlite-1.0.0.tgz",
+          "integrity": "sha1-2bM71NvefeawnjU0F24EZlP6vOs="
+        }
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -993,6 +1010,11 @@
         "safe-buffer": "^5.0.1",
         "unorm": "^1.3.3"
       }
+    },
+    "bloom-filter-cpp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bloom-filter-cpp/-/bloom-filter-cpp-1.2.0.tgz",
+      "integrity": "sha512-R5axBRU0tvJK6tZmTFj8pMdjWtjh6eUWDUVj2I8nyeCYVOUKbW+uzM8VsWvMlAYs82fdUUZmA4/rNGkHW+dPNw=="
     },
     "bluebird": {
       "version": "3.5.1",
@@ -2794,6 +2816,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "hashset-cpp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hashset-cpp/-/hashset-cpp-2.1.0.tgz",
+      "integrity": "sha512-+HbrTNQH/qiWeObpS0ZFP0INA4yalHCm0j/lHW1V6h106DO+EOp26xQQqFsjGtrqy6vgB7hucTZarByazSd1Uw=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3441,9 +3468,7 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "negotiator": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Brave for iOS",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "build:sync": "cd node_modules/brave-sync; npm install && npm run build; cd node_modules/brave-crypto; npm run build"
+    "build:sync": "cd node_modules/brave-sync; npm install && npm run build; cd node_modules/brave-crypto; npm run build",
+    "build:adblock": "cd node_modules/ad-block; npm install && npm run build"
   },
   "repository": {
     "type": "git",
@@ -12,9 +13,10 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-sync": "github:brave/sync#staging",
+    "brave-sync": "brave/sync#staging",
     "page-metadata-parser": "^1.1.2",
-    "readability": "mozilla/readability#3c76104adb00eb9897517e6be6c74c6c05918dfe"
+    "readability": "mozilla/readability#3c76104adb00eb9897517e6be6c74c6c05918dfe",
+    "ad-block": "brave/ad-block.git#b933cf5168c5284dc159735d8bcefb415d0cfc00"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->
Please check it out and see if it compiles and show blocked stats correctly for you.

I took `Adblocker.swift` class from 1.6 and cleaned it up a bit. 

Notes:
- I added support of downloading regional filters, although I don't see it in the app, do we even use region specific adblocking?
- I updated adblock library dependency to the latest version and pinned it.
- Some websites under or overreport number of blocked ads compared to 1.6

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
