### PR TITLE
Ref #1080: Added Peek and Pop to link preview.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -586,6 +586,7 @@
 		A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */; };
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
 		AB1B097A21F2F00400E0DD51 /* FavoritesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1B097921F2F00400E0DD51 /* FavoritesViewControllerTests.swift */; };
+		B0373FF8229D1493006F78B4 /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0373FF7229D1493006F78B4 /* PreviewViewController.swift */; };
 		C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */; };
 		C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */; };
 		C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */; };
@@ -1939,6 +1940,7 @@
 		A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeHelper.swift; sourceTree = "<group>"; };
 		A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightModeHelper.swift; sourceTree = "<group>"; };
 		AB1B097921F2F00400E0DD51 /* FavoritesViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewControllerTests.swift; sourceTree = "<group>"; };
+		B0373FF7229D1493006F78B4 /* PreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewViewController.swift; sourceTree = "<group>"; };
 		C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListViewController.swift; sourceTree = "<group>"; };
 		C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListAnimator.swift; sourceTree = "<group>"; };
 		C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabTrayButtonExtensions.swift; path = ../Browser/TabTrayButtonExtensions.swift; sourceTree = "<group>"; };
@@ -3767,6 +3769,7 @@
 				A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */,
 				7BA8D1C61BA037F500C8AE9E /* OpenInHelper.swift */,
 				D0C95E0D200FD3B200E4E51C /* PrintHelper.swift */,
+				B0373FF7229D1493006F78B4 /* PreviewViewController.swift */,
 				D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */,
 				FA6B2AC11D41F02D00429414 /* Punycode.swift */,
 				FA9294001D6584A200AC8D33 /* QRCode.xcassets */,
@@ -5909,6 +5912,7 @@
 				0A4BEF5D221AF1910005551A /* AdblockResourceDownloader.swift in Sources */,
 				0BA1E02E1B046F1E007675AF /* ErrorPageHelper.swift in Sources */,
 				D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */,
+				B0373FF8229D1493006F78B4 /* PreviewViewController.swift in Sources */,
 				59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */,
 				0A8C6993225BC7B100988715 /* ToolbarUrlActionsProtocol.swift in Sources */,
 				A1CDF22B20BDD6B8005C6E58 /* POPExtensions.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2319,7 +2319,7 @@ extension BrowserViewController: WKUIDelegate {
     
     func webView(_ webView: WKWebView, shouldPreviewElement elementInfo: WKPreviewElementInfo) -> Bool {
         guard let url = elementInfo.linkURL else { return false }
-        return !Storage.isIgnoredURL(url)
+        return url.eligibleForPeekAndPop
     }
     
     func webView(_ webView: WKWebView, commitPreviewingViewController previewingViewController: UIViewController) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2324,7 +2324,7 @@ extension BrowserViewController: WKUIDelegate {
     
     func webView(_ webView: WKWebView, commitPreviewingViewController previewingViewController: UIViewController) {
         guard let previewViewController = previewingViewController as? PreviewViewController else { return }
-        tabManager.selectedTab?.webView?.load(URLRequest(url: previewViewController.url))
+        tabManager.selectedTab?.loadRequest(URLRequest(url: previewViewController.url))
     }
     
     func webView(_ webView: WKWebView,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2318,15 +2318,13 @@ extension BrowserViewController: WKUIDelegate {
     }
     
     func webView(_ webView: WKWebView, shouldPreviewElement elementInfo: WKPreviewElementInfo) -> Bool {
-        guard let url = elementInfo.linkURL, !Storage.isIgnoredURL(url) else { return false }
-        return true
+        guard let url = elementInfo.linkURL else { return false }
+        return !Storage.isIgnoredURL(url)
     }
     
     func webView(_ webView: WKWebView, commitPreviewingViewController previewingViewController: UIViewController) {
-        guard let previewViewController = previewingViewController as? PreviewViewController,
-            let tab = tabManager.selectedTab,
-            let webView = tab.webView else { return }
-        webView.load(URLRequest(url: previewViewController.url))
+        guard let previewViewController = previewingViewController as? PreviewViewController else { return }
+        tabManager.selectedTab?.webView?.load(URLRequest(url: previewViewController.url))
     }
     
     func webView(_ webView: WKWebView, previewingViewControllerForElement elementInfo: WKPreviewElementInfo, defaultActions previewActions: [WKPreviewActionItem]) -> UIViewController? {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2340,10 +2340,18 @@ extension BrowserViewController: WKUIDelegate {
         }
 
         previewViewController.openURLInNewTab = { url in
-            guard let currentTab = self.tabManager.selectedTab else { return }
+            guard let _ = self.tabManager.selectedTab else { return }
             let tab = self.tabManager.addTab(PrivilegedRequest(url: url) as URLRequest,
                                              afterTab: self.tabManager.selectedTab,
-                                             isPrivate: currentTab.type.isPrivate)
+                                             isPrivate: false)
+            self.tabManager.selectTab(tab)
+        }
+        
+        previewViewController.openURLInNewPrivateTab = { url in
+            guard let _ = self.tabManager.selectedTab else { return }
+            let tab = self.tabManager.addTab(PrivilegedRequest(url: url) as URLRequest,
+                                             afterTab: self.tabManager.selectedTab,
+                                             isPrivate: true)
             self.tabManager.selectTab(tab)
         }
         

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2333,6 +2333,12 @@ extension BrowserViewController: WKUIDelegate {
         guard let tab = tabManager.selectedTab, let url = elementInfo.linkURL else { return nil }
         let previewViewController = PreviewViewController(tab: tab, url: url)
         
+        // If the URL is an image resource,
+        // we want to show the image without an empty white space in a preview page.
+        if url.isImageResource, let imageSize = url.imageSize {
+            previewViewController.preferredContentSize = imageSize
+        }
+
         previewViewController.openURLInNewTab = { url in
             guard let currentTab = self.tabManager.selectedTab else { return }
             let tab = self.tabManager.addTab(PrivilegedRequest(url: url) as URLRequest,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2327,7 +2327,9 @@ extension BrowserViewController: WKUIDelegate {
         tabManager.selectedTab?.webView?.load(URLRequest(url: previewViewController.url))
     }
     
-    func webView(_ webView: WKWebView, previewingViewControllerForElement elementInfo: WKPreviewElementInfo, defaultActions previewActions: [WKPreviewActionItem]) -> UIViewController? {
+    func webView(_ webView: WKWebView,
+                 previewingViewControllerForElement elementInfo: WKPreviewElementInfo,
+                 defaultActions previewActions: [WKPreviewActionItem]) -> UIViewController? {
         guard let tab = tabManager.selectedTab, let url = elementInfo.linkURL else { return nil }
         let previewViewController = PreviewViewController(tab: tab, url: url)
         

--- a/Client/Frontend/Browser/PreviewViewController.swift
+++ b/Client/Frontend/Browser/PreviewViewController.swift
@@ -10,6 +10,7 @@ import WebKit
 class PreviewViewController: UIViewController {
     
     var openURLInNewTab: ((URL) -> Void)?
+    var openURLInNewPrivateTab: ((URL) -> Void)?
     var copyURL: ((URL) -> Void)?
     var shareURL: ((URL) -> Void)?
     
@@ -21,6 +22,10 @@ class PreviewViewController: UIViewController {
             self.openURLInNewTab?(self.url)
         }
         
+        let openInNewPrivateTabAction = UIPreviewAction(title: Strings.OpenNewPrivateTabButtonTitle, style: .default) { _, _ in
+            self.openURLInNewPrivateTab?(self.url)
+        }
+        
         let copyAction = UIPreviewAction(title: Strings.CopyLinkActionTitle, style: .default) { _, _ in
             self.copyURL?(self.url)
         }
@@ -29,7 +34,11 @@ class PreviewViewController: UIViewController {
             self.shareURL?(self.url)
         }
         
-        return [openInNewTabAction, copyAction, shareAction]
+        if tab.type.isPrivate {
+            return [openInNewPrivateTabAction, copyAction, shareAction]
+        }
+        
+        return [openInNewTabAction, openInNewPrivateTabAction, copyAction, shareAction]
     }
 
     init(tab: Tab, url: URL) {

--- a/Client/Frontend/Browser/PreviewViewController.swift
+++ b/Client/Frontend/Browser/PreviewViewController.swift
@@ -29,7 +29,7 @@ class PreviewViewController: UIViewController {
             self.shareURL?(self.url)
         }
         
-        return [ openInNewTabAction, copyAction, shareAction ]
+        return [openInNewTabAction, copyAction, shareAction]
     }
 
     init(tab: Tab, url: URL) {

--- a/Client/Frontend/Browser/PreviewViewController.swift
+++ b/Client/Frontend/Browser/PreviewViewController.swift
@@ -17,15 +17,15 @@ class PreviewViewController: UIViewController {
     private(set) var url: URL
     
     override var previewActionItems: [UIPreviewActionItem] {
-        let openInNewTabAction = UIPreviewAction(title: Strings.OpenNewTabButtonTitle, style: .default) { previewAction, viewController in
+        let openInNewTabAction = UIPreviewAction(title: Strings.OpenNewTabButtonTitle, style: .default) { _, _ in
             self.openURLInNewTab?(self.url)
         }
         
-        let copyAction = UIPreviewAction(title: Strings.CopyLinkActionTitle, style: .default) { previewAction, viewController in
+        let copyAction = UIPreviewAction(title: Strings.CopyLinkActionTitle, style: .default) { _, _ in
             self.copyURL?(self.url)
         }
         
-        let shareAction = UIPreviewAction(title: Strings.ShareLinkActionTitle, style: .default) { previewAction, viewController in
+        let shareAction = UIPreviewAction(title: Strings.ShareLinkActionTitle, style: .default) { _, _ in
             self.shareURL?(self.url)
         }
         

--- a/Client/Frontend/Browser/PreviewViewController.swift
+++ b/Client/Frontend/Browser/PreviewViewController.swift
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Shared
+import Storage
+import WebKit
+
+class PreviewViewController: UIViewController {
+    
+    var openURLInNewTab: ((URL) -> Void)?
+    var copyURL: ((URL) -> Void)?
+    var shareURL: ((URL) -> Void)?
+    
+    private let tab: Tab
+    private(set) var url: URL
+    
+    override var previewActionItems: [UIPreviewActionItem] {
+        let openInNewTabAction = UIPreviewAction(title: Strings.OpenNewTabButtonTitle, style: .default) { previewAction, viewController in
+            self.openURLInNewTab?(self.url)
+        }
+        
+        let copyAction = UIPreviewAction(title: Strings.CopyLinkActionTitle, style: .default) { previewAction, viewController in
+            self.copyURL?(self.url)
+        }
+        
+        let shareAction = UIPreviewAction(title: Strings.ShareLinkActionTitle, style: .default) { previewAction, viewController in
+            self.shareURL?(self.url)
+        }
+        
+        return [ openInNewTabAction, copyAction, shareAction ]
+    }
+
+    init(tab: Tab, url: URL) {
+        self.tab = tab
+        self.url = url
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupWebView(tab.webView)
+    }
+    
+    fileprivate func setupWebView(_ webView: BraveWebView?) {
+        guard let webView = webView, !isIgnoredURL(url) else { return }
+        let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
+        clonedWebView.allowsLinkPreview = true
+        self.view.addSubview(clonedWebView)
+        
+        clonedWebView.snp.makeConstraints { make in
+            make.edges.equalTo(self.view)
+        }
+        
+        clonedWebView.load(URLRequest(url: url))
+    }
+}

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -203,7 +203,7 @@ class Tab: NSObject {
 
             webView.accessibilityLabel = Strings.WebContentAccessibilityLabel
             webView.allowsBackForwardNavigationGestures = true
-            webView.allowsLinkPreview = false
+            webView.allowsLinkPreview = true
 
             // Night mode enables this by toggling WKWebView.isOpaque, otherwise this has no effect.
             webView.backgroundColor = .black

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -437,6 +437,35 @@ extension URL {
         
         return true
     }
+    
+    public var isImageResource: Bool {
+        return ["jpg", "jpeg", "png", "gif"].contains(pathExtension)
+    }
+    
+    public var imageSize: CGSize? {
+        let imageSourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let imageSource = CGImageSourceCreateWithURL(self as CFURL, imageSourceOptions),
+            let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, imageSourceOptions) as? [AnyHashable: Any],
+            let pixelWidth = imageProperties[kCGImagePropertyPixelWidth as String],
+            let pixelHeight = imageProperties[kCGImagePropertyPixelHeight as String] else {
+                return nil
+        }
+        
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+        
+        // swiftlint:disable force_cast
+        CFNumberGetValue((pixelWidth as! CFNumber), .cgFloatType, &width)
+        
+        // swiftlint:disable force_cast
+        CFNumberGetValue((pixelHeight as! CFNumber), .cgFloatType, &height)
+        
+        guard width > 0, height > 0 else {
+            return nil
+        }
+        
+        return CGSize(width: width, height: height)
+    }
 }
 
 //MARK: Private Helpers

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -420,6 +420,25 @@ extension URL {
 
 }
 
+// Helpers to deal with Peek and Pop
+extension URL {
+    public var eligibleForPeekAndPop: Bool {
+        let ignoredSchemes = ["about"]
+        
+        guard let scheme = self.scheme else { return false }
+        
+        if let _ = ignoredSchemes.index(of: scheme) {
+            return false
+        }
+        
+        if self.host == "localhost" {
+            return false
+        }
+        
+        return true
+    }
+}
+
 //MARK: Private Helpers
 private extension URL {
     func publicSuffixFromHost( _ host: String, withAdditionalParts additionalPartCount: Int) -> String? {

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -510,5 +510,23 @@ class NSURLExtensionsTests: XCTestCase {
         goodurls.forEach { XCTAssertTrue(URL(string:$0)!.eligibleForPeekAndPop) }
         badurls.forEach { XCTAssertFalse(URL(string:$0)!.eligibleForPeekAndPop) }
     }
+    
+    func testisImageResource() {
+        let goodurls = [
+            "https://www.example.com/image.png",
+            "https://www.example.com/image.jpg",
+            "https://m.foo.com/bar/image.jpeg"
+        ]
+        let badurls = [
+            "https://www.example.com",
+            "https://www.example.com/index.html",
+            "https://m.foo.com/bar/baz?noo=abc#123",
+            "about:home",
+            "http://localhost:1234/about/firefox"
+        ]
+        
+        goodurls.forEach { XCTAssertTrue(URL(string:$0)!.isImageResource) }
+        badurls.forEach { XCTAssertFalse(URL(string:$0)!.isImageResource) }
+    }
 
 }

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -494,5 +494,21 @@ class NSURLExtensionsTests: XCTestCase {
         }
 
     }
+    
+    func testeligibleForPeekAndPop() {
+        let goodurls = [
+            "https://www.example.com",
+            "https://www.example.com/index.html",
+            "https://m.foo.com/bar/baz?noo=abc#123",
+            "https://m.example.co.uk/index.html"
+        ]
+        let badurls = [
+            "about:home",
+            "http://localhost:1234/about/firefox"
+        ]
+
+        goodurls.forEach { XCTAssertTrue(URL(string:$0)!.eligibleForPeekAndPop) }
+        badurls.forEach { XCTAssertFalse(URL(string:$0)!.eligibleForPeekAndPop) }
+    }
 
 }


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

This PR is about adding [Peek and Pop](https://developer.apple.com/documentation/uikit/peek_and_pop) to link preview. 

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

When a user peeks on a link, he will see the preview view of the link's content and when he swipes up, he will see the following actions: 

* Open in New Tab
* Copy Link
* Share Link

<img width="331" alt="Screen Shot 2019-05-29 at 09 14 10" src="https://user-images.githubusercontent.com/10795657/58541213-4a9ba700-81fb-11e9-8ae9-11e0d7a55bd6.png">
<img width="331" alt="Screen Shot 2019-05-29 at 09 14 27" src="https://user-images.githubusercontent.com/10795657/58541214-4a9ba700-81fb-11e9-8697-ee2e2617c1f0.png">
<img width="331" alt="Screen Shot 2019-05-29 at 09 20 57" src="https://user-images.githubusercontent.com/10795657/58541215-4a9ba700-81fb-11e9-955c-6169fcf3b50f.png">

There are a few things I would like to highlight:
* when a user opens a content via peek and pop feature, the URL will be loaded on a main view again (even though it has been loaded on a preview page);
* when a user opens a content via peek in a new tab (Open in New Tab action), the web view history (from a tab which it was opened) in a new tab is not available.

### Improvements

**1. Not reloading a page when it has been loaded on a view displayed via peek and pop**

I believe it would require a refactoring in a `BrowserViewController`. One idea would be to extract a content of this screen (basically the web view `webViewContainer`) in a separate view controller. In this way we could simply replace the peek view controller with the current content on a main view. 

<img width="825" alt="Screen Shot 2019-05-29 at 10 30 44" src="https://user-images.githubusercontent.com/10795657/58541960-e1b52e80-81fc-11e9-854d-0610eabb3c00.png">


**2. Keeping web view history when a user opens a content via peek in a new tab** 

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

closes https://github.com/brave/brave-ios/issues/1080