### PR TITLE
Fix #836: Enable multi-line Learn More button on empty private mode view

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -985,6 +985,7 @@ fileprivate class EmptyPrivateTabsView: UIView {
         $0.setTitle(Strings.Private_Tab_Link, for: [])
         $0.setTitleColor(UIConstants.PrivateModeTextHighlightColor, for: [])
         $0.titleLabel?.font = EmptyPrivateTabsViewUX.LearnMoreFont
+        $0.titleLabel?.numberOfLines = 0
     }
 
     let iconImageView = UIImageView(image: #imageLiteral(resourceName: "private_glasses")).then {


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

