### PR TITLE
To be reverted: Hide HTTPSE UI and disable HTTPSE shield

### DIFF
--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -35,7 +35,7 @@ class BraveShieldStatsView: UIView, Themeable {
     }()
     
     lazy var stats: [StatView] = {
-        return [self.adsStatView, self.httpsStatView, self.timeStatView]
+        return [self.adsStatView/*, self.httpsStatView*/, self.timeStatView]
     }()
     
     override init(frame: CGRect) {

--- a/Client/Frontend/ContentBlocker/BlocklistName.swift
+++ b/Client/Frontend/ContentBlocker/BlocklistName.swift
@@ -55,9 +55,9 @@ class BlocklistName: Hashable, CustomStringConvertible, ContentBlocker {
         
         // TODO #159: Setup image shield
         
-        if domain.isShieldExpected(.HTTPSE) {
-            onList.formUnion([.https])
-        }
+//        if domain.isShieldExpected(.HTTPSE) {
+//            onList.formUnion([.https])
+//        }
         
         return (onList, allLists.subtracting(onList))
     }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -233,7 +233,7 @@ class SettingsViewController: TableViewController {
             header: .title(Strings.Brave_Shield_Defaults),
             rows: [
                 BoolRow(title: Strings.Block_Ads_and_Tracking, option: Preferences.Shields.blockAdsAndTracking),
-                BoolRow(title: Strings.HTTPS_Everywhere, option: Preferences.Shields.httpsEverywhere),
+//                BoolRow(title: Strings.HTTPS_Everywhere, option: Preferences.Shields.httpsEverywhere),
                 BoolRow(title: Strings.Block_Phishing_and_Malware, option: Preferences.Shields.blockPhishingAndMalware),
                 BoolRow(title: Strings.Block_Scripts, option: Preferences.Shields.blockScripts),
                 BoolRow(title: Strings.Fingerprinting_Protection, option: Preferences.Shields.fingerprintingProtection),

--- a/Client/Frontend/Shields/ShieldsView.swift
+++ b/Client/Frontend/Shields/ShieldsView.swift
@@ -151,7 +151,7 @@ extension ShieldsViewController {
             addArrangedSubview(hostLabel)
             addArrangedSubview(statsHeaderLabel)
             setCustomSpacing(15.0, after: statsHeaderLabel)
-            let statViews = [adsTrackersStatView, httpsUpgradesStatView, scriptsBlockedStatView, fingerprintingStatView]
+            let statViews = [adsTrackersStatView/*, httpsUpgradesStatView*/, scriptsBlockedStatView, fingerprintingStatView]
             statViews.forEach {
                 addArrangedSubview($0)
                 if $0 !== statViews.last {
@@ -163,7 +163,7 @@ extension ShieldsViewController {
             addArrangedSubview(settingsDivider)
             addArrangedSubview(settingsHeaderLabel)
             
-            [adsTrackersControl, httpsUpgradesControl, blockMalwareControl, blockScriptsControl, fingerprintingControl].forEach {
+            [adsTrackersControl/*, httpsUpgradesControl*/, blockMalwareControl, blockScriptsControl, fingerprintingControl].forEach {
                 addArrangedSubview($0)
                 setCustomSpacing(18.0, after: $0)
             }

--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -74,7 +74,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
     
     private func updateShieldBlockStats() {
         shieldsView.shieldsContainerStackView.adsTrackersStatView.valueLabel.text = String(tab.contentBlocker.stats.adCount + tab.contentBlocker.stats.trackerCount)
-        shieldsView.shieldsContainerStackView.httpsUpgradesStatView.valueLabel.text = String(tab.contentBlocker.stats.httpsCount)
+//        shieldsView.shieldsContainerStackView.httpsUpgradesStatView.valueLabel.text = String(tab.contentBlocker.stats.httpsCount)
         shieldsView.shieldsContainerStackView.scriptsBlockedStatView.valueLabel.text = String(tab.contentBlocker.stats.scriptCount)
         shieldsView.shieldsContainerStackView.fingerprintingStatView.valueLabel.text = String(tab.contentBlocker.stats.fingerprintingCount)
     }
@@ -122,7 +122,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
         (.AdblockAndTp, shieldsView.shieldsContainerStackView.adsTrackersControl, Preferences.Shields.blockAdsAndTracking),
         (.SafeBrowsing, shieldsView.shieldsContainerStackView.blockMalwareControl, Preferences.Shields.blockPhishingAndMalware),
         (.NoScript, shieldsView.shieldsContainerStackView.blockScriptsControl, Preferences.Shields.blockScripts),
-        (.HTTPSE, shieldsView.shieldsContainerStackView.httpsUpgradesControl, Preferences.Shields.httpsEverywhere),
+//        (.HTTPSE, shieldsView.shieldsContainerStackView.httpsUpgradesControl, Preferences.Shields.httpsEverywhere),
         (.FpProtection, shieldsView.shieldsContainerStackView.fingerprintingControl, Preferences.Shields.fingerprintingProtection),
     ]
     


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Pull Request Checklist

- [ ] My patch has gone through review and I have addressed review comments
- [ ] My patch has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!`

- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have updated the *UI Tests* to cover new or changed functionality
- [ ] I have marked the bug with `[needsuplift]`
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here.

## Notes for testing this patch

If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified.
