### PR TITLE
Fix #1076: Add objcMembers annotation to SiteTableViewController

### DIFF
--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -70,6 +70,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView {
 /**
  * Provides base shared functionality for site rows and headers.
  */
+@objcMembers
 class SiteTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     fileprivate let CellIdentifier = "CellIdentifier"
     fileprivate let HeaderIdentifier = "HeaderIdentifier"


### PR DESCRIPTION
This is to prevent a bug where classes that inherit from SiteTableViewController
are not able to call delegate methods from UITableViewController.

This also fixes similar bugs in History and SearchView controllers.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

Alternatively, we could set `Swift 3 @objc inference` to `on` in build settings. But this will trigger some runtime warnings. Firefox seemed to work with the `@objcMembers` route too, see https://github.com/mozilla-mobile/firefox-ios/commit/e6d6aaa8c813dfc66943b6a1fcd89ff318913336

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
Test for regressions in:
- History panel
- Bookmarks panel
- SearchView panel(type few characters in url bar, verify some url suggestions below are showing)

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

