### PR TITLE
Fix #637: On iPad, show the partner popup after dismissing settings

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1371,7 +1371,15 @@ extension BrowserViewController: SettingsDelegate {
     }
     
     func settingsDidFinish(_ settingsViewController: SettingsViewController) {
-        settingsViewController.dismiss(animated: true)
+        settingsViewController.dismiss(animated: true, completion: {
+            // iPad doesn't receive a viewDidAppear because it displays settings as a floating modal window instead
+            // of a fullscreen overlay.
+            if UIDevice.isIpad && PrivateBrowsingManager.shared.isPrivateBrowsing {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    self.presentDuckDuckGoCallout()
+                }
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adaquate test plan exists for QA to validate (if applicable)

