### PR TITLE
Fix #516, correctly set white background for favicons.

### DIFF
--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -274,14 +274,15 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
             let json = JSON(file)
             var icons: [String: (color: UIColor, url: String)] = [:]
             json.forEach({
-                guard let url = $0.1["domain"].string, let color = $0.1["background_color"].string, var path = $0.1["image_url"].string else {
+                guard let url = $0.1["domain"].string, let color = $0.1["background_color"].string?.lowercased(),
+                    var path = $0.1["image_url"].string else {
                     return
                 }
                 path = path.replacingOccurrences(of: ".png", with: "")
                 let filePath = Bundle.main.path(forResource: "TopSites/" + path, ofType: "png")
                 if let filePath = filePath {
-                    if color == "#fff" || color == "#FFF" {
-                        icons[url] = (UIColor.clear, filePath)
+                    if color == "#fff" {
+                        icons[url] = (UIColor.white, filePath)
                     } else {
                         icons[url] = (UIColor(colorString: color.replacingOccurrences(of: "#", with: "")), filePath)
                     }


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

<img width="379" alt="zrzut ekranu 2018-12-5 o 19 01 51" src="https://user-images.githubusercontent.com/6950387/49533820-521f6a80-f8c0-11e8-8cc2-fcc6b8b6dfd0.png">

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
