### PR TITLE
Fix #1032: Only create temporary documents for main frame responses

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -266,7 +266,7 @@ extension BrowserViewController: WKNavigationDelegate {
         
         // If the content type is not HTML, create a temporary document so it can be downloaded and
         // shared to external applications later. Otherwise, clear the old temporary document.
-        if let tab = tabManager[webView] {
+        if let tab = tabManager[webView], navigationResponse.isForMainFrame {
             if response.mimeType?.isKindOfHTML == false, let request = request {
                 tab.temporaryDocument = TemporaryDocument(preflightResponse: response, request: request)
             } else {


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

- Verify original issue is solved (amazon.com → any product page → share)
- Verify sharing a non-html page (A pdf page, some exe/dmg download, etc.)
- Verify sharing regular pages (regression test)

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

