### PR TITLE
Fix #856: Add Rate Brave option in settings

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -455,6 +455,7 @@ public extension Strings {
     public static let Never_show = NSLocalizedString("NeverShow", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Never show", comment: "tabs bar show/hide option")
     public static let Always_show = NSLocalizedString("AlwaysShow", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Always show", comment: "tabs bar show/hide option")
     public static let Show_in_landscape_only = NSLocalizedString("ShowInLandscapeOnly", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Show in landscape only", comment: "tabs bar show/hide option")
+    public static let Rate_Brave = NSLocalizedString("RateBrave", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Rate Brave", comment: "Open the App Store to rate Brave.")
     public static let Report_a_bug = NSLocalizedString("ReportABug", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Report a bug", comment: "Show mail composer to report a bug.")
     public static let Privacy_Policy = NSLocalizedString("PrivacyPolicy", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Privacy Policy", comment: "Show Brave Browser Privacy Policy page from the Privacy section in the settings.")
     public static let Terms_of_Use = NSLocalizedString("TermsOfUse", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Terms of Use", comment: "Show Brave Browser TOS page from the Privacy section in the settings.")

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -320,6 +320,15 @@ class SettingsViewController: TableViewController {
                         self.dismiss(animated: true)
                     },
                     cellClass: MultilineButtonCell.self),
+                Row(text: Strings.Rate_Brave,
+                    selection: { [unowned self] in
+                        // Rate Brave
+                        guard let writeReviewURL = URL(string: "https://geo.itunes.apple.com/app/id1052879175?action=write-review")
+                            else { return }
+                        UIApplication.shared.open(writeReviewURL)
+                        self.dismiss(animated: true)
+                    },
+                    cellClass: MultilineValue1Cell.self),
                 Row(text: Strings.Privacy_Policy,
                     selection: { [unowned self] in
                         // Show privacy policy


### PR DESCRIPTION
Fix #856

Per "Manually Request a Review" in the ["Requesting App Store Reviews" documentation](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requesting_app_store_reviews):
> To enable a user to initiate a review as a result of an action in the UI use a deep link to the App Store page for your app with the query parameter action=write-review appended to the URL.

This change adds the Rate Brave option in settings. When Rate Brave is tapped, the App Store is opened with a screen to rate Brave.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:
1. Open Settings.
2. Tap **Rate Brave**.
3. The App Store should open, and a screen to rate Brave should be visible.

### Screenshots:

Settings option:
![](https://user-images.githubusercontent.com/19424103/53770436-a37dcc80-3ea4-11e9-907a-ac1c33a27d14.png)

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

