### PR TITLE
Fix #666: Disable top-level navigation for data scheme

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2096,7 +2096,7 @@ extension BrowserViewController: TabManagerDelegate {
 }
 
 /// List of schemes that are allowed to be opened in new tabs.
-private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "data", "about"]
+private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "about"]
 
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -43,6 +43,8 @@ class SearchTests: XCTestCase {
         checkInvalidURL("创业咖啡")
         checkInvalidURL("创业咖啡 中国")
         checkInvalidURL("创业咖啡. 中国")
+        checkInvalidURL("data:text/html;base64,SGVsbG8gV29ybGQhCg==")
+        checkInvalidURL("data://https://www.example.com,fake example.com")
     }
 
     func testURIFixupPunyCode() {

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -103,8 +103,10 @@ extension URL {
 // The list of permanent URI schemes has been taken from http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml 
 private let permanentURISchemes = ["aaa", "aaas", "about", "acap", "acct", "cap", "cid", "coap", "coaps", "crid", "data", "dav", "dict", "dns", "example", "file", "ftp", "geo", "go", "gopher", "h323", "http", "https", "iax", "icap", "im", "imap", "info", "ipp", "ipps", "iris", "iris.beep", "iris.lwz", "iris.xpc", "iris.xpcs", "jabber", "ldap", "mailto", "mid", "msrp", "msrps", "mtqp", "mupdate", "news", "nfs", "ni", "nih", "nntp", "opaquelocktoken", "pkcs11", "pop", "pres", "reload", "rtsp", "rtsps", "rtspu", "service", "session", "shttp", "sieve", "sip", "sips", "sms", "snmp", "soap.beep", "soap.beeps", "stun", "stuns", "tag", "tel", "telnet", "tftp", "thismessage", "tip", "tn3270", "turn", "turns", "tv", "urn", "vemmi", "vnc", "ws", "wss", "xcon", "xcon-userid", "xmlrpc.beep", "xmlrpc.beeps", "xmpp", "z39.50r", "z39.50s"]
 
-extension URL {
+private let ignoredSchemes = ["data"]
+private let supportedSchemes = permanentURISchemes.filter { !ignoredSchemes.contains($0) }
 
+extension URL {
     public func withQueryParams(_ params: [URLQueryItem]) -> URL {
         var components = URLComponents(url: self, resolvingAgainstBaseURL: false)!
         var items = (components.queryItems ?? [])
@@ -310,7 +312,7 @@ extension URL {
      */
     public var schemeIsValid: Bool {
         guard let scheme = scheme else { return false }
-        return permanentURISchemes.contains(scheme.lowercased())
+        return supportedSchemes.contains(scheme.lowercased())
     }
 
     public func havingRemovedAuthorisationComponents() -> URL {

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -297,7 +297,8 @@ class NSURLExtensionsTests: XCTestCase {
         let badurls = [
             "blah://google.com",
             "hax://localhost:6571/sessionrestore.html",
-            "leet://codes.com"
+            "leet://codes.com",
+            "data:text/html;base64,SGVsbG8gV29ybGQhCg=="
         ]
 
         goodurls.forEach { XCTAssertTrue(URL(string:$0)!.schemeIsValid, $0) }


### PR DESCRIPTION
fix https://github.com/brave/brave-ios/issues/666

Top-level navigation to `data:` urls are not supported on major mobile browsers. On Brave iOS, navigating to data-urls does not work correctly.

Try opening `data:text/html;base64,SGVsbG8gV29ybGQhCg==` in Desktop vs Mobile Browser

This PR removes support for navigating to data URLs.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

### Direct navigation to data:urls
1. Navigate to `data:text/html;base64,SGVsbG8gV29ybGQhCg==` should do a search instead of initiating a navigation to a data URL

### Popups and subresources
<!-- Any useful notes for reviewer explaining how best to test and verify. -->
1.  Navigate to http://dustiest-limitation.000webhostapp.com/data.html
2. Click on Google.com - data URL should not open
3. Images and CSS rules are loaded correctly.

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

