### PR TITLE
Fix #463: Fixes resolution issue in the favorites view

### DIFF
--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -13,18 +13,18 @@ public extension UIImageView {
         if let url = url, icon == nil {
             let domain = Domain.getOrCreateForUrl(url, context: DataController.viewContext)
             if let favicon = domain.favicon {
-                setIcon(favicon.url, forURL: url, completed: completionBlock, scaledDefaultIconSize: scaledDefaultIconSize)
+                setIconURL(favicon.url, forURL: url, completed: completionBlock, scaledDefaultIconSize: scaledDefaultIconSize)
                 return
             }
         }
-        setIcon(icon?.url, forURL: url, completed: completionBlock, scaledDefaultIconSize: scaledDefaultIconSize)
+        setIconURL(icon?.url, forURL: url, completed: completionBlock, scaledDefaultIconSize: scaledDefaultIconSize)
     }
     
-    public func setIcon(_ icon: FaviconMO?, forURL url: URL?, scaledDefaultIconSize: CGSize? = nil, completed completionBlock: ((UIColor, URL?) -> Void)? = nil) {
-        setIcon(icon?.url, forURL: url, completed: completionBlock, scaledDefaultIconSize: scaledDefaultIconSize)
+    public func setIconMO(_ icon: FaviconMO?, forURL url: URL?, scaledDefaultIconSize: CGSize? = nil, completed completionBlock: ((UIColor, URL?) -> Void)? = nil) {
+        setIconURL(icon?.url, forURL: url, completed: completionBlock, scaledDefaultIconSize: scaledDefaultIconSize)
     }
     
-    private func setIcon(_ iconURL: String?, forURL url: URL?, completed completionBlock: ((UIColor, URL?) -> Void)?, scaledDefaultIconSize: CGSize? = nil) {
+    private func setIconURL(_ iconURL: String?, forURL url: URL?, completed completionBlock: ((UIColor, URL?) -> Void)?, scaledDefaultIconSize: CGSize? = nil) {
         if let url = url, let defaultIcon = FaviconFetcher.getDefaultIconForURL(url: url), iconURL == nil {
             if let scaleToSize = scaledDefaultIconSize {
                 self.image = UIImage(contentsOfFile: defaultIcon.url)?.createScaled(scaleToSize)

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -67,8 +67,7 @@ class FavoritesDataSource: NSObject, UICollectionViewDataSource {
         guard let fav = frc?.object(at: indexPath) else { return UICollectionViewCell() }
 
         cell.textLabel.text = fav.displayTitle ?? fav.url
-        let n: FaviconMO? = nil // Distinguishes which setIcon function is called
-        cell.imageView.setIcon(n, forURL: URL(string: fav.url ?? ""), scaledDefaultIconSize: CGSize(width: 40, height: 40), completed: { (color, url) in
+        cell.imageView.setIconMO(nil, forURL: URL(string: fav.url ?? ""), scaledDefaultIconSize: CGSize(width: 40, height: 40), completed: { (color, url) in
             if fav.url == url?.absoluteString {
                 cell.imageView.backgroundColor = color
             }

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -67,9 +67,10 @@ class FavoritesDataSource: NSObject, UICollectionViewDataSource {
         guard let fav = frc?.object(at: indexPath) else { return UICollectionViewCell() }
 
         cell.textLabel.text = fav.displayTitle ?? fav.url
-        cell.imageView.setIcon(fav.domain?.favicon, forURL: URL(string: fav.url ?? ""), scaledDefaultIconSize: CGSize(width: 40, height: 40), completed: { (color, url) in
+        let n: FaviconMO? = nil // Distinguishes which setIcon function is called
+        cell.imageView.setIcon(n, forURL: URL(string: fav.url ?? ""), scaledDefaultIconSize: CGSize(width: 40, height: 40), completed: { (color, url) in
             if fav.url == url?.absoluteString {
-                cell.imageView.backgroundColor = color                
+                cell.imageView.backgroundColor = color
             }
         })
         cell.accessibilityLabel = cell.textLabel.text

--- a/Client/Frontend/Menu/BookmarksViewController.swift
+++ b/Client/Frontend/Menu/BookmarksViewController.swift
@@ -343,7 +343,7 @@ class BookmarksViewController: SiteTableViewController {
         cell.imageView?.layer.borderColor = BraveUX.faviconBorderColor.cgColor
         cell.imageView?.layer.borderWidth = BraveUX.faviconBorderWidth
         // favicon object associated through domain relationship - set from cache or download
-        cell.imageView?.setIcon(item.domain?.favicon, forURL: URL(string: item.url ?? ""))
+        cell.imageView?.setIconMO(item.domain?.favicon, forURL: URL(string: item.url ?? ""))
       }
     }
     

--- a/Client/Frontend/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Menu/HistoryViewController.swift
@@ -122,7 +122,7 @@ class HistoryViewController: SiteTableViewController {
     cell.imageView?.layer.cornerRadius = 6
     cell.imageView?.layer.masksToBounds = true
     
-    cell.imageView?.setIcon(site.domain?.favicon, forURL: URL(string: site.url ?? ""))
+    cell.imageView?.setIconMO(site.domain?.favicon, forURL: URL(string: site.url ?? ""))
   }
   
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

<img src="https://user-images.githubusercontent.com/18453121/49692059-6a8cc080-fb1e-11e8-9cc0-3a6511114282.gif" width="300px">

## Notes for testing this patch

Fixes [issue 463](https://github.com/brave/brave-ios/issues/463)

The issue stems from passing in a non-nil icon value into the setIcon function which uses that image as an upscale instead of using the FaviconFetcher. 
