### PR TITLE
Fix #566 & Migration code for keychain

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -61,6 +61,7 @@ extension Preferences {
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
         if let pinLockInfo = KeychainWrapper.standard.object(forKey: "pinLockInfo") as? AuthenticationKeychainInfo {
             KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(pinLockInfo)
+            KeychainWrapper.standard.removeObject(forKey: "pinLockInfo")
         }
         
         // Shields

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -59,14 +59,21 @@ extension Preferences {
         
         // Security
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
+        
+        // Solely for 1.6.6 -> 1.7 migration
         if let pinLockInfo = KeychainWrapper.standard.object(forKey: "pinLockInfo") as? AuthenticationKeychainInfo {
-            //Checks if browserLock was enabled in old app.
+            
+            // Checks if browserLock was enabled in old app (1.6.6)
             let browserLockKey = "\(keyPrefix)browserLock"
             let isBrowserLockEnabled = Preferences.defaultContainer.bool(forKey: browserLockKey)
+            
+            // Preference no longer controls passcode functionality, so delete it
             Preferences.defaultContainer.removeObject(forKey: browserLockKey)
             if isBrowserLockEnabled {
                 KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(pinLockInfo)
             }
+            
+            // No longer use this key, so remove, rely on other mechanisms
             KeychainWrapper.standard.removeObject(forKey: "pinLockInfo")
         }
         

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -60,7 +60,12 @@ extension Preferences {
         // Security
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
         if let pinLockInfo = KeychainWrapper.standard.object(forKey: "pinLockInfo") as? AuthenticationKeychainInfo {
-            KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(pinLockInfo)
+            //Checks if browserLock was enabled in old app.
+            let isBrowserLockEnabled: Bool = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: "profile.browserLock") ?? false
+            UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.removeObject(forKey: "profile.browserLock")
+            if isBrowserLockEnabled {
+                KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(pinLockInfo)
+            }
             KeychainWrapper.standard.removeObject(forKey: "pinLockInfo")
         }
         

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -61,8 +61,9 @@ extension Preferences {
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
         if let pinLockInfo = KeychainWrapper.standard.object(forKey: "pinLockInfo") as? AuthenticationKeychainInfo {
             //Checks if browserLock was enabled in old app.
-            let isBrowserLockEnabled: Bool = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.bool(forKey: "profile.browserLock") ?? false
-            UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.removeObject(forKey: "profile.browserLock")
+            let browserLockKey = "\(keyPrefix)browserLock"
+            let isBrowserLockEnabled = Preferences.defaultContainer.bool(forKey: browserLockKey)
+            Preferences.defaultContainer.removeObject(forKey: browserLockKey)
             if isBrowserLockEnabled {
                 KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(pinLockInfo)
             }

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -64,6 +64,8 @@ open class AuthenticationKeychainInfo: NSObject, NSCoding {
         if aDecoder.containsValue(forKey: "isPasscodeRequiredImmediately") {
             self.isPasscodeRequiredImmediately = aDecoder.decodeAsBool(forKey: "isPasscodeRequiredImmediately")
         } else if let interval = aDecoder.decodeObject(forKey: "requiredPasscodeInterval") as? NSNumber {
+            // This is solely used for 1.6.6 -> 1.7 migration
+            //  `requiredPasscodeInterval` is not re-encoded on this object
             self.isPasscodeRequiredImmediately = (interval == 2)
         } else {
             self.isPasscodeRequiredImmediately = true

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -25,7 +25,7 @@ public extension KeychainWrapper {
     }
 }
 
-open class AuthenticationKeychainInfo: NSObject, NSSecureCoding {
+open class AuthenticationKeychainInfo: NSObject, NSCoding {
     fileprivate(set) open var passcode: String?
     open var isPasscodeRequiredImmediately: Bool
     fileprivate(set) open var lockOutInterval: TimeInterval?
@@ -42,10 +42,6 @@ open class AuthenticationKeychainInfo: NSObject, NSSecureCoding {
         self.useTouchID = false
     }
 
-    public static var supportsSecureCoding: Bool {
-        return true
-    }
-    
     open func encode(with aCoder: NSCoder) {
         if let lockOutInterval = lockOutInterval, isLocked() {
             let interval = NSNumber(value: lockOutInterval as Double)
@@ -68,7 +64,7 @@ open class AuthenticationKeychainInfo: NSObject, NSSecureCoding {
         if aDecoder.containsValue(forKey: "isPasscodeRequiredImmediately") {
             self.isPasscodeRequiredImmediately = aDecoder.decodeAsBool(forKey: "isPasscodeRequiredImmediately")
         } else if let interval = aDecoder.decodeObject(forKey: "requiredPasscodeInterval") as? NSNumber {
-            self.isPasscodeRequiredImmediately = (interval == 0)
+            self.isPasscodeRequiredImmediately = (interval == 2)
         } else {
             self.isPasscodeRequiredImmediately = true
         }

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -25,7 +25,7 @@ public extension KeychainWrapper {
     }
 }
 
-open class AuthenticationKeychainInfo: NSObject, NSCoding, NSSecureCoding {
+open class AuthenticationKeychainInfo: NSObject, NSSecureCoding {
     fileprivate(set) open var passcode: String?
     open var isPasscodeRequiredImmediately: Bool
     fileprivate(set) open var lockOutInterval: TimeInterval?

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -34,7 +34,7 @@ open class AuthenticationKeychainInfo: NSObject, NSCoding, NSSecureCoding {
 
     // Timeout period before user can retry entering passcodes
     open var lockTimeInterval: TimeInterval = 15 * 60
-    
+
     public init(passcode: String) {
         self.passcode = passcode
         self.isPasscodeRequiredImmediately = true
@@ -68,7 +68,6 @@ open class AuthenticationKeychainInfo: NSObject, NSCoding, NSSecureCoding {
         if aDecoder.containsValue(forKey: "isPasscodeRequiredImmediately") {
             self.isPasscodeRequiredImmediately = aDecoder.decodeAsBool(forKey: "isPasscodeRequiredImmediately")
         } else if let interval = aDecoder.decodeObject(forKey: "requiredPasscodeInterval") as? NSNumber {
-            // We have updated the immediate lockout value to 2 from 0 due to timing issues with systemUptime()
             self.isPasscodeRequiredImmediately = (interval == 0)
         } else {
             self.isPasscodeRequiredImmediately = true


### PR DESCRIPTION
This will migrate browser lock settings from 1.6 to 1.7+.

**What this fixes**
#566 
And migrates user browser-lock settings (`isPasscodeRequiredImmediately`) from 1.6 to new builds.  
Prevents security loophole when updating the app (The lock wont be shown when you update from 1.6).

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch
@devs: bundle-id and app-groups has to be same -obviously

what to test:
1. browserlock policy is transfered 
2. passcode is 4 digit long if migrated, and its working
3 verify #566 is fixed
