### PR TITLE
Fix #938, remove passcode retry lock after entering foreground.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -348,7 +348,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         self.updateAuthenticationInfo()
         
         if let authInfo = KeychainWrapper.sharedAppContainerKeychain.authenticationInfo(), authInfo.isPasscodeRequiredImmediately {
-            authenticator?.promptUserForAuthentication()
+            authenticator?.willEnterForeground()
         }
     }
     

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -35,6 +35,10 @@ class AppAuthenticator {
     
     private let blurController = BlurController()
     
+    private lazy var passcodeVC: PasscodeEntryViewController = {
+        return PasscodeEntryViewController()
+    }()
+    
     /// Create an authenticator which protects a specific window
     init(protectedWindow: UIWindow, promptImmediately: Bool, isPasscodeEntryCancellable: Bool = true) {
         self.protectedWindow = protectedWindow
@@ -81,8 +85,13 @@ class AppAuthenticator {
         }
     }
     
+    func willEnterForeground() {
+        passcodeVC.passcodeCheckSetup()
+        promptUserForAuthentication()
+    }
+    
     /// Prompt the user for authentication based on settings
-    func promptUserForAuthentication() {
+    private func promptUserForAuthentication() {
         guard let authInfo = KeychainWrapper.sharedAppContainerKeychain.authenticationInfo(), !isPrompting else { return }
         
         showBackgroundBlur()
@@ -97,11 +106,11 @@ class AppAuthenticator {
                     self.dismissPrompt()
                     self.didCancelPasscodeEntry?()
                 } else {
-                    AppAuthenticator.presentPasscodeAuthentication(self.blurController, delegate: self, isCancellable: self.isPasscodeEntryCancellable)
+                    self.presentPasscodeAuthentication(self.blurController, delegate: self, isCancellable: self.isPasscodeEntryCancellable)
                 }
             },
             fallback: {
-                AppAuthenticator.presentPasscodeAuthentication(self.blurController, delegate: self, isCancellable: self.isPasscodeEntryCancellable)
+                self.presentPasscodeAuthentication(self.blurController, delegate: self, isCancellable: self.isPasscodeEntryCancellable)
             }
         )
         isPrompting = true
@@ -160,8 +169,8 @@ extension AppAuthenticator {
         }
     }
     
-    private static func presentPasscodeAuthentication(_ controller: UIViewController, delegate: PasscodeEntryDelegate?, isCancellable: Bool) {
-        let passcodeVC = PasscodeEntryViewController()
+    private func presentPasscodeAuthentication(_ controller: UIViewController, delegate: PasscodeEntryDelegate?, isCancellable: Bool) {
+        
         passcodeVC.isCancellable = isCancellable
         passcodeVC.delegate = delegate
         let navController = UINavigationController(rootViewController: passcodeVC)

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -33,7 +33,7 @@ open class AuthenticationKeychainInfo: NSObject, NSCoding {
     open var useTouchID: Bool
 
     // Timeout period before user can retry entering passcodes
-    open var lockTimeInterval: TimeInterval = 15 * 60
+    private let lockTimeInterval: TimeInterval = AppConstants.BuildChannel == .release ? 15 * 60 : 60
 
     public init(passcode: String) {
         self.passcode = passcode
@@ -112,5 +112,12 @@ public extension AuthenticationKeychainInfo {
             return false
         }
         return (SystemUtils.systemUptime() - (self.lockOutInterval ?? 0)) < lockTimeInterval
+    }
+    
+    var lockoutTimeLeft: TimeInterval? {
+        guard let lockOutInterval = lockOutInterval else { return nil }
+        
+        let timeLeft = (lockOutInterval + lockTimeInterval) - SystemUtils.systemUptime()
+        return timeLeft > 0 ? timeLeft : nil
     }
 }


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
See the STR in linked issue. For testing purposes I reduced the lockout timer from 15minutes to 1minute

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

