### PR TITLE
Fix #540: Show error page when for URLs missing a host (e.g. `https://`)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -298,6 +298,9 @@ extension BrowserViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         if let tab = tabManager[webView] {
             navigateInTab(tab: tab, to: navigation)
+            if tab === tabManager.selectedTab {
+                urlBar.updateProgressBar(1.0)
+            }
             tabsBar.reloadDataAndRestoreSelectedTab()
         }
     }

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -150,7 +150,6 @@ class ErrorPageHelper {
                   let errCode = Int(code),
                   let errDescription = query["description"] as? String,
                   let errURLString = query["url"] as? String,
-                  let errURLDomain = URL(string: errURLString)?.host,
                   var errDomain = query["domain"] as? String else {
                 return GCDWebServerResponse(statusCode: 404)
             }
@@ -175,7 +174,8 @@ class ErrorPageHelper {
                 }
                 errDomain = ""
             } else if CertErrors.contains(errCode) {
-                guard let query = request?.query, let certError = query["certerror"] as? String else {
+                guard let query = request?.query, let certError = query["certerror"] as? String,
+                    let errURLDomain = URL(string: errURLString)?.host else {
                     return GCDWebServerResponse(statusCode: 404)
                 }
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

![simulator screen shot - iphone x - 2018-12-17 at 14 51 51](https://user-images.githubusercontent.com/529104/50111803-a5bc7d00-020b-11e9-93e1-afd25608a40c.png)

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
