### PR TITLE
Fix #510: Fix punycode decoder and disable smart dashes in URL bar

### DIFF
--- a/Client/Frontend/Browser/Punycode.swift
+++ b/Client/Frontend/Browser/Punycode.swift
@@ -123,7 +123,7 @@ extension String {
         var n = initialN
         var bias = initialBias
         var pos = 0
-        if let ipos = input.index(of: delimiter) {
+        if let ipos = input.lastIndex(of: delimiter) {
             pos = ipos
             output.append(contentsOf: input[0 ..< pos])
             pos += 1
@@ -188,7 +188,7 @@ extension String {
         var labels = self.components(separatedBy: ".")
         for (index, part) in labels.enumerated() {
             if isValidPunycodeScala(part) {
-                let changeStr = String(part[part.index(part.startIndex, offsetBy: 4)...])
+                let changeStr = String(part[part.index(part.startIndex, offsetBy: prefixPunycode.count)...])
                 labels[index] = decode(changeStr)
             }
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -358,6 +358,7 @@ class URLBarView: UIView {
         locationTextField.keyboardType = .webSearch
         locationTextField.autocorrectionType = .no
         locationTextField.autocapitalizationType = .none
+        locationTextField.smartDashesType = .no
         locationTextField.returnKeyType = .go
         locationTextField.clearButtonMode = .whileEditing
         locationTextField.textAlignment = .left


### PR DESCRIPTION
Fixes #510

See https://github.com/brave/brave-ios/issues/510#issuecomment-445312822 for an explanation of the problem.

Explanation of changes:

- **Punycode.swift line 126**: find the last hyphen (the delimiter) instead of the first hyphen, in case the URL has other hyphens unrelated to punycode syntax
- **Punycode.swift line 191**: avoid using magic numbers in code: use the length of the punycode prefix instead
- **URLBarView.swift line line 361**: disable smart dashes for the URL field to prevent `--` from being automatically converted to `—`.

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

Smart dashes are now disabled in the URL bar (compare to https://github.com/brave/brave-ios/issues/510#issuecomment-445312822):

![](https://user-images.githubusercontent.com/19424103/49664742-62e2f400-fa18-11e8-86da-0962aad97c45.gif)

## Notes for testing this patch

There are two problems that each have separate verification steps.

Handling hyphens in punycode URL:
1. Open Brave and tap the URL bar.
2. Type `test-😄.com` and tap Go.
3. The app should not crash and should show an error page (the URL is not valid).

Handling the punycode prefix:
1. Open Brave and tap the URL bar.
2. Type `xn--`.
3. The text should remain `xn--` and not change to `xn—` (like the screen capture above).
