### PR TITLE
Fix #886: Update lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3578,9 +3578,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.debounce": {


### PR DESCRIPTION
Fixes #886.

The lodash dependency has been updated from 4.17.10 to 4.17.11 to fix a security issue. This change is the result of calling `npm audit fix`. Calling `npm audit` no longer shows any security vulnerabilities.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:
Not applicable.

### Screenshots:
Not applicable.

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

