### PR TITLE
Fix #625: Allow updating shields on all error pages

### DIFF
--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -14,7 +14,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
     private lazy var url: URL? = {
         guard let _url = tab.url else { return nil }
         
-        if _url.safeBrowsingErrorURL {
+        if _url.isErrorPageURL {
             return _url.originalURLFromErrorURL
         }
         


### PR DESCRIPTION
Allows the user to disable a shield which may have blocked an entire URL load

Note: Due to an issue with shield overrides respecting scheme, if you disable adblocking on a URL which got blocked on `http` and then when unblocked upgrades to `https`, it will still continue to block because `https` scheme shield overrides don't have that shield disabled (and since the original URL load is `http` it will look like it failed on `http` again)

This issue will be dealt with in a separate issue/PR

## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![simulator screen shot - iphone x - 2018-12-14 at 10 20 52](https://user-images.githubusercontent.com/529104/50014935-4a805580-ff93-11e8-9e08-f0f06b0aafc3.png)

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
