### PR TITLE
Fix #737: Don't show incorrect on/off states for settings switch cells

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -21,13 +21,34 @@ extension TabBarVisibility: RepresentableOptionType {
     }
 }
 
+/// The same style switch accessory view as in Static framework, except will not be recreated each time the Cell
+/// is configured, since it will be stored as is in `Row.Accessory.view`
+private class SwitchAccessoryView: UISwitch {
+    typealias ValueChange = (Bool) -> Void
+    
+    init(initialValue: Bool, valueChange: (ValueChange)? = nil) {
+        self.valueChange = valueChange
+        super.init(frame: .zero)
+        isOn = initialValue
+        addTarget(self, action: #selector(valueChanged), for: .valueChanged)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    var valueChange: ValueChange?
+    
+    @objc func valueChanged() {
+        valueChange?(self.isOn)
+    }
+}
+
 /// Just creates a switch toggle `Row` which updates a `Preferences.Option<Bool>`
 private func BoolRow(title: String, option: Preferences.Option<Bool>) -> Row {
     return Row(
         text: title,
-        accessory: .switchToggle(
-            value: option.value, { option.value = $0 }
-        ),
+        accessory: .view(SwitchAccessoryView(initialValue: option.value, valueChange: { option.value = $0 })),
         uuid: option.key
     )
 }


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

