### PR TITLE
Fix #567, never restore tabs in private only browsing mode.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -418,7 +418,6 @@ class BrowserViewController: UIViewController {
     
     fileprivate func setupTabs() {
         let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
-        let tabs = tabManager.tabsForCurrentMode
         let noTabsAdded = tabManager.tabsForCurrentMode.isEmpty
         
         var tabToSelect: Tab?
@@ -429,7 +428,7 @@ class BrowserViewController: UIViewController {
             // 2. We are in private browsing mode and need to add a new private tab.
             tabToSelect = isPrivate ? tabManager.addTab(isPrivate: true) : tabManager.restoreAllTabs()
         } else {
-            tabToSelect = tabs.last
+            tabToSelect = tabManager.tabsForCurrentMode.last
         }
         
         contentBlockListDeferred?.uponQueue(.main) { _ in

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -417,7 +417,21 @@ class BrowserViewController: UIViewController {
     }
     
     fileprivate func setupTabs() {
-        let tabToSelect = tabManager.restoreAllTabs()
+        let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
+        let tabs = tabManager.tabsForCurrentMode
+        let noTabsAdded = tabManager.tabsForCurrentMode.isEmpty
+        
+        var tabToSelect: Tab?
+        
+        if noTabsAdded {
+            // Two scenarios if there are no tabs in tabmanager:
+            // 1. We have not restored tabs yet, attempt to restore or make a new tab if there is nothing.
+            // 2. We are in private browsing mode and need to add a new private tab.
+            tabToSelect = isPrivate ? tabManager.addTab(isPrivate: true) : tabManager.restoreAllTabs()
+        } else {
+            tabToSelect = tabs.last
+        }
+        
         contentBlockListDeferred?.uponQueue(.main) { _ in
             self.tabManager.selectTab(tabToSelect)
         }
@@ -2814,11 +2828,7 @@ extension BrowserViewController: PreferencesObserver {
             let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
             switchToPrivacyMode(isPrivate: isPrivate)
             PrivateBrowsingManager.shared.isPrivateBrowsing = isPrivate
-            if let firstTab = tabManager.tabsForCurrentMode.first {
-                tabManager.selectTab(firstTab)
-            } else {
-                tabManager.addTabAndSelect(nil, isPrivate: isPrivate)
-            }
+            setupTabs()
             updateTabsBarVisibility()
         case Preferences.Shields.blockAdsAndTracking.key,
              Preferences.Shields.httpsEverywhere.key,

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -765,9 +765,6 @@ class TabManager: NSObject {
     fileprivate lazy var restoreTabsInternal: () -> Tab? = {
         let savedTabs = TabMO.getAll()
         if savedTabs.isEmpty { return { nil } }
-        
-        // We never want to restore tabs in PBM, private tabs are never saved to Core Data.
-        if Preferences.Privacy.privateBrowsingOnly.value { return { nil } }
 
         var tabToSelect: Tab?
         for savedTab in savedTabs {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -765,6 +765,9 @@ class TabManager: NSObject {
     fileprivate lazy var restoreTabsInternal: () -> Tab? = {
         let savedTabs = TabMO.getAll()
         if savedTabs.isEmpty { return { nil } }
+        
+        // We never want to restore tabs in PBM, private tabs are never saved to Core Data.
+        if Preferences.Privacy.privateBrowsingOnly.value { return { nil } }
 
         var tabToSelect: Tab?
         for savedTab in savedTabs {


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
