### PR TITLE
Fix #969: This fixes `Open Image In New Tab` button In Private window that opens the image in a Normal tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2494,7 +2494,8 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
             
             let openInNewTabAction = UIAlertAction(title: Strings.OpenImageInNewTabActionTitle, style: .default) { _ in
-                self.tabManager.addTab(URLRequest(url: url), afterTab: self.tabManager.selectedTab)
+                let isPrivate = PrivateBrowsingManager.shared.isPrivateBrowsing
+                self.tabManager.addTab(URLRequest(url: url), afterTab: self.tabManager.selectedTab, isPrivate: isPrivate)
                 self.scrollController.showToolbars(animated: true)
             }
             actionSheetController.addAction(openInNewTabAction, accessibilityIdentifier: "linkContextMenu.openImageInNewTab")


### PR DESCRIPTION
-The change happened in BrowserViewController.swift inside openInNewTabAction Alert Action completion.
-Fixed bug #969. 
-I also changed Cartfile SwiftyJSON from 4.1.0 to 4.2.0 because i had issue building the project with xcode log: "Module compiled with Swift 4.1.2 cannot be imported by the Swift 4.2 compiler: /brave-ios/Carthage/Build/iOS/SwiftyJSON.framework/Modules/SwiftyJSON.swiftmodule/x86_64.swiftmodule" 

## Test Plan:
1- Open private window
2- Long press on any image and tap "Open In New Tab" button
Result: The image should be opened in a new tab in private mode