### PR TITLE
Fix #562: Compile content rules when adblock file changes.

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -54,6 +54,9 @@ extension Preferences {
         static let httpsUpgradeCount = Option<Int>(key: "stats.http-upgrade", default: 0)
         static let fingerprintingCount = Option<Int>(key: "stats.fingerprinting", default: 0)
     }
+    public final class BlockFileVersion {
+        public static let adblock = Option<String?>(key: "blockfile.adblock", default: nil)
+    }
 }
 
 extension Preferences {


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
