### PR TITLE
Fixed #518, caused by non thread safe favourite order

### DIFF
--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesHelper.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesHelper.swift
@@ -15,9 +15,7 @@ struct FavoritesHelper {
 
     // MARK: - Favorites initialization
     static func addDefaultFavorites() {
-        PreloadedFavorites.getList().forEach { fav in
-            Bookmark.add(url: fav.url, title: fav.title, isFavorite: true)
-        }
+        Bookmark.add(defaults: PreloadedFavorites.getList())
     }
 
     static func convertToBookmarks(_ sites: [Site]) {

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesHelper.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesHelper.swift
@@ -15,7 +15,7 @@ struct FavoritesHelper {
 
     // MARK: - Favorites initialization
     static func addDefaultFavorites() {
-        Bookmark.add(defaults: PreloadedFavorites.getList())
+        Bookmark.add(from: PreloadedFavorites.getList())
     }
 
     static func convertToBookmarks(_ sites: [Site]) {

--- a/Data/models/Bookmark+Sync.swift
+++ b/Data/models/Bookmark+Sync.swift
@@ -93,8 +93,6 @@ extension Bookmark {
         } else {
             syncOrder = Sync.shared.getBookmarkOrder(previousOrder: lastBookmarkOrder, nextOrder: nil)
         }
-        
-        DataController.save(context: context)
     }
     
     class func removeSyncOrders() {

--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -243,13 +243,13 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
             format: "%K == %@ AND %K == NO", parentFolderKP, parent ?? nilArgumentForPredicate, isFavoriteKP)
     }
     
-    public class func add(defaults: [(url: URL, title: String)]) {
+    public class func add(from list: [(url: URL, title: String)]) {
         let context = DataController.newBackgroundContext()
         context.performAndWait {
-            defaults.forEach { fav in
+            list.forEach { fav in
                 Bookmark.add(url: fav.url, title: fav.title, isFavorite: true, save: false, context: context)
             }
-            context.saveContext()
+            DataController.save(context: context)
         }
     }
     

--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -200,7 +200,7 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         bk.syncOrder = root?.syncOrder
         
         if let location = site?.location, let url = URL(string: location) {
-            bk.domain = Domain.getOrCreateForUrl(url, context: context)
+            bk.domain = Domain.getOrCreateForUrl(url, context: context, save: false)
         }
         
         // This also sets up a parent folder
@@ -243,13 +243,25 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
             format: "%K == %@ AND %K == NO", parentFolderKP, parent ?? nilArgumentForPredicate, isFavoriteKP)
     }
     
+    public class func add(defaults: [(url: URL, title: String)]) {
+        let context = DataController.newBackgroundContext()
+        context.performAndWait {
+            defaults.forEach { fav in
+                Bookmark.add(url: fav.url, title: fav.title, isFavorite: true, save: false, context: context)
+            }
+            context.saveContext()
+        }
+    }
+    
     public class func add(url: URL?,
                           title: String?,
                           customTitle: String? = nil, // Folders only use customTitle
                           parentFolder: Bookmark? = nil,
                           isFolder: Bool = false,
                           isFavorite: Bool = false,
-                          syncOrder: String? = nil) {
+                          syncOrder: String? = nil,
+                          save: Bool = true,
+                          context: NSManagedObjectContext? = nil) {
         
         let site = SyncSite()
         site.title = title
@@ -263,7 +275,7 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         bookmark.site = site
         bookmark.syncOrder = syncOrder
         
-        _ = add(rootObject: bookmark, save: true, sendToSync: true, parentFolder: parentFolder)
+        _ = add(rootObject: bookmark, save: save, sendToSync: true, parentFolder: parentFolder, context: context ?? DataController.newBackgroundContext())
     }
     
     public class func contains(url: URL, getFavorites: Bool = false) -> Bool {

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -97,17 +97,3 @@ public class DataController: NSObject {
         container.persistentStoreDescriptions = [storeDescription]
     }
 }
-
-extension NSManagedObjectContext {
-    public func saveContext () {
-        if self.hasChanges {
-            do {
-                try self.save()
-            } catch {
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-        self.parent?.saveContext()
-    }
-}

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -98,3 +98,16 @@ public class DataController: NSObject {
     }
 }
 
+extension NSManagedObjectContext {
+    public func saveContext () {
+        if self.hasChanges {
+            do {
+                try self.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+        self.parent?.saveContext()
+    }
+}

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -44,15 +44,12 @@ public final class Domain: NSManagedObject, CRUD {
         //  A solution to consider is creating a new background context here, creating, saving, and then re-fetching
         //   that object in the requested context (regardless if it is `viewContext` or not)
         var newDomain: Domain!
-        // Since most calls are from main queue performandWait has no adavantage.
-//        context.performAndWait {
-//
-//            DataController.save(context: context)
-//        }
-        newDomain = Domain(entity: Domain.entity(context), insertInto: context)
-        newDomain.url = domainString
-        if save {
-            DataController.save(context: context)
+        context.performAndWait {
+            newDomain = Domain(entity: Domain.entity(context), insertInto: context)
+            newDomain.url = domainString
+            if save {
+                DataController.save(context: context)
+            }
         }
         return newDomain
     }

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -32,7 +32,7 @@ public final class Domain: NSManagedObject, CRUD {
         super.awakeFromInsert()
     }
 
-    public class func getOrCreateForUrl(_ url: URL, context: NSManagedObjectContext) -> Domain {
+    public class func getOrCreateForUrl(_ url: URL, context: NSManagedObjectContext, save: Bool = true) -> Domain {
         let domainString = url.domainURL.absoluteString
         if let domain = Domain.first(where: NSPredicate(format: "url == %@", domainString), context: context) {
             return domain
@@ -44,9 +44,14 @@ public final class Domain: NSManagedObject, CRUD {
         //  A solution to consider is creating a new background context here, creating, saving, and then re-fetching
         //   that object in the requested context (regardless if it is `viewContext` or not)
         var newDomain: Domain!
-        context.performAndWait {
-            newDomain = Domain(entity: Domain.entity(context), insertInto: context)
-            newDomain.url = domainString
+        // Since most calls are from main queue performandWait has no adavantage.
+//        context.performAndWait {
+//
+//            DataController.save(context: context)
+//        }
+        newDomain = Domain(entity: Domain.entity(context), insertInto: context)
+        newDomain.url = domainString
+        if save {
             DataController.save(context: context)
         }
         return newDomain


### PR DESCRIPTION
**Why**
Initial sync order was created in parallel, causing same order for more than one bookmark. This bug was further visible when user reorders the bookmarks and new orders are to be generated.

**Fix applied**

Background context performblockAndWait and all nested contexts changed to the original background context

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
