### PR TITLE
Fix #1165: Add ability to go back from nested folder in bookmarks menu.

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -331,6 +331,9 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         nextController.bookmarksDidChange = bookmarksDidChange
         nextController.toolbarUrlActionsDelegate = toolbarUrlActionsDelegate
         
+        // Show `Done` button on nested folder levels.
+        nextController.navigationItem.setRightBarButton(navigationItem.rightBarButtonItem, animated: true)
+        
         self.navigationController?.pushViewController(nextController, animated: true)
       }
     }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -145,7 +145,7 @@ class MenuViewController: UITableViewController {
         let nav = SettingsNavigationController(rootViewController: viewController)
         nav.modalPresentationStyle = .formSheet
         
-        let button = UIBarButtonItem(barButtonSystemItem: doneButton.style, target: nav, action: #selector(SettingsNavigationController.done))
+        let button = UIBarButtonItem(barButtonSystemItem: doneButton.style, target: nav, action: #selector(nav.done))
         
         switch doneButton.position {
         case .left: nav.navigationBar.topItem?.leftBarButtonItem = button


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
Create few nested folders and see if, `Done` button is showing and can be used to dismiss the whole bookmarks screen.

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

