### PR TITLE
Revert to using `order` for Bookmarks/Favorites.

### DIFF
--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -307,13 +307,6 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         }
         
         DataController.save(context: frc.managedObjectContext)
-        
-        // I am stumped, I can't find the notification that animation is complete for moving.
-        // If I save while the animation is happening, the rows look screwed up (draw on top of each other).
-        // Adding a delay to let animation complete avoids this problem
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) {
-            
-        }
     }
     
     // TODO: Migration syncUUIDS still needs to be solved

--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -82,10 +82,9 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         fetchRequest.entity = Bookmark.entity(context: context)
         fetchRequest.fetchBatchSize = 20
         
-        let syncOrderSort = NSSortDescriptor(key: "syncOrder", ascending: true,
-                                             selector: #selector(NSString.localizedStandardCompare))
-        let createdSort = NSSortDescriptor(key: "created", ascending: true)
-        fetchRequest.sortDescriptors = [syncOrderSort, createdSort]
+        let orderSort = NSSortDescriptor(key: "order", ascending: true)
+        let createdSort = NSSortDescriptor(key: "created", ascending: false)
+        fetchRequest.sortDescriptors = [orderSort, createdSort]
         
         fetchRequest.predicate = forFavorites ?
             NSPredicate(format: "isFavorite == YES") : allBookmarksOfAGivenLevelPredicate(parent: parentFolder)
@@ -197,7 +196,6 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         bk.isFavorite = bookmark?.isFavorite ?? bk.isFavorite
         bk.isFolder = bookmark?.isFolder ?? bk.isFolder
         bk.syncUUID = root?.objectId ?? bk.syncUUID ?? SyncCrypto.uniqueSerialBytes(count: 16)
-        bk.syncOrder = root?.syncOrder
         
         if let location = site?.location, let url = URL(string: location) {
             bk.domain = Domain.getOrCreateForUrl(url, context: context, save: false)
@@ -215,10 +213,6 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
                 // TODO: Setup via bk.children property instead
                 children.forEach { $0.syncParentUUID = bk.syncParentUUID }
             }
-        }
-        
-        if bk.syncOrder == nil {
-            bk.newSyncOrder(forFavorites: bk.isFavorite, context: context)
         }
         
         if save {
@@ -273,7 +267,6 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         bookmark.isFolder = isFolder
         bookmark.parentFolderObjectId = parentFolder?.syncUUID
         bookmark.site = site
-        bookmark.syncOrder = syncOrder
         
         _ = add(rootObject: bookmark, save: save, sendToSync: true, parentFolder: parentFolder, context: context ?? DataController.newBackgroundContext())
     }
@@ -283,81 +276,29 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         return count > 0
     }
     
-    public class func reorderBookmarks(frc: NSFetchedResultsController<Bookmark>?, sourceIndexPath: IndexPath,
-                                       destinationIndexPath: IndexPath) {
+    public class func reorderBookmarks(
+        frc: NSFetchedResultsController<Bookmark>?,
+        sourceIndexPath: IndexPath,
+        destinationIndexPath: IndexPath) {
         guard let frc = frc else { return }
         
         let dest = frc.object(at: destinationIndexPath)
         let src = frc.object(at: sourceIndexPath)
         
-        if dest === src { return }
-        
-        // Note: sync order is also used for ordering favorites and non synchronized bookmarks.
-        reorderWithSyncOrder(frc: frc, sourceBookmark: src, destinationBookmark: dest,
-                             sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath)
-        
-        DataController.save(context: frc.managedObjectContext)
-        if !src.isFavorite { Sync.shared.sendSyncRecords(action: .update, records: [src]) }
-    }
-    
-    private class func reorderWithSyncOrder(frc: NSFetchedResultsController<Bookmark>,
-                                            sourceBookmark src: Bookmark,
-                                            destinationBookmark dest: Bookmark,
-                                            sourceIndexPath: IndexPath,
-                                            destinationIndexPath: IndexPath) {
-        
-        let isMovingUp = sourceIndexPath.row > destinationIndexPath.row
-        
-        // Depending on drag direction, all other bookmarks are pushed up or down.
-        if isMovingUp {
-            var prev: String?
-            
-            // Bookmark at the top has no previous bookmark.
-            if destinationIndexPath.row > 0 {
-                let index = IndexPath(row: destinationIndexPath.row - 1, section: destinationIndexPath.section)
-                prev = frc.object(at: index).syncOrder
-            }
-            
-            let next = dest.syncOrder
-            src.syncOrder = Sync.shared.getBookmarkOrder(previousOrder: prev, nextOrder: next)
-        } else {
-            let prev = dest.syncOrder
-            var next: String?
-            
-            // Bookmark at the bottom has no next bookmark.
-            if let objects = frc.fetchedObjects, destinationIndexPath.row + 1 < objects.count {
-                let index = IndexPath(row: destinationIndexPath.row + 1, section: destinationIndexPath.section)
-                next = frc.object(at: index).syncOrder
-            }
-            
-            src.syncOrder = Sync.shared.getBookmarkOrder(previousOrder: prev, nextOrder: next)
+        if dest === src {
+            return
         }
-    }
-    
-    private class func reorderFavorites(frc: NSFetchedResultsController<Bookmark>,
-                                        sourceBookmark src: Bookmark,
-                                        destinationBookmark dest: Bookmark,
-                                        sourceIndexPath: IndexPath,
-                                        destinationIndexPath: IndexPath) {
+        
         // Warning, this could be a bottleneck, grabs ALL the bookmarks in the current folder
         // But realistically, with a batch size of 20, and most reads around 1ms, a bottleneck here is an edge case.
         // Optionally: grab the parent folder, and the on a bg thread iterate the bms and update their order. Seems like overkill.
-        guard var bms = frc.fetchedObjects else {
-            log.error("Bookmark's frc fetched objects is nil")
-            return
-        }
-        
-        guard let indexOfSourceBookmark = bms.index(of: src), let indexOfDestBookmark = bms.index(of: dest) else {
-            log.error("Index either source or destination bookmark is nil")
-            return
-        }
-        
-        bms.remove(at: indexOfSourceBookmark)
+        var bms = frc.fetchedObjects!
+        bms.remove(at: bms.index(of: src)!)
         if sourceIndexPath.row > destinationIndexPath.row {
             // insert before
-            bms.insert(src, at: indexOfDestBookmark)
+            bms.insert(src, at: bms.index(of: dest)!)
         } else {
-            let end = indexOfDestBookmark + 1
+            let end = bms.index(of: dest)! + 1
             bms.insert(src, at: end)
         }
         
@@ -365,11 +306,13 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
             bms[i].order = Int16(i)
         }
         
+        DataController.save(context: frc.managedObjectContext)
+        
         // I am stumped, I can't find the notification that animation is complete for moving.
         // If I save while the animation is happening, the rows look screwed up (draw on top of each other).
         // Adding a delay to let animation complete avoids this problem
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) {
-            DataController.save(context: frc.managedObjectContext)
+            
         }
     }
     

--- a/DataTests/BookmarkTests.swift
+++ b/DataTests/BookmarkTests.swift
@@ -78,17 +78,9 @@ class BookmarkTests: CoreDataTestCase {
         XCTAssertEqual(objects.count, bookmarksToAdd)
         
         // Testing if it sorts correctly
-        XCTAssertEqual(objects.first?.title, "1")
-        XCTAssertEqual(objects[5].title, "6")
-        XCTAssertEqual(objects.last?.title, "10")
-        
-        // Folder sort is before create sort, the folder should appear at the top.
-        let folderTitle = "100"
-        createAndWait(url: URL(string: ""), title: folderTitle, isFolder: true)
-        
-        try! frc.performFetch()
-        let obj = frc.fetchedObjects!.last
-        XCTAssertEqual(obj?.title, folderTitle)
+        XCTAssertEqual(objects.first?.title, "10")
+        XCTAssertEqual(objects[5].title, "5")
+        XCTAssertEqual(objects.last?.title, "1")
     }
     
     func testFrcWithParentFolder() {
@@ -292,8 +284,8 @@ class BookmarkTests: CoreDataTestCase {
         let sourceObject = result.src
         let destinationObject = result.dest
         
-        XCTAssertEqual(sourceObject.syncOrder, "0.0.6.1")
-        XCTAssertEqual(destinationObject.syncOrder, "0.0.6")
+        XCTAssertEqual(sourceObject.order, 5)
+        XCTAssertEqual(destinationObject.order, 4)
     }
     
     func testBookmarkReorderDragUp() {
@@ -301,8 +293,8 @@ class BookmarkTests: CoreDataTestCase {
         let sourceObject = result.src
         let destinationObject = result.dest
         
-        XCTAssertEqual(sourceObject.syncOrder, "0.0.1.1")
-        XCTAssertEqual(destinationObject.syncOrder, "0.0.2")
+        XCTAssertEqual(sourceObject.order, 1)
+        XCTAssertEqual(destinationObject.order, 2)
     }
     
     func testBookmarkReorderTopToBottom() {
@@ -310,8 +302,8 @@ class BookmarkTests: CoreDataTestCase {
         let sourceObject = result.src
         let destinationObject = result.dest
         
-        XCTAssertEqual(sourceObject.syncOrder, "0.0.0.1")
-        XCTAssertEqual(destinationObject.syncOrder, "0.0.1")
+        XCTAssertEqual(sourceObject.order, 0)
+        XCTAssertEqual(destinationObject.order, 1)
     }
     
     func testBookmarkReorderBottomToTop() {
@@ -319,8 +311,8 @@ class BookmarkTests: CoreDataTestCase {
         let sourceObject = result.src
         let destinationObject = result.dest
         
-        XCTAssertEqual(sourceObject.syncOrder, "0.0.11")
-        XCTAssertEqual(destinationObject.syncOrder, "0.0.10")
+        XCTAssertEqual(sourceObject.order, 9)
+        XCTAssertEqual(destinationObject.order, 8)
     }
     
     func testBookmarksReorderSameIndexPaths() {
@@ -348,28 +340,6 @@ class BookmarkTests: CoreDataTestCase {
         
         Bookmark.reorderBookmarks(frc: nil, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath)
         // Assert nothing.
-    }
-    
-    func testSortingManyBookmarks() {
-        let sortedOrders = ["1.1.0.1", "1.1.1", "1.1.2", "1.1.3", "1.1.4", "1.1.5", "1.1.6", "1.1.7", "1.1.8",
-                            "1.1.9", "1.1.10", "1.1.11", "1.1.12", "1.1.12.1", "1.1.12.1.2", "1.1.12.1.3",
-                            "1.1.13", "1.1.14", "1.1.15", "1.1.16", "1.1.17", "1.1.19", "1.1.20", "1.1.21"]
-        
-        let shuffledOrders = sortedOrders.shuffled()
-        XCTAssertNotEqual(sortedOrders, shuffledOrders)
-        
-        // Adding bookmarks in random order
-        shuffledOrders.forEach {
-            let url = URL(string: "http://brave.com/\($0)")!
-            createAndWait(url: url, title: "Brave", syncOrder: $0)
-        }
-        
-        let frc = Bookmark.frc(parentFolder: nil)
-        // Frc should sort them back
-        try! frc.performFetch()
-        let frcOrders = frc.fetchedObjects!.compactMap { $0.syncOrder }
-        
-        XCTAssertEqual(sortedOrders, frcOrders)
     }
     
     // MARK: - Delete
@@ -528,16 +498,15 @@ class BookmarkTests: CoreDataTestCase {
         let sourceObject = frc.object(at: sourceIndexPath)
         let destinationObject = frc.object(at: destinationIndexPath)
         
-        let sourceOrderBefore = (frc.object(at: sourceIndexPath)).syncOrder
-        let destinationOrderBefore = (frc.object(at: destinationIndexPath)).syncOrder
+        let sourceOrderBefore = (frc.object(at: sourceIndexPath)).order
+        let destinationOrderBefore = (frc.object(at: destinationIndexPath)).order
         
         // CD objects we saved before will get updated after this call.
         Bookmark.reorderBookmarks(frc: frc, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath)
         
         // Test order has changed, won't work when swapping bookmarks with order = 0
         if !skipOrderChangeTests {
-            XCTAssertNotEqual(sourceObject.syncOrder, sourceOrderBefore)
-            XCTAssertEqual(destinationObject.syncOrder, destinationOrderBefore)
+            XCTAssertNotEqual(sourceObject.order, sourceOrderBefore)
         }
         
         return (sourceObject, destinationObject)

--- a/DataTests/FavoriteTests.swift
+++ b/DataTests/FavoriteTests.swift
@@ -118,7 +118,7 @@ class FavoriteTests: CoreDataTestCase {
         // Upon re-order, each now has a given order
         reorder(0, toIndex: 2)
         // Check to see if an order (2) has been given to fetchedObjects index 0
-        XCTAssertEqual(fetchController.fetchedObjects![0].syncOrder, "0.0.3.1")
+        XCTAssertEqual(fetchController.fetchedObjects![0].order, 2)
         
         // Verify that order is now taken into account by refetching
         try! fetchController.performFetch()
@@ -136,9 +136,9 @@ class FavoriteTests: CoreDataTestCase {
         
         reorder(0, toIndex: 2)
         // Check to see if an order (2) has been given to fetchedObjects index 0
-        XCTAssertEqual(first.syncOrder, "0.0.3.1")
+        XCTAssertEqual(first.order, 2)
         // The second favorite should have been pushed backwards to 0 since we moved the original 0 to 2
-        XCTAssertEqual(second.syncOrder, "0.0.2")
+        XCTAssertEqual(second.order, 0)
         
         // Order is now taken into account by refetching
         try! fetchController.performFetch()
@@ -149,7 +149,7 @@ class FavoriteTests: CoreDataTestCase {
         // Verify that the first object at index 0 is the original pushed back one
         XCTAssertEqual(fetchController.fetchedObjects![0], second)
         // Verify that the object at index 1 was pushed back
-        XCTAssertEqual(fetchController.fetchedObjects![1].syncOrder, "0.0.3")
+        XCTAssertEqual(fetchController.fetchedObjects![1].order, 1)
     }
     
     func testMoveToStart() {
@@ -162,7 +162,7 @@ class FavoriteTests: CoreDataTestCase {
         let startIndex = fetchController.fetchedObjects!.startIndex
         
         reorder(3, toIndex: startIndex)
-        XCTAssertEqual(object.syncOrder, "0.0.0.1")
+        XCTAssertEqual(object.order, 0)
         
         // Order is now taken into account by refetching
         try! fetchController.performFetch()
@@ -181,7 +181,7 @@ class FavoriteTests: CoreDataTestCase {
         let endIndex = fetchController.fetchedObjects!.endIndex - 1
         
         reorder(0, toIndex: endIndex)
-        XCTAssertEqual(first.syncOrder, "0.0.6")
+        XCTAssertEqual(first.order, 4)
         
         // Order is now taken into account by refetching
         try! fetchController.performFetch()


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
