### PR TITLE
 FIX #87: Option to suppress alerts on webpages.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -89,8 +89,8 @@ extension Strings {
     public static let OpenPhoneSettingsActionTitle = NSLocalizedString("OpenPhoneSettingsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Open Settings", comment: "See http://mzl.la/1G7uHo7")
     public static let CopyImageActionTitle = NSLocalizedString("CopyImageActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Copy Image", comment: "Context menu item for copying an image to the clipboard")
     public static let CloseAllTabsTitle = NSLocalizedString("CloseAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Close All %i Tabs", comment: "")
-    public static let SuppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "")
-    public static let SuppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Prevent this page from creating additional alerts", comment: "")
+    public static let SuppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "Title of alert that seeks permission from user to suppress future JS alerts")
+    public static let SuppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Prevent this page from creating additional alerts", comment: "Message body of alert that seeks permission from user to suppress future JS alerts")
 }
 
 // MARK:-  ErrorPageHelper.swift

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -90,7 +90,7 @@ extension Strings {
     public static let CopyImageActionTitle = NSLocalizedString("CopyImageActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Copy Image", comment: "Context menu item for copying an image to the clipboard")
     public static let CloseAllTabsTitle = NSLocalizedString("CloseAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Close All %i Tabs", comment: "")
     public static let SuppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "")
-    public static let SuppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts on this page for this session?", comment: "")    
+    public static let SuppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Prevent this page from creating additional alerts", comment: "")
 }
 
 // MARK:-  ErrorPageHelper.swift

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -89,6 +89,8 @@ extension Strings {
     public static let OpenPhoneSettingsActionTitle = NSLocalizedString("OpenPhoneSettingsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Open Settings", comment: "See http://mzl.la/1G7uHo7")
     public static let CopyImageActionTitle = NSLocalizedString("CopyImageActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Copy Image", comment: "Context menu item for copying an image to the clipboard")
     public static let CloseAllTabsTitle = NSLocalizedString("CloseAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Close All %i Tabs", comment: "")
+    public static let SuppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "")
+    public static let SuppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts on this page for this session?", comment: "")    
 }
 
 // MARK:-  ErrorPageHelper.swift

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -16,7 +16,7 @@ import Shared
 /// a runtime exception is thrown.
 class JSPromptAlertController: UIAlertController {
     
-    var info: JSAlertInfo!
+    var info: JSAlertInfo?
     var showsCancel: Bool = false
     
     class func newController(title: String?, message: String?, preferredStyle: UIAlertController.Style = .alert, info: JSAlertInfo, showCancel: Bool = true) -> JSPromptAlertController {
@@ -28,14 +28,14 @@ class JSPromptAlertController: UIAlertController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        if info.suppressHandler != nil {
+        if let handler = info?.suppressHandler {
             self.addAction(UIAlertAction(title: Strings.SuppressAlertsActionTitle, style: .default, handler: { _ in
-                self.info.suppressHandler?(true)
+                handler(true)
             }))
         }
         if showsCancel {
             self.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: { _ in
-                self.info.cancel()
+                self.info?.cancel()
             }))
         }
     }

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -19,11 +19,10 @@ class JSPromptAlertController: UIAlertController {
     var info: JSAlertInfo?
     var showsCancel: Bool = false
     
-    class func newController(title: String?, message: String?, preferredStyle: UIAlertController.Style = .alert, info: JSAlertInfo, showCancel: Bool = true) -> JSPromptAlertController {
-        let controller = JSPromptAlertController(title: title, message: message, preferredStyle: preferredStyle)
-        controller.info = info
-        controller.showsCancel = showCancel
-        return controller
+    convenience init(title: String?, message: String?, preferredStyle: UIAlertController.Style = .alert, info: JSAlertInfo, showCancel: Bool = true) {
+        self.init(title: title, message: message, preferredStyle: preferredStyle)
+        self.info = info
+        self.showsCancel = showCancel
     }
     
     override func viewDidLoad() {
@@ -69,7 +68,7 @@ struct MessageAlert: JSAlertInfo {
     var suppressHandler: SuppressHandler?
 
     func alertController() -> JSPromptAlertController {
-        let alertController = JSPromptAlertController.newController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
+        let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
                                                                     message: message,
                                                                     info: self,
                                                                     showCancel: false)
@@ -92,7 +91,7 @@ struct ConfirmPanelAlert: JSAlertInfo {
 
     func alertController() -> JSPromptAlertController {
         // Show JavaScript confirm dialogs.
-        let alertController = JSPromptAlertController.newController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
+        let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
                                                                     message: message,
                                                                     info: self)
         alertController.addAction(UIAlertAction(title: Strings.OKString, style: .default) { _ in
@@ -114,7 +113,7 @@ struct TextInputAlert: JSAlertInfo {
     var suppressHandler: SuppressHandler?
     
     func alertController() -> JSPromptAlertController {
-        let alertController = JSPromptAlertController.newController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
+        let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
                                                                     message: message,
                                                                     info: self)
         var input: UITextField!

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -33,14 +33,17 @@ class JSPromptAlertController: UIAlertController {
  *  of the provided completionHandler to let us generate the UIAlertController when needed.
  */
 protocol JSAlertInfo {
+    typealias SuppressHandler = ((Bool) -> Void)?
     func alertController() -> JSPromptAlertController
     func cancel()
+    var suppressHandler: SuppressHandler {get set}
 }
 
 struct MessageAlert: JSAlertInfo {
     let message: String
     let frame: WKFrameInfo
     let completionHandler: () -> Void
+    var suppressHandler: SuppressHandler
 
     func alertController() -> JSPromptAlertController {
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
@@ -49,6 +52,11 @@ struct MessageAlert: JSAlertInfo {
         alertController.addAction(UIAlertAction(title: Strings.OKString, style: .default) { _ in
             self.completionHandler()
         })
+        if suppressHandler != nil {
+            alertController.addAction(UIAlertAction(title: "Suppress Alerts", style: .default) { _ in
+                self.suppressHandler?(true)
+            })
+        }
         alertController.alertInfo = self
         return alertController
     }
@@ -62,6 +70,7 @@ struct ConfirmPanelAlert: JSAlertInfo {
     let message: String
     let frame: WKFrameInfo
     let completionHandler: (Bool) -> Void
+    var suppressHandler: SuppressHandler
 
     init(message: String, frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
         self.message = message
@@ -75,6 +84,11 @@ struct ConfirmPanelAlert: JSAlertInfo {
         alertController.addAction(UIAlertAction(title: Strings.OKString, style: .default) { _ in
             self.completionHandler(true)
         })
+        if suppressHandler != nil {
+            alertController.addAction(UIAlertAction(title: "Suppress Alerts", style: .default) { _ in
+                self.suppressHandler?(true)
+            })
+        }
         alertController.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel) { _ in
             self.cancel()
         })
@@ -92,6 +106,7 @@ struct TextInputAlert: JSAlertInfo {
     let frame: WKFrameInfo
     let completionHandler: (String?) -> Void
     let defaultText: String?
+    var suppressHandler: SuppressHandler
 
     var input: UITextField!
 
@@ -112,6 +127,11 @@ struct TextInputAlert: JSAlertInfo {
         alertController.addAction(UIAlertAction(title: Strings.OKString, style: .default) { _ in
             self.completionHandler(input.text)
         })
+        if suppressHandler != nil {
+            alertController.addAction(UIAlertAction(title: "Suppress Alerts", style: .default) { _ in
+                self.suppressHandler?(true)
+            })
+        }
         alertController.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel) { _ in
             self.cancel()
         })

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -53,7 +53,7 @@ struct MessageAlert: JSAlertInfo {
             self.completionHandler()
         })
         if suppressHandler != nil {
-            alertController.addAction(UIAlertAction(title: "Suppress Alerts", style: .default) { _ in
+            alertController.addAction(UIAlertAction(title: Strings.SuppressAlertsActionTitle, style: .default) { _ in
                 self.suppressHandler?(true)
             })
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2219,6 +2219,11 @@ extension BrowserViewController: WKUIDelegate {
                 suppressSheet.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: { _ in
                     completionHandler()
                 }))
+                if UIDevice.current.userInterfaceIdiom == .pad, let popoverController = suppressSheet.popoverPresentationController {
+                    popoverController.sourceView = self.view
+                    popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+                    popoverController.permittedArrowDirections = []
+                }
                 self.present(suppressSheet, animated: true)
             } else {
                 completionHandler()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2202,7 +2202,9 @@ extension BrowserViewController: WKUIDelegate {
     func handleAlert<T: JSAlertInfo>(webView: WKWebView, alert: inout T, completionHandler: @escaping () -> Void) {
         guard let promptingTab = tabManager[webView], !promptingTab.blockAllAlerts else {
             tabManager[webView]?.cancelQueuedAlerts()
-            completionHandler()
+            webView.evaluateJavaScript("window.alert = window.confirm = window.prompt = function(e) {}") { _, _ in
+                completionHandler()
+            }
             return
         }
         promptingTab.alertShownCount += 1

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2186,14 +2186,14 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
-        var confirmAlert = ConfirmPanelAlert(message: message, frame: frame, completionHandler: completionHandler)
+        var confirmAlert = ConfirmPanelAlert(message: message, frame: frame, completionHandler: completionHandler, suppressHandler: nil)
         handleAlert(webView: webView, alert: &confirmAlert) { (val) in
             completionHandler(val as? Bool ?? false)
         }
     }
 
     func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (String?) -> Void) {
-        var textInputAlert = TextInputAlert(message: prompt, frame: frame, completionHandler: completionHandler, defaultText: defaultText)
+        var textInputAlert = TextInputAlert(message: prompt, frame: frame, completionHandler: completionHandler, defaultText: defaultText, suppressHandler: nil)
         handleAlert(webView: webView, alert: &textInputAlert) { (val) in
             completionHandler(val as? String)
         }
@@ -2206,7 +2206,7 @@ extension BrowserViewController: WKUIDelegate {
             return
         }
         promptingTab.alertShownCount += 1
-        alert.suppressHandler = promptingTab.alertShownCount > 1 ? ({[unowned self] suppress in
+        var suppressBlock: JSAlertInfo.SuppressHandler = ({[unowned self] suppress in
             if suppress {
                 func suppressDialogues() {
                     promptingTab.blockAllAlerts = true
@@ -2225,7 +2225,8 @@ extension BrowserViewController: WKUIDelegate {
             } else {
                 completionHandler(nil)
             }
-        }) : nil
+        })
+        alert.suppressHandler = promptingTab.alertShownCount > 1 ? suppressBlock : nil
         if shouldDisplayJSAlertForWebView(webView) {
             let controller = alert.alertController()
             controller.delegate = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2180,29 +2180,29 @@ extension BrowserViewController: WKUIDelegate {
 
     func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
         var messageAlert = MessageAlert(message: message, frame: frame, completionHandler: completionHandler, suppressHandler: nil)
-        handleAlert(webView: webView, alert: &messageAlert) { _ in
+        handleAlert(webView: webView, alert: &messageAlert) {
             completionHandler()
         }
     }
 
     func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
         var confirmAlert = ConfirmPanelAlert(message: message, frame: frame, completionHandler: completionHandler, suppressHandler: nil)
-        handleAlert(webView: webView, alert: &confirmAlert) { _ in
+        handleAlert(webView: webView, alert: &confirmAlert) {
             completionHandler(false)
         }
     }
 
     func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (String?) -> Void) {
         var textInputAlert = TextInputAlert(message: prompt, frame: frame, completionHandler: completionHandler, defaultText: defaultText, suppressHandler: nil)
-        handleAlert(webView: webView, alert: &textInputAlert) { _ in
+        handleAlert(webView: webView, alert: &textInputAlert) {
             completionHandler(nil)
         }
     }
     
-    func handleAlert<T: JSAlertInfo>(webView: WKWebView, alert: inout T, completionHandler: @escaping (Any?) -> Void) {
+    func handleAlert<T: JSAlertInfo>(webView: WKWebView, alert: inout T, completionHandler: @escaping () -> Void) {
         guard let promptingTab = tabManager[webView], !promptingTab.blockAllAlerts else {
             tabManager[webView]?.cancelQueuedAlerts()
-            completionHandler(nil)
+            completionHandler()
             return
         }
         promptingTab.alertShownCount += 1
@@ -2211,24 +2211,24 @@ extension BrowserViewController: WKUIDelegate {
                 func suppressDialogues(_: UIAlertAction) {
                     promptingTab.blockAllAlerts = true
                     self.tabManager[webView]?.cancelQueuedAlerts()
-                    completionHandler(nil)
+                    completionHandler()
                 }
                 // Show confirm alert here.
                 let suppressSheet = UIAlertController(title: nil, message: Strings.SuppressAlertsActionMessage, preferredStyle: .actionSheet)
                 suppressSheet.addAction(UIAlertAction(title: Strings.SuppressAlertsActionTitle, style: .destructive, handler: suppressDialogues))
                 suppressSheet.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: { _ in
-                    completionHandler(nil)
+                    completionHandler()
                 }))
-                self.present(suppressSheet, animated: true, completion: nil)
+                self.present(suppressSheet, animated: true)
             } else {
-                completionHandler(nil)
+                completionHandler()
             }
         }
         alert.suppressHandler = promptingTab.alertShownCount > 1 ? suppressBlock : nil
         if shouldDisplayJSAlertForWebView(webView) {
             let controller = alert.alertController()
             controller.delegate = self
-            present(controller, animated: true, completion: nil)
+            present(controller, animated: true)
         } else {
             promptingTab.queueJavascriptAlertPrompt(alert)
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2206,11 +2206,25 @@ extension BrowserViewController: WKUIDelegate {
             return
         }
         promptingTab.alertShownCount += 1
-        alert.suppressHandler = promptingTab.alertShownCount > 1 ? ({ suppress in
-            // Show confirm alert here.
-            promptingTab.blockAllAlerts = suppress
-            suppress ? self.tabManager[webView]?.cancelQueuedAlerts() : nil
-            completionHandler(nil)
+        alert.suppressHandler = promptingTab.alertShownCount > 1 ? ({[unowned self] suppress in
+            if suppress {
+                func suppressDialogues() {
+                    promptingTab.blockAllAlerts = true
+                    self.tabManager[webView]?.cancelQueuedAlerts()
+                    completionHandler(nil)
+                }
+                // Show confirm alert here.
+                let suppressSheet = UIAlertController(title: nil, message: Strings.SuppressAlertsActionMessage, preferredStyle: .actionSheet)
+                suppressSheet.addAction(UIAlertAction(title: Strings.SuppressAlertsActionTitle, style: .destructive, handler: { (action) in
+                    suppressDialogues()
+                }))
+                suppressSheet.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: { (action) in
+                    completionHandler(nil)
+                }))
+                self.present(suppressSheet, animated: true, completion: nil)
+            } else {
+                completionHandler(nil)
+            }
         }) : nil
         if shouldDisplayJSAlertForWebView(webView) {
             let controller = alert.alertController()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -211,7 +211,11 @@ extension BrowserViewController: WKNavigationDelegate {
                     webView.configuration.userContentController.remove(rule)
                 }
             }
-            
+            // Reset the block alert bool on new host. 
+            if let newHost: String = url.host, let oldHost: String = webView.url?.host, newHost != oldHost {
+                self.tabManager.selectedTab?.alertShownCount = 0
+                self.tabManager.selectedTab?.blockAllAlerts = false
+            }
             decisionHandler(.allow)
             return
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -196,7 +196,12 @@ extension BrowserViewController: WKNavigationDelegate {
                     tab.userScriptManager?.isFingerprintingProtectionEnabled = domainForShields.isShieldExpected(.FpProtection, isPrivateBrowsing: isPrivateBrowsing)
                 }
 
-                webView.configuration.preferences.javaScriptEnabled = !domainForShields.isShieldExpected(.NoScript, isPrivateBrowsing: isPrivateBrowsing)
+                webView.configuration.preferences.javaScriptEnabled = !domainForShields.(.NoScript, isPrivateBrowsing: isPrivateBrowsing)
+            }
+            // Reset the block alert bool on new host. 
+            if url.host != webView.url?.host {
+                self.tabManager.selectedTab?.alertShownCount = 0
+                self.tabManager.selectedTab?.blockAllAlerts = false
             }
             
             //Cookie Blocking code below

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -196,12 +196,7 @@ extension BrowserViewController: WKNavigationDelegate {
                     tab.userScriptManager?.isFingerprintingProtectionEnabled = domainForShields.isShieldExpected(.FpProtection, isPrivateBrowsing: isPrivateBrowsing)
                 }
 
-                webView.configuration.preferences.javaScriptEnabled = !domainForShields.(.NoScript, isPrivateBrowsing: isPrivateBrowsing)
-            }
-            // Reset the block alert bool on new host. 
-            if url.host != webView.url?.host {
-                self.tabManager.selectedTab?.alertShownCount = 0
-                self.tabManager.selectedTab?.blockAllAlerts = false
+                webView.configuration.preferences.javaScriptEnabled = !domainForShields.isShieldExpected(.NoScript, isPrivateBrowsing: isPrivateBrowsing)
             }
             
             //Cookie Blocking code below

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -47,6 +47,8 @@ class Tab: NSObject {
     
     let rewardsId: UInt32
     
+    var alertShownCount: Int = 0
+    var blockAllAlerts: Bool = false
     private(set) var type: TabType = .regular
     
     var isPrivate: Bool {


### PR DESCRIPTION
Added the `suppress alert` logic for WKUIDelegate methods to show prompts. This is a fix for #87 

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:
- https://dustiest-limitation.000webhostapp.com/alert.html
- https://dustiest-limitation.000webhostapp.com/prompt.html
- https://dustiest-limitation.000webhostapp.com/confirm.html
- https://dustiest-limitation.000webhostapp.com/iframe_alert.html
- https://dustiest-limitation.000webhostapp.com/iframe_prompt.html
- https://dustiest-limitation.000webhostapp.com/iframe_confirm.html
<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)
