### PR TITLE
Fix #665: fixes isFolder flag while retrieving non-folder bookmarks

### DIFF
--- a/Client/Frontend/Menu/BookmarksViewController.swift
+++ b/Client/Frontend/Menu/BookmarksViewController.swift
@@ -624,7 +624,7 @@ extension BookmarksViewController {
   }
   
   private func actionsForFolder(_ folder: Bookmark) -> [UIAlertAction] {
-    let children = Bookmark.getChildren(forFolderUUID: folder.syncUUID, ignoreFolders: true) ?? []
+    let children = Bookmark.getNonFolderChildren(forFolderUUID: folder.syncUUID) ?? []
     
     let urls: [URL] = children.compactMap { b in
       guard let url = b.url else { return nil }

--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -208,7 +208,7 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         //  (e.g. sync sent down bookmark before parent folder)
         if bk.isFolder {
             // Find all children and attach them
-            if let children = Bookmark.getChildren(forFolderUUID: bk.syncUUID) {
+            if let children = Bookmark.getNonFolderChildren(forFolderUUID: bk.syncUUID) {
                 
                 // TODO: Setup via bk.children property instead
                 children.forEach { $0.syncParentUUID = bk.syncParentUUID }
@@ -377,7 +377,7 @@ extension Bookmark {
         return NSPredicate(format: "\(urlKeyPath) == %@ AND \(isFavoriteKeyPath) == \(NSNumber(value: getFavorites))", url.absoluteString)
     }
     
-    public static func getChildren(forFolderUUID syncUUID: [Int]?, ignoreFolders: Bool = false) -> [Bookmark]? {
+    public static func getNonFolderChildren(forFolderUUID syncUUID: [Int]?) -> [Bookmark]? {
         guard let searchableUUID = SyncHelpers.syncDisplay(fromUUID: syncUUID) else {
             return nil
         }
@@ -385,8 +385,8 @@ extension Bookmark {
         let syncParentDisplayUUIDKeyPath = #keyPath(Bookmark.syncParentDisplayUUID)
         let isFolderKeyPath = #keyPath(Bookmark.isFolder)
         
-        let predicate = NSPredicate(format: "\(syncParentDisplayUUIDKeyPath) == %@ AND \(isFolderKeyPath) == %@",
-            searchableUUID, NSNumber(value: ignoreFolders))
+        let predicate = NSPredicate(format: "\(syncParentDisplayUUIDKeyPath) == %@ AND \(isFolderKeyPath) == 0",
+            searchableUUID)
         
         return all(where: predicate)
     }

--- a/DataTests/BookmarkTests.swift
+++ b/DataTests/BookmarkTests.swift
@@ -151,17 +151,23 @@ class BookmarkTests: CoreDataTestCase {
         XCTAssertFalse(Bookmark.contains(url: wrongUrl))
     }
     
-    func testGetChildren() {
+    func testGetNonFolderChildren() {
         let folder = createAndWait(url: nil, title: nil, customTitle: "Folder", isFolder: true)
         
-        let nonNestedBookmarksToAdd = 3
-        insertBookmarks(amount: nonNestedBookmarksToAdd)
+        let nonFolderBookmarksCount = 3
+        insertBookmarks(amount: nonFolderBookmarksCount, parent: folder)
         
-        // Few bookmarks inside our folder.
-        let nestedBookmarksCount = 5
-        insertBookmarks(amount: nestedBookmarksCount, parent: folder)
+        // Add folder bookmark.
+        createAndWait(url: nil,
+                      title: nil,
+                      customTitle: "InFolder",
+                      parentFolder: folder,
+                      isFolder: true,
+                      isFavorite: false,
+                      color: nil,
+                      syncOrder: nil)
         
-        XCTAssertEqual(Bookmark.getChildren(forFolderUUID: folder.syncUUID)?.count, nestedBookmarksCount)
+        XCTAssertEqual(Bookmark.getNonFolderChildren(forFolderUUID: folder.syncUUID)?.count, nonFolderBookmarksCount)
     }
     
     func testGetTopLevelFolders() {


### PR DESCRIPTION
Fix #665 
Fixes `isFolder` flag while retrieving non-folder bookmarks in formerly called `getChildren` method to be always `false`.
Since the `ignoreFolders` parameter is not needed anymore. I've removed it and changed the method name to be `getNonFolderChildren`.
Now while opening multiple bookmarks in a folder, it will retrieve all non folder favorites inside that folder and open them (it doesn't close the bookmarks popup. But this is another issue that I'll create)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues/665) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] No user-facing strings
- [x] No new files.


## Test Plan:

1. Create a bookmark folder.
2. Open the folder.
3. Go to at least two websites and add the bookmarks to the folder
4. Long-press the folder.
5. It will show action sheet to open all bookmarks

### Screenshots:

![simulator screen shot - iphone xr - 2019-01-20 at 11 47 57](https://user-images.githubusercontent.com/14965412/51436588-5ef9f100-1ca9-11e9-822d-cc1b7961430f.png)
![simulator screen shot - iphone xr - 2019-01-20 at 11 48 44](https://user-images.githubusercontent.com/14965412/51436589-5f928780-1ca9-11e9-8115-33d83d004372.png)


### Request review from:
@jhreis & @iccub 


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

