### PR TITLE
Fix #1141: Added locale decimal formatting to Sheild Stats

### DIFF
--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -71,7 +71,6 @@ class BraveShieldStatsView: UIView, Themeable {
     }
     
     @objc private func update() {
-        BraveGlobalShieldStats.shared.httpse = 12345
         adsStatView.stat = (BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection).decimalFormattedString ?? "0"
         httpsStatView.stat = BraveGlobalShieldStats.shared.httpse.decimalFormattedString ?? "0"
         timeStatView.stat = timeSaved
@@ -104,10 +103,12 @@ class BraveShieldStatsView: UIView, Themeable {
                 text = Strings.ShieldsTimeStatsDays
             }
             
+
             if let counterLocaleStr = Int(counter).decimalFormattedString {
                 return counterLocaleStr + text
             } else {
                 return "0" + Strings.ShieldsTimeStatsSeconds     // If decimalFormattedString returns nil, default to "0s"
+
             }
         }
     }

--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -71,8 +71,8 @@ class BraveShieldStatsView: UIView, Themeable {
     }
     
     @objc private func update() {
-        adsStatView.stat = "\(BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection)"
-        httpsStatView.stat = "\(BraveGlobalShieldStats.shared.httpse)"
+        adsStatView.stat = (BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection).toLocaleString() ?? "0"
+        httpsStatView.stat = BraveGlobalShieldStats.shared.httpse.toLocaleString() ?? "0"
         timeStatView.stat = timeSaved
     }
     
@@ -103,7 +103,11 @@ class BraveShieldStatsView: UIView, Themeable {
                 text = Strings.ShieldsTimeStatsDays
             }
             
-            return "\(Int(counter))\(text)"
+            if let counterLocaleStr = Int(counter).toLocaleString() {
+                return counterLocaleStr + text
+            } else {
+                return "0" + Strings.ShieldsTimeStatsSeconds     // If toLocaleString() returns nil, default to "0s"
+            }
         }
     }
 }
@@ -165,5 +169,15 @@ class StatView: UIView {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+extension BinaryInteger {
+    func toLocaleString() -> String? {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
+        numberFormatter.locale = NSLocale.current
+        return numberFormatter.string(from: self as! NSNumber)
     }
 }

--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -103,12 +103,10 @@ class BraveShieldStatsView: UIView, Themeable {
                 text = Strings.ShieldsTimeStatsDays
             }
             
-
             if let counterLocaleStr = Int(counter).decimalFormattedString {
                 return counterLocaleStr + text
             } else {
                 return "0" + Strings.ShieldsTimeStatsSeconds     // If decimalFormattedString returns nil, default to "0s"
-
             }
         }
     }
@@ -173,7 +171,6 @@ class StatView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 }
-
 
 fileprivate extension Int {
     var decimalFormattedString: String? {

--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -71,8 +71,9 @@ class BraveShieldStatsView: UIView, Themeable {
     }
     
     @objc private func update() {
-        adsStatView.stat = (BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection).toLocaleString() ?? "0"
-        httpsStatView.stat = BraveGlobalShieldStats.shared.httpse.toLocaleString() ?? "0"
+        BraveGlobalShieldStats.shared.httpse = 12345
+        adsStatView.stat = (BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection).decimalFormattedString ?? "0"
+        httpsStatView.stat = BraveGlobalShieldStats.shared.httpse.decimalFormattedString ?? "0"
         timeStatView.stat = timeSaved
     }
     
@@ -103,10 +104,10 @@ class BraveShieldStatsView: UIView, Themeable {
                 text = Strings.ShieldsTimeStatsDays
             }
             
-            if let counterLocaleStr = Int(counter).toLocaleString() {
+            if let counterLocaleStr = Int(counter).decimalFormattedString {
                 return counterLocaleStr + text
             } else {
-                return "0" + Strings.ShieldsTimeStatsSeconds     // If toLocaleString() returns nil, default to "0s"
+                return "0" + Strings.ShieldsTimeStatsSeconds     // If decimalFormattedString returns nil, default to "0s"
             }
         }
     }
@@ -173,11 +174,11 @@ class StatView: UIView {
 }
 
 
-extension BinaryInteger {
-    func toLocaleString() -> String? {
+fileprivate extension Int {
+    var decimalFormattedString: String? {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = NumberFormatter.Style.decimal
         numberFormatter.locale = NSLocale.current
-        return numberFormatter.string(from: self as! NSNumber)
+        return numberFormatter.string(from: self as NSNumber)
     }
 }


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
If you don't have 1000+ blocks, you might want to test the function by temporarily using a constant at line 74 instead of the real block count. Eg: `adsStatView.stat = toLocaleString(num: 12345)`.

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Old                                      |  New
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone Xs - 2019-07-01 at 09 52 12](https://user-images.githubusercontent.com/6990701/60434154-ce83ed00-9c06-11e9-8a34-72f054459385.png)  | ![Simulator Screen Shot - iPhone Xs - 2019-07-01 at 09 48 27](https://user-images.githubusercontent.com/6990701/60434155-cf1c8380-9c06-11e9-9e21-5698cf0e5e19.png)




## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)