### PR TITLE
Fix #992: Update empty bookmark title from desktop sync.

### DIFF
--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -121,6 +121,9 @@ public final class Bookmark: NSManagedObject, WebsitePresentable, Syncable, CRUD
     // MARK: Update
     
     public func update(customTitle: String?, url: String?) {
+        // Title can't be empty, except when coming from Sync
+        let isTitleEmpty = customTitle?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true
+        if customTitle == nil || isTitleEmpty { return }
         updateInternal(customTitle: customTitle, url: url)
     }
     
@@ -313,10 +316,8 @@ extension Bookmark {
                 return
             }
             
-            if let ct = customTitle, !ct.isEmpty {
-                bookmarkToUpdate.customTitle = ct
-                bookmarkToUpdate.title = ct
-            }
+            bookmarkToUpdate.customTitle = customTitle
+            bookmarkToUpdate.title = customTitle
             
             if let u = url, !u.isEmpty {
                 bookmarkToUpdate.url = url

--- a/DataTests/FavoriteTests.swift
+++ b/DataTests/FavoriteTests.swift
@@ -44,6 +44,7 @@ class FavoriteTests: CoreDataTestCase {
     func testEditFavoriteURL() {
         let url = "http://brave.com"
         let newUrl = "http://updated.example.com"
+        let newTitle = "newtitle"
         
         let object = createAndWait(url: URL(string: url), title: "title")
         
@@ -51,7 +52,7 @@ class FavoriteTests: CoreDataTestCase {
         XCTAssertEqual(object.url, url)
         
         backgroundSaveAndWaitForExpectation {
-            object.update(customTitle: nil, url: newUrl)
+            object.update(customTitle: newTitle, url: newUrl)
         }
         // Make sure only one record was added to DB
         XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 1)


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

