### PR TITLE
Fix #739: Supporting favorites without http/https prefix

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -534,6 +534,7 @@
 		A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83E5AB61C1D993D0026D912 /* UIPasteboardExtensions.swift */; };
 		A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */; };
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
+		AB1B097A21F2F00400E0DD51 /* FavoritesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1B097921F2F00400E0DD51 /* FavoritesViewControllerTests.swift */; };
 		C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */; };
 		C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */; };
 		C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */; };
@@ -1822,6 +1823,7 @@
 		A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIPasteboardExtensionsTests.swift; sourceTree = "<group>"; };
 		A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeHelper.swift; sourceTree = "<group>"; };
 		A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightModeHelper.swift; sourceTree = "<group>"; };
+		AB1B097921F2F00400E0DD51 /* FavoritesViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewControllerTests.swift; sourceTree = "<group>"; };
 		C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListViewController.swift; sourceTree = "<group>"; };
 		C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListAnimator.swift; sourceTree = "<group>"; };
 		C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabTrayButtonExtensions.swift; path = ../Browser/TabTrayButtonExtensions.swift; sourceTree = "<group>"; };
@@ -3933,6 +3935,7 @@
 				E696FE501C47F86E00EC007C /* AuthenticatorTests.swift */,
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
+				AB1B097921F2F00400E0DD51 /* FavoritesViewControllerTests.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				E683F0A51E92E0820035D990 /* MockableHistory.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
@@ -5699,6 +5702,7 @@
 				3BFCBF201E04B1C50070C042 /* UIImageViewExtensionsTests.swift in Sources */,
 				E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,
+				AB1B097A21F2F00400E0DD51 /* FavoritesViewControllerTests.swift in Sources */,
 				2795274A21A890EB00921AA1 /* FingerprintingProtectionTests.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				0A4214E921A6EBCF006B8E39 /* SafeBrowsingTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1562,9 +1562,13 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBar(_ urlBar: URLBarView, didSubmitText text: String) {
+        processAddressBar(text: text, visitType: nil)
+    }
+
+    func processAddressBar(text: String, visitType: VisitType?) {
         if let fixupURL = URIFixup.getURL(text) {
             // The user entered a URL, so use it.
-            finishEditingAndSubmit(fixupURL, visitType: VisitType.typed)
+            finishEditingAndSubmit(fixupURL, visitType: visitType ?? .typed)
             return
         }
 
@@ -1585,7 +1589,7 @@ extension BrowserViewController: URLBarDelegate {
                 urlString.replaceSubrange(range, with: escapedQuery)
 
                 if let url = URL(string: urlString) {
-                    self.finishEditingAndSubmit(url, visitType: VisitType.typed)
+                    self.finishEditingAndSubmit(url, visitType: visitType ?? .typed)
                     return
                 }
             }
@@ -2892,8 +2896,8 @@ extension BrowserViewController: HomeMenuControllerDelegate {
 
 extension BrowserViewController: TopSitesDelegate {
     
-    func didSelectUrl(url: URL) {
-        finishEditingAndSubmit(url, visitType: .bookmark)
+    func didSelect(input: String) {
+        processAddressBar(text: input, visitType: .bookmark)
     }
     
     func didTapDuckDuckGoCallout() {

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -12,8 +12,8 @@ import Data
 
 private let log = Logger.browserLogger
 
-protocol TopSitesDelegate: class {
-    func didSelectUrl(url: URL)
+protocol TopSitesDelegate: AnyObject {
+    func didSelect(input: String)
     func didTapDuckDuckGoCallout()
 }
 
@@ -27,7 +27,7 @@ class FavoritesViewController: UIViewController, Themeable {
     weak var delegate: TopSitesDelegate?
     
     // MARK: - Favorites collection view properties
-    private lazy var collection: UICollectionView = {
+    private (set) internal lazy var collection: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.minimumInteritemSpacing = 0
         layout.minimumLineSpacing = 6
@@ -46,7 +46,7 @@ class FavoritesViewController: UIViewController, Themeable {
         }
         return view
     }()
-    private lazy var dataSource: FavoritesDataSource = { return FavoritesDataSource() }()
+    private let dataSource: FavoritesDataSource
     
     private let braveShieldStatsView = BraveShieldStatsView(frame: CGRect.zero).then {
         $0.autoresizingMask = [.flexibleWidth]
@@ -73,8 +73,9 @@ class FavoritesViewController: UIViewController, Themeable {
     
     private let profile: Profile
     
-    init(profile: Profile) {
+    init(profile: Profile, dataSource: FavoritesDataSource = FavoritesDataSource()) {
         self.profile = profile
+        self.dataSource = dataSource
         
         super.init(nibName: nil, bundle: nil)
         NotificationCenter.default.do {
@@ -235,9 +236,9 @@ extension FavoritesViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let fav = dataSource.favoriteBookmark(at: indexPath)
         
-        guard let urlString = fav?.url, let url = URL(string: urlString) else { return }
+        guard let urlString = fav?.url else { return }
         
-        delegate?.didSelectUrl(url: url)
+        delegate?.didSelect(input: urlString)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -316,7 +317,7 @@ extension FavoritesViewController: FavoriteCellDelegate {
                                                                     if let cTitle = callbackTitle, !cTitle.isEmpty, let cUrl = callbackUrl, !cUrl.isEmpty {
                                                                         if URL(string: cUrl) != nil {
                                                                             fav.update(customTitle: cTitle,
-                                                                                       url: cUrl)
+                                                                                       url: cUrl, save: true)
                                                                         }
                                                                     }
                                                                     self.dataSource.isEditing = false

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -75,11 +75,6 @@ class FavoritesDataSource: NSObject, UICollectionViewDataSource {
         cell.accessibilityLabel = cell.textLabel.text
 
         cell.toggleEditButton(isEditing)
-
-        guard let urlString = fav.url, let url = URL(string: urlString) else {
-            log.error("configureCell url is nil")
-            return UICollectionViewCell()
-        }
         
         return cell
     }

--- a/ClientTests/FavoritesViewControllerTests.swift
+++ b/ClientTests/FavoritesViewControllerTests.swift
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Data
+@testable import Client
+
+class FavoritesViewControllerTests: XCTestCase {
+
+    var dataSource: MockFavoritesDataSource!
+    var delegate: MockTopSitesDelegate!
+    var vc: FavoritesViewController!
+    var collectionView: UICollectionView!
+
+    override func setUp() {
+        super.setUp()
+
+        delegate = MockTopSitesDelegate()
+        dataSource = MockFavoritesDataSource()
+        vc = FavoritesViewController(profile: MockProfile(), dataSource: dataSource)
+        vc.delegate = delegate
+        collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
+    }
+
+    override func tearDown() {
+        dataSource = nil
+        delegate = nil
+        vc = nil
+        collectionView = nil
+        
+        super.tearDown()
+    }
+
+    func testFavoritesViewControllerLoadsView() {
+        let viewController = FavoritesViewController(profile: MockProfile(), dataSource: MockFavoritesDataSource())
+        XCTAssertNotNil(viewController.view, "Unable to load view")
+        XCTAssertNotNil(viewController.view.subviews.first { $0 is UICollectionView }, "`UICollectionView` missing from `FavoritesViewController` view.")
+        XCTAssertNil(viewController.linkNavigationDelegate)
+        XCTAssertNil(viewController.delegate)
+    }
+
+    func testTopSiteDelegate_ReceivesString() {
+        let index = IndexPath(item: 0, section: 0)
+        let I_LOVE_CHOCOLATE = "I Love Chocolate"
+        dataSource.bookmarks[index] = createBookmark(I_LOVE_CHOCOLATE)
+
+        // Firing `UICollectionView` delegate method
+        vc.collectionView(collectionView, didSelectItemAt: index)
+        
+        XCTAssertEqual(delegate.input, I_LOVE_CHOCOLATE, "The Favorites destination is incorrect.")
+        XCTAssertFalse(delegate.isReturningURL, "Favorites should work for any string NOT just URL's.")
+    }
+
+    func testTopSiteDelegate_ReceivesFullURL() {
+        let index = IndexPath(item: 0, section: 0)
+        let HTTPS_BRAVE_COM = "https://www.brave.com"
+        dataSource.bookmarks[index] = createBookmark(HTTPS_BRAVE_COM)
+
+        vc.collectionView(collectionView, didSelectItemAt: index)
+
+        XCTAssertEqual(delegate.input, HTTPS_BRAVE_COM, "The Favorites destination is incorrect.")
+        XCTAssertTrue(delegate.isReturningURL, "Favorites should work for URL's.")
+    }
+
+    func testTopSiteDelegate_ReceivesURLWithoutScheme() {
+        let index = IndexPath(item: 0, section: 0)
+        let BRAVE_COM = "brave.com"
+        dataSource.bookmarks[index] = createBookmark(BRAVE_COM)
+
+        vc.collectionView(collectionView, didSelectItemAt: index)
+
+        XCTAssertEqual(delegate.input, BRAVE_COM, "The Favorites destination is incorrect.")
+        XCTAssertTrue(delegate.isReturningURL, "Favorites should work for URL's without a scheme.")
+    }
+
+    func testTopSiteDelegate_EmptyString() {
+        let index = IndexPath(item: 0, section: 0)
+        let EMPTY_STRING = ""
+        dataSource.bookmarks[index] = createBookmark(EMPTY_STRING)
+
+        vc.collectionView(collectionView, didSelectItemAt: index)
+
+        XCTAssertEqual(delegate.input, EMPTY_STRING, "The Favorites destination is incorrect.")
+        XCTAssertTrue(delegate.didSelectInputString)
+        XCTAssertFalse(delegate.isReturningURL)
+    }
+
+    func testTopSiteDelegate_NilURL() {
+        let index = IndexPath(item: 0, section: 0)
+        let NIL_URL: String? = nil
+        dataSource.bookmarks[index] = createBookmark(NIL_URL)
+
+        vc.collectionView(collectionView, didSelectItemAt: index)
+
+        XCTAssertEqual(delegate.input, NIL_URL, "The Favorites destination is incorrect.")
+        XCTAssertFalse(delegate.didSelectInputString)
+    }
+
+    fileprivate func createBookmark(_ urlString: String? = nil) -> Bookmark? {
+        return Bookmark(context: DataController.viewContext).then {
+            $0.url = urlString
+        }
+    }
+}
+
+class MockFavoritesDataSource: FavoritesDataSource {
+
+    var bookmarks = [IndexPath: Bookmark]()
+
+    var _isEditing: Bool = false
+    override var isEditing: Bool {
+        get { return _isEditing }
+        set { _isEditing = newValue }
+    }
+
+    override init() {
+    }
+
+    override func favoriteBookmark(at indexPath: IndexPath) -> Bookmark? {
+        return bookmarks[indexPath]
+    }
+}
+
+class MockTopSitesDelegate: TopSitesDelegate {
+
+    var didSelectInputString = false
+    var didTapCallout = false
+    var input: String?
+
+    func didSelect(input: String) {
+        didSelectInputString = true
+        self.input = input
+    }
+
+    func didTapDuckDuckGoCallout() {
+        didTapCallout = true
+    }
+
+    /// Checks that there is a `urlString` AND is it able to be created into a `URL`.
+    var isReturningURL: Bool {
+        guard let input = self.input else { return false }
+        return URL(string: input) != nil
+    }
+}


### PR DESCRIPTION
**Fix** https://github.com/brave/brave-ios/issues/739
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

## Other Comments

This change enables the _Favorites_ to accept pretty much any string not just URL's. The _Favorites_ UI allowed for easier changes but modifying the _Bookmarks_ to accept values that are not URL's is little more involved. In the nature of keeping PR's small, I think those changes would be better served in another PR.

The `BookmarksViewController` uses `URLRow` which requires the value to be an actual `URL`. [See details here](https://github.com/brave/brave-ios/blob/12df4aac9219cc6795866eab9de16f8696d5e45f/Client/Frontend/Menu/BookmarksViewController.swift#L95)