### PR TITLE
Fix #979: Allow pin entry screen to overlay videos

### DIFF
--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -26,6 +26,7 @@ class AppAuthenticator {
                 let w = UIWindow()
                 w.backgroundColor = .clear
                 w.rootViewController = self.blurController
+                w.windowLevel = UIWindow.Level(UIWindowLevelStatusBar - 1)
                 _window = w
             }
             return _window


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

1. Turn on PIN code
2. Go to YouTube.com, start a video, make it fullscreen
3. Background app, foreground app
4. Verify also shows over regular browser

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

