### PR TITLE
Fix #471: Migrate per-domain shield overrides

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -6,6 +6,7 @@ import Foundation
 import Shared
 import BraveShared
 import SwiftKeychainWrapper
+import Data
 
 private let log = Logger.browserLogger
 
@@ -82,6 +83,39 @@ extension Preferences {
         // This needs to be translated to our new preference.
         Preferences.General.isFirstLaunch.value = Preferences.DAU.lastLaunchInfo.value == nil
         
+        // Migrate the shield overrides
+        migrateShieldOverrides()
+        
         Preferences.Migration.completed.value = true
+    }
+    
+    private class func migrateShieldOverrides() {
+        // 1.6 had an unfortunate bug that caused shield overrides to create new Domain objects using `http` regardless
+        // which would lead to a duplicated Domain object using http that held custom shield overides settings for that
+        // domain
+        //
+        // Therefore we need to migrate any `http` Domains shield overrides to its sibiling `https` domain if it exists
+        let allHttpPredicate = NSPredicate(format: "url BEGINSWITH[cd] 'http://'")
+        let backgroundContext = DataController.newBackgroundContext()
+        
+        guard let httpDomains = Domain.all(where: allHttpPredicate, context: backgroundContext) else {
+            return
+        }
+        
+        for domain in httpDomains {
+            guard let urlString = domain.url, var urlComponents = URLComponents(string: urlString) else { continue }
+            urlComponents.scheme = "https"
+            guard let httpsUrl = urlComponents.url?.absoluteString else { continue }
+            if let httpsDomain = Domain.first(where: NSPredicate(format: "url == %@", httpsUrl), context: backgroundContext) {
+                httpsDomain.shield_allOff = domain.shield_allOff
+                httpsDomain.shield_adblockAndTp = domain.shield_adblockAndTp
+                httpsDomain.shield_noScript = domain.shield_noScript
+                httpsDomain.shield_fpProtection = domain.shield_fpProtection
+                httpsDomain.shield_safeBrowsing = domain.shield_safeBrowsing
+                httpsDomain.shield_httpse = domain.shield_httpse
+                // Could call `domain.delete()` here (or add to batch to delete)
+            }
+        }
+        DataController.save(context: backgroundContext)
     }
 }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -244,7 +244,6 @@ extension URL {
             components.scheme = self.scheme
             components.port = self.port
             components.host = normalized
-            components.path = "/"
             return components.url ?? self
         }
         return self

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -358,9 +358,9 @@ class NSURLExtensionsTests: XCTestCase {
 
     func testdomainURL() {
         let urls = [
-            ("https://www.example.com/index.html", "https://example.com/"),
-            ("https://mail.example.com/index.html", "https://mail.example.com/"),
-            ("https://mail.example.co.uk/index.html", "https://mail.example.co.uk/"),
+            ("https://www.example.com/index.html", "https://example.com"),
+            ("https://mail.example.com/index.html", "https://mail.example.com"),
+            ("https://mail.example.co.uk/index.html", "https://mail.example.co.uk"),
         ]
         urls.forEach { XCTAssertEqual(URL(string:$0.0)!.domainURL.absoluteString, $0.1) }
     }


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

_None included_

## Notes for testing this patch

- Install 1.6.6 and make sure you visit a few pages and set custom shield overrides for a few
- Install 1.7
- The ones that you make custom overrides to should migrate
