### PR TITLE
Fixed #515 for case of entering PBM from inside a normal tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -780,7 +780,13 @@ class BrowserViewController: UIViewController {
         }
         
         func shouldShowTabBar() -> Bool {
-            let tabCount = tabManager.tabsForCurrentMode.count
+            let tabCount: Int
+            if !PrivateBrowsingManager.shared.isPrivateBrowsing && tabManager.selectedTab?.isPrivate == true {
+                // Entering PBM from normal
+                tabCount = 1
+            } else {
+                tabCount = tabManager.tabsForCurrentMode.count
+            }
             guard let tabBarVisibility = TabBarVisibility(rawValue: Preferences.General.tabBarVisibility.value) else {
                 // This should never happen
                 assertionFailure("Invalid tab bar visibility preference: \(Preferences.General.tabBarVisibility.value).")
@@ -2010,7 +2016,13 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     fileprivate func updateTabCountUsingTabManager(_ tabManager: TabManager) {
-        let count = tabManager.tabsForCurrentMode.count
+        let count: Int
+        if !PrivateBrowsingManager.shared.isPrivateBrowsing && tabManager.selectedTab?.isPrivate == true {
+            // Entering PBM from normal
+            count = 1
+        } else {
+            count = tabManager.tabsForCurrentMode.count
+        }
         toolbar?.updateTabCount(count)
         urlBar.updateTabCount(count)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2366,7 +2366,6 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             let tabType = currentTab.type
 
             let addTab = { (rURL: URL, isPrivate: Bool) in
-                PrivateBrowsingManager.shared.isPrivateBrowsing = isPrivate
                     let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)
 
                     // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -780,13 +780,7 @@ class BrowserViewController: UIViewController {
         }
         
         func shouldShowTabBar() -> Bool {
-            let tabCount: Int
-            if !PrivateBrowsingManager.shared.isPrivateBrowsing && tabManager.selectedTab?.isPrivate == true {
-                // Entering PBM from normal
-                tabCount = 1
-            } else {
-                tabCount = tabManager.tabsForCurrentMode.count
-            }
+            let tabCount = tabManager.tabsForCurrentMode.count
             guard let tabBarVisibility = TabBarVisibility(rawValue: Preferences.General.tabBarVisibility.value) else {
                 // This should never happen
                 assertionFailure("Invalid tab bar visibility preference: \(Preferences.General.tabBarVisibility.value).")
@@ -2016,13 +2010,7 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     fileprivate func updateTabCountUsingTabManager(_ tabManager: TabManager) {
-        let count: Int
-        if !PrivateBrowsingManager.shared.isPrivateBrowsing && tabManager.selectedTab?.isPrivate == true {
-            // Entering PBM from normal
-            count = 1
-        } else {
-            count = tabManager.tabsForCurrentMode.count
-        }
+        let count = tabManager.tabsForCurrentMode.count
         toolbar?.updateTabCount(count)
         urlBar.updateTabCount(count)
     }
@@ -2378,6 +2366,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             let tabType = currentTab.type
 
             let addTab = { (rURL: URL, isPrivate: Bool) in
+                PrivateBrowsingManager.shared.isPrivateBrowsing = isPrivate
                     let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)
 
                     // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -193,7 +193,10 @@ class TabManager: NSObject {
         if previous === tab {
             return
         }
-
+        // Convert the global mode to private if opening private tab from normal tab/ history/bookmark.
+        if selectedTab?.isPrivate == false && tab?.isPrivate == true {
+            PrivateBrowsingManager.shared.isPrivateBrowsing = true
+        }
         // Make sure to wipe the private tabs if the user has the pref turned on
         if !TabType.of(tab).isPrivate {
             removeAllPrivateTabs()


### PR DESCRIPTION
No check was in place to see if the new private tab was opened from a normal tab link
Hence a check was put in place
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
