### PR TITLE
Fix #590: Don't show padlock while content blocker rules are compiling

### DIFF
--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -136,6 +136,7 @@ class TabLocationView: UIView {
 
     fileprivate lazy var lockImageView: UIImageView = {
         let lockImageView = UIImageView(image: #imageLiteral(resourceName: "lock_verified").template)
+        lockImageView.isHidden = true // Hidden by default
         lockImageView.tintColor = UIColor.Photon.Green50
         lockImageView.isAccessibilityElement = true
         lockImageView.contentMode = .center


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![simulator screen shot - iphone x - 2018-12-13 at 12 19 38](https://user-images.githubusercontent.com/529104/49955657-5e638300-fed1-11e8-81f2-e67936afff62.png)

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
