### PR TITLE
Fix #1096: Get currentTabUrl before going before going on bg thread.

### DIFF
--- a/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -83,16 +83,9 @@ class AdBlockStats: LocalAdblockResourceProtocol {
         adblockStatsResources[currentLocaleCode] = ABPFilterLibWrapper()
     }
     
-    func shouldBlock(_ request: URLRequest) -> Bool {
+    func shouldBlock(_ request: URLRequest, currentTabUrl: URL?) -> Bool {
         guard let url = request.url else {
             return false
-        }
-        
-        var currentTabUrl: URL?
-        
-        DispatchQueue.main.async {
-            guard let delegate = UIApplication.shared.delegate as? AppDelegate else { return }
-            currentTabUrl = delegate.browserViewController.tabManager.selectedTab?.url
         }
         
         // Do not block main frame urls


### PR DESCRIPTION


<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

