### PR TITLE
Fix #989: Fix Rate Brave URL added in 30dd20e

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -325,7 +325,7 @@ class SettingsViewController: TableViewController {
                 Row(text: Strings.Rate_Brave,
                     selection: { [unowned self] in
                         // Rate Brave
-                        guard let writeReviewURL = URL(string: "https://geo.itunes.apple.com/app/id1052879175?action=write-review")
+                        guard let writeReviewURL = URL(string: "https://itunes.apple.com/app/id1052879175?action=write-review")
                             else { return }
                         UIApplication.shared.open(writeReviewURL)
                         self.dismiss(animated: true)


### PR DESCRIPTION
Fixes #989

This is a followup of PR #873 (30dd20e); see that PR for the test plan and screenshots.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)