### PR TITLE
Fix #927, migrate syncOrder for reordering changes in 1.8

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -104,7 +104,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         let profile = getProfile(application)
         let profilePrefix = profile.prefs.getBranchPrefix()
-        Preferences.migratePreferences(keyPrefix: profilePrefix)
+        Migration.launchMigrations(keyPrefix: profilePrefix)
 
         if !DebugSettingsBundleOptions.disableLocalWebServer {
             // Set up a web server that serves us static content. Do this early so that it is ready when the UI is presented.

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -10,10 +10,22 @@ import Data
 
 private let log = Logger.browserLogger
 
-extension Preferences {
+class Migration {
+    static func launchMigrations(keyPrefix: String) {
+        Preferences.migratePreferences(keyPrefix: keyPrefix)
+        
+        if !Preferences.Migration.syncOrderCompleted.value {
+            Bookmark.syncOrderMigration()
+            Preferences.Migration.syncOrderCompleted.value = true
+        }
+    }
+}
+
+fileprivate extension Preferences {
     /// Migration preferences
     final class Migration {
         static let completed = Option<Bool>(key: "migration.completed", default: false)
+        static let syncOrderCompleted = Option<Bool>(key: "migration.sync-order.completed", default: false)
     }
     
     /// Migrate the users preferences from prior versions of the app (<2.0)

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -623,7 +623,16 @@ extension Sync {
         let next = nextOrder ?? ""
         
         let getBookmarkOrderFunction = jsContext?.objectForKeyedSubscript("getBookmarkOrder")
-        return getBookmarkOrderFunction?.call(withArguments: [prev, next]).toString()
+        
+        guard let value = getBookmarkOrderFunction?.call(withArguments: [prev, next]).toString() else {
+            return nil
+        }
+        
+        if Bookmark.isSyncOrderValid(value) {
+            return value
+        }
+        
+        return nil
     }
 }
 

--- a/DataTests/BookmarkTests.swift
+++ b/DataTests/BookmarkTests.swift
@@ -487,6 +487,19 @@ class BookmarkTests: CoreDataTestCase {
     
     // MARK: - Helpers
     
+    func testSyncOrderValidation() {
+        // Valid values
+        ["0.0.1", "12.23.345.454", "1.2.3.4.5.6.7"].forEach {
+            XCTAssertTrue(Bookmark.isSyncOrderValid($0))
+        }
+        
+        // Invalid values
+        [".1.2.3", "1.2.3.", "undefined", "null" , "1,2.3", "-1.0.2", "1.a.3",
+         "1", "12", "1.2", "1.2..3, 1.2.43a.42"].forEach {
+            XCTAssertFalse(Bookmark.isSyncOrderValid($0), "False positive for : \($0)")
+        }
+    }
+    
     /// Wrapper around `Bookmark.create()` with context save wait expectation and fetching object from view context.
     @discardableResult 
     private func createAndWait(url: URL?, title: String?, customTitle: String? = nil, 


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

