### PR TITLE
Fix #1207: Bring back reload button to address bar.

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -11,7 +11,7 @@ class BottomToolbarView: UIView, ToolbarProtocol {
     weak var tabToolbarDelegate: ToolbarDelegate?
 
     let tabsButton = TabsButton()
-    let reloadButton = ToolbarButton()
+    let forwardButton = ToolbarButton()
     let backButton = ToolbarButton()
     let shareButton = ToolbarButton()
     let addTabButton = ToolbarButton()
@@ -20,21 +20,9 @@ class BottomToolbarView: UIView, ToolbarProtocol {
 
     var helper: ToolbarHelper?
     private let contentView = UIStackView()
-    
-    var loading: Bool = false {
-        didSet {
-            if loading {
-                reloadButton.setImage(#imageLiteral(resourceName: "nav-stop").template, for: .normal)
-                reloadButton.accessibilityLabel = Strings.TabToolbarStopButtonAccessibilityLabel
-            } else {
-                reloadButton.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
-                reloadButton.accessibilityLabel = Strings.TabToolbarReloadButtonAccessibilityLabel
-            }
-        }
-    }
 
     fileprivate override init(frame: CGRect) {
-        actionButtons = [backButton, reloadButton, addTabButton, tabsButton, menuButton]
+        actionButtons = [backButton, forwardButton, addTabButton, tabsButton, menuButton]
         super.init(frame: frame)
         setupAccessibility()
 
@@ -57,7 +45,7 @@ class BottomToolbarView: UIView, ToolbarProtocol {
 
     private func setupAccessibility() {
         backButton.accessibilityIdentifier = "TabToolbar.backButton"
-        reloadButton.accessibilityIdentifier = "TabToolbar.reloadButton"
+        forwardButton.accessibilityIdentifier = "TabToolbar.forwardButton"
         tabsButton.accessibilityIdentifier = "TabToolbar.tabsButton"
         shareButton.accessibilityIdentifier = "TabToolbar.shareButton"
         addTabButton.accessibilityIdentifier = "TabToolbar.addTabButton"

--- a/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -40,22 +40,11 @@ class ToolbarHelper: NSObject {
         toolbar.menuButton.accessibilityLabel = Strings.TabToolbarMenuButtonAccessibilityLabel
         toolbar.menuButton.addTarget(self, action: #selector(didClickMenu), for: UIControl.Event.touchUpInside)
         
-        if let forwardButton = toolbar.forwardButton {
-            forwardButton.setImage(#imageLiteral(resourceName: "nav-forward").template, for: .normal)
-            forwardButton.accessibilityLabel = Strings.TabToolbarForwardButtonAccessibilityLabel
-            let longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressForward))
-            forwardButton.addGestureRecognizer(longPressGestureForwardButton)
-            forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
-        }
-        
-        toolbar.reloadButton.accessibilityIdentifier = "TabToolbar.stopReloadButton"
-        toolbar.reloadButton.accessibilityLabel = Strings.TabToolbarReloadButtonAccessibilityLabel
-        toolbar.reloadButton.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
-        toolbar.reloadButton.tintColor = UIColor.Photon.Grey30
-        
-        let longPressGestureStopReloadButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressStopReload(_:)))
-        toolbar.reloadButton.addGestureRecognizer(longPressGestureStopReloadButton)
-        toolbar.reloadButton.addTarget(self, action: #selector(didClickStopReload), for: .touchUpInside)
+        toolbar.forwardButton.setImage(#imageLiteral(resourceName: "nav-forward").template, for: .normal)
+        toolbar.forwardButton.accessibilityLabel = Strings.TabToolbarForwardButtonAccessibilityLabel
+        let longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressForward))
+        toolbar.forwardButton.addGestureRecognizer(longPressGestureForwardButton)
+        toolbar.forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
         
         setTheme(theme: .regular, forButtons: toolbar.actionButtons)
     }
@@ -83,16 +72,12 @@ class ToolbarHelper: NSObject {
     }
     
     func didClickForward() {
-        guard let forwardButton = toolbar.forwardButton else { return }
-        
-        toolbar.tabToolbarDelegate?.tabToolbarDidPressForward(toolbar, button: forwardButton)
+        toolbar.tabToolbarDelegate?.tabToolbarDidPressForward(toolbar, button: toolbar.forwardButton)
     }
     
     func didLongPressForward(_ recognizer: UILongPressGestureRecognizer) {
-        guard let forwardButton = toolbar.forwardButton else { return }
-        
         if recognizer.state == .began {
-            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressForward(toolbar, button: forwardButton)
+            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressForward(toolbar, button: toolbar.forwardButton)
         }
     }
     
@@ -107,20 +92,6 @@ class ToolbarHelper: NSObject {
     func didLongPressAddTab(_ longPress: UILongPressGestureRecognizer) {
         if longPress.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressAddTab(toolbar, button: toolbar.shareButton)
-        }
-    }
-    
-    func didClickStopReload() {
-        if toolbar.loading {
-            toolbar.tabToolbarDelegate?.tabToolbarDidPressStop(toolbar, button: toolbar.reloadButton)
-        } else {
-            toolbar.tabToolbarDelegate?.tabToolbarDidPressReload(toolbar, button: toolbar.reloadButton)
-        }
-    }
-    
-    func didLongPressStopReload(_ longPress: UILongPressGestureRecognizer) {
-        if longPress.state == .began && !toolbar.loading {
-            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressReload(toolbar, button: toolbar.reloadButton)
         }
     }
 }

--- a/Client/Frontend/Browser/Toolbars/ToolbarProtocols.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarProtocols.swift
@@ -5,34 +5,24 @@
 import Foundation
 
 protocol ToolbarProtocol: class {
-    /// A buttons can behave different depending on web load state.
-    /// For example reload button can switch to stop button when a website is loading.
-    var loading: Bool { get set }
     
     var tabToolbarDelegate: ToolbarDelegate? { get set }
     var tabsButton: TabsButton { get }
     var backButton: ToolbarButton { get }
+    var forwardButton: ToolbarButton { get }
     var shareButton: ToolbarButton { get }
     var addTabButton: ToolbarButton { get }
     var menuButton: ToolbarButton { get }
     var actionButtons: [Themeable & UIButton] { get }
-    var reloadButton: ToolbarButton { get }
-    
-    // Optional buttons
-    var forwardButton: ToolbarButton? { get }
     
     func updateBackStatus(_ canGoBack: Bool)
     func updatePageStatus(_ isWebPage: Bool)
     func updateTabCount(_ count: Int)
-    
-    // Optional methods
-    func updateForwardStatus(_ canGoForward: Bool)
 }
 
 extension ToolbarProtocol {
     func updatePageStatus(_ isWebPage: Bool) {
         shareButton.isEnabled = isWebPage
-        reloadButton.isEnabled = isWebPage
     }
     
     func updateBackStatus(_ canGoBack: Bool) {
@@ -40,14 +30,12 @@ extension ToolbarProtocol {
     }
     
     func updateForwardStatus(_ canGoForward: Bool) {
-        forwardButton?.isEnabled = canGoForward
+        forwardButton.isEnabled = canGoForward
     }
     
     func updateTabCount(_ count: Int) {
         tabsButton.updateTabCount(count)
     }
-    
-    var forwardButton: ToolbarButton? { return nil }
 }
 
 protocol ToolbarDelegate: class {
@@ -62,7 +50,4 @@ protocol ToolbarDelegate: class {
     func tabToolbarDidPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidSwipeToChangeTabs(_ tabToolbar: ToolbarProtocol, direction: UISwipeGestureRecognizer.Direction)
-    func tabToolbarDidPressReload(_ tabToolbar: ToolbarProtocol, button: UIButton)
-    func tabToolbarDidPressStop(_ tabToolbar: ToolbarProtocol, button: UIButton)
-    func tabToolbarDidLongPressReload(_ tabToolbar: ToolbarProtocol, button: UIButton)
 }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -38,6 +38,10 @@ protocol TopToolbarDelegate: class {
     func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView)
     func topToolbarDidTapBraveShieldsButton(_ topToolbar: TopToolbarView)
     func topToolbarDidTapMenuButton(_ topToolbar: TopToolbarView)
+    
+    func topToolbarDidLongPressReloadButton(_ urlBar: TopToolbarView, from button: UIButton)
+    func topToolbarDidPressStop(_ urlBar: TopToolbarView)
+    func topToolbarDidPressReload(_ urlBar: TopToolbarView)
 }
 
 class TopToolbarView: UIView, ToolbarProtocol {
@@ -47,18 +51,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
     // MARK: - ToolbarProtocol properties
     
     weak var tabToolbarDelegate: ToolbarDelegate?
-    
-    var loading: Bool = false {
-        didSet {
-            if loading {
-                reloadButton.setImage(#imageLiteral(resourceName: "nav-stop").template, for: .normal)
-                reloadButton.accessibilityLabel = Strings.TabToolbarStopButtonAccessibilityLabel
-            } else {
-                reloadButton.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
-                reloadButton.accessibilityLabel = Strings.TabToolbarReloadButtonAccessibilityLabel
-            }
-        }
-    }
     
     // MARK: - State
     
@@ -146,8 +138,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     }()
 
     var bookmarkButton = ToolbarButton()
-    var forwardButton: ToolbarButton? = ToolbarButton()
-    var reloadButton = ToolbarButton()
+    var forwardButton = ToolbarButton()
     var shareButton = ToolbarButton()
     var addTabButton = ToolbarButton()
     lazy var menuButton = ToolbarButton().then {
@@ -165,7 +156,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     }()
 
     lazy var actionButtons: [Themeable & UIButton] =
-        [self.shareButton, self.reloadButton, self.tabsButton,
+        [self.shareButton, self.tabsButton,
          self.forwardButton, self.backButton, self.menuButton].compactMap { $0 }
     
     /// Update the shields icon based on whether or not shields are enabled for this site
@@ -232,11 +223,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
         }
         
         navigationStackView.addArrangedSubview(backButton)
-        if let forwardButton = forwardButton {
-            // Forward button should be only visible in iPad/landscape mode.
-            navigationStackView.addArrangedSubview(forwardButton)
-        }
-        navigationStackView.addArrangedSubview(reloadButton)
+        navigationStackView.addArrangedSubview(forwardButton)
         
         [navigationStackView, locationContainer, tabsButton, menuButton, cancelButton].forEach {
             mainStackView.addArrangedSubview($0)
@@ -479,6 +466,19 @@ extension TopToolbarView: TabLocationViewDelegate {
     }
     
     func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {
+        delegate?.topToolbarDidLongPressLocation(self)
+    }
+    
+    func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView) {
+        delegate?.topToolbarDidPressReload(self)
+    }
+    
+    func tabLocationViewDidTapStop(_ tabLocationView: TabLocationView) {
+        delegate?.topToolbarDidPressStop(self)
+    }
+    
+    func tabLocationViewDidLongPressReload(_ tabLocationView: TabLocationView, from button: UIButton) {
+        delegate?.topToolbarDidLongPressReloadButton(self, from: button)
         delegate?.topToolbarDidLongPressLocation(self)
     }
 


### PR DESCRIPTION
This commit partially reverts issue #1134.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Updated UI:

<img width="544" alt="Zrzut ekranu 2019-07-4 o 16 45 18" src="https://user-images.githubusercontent.com/6950387/60675641-1dd35300-9e7d-11e9-9072-52188b5f1702.png">
<img width="544" alt="Zrzut ekranu 2019-07-4 o 16 45 23" src="https://user-images.githubusercontent.com/6950387/60675642-1dd35300-9e7d-11e9-80a0-5e46af13bca6.png">
<img width="950" alt="Zrzut ekranu 2019-07-4 o 16 45 30" src="https://user-images.githubusercontent.com/6950387/60675643-1e6be980-9e7d-11e9-90bf-614814153edb.png">
<img width="950" alt="Zrzut ekranu 2019-07-4 o 16 45 35" src="https://user-images.githubusercontent.com/6950387/60675644-1e6be980-9e7d-11e9-9310-2b2258fc50b6.png">



## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

