### PR TITLE
Fix #1023: Fix Pinch to Zoom not working correctly on all sites

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -189,6 +189,7 @@ class Tab: NSObject {
             configuration!.preferences = WKPreferences()
             configuration!.preferences.javaScriptCanOpenWindowsAutomatically = false
             configuration!.allowsInlineMediaPlayback = true
+            configuration!.ignoresViewportScaleLimits = true
             let webView = TabWebView(frame: .zero, configuration: configuration!)
             webView.delegate = self
             configuration = nil


### PR DESCRIPTION
Fix #1023

This change sets `ignoresViewportScaleLimits` to `true`. From [the documentation](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2274633-ignoresviewportscalelimits):
> Setting this property to TRUE allows the webpage to be scaled, regardless of the author's intent. The ignoresViewportScaleLimits property overrides the user-scalable HTML property in a webpage. Defaults to FALSE.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

1. Open Brave and navigate to https://www.homedepot.com/.
2. Make sure that the webpage can be zoomed in and out with the pinch to zoom gesture.

### Screenshots:
![](https://user-images.githubusercontent.com/19424103/55445011-e3f16880-557e-11e9-8007-b1ef0526f3d2.gif)

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)