### PR TITLE
Fix #630: "Open in" respects private-only-browsing

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import BraveShared
 
 // Used by the App to navigate to different views.
 // To open a URL use /open-url or to open a blank tab use /open-url with no params
@@ -47,7 +48,8 @@ enum NavigationPath: Equatable {
             self = .deepLink(link)
         } else if urlString.starts(with: "\(scheme)://open-url") {
             let url = components.valueForQuery("url")?.asURL
-            let isPrivate = Bool(components.valueForQuery("private") ?? "") ?? false
+            let forcedPrivate = Preferences.Privacy.privateBrowsingOnly.value || PrivateBrowsingManager.shared.isPrivateBrowsing
+            let isPrivate = Bool(components.valueForQuery("private") ?? "") ?? forcedPrivate
             self = .url(webURL: url, isPrivate: isPrivate)
         } else if urlString.starts(with: "\(scheme)://open-text") {
             let text = components.valueForQuery("text")

--- a/ClientTests/NavigationRouterTests.swift
+++ b/ClientTests/NavigationRouterTests.swift
@@ -5,10 +5,22 @@
 import Foundation
 @testable import Client
 import WebKit
-
+import BraveShared
 import XCTest
 
 class NavigationRouterTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        PrivateBrowsingManager.shared.isPrivateBrowsing = false
+        Preferences.Privacy.privateBrowsingOnly.reset()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        PrivateBrowsingManager.shared.isPrivateBrowsing = false
+        Preferences.Privacy.privateBrowsingOnly.reset()
+    }
     
     var appScheme: String {
         let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as! [AnyObject]
@@ -28,5 +40,46 @@ class NavigationRouterTests: XCTestCase {
         
         let badNav = NavigationPath(url: URL(string: "\(appScheme)://open-url?url=blah")!)
         XCTAssertEqual(badNav, NavigationPath.url(webURL: URL(string: "blah"), isPrivate: false))
+    }
+    
+    func testDefaultNavigationPath() {
+        let url = URL(string: "https://duckduckgo.com")!
+        let appURL = URL(string: "\(self.appScheme)://open-url?url=\(url.absoluteString.escape()!)")!
+        let path = NavigationPath(url: appURL)!
+        
+        XCTAssertEqual(path, NavigationPath.url(webURL: url, isPrivate: false))
+    }
+    
+    func testNavigationPathInPrivateBrowsingOnlyMode() {
+        Preferences.Privacy.privateBrowsingOnly.value = true
+        
+        let url = URL(string: "https://duckduckgo.com")!
+        let appURL = URL(string: "\(self.appScheme)://open-url?url=\(url.absoluteString.escape()!)")!
+        let path = NavigationPath(url: appURL)!
+        
+        // Should inheritely be private by default
+        XCTAssertEqual(path, NavigationPath.url(webURL: url, isPrivate: true))
+    }
+    
+    func testNavigationPathAlreadyInPrivateBrowsingMode() {
+        PrivateBrowsingManager.shared.isPrivateBrowsing = true
+        
+        let url = URL(string: "https://duckduckgo.com")!
+        let appURL = URL(string: "\(self.appScheme)://open-url?url=\(url.absoluteString.escape()!)")!
+        let path = NavigationPath(url: appURL)!
+        
+        // Should inheritely be private by default
+        XCTAssertEqual(path, NavigationPath.url(webURL: url, isPrivate: true))
+    }
+    
+    func testNavigationPathForcedRegularMode() {
+        PrivateBrowsingManager.shared.isPrivateBrowsing = true
+        
+        let url = URL(string: "https://duckduckgo.com")!
+        let appURL = URL(string: "\(self.appScheme)://open-url?url=\(url.absoluteString.escape()!)&private=false")!
+        let path = NavigationPath(url: appURL)!
+        
+        // Should be regular due to specified argument in the URL
+        XCTAssertEqual(path, NavigationPath.url(webURL: url, isPrivate: false))
     }
 }


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
