### PR TITLE
Fix #570: Add linebreak to shieldsview stat label

### DIFF
--- a/Client/Frontend/Shields/ShieldsView.swift
+++ b/Client/Frontend/Shields/ShieldsView.swift
@@ -191,6 +191,7 @@ extension ShieldsViewController {
             let l = UILabel()
             l.font = .systemFont(ofSize: 15.0)
             l.adjustsFontSizeToFitWidth = true
+            l.numberOfLines = 0
             return l
         }()
         /// Create the stat view with a given title and color


### PR DESCRIPTION
Fixes #570 

- [x] Issue exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* updated
- [x] User-facing strings use `NSLocalizableString()`
- [x] No new files.


## Test Plan:

1. Switch device language to French
2. Visit any site and open up shields
3. Shields stat title label line break

### Screenshots:

![simulator screen shot - iphone xr - 2019-01-17 at 12 49 32](https://user-images.githubusercontent.com/14965412/51306273-5c538d80-1a56-11e9-95cb-afb174996f4f.png)

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

