### PR TITLE
Fix #1216: Opening a tab in private mode switches to PBM correctly.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2845,6 +2845,7 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
     }
     
     func openInNewTab(_ url: URL, isPrivate: Bool) {
+        topToolbar.leaveOverlayMode()
         select(url, visitType: .unknown, action: .openInNewTab(isPrivate: isPrivate))
     }
     

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/ToolbarUrlActionsProtocol.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/ToolbarUrlActionsProtocol.swift
@@ -51,7 +51,7 @@ extension ToolbarUrlActionsProtocol {
         
         let newPrivateTabAction = currentTabIsPrivate ? nil :
             Action(title: Strings.OpenNewPrivateTabButtonTitle, action: {
-                delegate.openInNewTab(url, isPrivate: currentTabIsPrivate)
+                delegate.openInNewTab(url, isPrivate: true)
             })
         
         let copyAction = Action(title: Strings.CopyLinkActionTitle,


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

