### PR TITLE
Fix #538: Align the two empty private tab mode labels

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -956,7 +956,6 @@ fileprivate class EmptyPrivateTabsView: UIView {
     
     let stackView = UIStackView().then {
         $0.axis = .vertical
-        $0.alignment = .center
         $0.spacing = EmptyPrivateTabsViewUX.StackViewSpacing
     }
     
@@ -989,6 +988,7 @@ fileprivate class EmptyPrivateTabsView: UIView {
     }
 
     let iconImageView = UIImageView(image: #imageLiteral(resourceName: "private_glasses")).then {
+        $0.contentMode = .center
         $0.setContentHuggingPriority(.required, for: .vertical)
         $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
     }


### PR DESCRIPTION
Low priority merge

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

_None included_
