### PR TITLE
Fix #775: Leave sync group after removing it on another device.

### DIFF
--- a/Data/models/Device.swift
+++ b/Data/models/Device.swift
@@ -94,6 +94,21 @@ public final class Device: NSManagedObject, Syncable, CRUD {
         return sharedCurrentDevice
     }
     
+    public func remove(sendToSync: Bool = true) {
+        guard let context = managedObjectContext else { return }
+        
+        if sendToSync {
+            Sync.shared.sendSyncRecords(action: .delete, records: [self])
+        }
+        
+        if isCurrentDevice {
+            Sync.shared.leaveSyncGroup(sendToSync: false)
+        } else {
+            context.delete(self)
+            DataController.save(context: context)
+        }
+    }
+    
     public class func deleteAll() {
         sharedCurrentDevice = nil
         Device.deleteAll(includesPropertyValues: false)

--- a/Data/models/Syncable.swift
+++ b/Data/models/Syncable.swift
@@ -20,6 +20,8 @@ public protocol Syncable: class /* where Self: NSManagedObject */ {
     func update(syncRecord record: SyncRecord?)
     
     @discardableResult static func add(rootObject root: SyncRecord?, save: Bool, sendToSync: Bool, context: NSManagedObjectContext) -> Syncable?
+    
+    func remove(sendToSync: Bool)
 }
 
 extension Syncable {


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

1. Pair two devices: A and B
2. Remove device A on device B
3. Open device A, open Sync settings and verify that Sync welcome screen is presented

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

