### PR TITLE
Fix #752: Add HTTPSE file version preference to be upgradable with app

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -56,6 +56,7 @@ extension Preferences {
     }
     public final class BlockFileVersion {
         public static let adblock = Option<String?>(key: "blockfile.adblock", default: nil)
+        public static let httpse = Option<String?>(key: "blockfile.httpse", default: nil)
     }
 }
 

--- a/Client/Frontend/ContentBlocker/BlocklistName.swift
+++ b/Client/Frontend/ContentBlocker/BlocklistName.swift
@@ -30,14 +30,18 @@ class BlocklistName: Hashable, CustomStringConvertible, ContentBlocker {
         return "<\(type(of: self)): \(self.filename)>"
     }
     
+    private static let blocklistFileVersionMap: [BlocklistName: Preferences.Option<String?>] = [
+        BlocklistName.ad: Preferences.BlockFileVersion.adblock,
+        BlocklistName.https: Preferences.BlockFileVersion.httpse
+    ]
+    
     lazy var fileVersionPref: Preferences.Option<String?>? = {
-        let prefMap = [BlocklistName.ad: Preferences.BlockFileVersion.adblock]
-        return prefMap[self]
+        return BlocklistName.blocklistFileVersionMap[self]
     }()
     
     lazy var fileVersion: String? = {
-        let adVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
-        return self == .ad ? adVersion : nil
+        guard let _ = BlocklistName.blocklistFileVersionMap[self] else { return nil }
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
     }()
     
     static func blocklists(forDomain domain: Domain) -> (on: Set<BlocklistName>, off: Set<BlocklistName>) {


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

See ticket

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

