### PR TITLE
Fixed #537: Fix favorite edit crash (#549)

### DIFF
--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -90,7 +90,7 @@ extension FavoritesDataSource: NSFetchedResultsControllerDelegate {
 
         switch type {
         case .insert:
-            if let indexPath = indexPath {
+            if let indexPath = newIndexPath {
                 collectionView?.insertItems(at: [indexPath])
             }
         case .delete:


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
