### PR TITLE
Fix #1134: Address bar revamp.

### DIFF
--- a/BraveShared/BraveUX.swift
+++ b/BraveShared/BraveUX.swift
@@ -88,7 +88,7 @@ public struct BraveUX {
     // Setting this to clearColor() and setting LocationContainerBackgroundColor to a definitive color
     //  with transparency (e.g. allwhile 0.3 alpha) is how to make a non-opaque URL bar (e.g. for blurring).
     // Not currently needed since top bar is entirely opaque
-    public static let LocationBarBackgroundColor = GreyB
+    public static let LocationBarBackgroundColor = #colorLiteral(red: 0.8431372549, green: 0.8431372549, blue: 0.8784313725, alpha: 1)
     public static let LocationContainerBackgroundColor = LocationBarBackgroundColor
     
     // Editing colors same as standard coloring

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		0AADC4D420D2A6A200FDE368 /* FavoritesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AADC4D020D2A6A200FDE368 /* FavoritesDataSource.swift */; };
 		0AADC4D520D2A6A200FDE368 /* PreloadedFavorites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AADC4D120D2A6A200FDE368 /* PreloadedFavorites.swift */; };
 		0AADC4D720D2B03900FDE368 /* BraveShieldStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AADC4D620D2B03900FDE368 /* BraveShieldStatsView.swift */; };
+		0AB2442C22AA789B00B4D9DD /* ReaderModeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB2442B22AA789B00B4D9DD /* ReaderModeButton.swift */; };
 		0ABA874320E68CF500D2694F /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		0AD4FEEA223A9A5500E00C05 /* BundledJSProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD4FEE9223A9A5500E00C05 /* BundledJSProtocol.swift */; };
 		0AD4FEEC223A9C1300E00C05 /* BrowserifiedJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD4FEEB223A9C1300E00C05 /* BrowserifiedJS.swift */; };
@@ -124,7 +125,7 @@
 		0BDA56B41B26B203008C9B96 /* SQLiteLogins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BDA56B31B26B203008C9B96 /* SQLiteLogins.swift */; };
 		0BEF44631E31165700187C32 /* EarlGrey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEF44621E31165700187C32 /* EarlGrey.swift */; };
 		0BF0DB4A1E57B05E009172B0 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075861E37F7AB006961AC /* LaunchArguments.swift */; };
-		0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF0DB931A8545800039F300 /* URLBarView.swift */; };
+		0BF0DB941A8545800039F300 /* TopToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF0DB931A8545800039F300 /* TopToolbarView.swift */; };
 		0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */; };
 		0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
@@ -1208,6 +1209,7 @@
 		0AADC4D020D2A6A200FDE368 /* FavoritesDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesDataSource.swift; sourceTree = "<group>"; };
 		0AADC4D120D2A6A200FDE368 /* PreloadedFavorites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreloadedFavorites.swift; sourceTree = "<group>"; };
 		0AADC4D620D2B03900FDE368 /* BraveShieldStatsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BraveShieldStatsView.swift; sourceTree = "<group>"; };
+		0AB2442B22AA789B00B4D9DD /* ReaderModeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeButton.swift; sourceTree = "<group>"; };
 		0AD4FEE9223A9A5500E00C05 /* BundledJSProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledJSProtocol.swift; sourceTree = "<group>"; };
 		0AD4FEEB223A9C1300E00C05 /* BrowserifiedJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserifiedJS.swift; sourceTree = "<group>"; };
 		0AD4FEED223AA09D00E00C05 /* BrowserifyExposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserifyExposable.swift; sourceTree = "<group>"; };
@@ -1254,7 +1256,7 @@
 		0BDA56B11B26B1E4008C9B96 /* Logins.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Logins.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0BDA56B31B26B203008C9B96 /* SQLiteLogins.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteLogins.swift; sourceTree = "<group>"; };
 		0BEF44621E31165700187C32 /* EarlGrey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EarlGrey.swift; sourceTree = "<group>"; };
-		0BF0DB931A8545800039F300 /* URLBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLBarView.swift; sourceTree = "<group>"; };
+		0BF0DB931A8545800039F300 /* TopToolbarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopToolbarView.swift; sourceTree = "<group>"; };
 		0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsetButton.swift; sourceTree = "<group>"; };
 		0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFavicons.swift; sourceTree = "<group>"; };
 		0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = noTitle.html; sourceTree = "<group>"; };
@@ -3268,9 +3270,11 @@
 		44331DD0225519E2007E3E93 /* UrlBar */ = {
 			isa = PBXGroup;
 			children = (
-				0BF0DB931A8545800039F300 /* URLBarView.swift */,
+				0BF0DB931A8545800039F300 /* TopToolbarView.swift */,
 				44331DD7225521B6007E3E93 /* UrlBarTextField.swift */,
 				44331DD922552313007E3E93 /* LocationContainerView.swift */,
+				E4CD9F2C1A6DC91200318571 /* TabLocationView.swift */,
+				0AB2442B22AA789B00B4D9DD /* ReaderModeButton.swift */,
 			);
 			path = UrlBar;
 			sourceTree = "<group>";
@@ -3772,7 +3776,6 @@
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				D3A994961A3686BD008AD1AC /* Tab.swift */,
 				C6620BB3213BCEC6009FE75A /* TabType.swift */,
-				E4CD9F2C1A6DC91200318571 /* TabLocationView.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */,
 				DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */,
@@ -5657,7 +5660,7 @@
 				4422D55A21BFFB7F00BF1855 /* regexp.cc in Sources */,
 				0A7B5D722269E7AD00AADF22 /* BookmarkEditMode.swift in Sources */,
 				4422D4DC21BFFB7600BF1855 /* block_builder.cc in Sources */,
-				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
+				0BF0DB941A8545800039F300 /* TopToolbarView.swift in Sources */,
 				4422D4C321BFFB7600BF1855 /* coding.cc in Sources */,
 				595E0EE121CAEF5B00813D49 /* FileManagerExtension.swift in Sources */,
 				C615FAD9212A1E2600A8168C /* WebImageCache.swift in Sources */,
@@ -5809,6 +5812,7 @@
 				E65075511E37F6D1006961AC /* NSURLExtensionsMailTo.swift in Sources */,
 				D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */,
 				D03F8EB22004014E003C2224 /* FaviconHandler.swift in Sources */,
+				0AB2442C22AA789B00B4D9DD /* ReaderModeButton.swift in Sources */,
 				4422D55E21BFFB7F00BF1855 /* mimics_pcre.cc in Sources */,
 				4422D57321BFFB7F00BF1855 /* stringpiece.cc in Sources */,
 				27187808216526090006036E /* AlertPopupView.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -61,7 +61,7 @@ private extension TrayToBrowserAnimator {
 
         let finalFrame = calculateExpandedCellFrameFromBVC(bvc)
         bvc.footer.alpha = shouldDisplayFooterForBVC(bvc) ? 1 : 0
-        bvc.urlBar.isTransitioning = true
+        bvc.topToolbar.isTransitioning = true
 
         // Re-calculate the starting transforms for header/footer views in case we switch orientation
         resetTransformsForViews([bvc.header, bvc.readerModeBar, bvc.footer])
@@ -93,7 +93,7 @@ private extension TrayToBrowserAnimator {
             toggleWebViewVisibility(true, usingTabManager: bvc.tabManager)
             bvc.webViewContainerBackdrop.isHidden = false
             bvc.favoritesViewController?.view.isHidden = false
-            bvc.urlBar.isTransitioning = false
+            bvc.topToolbar.isTransitioning = false
             bvc.updateTabsBarVisibility()
             transitionContext.completeTransition(true)
         })
@@ -161,7 +161,7 @@ private extension BrowserToTrayAnimator {
         bvc.statusBarOverlay.isHidden = true
         bvc.toggleSnackBarVisibility(show: false)
         toggleWebViewVisibility(false, usingTabManager: bvc.tabManager)
-        bvc.urlBar.isTransitioning = true
+        bvc.topToolbar.isTransitioning = true
 
         // Since we are hiding the collection view and the snapshot API takes the snapshot after the next screen update,
         // the screenshot ends up being blank unless we set the collection view hidden after the screen update happens.
@@ -188,7 +188,7 @@ private extension BrowserToTrayAnimator {
                 
                 transformHeaderFooterForBVC(bvc, toFrame: finalFrame, container: container)
 
-                bvc.urlBar.updateAlphaForSubviews(0)
+                bvc.topToolbar.updateAlphaForSubviews(0)
                 bvc.footer.alpha = 0
                 tabCollectionViewSnapshot.alpha = 1
 
@@ -205,7 +205,7 @@ private extension BrowserToTrayAnimator {
                 bvc.favoritesViewController?.view.isHidden = false
 
                 resetTransformsForViews([bvc.header, bvc.readerModeBar, bvc.footer])
-                bvc.urlBar.isTransitioning = false
+                bvc.topToolbar.isTransitioning = false
                 transitionContext.completeTransition(true)
             })
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -33,7 +33,7 @@ extension BrowserViewController {
 
     @objc private func selectLocationBarKeyCommand() {
         scrollController.showToolbars(animated: true)
-        urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
+        topToolbar.tabLocationViewDidTapLocation(topToolbar.locationView)
     }
 
     @objc private func newTabKeyCommand() {
@@ -125,7 +125,7 @@ extension BrowserViewController {
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 
-        if urlBar.inOverlayMode {
+        if topToolbar.inOverlayMode {
             return tabNavigation + searchLocationCommands
         } else if !isEditingText {
             return tabNavigation + overidesTextEditing

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -42,7 +42,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // (orange color) as soon as the page has loaded.
         if let url = webView.url {
             if !url.isReaderModeURL {
-                urlBar.updateReaderModeState(ReaderModeState.unavailable)
+                topToolbar.updateReaderModeState(ReaderModeState.unavailable)
                 hideReaderModeBar(animated: false)
             }
         }
@@ -333,7 +333,7 @@ extension BrowserViewController: WKNavigationDelegate {
         if let tab = tabManager[webView] {
             navigateInTab(tab: tab, to: navigation)
             if tab === tabManager.selectedTab {
-                urlBar.updateProgressBar(1.0)
+                topToolbar.updateProgressBar(1.0)
             }
             tabsBar.reloadDataAndRestoreSelectedTab()
         }

--- a/Client/Frontend/Browser/Search/SearchLoader.swift
+++ b/Client/Frontend/Browser/Search/SearchLoader.swift
@@ -24,13 +24,13 @@ typealias SearchLoader = _SearchLoader<AnyObject, AnyObject>
  */
 class _SearchLoader<UnusedA, UnusedB>: Loader<[Site], SearchViewController> {
     fileprivate let profile: Profile
-    fileprivate let urlBar: URLBarView
+    fileprivate let topToolbar: TopToolbarView
     fileprivate let frecentHistory: FrecentHistory
     fileprivate var inProgress: Cancellable?
 
-    init(profile: Profile, urlBar: URLBarView) {
+    init(profile: Profile, topToolbar: TopToolbarView) {
         self.profile = profile
-        self.urlBar = urlBar
+        self.topToolbar = topToolbar
         frecentHistory = profile.history.getFrecentHistory()
 
         super.init()
@@ -77,7 +77,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<[Site], SearchViewController> {
                 self.load(result)
                 for site in result {
                     if let completion = self.completionForURL(site.url) {
-                        self.urlBar.setAutocompleteSuggestion(completion)
+                        self.topToolbar.setAutocompleteSuggestion(completion)
                         return
                     }
                 }
@@ -85,7 +85,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<[Site], SearchViewController> {
                 // If there are no search history matches, try matching one of the Alexa top domains.
                 for domain in self.topDomains {
                     if let completion = self.completionForDomain(domain) {
-                        self.urlBar.setAutocompleteSuggestion(completion)
+                        self.topToolbar.setAutocompleteSuggestion(completion)
                         return
                     }
                 }

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -38,7 +38,7 @@ class TabScrollingController: NSObject {
 
     weak var header: UIView?
     weak var footer: UIView?
-    weak var urlBar: URLBarView?
+    weak var topToolbar: TopToolbarView?
     weak var tabsBar: TabsBarViewController?
     weak var snackBars: UIView?
 
@@ -225,7 +225,7 @@ private extension TabScrollingController {
         footerBottomOffset = clamp(updatedOffset, min: 0, max: bottomScrollHeight)
 
         let alpha = 1 - abs(headerTopOffset / topScrollHeight)
-        urlBar?.updateAlphaForSubviews(alpha)
+        topToolbar?.updateAlphaForSubviews(alpha)
         let tabsAlpha = 1 - abs((headerTopOffset - tabsBarOffset) / topScrollHeight)
         tabsBar?.view.alpha = tabsAlpha
     }
@@ -247,7 +247,7 @@ private extension TabScrollingController {
         self.headerTopOffset = headerOffset
         self.footerBottomOffset = footerOffset
         let animation: () -> Void = {
-            self.urlBar?.updateAlphaForSubviews(alpha)
+            self.topToolbar?.updateAlphaForSubviews(alpha)
             self.tabsBar?.view.alpha = alpha
             self.header?.superview?.layoutIfNeeded()
         }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -527,7 +527,7 @@ class TabTrayController: UIViewController, Themeable {
                 let appDelegate = UIApplication.shared.delegate as? AppDelegate,
                 let bvc = appDelegate.browserViewController {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                    bvc.urlBar.tabLocationViewDidTapLocation(bvc.urlBar.locationView)
+                    bvc.topToolbar.tabLocationViewDidTapLocation(bvc.topToolbar.locationView)
                 }
             }
 

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -7,11 +7,11 @@ import SnapKit
 import Shared
 import BraveShared
 
-class BottomToolbarView: UIView {
+class BottomToolbarView: UIView, ToolbarProtocol {
     weak var tabToolbarDelegate: ToolbarDelegate?
 
     let tabsButton = TabsButton()
-    let forwardButton = ToolbarButton()
+    let reloadButton = ToolbarButton()
     let backButton = ToolbarButton()
     let shareButton = ToolbarButton()
     let addTabButton = ToolbarButton()
@@ -20,9 +20,21 @@ class BottomToolbarView: UIView {
 
     var helper: ToolbarHelper?
     private let contentView = UIStackView()
+    
+    var loading: Bool = false {
+        didSet {
+            if loading {
+                reloadButton.setImage(#imageLiteral(resourceName: "nav-stop").template, for: .normal)
+                reloadButton.accessibilityLabel = Strings.TabToolbarStopButtonAccessibilityLabel
+            } else {
+                reloadButton.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
+                reloadButton.accessibilityLabel = Strings.TabToolbarReloadButtonAccessibilityLabel
+            }
+        }
+    }
 
     fileprivate override init(frame: CGRect) {
-        actionButtons = [backButton, forwardButton, addTabButton, tabsButton, menuButton]
+        actionButtons = [backButton, reloadButton, addTabButton, tabsButton, menuButton]
         super.init(frame: frame)
         setupAccessibility()
 
@@ -45,7 +57,7 @@ class BottomToolbarView: UIView {
 
     private func setupAccessibility() {
         backButton.accessibilityIdentifier = "TabToolbar.backButton"
-        forwardButton.accessibilityIdentifier = "TabToolbar.forwardButton"
+        reloadButton.accessibilityIdentifier = "TabToolbar.reloadButton"
         tabsButton.accessibilityIdentifier = "TabToolbar.tabsButton"
         shareButton.accessibilityIdentifier = "TabToolbar.shareButton"
         addTabButton.accessibilityIdentifier = "TabToolbar.addTabButton"
@@ -98,26 +110,6 @@ class BottomToolbarView: UIView {
         default:
             break
         }
-    }
-}
-
-// MARK: - ToolbarProtocol
-
-extension BottomToolbarView: ToolbarProtocol {
-    func updateBackStatus(_ canGoBack: Bool) {
-        backButton.isEnabled = canGoBack
-    }
-
-    func updateForwardStatus(_ canGoForward: Bool) {
-        forwardButton.isEnabled = canGoForward
-    }
-
-    func updatePageStatus(_ isWebPage: Bool) {
-        shareButton.isEnabled = isWebPage
-    }
-
-    func updateTabCount(_ count: Int) {
-        tabsButton.updateTabCount(count)
     }
 }
 

--- a/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -23,12 +23,6 @@ class ToolbarHelper: NSObject {
         toolbar.backButton.addGestureRecognizer(longPressGestureBackButton)
         toolbar.backButton.addTarget(self, action: #selector(didClickBack), for: .touchUpInside)
         
-        toolbar.forwardButton.setImage(#imageLiteral(resourceName: "nav-forward").template, for: .normal)
-        toolbar.forwardButton.accessibilityLabel = Strings.TabToolbarForwardButtonAccessibilityLabel
-        let longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressForward))
-        toolbar.forwardButton.addGestureRecognizer(longPressGestureForwardButton)
-        toolbar.forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
-        
         toolbar.tabsButton.addTarget(self, action: #selector(didClickTabs), for: .touchUpInside)
         let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTabs))
         toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
@@ -45,6 +39,23 @@ class ToolbarHelper: NSObject {
         toolbar.menuButton.setImage(#imageLiteral(resourceName: "menu-More-Options").template, for: .normal)
         toolbar.menuButton.accessibilityLabel = Strings.TabToolbarMenuButtonAccessibilityLabel
         toolbar.menuButton.addTarget(self, action: #selector(didClickMenu), for: UIControl.Event.touchUpInside)
+        
+        if let forwardButton = toolbar.forwardButton {
+            forwardButton.setImage(#imageLiteral(resourceName: "nav-forward").template, for: .normal)
+            forwardButton.accessibilityLabel = Strings.TabToolbarForwardButtonAccessibilityLabel
+            let longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressForward))
+            forwardButton.addGestureRecognizer(longPressGestureForwardButton)
+            forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
+        }
+        
+        toolbar.reloadButton.accessibilityIdentifier = "TabToolbar.stopReloadButton"
+        toolbar.reloadButton.accessibilityLabel = Strings.TabToolbarReloadButtonAccessibilityLabel
+        toolbar.reloadButton.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
+        toolbar.reloadButton.tintColor = UIColor.Photon.Grey30
+        
+        let longPressGestureStopReloadButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressStopReload(_:)))
+        toolbar.reloadButton.addGestureRecognizer(longPressGestureStopReloadButton)
+        toolbar.reloadButton.addTarget(self, action: #selector(didClickStopReload), for: .touchUpInside)
         
         setTheme(theme: .regular, forButtons: toolbar.actionButtons)
     }
@@ -72,12 +83,16 @@ class ToolbarHelper: NSObject {
     }
     
     func didClickForward() {
-        toolbar.tabToolbarDelegate?.tabToolbarDidPressForward(toolbar, button: toolbar.forwardButton)
+        guard let forwardButton = toolbar.forwardButton else { return }
+        
+        toolbar.tabToolbarDelegate?.tabToolbarDidPressForward(toolbar, button: forwardButton)
     }
     
     func didLongPressForward(_ recognizer: UILongPressGestureRecognizer) {
+        guard let forwardButton = toolbar.forwardButton else { return }
+        
         if recognizer.state == .began {
-            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressForward(toolbar, button: toolbar.forwardButton)
+            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressForward(toolbar, button: forwardButton)
         }
     }
     
@@ -92,6 +107,20 @@ class ToolbarHelper: NSObject {
     func didLongPressAddTab(_ longPress: UILongPressGestureRecognizer) {
         if longPress.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressAddTab(toolbar, button: toolbar.shareButton)
+        }
+    }
+    
+    func didClickStopReload() {
+        if toolbar.loading {
+            toolbar.tabToolbarDelegate?.tabToolbarDidPressStop(toolbar, button: toolbar.reloadButton)
+        } else {
+            toolbar.tabToolbarDelegate?.tabToolbarDidPressReload(toolbar, button: toolbar.reloadButton)
+        }
+    }
+    
+    func didLongPressStopReload(_ longPress: UILongPressGestureRecognizer) {
+        if longPress.state == .began && !toolbar.loading {
+            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressReload(toolbar, button: toolbar.reloadButton)
         }
     }
 }

--- a/Client/Frontend/Browser/Toolbars/ToolbarProtocols.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarProtocols.swift
@@ -5,19 +5,49 @@
 import Foundation
 
 protocol ToolbarProtocol: class {
+    /// A buttons can behave different depending on web load state.
+    /// For example reload button can switch to stop button when a website is loading.
+    var loading: Bool { get set }
+    
     var tabToolbarDelegate: ToolbarDelegate? { get set }
     var tabsButton: TabsButton { get }
-    var forwardButton: ToolbarButton { get }
     var backButton: ToolbarButton { get }
     var shareButton: ToolbarButton { get }
     var addTabButton: ToolbarButton { get }
     var menuButton: ToolbarButton { get }
     var actionButtons: [Themeable & UIButton] { get }
+    var reloadButton: ToolbarButton { get }
+    
+    // Optional buttons
+    var forwardButton: ToolbarButton? { get }
     
     func updateBackStatus(_ canGoBack: Bool)
-    func updateForwardStatus(_ canGoForward: Bool)
     func updatePageStatus(_ isWebPage: Bool)
     func updateTabCount(_ count: Int)
+    
+    // Optional methods
+    func updateForwardStatus(_ canGoForward: Bool)
+}
+
+extension ToolbarProtocol {
+    func updatePageStatus(_ isWebPage: Bool) {
+        shareButton.isEnabled = isWebPage
+        reloadButton.isEnabled = isWebPage
+    }
+    
+    func updateBackStatus(_ canGoBack: Bool) {
+        backButton.isEnabled = canGoBack
+    }
+    
+    func updateForwardStatus(_ canGoForward: Bool) {
+        forwardButton?.isEnabled = canGoForward
+    }
+    
+    func updateTabCount(_ count: Int) {
+        tabsButton.updateTabCount(count)
+    }
+    
+    var forwardButton: ToolbarButton? { return nil }
 }
 
 protocol ToolbarDelegate: class {
@@ -32,4 +62,7 @@ protocol ToolbarDelegate: class {
     func tabToolbarDidPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidSwipeToChangeTabs(_ tabToolbar: ToolbarProtocol, direction: UISwipeGestureRecognizer.Direction)
+    func tabToolbarDidPressReload(_ tabToolbar: ToolbarProtocol, button: UIButton)
+    func tabToolbarDidPressStop(_ tabToolbar: ToolbarProtocol, button: UIButton)
+    func tabToolbarDidLongPressReload(_ tabToolbar: ToolbarProtocol, button: UIButton)
 }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/ReaderModeButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/ReaderModeButton.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+class ReaderModeButton: UIButton {
+    var selectedTintColor: UIColor?
+    var unselectedTintColor: UIColor?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        adjustsImageWhenHighlighted = false
+        setImage(#imageLiteral(resourceName: "reader").template, for: .normal)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            self.tintColor = (isHighlighted || isSelected) ? selectedTintColor : unselectedTintColor
+        }
+    }
+    
+    override open var isHighlighted: Bool {
+        didSet {
+            self.tintColor = (isHighlighted || isSelected) ? selectedTintColor : unselectedTintColor
+        }
+    }
+    
+    override var tintColor: UIColor! {
+        didSet {
+            self.imageView?.tintColor = self.tintColor
+        }
+    }
+    
+    private var _readerModeState: ReaderModeState = .unavailable
+    
+    var readerModeState: ReaderModeState {
+        get {
+            return _readerModeState
+        }
+        set (newReaderModeState) {
+            _readerModeState = newReaderModeState
+            switch _readerModeState {
+            case .available:
+                self.isEnabled = true
+                self.isSelected = false
+            case .unavailable:
+                self.isEnabled = false
+                self.isSelected = false
+            case .active:
+                self.isEnabled = true
+                self.isSelected = true
+            }
+        }
+    }
+}

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -62,7 +62,8 @@ extension UIColor {
         static let ReaderModeButtonUnselected = BrowserColor(normal: Photon.Grey50, pbm: Photon.Grey40)
         static let PageOptionsSelected = ReaderModeButtonSelected
         static let PageOptionsUnselected = UIColor.Browser.Tint
-        static let Separator = BrowserColor(normal: Photon.Grey30, pbm: Photon.Grey70)
+        static let Separator = BrowserColor(normal: #colorLiteral(red: 0.7333333333, green: 0.7333333333, blue: 0.8039215686, alpha: 1), pbm: Photon.Grey70)
+        
     }
 
     // The back/forward/refresh/menu button (bottom toolbar)


### PR DESCRIPTION
- Embed shields button into URL bar
- Replace forward button with reload button in portrait mode
- Move reload button next to back/forward in horizontal mode
- Show a line separator between shields button and reader mode(if avaialble)
- Small color changes
- Rename `URLBarView` to `TopToolbarView` 

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
Not much changed. Just test if reload button works correctly and test if UI looks good on both landscape and portrait.

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="544" alt="Zrzut ekranu 2019-06-10 o 15 01 58" src="https://user-images.githubusercontent.com/6950387/59204979-1c767980-8ba2-11e9-923f-0752c080afb4.png">
<img width="950" alt="Zrzut ekranu 2019-06-10 o 15 02 00" src="https://user-images.githubusercontent.com/6950387/59204980-1c767980-8ba2-11e9-90b1-faed2821aca2.png">


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

