### PR TITLE
[Blocked Security Review]Fixes #1144 Sharing of session amongst tabs and sharing of Authenticated Documents

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -510,6 +510,8 @@
 		5DE768AE20B443E500FF5533 /* JSONSerializationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE768AD20B443E500FF5533 /* JSONSerializationExtensions.swift */; };
 		5DE768B020B4601700FF5533 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE768AF20B4601600FF5533 /* UIColorExtensions.swift */; };
 		5DE768B120B4713000FF5533 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
+		5E3477E922D7771700B0D5F8 /* ResourceDownloader.js in Resources */ = {isa = PBXBuildFile; fileRef = 5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */; };
+		5E34781022D7A1D200B0D5F8 /* ResourceDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */; };
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
 		744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */; };
 		7479B4EF1C5306A200DF000B /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7479B4ED1C5306A200DF000B /* Reachability.swift */; };
@@ -1875,6 +1877,8 @@
 		5DE768AA20B346B700FF5533 /* BraveGlobalShieldStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BraveGlobalShieldStats.swift; sourceTree = "<group>"; };
 		5DE768AD20B443E500FF5533 /* JSONSerializationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializationExtensions.swift; sourceTree = "<group>"; };
 		5DE768AF20B4601600FF5533 /* UIColorExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
+		5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ResourceDownloader.js; sourceTree = "<group>"; };
+		5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManager.swift; sourceTree = "<group>"; };
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MailtoLinkHandler.swift; sourceTree = "<group>"; };
 		7479B4ED1C5306A200DF000B /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ThirdParty/Reachability.swift; sourceTree = "<group>"; };
@@ -3597,6 +3601,7 @@
 				595E0EDA21CAD97C00813D49 /* CookieControl.js */,
 				F930CDAB227000F200A23FE1 /* U2F.js */,
 				F99505FE22937E3900CC6543 /* U2F-low-level.js */,
+				5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */,
 			);
 			path = UserScripts;
 			sourceTree = "<group>";
@@ -3832,6 +3837,7 @@
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				D0FCF7F41FE45842004A7995 /* UserScriptManager.swift */,
 				279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */,
+				5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */,
 			);
 			indentWidth = 4;
 			path = Browser;
@@ -5193,6 +5199,7 @@
 				E4B7B77D1A793CF20022C5E0 /* FiraSans-Regular.ttf in Resources */,
 				4422D55221BFFB7E00BF1855 /* make_unicode_casefold.py in Resources */,
 				E4B7B7791A793CF20022C5E0 /* FiraSans-Light.ttf in Resources */,
+				5E3477E922D7771700B0D5F8 /* ResourceDownloader.js in Resources */,
 				F99505FF22937E3900CC6543 /* U2F-low-level.js in Resources */,
 				D0FCF8081FE4772D004A7995 /* MainFrameAtDocumentStart.js in Resources */,
 				0A0D3D5021A5609600BEE65B /* SafeBrowsingError.html in Resources */,
@@ -5790,6 +5797,7 @@
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				0AADC4D220D2A6A200FDE368 /* FavoritesHelper.swift in Sources */,
+				5E34781022D7A1D200B0D5F8 /* ResourceDownloadManager.swift in Sources */,
 				C690C2142130121E00E6EEE9 /* WebImageCacheManager.swift in Sources */,
 				A104E199210A384400D2323E /* ShieldsViewController.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -512,6 +512,7 @@
 		5DE768B120B4713000FF5533 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		5E3477E922D7771700B0D5F8 /* ResourceDownloader.js in Resources */ = {isa = PBXBuildFile; fileRef = 5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */; };
 		5E34781022D7A1D200B0D5F8 /* ResourceDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */; };
+		5E9288CA22DF864C007BE7A6 /* TabSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9288C922DF864C007BE7A6 /* TabSessionTests.swift */; };
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
 		744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */; };
 		7479B4EF1C5306A200DF000B /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7479B4ED1C5306A200DF000B /* Reachability.swift */; };
@@ -1879,6 +1880,7 @@
 		5DE768AF20B4601600FF5533 /* UIColorExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
 		5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ResourceDownloader.js; sourceTree = "<group>"; };
 		5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManager.swift; sourceTree = "<group>"; };
+		5E9288C922DF864C007BE7A6 /* TabSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSessionTests.swift; sourceTree = "<group>"; };
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MailtoLinkHandler.swift; sourceTree = "<group>"; };
 		7479B4ED1C5306A200DF000B /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ThirdParty/Reachability.swift; sourceTree = "<group>"; };
@@ -4208,6 +4210,7 @@
 				0A4214E821A6EBCF006B8E39 /* SafeBrowsingTests.swift */,
 				5953AAEE2226E9D800A92DE1 /* HttpCookieExtensionTest.swift */,
 				F939FBFD22A596B900D9CD3F /* U2FTests.swift */,
+				5E9288C922DF864C007BE7A6 /* TabSessionTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -6030,6 +6033,7 @@
 				AB1B097A21F2F00400E0DD51 /* FavoritesViewControllerTests.swift in Sources */,
 				2795274A21A890EB00921AA1 /* FingerprintingProtectionTests.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
+				5E9288CA22DF864C007BE7A6 /* TabSessionTests.swift in Sources */,
 				0A4214E921A6EBCF006B8E39 /* SafeBrowsingTests.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,
 				0A4BEFDE221F03C80005551A /* NetworkManagerTests.swift in Sources */,

--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -7,10 +7,22 @@ import WebKit
 
 class BraveWebView: WKWebView {
     
+    private static var nonPersistentDataStore: WKWebsiteDataStore?
+    private static func sharedNonPersistentDataStore() -> WKWebsiteDataStore {
+        if let dataStore = nonPersistentDataStore {
+            return dataStore
+        }
+        
+        let dataStore = WKWebsiteDataStore.nonPersistent()
+        nonPersistentDataStore = dataStore
+        return dataStore
+    }
+    
     init(frame: CGRect, configuration: WKWebViewConfiguration = WKWebViewConfiguration(), isPrivate: Bool = true) {
         if isPrivate {
-            configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+            configuration.websiteDataStore = BraveWebView.sharedNonPersistentDataStore()
         } else {
+            BraveWebView.nonPersistentDataStore = nil //switching to normal mode destroys all data-stores
             configuration.websiteDataStore = WKWebsiteDataStore.default()
         }
         

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1896,6 +1896,8 @@ extension BrowserViewController: TabDelegate {
         tab.addContentScript(FingerprintingProtection(tab: tab), name: FingerprintingProtection.name())
         
         tab.addContentScript(U2FExtensions(tab: tab), name: U2FExtensions.name())
+        
+        tab.addContentScript(ResourceDownloadManager(tab: tab), name: ResourceDownloadManager.name())
     }
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -268,7 +268,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // shared to external applications later. Otherwise, clear the old temporary document.
         if let tab = tabManager[webView] {
             if response.mimeType?.isKindOfHTML == false, let request = request {
-                tab.temporaryDocument = TemporaryDocument(preflightResponse: response, request: request)
+                tab.temporaryDocument = TemporaryDocument(preflightResponse: response, request: request, tab: tab)
             } else {
                 tab.temporaryDocument = nil
             }

--- a/Client/Frontend/Browser/ResourceDownloadManager.swift
+++ b/Client/Frontend/Browser/ResourceDownloadManager.swift
@@ -48,7 +48,7 @@ class ResourceDownloadManager: TabContentScript {
         do {
             let response = try DownloadedResourceResponse.from(message: message)
             tab?.temporaryDocument?.onDocumentDownloaded(document: response, error: nil)
-        } catch let error {
+        } catch {
             tab?.temporaryDocument?.onDocumentDownloaded(document: nil, error: error)
         }
     }

--- a/Client/Frontend/Browser/ResourceDownloadManager.swift
+++ b/Client/Frontend/Browser/ResourceDownloadManager.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import WebKit
+import Data
+import BraveShared
+
+struct DownloadedResourceResponse: Decodable {
+    let statusCode: Int
+    let data: Data?
+    
+    static func from(message: WKScriptMessage) throws -> DownloadedResourceResponse? {
+        let data = try JSONSerialization.data(withJSONObject: message.body, options: .prettyPrinted)
+        return try JSONDecoder().decode(DownloadedResourceResponse.self, from: data)
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.statusCode = try container.decode(Int.self, forKey: .statusCode)
+        self.data = Data(base64Encoded: try container.decode(String.self, forKey: .base64Data))
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case statusCode
+        case base64Data
+    }
+}
+
+class ResourceDownloadManager: TabContentScript {
+    fileprivate weak var tab: Tab?
+    
+    init(tab: Tab) {
+        self.tab = tab
+    }
+    
+    static func name() -> String {
+        return "ResourceDownloadManager"
+    }
+    
+    func scriptMessageHandlerName() -> String? {
+        return "resourceDownloadManager"
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        
+        do {
+            let response = try DownloadedResourceResponse.from(message: message)
+            tab?.temporaryDocument?.onDocumentDownloaded(document: response, error: nil)
+        } catch let error {
+            tab?.temporaryDocument?.onDocumentDownloaded(document: nil, error: error)
+        }
+    }
+    
+    static func downloadResource(for tab: Tab, url: URL) {        
+        let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+
+        tab.webView?.evaluateJavaScript("D\(token).download(\"\(url)\");", completionHandler: { _, error in
+            if let error = error {
+                tab.temporaryDocument?.onDocumentDownloaded(document: nil, error: error)
+            }
+        })
+    }
+}

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -528,7 +528,11 @@ class TabManager: NSObject {
         }
 
         if tab.isPrivate {
-            removeAllBrowsingDataForTab(tab)
+            // Only when ALL tabs are dead, we clean up.
+            // This is because other tabs share the same data-store.
+            if allTabs.filter({ $0.isPrivate }).count <= 1 {
+                removeAllBrowsingDataForTab(tab)
+            }
         }
 
         let oldSelectedTab = selectedTab

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -530,7 +530,7 @@ class TabManager: NSObject {
         if tab.isPrivate {
             // Only when ALL tabs are dead, we clean up.
             // This is because other tabs share the same data-store.
-            if allTabs.filter({ $0.isPrivate }).count <= 1 {
+            if tabsForCurrentMode.count <= 1 {
                 removeAllBrowsingDataForTab(tab)
             }
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -530,7 +530,7 @@ class TabManager: NSObject {
         if tab.isPrivate {
             // Only when ALL tabs are dead, we clean up.
             // This is because other tabs share the same data-store.
-            if tabsForCurrentMode.count <= 1 {
+            if tabs(withType: .private).count <= 1 {
                 removeAllBrowsingDataForTab(tab)
             }
         }
@@ -626,11 +626,7 @@ class TabManager: NSObject {
     }
 
     func removeAllBrowsingDataForTab(_ tab: Tab, completionHandler: @escaping () -> Void = {}) {
-        let dataTypes = Set([WKWebsiteDataTypeCookies,
-                             WKWebsiteDataTypeLocalStorage,
-                             WKWebsiteDataTypeSessionStorage,
-                             WKWebsiteDataTypeWebSQLDatabases,
-                             WKWebsiteDataTypeIndexedDBDatabases])
+        let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
         tab.webView?.configuration.websiteDataStore.removeData(ofTypes: dataTypes,
                                                                modifiedSince: Date.distantPast,
                                                                completionHandler: completionHandler)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -528,10 +528,18 @@ class TabManager: NSObject {
         }
 
         if tab.isPrivate {
+            //Remove this webview from the shared storage.
+            tab.webView?.removePersistentStore()
+            
             // Only when ALL tabs are dead, we clean up.
             // This is because other tabs share the same data-store.
             if tabs(withType: .private).count <= 1 {
                 removeAllBrowsingDataForTab(tab)
+                
+                //After clearing the very last webview from the storage, give it a blank persistent store
+                //This is the only way to guarantee that the last reference to the shared persistent store
+                //reaches zero and destroys all its data.
+                configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
             }
         }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -528,9 +528,6 @@ class TabManager: NSObject {
         }
 
         if tab.isPrivate {
-            //Remove this webview from the shared storage.
-            tab.webView?.removePersistentStore()
-            
             // Only when ALL tabs are dead, we clean up.
             // This is because other tabs share the same data-store.
             if tabs(withType: .private).count <= 1 {
@@ -539,6 +536,8 @@ class TabManager: NSObject {
                 //After clearing the very last webview from the storage, give it a blank persistent store
                 //This is the only way to guarantee that the last reference to the shared persistent store
                 //reaches zero and destroys all its data.
+                
+                BraveWebView.removeNonPersistentStore()
                 configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
             }
         }

--- a/Client/Frontend/Browser/TabPrintPageRenderer.swift
+++ b/Client/Frontend/Browser/TabPrintPageRenderer.swift
@@ -11,7 +11,9 @@ private struct PrintedPageUX {
 }
 
 class TabPrintPageRenderer: UIPrintPageRenderer {
-    fileprivate weak var tab: Tab?
+    private weak var tab: Tab?
+    private let displayTitle: String
+    
     let textAttributes = [NSAttributedString.Key.font: PrintedPageUX.PageTextFont]
     let dateString: String
 
@@ -20,6 +22,8 @@ class TabPrintPageRenderer: UIPrintPageRenderer {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
+        
+        self.displayTitle = tab.displayTitle
         self.dateString = dateFormatter.string(from: Date())
 
         super.init()
@@ -51,7 +55,7 @@ class TabPrintPageRenderer: UIPrintPageRenderer {
         let headerRect = paperRect.inset(by: headerInsets)
 
         // page title on left
-        self.drawTextAtPoint(tab!.displayTitle, rect: headerRect, onLeft: true)
+        self.drawTextAtPoint(displayTitle, rect: headerRect, onLeft: true)
 
         // date on right
         self.drawTextAtPoint(dateString, rect: headerRect, onLeft: false)

--- a/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/Client/Frontend/Browser/TemporaryDocument.swift
@@ -9,22 +9,19 @@ import Shared
 private let temporaryDocumentOperationQueue = OperationQueue()
 
 class TemporaryDocument: NSObject {
-    fileprivate let request: URLRequest
-    fileprivate let filename: String
+    private weak var tab: Tab?
+    private let request: URLRequest
+    private let filename: String
 
-    fileprivate var session: URLSession?
+    private var localFileURL: URL?
+    private var pendingResult: Deferred<URL>?
 
-    fileprivate var downloadTask: URLSessionDownloadTask?
-    fileprivate var localFileURL: URL?
-    fileprivate var pendingResult: Deferred<URL>?
-
-    init(preflightResponse: URLResponse, request: URLRequest) {
+    init(preflightResponse: URLResponse, request: URLRequest, tab: Tab) {
         self.request = request
         self.filename = preflightResponse.suggestedFilename ?? "unknown"
+        self.tab = tab
 
         super.init()
-
-        self.session = URLSession(configuration: .default, delegate: self, delegateQueue: temporaryDocumentOperationQueue)
     }
 
     deinit {
@@ -47,13 +44,51 @@ class TemporaryDocument: NSObject {
 
         let result = Deferred<URL>()
         pendingResult = result
-
-        downloadTask = session?.downloadTask(with: request)
-        downloadTask?.resume()
-
-        UIApplication.shared.isNetworkActivityIndicatorVisible = true
+        
+        if let tab = self.tab, let url = request.url {
+            ResourceDownloadManager.downloadResource(for: tab, url: url)
+            
+            ensureMainThread {
+                UIApplication.shared.isNetworkActivityIndicatorVisible = true
+            }
+        } else {
+            onDocumentDownloaded(document: nil, error: nil)
+        }
 
         return result
+    }
+    
+    func onDocumentDownloaded(document: DownloadedResourceResponse?, error: Error?) {
+        ensureMainThread {
+            UIApplication.shared.isNetworkActivityIndicatorVisible = false
+        }
+        
+        // Store the blob/data in a local temporary file.
+        if let document = document, let data = document.data, !data.isEmpty {
+            let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("TempDocs")
+            let url = tempDirectory.appendingPathComponent(filename)
+            
+            do {
+                try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true, attributes: nil)
+                try FileManager.default.removeItem(at: url)
+                try data.write(to: url, options: [.atomic])
+                
+                localFileURL = url
+                pendingResult?.fill(url)
+                pendingResult = nil
+                return
+            } catch {
+                // let the error pass through to the below handler..
+            }
+        }
+        
+        // If we encounter an error downloading the temp file, just return with the
+        // original remote URL so it can still be shared as a web URL.
+        if let url = request.url {
+            pendingResult?.fill(url)
+        }
+        
+        pendingResult = nil
     }
 }
 

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -126,6 +126,10 @@ class UserScriptManager {
             return nil
         }
         var alteredSource: String = source
+        
+        //Verify that the application itself is making a call to the JS script instead of other scripts on the page.
+        //This variable will be unique amongst scripts loaded in the page.
+        //When the script is called, the token is provided in order to access teh script variable.
         let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<downloadManager>", with: "D\(token)", options: .literal)
         

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -119,6 +119,18 @@ class UserScriptManager {
 
         return WKUserScript(source: alteredSource, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     }()
+    
+    private let resourceDownloadManagerUserScript: WKUserScript? = {
+        guard let path = Bundle.main.path(forResource: "ResourceDownloader", ofType: "js"), let source = try? String(contentsOfFile: path) else {
+            log.error("Failed to load ResourceDownloader.js")
+            return nil
+        }
+        var alteredSource: String = source
+        let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        alteredSource = alteredSource.replacingOccurrences(of: "$<downloadManager>", with: "D\(token)", options: .literal)
+        
+        return WKUserScript(source: alteredSource, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+    }()
 
     private func reloadUserScripts() {
         tab?.webView?.configuration.userContentController.do {
@@ -137,6 +149,10 @@ class UserScriptManager {
             }
 
             if isU2FEnabled, let script = U2FLowLevelUserScript {
+                $0.addUserScript(script)
+            }
+            
+            if let script = resourceDownloadManagerUserScript {
                 $0.addUserScript(script)
             }
         }

--- a/Client/Frontend/UserContent/UserScripts/ResourceDownloader.js
+++ b/Client/Frontend/UserContent/UserScripts/ResourceDownloader.js
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"use strict";
+
+var $<downloadManager> = (function() {
+    function postMessage(msg) {
+        if (msg) {
+            webkit.messageHandlers.resourceDownloadManager.postMessage(msg);
+        }
+    }
+                               
+    function downloadPageResource(link) {
+        var xhr = new XMLHttpRequest();
+        xhr.responseType = "arraybuffer";
+        xhr.onreadystatechange = function() {
+            if (this.readyState == XMLHttpRequest.DONE) {
+                if (this.status == 200) {
+                    var byteArray = new Uint8Array(this.response);
+                    var binaryString = new Array(byteArray.length);
+
+                    for (var i = 0; i < byteArray.length; ++i) {
+                        binaryString[i] = String.fromCharCode(byteArray[i]);
+                    }
+
+                    var data = binaryString.join('');
+                    var base64 = window.btoa(data);
+
+                    postMessage({ "statusCode": this.status, "base64Data": base64 });
+                }
+                else {
+                    postMessage({ "statusCode": this.status, "base64Data": "" });
+                }
+            }
+        };
+        xhr.open("GET", link, true);
+        xhr.send(null);
+    };
+                    
+    return {
+        download: downloadPageResource
+    };
+})()

--- a/ClientTests/TabSessionTests.swift
+++ b/ClientTests/TabSessionTests.swift
@@ -1,0 +1,446 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Shared
+import BraveShared
+import Storage
+import WebKit
+import ObjectiveC.runtime
+@testable import Client
+
+private extension WKWebView {
+    class func swizzleMe() {
+        let originalSelector = #selector(WKWebView.init(frame:configuration:))
+        let swizzledSelector = #selector(WKWebView.reInit(frame:configuration:))
+        
+        let originalMethod = class_getInstanceMethod(self, originalSelector)!
+        let swizzledMethod = class_getInstanceMethod(self, swizzledSelector)!
+        
+        let didAddMethod = class_addMethod(self, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
+        
+        if didAddMethod {
+            class_replaceMethod(self, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    }
+    
+    @objc
+    func reInit(frame: CGRect, configuration: WKWebViewConfiguration) -> WKWebView {
+        configuration.setValue(true, forKey: "alwaysRunsAtForegroundPriority")
+        return reInit(frame: frame, configuration: configuration)
+    }
+}
+
+private extension HTTPCookie {
+    class func filter(cookies: [HTTPCookie], for url: URL) -> [HTTPCookie]? {
+        guard let host = url.host?.lowercased() else { return nil }
+        return cookies.filter({ $0.validFor(host: host) })
+    }
+    
+    private func validFor(host: String) -> Bool {
+        guard domain.hasPrefix(".") else { return host == domain }
+        return host == domain.dropFirst() || host.hasSuffix(domain)
+    }
+}
+
+private class WebViewNavigationAdapter: NSObject, WKNavigationDelegate {
+    private let didFailListener: ((Error) -> Void)?
+    private let didFinishListener: (() -> Void)?
+    
+    init(didFailListener: ((Error) -> Void)? = nil, didFinishListener: (() -> Void)? = nil) {
+        self.didFailListener = didFailListener
+        self.didFinishListener = didFinishListener
+        super.init()
+    }
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        decisionHandler(.allow)
+    }
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        decisionHandler(.allow)
+    }
+    
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        didFinishListener?()
+    }
+    
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        didFailListener?(error)
+    }
+}
+
+class TabSessionTests: XCTestCase {
+    private var tabManager: TabManager!
+    
+    override class func setUp() {
+        super.setUp()
+//        WKWebView.swizzleMe()
+    }
+    
+    override func setUp() {
+        super.setUp()
+        
+        tabManager = { () -> TabManager in
+            let profile = BrowserProfile(localName: "profile")
+            return TabManager(prefs: profile.prefs, imageStore: nil)
+        }()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        tabManager = nil
+    }
+    
+    private func destroyData(_ completion: @escaping () -> Void) {
+        tabManager.removeAll()
+        tabManager.resetConfiguration()
+        tabManager.resetProcessPool()
+        tabManager.reset()
+        
+        let group = DispatchGroup()
+        group.enter()
+        HTTPCookieStorage.shared.removeCookies(since: .distantPast)
+        WKWebsiteDataStore.default().httpCookieStore.getAllCookies({
+            $0.forEach({
+                group.enter()
+                WKWebsiteDataStore.default().httpCookieStore.delete($0, completionHandler: {
+                    group.leave()
+                })
+            })
+        })
+        WKWebsiteDataStore.default().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+                                                modifiedSince: .distantPast,
+                                                completionHandler: {
+            group.leave()
+        })
+
+        group.notify(queue: .main, execute: {
+            completion()
+        })
+    }
+    
+    func testPrivateTabSessionSharing() {
+        let dataStoreExpectation = XCTestExpectation(description: "dataStorePersistence")
+        let cookieStoreExpectation = XCTestExpectation(description: "cookieStorePersistence")
+        var webViewNavigationAdapter = WebViewNavigationAdapter()
+        
+        destroyData {
+            let urls = ["https://bing.com",
+                        "https://google.com",
+                        "https://yandex.ru",
+                        "https://yahoo.com"]
+            
+            self.tabManager.addTabsForURLs(urls.compactMap({ URL(string: $0) }), zombie: false, isPrivate: true)
+            XCTAssertTrue(self.tabManager.allTabs.count == 4, "Error: Not all Tabs are created equally")
+            
+            let group = DispatchGroup()
+            self.tabManager.allTabs.forEach({
+                XCTAssertNotNil($0.webView, "WebView is not created yet")
+                if $0.webView?.configuration.websiteDataStore.isPersistent == true {
+                    XCTFail("Private Tab is storing data persistently!")
+                }
+                
+                group.enter()
+            })
+            
+            webViewNavigationAdapter = WebViewNavigationAdapter(didFailListener: { _ in
+                group.leave()
+            }, didFinishListener: {
+                group.leave()
+            })
+            self.tabManager.addNavigationDelegate(webViewNavigationAdapter)
+            
+            group.notify(queue: .main) {
+                // All requests finished loading.. time to check the cookies..
+                let group = DispatchGroup()
+                self.tabManager.allTabs.forEach({
+                    group.enter()
+                    $0.webView?.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), completionHandler: { records in
+                        XCTAssertFalse(records.isEmpty, "Error: Data Store not shared amongst private tabs!")
+                        
+                        let recordNames = Set<String>(records.compactMap({ URL(string: "http://\($0.displayName)")?.host }))
+                        let urlNames = Set<String>(urls.compactMap({ URL(string: $0)?.host }))
+                        
+                        XCTAssertTrue(urlNames.isSubset(of: recordNames), "Data Store records do not match!")
+                        group.leave()
+                    })
+                    
+                    group.enter()
+                    $0.webView?.configuration.websiteDataStore.httpCookieStore.getAllCookies({ cookies in
+                        XCTAssertFalse(cookies.isEmpty, "Error: Cookies not shared amongst private tabs!")
+                        
+                        urls.compactMap({ URL(string: $0) }).forEach({
+                            let cookiesForURL = HTTPCookie.filter(cookies: cookies, for: $0) ?? []
+                            XCTAssertFalse(cookiesForURL.isEmpty, "Cookie Store records do not match!")
+                        })
+                        
+                        group.leave()
+                    })
+                })
+                
+                group.notify(queue: .main) {
+                    dataStoreExpectation.fulfill()
+                    cookieStoreExpectation.fulfill()
+                }
+            }
+        }
+        wait(for: [dataStoreExpectation, cookieStoreExpectation], timeout: 30.0)
+    }
+    
+    func testPrivateTabNonPersistence() {
+        let dataStoreExpectation = XCTestExpectation(description: "dataStorePersistence")
+        let cookieStoreExpectation = XCTestExpectation(description: "cookieStorePersistence")
+        var webViewNavigationAdapter = WebViewNavigationAdapter()
+        
+        destroyData {
+            let urls = ["https://bing.com",
+                        "https://google.com",
+                        "https://yandex.ru",
+                        "https://yahoo.com"]
+            
+            self.tabManager.addTabsForURLs(urls.compactMap({ URL(string: $0) }), zombie: false, isPrivate: true)
+            XCTAssertTrue(self.tabManager.allTabs.count == 4, "Error: Not all Tabs are created equally")
+            
+            let group = DispatchGroup()
+            self.tabManager.allTabs.forEach({
+                XCTAssertNotNil($0.webView, "WebView is not created yet")
+                if $0.webView?.configuration.websiteDataStore.isPersistent == true {
+                    XCTFail("Private Tab is storing data persistently!")
+                }
+                
+                group.enter()
+            })
+            
+            webViewNavigationAdapter = WebViewNavigationAdapter(didFailListener: { _ in
+                group.leave()
+            }, didFinishListener: {
+                group.leave()
+            })
+            self.tabManager.addNavigationDelegate(webViewNavigationAdapter)
+            
+            group.notify(queue: .main) {
+                // All requests finished loading.. kill all tabs.. check the cookies..
+                self.tabManager.removeAll()
+                
+                // When the tab manager destroys tabs, if there are no tabs left, it adds a new zombie tab.
+                // Hence the count of 1.
+                XCTAssertTrue(self.tabManager.allTabs.count == 1, "Error: Not all Tabs are destroyed equally")
+                
+                let group = DispatchGroup()
+                self.tabManager.allTabs.forEach({
+                    group.enter()
+                    $0.webView?.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), completionHandler: { records in
+                        XCTAssertTrue(records.filter({ $0.displayName != "localhost" }).isEmpty, "Error: Data Store not cleared when tabs destroyed!")
+                        group.leave()
+                    })
+                    
+                    group.enter()
+                    $0.webView?.configuration.websiteDataStore.httpCookieStore.getAllCookies({ cookies in
+                        XCTAssertTrue(cookies.isEmpty, "Error: Cookies Store not cleared when tabs destroyed!")
+                        group.leave()
+                    })
+                })
+                
+                group.notify(queue: .main) {
+                    dataStoreExpectation.fulfill()
+                    cookieStoreExpectation.fulfill()
+                }
+            }
+        }
+        
+        wait(for: [dataStoreExpectation, cookieStoreExpectation], timeout: 30.0)
+    }
+    
+    func testTabsPrivateToNormal() {
+        let dataStoreExpectation = XCTestExpectation(description: "dataStorePersistence")
+        let cookieStoreExpectation = XCTestExpectation(description: "cookieStorePersistence")
+        var webViewNavigationAdapter = WebViewNavigationAdapter()
+
+        destroyData {
+            let url = URL(string: "https://yandex.ru")!
+            let otherURL = URL(string: "https://google.com")!
+            
+            self.tabManager.addTabsForURLs([url], zombie: false, isPrivate: true)
+            XCTAssertTrue(self.tabManager.allTabs.count == 1, "Error: Not all Tabs are created equally")
+            
+            let group = DispatchGroup()
+            self.tabManager.allTabs.forEach({
+                XCTAssertNotNil($0.webView, "WebView is not created yet")
+                if $0.webView?.configuration.websiteDataStore.isPersistent == true {
+                    XCTFail("Private Tab is storing data persistently!")
+                }
+                
+                group.enter()
+            })
+            
+            webViewNavigationAdapter = WebViewNavigationAdapter(didFailListener: { _ in
+                group.leave()
+            }, didFinishListener: {
+                group.leave()
+            })
+            self.tabManager.addNavigationDelegate(webViewNavigationAdapter)
+            
+            // All requests finished loading.. switch to normal mode.. check the cookies..
+            group.notify(queue: .main) {
+                let group = DispatchGroup()
+                webViewNavigationAdapter = WebViewNavigationAdapter(didFailListener: { _ in
+                    group.leave()
+                }, didFinishListener: {
+                    group.leave()
+                })
+                
+                self.tabManager.addNavigationDelegate(webViewNavigationAdapter)
+                self.tabManager.addTabsForURLs([otherURL], zombie: false, isPrivate: false)
+                
+                // When the tab manager switches to normal mode from private
+                // It should kill all private tabs..
+                XCTAssertTrue(self.tabManager.tabs(withType: .private).isEmpty, "Error: Private tabs not destroyed when switching to normal mode!")
+                
+                XCTAssertFalse(self.tabManager.tabs(withType: .regular).isEmpty, "Error: Normal tab not created")
+                
+                self.tabManager.allTabs.forEach({
+                    XCTAssertNotNil($0.webView, "WebView is not created yet")
+                    if $0.webView?.configuration.websiteDataStore.isPersistent == false {
+                        XCTFail("Normal Tab is not storing data persistently!")
+                    }
+                    
+                    group.enter()
+                })
+                
+                group.notify(queue: .main) {
+                    let group = DispatchGroup()
+                    
+                    self.tabManager.tabs(withType: .regular).forEach({
+                        group.enter()
+                        $0.webView?.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), completionHandler: { records in
+                            XCTAssertFalse(records.isEmpty, "Error: Data Store not persistent in normal mode!")
+                            
+                            let recordNames = Set<String>(records.compactMap({ URL(string: "http://\($0.displayName)")?.host }))
+                            let urlNames = Set<String>([url.host ?? "FailedTestDomain"])
+                            
+                            XCTAssertFalse(urlNames.isSubset(of: recordNames), "Data Store leaking from private tab to normal tab!")
+                            
+                            group.leave()
+                        })
+                        
+                        group.enter()
+                        $0.webView?.configuration.websiteDataStore.httpCookieStore.getAllCookies({ cookies in
+                            XCTAssertFalse(cookies.isEmpty, "Error: Cookies Store not persistent in normal mode!")
+                            
+                            let cookiesForURL = HTTPCookie.filter(cookies: cookies, for: url) ?? []
+                            XCTAssertTrue(cookiesForURL.isEmpty, "Cookie Store leaking from private tab to normal tab!")
+                            
+                            group.leave()
+                        })
+                    })
+                    
+                    group.notify(queue: .main) {
+                        dataStoreExpectation.fulfill()
+                        cookieStoreExpectation.fulfill()
+                    }
+                }
+            }
+        }
+        
+        wait(for: [dataStoreExpectation, cookieStoreExpectation], timeout: 30.0)
+    }
+    
+    func testTabsNormalToPrivate() {
+        let dataStoreExpectation = XCTestExpectation(description: "dataStorePersistence")
+        let cookieStoreExpectation = XCTestExpectation(description: "cookieStorePersistence")
+        var webViewNavigationAdapter = WebViewNavigationAdapter()
+        
+        destroyData {
+            let url = URL(string: "https://yandex.ru")!
+            let otherURL = URL(string: "https://google.com")!
+            
+            self.tabManager.addTabsForURLs([url], zombie: false, isPrivate: false)
+            XCTAssertTrue(self.tabManager.allTabs.count == 1, "Error: Not all Tabs are created equally")
+            
+            let group = DispatchGroup()
+            self.tabManager.allTabs.forEach({
+                XCTAssertNotNil($0.webView, "WebView is not created yet")
+                if $0.webView?.configuration.websiteDataStore.isPersistent == false {
+                    XCTFail("Normal Tab is not storing data persistently!")
+                }
+                
+                group.enter()
+            })
+            
+            webViewNavigationAdapter = WebViewNavigationAdapter(didFailListener: { _ in
+                group.leave()
+            }, didFinishListener: {
+                group.leave()
+            })
+            self.tabManager.addNavigationDelegate(webViewNavigationAdapter)
+            
+            // All requests finished loading.. switch to private mode.. check the cookies..
+            group.notify(queue: .main) {
+                let group = DispatchGroup()
+                webViewNavigationAdapter = WebViewNavigationAdapter(didFailListener: { _ in
+                    group.leave()
+                }, didFinishListener: {
+                    group.leave()
+                })
+                
+                self.tabManager.addNavigationDelegate(webViewNavigationAdapter)
+                self.tabManager.addTabsForURLs([otherURL], zombie: false, isPrivate: true)
+                
+                // When the tab manager switches to private mode from normal
+                // It should keep both private and normal tabs
+                XCTAssertFalse(self.tabManager.tabs(withType: .private).isEmpty, "Error: Private tabs not created")
+                XCTAssertFalse(self.tabManager.tabs(withType: .regular).isEmpty, "Error: Normal tab not created")
+                
+                self.tabManager.tabs(withType: .private).forEach({
+                    XCTAssertNotNil($0.webView, "WebView is not created yet")
+                    if $0.webView?.configuration.websiteDataStore.isPersistent == true {
+                        XCTFail("Private Tab is storing data persistently!")
+                    }
+                    
+                    group.enter()
+                })
+                
+                group.notify(queue: .main) {
+                    let group = DispatchGroup()
+                    
+                    self.tabManager.tabs(withType: .private).forEach({
+                        //This is what I believe to be a bug in WKWebView where a non-persistent store can view DISK CACHE from a persistent store.
+                        //It doesn't make a difference though because it's not transfering sensitive information, session, or cookies!
+                        //Can be verified via Safari Development Tools.
+                        // - Brandon T.
+                        
+    //                    group.enter()
+    //                    $0.webView?.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), completionHandler: { records in
+    //                        let recordNames = Set<String>(records.compactMap({ URL(string: "http://\($0.displayName)")?.host }))
+    //                        let urlNames = Set<String>([url.host ?? "FailedTestDomain"])
+    //
+    //                        XCTAssertFalse(urlNames.isSubset(of: recordNames), "Data Store leaking from normal tab to private tab!")
+    //
+    //                        group.leave()
+    //                    })
+                        
+                        group.enter()
+                        $0.webView?.configuration.websiteDataStore.httpCookieStore.getAllCookies({ cookies in
+                            let cookiesForURL = HTTPCookie.filter(cookies: cookies, for: url) ?? []
+                            XCTAssertTrue(cookiesForURL.isEmpty, "Cookie Store leaking from normal tab to private tab!")
+                            
+                            group.leave()
+                        })
+                    })
+                    
+                    group.notify(queue: .main) {
+                        dataStoreExpectation.fulfill()
+                        cookieStoreExpectation.fulfill()
+                    }
+                }
+            }
+        }
+        
+        wait(for: [dataStoreExpectation, cookieStoreExpectation], timeout: 30.0)
+    }
+}

--- a/ClientTests/TabSessionTests.swift
+++ b/ClientTests/TabSessionTests.swift
@@ -207,6 +207,7 @@ class TabSessionTests: XCTestCase {
 						"https://hotmail.com"]
 			
 			self.tabManager.addTabsForURLs(urls.compactMap({ URL(string: $0) }), zombie: false, isPrivate: false)
+            self.tabManager.removeTabs(self.tabManager.allTabs.filter({ $0.url?.absoluteString.contains("localhost") ?? false }))
             if self.tabManager.allTabs.count != 4 {
                 XCTFail("Error: Not all Tabs are created equally")
                 return dataStoreExpectation.fulfill()
@@ -219,7 +220,7 @@ class TabSessionTests: XCTestCase {
                     return dataStoreExpectation.fulfill()
                 }
                 
-                if webView.configuration.websiteDataStore.isPersistent == false {
+                if !webView.configuration.websiteDataStore.isPersistent {
                     XCTFail("Normal Tab is not storing data persistently!")
                     return dataStoreExpectation.fulfill()
                 }
@@ -242,6 +243,11 @@ class TabSessionTests: XCTestCase {
                 
 				// All requests finished loading.. time to check the cookies..
 				let group = DispatchGroup()
+                if self.tabManager.allTabs.isEmpty {
+                    XCTFail("Tabs somehow destroyed")
+                    return dataStoreExpectation.fulfill()
+                }
+                
                 for tab in self.tabManager.allTabs {
                     guard let webView = tab.webView else {
                         XCTFail("WebView died unexpectedly")

--- a/ClientTests/TabSessionTests.swift
+++ b/ClientTests/TabSessionTests.swift
@@ -76,6 +76,7 @@ private class WebViewNavigationAdapter: NSObject, WKNavigationDelegate {
 
 class TabSessionTests: XCTestCase {
     private var tabManager: TabManager!
+    private let maxTimeout = 60.0
     
     override class func setUp() {
         super.setUp()
@@ -193,7 +194,7 @@ class TabSessionTests: XCTestCase {
                 }
             }
         }
-        wait(for: [dataStoreExpectation], timeout: 30.0)
+        wait(for: [dataStoreExpectation], timeout: maxTimeout)
     }
 	
 	func testNormalTabSessionSharing() {
@@ -202,9 +203,9 @@ class TabSessionTests: XCTestCase {
 		
 		destroyData {
 			let urls = ["https://stackoverflow.com",
-						"https://gmail.com",
-						"https://mail.ru",
-						"https://hotmail.com"]
+						"https://discordapp.com",
+						"https://apple.com",
+						"https://slack.com"]
 			
 			self.tabManager.addTabsForURLs(urls.compactMap({ URL(string: $0) }), zombie: false, isPrivate: false)
             self.tabManager.removeTabs(self.tabManager.allTabs.filter({ $0.url?.absoluteString.contains("localhost") ?? false }))
@@ -271,7 +272,7 @@ class TabSessionTests: XCTestCase {
 				}
 			}
 		}
-		wait(for: [dataStoreExpectation], timeout: 30.0)
+		wait(for: [dataStoreExpectation], timeout: maxTimeout)
 	}
     
     func testPrivateTabNonPersistence() {
@@ -384,7 +385,7 @@ class TabSessionTests: XCTestCase {
             }
         }
         
-        wait(for: [dataStoreExpectation], timeout: 30.0)
+        wait(for: [dataStoreExpectation], timeout: maxTimeout)
     }
     
     func testTabsPrivateToNormal() {
@@ -489,7 +490,7 @@ class TabSessionTests: XCTestCase {
             }
         }
         
-        wait(for: [dataStoreExpectation], timeout: 30.0)
+        wait(for: [dataStoreExpectation], timeout: maxTimeout)
     }
     
     func testTabsNormalToPrivate() {
@@ -593,6 +594,6 @@ class TabSessionTests: XCTestCase {
             }
         }
         
-        wait(for: [dataStoreExpectation], timeout: 30.0)
+        wait(for: [dataStoreExpectation], timeout: maxTimeout)
     }
 }


### PR DESCRIPTION
**BUG FIXES:**

- Fixes: https://github.com/brave/brave-ios/issues/1144
- Fixed a background thread issue where "displayTitle" is being called on WKWebView on a non-main thread causing the PrintPreview to have undefined-behaviour.
- Fixed opening Authenticated documents in Private-Browsing mode when it opens in a new tab.
- Fixed opening Authenticated documents and attempting to share, or print them.
- Fixes tabs not having the same data store as other tabs (IE: Log-In to any website on one tab should log you in on another tab).
- Fixed destroying of data-store to only happen when ALL tabs are destroyed.
- Changed Temporary Storage to pull out the document from the WebPage instead of making server calls outside the webview's session (IE: No need for cookie injecting, etc).. Instead, we get the webview to give us the document via Javascript injection which passes the document to iOS for display/saving, etc..

**WHAT I TESTED:**
- Log into Email (gmail.com) in PrivateTab-A
   - Refresh PrivateTab-B
   - PrivateTab-B is also logged in.

- Log out of Email (gmail.com) in PrivateTab-A
   - Refresh PrivateTab-B
   - PrivateTab-B is logged out.

- Above tested in normal mode as well.

- Log into PrivateTab-A
   - Open Normal Tab
   - Normal tab is NOT logged in.
   - Switch back to private mode, all tabs are gone.

- Log into Normal Tab-A
   - Open PrivateTab
   - Private Tab is not logged in
   - Switch back to Normal Tab - Still logged in.

- Log into banking website in PrivateTab-A
   - View statements (It opens statements a PDF in PrivateTab-B [ authenticated document ])
   - Success (PDF opened).
   - Share PDF in PrivateTab-B (Works).

- Log into banking website in PrivateTab-A
   - Switched to Normal mode and back to PrivateMode.
   - Tabs killed, cookies and sessions are cleared successfully for all Private Tabs.

- Log into banking website in PrivateTab-A
   - Open second PrivateTab-B.
   - Kill both Tabs.
   - Cookies and sessions are cleared successfully for all Private Tabs.

- Log into banking website in PrivateTab-A
   - View statements as PDF (opens in a new PrivateTab-B).
   - Turn Internet OFF
   - Share PDF and Print (works without internet because no requests are made)
   - Kill tabs
   - Cookies and sessions are cleared successfully for all Private Tabs.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

