### PR TITLE
Fix #1100: Use the correct web data store when switching between private & normal mode

### DIFF
--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -10,6 +10,8 @@ class BraveWebView: WKWebView {
     init(frame: CGRect, configuration: WKWebViewConfiguration = WKWebViewConfiguration(), privacyProtection: PrivacyProtectionProtocol = PrivacyProtection()) {
         if privacyProtection.nonPersistent {
             configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        } else {
+            configuration.websiteDataStore = WKWebsiteDataStore.default()
         }
         
         super.init(frame: frame, configuration: configuration)


### PR DESCRIPTION
The WkWebviewConfiguration's DataStore is now switched back to default on normal mode.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
Follow old STR:
STR
1. Launch Brave
2. Visit a website with cookie nag screen like www.dvhn.nl
3. Accept cookies
4. Open incognito mode and open a random website
5. Close incognito mode
6. Close regular website tab
7. Open website that uses cookies again
*Actual result:*
Not having to login again/accept cookie warnings
*Expected result:*
Not having to login again/accept cookie warnings

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

