### PR TITLE
Fix #859: Delete nested bookmarks on a single context.

### DIFF
--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -387,15 +387,14 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
         return self.add(rootObject: bookmark)
     }
     
-    public func delete(sendToSync: Bool = true) {
+    public func delete(save: Bool = true, sendToSync: Bool = true, context: NSManagedObjectContext? = nil) {
         func deleteFromStore() {
-            let context = DataController.newBackgroundContext()
+            let context = context ?? DataController.newBackgroundContext()
             
             do {
                 let objectOnContext = try context.existingObject(with: self.objectID)
                 context.delete(objectOnContext)
-                
-                DataController.save(context: context)
+                if save { DataController.save(context: context)}
             } catch {
                 log.warning("Could not find object: \(self) on a background context.")
             }
@@ -577,8 +576,8 @@ extension Bookmark {
         // No auto-save, must be handled by caller if desired
     }
     
-    public func deleteResolvedRecord() {
-        delete(sendToSync: false)
+    public func deleteResolvedRecord(save: Bool, context: NSManagedObjectContext?) {
+        delete(save: save, sendToSync: false, context: context)
     }
     
     public func asDictionary(deviceId: [Int]?, action: Int?) -> [String: Any] {

--- a/Data/models/CRUDProtocols.swift
+++ b/Data/models/CRUDProtocols.swift
@@ -13,7 +13,7 @@ private let log = Logger.browserLogger
 typealias CRUD = Readable & Deletable
 
 public protocol Deletable where Self: NSManagedObject {
-    func delete()
+    func delete(context: NSManagedObjectContext)
     static func deleteAll(predicate: NSPredicate?, context: NSManagedObjectContext,
                           includesPropertyValues: Bool, save: Bool)
 }
@@ -27,8 +27,7 @@ public protocol Readable where Self: NSManagedObject {
 
 // MARK: - Implementations
 public extension Deletable where Self: NSManagedObject {
-    func delete() {
-        let context = DataController.newBackgroundContext()
+    func delete(context: NSManagedObjectContext = DataController.newBackgroundContext()) {
         
         do {
             let objectOnContext = try context.existingObject(with: self.objectID)

--- a/Data/models/Device.swift
+++ b/Data/models/Device.swift
@@ -64,7 +64,7 @@ public final class Device: NSManagedObject, Syncable, CRUD {
         return sharedCurrentDevice
     }
     
-    public func remove(sendToSync: Bool = true) {
+    public func remove(save: Bool = true, sendToSync: Bool = true) {
         guard let context = managedObjectContext else { return }
         
         if sendToSync {
@@ -75,7 +75,7 @@ public final class Device: NSManagedObject, Syncable, CRUD {
             Sync.shared.leaveSyncGroup(sendToSync: false)
         } else {
             context.delete(self)
-            DataController.save(context: context)
+            if save { DataController.save(context: context) }
         }
     }
     
@@ -142,8 +142,8 @@ extension Device {
         // No save currently
     }
     
-    public func deleteResolvedRecord() {
-        remove(sendToSync: false)
+    public func deleteResolvedRecord(save: Bool, context: NSManagedObjectContext?) {
+        remove(save: save, sendToSync: false)
     }
     
     // This should be abstractable

--- a/Data/models/Syncable.swift
+++ b/Data/models/Syncable.swift
@@ -21,7 +21,7 @@ public protocol Syncable: class /* where Self: NSManagedObject */ {
     // resolved records from sync should be never sent back to the sync server.
     static func createResolvedRecord(rootObject root: SyncRecord?, save: Bool, context: NSManagedObjectContext)
     func updateResolvedRecord(_ record: SyncRecord?)
-    func deleteResolvedRecord()
+    func deleteResolvedRecord(save: Bool, context: NSManagedObjectContext?)
 }
 
 extension Syncable {

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -461,7 +461,7 @@ extension Sync {
                 
                 var action = SyncActions(rawValue: fetchedRoot.action ?? -1)
                 if action == SyncActions.delete {
-                    clientRecord?.deleteResolvedRecord()
+                    clientRecord?.deleteResolvedRecord(save: false, context: context)
                 } else if action == SyncActions.create {
                     
                     if clientRecord != nil {


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

Two things were changed
- Using one context for deleting all sync records
- Saving this context after all objects are deleted, previously we saved context after each delete operation

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adaquate test plan exists for QA to validate (if applicable)

