### PR TITLE
Fix #1141: Added locale decimal formatting to Sheild Stats

### DIFF
--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -71,8 +71,8 @@ class BraveShieldStatsView: UIView, Themeable {
     }
     
     @objc private func update() {
-        adsStatView.stat = "\(BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection)"
-        httpsStatView.stat = "\(BraveGlobalShieldStats.shared.httpse)"
+        adsStatView.stat = toLocaleString(num: BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection)
+        httpsStatView.stat = toLocaleString(num: BraveGlobalShieldStats.shared.httpse)
         timeStatView.stat = timeSaved
     }
     
@@ -103,8 +103,15 @@ class BraveShieldStatsView: UIView, Themeable {
                 text = Strings.ShieldsTimeStatsDays
             }
             
-            return "\(Int(counter))\(text)"
+            return toLocaleString(num: Int(counter)) + text
         }
+    }
+    
+    func toLocaleString(num: Int) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
+        numberFormatter.locale = NSLocale.current
+        return numberFormatter.string(from: num as NSNumber) ?? ""
     }
 }
 


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
If you don't have 1000+ blocks, you might want to test the function by temporarily using a constant at line 74 instead of the real block count. Eg: `adsStatView.stat = toLocaleString(num: 12345)`.

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Old                                      |  New
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone Xs - 2019-07-01 at 09 52 12](https://user-images.githubusercontent.com/6990701/60419637-0fb7d500-9be6-11e9-85ce-11d0e3ea271d.png)  |  ![Simulator Screen Shot - iPhone Xs - 2019-07-01 at 09 48 27](https://user-images.githubusercontent.com/6990701/60419367-64a71b80-9be5-11e9-8be1-460c0c34f547.png)



## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

