### PR TITLE
Adding support for FIDO/FIDO2 APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ python-env/
 Carthage/
 
 ThirdParty/google-breakpad
+ThirdParty/YubiKit
 
 # Saved Sync credentials for tests.
 signedInUser.json
@@ -86,3 +87,4 @@ BuildId.xcconfig
 Client/Configuration/Local/
 
 adblock-regions.txt
+yubikit.log

--- a/Client-Bridging-Header.h
+++ b/Client-Bridging-Header.h
@@ -20,4 +20,7 @@
 #import "NSData+GZIP.h"
 #import "NSFileManager+Tar.h"
 
+#import <YubiKit/YubiKit.h>
+#import <CommonCrypto/CommonCrypto.h>
+
 #endif

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -8414,16 +8414,20 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/ThirdParty/sqlcipher",
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -8463,14 +8467,9 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
-					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/ThirdParty/YubiKit",
-				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -8492,17 +8491,6 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/ThirdParty/sqlcipher",
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
-					"$(SRCROOT)/ThirdParty/YubiKit/include/",
-				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)";
@@ -8820,16 +8808,20 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/ThirdParty/sqlcipher",
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -8869,14 +8861,9 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
-					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/ThirdParty/YubiKit",
-				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -8959,17 +8946,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/ThirdParty/sqlcipher",
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
-					"$(SRCROOT)/ThirdParty/YubiKit/include/",
 				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -9229,16 +9205,20 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/ThirdParty/sqlcipher",
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -9278,14 +9258,9 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
-					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/ThirdParty/YubiKit",
-				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -9305,17 +9280,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/ThirdParty/sqlcipher",
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
-					"$(SRCROOT)/ThirdParty/YubiKit/include/",
 				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -9461,16 +9425,20 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/ThirdParty/sqlcipher",
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
 					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -9510,14 +9478,9 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
-					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/ThirdParty/YubiKit",
-				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -9556,17 +9519,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/ThirdParty/sqlcipher",
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
-					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
-					"$(SRCROOT)/ThirdParty/YubiKit/include/",
 				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -830,6 +830,15 @@
 		F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21D91A090F8100AAB793 /* ClientTests.swift */; };
 		F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21E51A0910F600AAB793 /* AppDelegate.swift */; };
 		F84B220B1A0910F600AAB793 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B21EF1A0910F600AAB793 /* Images.xcassets */; };
+		F930CDAC227000F200A23FE1 /* U2F.js in Resources */ = {isa = PBXBuildFile; fileRef = F930CDAB227000F200A23FE1 /* U2F.js */; };
+		F930CDAE2270015C00A23FE1 /* U2FExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F930CDAD2270015C00A23FE1 /* U2FExtensions.swift */; };
+		F930CDB82270040D00A23FE1 /* WebAuthnClientData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F930CDB72270040D00A23FE1 /* WebAuthnClientData.swift */; };
+		F930CDC9227006D600A23FE1 /* WebAuthnRegisterRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F930CDC8227006D600A23FE1 /* WebAuthnRegisterRequest.swift */; };
+		F930CDD12270F09000A23FE1 /* WebAuthnAuthenticateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F930CDD02270F09000A23FE1 /* WebAuthnAuthenticateRequest.swift */; };
+		F930CDD72270F14300A23FE1 /* WebAuthnUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F930CDD62270F14300A23FE1 /* WebAuthnUtils.swift */; };
+		F939FBFE22A596B900D9CD3F /* U2FTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F939FBFD22A596B900D9CD3F /* U2FTests.swift */; };
+		F98E1EA122B6D70E0018AF29 /* libYubiKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AC8E23A22A6C56D0064F3FA /* libYubiKit.a */; };
+		F99505FF22937E3900CC6543 /* U2F-low-level.js in Resources */ = {isa = PBXBuildFile; fileRef = F99505FE22937E3900CC6543 /* U2F-low-level.js */; };
 		FA6B2AC21D41F02D00429414 /* Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* Punycode.swift */; };
 		FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */; };
 		FA9294011D6584A200AC8D33 /* QRCode.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA9294001D6584A200AC8D33 /* QRCode.xcassets */; };
@@ -1210,6 +1219,7 @@
 		0AADC4D120D2A6A200FDE368 /* PreloadedFavorites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreloadedFavorites.swift; sourceTree = "<group>"; };
 		0AADC4D620D2B03900FDE368 /* BraveShieldStatsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BraveShieldStatsView.swift; sourceTree = "<group>"; };
 		0AB2442B22AA789B00B4D9DD /* ReaderModeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeButton.swift; sourceTree = "<group>"; };
+		0AC8E23A22A6C56D0064F3FA /* libYubiKit.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libYubiKit.a; path = ThirdParty/YubiKit/libYubiKit.a; sourceTree = "<group>"; };
 		0AD4FEE9223A9A5500E00C05 /* BundledJSProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledJSProtocol.swift; sourceTree = "<group>"; };
 		0AD4FEEB223A9C1300E00C05 /* BrowserifiedJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserifiedJS.swift; sourceTree = "<group>"; };
 		0AD4FEED223AA09D00E00C05 /* BrowserifyExposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserifyExposable.swift; sourceTree = "<group>"; };
@@ -2203,6 +2213,14 @@
 		F84B21E51A0910F600AAB793 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AppDelegate.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		F84B21EF1A0910F600AAB793 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		F84B22431A09165600AAB793 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F930CDAB227000F200A23FE1 /* U2F.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = U2F.js; sourceTree = "<group>"; };
+		F930CDAD2270015C00A23FE1 /* U2FExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = U2FExtensions.swift; sourceTree = "<group>"; };
+		F930CDB72270040D00A23FE1 /* WebAuthnClientData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnClientData.swift; sourceTree = "<group>"; };
+		F930CDC8227006D600A23FE1 /* WebAuthnRegisterRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnRegisterRequest.swift; sourceTree = "<group>"; };
+		F930CDD02270F09000A23FE1 /* WebAuthnAuthenticateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnAuthenticateRequest.swift; sourceTree = "<group>"; };
+		F930CDD62270F14300A23FE1 /* WebAuthnUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnUtils.swift; sourceTree = "<group>"; };
+		F939FBFD22A596B900D9CD3F /* U2FTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = U2FTests.swift; sourceTree = "<group>"; };
+		F99505FE22937E3900CC6543 /* U2F-low-level.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "U2F-low-level.js"; sourceTree = "<group>"; };
 		FA6B2AC11D41F02D00429414 /* Punycode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Punycode.swift; sourceTree = "<group>"; };
 		FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QRCodeViewController.swift; sourceTree = "<group>"; };
 		FA9294001D6584A200AC8D33 /* QRCode.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = QRCode.xcassets; sourceTree = "<group>"; };
@@ -2237,6 +2255,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F98E1EA122B6D70E0018AF29 /* libYubiKit.a in Frameworks */,
 				A1AD4BD120BF3F4D007A6EA1 /* Eureka.framework in Frameworks */,
 				E6231C051B90A472005ABB0D /* libxml2.2.tbd in Frameworks */,
 				E6231C011B90A44F005ABB0D /* libz.tbd in Frameworks */,
@@ -2703,6 +2722,7 @@
 		28EADE5C1AFC3A6D007FB2FB /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				F930CDB02270029B00A23FE1 /* WebAuthN */,
 				A1CDF22A20BDD6B8005C6E58 /* POPExtensions.swift */,
 				E650754D1E37F6AE006961AC /* GeometryExtensions.swift */,
 				D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */,
@@ -2718,6 +2738,7 @@
 				A1AD4BE220C0861D007A6EA1 /* UIBarButtonItemExtensions.swift */,
 				595E0EE021CAEF5B00813D49 /* FileManagerExtension.swift */,
 				592F521D2217327B0078395E /* HttpCookieExtension.swift */,
+				F930CDAD2270015C00A23FE1 /* U2FExtensions.swift */,
 			);
 			indentWidth = 4;
 			name = Extensions;
@@ -3433,6 +3454,7 @@
 		7B604FC11C496005006EEEC3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0AC8E23A22A6C56D0064F3FA /* libYubiKit.a */,
 				A1F66A7F20DD87CA00303328 /* Static.framework */,
 				A1AD4BD520BF476E007A6EA1 /* FastImageCache.framework */,
 				A1AD4BD020BF3F4D007A6EA1 /* Eureka.framework */,
@@ -3553,6 +3575,8 @@
 				D0FCF7E81FE44D8F004A7995 /* AllFrames */,
 				D0FCF7E91FE44DA2004A7995 /* MainFrame */,
 				595E0EDA21CAD97C00813D49 /* CookieControl.js */,
+				F930CDAB227000F200A23FE1 /* U2F.js */,
+				F99505FE22937E3900CC6543 /* U2F-low-level.js */,
 			);
 			path = UserScripts;
 			sourceTree = "<group>";
@@ -4155,6 +4179,7 @@
 				2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */,
 				0A4214E821A6EBCF006B8E39 /* SafeBrowsingTests.swift */,
 				5953AAEE2226E9D800A92DE1 /* HttpCookieExtensionTest.swift */,
+				F939FBFD22A596B900D9CD3F /* U2FTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -4278,6 +4303,17 @@
 				E40A18F61EDC73D5006B7F28 /* Entitlements */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		F930CDB02270029B00A23FE1 /* WebAuthN */ = {
+			isa = PBXGroup;
+			children = (
+				F930CDC8227006D600A23FE1 /* WebAuthnRegisterRequest.swift */,
+				F930CDD02270F09000A23FE1 /* WebAuthnAuthenticateRequest.swift */,
+				F930CDD62270F14300A23FE1 /* WebAuthnUtils.swift */,
+				F930CDB72270040D00A23FE1 /* WebAuthnClientData.swift */,
+			);
+			path = WebAuthN;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -5117,6 +5153,7 @@
 				E4B7B7631A793CF20022C5E0 /* CharisSILI.ttf in Resources */,
 				E4CD9F541A71506400318571 /* Reader.html in Resources */,
 				C6345ECB2113B3A000CFB983 /* SearchPlugins in Resources */,
+				F930CDAC227000F200A23FE1 /* U2F.js in Resources */,
 				5D7001C222249F7B00E576FB /* ShortNameToFileMapping.json in Resources */,
 				4422D55921BFFB7F00BF1855 /* unicode.py in Resources */,
 				7B2142FE1E5E055000CDD3FC /* InfoPlist.strings in Resources */,
@@ -5134,6 +5171,7 @@
 				E4B7B77D1A793CF20022C5E0 /* FiraSans-Regular.ttf in Resources */,
 				4422D55221BFFB7E00BF1855 /* make_unicode_casefold.py in Resources */,
 				E4B7B7791A793CF20022C5E0 /* FiraSans-Light.ttf in Resources */,
+				F99505FF22937E3900CC6543 /* U2F-low-level.js in Resources */,
 				D0FCF8081FE4772D004A7995 /* MainFrameAtDocumentStart.js in Resources */,
 				0A0D3D5021A5609600BEE65B /* SafeBrowsingError.html in Resources */,
 				74821FFE1DB6D3AC00EEEA72 /* MailSchemes.plist in Resources */,
@@ -5747,6 +5785,7 @@
 				4422D55821BFFB7F00BF1855 /* unicode_casefold.cc in Sources */,
 				C6620BBB213BCEC6009FE75A /* TabType.swift in Sources */,
 				0A4325AE21B1C5D70041625B /* no_fingerprint_domain.cc in Sources */,
+				F930CDB82270040D00A23FE1 /* WebAuthnClientData.swift in Sources */,
 				4422D50721BFFB7600BF1855 /* port_posix.cc in Sources */,
 				E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */,
 				A16DC67F20E585D90069C8E1 /* PasscodeSettingsViewController.swift in Sources */,
@@ -5772,6 +5811,7 @@
 				4422D4E821BFFB7600BF1855 /* log_writer.cc in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				0A7B5D6722689C5D00AADF22 /* AddEditHeaderView.swift in Sources */,
+				F930CDD12270F09000A23FE1 /* WebAuthnAuthenticateRequest.swift in Sources */,
 				C6B81B81212D6C1100996084 /* NoPrivacyProtection.swift in Sources */,
 				D8C75DF3207584C400BB8AD0 /* UIImageViewAligned.m in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
@@ -5845,6 +5885,7 @@
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,
 				5D24AF8221BA459000F9506A /* BlocklistName.swift in Sources */,
 				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
+				F930CDC9227006D600A23FE1 /* WebAuthnRegisterRequest.swift in Sources */,
 				0BD19A671A25309B0084FBA7 /* NSUserDefaultsPrefs.swift in Sources */,
 				4422D4F021BFFB7600BF1855 /* write_batch.cc in Sources */,
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
@@ -5867,6 +5908,7 @@
 				0A1E84412190A57F0042F782 /* SyncViewController.swift in Sources */,
 				0AADC4C820D2A55A00FDE368 /* FavoritesViewController.swift in Sources */,
 				0A43293021B1C7F50041625B /* AdBlockStats.swift in Sources */,
+				F930CDAE2270015C00A23FE1 /* U2FExtensions.swift in Sources */,
 				E65075571E37F714006961AC /* FaviconFetcher.swift in Sources */,
 				0AEFB88722299E6A007AF600 /* AdblockerType.swift in Sources */,
 				D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */,
@@ -5909,6 +5951,7 @@
 				44331DBB22521013007E3E93 /* MenuViewController.swift in Sources */,
 				4422D4BC21BFFB7600BF1855 /* testharness.cc in Sources */,
 				3BE7275D1CCFE8B60099189F /* CustomSearchHandler.swift in Sources */,
+				F930CDD72270F14300A23FE1 /* WebAuthnUtils.swift in Sources */,
 				A1FEEE2020BF28D900298DA2 /* Then.swift in Sources */,
 				0A1E84442190A57F0042F782 /* SyncCameraView.swift in Sources */,
 				A1CA29C420E1746A00CB9126 /* OptionSelectionViewController.swift in Sources */,
@@ -5961,6 +6004,7 @@
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */,
+				F939FBFE22A596B900D9CD3F /* U2FTests.swift in Sources */,
 				0A4BEFD6221E13830005551A /* ContentBlockerTests.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
 				D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */,
@@ -8419,9 +8463,14 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -8443,6 +8492,17 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/ThirdParty/sqlcipher",
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+					"$(SDKROOT)/usr/include/libxml2",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include/",
+				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)";
@@ -8809,9 +8869,14 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -8894,6 +8959,17 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/ThirdParty/sqlcipher",
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+					"$(SDKROOT)/usr/include/libxml2",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include/",
 				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -9202,9 +9278,14 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -9224,6 +9305,17 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/ThirdParty/sqlcipher",
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+					"$(SDKROOT)/usr/include/libxml2",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include/",
 				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -9418,9 +9510,14 @@
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(SRCROOT)/node_modules/bloom-filter-cpp",
 					"$(SRCROOT)/node_modules/hashset-cpp",
+					"$(SRCROOT)/ThirdParty/YubiKit/include",
 				);
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/ThirdParty/YubiKit",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -9459,6 +9556,17 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/ThirdParty/sqlcipher",
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+					"$(SDKROOT)/usr/include/libxml2",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/leveldb/**",
+					"$(SRCROOT)/Client/WebFilters/ShieldStats/Httpse/ThirdParty/re2",
+					"$(SRCROOT)/ThirdParty/YubiKit/include/",
 				);
 				INFOPLIST_FILE = ClientTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1874,6 +1874,8 @@ extension BrowserViewController: TabDelegate {
         tab.addContentScript(FocusHelper(tab: tab), name: FocusHelper.name())
         
         tab.addContentScript(FingerprintingProtection(tab: tab), name: FingerprintingProtection.name())
+        
+        tab.addContentScript(U2FExtensions(tab: tab), name: U2FExtensions.name())
     }
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -953,7 +953,7 @@ class BrowserViewController: UIViewController {
             guard let tab = tabManager[webView] else {
                 break
             }
-            
+            tab.userScriptManager?.isU2FEnabled = webView.hasOnlySecureContent
             if tab.contentIsSecure && !webView.hasOnlySecureContent {
                 tab.contentIsSecure = false
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -247,6 +247,12 @@ extension BrowserViewController: WKNavigationDelegate {
                 }
             }
         }
+        
+        // U2F code below
+        if let tab = tabManager[webView] {
+            // U2F should only be available in secure contexts
+            tab.userScriptManager?.isU2FEnabled = webView.hasOnlySecureContent
+        }
 
         // We can only show this content in the web view if this URL is not pending
         // download via the context menu.

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -247,12 +247,6 @@ extension BrowserViewController: WKNavigationDelegate {
                 }
             }
         }
-        
-        // U2F code below
-        if let tab = tabManager[webView] {
-            // U2F should only be available in secure contexts
-            tab.userScriptManager?.isU2FEnabled = webView.hasOnlySecureContent
-        }
 
         // We can only show this content in the web view if this URL is not pending
         // download via the context menu.

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -211,7 +211,7 @@ class Tab: NSObject {
 
             self.webView = webView
             self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
-            self.userScriptManager = UserScriptManager(tab: self, isFingerprintingProtectionEnabled: Preferences.Shields.fingerprintingProtection.value, isCookieBlockingEnabled: Preferences.Privacy.blockAllCookies.value)
+            self.userScriptManager = UserScriptManager(tab: self, isFingerprintingProtectionEnabled: Preferences.Shields.fingerprintingProtection.value, isCookieBlockingEnabled: Preferences.Privacy.blockAllCookies.value, isU2FEnabled: webView.hasOnlySecureContent)
             tabDelegate?.tab?(self, didCreateWebView: webView)
         }
     }

--- a/Client/Frontend/UserContent/UserScripts/U2F-low-level.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F-low-level.js
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// FIDO - Low Level API
+var $<u2f> = window.u2f
+
+try {
+    var sameOrigin = (window.top.location.origin == window.location.origin)
+    if (!sameOrigin) {
+        $<u2f> = {}
+    }
+} catch (e) {
+    $<u2f> = {}
+}
+
+Object.defineProperty($<u2f>, 'receiveChannel', {
+  value: new MessageChannel()
+})
+
+Object.defineProperty($<u2f>, 'sendChannel', {
+  value: new MessageChannel()
+})
+
+Object.defineProperty($<u2f>, 'low_level_id', {
+  value: 1
+})
+
+Object.defineProperty(window, 'js_api_version', {
+  value: 1
+})
+
+// Some implementations of low level legacy APIs use these constants
+// we define the constants here to maintain consistency
+Object.defineProperty($<u2f>, 'ErrorCodes', {
+  value: {
+    'U2F_REGISTER_REQUEST': 'u2f_register_request',
+    'U2F_SIGN_REQUEST': 'u2f_sign_request',
+    'U2F_REGISTER_RESPONSE': 'u2f_register_response',
+    'U2F_SIGN_RESPONSE': 'u2f_sign_response'
+  }
+})
+
+Object.defineProperty($<u2f>, 'MessageTypes', {
+  value: {
+    'OK': 0,
+    'OTHER_ERROR': 1,
+    'BAD_REQUEST': 2,
+    'CONFIGURATION_UNSUPPORTED': 3,
+    'DEVICE_INELIGIBLE': 4,
+    'TIMEOUT': 5
+  }
+})
+
+Object.defineProperty($<u2f>, 'postLowLevelRegister', {
+  value: function (requestId, fromNative, version, registerationData, clientData, errorCode, errorMessage) {
+    if (fromNative) {
+      caller = window.top.$<u2f>.caller[handle]
+      caller.$<u2f>.postLowLevelRegister(requestId, false, version, registerationData, clientData, errorCode, errorMessage);
+      return;
+    }
+    var response = {}
+    var registerResponse = {}
+
+    if (errorCode > 1) {
+      registerResponse = {
+        'errorCode': errorCode,
+        'errorMessage': errorMessage
+      }
+    } else {
+      registerResponse = new RegisterResponse(version, registerationData, clientData)
+    }
+
+    response = {
+      type: $<u2f>.MessageTypes.U2F_REGISTER_RESPONSE,
+      requestId: requestId,
+      responseData: registerResponse
+    }
+    $<u2f>.sendChannel.port1.postMessage(response)
+  }
+})
+
+Object.defineProperty($<u2f>, 'postLowLevelSign', {
+  value: function (requestId, fromNative, keyHandle, signatureData, clientData, errorCode, errorMessage) {
+    if (fromNative) {
+      caller = window.top.$<u2f>.caller[handle]
+      caller.$<u2f>.postLowLevelSign(handle, false, version, registerationData, clientData, errorCode, errorMessage);
+      return;
+    }
+
+    var response = {}
+    var registerResponse = {}
+
+    if (errorCode > 1) {
+      signResponse = {
+        'errorCode': errorCode,
+        'errorMessage': errorMessage
+      }
+    } else {
+      signResponse = new SignResponse(keyHandle, signatureData, clientData)
+    }
+
+    response = {
+      type: $<u2f>.MessageTypes.U2F_SIGN_RESPONSE,
+      requestId: requestId,
+      responseData: signResponse
+    }
+    $<u2f>.sendChannel.port1.postMessage(response)
+  }
+})
+
+Object.defineProperty($<u2f>, 'getPortSingleton_', {
+  value: function (callback) {
+    $<u2f>.sendChannel.port1.onmessage = u2f.responseHandler_
+    $<u2f>.sendChannel.port2.onmessage = u2f.responseHandler_
+    window.top.$<u2f>.caller[handle] = window
+
+    callback($<u2f>.receiveChannel.port1)
+  }
+})
+
+$<u2f>.receiveChannel.port2.onmessage = function (e) {
+  const handle = $<u2f>.low_level_id++
+  webkit.messageHandlers.U2F.postMessage({ name: 'fido-low-level', handle: handle, data: JSON.stringify(e.data) })
+}
+
+try {
+    var sameOrigin = (window.top.location.origin == window.location.origin)
+    if (!sameOrigin) {
+        $<u2f> = undefined
+    }
+} catch (e) {
+    $<u2f> = undefined
+}
+

--- a/Client/Frontend/UserContent/UserScripts/U2F.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F.js
@@ -1,0 +1,317 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// The $<> is used to replace the var name at runtime with a random string.
+
+// FIDO2 - WebAuthn
+var $<webauthn> = {}
+
+// We use the define property method to avoid the properties from being changed
+// by default configurable, enumerable and writable properties of the object
+// are false
+Object.defineProperty($<webauthn>, 'id', {
+  value: 0
+})
+
+// Used to handle calls from iframes
+Object.defineProperty($<webauthn>, 'caller', {
+  value: []
+ })
+
+Object.defineProperty($<webauthn>, 'reject', {
+  value: []
+})
+
+Object.defineProperty($<webauthn>, 'resolve', {
+  value: []
+})
+
+Object.defineProperty($<webauthn>, 'data', {
+  value: {}
+})
+
+// FIDO - High Level API
+var $<u2f> = {}
+
+Object.defineProperty($<u2f>, 'id', {
+  value: 0
+})
+
+Object.defineProperty($<u2f>, 'resolve', {
+  value: []
+})
+
+Object.defineProperty($<u2f>, 'caller', {
+  value: []
+})
+
+Object.defineProperty(window, 'base64ToArrayBuffer', {
+  value: function (base64) {
+    var binary_string = window.atob(base64)
+    var len = binary_string.length
+    var bytes = new Uint8Array(len)
+    for (var i = 0; i < len; i++) {
+      bytes[i] = binary_string.charCodeAt(i)
+    }
+    return bytes.buffer
+  }
+})
+
+Object.defineProperty(window, 'webSafe64', {
+  value: function (base64) {
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+})
+
+class $<pkc> {
+  constructor (id, response) {
+    this.rawId = window.base64ToArrayBuffer(id)
+    this.id = window.webSafe64(id)
+    this.response = response
+    this.clientExtensionResults = {}
+    this.type = "public-key"
+  }
+
+  getClientExtensionResults() {
+    return this.clientExtensionResults;
+  }
+}
+
+class $<attest> {
+  constructor (attestationObject, clientDataJSON) {
+    this.attestationObject = window.base64ToArrayBuffer(attestationObject)
+    this.clientDataJSON = window.base64ToArrayBuffer(clientDataJSON)
+  }
+}
+
+class $<assert> {
+  constructor (authenticatorData, clientDataJSON, signature) {
+    this.authenticatorData = window.base64ToArrayBuffer(authenticatorData)
+    this.clientDataJSON = window.base64ToArrayBuffer(clientDataJSON)
+    this.signature = window.base64ToArrayBuffer(signature)
+  }
+}
+
+class $<u2fregister> {
+  constructor (version, registrationData, clientData) {
+    this.version = version
+    this.registrationData = registrationData
+    this.clientData = clientData
+  }
+}
+
+class $<u2fsign> {
+  constructor (keyHandle, signatureData, clientData) {
+    this.keyHandle = keyHandle
+    this.signatureData = signatureData
+    this.clientData = clientData
+  }
+}
+
+Object.defineProperty($<webauthn>, 'postCreate', {
+  value:
+    function (handle, fromNative, id, attestationObject, clientDataJSON, errorName, errorDescription) {
+      if (fromNative) {
+        caller = window.top.$<webauthn>.caller[handle]
+        caller.$<webauthn>.postCreate(handle, false, id, attestationObject, clientDataJSON, errorName, errorDescription);
+        return;
+      }
+      if (errorName) {
+        $<webauthn>.reject[handle](new DOMException(errorDescription, errorName))
+        return
+      }
+      response = new $<attest>(attestationObject, clientDataJSON)
+      data = new $<pkc>(id, response)
+      $<webauthn>.resolve[handle](data)
+    }
+})
+
+Object.defineProperty($<webauthn>, 'postGet', {
+  value: function (handle, fromNative, id, authenticatorData, clientDataJSON, signature, errorName, errorDescription) {
+    if (fromNative) {
+      caller = window.top.$<webauthn>.caller[handle]
+      caller.$<webauthn>.postGet(handle, false, id, authenticatorData, clientDataJSON, signature, errorName, errorDescription);
+      return;
+    }
+    if (errorName) {
+      $<webauthn>.reject(new DOMException(errorDescription, errorName))
+      return
+    }
+    response = new $<assert>(authenticatorData, clientDataJSON, signature)
+    data = new $<pkc>(id, response)
+    $<webauthn>.resolve[handle](data)
+  }
+})
+
+Object.defineProperty($<u2f>, 'postSign', {
+  value: function (handle, fromNative, keyHandle, signatureData, clientData, errorCode, errorMessage) {
+    if (fromNative) {
+      caller = window.top.$<u2f>.caller[handle]
+      caller.$<u2f>.postSign(handle, false, keyHandle, signatureData, clientData, errorCode, errorMessage);
+      return;
+    }
+    if (errorCode > 1) {
+      errorData = {
+        'errorCode': errorCode,
+        'errorMessage': errorMessage
+      }
+      $<u2f>.resolve[handle](errorData)
+      return
+    }
+    response = new $<u2fsign>(keyHandle, signatureData, clientData)
+    $<u2f>.resolve[handle](response)
+  }
+})
+
+Object.defineProperty($<u2f>, 'postRegister', {
+  value: function (handle, fromNative, version, registerationData, clientData, errorCode, errorMessage) {
+    if (fromNative) {
+      caller = window.top.$<u2f>.caller[handle]
+      caller.$<u2f>.postRegister(handle, false, version, registerationData, clientData, errorCode, errorMessage);
+      return;
+    }
+    if (errorCode > 1) {
+      errorData = {
+        'errorCode': errorCode,
+        'errorMessage': errorMessage
+      }
+      $<u2f>.resolve[handle](errorData)
+      return
+    }
+    response = new $<u2fregister>(version, registerationData, clientData)
+    $<u2f>.resolve[handle](response)
+  }
+})
+
+Object.defineProperty(window, 'stringifyArrayCleaner', {
+  value: function (k, v) {
+    // in some cases v instanceof ArrayBuffer is false
+    if (v && v.constructor.name ===  "ArrayBuffer") {
+      return btoa(String.fromCharCode.apply(null, new Uint8Array(v)))
+    } else if (v instanceof Uint8Array) {
+      return btoa(String.fromCharCode.apply(null, v))
+    }
+    return v
+  }
+})
+
+Object.defineProperty($<webauthn>, 'create', {
+  value: function (args) {
+    const cleanedArgs = JSON.stringify(args, stringifyArrayCleaner)
+    const handle = $<webauthn>.id++
+    return new Promise(
+      function (resolve, reject) {
+        $<webauthn>.reject[handle] = reject
+        $<webauthn>.resolve[handle] = resolve
+        window.top.$<webauthn>.caller[handle] = window
+        webkit.messageHandlers.U2F.postMessage({ name: 'fido2-create', data: cleanedArgs, handle: handle })
+      }
+    )
+  }
+})
+
+Object.defineProperty($<webauthn>, 'get', {
+  value: function (args) {
+    const cleanedArgs = JSON.stringify(args, stringifyArrayCleaner)
+    const handle = $<webauthn>.id++
+    return new Promise(
+      function (resolve, reject) {
+        const handle = $<webauthn>.id++
+        $<webauthn>.reject[handle] = reject
+        $<webauthn>.resolve[handle] = resolve
+        window.top.$<webauthn>.caller[handle] = window
+        webkit.messageHandlers.U2F.postMessage({ name: 'fido2-get', data: cleanedArgs, handle: handle })
+      }
+    )
+  }
+})
+
+Object.defineProperty($<u2f>, 'sign', {
+  value: function (appId, challenge, registeredKeys, callback) {
+    return new Promise(
+      function (resolve, reject) {
+        const handle = $<u2f>.id++
+        $<u2f>.resolve[handle] = callback
+        window.top.$<u2f>.caller[handle] = window
+        webkit.messageHandlers.U2F.postMessage({ name: 'fido-sign', appId: appId, challenge: challenge, keys: JSON.stringify(registeredKeys), handle: handle })
+      }
+    )
+  }
+})
+                      
+// From: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable
+// We currently don't support a 'user-verifying platform authenticator'
+Object.defineProperty($<pkc>, 'isUserVerifyingPlatformAuthenticatorAvailable', {
+  value: function () {
+    return new Promise(
+      function (resolve, reject) {
+        resolve(false);
+      }
+    )
+  }
+})
+
+
+Object.defineProperty($<u2f>, 'register', {
+  value: function (appId, registerRequests, registeredKeys, responseHandler) {
+    return new Promise(
+      function (resolve, reject) {
+        const handle = $<u2f>.id++
+        $<u2f>.resolve[handle] = responseHandler
+        window.top.$<u2f>.caller[handle] = window
+        webkit.messageHandlers.U2F.postMessage({ name: 'fido-register', appId: appId, requests: JSON.stringify(registerRequests), keys: JSON.stringify(registeredKeys), handle: handle })
+      })
+  }
+})
+
+// FIDO2 APIs are not available in 3p iframes
+Object.defineProperty(window, 'undefineU2F', {
+  value: function () {
+    $<webauthn> = undefined;
+    $<u2f> = undefined;
+    $<attest> = undefined;
+    $<assert> = undefined;
+    $<u2fsign> = undefined;
+    $<u2fregister> = undefined;
+  }
+})
+
+Object.defineProperty(window, 'PublicKeyCredential', {
+  value: $<pkc>
+})
+
+Object.defineProperty(window, 'AuthenticatorAttestationResponse', {
+  value: $<attest>
+})
+
+Object.defineProperty(window, 'AuthenticatorAssertionResponse', {
+  value: $<assert>
+})
+
+Object.defineProperty($<u2f>, 'SignResponse', {
+  value: $<u2fsign>
+})
+
+Object.defineProperty($<u2f>, 'RegisterResponse', {
+  value: $<u2fregister>
+})
+
+try {
+    var sameOrigin = (window.top.location.origin == window.location.origin)
+    if (!sameOrigin) {
+        window.undefineU2F();
+    }
+} catch (e) {
+    window.undefineU2F();
+}
+
+// Hook $<webauthn> to navigator.credentials
+Object.defineProperty(navigator, 'credentials', {
+  value: $<webauthn>
+})
+
+// Hook $<u2f> to window.u2f
+Object.defineProperty(window, 'u2f', {
+   value: $<u2f>
+})

--- a/Client/Frontend/UserContent/UserScripts/U2F.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F.js
@@ -135,7 +135,7 @@ Object.defineProperty($<webauthn>, 'postGet', {
       return;
     }
     if (errorName) {
-      $<webauthn>.reject(new DOMException(errorDescription, errorName))
+      $<webauthn>.reject[handle](new DOMException(errorDescription, errorName))
       return
     }
     response = new $<assert>(authenticatorData, clientDataJSON, signature)

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -128,6 +128,10 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UISupportedExternalAccessoryProtocols</key>
+	<array>
+		<string>com.yubico.ylp</string>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Client/U2FExtensions.swift
+++ b/Client/U2FExtensions.swift
@@ -1,0 +1,866 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Data
+import Shared
+import WebKit
+
+private struct FIDORegisterRequest: Codable {
+    var challenge: String
+    var version: String
+    var appId: String?
+}
+
+private struct FIDOSignRequest: Codable {
+    var version: String
+    var challenge: String?
+    var keyHandle: String
+    var appId: String?
+}
+
+private struct FIDOLowLevel: Codable {
+    var type: String
+    var timeoutSeconds: Int
+    var requestId: Int
+}
+
+private struct FIDOLowLevelRegisterRequests: Codable {
+    var registerRequests: [FIDORegisterRequest]?
+}
+
+private struct FIDOLowLevelSignRequests: Codable {
+    var signRequests: [FIDOSignRequest]?
+}
+
+private enum U2FErrorCodes: Int {
+    case ok = 1, other_error, bad_request, configuration_unsupported, device_ineligible, timeout
+}
+
+private let log = Logger.browserLogger
+private let defaultErrorCode = U2FErrorCodes.ok.rawValue
+private let authSuccess = -1
+
+private let signRequest = "u2f_sign_request"
+private let registerRequest = "u2f_register_request"
+
+// These are messages that are logged when U2F service encounters any errors
+private enum U2FErrorMessages: String {
+    case Error = "Error executing U2F request"
+    case ErrorRegistration = "Error executing U2F registration request"
+    case ErrorAuthentication = "Error executing U2F authentication request"
+}
+
+private enum FIDO2ErrorMessages: String {
+    case NotAllowedError = "NotAllowedError"
+    case SecurityError = "SecurityError"
+}
+
+class U2FExtensions: NSObject {
+    fileprivate weak var tab: Tab?
+    
+    // There can be multiple Registration/Authentication requests at any time
+    // We use handles to keep track of different requests
+    fileprivate var fido2RegHandles: [Int] = []
+    fileprivate var fido2AuthHandles: [Int] = []
+    fileprivate var fidoRegHandles: [Int] = []
+    fileprivate var fidoSignHandles: [Int] = []
+    
+    fileprivate var requestId: [Int: Int] = [:]
+    fileprivate var fidoRequests: [Int: Int] = [:]
+    
+    fileprivate var fido2RegisterRequest: [Int: WebAuthnRegisterRequest] = [:]
+    fileprivate var fido2AuthRequest: [Int: WebAuthnAuthenticateRequest] = [:]
+    
+    fileprivate var fidoRegisterRequest: [Int: FIDORegisterRequest] = [:]
+    fileprivate var fidoSignRequests: [Int: [FIDOSignRequest]] = [:]
+    
+    fileprivate static var observationContext = 0
+    
+    // Using a property style approch to avoid observing twice.
+    private var observeKeyUpdates: Bool = false {
+        didSet {
+            if oldValue == observeKeyUpdates {
+                return
+            }
+            
+            let keySession = YubiKitManager.shared.keySession as AnyObject
+            
+            if observeKeyUpdates {
+                keySession.addObserver(self, forKeyPath: #keyPath(YKFKeySession.sessionState), options: [.new, .old], context: &U2FExtensions.observationContext)
+            } else {
+                keySession.removeObserver(self, forKeyPath: #keyPath(YKFKeySession.sessionState))
+            }
+        }
+    }
+
+    init(tab: Tab) {
+        self.tab = tab
+        defer {
+            observeKeyUpdates = true
+        }
+        super.init()
+        
+        // Make sure the session is started
+        YubiKitManager.shared.keySession.startSession()
+    }
+    
+    deinit {
+        observeKeyUpdates = false
+    }
+    
+    // rpId should be a registrable domain suffix or equal to the effectiveDomain
+    func validateRPId(url: String, rpId: String) -> Bool {
+        guard let currentURL = URL(string: url) else {
+            return false
+        }
+        
+        guard let rpIdURL = URL(string: rpId) else {
+            return false
+        }
+        
+        guard let currentURLHost = currentURL.host else {
+            return false
+        }
+        
+        // in some cases rp id is abc.com, when parsed as URL host is set to nil
+        guard let rpIdHost = rpIdURL.host else {
+            return currentURLHost.hasSuffix(rpId)
+        }
+        
+        return currentURLHost.hasSuffix(rpIdHost)
+    }
+
+    private func getCurrentURL() -> String? {
+        guard let url = self.tab?.webView?.url else {
+            return nil
+        }
+        return url.domainURL.absoluteString
+    }
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        guard context == &U2FExtensions.observationContext else {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+            return
+        }
+        
+        if keyPath == #keyPath(YKFKeySession.sessionState) {
+            ensureMainThread {
+                self.handleSessionStateChange()
+            }
+        }
+    }
+    
+    // FIDO2 Registration
+    private func requestFIDO2Registration(handle: Int, request: WebAuthnRegisterRequest) {
+        fido2RegHandles.append(handle)
+        fido2RegisterRequest[handle] = request
+
+        guard YubiKitManager.shared.keySession.sessionState == .open else {
+            return
+        }
+        
+        handleFIDO2Registration(handle: handle, request: request)
+    }
+    
+    private func handleFIDO2Registration(handle: Int, request: WebAuthnRegisterRequest) {
+        let makeCredentialRequest = YKFKeyFIDO2MakeCredentialRequest()
+        guard let url = getCurrentURL() else {
+            sendFIDO2RegistrationError(handle: handle, errorName: FIDO2ErrorMessages.SecurityError.rawValue)
+            return
+        }
+        
+        let clientData = WebAuthnClientData(type: WebAuthnClientDataType.create.rawValue, challenge: request.challenge, origin: url)
+        
+        do {
+            let clientDataJSON = try JSONEncoder().encode(clientData)
+            guard let clientDataHash = clientDataHash(data: clientDataJSON) else {
+                sendFIDO2RegistrationError(handle: handle)
+                return
+            }
+            
+            makeCredentialRequest.clientDataHash = clientDataHash
+            
+            let rp = YKFFIDO2PublicKeyCredentialRpEntity()
+            // If rpId is not present, then set rpId to effectiveDomain
+            // https://www.w3.org/TR/webauthn/#GetAssn-DetermineRpId
+            if request.rpId == "" {
+                guard let rpId = self.tab?.webView?.url?.absoluteString else {
+                    sendFIDO2RegistrationError(handle: handle)
+                    return
+                }
+                rp.rpId = rpId
+            } else {
+                rp.rpId = request.rpId
+            }
+
+            guard validateRPId(url: url, rpId: rp.rpId) else {
+                sendFIDO2RegistrationError(handle: handle, errorName: FIDO2ErrorMessages.SecurityError.rawValue)
+                return
+            }
+                
+            rp.rpName = request.rpName
+            makeCredentialRequest.rp = rp
+            
+            let user = YKFFIDO2PublicKeyCredentialUserEntity()
+            guard let userId = Data(base64Encoded: request.userId) else {
+                sendFIDO2RegistrationError(handle: handle)
+                return
+            }
+            user.userId = userId
+            user.userName = request.username
+            makeCredentialRequest.user = user
+            
+            let param = YKFFIDO2PublicKeyCredentialParam()
+            param.alg = request.pubKeyAlg
+            makeCredentialRequest.pubKeyCredParams = [param]
+            
+            let makeOptions = [YKFKeyFIDO2MakeCredentialRequestOptionRK: request.residentKey]
+            makeCredentialRequest.options = makeOptions
+            
+            guard let fido2Service = YubiKitManager.shared.keySession.fido2Service else {
+                self.sendFIDO2RegistrationError(handle: handle)
+                return
+            }
+            
+            fido2Service.execute(makeCredentialRequest) { [weak self] response, error in
+                guard let self = self else {
+                    log.error(U2FErrorMessages.ErrorRegistration.rawValue)
+                    return
+                }
+                guard error == nil else {
+                    let errorDescription = error?.localizedDescription ?? Strings.U2FRegistrationError
+                    self.sendFIDO2RegistrationError(handle: handle, errorDescription: errorDescription)
+                    return
+                }
+                
+                guard let response = response else {
+                    self.sendFIDO2RegistrationError(handle: handle)
+                    return
+                }
+                self.finalizeFIDO2Registration(handle: handle, response: response, clientDataJSON: clientDataJSON.base64EncodedString(), error: nil)
+            }
+        } catch let error as NSError {
+            sendFIDO2RegistrationError(handle: handle, errorDescription: error.localizedDescription)
+        }
+    }
+    
+    private func finalizeFIDO2Registration(handle: Int, response: YKFKeyFIDO2MakeCredentialResponse, clientDataJSON: String, error: NSErrorPointer) {
+        guard error == nil else {
+            let errorDescription = error?.pointee?.localizedDescription ?? Strings.U2FRegistrationError
+            sendFIDO2RegistrationError(handle: handle, errorDescription: errorDescription)
+            return
+        }
+        
+        let attestationString = response.webauthnAttestationObject.base64EncodedString()
+        guard let authenticatorData = response.authenticatorData else {
+            sendFIDO2RegistrationError(handle: handle)
+            return
+        }
+
+        let credentialId = authenticatorData.credentialId
+        guard let credentialIdString = credentialId?.base64EncodedString() else {
+            sendFIDO2RegistrationError(handle: handle)
+            return
+        }
+        cleanupFIDO2Registration(handle: handle)
+        ensureMainThread {
+            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postCreate('\(handle)', \(true), '\(credentialIdString)', '\(attestationString)', '\(clientDataJSON)', '', '')", completionHandler: { _, error in
+                if error != nil {
+                    let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
+                    log.error(errorDescription)
+                }
+                return
+        }) }
+    }
+    
+    private func sendFIDO2RegistrationError(handle: Int, errorName: String = FIDO2ErrorMessages.NotAllowedError.rawValue, errorDescription: String = Strings.U2FRegistrationError) {
+        cleanupFIDO2Registration(handle: handle)
+        ensureMainThread {
+            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postCreate('\(handle)', \(true),'', '', '', '\(errorName)', '\(errorDescription)')", completionHandler: { _, error in
+                if error != nil {
+                    let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
+                    log.error(errorDescription)
+                }
+                return
+        }) }
+    }
+    
+    private func cleanupFIDO2Registration(handle: Int) {
+        guard let index = fido2RegHandles.firstIndex(of: handle) else {
+            log.error(U2FErrorMessages.ErrorRegistration)
+            return
+        }
+        fido2RegHandles.remove(at: index)
+        fido2RegisterRequest.removeValue(forKey: handle)
+    }
+    
+    // FIDO2 Authentication
+    private func requestFIDO2Authentication(handle: Int, request: WebAuthnAuthenticateRequest) {
+        fido2AuthHandles.append(handle)
+        fido2AuthRequest[handle] = request
+        
+        guard YubiKitManager.shared.keySession.sessionState == .open else {
+            return
+        }
+        
+        handleFIDO2Authentication(handle: handle, request: request)
+    }
+    
+    private func handleFIDO2Authentication(handle: Int, request: WebAuthnAuthenticateRequest) {
+        let getAssertionRequest = YKFKeyFIDO2GetAssertionRequest()
+        guard let url = getCurrentURL() else {
+            sendFIDO2AuthenticationError(handle: handle, errorName: FIDO2ErrorMessages.SecurityError.rawValue)
+            return
+        }
+        
+        let clientData = WebAuthnClientData(type: WebAuthnClientDataType.get.rawValue, challenge: request.challenge, origin: url)
+        do {
+            let clientDataJSON = try JSONEncoder().encode(clientData)
+            guard let allowCredential = request.allowCredentials.first else {
+                sendFIDO2AuthenticationError(handle: handle)
+                return
+            }
+            let requestId = allowCredential
+            
+            getAssertionRequest.rpId = request.rpID
+            
+            guard validateRPId(url: url, rpId: getAssertionRequest.rpId) else {
+                sendFIDO2RegistrationError(handle: handle, errorName: FIDO2ErrorMessages.SecurityError.rawValue)
+                return
+            }
+
+            guard let clientDataHash = clientDataHash(data: clientDataJSON) else {
+                sendFIDO2AuthenticationError(handle: handle)
+                return
+            }
+            getAssertionRequest.clientDataHash = clientDataHash
+            getAssertionRequest.options = [YKFKeyFIDO2GetAssertionRequestOptionUP: true]
+            
+            var allowList = [YKFFIDO2PublicKeyCredentialDescriptor]()
+            for credentialId in request.allowCredentials {
+                let credentialDescriptor = YKFFIDO2PublicKeyCredentialDescriptor()
+                
+                guard let credentialIdData = Data(base64Encoded: credentialId) else {
+                    sendFIDO2AuthenticationError(handle: handle)
+                    return
+                }
+                
+                credentialDescriptor.credentialId = credentialIdData
+                let credType = YKFFIDO2PublicKeyCredentialType()
+                credType.name = "public-key"
+                credentialDescriptor.credentialType = credType
+                allowList.append(credentialDescriptor)
+            }
+            getAssertionRequest.allowList = allowList
+            
+            guard let fido2Service = YubiKitManager.shared.keySession.fido2Service else {
+                sendFIDO2AuthenticationError(handle: handle)
+                return
+            }
+            
+            fido2Service.execute(getAssertionRequest) { [weak self] response, error in
+                guard let self = self else {
+                    log.error(U2FErrorMessages.ErrorAuthentication.rawValue)
+                    return
+                }
+                guard error == nil else {
+                    let errorDescription = error?.localizedDescription ?? Strings.U2FAuthenticationError
+                    self.sendFIDO2AuthenticationError(handle: handle, errorDescription: errorDescription)
+                    return
+                }
+                
+                // The reponse from the key must not be empty at this point.
+                guard let response = response else {
+                    self.sendFIDO2AuthenticationError(handle: handle)
+                    return
+                }
+                self.finalizeFIDO2Authentication(handle: handle, response: response, requestId: requestId, clientDataJSON: clientDataJSON, error: nil)
+            }
+        } catch let error as NSError {
+            sendFIDO2AuthenticationError(handle: handle, errorDescription: error.localizedDescription)
+            return
+        }
+    }
+    
+    private func finalizeFIDO2Authentication(handle: Int, response: YKFKeyFIDO2GetAssertionResponse, requestId: String, clientDataJSON: Data, error: NSErrorPointer) {
+        guard error == nil else {
+            let errorDescription = error?.pointee?.localizedDescription ?? Strings.U2FAuthenticationError
+            sendFIDO2AuthenticationError(handle: handle, errorDescription: errorDescription)
+            return
+        }
+        
+        let authenticatorData = response.authData.base64EncodedString()
+        let clientDataJSONString = clientDataJSON.base64EncodedString()
+        let sig = response.signature.base64EncodedString()
+        
+        cleanupFIDO2Authentication(handle: handle)
+        ensureMainThread {
+            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postGet('\(handle)', \(true), '\(requestId)', '\(authenticatorData)', '\(clientDataJSONString)', '\(sig)', '')", completionHandler: { _, error in
+                if error != nil {
+                    let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
+                    log.error(errorDescription)
+                }
+            return
+        }) }
+    }
+    
+    private func sendFIDO2AuthenticationError(handle: Int, errorName: String = FIDO2ErrorMessages.NotAllowedError.rawValue, errorDescription: String = Strings.U2FAuthenticationError) {
+        cleanupFIDO2Authentication(handle: handle)
+        ensureMainThread {
+            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postGet('\(handle)', \(true), '', '', '', '', '\(errorName)', '\(errorDescription)')", completionHandler: { _, error in
+                if error != nil {
+                    let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
+                    log.error(errorDescription)
+                }
+            return
+        }) }
+    }
+    
+    private func cleanupFIDO2Authentication(handle: Int) {
+        guard let index = fido2AuthHandles.firstIndex(of: handle) else {
+            log.error(U2FErrorMessages.ErrorRegistration)
+            return
+        }
+        fido2AuthHandles.remove(at: index)
+        fido2AuthRequest.removeValue(forKey: handle)
+    }
+    
+    // FIDO Registration
+    private func requestFIDORegistration(handle: Int, requests: [FIDORegisterRequest], id: Int) {
+        fidoRegHandles.append(handle)
+        
+        guard let request = requests.first else {
+            sendFIDORegistrationError(handle: handle, requestId: id, errorCode: U2FErrorCodes.bad_request)
+            return
+        }
+    
+        fidoRegisterRequest[handle] = request
+        
+        if id > -1 {
+            requestId[handle] = id
+        }
+
+        guard YubiKitManager.shared.keySession.sessionState == .open else {
+            return
+        }
+        
+        handleFIDORegistration(handle: handle, request: request, requestId: id)
+    }
+    
+    private func handleFIDORegistration(handle: Int, request: FIDORegisterRequest, requestId: Int) {
+        guard let registerRequest = YKFKeyU2FRegisterRequest(challenge: request.challenge, appId: request.appId ?? "") else {
+            sendFIDORegistrationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.bad_request)
+            return
+        }
+        
+        guard let u2fservice = YubiKitManager.shared.keySession.u2fService else {
+            sendFIDORegistrationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error)
+            return
+        }
+        
+        u2fservice.execute(registerRequest) { [weak self] response, error in
+            guard let self = self else {
+                log.error(U2FErrorMessages.Error.rawValue)
+                return
+            }
+            
+            guard error == nil else {
+                let errorMessage = error?.localizedDescription ?? Strings.U2FRegistrationError
+                self.sendFIDORegistrationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error, errorMessage: errorMessage)
+                return
+            }
+            guard let clientData = response?.clientData.websafeBase64String() else {
+                self.sendFIDORegistrationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error)
+                return
+            }
+            guard let registrationData = response?.registrationData.websafeBase64String() else {
+                self.sendFIDORegistrationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error)
+                return
+            }
+            
+            self.cleanupFIDORegistration(handle: handle)
+            if requestId > -1 {
+                ensureMainThread {
+                    self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelRegister(\(requestId), \(true), '\(request.version)', '\(registrationData)', '\(clientData)', \(defaultErrorCode), '')", completionHandler: { _, error in
+                        if error != nil {
+                            let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
+                            log.error(errorDescription)
+                        }
+                    return
+                }) }
+                return
+            }
+
+            ensureMainThread {
+                self.tab?.webView?.evaluateJavaScript("u2f.postRegister('\(handle)', \(true), '\(request.version)', '\(registrationData)', '\(clientData)', \(defaultErrorCode), '')", completionHandler: { _, error in
+                    if error != nil {
+                        let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
+                        log.error(errorDescription)
+                    }
+                return
+            }) }
+        }
+    }
+    
+    private func sendFIDORegistrationError(handle: Int, requestId: Int, errorCode: U2FErrorCodes, errorMessage: String = Strings.U2FRegistrationError) {
+        cleanupFIDORegistration(handle: handle)
+        if requestId > -1 {
+            ensureMainThread {
+                self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelRegister(\(requestId), \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+                    if error != nil {
+                        let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
+                        log.error(errorDescription)
+                    }
+                return
+            }) }
+            return
+        }
+        
+        ensureMainThread {
+            self.tab?.webView?.evaluateJavaScript("u2f.postRegister('\(handle)', \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+                if error != nil {
+                    let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
+                    log.error(errorDescription)
+                }
+                return
+            }) }
+    }
+    
+    private func cleanupFIDORegistration(handle: Int) {
+        guard let index = fidoRegHandles.firstIndex(of: handle) else {
+            log.error(U2FErrorMessages.ErrorRegistration)
+            return
+        }
+        fidoRegHandles.remove(at: index)
+        fidoRegisterRequest.removeValue(forKey: handle)
+        requestId.removeValue(forKey: handle)
+    }
+    
+    // FIDO Authetication
+    private func requestFIDOAuthentication(handle: Int, keys: [FIDOSignRequest], id: Int) {
+        fidoSignHandles.append(handle)
+        fidoSignRequests[handle] = keys
+        fidoRequests[handle] = keys.count
+        
+        if id > -1 {
+            requestId[handle] = id
+        }
+
+        guard YubiKitManager.shared.keySession.sessionState == .open else {
+            return
+        }
+        
+        handleFIDOAuthentication(handle: handle, keys: keys, requestId: id)
+    }
+    
+    private func handleFIDOAuthentication(handle: Int, keys: [FIDOSignRequest], requestId: Int) {
+        guard let u2fservice = YubiKitManager.shared.keySession.u2fService else {
+            sendFIDOAuthenticationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error)
+            return
+        }
+        for key in keys {
+            guard let signRequest = YKFKeyU2FSignRequest(challenge: key.challenge ?? "", keyHandle: key.keyHandle, appId: key.appId ?? "") else {
+                sendFIDOAuthenticationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.bad_request)
+                return
+            }
+            
+            guard var count = self.fidoRequests[handle] else {
+                log.error(U2FErrorMessages.ErrorAuthentication.rawValue)
+                return
+            }
+            
+            if count == authSuccess {
+                // auth was successful we don't need to execute again
+                return
+            }
+            
+            u2fservice.execute(signRequest) { [weak self] response, error in
+                guard let self = self else {
+                    log.error(U2FErrorMessages.ErrorAuthentication.rawValue)
+                    return
+                }
+                
+                count -= 1
+                self.fidoRequests[handle] = count
+                
+                guard error == nil else {
+                    if count == 0 {
+                        let errorMessage = error?.localizedDescription ?? Strings.U2FAuthenticationError
+                        self.sendFIDOAuthenticationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error, errorMessage: errorMessage)
+                    }
+                    return
+                }
+                guard let keyHandle = response?.keyHandle else {
+                    self.sendFIDOAuthenticationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error)
+                    return
+                }
+                guard let signature = response?.signature.websafeBase64String() else {
+                    self.sendFIDOAuthenticationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error)
+                    return
+                }
+                guard let clientData = response?.clientData.websafeBase64String() else {
+                    self.sendFIDOAuthenticationError(handle: handle, requestId: requestId, errorCode: U2FErrorCodes.other_error)
+                    return
+                }
+                
+                self.fidoRequests[handle] = authSuccess
+                
+                self.cleanupFIDOAuthentication(handle: handle)
+                if requestId > -1 {
+                    ensureMainThread {
+                        self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelSign(\(requestId), \(true), '\(keyHandle)', '\(signature)', '\(clientData)', \(defaultErrorCode), '')", completionHandler: { _, error in
+                            if error != nil {
+                                let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
+                                log.error(errorDescription)
+                            }
+                        return
+                    }) }
+                    return
+                }
+
+                ensureMainThread {
+                    self.tab?.webView?.evaluateJavaScript("u2f.postSign('\(handle)', \(true), '\(keyHandle)', '\(signature)', '\(clientData)', \(defaultErrorCode), '')", completionHandler: { _, error in
+                        if error != nil {
+                            let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
+                            log.error(errorDescription)
+                        }
+                    return
+                }) }
+            }
+        }
+    }
+    
+    private func sendFIDOAuthenticationError(handle: Int, requestId: Int, errorCode: U2FErrorCodes, errorMessage: String = Strings.U2FAuthenticationError) {
+        cleanupFIDOAuthentication(handle: handle)
+        
+        if requestId > -1 {
+            ensureMainThread {
+                self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelSign(\(requestId), \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+                    if error != nil {
+                        let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
+                        log.error(errorDescription)
+                    }
+                return
+            }) }
+            return
+        }
+        
+        ensureMainThread {
+            self.tab?.webView?.evaluateJavaScript("u2f.postSign('\(handle)', \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+                if error != nil {
+                    let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
+                    log.error(errorDescription)
+                }
+            return
+        }) }
+    }
+    
+    private func cleanupFIDOAuthentication(handle: Int) {
+        guard let index = fidoSignHandles.firstIndex(of: handle) else {
+            log.error(U2FErrorMessages.ErrorRegistration)
+            return
+        }
+        fidoSignHandles.remove(at: index)
+        fidoSignRequests.removeValue(forKey: handle)
+        requestId.removeValue(forKey: handle)
+    }
+    
+    private func handleSessionStateChange() {
+        observeKeyUpdates = false
+        defer {
+            observeKeyUpdates = true
+        }
+        let sessionState = YubiKitManager.shared.keySession.sessionState
+        if sessionState == .open { // The key session is ready to be used.
+            if !fido2RegHandles.isEmpty {
+                guard let handle = fido2RegHandles.first else {
+                    log.error(U2FErrorMessages.ErrorRegistration)
+                    return
+                }
+                guard let request = fido2RegisterRequest[handle] else {
+                    sendFIDO2RegistrationError(handle: handle)
+                    return
+                }
+                handleFIDO2Registration(handle: handle, request: request)
+            }
+            
+            if !fidoRegHandles.isEmpty {
+                guard let handle = fidoRegHandles.first else {
+                    log.error(U2FErrorMessages.ErrorRegistration)
+                    return
+                }
+                guard let request = fidoRegisterRequest[handle] else {
+                    sendFIDORegistrationError(handle: handle, requestId: requestId[handle] ?? -1, errorCode: U2FErrorCodes.other_error)
+                    return
+                }
+                handleFIDORegistration(handle: handle, request: request, requestId: requestId[handle] ?? -1)
+            }
+        
+            if !fido2AuthHandles.isEmpty {
+                guard let handle = fido2AuthHandles.first else {
+                    log.error(U2FErrorMessages.ErrorAuthentication)
+                    return
+                }
+                guard let request = fido2AuthRequest[handle] else {
+                    sendFIDO2AuthenticationError(handle: handle)
+                    return
+                }
+                handleFIDO2Authentication(handle: handle, request: request)
+            }
+        
+            if !fidoSignHandles.isEmpty {
+                guard let handle = fidoSignHandles.first else {
+                    log.error(U2FErrorMessages.ErrorAuthentication)
+                    return
+                }
+                guard let keys = fidoSignRequests[handle] else {
+                    sendFIDOAuthenticationError(handle: handle, requestId: requestId[handle] ?? -1, errorCode: U2FErrorCodes.other_error)
+                    return
+                }
+                handleFIDOAuthentication(handle: handle, keys: keys, requestId: requestId[handle] ?? -1)
+            }
+        }
+    }
+}
+
+// MARK: - TabContentScript
+extension U2FExtensions: TabContentScript {
+    static func name() -> String {
+        return "U2F"
+    }
+    
+    func scriptMessageHandlerName() -> String? {
+        return "U2F"
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        if message.name == "U2F", let body = message.body as? NSDictionary {
+            
+            guard let name = body["name"] as? String, let handle = body["handle"] as? Int else {
+                log.error(U2FErrorMessages.Error)
+                return
+            }
+            
+            // FIDO2 is the new webauthn API
+            // https://www.w3.org/TR/webauthn/
+            if name == "fido2-create" {
+                guard let data = body["data"] as? String, let jsonData = data.data(using: String.Encoding.utf8) else {
+                    sendFIDO2RegistrationError(handle: handle)
+                    return
+                }
+                
+                do {
+                    let request =  try JSONDecoder().decode(WebAuthnRegisterRequest.self, from: jsonData)
+                    requestFIDO2Registration(handle: handle, request: request)
+                } catch let error as NSError {
+                    sendFIDO2RegistrationError(handle: handle, errorDescription: error.localizedDescription)
+                }
+                return
+            }
+            
+            if name == "fido2-get" {
+                guard let data = body["data"] as? String, let jsonData = data.data(using: String.Encoding.utf8) else {
+                    sendFIDO2AuthenticationError(handle: handle)
+                    return
+                }
+                
+                do {
+                    let request =  try JSONDecoder().decode(WebAuthnAuthenticateRequest.self, from: jsonData)
+                    requestFIDO2Authentication(handle: handle, request: request)
+                } catch let error as NSError {
+                    sendFIDO2RegistrationError(handle: handle, errorDescription: error.localizedDescription)
+                }
+                
+                return
+            }
+
+            // High Level FIDO U2F API
+            // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html#high-level-javascript-api
+            if name == "fido-register" {
+                guard let appId = body["appId"] as? String, let requests = body["requests"] as? String else {
+                    sendFIDORegistrationError(handle: handle, requestId: -1, errorCode: U2FErrorCodes.bad_request)
+                    return
+                }
+                
+                let jsonData = Data(requests.utf8)
+                let decoder = JSONDecoder()
+                do {
+                    var registerRequests = try decoder.decode([FIDORegisterRequest].self, from: jsonData)
+                    for index in registerRequests.indices {
+                        registerRequests[index].appId = appId
+                    }
+                    requestFIDORegistration(handle: handle, requests: registerRequests, id: -1)
+                } catch let error as NSError {
+                    sendFIDORegistrationError(handle: handle, requestId: -1, errorCode: U2FErrorCodes.bad_request, errorMessage: error.localizedDescription)
+                    return
+                }
+                return
+            }
+            
+            if name == "fido-sign" {
+                guard let appId = body["appId"] as? String, let challenge = body["challenge"] as? String, let keys = body["keys"] as? String else {
+                    sendFIDOAuthenticationError(handle: handle, requestId: -1, errorCode: U2FErrorCodes.bad_request)
+                    return
+                }
+                
+                let jsonData = Data(keys.utf8)
+                let decoder = JSONDecoder()
+                do {
+                    var registeredKeys = try decoder.decode([FIDOSignRequest].self, from: jsonData)
+                    for index in registeredKeys.indices {
+                        registeredKeys[index].challenge = challenge
+                        registeredKeys[index].appId = appId
+                    }
+                    requestFIDOAuthentication(handle: handle, keys: registeredKeys, id: -1)
+                } catch let error as NSError {
+                    sendFIDOAuthenticationError(handle: handle, requestId: -1, errorCode: U2FErrorCodes.bad_request, errorMessage: error.localizedDescription)
+                    return
+                }
+                return
+            }
+
+            // Low Level FIDO U2F API use message port for interaction
+            // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html#low-level-messageport-api
+            if name == "fido-low-level" {
+                guard let data = body["data"] as? String else {
+                    log.error(U2FErrorMessages.Error.rawValue)
+                    return
+                }
+
+                let jsonData = Data(data.utf8)
+                let decoder = JSONDecoder()
+                do {
+                    let lowLevelRequest = try decoder.decode(FIDOLowLevel.self, from: jsonData)
+                    if lowLevelRequest.type == registerRequest {
+                        let request = try decoder.decode(FIDOLowLevelRegisterRequests.self, from: jsonData)
+                        guard let registerRequests = request.registerRequests else {
+                            log.error(Strings.U2FRegistrationError)
+                            return
+                        }
+                        requestFIDORegistration(handle: handle, requests: registerRequests, id: lowLevelRequest.requestId)
+                    }
+                    if lowLevelRequest.type == signRequest {
+                        let request = try decoder.decode(FIDOLowLevelSignRequests.self, from: jsonData)
+                        guard let signRequests = request.signRequests else {
+                            log.error(Strings.U2FAuthenticationError)
+                            return
+                        }
+                        requestFIDOAuthentication(handle: handle, keys: signRequests, id: lowLevelRequest.requestId)
+                    }
+                } catch let error as NSError {
+                    log.error(error.localizedDescription)
+                    return
+                }
+                return
+            }
+        }
+    }
+}
+
+extension Strings {
+    //FIDO & FIDO2 Error messages
+    public static let tryAgain = NSLocalizedString("tryAgain", tableName: "BraveShared", bundle: Bundle.braveShared, value: ", please try again.", comment: "Suffix for error strings")
+    public static let U2FRegistrationError = NSLocalizedString("U2FRegistrationError", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Error registering your security key", comment: "Error handling U2F registration.") + tryAgain
+    public static let U2FAuthenticationError = NSLocalizedString("U2FAuthenticationError", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Error authenticating your security key", comment: "Error handling U2F authentication.") + tryAgain
+}

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -4,9 +4,10 @@
 import Shared
 
 struct WebAuthnAuthenticateRequest {
-    var rpID: String
+    var rpID: String?
     var challenge: String
     var allowCredentials: Array<String> = []
+    var userVerification: Bool
     
     enum RequestKeys: String, CodingKey {
         case publicKey
@@ -17,6 +18,7 @@ struct WebAuthnAuthenticateRequest {
         case challenge
         case allowCredentials
         case authenticatorSelection
+        case userVerification
     }
 }
 
@@ -30,9 +32,10 @@ extension WebAuthnAuthenticateRequest: Decodable {
         let request = try decoder.container(keyedBy: RequestKeys.self)
         let publicKeyDictionary = try request.nestedContainer(keyedBy: PublicKeyDictionaryKeys.self, forKey: .publicKey)
         
-        rpID = try publicKeyDictionary.decode(String.self, forKey: .rpId)
-        
+        rpID = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .rpId)
         challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)
+        let userVerifcationString = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .userVerification) ?? ""
+        userVerification = userVerifcationString == "required"
         
         let allowCredentialsArray = try publicKeyDictionary.decode([AllowCredentials].self, forKey: .allowCredentials)
     

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import Shared
+
+struct WebAuthnAuthenticateRequest {
+    var rpID: String
+    var challenge: String
+    var allowCredentials: Array<String> = []
+    
+    enum RequestKeys: String, CodingKey {
+        case publicKey
+    }
+    
+    enum PublicKeyDictionaryKeys: String, CodingKey {
+        case rpId
+        case challenge
+        case allowCredentials
+        case authenticatorSelection
+    }
+}
+
+private struct AllowCredentials: Codable {
+    var id: String
+    var type: String
+}
+
+extension WebAuthnAuthenticateRequest: Decodable {
+    init(from decoder: Decoder) throws {
+        let request = try decoder.container(keyedBy: RequestKeys.self)
+        let publicKeyDictionary = try request.nestedContainer(keyedBy: PublicKeyDictionaryKeys.self, forKey: .publicKey)
+        
+        rpID = try publicKeyDictionary.decode(String.self, forKey: .rpId)
+        
+        challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)
+        
+        let allowCredentialsArray = try publicKeyDictionary.decode([AllowCredentials].self, forKey: .allowCredentials)
+    
+        for credential in allowCredentialsArray {
+            let publicKey = credential.id
+            allowCredentials.append(publicKey)
+        }
+    }
+}

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -6,7 +6,7 @@ import Shared
 struct WebAuthnAuthenticateRequest {
     var rpID: String?
     var challenge: String
-    var allowCredentials: Array<String> = []
+    var allowCredentials: [String] = []
     var userVerification: Bool
     
     enum RequestKeys: String, CodingKey {

--- a/Client/WebAuthN/WebAuthnClientData.swift
+++ b/Client/WebAuthN/WebAuthnClientData.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Shared
+
+enum  WebAuthnClientDataType: String {
+    case create = "webauthn.create"
+    case get = "webauthn.get"
+}
+
+struct WebAuthnClientData {
+    var type: String
+    var challenge: String
+    var origin: String
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case challenge
+        case origin
+    }
+    
+    init(type: String, challenge: String, origin: String) {
+        self.type = type
+        self.challenge = challenge
+        self.origin = origin
+    }
+}
+
+extension WebAuthnClientData: Encodable {
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(origin, forKey: .origin)
+        
+        let challengeData = Data(base64Encoded: challenge)
+        let websafeChallenge = challengeData?.websafeBase64String()
+        try container.encode(websafeChallenge, forKey: .challenge)
+    }
+}
+
+func clientDataHash (data: Data) -> Data? {
+    var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+    data.withUnsafeBytes {
+        _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+    }
+    return Data(hash)
+}

--- a/Client/WebAuthN/WebAuthnClientData.swift
+++ b/Client/WebAuthN/WebAuthnClientData.swift
@@ -19,12 +19,6 @@ struct WebAuthnClientData {
         case challenge
         case origin
     }
-    
-    init(type: String, challenge: String, origin: String) {
-        self.type = type
-        self.challenge = challenge
-        self.origin = origin
-    }
 }
 
 extension WebAuthnClientData: Encodable {

--- a/Client/WebAuthN/WebAuthnRegisterRequest.swift
+++ b/Client/WebAuthN/WebAuthnRegisterRequest.swift
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import Shared
+
+struct WebAuthnRegisterRequest {
+    var username: String
+    var userId: String
+    
+    var rpId: String
+    var rpName: String
+    
+    var pubKeyAlg: Int
+    var residentKey: Bool
+    
+    var challenge: String
+    
+    enum CodingKeys: String, CodingKey {
+        case username
+        case userId
+        case rpId
+        case rpName
+        case pubKeyAlg
+        case residentKey
+    }
+    
+    enum RequestKeys: String, CodingKey {
+        case publicKey
+    }
+    
+    enum PublicKeyDictionaryKeys: String, CodingKey {
+        case user
+        case rp
+        case pubKeyCredParams
+        case challenge
+        case authenticatorSelection
+    }
+    
+    enum UserKeys: String, CodingKey {
+        case name
+        case id
+    }
+
+    enum pubKeyCredParams: String, CodingKey {
+        case alg
+    }
+}
+
+private struct PubKeyCredParams: Codable {
+    var alg: Int
+    var type: String
+}
+
+private struct AuthenticatorSelection: Codable {
+    var requireResidentKey: Bool?
+    var userVerification: String?
+}
+
+extension WebAuthnRegisterRequest: Decodable {
+    init(from decoder: Decoder) throws {
+        let request = try decoder.container(keyedBy: RequestKeys.self)
+        let publicKeyDictionary = try request.nestedContainer(keyedBy: PublicKeyDictionaryKeys.self, forKey: .publicKey)
+       
+        let userDictionary = try publicKeyDictionary.nestedContainer(keyedBy: UserKeys.self, forKey: .user)
+        
+        username = try userDictionary.decode(String.self, forKey: .name)
+        userId = try userDictionary.decode(String.self, forKey: .id)
+        
+        let rpDictionary = try publicKeyDictionary.nestedContainer(keyedBy: UserKeys.self, forKey: .rp)
+        rpId = try rpDictionary.decodeIfPresent(String.self, forKey: .id) ?? ""
+        rpName = try rpDictionary.decode(String.self, forKey: .name)
+        
+        let pubKeyCredParamsArray = try publicKeyDictionary.decode([PubKeyCredParams].self, forKey: .pubKeyCredParams)
+        let pubKeyCredParam = pubKeyCredParamsArray.first
+        
+        // -7 (ECC) or -257 (RSA)
+        pubKeyAlg = pubKeyCredParam?.alg ?? -7
+        
+        if let authenticatorSelection = try publicKeyDictionary.decodeIfPresent(AuthenticatorSelection.self, forKey: .authenticatorSelection) {
+            residentKey = authenticatorSelection.requireResidentKey ?? false
+        } else {
+            residentKey = false
+        }
+        
+        challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)
+    }
+}

--- a/Client/WebAuthN/WebAuthnRegisterRequest.swift
+++ b/Client/WebAuthN/WebAuthnRegisterRequest.swift
@@ -5,14 +5,15 @@ import Shared
 
 struct WebAuthnRegisterRequest {
     var username: String
-    var userId: String
+    var userID: String
     
-    var rpId: String
+    var rpID: String?
     var rpName: String
     
     var pubKeyAlg: Int
     var residentKey: Bool
     
+    var userVerification: Bool
     var challenge: String
     
     enum CodingKeys: String, CodingKey {
@@ -64,10 +65,10 @@ extension WebAuthnRegisterRequest: Decodable {
         let userDictionary = try publicKeyDictionary.nestedContainer(keyedBy: UserKeys.self, forKey: .user)
         
         username = try userDictionary.decode(String.self, forKey: .name)
-        userId = try userDictionary.decode(String.self, forKey: .id)
+        userID = try userDictionary.decode(String.self, forKey: .id)
         
         let rpDictionary = try publicKeyDictionary.nestedContainer(keyedBy: UserKeys.self, forKey: .rp)
-        rpId = try rpDictionary.decodeIfPresent(String.self, forKey: .id) ?? ""
+        rpID = try rpDictionary.decodeIfPresent(String.self, forKey: .id)
         rpName = try rpDictionary.decode(String.self, forKey: .name)
         
         let pubKeyCredParamsArray = try publicKeyDictionary.decode([PubKeyCredParams].self, forKey: .pubKeyCredParams)
@@ -78,8 +79,10 @@ extension WebAuthnRegisterRequest: Decodable {
         
         if let authenticatorSelection = try publicKeyDictionary.decodeIfPresent(AuthenticatorSelection.self, forKey: .authenticatorSelection) {
             residentKey = authenticatorSelection.requireResidentKey ?? false
+            userVerification = authenticatorSelection.userVerification == "required"
         } else {
             residentKey = false
+            userVerification = false
         }
         
         challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)

--- a/Client/WebAuthN/WebAuthnUtils.swift
+++ b/Client/WebAuthN/WebAuthnUtils.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+extension String {
+    func websafeBase64String() -> String? {
+        guard let base64Data = self.data(using: .utf8) else {
+            return nil
+        }
+        return (base64Data as NSData).ykf_websafeBase64EncodedString()
+    }
+}
+
+extension Data {
+    func websafeBase64String() -> String? {
+        return (self as NSData).ykf_websafeBase64EncodedString()
+    }
+}

--- a/ClientTests/U2FTests.swift
+++ b/ClientTests/U2FTests.swift
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import XCTest
+
+import Shared
+import Storage
+import WebKit
+import Alamofire
+@testable import Client
+
+class U2FTests: XCTestCase {
+    
+    let expectedrpID = "demo.brave.com"
+    
+    func testWebAuthnRegisterRequest() {
+        let webAuthnRegisterData = "{\"publicKey\":{\"attestation\":\"direct\",\"authenticatorSelection\":{\"requireResidentKey\":false,\"userVerification\":\"discouraged\"},\"pubKeyCredParams\":[{\"alg\":-7,\"type\":\"public-key\"},{\"alg\":-257,\"type\":\"public-key\"}],\"rp\":{\"id\":\"demo.brave.com\",\"name\":\"Brave\"},\"timeout\":90000,\"challenge\": \"mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=\",\"user\":{\"displayName\":\"Brave demo user\",\"name\":\"Brave demo user\",\"id\":\"OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=\"},\"excludeCredentials\":[]},\"signal\":{}}"
+        guard let jsonData = webAuthnRegisterData.data(using: String.Encoding.utf8) else {
+            XCTFail()
+            return
+        }
+        
+        do {
+            let request =  try JSONDecoder().decode(WebAuthnRegisterRequest.self, from: jsonData)
+            XCTAssertEqual(request.username, "Brave demo user", "request username is correct.")
+            XCTAssertEqual(request.userId, "OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=", "request user id is correct.")
+            XCTAssertEqual(request.rpId, expectedrpID, "request rp id is correct.")
+            XCTAssertEqual(request.rpName, "Brave", "request rp name is correct.")
+            XCTAssertEqual(request.pubKeyAlg, -7, "request pub key alg is correct.")
+            XCTAssertFalse(request.residentKey, "request resident key is correct.")
+            XCTAssertEqual(request.challenge, "mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=", "request challenge is correct.")
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testWebAuthnAuthenticateRequest() {
+        let webAuthnAuthenticateData = "{\"publicKey\":{\"allowCredentials\":[{\"type\":\"public-key\",\"id\":\"OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=\"}],\"rpId\":\"demo.brave.com\",\"timeout\":90000,\"userVerification\":\"discouraged\",\"challenge\":\"mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=\"},\"signal\":{}}"
+        guard let jsonData = webAuthnAuthenticateData.data(using: String.Encoding.utf8) else {
+            XCTFail()
+            return
+        }
+        
+        do {
+            let request =  try JSONDecoder().decode(WebAuthnAuthenticateRequest.self, from: jsonData)
+            XCTAssertEqual(request.rpID, expectedrpID, "request rp id is correct.")
+            XCTAssertEqual(request.challenge, "mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=", "request challenge is correct.")
+            XCTAssertEqual(request.allowCredentials.count, 1, "request allowCredential count is correct")
+            XCTAssertEqual(request.allowCredentials.first, "OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=", "request allowCredential is correct")
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testValidateRPId() {
+        guard let currentURL = URL(string: "https://rp.example.domain") else {
+            XCTFail()
+            return
+        }
+        
+        let rpIdURLs = [
+            "example.domain",
+            "https://test.example.domain",
+            "https://test.examples.domain.com",
+        ]
+        let tab = Tab(configuration: WKWebViewConfiguration())
+        let U2FExtension = U2FExtensions(tab: tab)
+        XCTAssertTrue(U2FExtension.validateRPId(url: currentURL.absoluteString, rpId: rpIdURLs[0]), "rpID URL is valid.")
+        for url in rpIdURLs.dropFirst() {
+            XCTAssertFalse(U2FExtension.validateRPId(url: currentURL.absoluteString, rpId: url), "rpID URLs is invalid.")
+        }
+    }
+}

--- a/ClientTests/U2FTests.swift
+++ b/ClientTests/U2FTests.swift
@@ -25,8 +25,8 @@ class U2FTests: XCTestCase {
         do {
             let request =  try JSONDecoder().decode(WebAuthnRegisterRequest.self, from: jsonData)
             XCTAssertEqual(request.username, "Brave demo user", "request username is correct.")
-            XCTAssertEqual(request.userId, "OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=", "request user id is correct.")
-            XCTAssertEqual(request.rpId, expectedrpID, "request rp id is correct.")
+            XCTAssertEqual(request.userID, "OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=", "request user id is correct.")
+            XCTAssertEqual(request.rpID, expectedrpID, "request rp id is correct.")
             XCTAssertEqual(request.rpName, "Brave", "request rp name is correct.")
             XCTAssertEqual(request.pubKeyAlg, -7, "request pub key alg is correct.")
             XCTAssertFalse(request.residentKey, "request resident key is correct.")
@@ -60,16 +60,21 @@ class U2FTests: XCTestCase {
             return
         }
         
-        let rpIdURLs = [
-            "example.domain",
-            "https://test.example.domain",
+        var rpIdURLs = [
+            "rp.example.domain", // valid
+            "example.domain",    // valid
+            "https://bp.example.domain",
             "https://test.examples.domain.com",
+            "https://test.rp.examples.domain",
+            "https://domain"
         ]
+        
         let tab = Tab(configuration: WKWebViewConfiguration())
         let U2FExtension = U2FExtensions(tab: tab)
-        XCTAssertTrue(U2FExtension.validateRPId(url: currentURL.absoluteString, rpId: rpIdURLs[0]), "rpID URL is valid.")
-        for url in rpIdURLs.dropFirst() {
-            XCTAssertFalse(U2FExtension.validateRPId(url: currentURL.absoluteString, rpId: url), "rpID URLs is invalid.")
+        XCTAssertTrue(U2FExtension.validateRPID(url: currentURL.absoluteString, rpId: rpIdURLs.removeFirst()), "rpID URL is valid.")
+        XCTAssertTrue(U2FExtension.validateRPID(url: currentURL.absoluteString, rpId: rpIdURLs.removeFirst()), "rpID URL is valid.")
+        for url in rpIdURLs {
+            XCTAssertFalse(U2FExtension.validateRPID(url: currentURL.absoluteString, rpId: url), "rpID URLs is invalid.")
         }
     }
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -64,3 +64,19 @@ do
     && cp -n Local.templates/$CONFIG_FILE Local/$CONFIG_FILE \
   )
 done
+
+# Build Yubikit
+YUBIKIT_DIR=Carthage/Checkouts/yubikit-ios
+YUBIKIT_OUT=ThirdParty/YubiKit
+SRCDIR=$PWD
+
+rm -rf $YUBIKIT_DIR
+rm -rf $YUBIKIT_OUT
+
+git clone -b simulator_release --single-branch --depth 1 https://github.com/jumde/yubikit-ios/ $YUBIKIT_DIR
+
+mkdir -p $SRCDIR/$YUBIKIT_OUT/include
+pushd $YUBIKIT_DIR/YubiKit
+sh build.sh > yubikit.log 2>&1
+cp -r build/release_universal/  $SRCDIR/$YUBIKIT_OUT/
+popd


### PR DESCRIPTION
fix https://github.com/brave/brave-ios/issues/1148
fix https://github.com/brave/brave-ios/issues/1150
fix https://github.com/brave/brave-ios/issues/1159
fix https://github.com/brave/brave-ios/issues/1163
fix https://github.com/brave/brave-ios/issues/1176

## Description
This PR implements javascript FIDO/FIDO2 APIs for the Brave iOS browser. With these APIs users will be able to use the lightning yubikeys keys as a second factor for authentication.

FIDO2 (WebAuthn) and FIDO rely on javascript APIs (navigator.credentials.create, navigator.credentials.get, u2f.sign, u2f.register). These are currently not available with WKWebView.

Scripts which define these APIs are injected at document start and end. These APIs hooks invoke services provided by the Yubico SDK to sign and register the requests passed using javascript.

For more details about the APIs refer to:
https://fidoalliance.org/fido2/
https://FIDOalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.

## Test Plan:

1. Navigate to the demo sites and make sure FIDO/FIDO2 workflow completes.
2. For other real sites:
  - create an account
  - enable 2FA
  - Registering 2FA keys should succeed.
  - Logout and try logging back in with the security key
  - Should succeed.

### Demo Sites:

1. WebAuthn
  - demo.yubico.com/u2f
  - webauthn.io
  - webauthntest.azurewebsites.net/
2. High Level Legacy U2F - mdp.github.io/u2fdemo
3. Low Level Legacy U2F - u2fdemo.hypersecu.com
4. APIs in secure context - http://dustiest-limitation.000webhostapp.com/nonsecure-u2f.html
5. APIs in 3p iframes - http://dustiest-limitation.000webhostapp.com/fido-iframe.html

### Sites that are working:
Without UA change:

1. github.com
2. bitbucket.org
3. 1Password.com
4. login.gov

Need UA change: https://github.com/brave/brave-ios/pull/1158/files#diff-1b680c574387c7d713ce005b70d406acR58

1. console.aws.amazon.com
2. twitter.com

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

