### PR TITLE
Fix #458: Present passcode entry when user cancel's biometrics input

### DIFF
--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -96,8 +96,7 @@ class AppAuthenticator {
                     self.dismissPrompt()
                     self.didCancelPasscodeEntry?()
                 } else {
-                    self.isPrompting = false
-                    self.promptUserForAuthentication()
+                    AppAuthenticator.presentPasscodeAuthentication(self.blurController, delegate: self, isCancellable: self.isPasscodeEntryCancellable)
                 }
             },
             fallback: {


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
