### PR TITLE
Fix #592: Add context menu to the add-tab button on iPad

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1671,20 +1671,26 @@ extension BrowserViewController: TabToolbarDelegate {
         showAddTabContextMenu(sourceView: toolbar ?? urlBar, button: button)
     }
     
-    func showAddTabContextMenu(sourceView: UIView, button: UIButton) {
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alertController.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: nil))
+    private func addTabAlertActions() -> [UIAlertAction] {
+        var actions: [UIAlertAction] = []
         if !PrivateBrowsingManager.shared.isPrivateBrowsing {
             let newPrivateTabAction = UIAlertAction(title: Strings.NewPrivateTabTitle, style: .default, handler: { [unowned self] _ in
                 // BRAVE TODO: Add check for DuckDuckGo popup (and based on 1.6, whether the browser lock is enabled?)
                 // before focusing on the url bar
                 self.openBlankNewTab(focusLocationField: true, isPrivate: true)
             })
-            alertController.addAction(newPrivateTabAction)
+            actions.append(newPrivateTabAction)
         }
-        alertController.addAction(UIAlertAction(title: Strings.NewTabTitle, style: .default, handler: { [unowned self] _ in
+        actions.append(UIAlertAction(title: Strings.NewTabTitle, style: .default, handler: { [unowned self] _ in
             self.openBlankNewTab(focusLocationField: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
         }))
+        return actions
+    }
+    
+    func showAddTabContextMenu(sourceView: UIView, button: UIButton) {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alertController.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: nil))
+        addTabAlertActions().forEach(alertController.addAction)
         alertController.popoverPresentationController?.sourceView = sourceView
         alertController.popoverPresentationController?.sourceRect = button.frame
         let generator = UIImpactFeedbackGenerator(style: .heavy)
@@ -1707,6 +1713,12 @@ extension BrowserViewController: TabToolbarDelegate {
             return
         }
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar.view.isHidden) ||
+            (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {
+            addTabAlertActions().forEach(controller.addAction)
+        }
+        
         if tabManager.tabsForCurrentMode.count > 1 {
             controller.addAction(UIAlertAction(title: String(format: Strings.CloseAllTabsTitle, tabManager.tabsForCurrentMode.count), style: .destructive, handler: { _ in
                 self.tabManager.removeAll()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1668,6 +1668,10 @@ extension BrowserViewController: TabToolbarDelegate {
     }
 
     func tabToolbarDidLongPressAddTab(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        showAddTabContextMenu(sourceView: toolbar ?? urlBar, button: button)
+    }
+    
+    func showAddTabContextMenu(sourceView: UIView, button: UIButton) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: nil))
         if !PrivateBrowsingManager.shared.isPrivateBrowsing {
@@ -1681,6 +1685,8 @@ extension BrowserViewController: TabToolbarDelegate {
         alertController.addAction(UIAlertAction(title: Strings.NewTabTitle, style: .default, handler: { [unowned self] _ in
             self.openBlankNewTab(focusLocationField: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
         }))
+        alertController.popoverPresentationController?.sourceView = sourceView
+        alertController.popoverPresentationController?.sourceRect = button.frame
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
         present(alertController, animated: true)
@@ -1745,6 +1751,10 @@ extension BrowserViewController: TabsBarViewControllerDelegate {
         if tab == tabManager.selectedTab { return }
         urlBar.leaveOverlayMode(didCancel: true)
         tabManager.selectTab(tab)
+    }
+    
+    func tabsBarDidLongPressAddTab(_ tabsBarController: TabsBarViewController, button: UIButton) {
+        showAddTabContextMenu(sourceView: tabsBarController.view, button: button)
     }
 }
 

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -10,6 +10,7 @@ import BraveShared
 
 protocol TabsBarViewControllerDelegate: class {
     func tabsBarDidSelectTab(_ tabsBarController: TabsBarViewController, _ tab: Tab)
+    func tabsBarDidLongPressAddTab(_ tabsBarController: TabsBarViewController, button: UIButton)
 }
 
 class TabsBarViewController: UIViewController {
@@ -25,6 +26,7 @@ class TabsBarViewController: UIViewController {
         button.tintColor = UIColor.black
         button.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(addTabPressed), for: .touchUpInside)
+        button.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressAddTab(_:))))
         button.backgroundColor = .clear
         return button
     }()
@@ -130,6 +132,12 @@ class TabsBarViewController: UIViewController {
     
     @objc func addTabPressed() {
         tabManager?.addTabAndSelect(isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+    }
+    
+    @objc private func didLongPressAddTab(_ longPress: UILongPressGestureRecognizer) {
+        if longPress.state == .began {
+            delegate?.tabsBarDidLongPressAddTab(self, button: plusButton)
+        }
     }
     
     func updateData() {


### PR DESCRIPTION
Also: Show new tab context items in the tabs long press when + is unavailable

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![ipad-add 2x](https://user-images.githubusercontent.com/529104/49596893-58a5f480-f949-11e8-9e33-bfbe7b799505.png)

![ipad-no-tabs-bar 2x](https://user-images.githubusercontent.com/529104/49596883-53e14080-f949-11e8-9a72-1efaad7fe428.png)

![iphone-landscape 3x](https://user-images.githubusercontent.com/529104/49596914-65c2e380-f949-11e8-8f48-555182d6ab29.png)


## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
