### PR TITLE
Fix #634: Fix new tab keyboard shortcut in private browsing

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -37,7 +37,7 @@ extension BrowserViewController {
     }
 
     @objc private func newTabKeyCommand() {
-        openBlankNewTab(focusLocationField: true, isPrivate: false)
+        openBlankNewTab(focusLocationField: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
     }
 
     @objc private func newPrivateTabKeyCommand() {


### PR DESCRIPTION
Fixes #634

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

Here is what happens after pressing Command+T with the fix:
![](https://user-images.githubusercontent.com/19424103/50050586-1d33c480-00c5-11e9-9d70-86321db12f6d.gif)

## Notes for testing this patch

1. Run Brave on iPad Pro (device with keyboard or simulator).
2. Tap the tabs button and change tap the Private button to enable private browsing.
3. Tap the plus button to create a new tab.
4. Press the keyboard shortcut Command+T.
5. Make sure a new tab is opened.