### PR TITLE
Fixed Passcode UI not resetting when going to foreground (Fix #1203)

### DIFF
--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -102,12 +102,13 @@ extension PasscodeEntryViewController: PasscodeInputViewDelegate {
         } else {
             passcodePane.shakePasscode()
             failIncorrectPasscode(inputView)
-            passcodePane.codeInputView.resetCode()
             
             setUpTimer()
 
             // Store mutations on authentication info object
             KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(authenticationInfo)
         }
+        
+        passcodePane.codeInputView.resetCode()
     }
 }


### PR DESCRIPTION
Fixes Issue: https://github.com/brave/brave-ios/issues/1203

Issue:
1. Have passcode set.
2. Restart application.
3. Authenticate with passcode.
4. Go to private browsing.
5. Search for anything.. Stackoverflow for example.
6. Minimize app to background
7. It prompts to authenticate but authentication is already filled in from the first time we authenticated..

Solution:
Fixed Passcode UI not resetting when going to foreground by calling "resetCode" when successfully entered.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

