### PR TITLE
Fix #947: Added functionality of exiting overlay mode by tapping somewhere else

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -405,8 +405,17 @@ class BrowserViewController: UIViewController {
         // links into the view from other apps.
         let dropInteraction = UIDropInteraction(delegate: self)
         view.addInteraction(dropInteraction)
-        
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tappingOutOfOverlayMode(_:)))
+        self.view.addGestureRecognizer(tapGesture)
+
         initializeSyncWebView()
+    }
+    
+    @objc func tappingOutOfOverlayMode(_ sender: UITapGestureRecognizer) {
+        if urlBar.inOverlayMode {
+            urlBar.leaveOverlayMode(didCancel: true)
+        }
     }
     
     /// Initialize Sync without connecting. Sync webview needs to be in a "permanent" location


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:
**Important**: The behavior described in the issue is still present. I believe the solution is sufficient.

1. Press + for new tab from new tab screen
2. Tap anywhere on screen to remove keyboard and exiting OverlayMode as intended (Same as pressing Cancel)

#### Alternatively to see that the minor issue is still there but unnoticeable: 

1. Press + for new tab from new tab screen
2. Scroll anywhere on screen to remove keyboard 
3. View is still in OverlayMode
4. Tap anywhere on screen to exit OverlayMode

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

