### PR TITLE
Fix #1120: Adblock Fifo dictionary race condition crashfix.

### DIFF
--- a/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
@@ -53,6 +53,7 @@ enum TPStatsResourceType: String {
 
 class TPStatsBlocklistChecker {
     static let shared = TPStatsBlocklistChecker()
+    private let adblockSerialQueue = DispatchQueue(label: "com.brave.adblock-dispatch-queue")
 
     func isBlocked(request: URLRequest, domain: Domain, resourceType: TPStatsResourceType? = nil) -> Deferred<BlocklistName?> {
         let deferred = Deferred<BlocklistName?>()
@@ -74,7 +75,7 @@ class TPStatsBlocklistChecker {
         }
         let currentTabUrl = delegate.browserViewController.tabManager.selectedTab?.url
         
-        DispatchQueue.global().async {
+        adblockSerialQueue.async {
             let enabledLists = domainBlockLists
             
             if let resourceType = resourceType {


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

The crashes are related to saving and accessing FIFO dictionary, since the current queue is global-concurrent it can trigger race conditions. Especially when there's ad heavy websites and multiple requests needs to be checked by adblock library.

The solution here is to use background but serialized queue, so the fifo dict will be never accessed by more than one thread at the time

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
I could not reproduce any crash since 1.9.3 but I can still see it happening via Xcode organizer.

The STR should be the same as with https://github.com/brave/brave-ios/pull/1095
Browse through ad heavy websites, streaming services and see if any crashes happen

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

