### PR TITLE
Fix #789: Don't add a Device if it already exists.

### DIFF
--- a/DataTests/DeviceTests.swift
+++ b/DataTests/DeviceTests.swift
@@ -59,6 +59,26 @@ class DeviceTests: CoreDataTestCase {
         XCTAssertEqual(try! DataController.viewContext.fetch(fetchRequest).count, 1)
     }
     
+    func testUniqueSyncUUID() {
+        let context = DataController.newBackgroundContext()
+        var device: Device!
+        XCTAssertEqual(try! DataController.viewContext.fetch(fetchRequest).count, 0)
+        backgroundSaveAndWaitForExpectation {
+            device = Device.add(rootObject: nil, save: true, sendToSync: false, context: context) as? Device
+            XCTAssertNotNil(device)
+        }
+        XCTAssertEqual(try! DataController.viewContext.fetch(fetchRequest).count, 1)
+        
+        let root = SyncDevice()
+        root.objectId = device.syncUUID
+        
+        backgroundSaveAndWaitForExpectation {
+            _ = Device.add(rootObject: root, save: true, sendToSync: false, context: context) as? Device
+        }
+        
+        XCTAssertEqual(try! DataController.viewContext.fetch(fetchRequest).count, 1)
+    }
+    
     func testUpdate() {
         let newName = "newName"
         let newDeviceId = [1, 2, 3]


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

This is a workaround solution. Proper fix will be done once https://github.com/brave/brave-ios/pull/681 is merged in, so we have an OperationQueue to avoid any race conditions.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adaquate test plan exists for QA to validate (if applicable)

