### PR TITLE
Fix #951: Set `customTitle` to `title` when updating a Bookmark.

### DIFF
--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -314,7 +314,8 @@ extension Bookmark {
             }
             
             if let ct = customTitle, !ct.isEmpty {
-                bookmarkToUpdate.customTitle = customTitle
+                bookmarkToUpdate.customTitle = ct
+                bookmarkToUpdate.title = ct
             }
             
             if let u = url, !u.isEmpty {

--- a/DataTests/BookmarkTests.swift
+++ b/DataTests/BookmarkTests.swift
@@ -197,7 +197,6 @@ class BookmarkTests: CoreDataTestCase {
     }
     
     func testGetAllBookmarks() {
-        let context = DataController.viewContext
         let bookmarksCount = 3
         insertBookmarks(amount: bookmarksCount)
         // Adding a favorite(non-bookmark type of bookmark)
@@ -230,15 +229,16 @@ class BookmarkTests: CoreDataTestCase {
         
         let newObject = try! DataController.viewContext.fetch(fetchRequest).first!
         
-        XCTAssertNotEqual(newObject.displayTitle, customTitle)
+        XCTAssertNotEqual(newObject.title, customTitle)
+        XCTAssertNotEqual(newObject.customTitle, customTitle)
         XCTAssertNotEqual(newObject.url, url)
         
-        XCTAssertEqual(newObject.displayTitle, newCustomTitle)
+        XCTAssertEqual(newObject.title, newCustomTitle)
+        XCTAssertEqual(newObject.customTitle, newCustomTitle)
         XCTAssertEqual(newObject.url, newUrl)
     }
     
     func testUpdateBookmarkNoChanges() {
-        let context = DataController.viewContext
         let customTitle = "Brave"
         let url = "http://brave.com"
                 
@@ -256,7 +256,6 @@ class BookmarkTests: CoreDataTestCase {
     }
     
     func testUpdateBookmarkBadUrl() {
-        let context = DataController.viewContext
         let customTitle = "Brave"
         let url = "http://brave.com"
         let badUrl = "   " // Empty spaces cause URL(string:) to return nil


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

