### PR TITLE
Fixed Opening Authenticated Documents in private and non-private mode.

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -83,6 +83,7 @@ class Tab: NSObject {
     var url: URL?
     var mimeType: String?
     var isEditing: Bool = false
+    let cookieStorage = BATEphemeralCookieStorage()
 
     // When viewing a non-HTML content type in the webview (like a PDF document), this URL will
     // point to a tempfile containing the content so it can be shared to external applications.

--- a/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/Client/Frontend/Browser/TemporaryDocument.swift
@@ -3,10 +3,144 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import WebKit
 import Deferred
 import Shared
 
 private let temporaryDocumentOperationQueue = OperationQueue()
+
+class BATEphemeralCookieStorage: HTTPCookieStorage {
+    private var _allCookies: [String: HTTPCookie]
+    private let queue = DispatchQueue(label: "org.bat.cookie.storage.queue")
+    
+    private var allCookies: [String: HTTPCookie] {
+        get {
+            dispatchPrecondition(condition: DispatchPredicate.onQueue(self.queue))
+            return self._allCookies
+        }
+        set {
+            dispatchPrecondition(condition: DispatchPredicate.onQueue(self.queue))
+            self._allCookies = newValue
+        }
+    }
+
+    override init() {
+        _allCookies = [:]
+        super.init()
+        cookieAcceptPolicy = .always
+    }
+    
+    override var cookies: [HTTPCookie]? {
+        return Array(self.queue.sync { self.allCookies.values })
+    }
+    
+    override func setCookie(_ cookie: HTTPCookie) {
+        self.queue.sync {
+            guard cookieAcceptPolicy != .never else { return }
+            
+            let key = cookie.domain + cookie.path + cookie.name
+            if allCookies.index(forKey: key) != nil {
+                allCookies.updateValue(cookie, forKey: key)
+            } else {
+                allCookies[key] = cookie
+            }
+            
+            let expired = allCookies.filter { (_, value) in
+                value.expiresDate != nil && value.expiresDate!.timeIntervalSinceNow < 0
+            }
+            
+            for key in expired.keys {
+                self.allCookies.removeValue(forKey: key)
+            }
+        }
+    }
+    
+    override func deleteCookie(_ cookie: HTTPCookie) {
+        self.queue.sync {
+            let key = cookie.domain + cookie.path + cookie.name
+            self.allCookies.removeValue(forKey: key)
+        }
+    }
+    
+    override func removeCookies(since date: Date) {
+        self.queue.sync {
+            let cookiesSinceDate = self.allCookies.values.filter {
+                if let creationDate = $0.properties?[HTTPCookiePropertyKey(rawValue: "created")] as? Double {
+                    return creationDate >  date.timeIntervalSinceReferenceDate
+                }
+                return false
+            }
+            
+            for cookie in cookiesSinceDate {
+                let key = cookie.domain + cookie.path + cookie.name
+                self.allCookies.removeValue(forKey: key)
+            }
+        }
+    }
+    
+    override func cookies(for url: URL) -> [HTTPCookie]? {
+        guard let host = url.host?.lowercased() else { return nil }
+        return Array(self.queue.sync(execute: { allCookies }).values.filter {
+            guard $0.domain.hasPrefix(".") else { return host == $0.domain }
+            return host == $0.domain.dropFirst() || host.hasSuffix($0.domain)
+        })
+    }
+    
+    override func setCookies(_ cookies: [HTTPCookie], for url: URL?, mainDocumentURL: URL?) {
+        guard cookieAcceptPolicy != .never else { return }
+        guard let urlHost = url?.host?.lowercased() else { return }
+        
+        if mainDocumentURL != nil && cookieAcceptPolicy == .onlyFromMainDocumentDomain {
+            guard let mainDocumentHost = mainDocumentURL?.host?.lowercased() else { return }
+            guard mainDocumentHost.hasSuffix(urlHost) else { return }
+        }
+        
+        let validCookies = cookies.filter {
+            guard $0.domain.hasPrefix(".") else { return urlHost == $0.domain }
+            return urlHost == $0.domain.dropFirst() || urlHost.hasSuffix($0.domain)
+        }
+        
+        for cookie in validCookies {
+            setCookie(cookie)
+        }
+    }
+    
+    override var cookieAcceptPolicy: HTTPCookie.AcceptPolicy {
+        get {
+            return .always
+        }
+        
+        set {
+            
+        }
+    }
+    
+    override func sortedCookies(using sortOrder: [NSSortDescriptor]) -> [HTTPCookie] {
+        return queue.sync {
+            let cookies = Array(allCookies.values) as NSArray
+            return cookies.sortedArray(using: sortOrder) as? [HTTPCookie] ?? []
+        }
+    }
+    
+    override var description: String {
+        return "Ephemeral <BATMemoryCookieStorage cookies count:\(cookies?.count ?? 0)>"
+    }
+    
+    func apply(to request: URLRequest) -> URLRequest {
+        if let url = request.url, let cookies = self.cookies(for: url) {
+            var headers = request.allHTTPHeaderFields ?? [:]
+            HTTPCookie.requestHeaderFields(with: cookies).forEach({
+                headers.updateValue($0.value, forKey: $0.key)
+            })
+            
+            var result = request
+            result.allHTTPHeaderFields = headers
+            return result
+        }
+        
+        return request
+    }
+}
 
 class TemporaryDocument: NSObject {
     fileprivate let request: URLRequest
@@ -17,6 +151,7 @@ class TemporaryDocument: NSObject {
     fileprivate var downloadTask: URLSessionDownloadTask?
     fileprivate var localFileURL: URL?
     fileprivate var pendingResult: Deferred<URL>?
+    fileprivate let cookieStorage = BATEphemeralCookieStorage()
 
     init(preflightResponse: URLResponse, request: URLRequest) {
         self.request = request
@@ -24,7 +159,11 @@ class TemporaryDocument: NSObject {
 
         super.init()
 
-        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: temporaryDocumentOperationQueue)
+        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: temporaryDocumentOperationQueue).then {
+            $0.configuration.httpCookieStorage = self.cookieStorage
+            $0.configuration.httpCookieAcceptPolicy = .always
+            $0.configuration.httpShouldSetCookies = true
+        }
     }
 
     deinit {
@@ -32,6 +171,12 @@ class TemporaryDocument: NSObject {
         if let url = localFileURL {
             try? FileManager.default.removeItem(at: url)
         }
+    }
+    
+    func setCookies(_ cookies: [HTTPCookie]?) {
+        cookies?.forEach({
+            self.cookieStorage.setCookie($0)
+        })
     }
 
     func getURL() -> Deferred<URL> {
@@ -47,8 +192,8 @@ class TemporaryDocument: NSObject {
 
         let result = Deferred<URL>()
         pendingResult = result
-
-        downloadTask = session?.downloadTask(with: request)
+        
+        downloadTask = session?.downloadTask(with: self.cookieStorage.apply(to: self.request))
         downloadTask?.resume()
 
         UIApplication.shared.isNetworkActivityIndicatorVisible = true


### PR DESCRIPTION
- Fixed a background thread issue.
- Fixed opening Authenticated documents in Private-Browsing mode when it opens in a new tab.
- Fixed opening Authenticated documents and attempting to share, or print them.
- Added Ephemeral Cookie Storage (in memory only.. once a tab is closed, all information is lost) for tabs to support opening Authenticated documents.
- Made TemporaryDocument URLSession use the ephemeral cookie storage.

Fixes: https://github.com/brave/brave-ios/issues/1144

**Discovered Problem(s):**
- Private Tabs do NOT share session & cookies amongst its child tabs.. For example, if I open a Bank website on TabA and log in, then I go to statements and it happens to open in TabB (`target=__blank`), it will ask for re-authentication because cookies & session from TabA did not pass on to child TabB.

- Session and Cookies not shared amongst NSURLSession. When WKWebView makes a request to a banking website, it stores the cookies and session internal in the `WKWebsiteDataStore.instance.httpCookieStorage`.. when downloading a document, we are downloading with `NSURLSession` and the cookies are not passed along. Therefore, when downloading opening documents in the webview, it displays fine, but when attempting to print (at which point it "downloads with NSURLSession"), it will download a redirected HTML "login" page instead of the document requested because the session information wasn't passed along.

**Solution:**
- When creating a new WebView from a parent one (IE: new tab), pass the cookies along to the new tab's website data store. (Same behaviour as Brave, Firefox, and Chrome **Desktop**).
However, if two tabs are completely independent of each other, the cookies should NOT be shared!

- When downloading a document, store the cookies in MEMORY only (ephemeral storage), and pass it along to the child-tabs and TemporaryDocument. This allows the `TemporaryDocument` to request the pdf/image/etc.. We should probably be using `NSURLSession(configuration: .ephemeral)` as well.. instead of `.default`.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

