### PR TITLE
Fix #604: Cleanup Deprecated APIs and SwiftLint warnings

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -15,6 +15,8 @@
 
 import Shared
 
+// swiftlint:disable line_length
+
 // MARK:-  Common Strings Here.
 public extension Strings {
     public static let CancelButtonTitle = NSLocalizedString("CancelButtonTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Cancel", comment: "")

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -82,7 +82,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     @discardableResult fileprivate func startApplication(_ application: UIApplication, withLaunchOptions launchOptions: [AnyHashable: Any]?) -> Bool {
         log.info("startApplication begin")
         
-        
         // Set the Firefox UA for browsing.
         setUserAgent()
 

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -83,7 +83,7 @@ class SyncAddDeviceViewController: SyncViewController {
 
         view.addSubview(stackView)
         stackView.snp.makeConstraints { make in
-            make.top.equalTo(self.topLayoutGuide.snp.bottom)
+            make.top.equalTo(self.view.safeArea.top)
             make.left.right.equalTo(self.view)
             make.bottom.equalTo(self.view.safeArea.bottom).inset(24)
         }

--- a/Client/Frontend/Sync/SyncPairCameraViewController.swift
+++ b/Client/Frontend/Sync/SyncPairCameraViewController.swift
@@ -30,7 +30,7 @@ class SyncPairCameraViewController: SyncViewController {
         view.addSubview(stackView)
 
         stackView.snp.makeConstraints { make in
-            make.top.equalTo(self.topLayoutGuide.snp.bottom).offset(16)
+            make.top.equalTo(self.view.safeArea.top).offset(16)
             make.left.right.equalTo(self.view).inset(16)
             make.bottom.equalTo(self.view.safeArea.bottom).inset(16)
         }

--- a/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
+++ b/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
@@ -110,7 +110,7 @@ class SyncSelectDeviceTypeViewController: SyncViewController {
         view.addSubview(stackView)
 
         stackView.snp.makeConstraints { make in
-            make.top.equalTo(self.topLayoutGuide.snp.bottom).offset(16)
+            make.top.equalTo(self.view.safeArea.top).offset(16)
             make.left.right.equalTo(self.view).inset(16)
             make.bottom.equalTo(self.view.safeArea.bottom).inset(16)
         }

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -103,7 +103,7 @@ class SyncWelcomeViewController: SyncViewController {
 
         view.addSubview(mainStackView)
         mainStackView.snp.makeConstraints { make in
-            make.top.equalTo(self.topLayoutGuide.snp.bottom)
+            make.top.equalTo(self.view.safeArea.top)
             // This VC doesn't rotate, no need to check for left and right safe area constraints.
             make.left.right.equalTo(self.view).inset(16)
             make.bottom.equalTo(self.view.safeArea.bottom).inset(32)

--- a/Client/WebFilters/AdblockStats/AdBlockStats.swift
+++ b/Client/WebFilters/AdblockStats/AdBlockStats.swift
@@ -53,6 +53,7 @@ class AdBlockStats {
         parseAdblockRegionsFile()
         
         // so that didSet is called from init
+        // swiftlint:disable:next inert_defer
         defer { currentLocaleCode = Locale.current.languageCode ?? AdBlockStats.defaultLocale }
     }
     

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -215,7 +215,7 @@ public class Sync: JSInjector {
         get {
             if !UserDefaults.standard.bool(forKey: prefNameSeed) {
                 // This must be true to stay in sync group
-                KeychainWrapper.standard.remove(key: prefNameSeed)
+                KeychainWrapper.standard.removeObject(forKey: prefNameSeed)
                 return nil
             }
             
@@ -258,13 +258,13 @@ public class Sync: JSInjector {
             fetchTimer?.invalidate()
             fetchTimer = nil
             
-            KeychainWrapper.standard.remove(key: prefNameSeed)
+            KeychainWrapper.standard.removeObject(forKey: prefNameSeed)
         }
     }
     
     public var syncSeedArray: [Int]? {
         let splitBytes = syncSeed?.components(separatedBy: CharacterSet(charactersIn: "[], ")).filter { !$0.isEmpty }
-        let seed = splitBytes?.map { Int($0) }.flatMap { $0 }
+        let seed = splitBytes?.compactMap { Int($0) }
         return seed?.count == Sync.SeedByteLength ? seed : nil
     }
     

--- a/Data/sync/SyncCrypto.swift
+++ b/Data/sync/SyncCrypto.swift
@@ -161,7 +161,7 @@ public class SyncCrypto: JSInjector {
 }
 
 extension SyncCrypto: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         self.isSyncCryptoReady = true
     }
 }


### PR DESCRIPTION
Fixes #604

Summary of changes:

- Disable SwiftLint in certain places
  - **BraveStrings.swift**: disable `line_length` for the whole file because localization strings may be longer than 1000 characters
  - **AdBlockStats.swift**: disable `inert_defer` for line 57 because defer is not pointless (see comment on line 55)
- Change deprecated `topLayoutGuide` to `safeArea.top`
- Change deprecated `KeychainWrapper.standard.remove(key:)` to `KeychainWrapper.standard.removeObject(forKey:)`
- Change deprecated `flatMap` to `compactMap`
- Remove extra line in **AppDelegate.swift**
- Fix method signature access control in **SyncCrypto.swift**, line 164

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have updated the *UI Tests* to cover new or changed functionality
- [x] I have marked the bug with `[needsuplift]`
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Notes for testing this patch
No QA needed.