### PR TITLE
Fix #1195: Popover arrow is now centered in the button presenting it

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -182,8 +182,7 @@ class TabLocationView: UIView {
         }
         
         // Make tappable area bigger than the icon.
-        // This also adds right inset, which when tapped, will open the shields panel.
-        shieldsButton.contentEdgeInsets = UIEdgeInsets(top: 2, left: 4, bottom: 2, right: 13)
+        shieldsButton.contentEdgeInsets = UIEdgeInsets(top: 6, left: 6, bottom: 6, right: 6)
         
         urlTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
@@ -198,7 +197,8 @@ class TabLocationView: UIView {
         addSubview(contentView)
 
         contentView.snp.makeConstraints { make in
-            make.edges.equalTo(self)
+            make.leading.top.bottom.equalTo(self)
+            make.trailing.equalTo(self).offset(-6)
         }
         
         lockImageView.snp.makeConstraints { make in


### PR DESCRIPTION
Note: the variant in BraveRewards branch will have to be updated the same way

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

