### PR TITLE
Fixed #518 (Duplication of default favourite sites) for migration case

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -22,6 +22,9 @@ extension Preferences {
             return
         }
         
+        // Migration of fav and bookmarks from Older than 1.7
+        updateSyncOrder()
+        
         // Grab the user defaults that Prefs saves too and the key prefix all objects inside it are saved under
         let userDefaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)
         
@@ -101,6 +104,13 @@ extension Preferences {
         migrateShieldOverrides()
         
         Preferences.Migration.completed.value = true
+    }
+    
+    private class func updateSyncOrder() {
+        let context = DataController.newBackgroundContext()
+        if let _ = Bookmark.updateBookmarksWithNewSyncOrder(context: context, ignoreFavorite: false) {
+            DataController.save(context: context)
+        }
     }
     
     private class func migrateShieldOverrides() {

--- a/Data/models/Bookmark+Sync.swift
+++ b/Data/models/Bookmark+Sync.swift
@@ -57,6 +57,7 @@ extension Bookmark {
                 }
             }
         }
+        updateWithPredicates(predicates: predicates)
         return bookmarksToSend
     }
     

--- a/Data/models/Bookmark+Sync.swift
+++ b/Data/models/Bookmark+Sync.swift
@@ -12,12 +12,13 @@ private let log = Logger.browserLogger
 extension Bookmark {
     /// Sets order for all bookmarks. Needed after user joins sync group for the first time.
     /// Returns an array of bookmarks with updated `syncOrder`.
-    class func updateBookmarksWithNewSyncOrder(parentFolder: Bookmark? = nil,
-                                               context: NSManagedObjectContext) -> [Bookmark]? {
+    public class func updateBookmarksWithNewSyncOrder(parentFolder: Bookmark? = nil,
+                                               context: NSManagedObjectContext,
+                                               ignoreFavorite: Bool = true) -> [Bookmark]? {
         
         var bookmarksToSend = [Bookmark]()
         
-        let predicate = allBookmarksOfAGivenLevelPredicate(parent: parentFolder)
+        let predicate = ignoreFavorite ? allBookmarksOfAGivenLevelPredicate(parent: parentFolder) : NSPredicate(format: "isFavorite == true")
         
         let orderSort = NSSortDescriptor(key: #keyPath(Bookmark.order), ascending: true)
         let createdSort = NSSortDescriptor(key: #keyPath(Bookmark.created), ascending: false)


### PR DESCRIPTION
Fixes a case in #518 which happens during 1.6 to 1.7 migration. Since default favs are already created their syncOrder is nil during db migration. This causes duplication in Fav screen.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
