### PR TITLE
Fix #918: Download adblock lists from the server.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -242,7 +242,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             UrpLog.log("Failed to initialize user referral program")
         }
         
-        AdblockResourceDownloader.shared.regionalAdblockResourcesSetup()
+        AdblockResourceDownloader.shared.startLoading()
 
         UINavigationBar.appearance().tintColor = BraveUX.BraveOrange
       

--- a/Client/WebFilters/AdblockResourceDownloader.swift
+++ b/Client/WebFilters/AdblockResourceDownloader.swift
@@ -34,6 +34,11 @@ class AdblockResourceDownloader {
         Preferences.Shields.useRegionAdBlock.observe(from: self)
     }
     
+    func startLoading() {
+        AdblockResourceDownloader.shared.regionalAdblockResourcesSetup()
+        AdblockResourceDownloader.shared.generalAdblockResourcesSetup()
+    }
+    
     func regionalAdblockResourcesSetup() {
         if !Preferences.Shields.useRegionAdBlock.value {
             log.debug("Regional adblocking disabled, aborting attempt to download regional resources")
@@ -43,6 +48,13 @@ class AdblockResourceDownloader {
         downloadResources(type: .regional(locale: locale),
                           queueName: "Regional adblock setup").uponQueue(.main) {
             log.debug("Regional blocklists download and setup completed.")
+        }
+    }
+    
+    func generalAdblockResourcesSetup() {
+        downloadResources(type: .general,
+                          queueName: "General adblock setup").uponQueue(.main) {
+                            log.debug("General blocklists download and setup completed.")
         }
     }
     

--- a/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -7,37 +7,24 @@ import Deferred
 
 private let log = Logger.browserLogger
 
-fileprivate struct AdblockStatsResource: Hashable {
-    let abpWrapper: ABPFilterLibWrapper
-    let id: String
-    
-    init(abpWrapper: ABPFilterLibWrapper = ABPFilterLibWrapper(), id: String) {
-        self.abpWrapper = abpWrapper
-        self.id = id
-    }
-    
-    static func == (lhs: AdblockStatsResource, rhs: AdblockStatsResource) -> Bool {
-        return lhs.id == rhs.id
-    }
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-}
-
 class AdBlockStats: LocalAdblockResourceProtocol {
     static let shared = AdBlockStats()
     
     typealias LocaleCode = String
     static let defaultLocale = "en"
     
-    private let blockListFileName = "ABPFilterParserData"
+    /// File name of bundled general blocklist.
+    private let bundledGeneralBlocklist = "ABPFilterParserData"
     
     fileprivate var fifoCacheOfUrlsChecked = FifoDict()
     
     fileprivate lazy var adblockStatsResources: [String: ABPFilterLibWrapper] = {
-        let generalAdblocker = [AdblockerType.general.identifier: ABPFilterLibWrapper()]
-        return generalAdblocker
+        // Two general blocklists are provided:
+        // 1. bundled with small amount of general blocklist rules.
+        // 2. A bigger list, downloaded from the server.
+        let generalAdblockers = [bundledGeneralBlocklist: ABPFilterLibWrapper(),
+                                AdblockerType.general.identifier: ABPFilterLibWrapper()]
+        return generalAdblockers
     }()
     
     let currentLocaleCode: LocaleCode
@@ -49,9 +36,13 @@ class AdBlockStats: LocalAdblockResourceProtocol {
         updateRegionalAdblockEnabledState()
     }
     
+    private func isGeneralAdblocker(id: String) -> Bool {
+        return id == AdblockerType.general.identifier || id == bundledGeneralBlocklist
+    }
+    
     func startLoading() {
-        loadLocalData(name: blockListFileName, type: "dat") { data in
-            self.setDataFile(data: data, id: AdblockerType.general.identifier)
+        loadLocalData(name: bundledGeneralBlocklist, type: "dat") { data in
+            self.setDataFile(data: data, id: bundledGeneralBlocklist)
         }
         
         loadDatFilesFromDocumentsDirectory()
@@ -125,7 +116,7 @@ class AdBlockStats: LocalAdblockResourceProtocol {
         let header = "*/*"
         
         for (id, adblocker) in adblockStatsResources where adblocker.hasDataFile() {
-            if id != AdblockerType.general.identifier && !isRegionalAdblockEnabled { continue }
+            if !isGeneralAdblocker(id: id) && !isRegionalAdblockEnabled { continue }
             
             isBlocked = adblocker.isBlockedConsideringType(url.absoluteString,
                                                                       mainDocumentUrl: mainDocDomain,


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
Test if adblocking is still working.

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

