### PR TITLE
Fix #888: exiting PB mode causes normal tab to become blank with incorrect URL

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -283,6 +283,11 @@ class TabManager: NSObject {
         }
     }
 
+    ///Called to turn selectedIndex back to -1
+    func resetSelectedIndex() {
+        _selectedIndex = -1
+    }
+    
     func expireSnackbars() {
         assert(Thread.isMainThread)
 
@@ -569,6 +574,7 @@ class TabManager: NSObject {
             // It might have changed index, so we look it up again.
             _selectedIndex = allTabs.index(of: oldTab) ?? -1
         } else if let parentTab = tab.parent,
+            currentTabs.count > 1,
             let newTab = currentTabs.reduce(currentTabs.first, { currentBestTab, tab2 in
             if let tab1 = currentBestTab, let time1 = tab1.lastExecutedTime {
                 if let time2 = tab2.lastExecutedTime {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -457,6 +457,9 @@ class TabTrayController: UIViewController, Themeable {
         // we clear out all of the private tabs
         tabManager.willSwitchTabMode(leavingPBM: privateMode)
         privateMode = !privateMode
+        
+        //When we switch from Private => Regular make sure we reset _selectedIndex, fix for bug #888
+        tabManager.resetSelectedIndex()
 
         toolbar.privateModeButton.isSelected = privateMode
         collectionView.layoutSubviews()


### PR DESCRIPTION
the main hole i see was responsible for that bug was (previous ?? selectedTab) so either we:
1- comment (?? selectedTab) part and accept the fact we will keep applying theme for even the same tab type or
2- dive deep and make some changes to the process

# Changes that happened:

1- When user tab private button and didTogglePrivateMode() gets called -> we will reset the selectedIndex “tabManager.resetSelectedIndex()”
2- When user remove a tab and removeTab(_ tab: Tab) gets called -> in first 'else if' statement we will check if the “currentTabs.count > 1”

# The Flow

1- When user tab private button and didTogglePrivateMode() gets called -> we will reset the selectedIndex and turn it to -1 “tabManager.resetSelectedIndex()”
2, a- When user remove a tab and removeTab(_ tab: Tab) gets called -> in else if statement we will check if the “currentTabs.count > 1”
2, b- in selectTab(_ tab: Tab?, previous: Tab? = nil) previous local variable will be nil so the function won’t return from “previous === tab condition”  and will continue until it calls tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) and the theme gets changed once only

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.

## Test Plan:

1- open any url
2, a- long press on any link and press “Open in new tab”
2, b- long press on any link and press “Open in new private tab”
3- press tabs button on bottom right corner
4- press private button on bottom left corner 
5- swipe to remove the 2nd tab from regular mode
6- tap on the first tab
-you will find the website of step 1 

### Screenshots:

## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)
