### PR TITLE
Fix #1125: Update PopoverController from rewards-ios.

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -78,6 +78,7 @@ class MenuViewController: UITableViewController {
                                               bottom: UX.topBottomInset, right: 0)
         
         tableView.showsVerticalScrollIndicator = false
+        tableView.isScrollEnabled = false
         
         // Hide separator line of the last cell.
         tableView.tableFooterView =
@@ -86,13 +87,17 @@ class MenuViewController: UITableViewController {
         // TODO: Make the background view transparent with alpha 0.6
         // simple setting its alpha doesn't seem to work.
         tableView.backgroundColor = #colorLiteral(red: 0.9529411765, green: 0.9529411765, blue: 0.9647058824, alpha: 1)
-    }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
         
-        let size = CGSize(width: 200, height: tableView.rect(forSection: 0).height + UX.topBottomInset * 2)
-        preferredContentSize = size
+        let size = CGSize(width: 200, height: UIScreen.main.bounds.height)
+        
+        let fit = view.systemLayoutSizeFitting(
+            size,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .defaultHigh
+        )
+        
+        preferredContentSize = CGSize(width: fit.width, height: fit.height + UX.topBottomInset * 2)
+        
     }
     
     // MARK: - Table view data source
@@ -194,5 +199,5 @@ class MenuViewController: UITableViewController {
 
 extension MenuViewController: PopoverContentComponent {
     var isPanToDismissEnabled: Bool { return false }
-
+    var extendEdgeIntoArrow: Bool { return false }
 }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -198,6 +198,5 @@ class MenuViewController: UITableViewController {
 // MARK: - PopoverContentComponent
 
 extension MenuViewController: PopoverContentComponent {
-    var isPanToDismissEnabled: Bool { return false }
     var extendEdgeIntoArrow: Bool { return false }
 }

--- a/Client/Frontend/Popover/PopoverContentComponent.swift
+++ b/Client/Frontend/Popover/PopoverContentComponent.swift
@@ -7,6 +7,10 @@ import UIKit
 
 /// Defines behavior of a component which will be used with a `PopoverController`
 protocol PopoverContentComponent {
+    /// Whether or not the controller's frame begins at 0 (allowing it to bleed into the arrow) or start under the arrow
+    ///
+    /// Use safeAreaLayoutGuide to constrain content within the popover content view
+    var extendEdgeIntoArrow: Bool { get }
     /// Whether or not the pan to dismiss gesture is enabled. Optional, true by defualt
     var isPanToDismissEnabled: Bool { get }
     /// Allows the component to decide whether or not the popover should dismiss based on some gestural action (tapping
@@ -17,6 +21,10 @@ protocol PopoverContentComponent {
 }
 
 extension PopoverContentComponent {
+    var extendEdgeIntoArrow: Bool {
+        return true
+    }
+    
     var isPanToDismissEnabled: Bool {
         return true
     }
@@ -26,5 +34,11 @@ extension PopoverContentComponent {
     }
     
     func popoverDidDismiss(_ popoverController: PopoverController) {
+    }
+}
+
+extension PopoverContentComponent where Self: UINavigationController {
+    var extendEdgeIntoArrow: Bool {
+        return false
     }
 }

--- a/Client/Frontend/Popover/PopoverController.swift
+++ b/Client/Frontend/Popover/PopoverController.swift
@@ -522,47 +522,6 @@ extension PopoverController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return contentController.isPanToDismissEnabled
     }
-    
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        guard let pan = gestureRecognizer as? UIPanGestureRecognizer else {
-            return false
-        }
-        
-        // Don't allow for pan gesture while table view is in editing mode.
-        // This bug only occurs for bookmarks at nested levels, see issue #687.
-        if let tableView = otherGestureRecognizer.view as? UITableView, tableView.isEditing {
-            gestureRecognizer.cancel()
-            return false
-        }
-        
-        if let scrollView = otherGestureRecognizer.view as? UIScrollView {
-            return false
-            
-            let topInset = scrollView.adjustedContentInset.top
-            let leftInset = scrollView.adjustedContentInset.left
-            
-            let velocity = pan.velocity(in: pan.view)
-            if abs(velocity.y) > abs(velocity.x) {
-                if scrollView.contentOffset.y >= scrollView.contentSize.height - scrollView.frame.size.height && velocity.y < 0 ||
-                    scrollView.contentOffset.y <= -topInset && velocity.y > 0 {
-                    otherGestureRecognizer.cancel()
-                    return true
-                }
-            } else {
-                if let tableView = scrollView as? UITableView, let ds = tableView.dataSource, velocity.x < 0, ds.responds(to: #selector(UITableViewDataSource.tableView(_:commit:forRowAt:))) {
-                    // Fix table view cell actions
-                    pan.cancel()
-                    return false
-                }
-                if scrollView.contentOffset.x >= scrollView.contentSize.width - scrollView.frame.size.width && velocity.x < 0 ||
-                    scrollView.contentOffset.x <= -leftInset && velocity.x > 0 {
-                    otherGestureRecognizer.cancel()
-                    return true
-                }
-            }
-        }
-        return false
-    }
 }
 
 extension PopoverController: UINavigationControllerDelegate {

--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -118,7 +118,13 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
         }
         shieldsView.stackView.setNeedsLayout()
         shieldsView.stackView.layoutIfNeeded()
-        preferredContentSize = CGSize(width: PopoverController.preferredPopoverWidth, height: shieldsView.stackView.bounds.height)
+        
+        let size = CGSize(width: PopoverController.preferredPopoverWidth, height: UIScreen.main.bounds.height)
+        preferredContentSize = shieldsView.stackView.systemLayoutSizeFitting(
+            size,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
     }
     
     // MARK: -
@@ -155,13 +161,6 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
                 self.shieldsSettingsChanged?(self)
             }
         }
-    }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        shieldsView.stackView.layoutIfNeeded()
-        preferredContentSize = CGSize(width: PopoverController.preferredPopoverWidth, height: shieldsView.stackView.bounds.height)
     }
     
     @available(*, unavailable)


### PR DESCRIPTION
This change also required small adjustments to calculating contentSize
for Shields and Menu view controllers.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
Test if popup views: shields panel and menu panel are showing correctly in both portrait and landscape.

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

