### PR TITLE
Fix #1192: HTTPSE shield setting is now scheme independent.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -160,6 +160,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 if let mainDocumentURL = navigationAction.request.mainDocumentURL, url.scheme == "http" {
                     let domainForShields = Domain.getOrCreate(forUrl: mainDocumentURL)
                     let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
+                    // Loading bad data
                     if domainForShields.isShieldExpected(.HTTPSE, isPrivateBrowsing: isPrivateBrowsing) && HttpsEverywhereStats.shared.shouldUpgrade(url) {
                         // Check if HTTPSE is on and if it is, whether or not this http url would be upgraded
                         pendingHTTPUpgrades[urlHost] = navigationAction.request

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -160,7 +160,6 @@ extension BrowserViewController: WKNavigationDelegate {
                 if let mainDocumentURL = navigationAction.request.mainDocumentURL, url.scheme == "http" {
                     let domainForShields = Domain.getOrCreate(forUrl: mainDocumentURL)
                     let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
-                    // Loading bad data
                     if domainForShields.isShieldExpected(.HTTPSE, isPrivateBrowsing: isPrivateBrowsing) && HttpsEverywhereStats.shared.shouldUpgrade(url) {
                         // Check if HTTPSE is on and if it is, whether or not this http url would be upgraded
                         pendingHTTPUpgrades[urlHost] = navigationAction.request

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -23,6 +23,10 @@ public final class Domain: NSManagedObject, CRUD {
     @NSManaged public var historyItems: NSSet?
     @NSManaged public var bookmarks: NSSet?
     
+    private var urlComponents: URLComponents? {
+        return URLComponents(string: url ?? "")
+    }
+    
     // MARK: - Public interface
     
     public class func getOrCreate(forUrl url: URL) -> Domain {
@@ -80,7 +84,7 @@ public final class Domain: NSManagedObject, CRUD {
             }
             
             for domain in httpDomains {
-                guard let urlString = domain.url, var urlComponents = URLComponents(string: urlString) else { continue }
+                guard var urlComponents = domain.urlComponents else { continue }
                 urlComponents.scheme = "https"
                 guard let httpsUrl = urlComponents.url?.absoluteString else { continue }
                 if let httpsDomain = Domain.first(where: NSPredicate(format: "url == %@", httpsUrl), context: context) {
@@ -199,7 +203,12 @@ extension Domain {
         switch shield {
         case .AllOff: shield_allOff = setting
         case .AdblockAndTp: shield_adblockAndTp = setting
-        case .HTTPSE: shield_httpse = setting
+        case .HTTPSE:
+          shield_httpse = setting
+            
+          // HTTPSE must be scheme indepedent or user may get stuck not being able to access the http version
+          //  of a website (turning off httpse for an upgraded-https domain does not allow access to http version)
+          self.domainForInverseHttpScheme()?.shield_httpse = setting
         case .SafeBrowsing: shield_safeBrowsing = setting
         case .FpProtection: shield_fpProtection = setting
         case .NoScript: shield_noScript = setting
@@ -255,5 +264,24 @@ extension Domain {
             return domain.getBraveShield(shield)
         }
         return shield.globalPreference
+    }
+    
+    /// Returns `url` but switches the scheme from `http` <-> `https`
+    private func domainForInverseHttpScheme() -> Domain? {
+        
+        guard var urlComponents = self.urlComponents else { return nil }
+        
+        // Flip the scheme if valid
+        
+        switch urlComponents.scheme {
+        case "http": urlComponents.scheme = "https"
+        case "https": urlComponents.scheme = "http"
+        default: return nil
+        }
+        
+        guard let url = urlComponents.url else { return nil }
+        
+        // Return the flipped scheme version of `url`
+        return Domain.getOrCreate(forUrl: url)
     }
 }

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -208,7 +208,7 @@ extension Domain {
             
           // HTTPSE must be scheme indepedent or user may get stuck not being able to access the http version
           //  of a website (turning off httpse for an upgraded-https domain does not allow access to http version)
-          self.domainForInverseHttpScheme()?.shield_httpse = setting
+          self.domainForInverseHttpScheme(context: context)?.shield_httpse = setting
         case .SafeBrowsing: shield_safeBrowsing = setting
         case .FpProtection: shield_fpProtection = setting
         case .NoScript: shield_noScript = setting
@@ -267,7 +267,7 @@ extension Domain {
     }
     
     /// Returns `url` but switches the scheme from `http` <-> `https`
-    private func domainForInverseHttpScheme() -> Domain? {
+    private func domainForInverseHttpScheme(context: NSManagedObjectContext) -> Domain? {
         
         guard var urlComponents = self.urlComponents else { return nil }
         
@@ -282,6 +282,6 @@ extension Domain {
         guard let url = urlComponents.url else { return nil }
         
         // Return the flipped scheme version of `url`
-        return Domain.getOrCreate(forUrl: url)
+        return Domain.getOrCreateInternal(url, context: context, save: true)
     }
 }

--- a/DataTests/DomainTests.swift
+++ b/DataTests/DomainTests.swift
@@ -63,10 +63,14 @@ class DomainTests: CoreDataTestCase {
     
     /// Tests non-HTTPSE shields
     func testNormalShieldSettings() {
-        let url = url2HTTPS
         let domain = Domain.getOrCreate(forUrl: url2HTTPS)
-        Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
-        Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: false, isPrivateBrowsing: false)
+        backgroundSaveAndWaitForExpectation {
+            Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
+        }
+        
+        backgroundSaveAndWaitForExpectation {
+            Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: false, isPrivateBrowsing: false)
+        }
         
         XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, isPrivateBrowsing: false))
         // Not testing via isSheildExpected, since that adds default checks
@@ -79,8 +83,13 @@ class DomainTests: CoreDataTestCase {
         
         // Setting to "new" values
         // Setting to same value
-        Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
-        Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: true, isPrivateBrowsing: false)
+        backgroundSaveAndWaitForExpectation {
+            Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
+        }
+        
+        backgroundSaveAndWaitForExpectation {
+            Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: true, isPrivateBrowsing: false)
+        }
         
         XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, isPrivateBrowsing: false))
         XCTAssertTrue(domain.isShieldExpected(BraveShield.AdblockAndTp, isPrivateBrowsing: false))
@@ -93,7 +102,9 @@ class DomainTests: CoreDataTestCase {
     /// Testing HTTPSE
     /// if setting an HTTP scheme, that HTTPS is also set
     func testHTTPSEforHTTPsetter() {
-        Domain.setBraveShield(forUrl: url, shield: .HTTPSE, isOn: true, isPrivateBrowsing: false)
+        backgroundSaveAndWaitForExpectation {
+            Domain.setBraveShield(forUrl: url, shield: .HTTPSE, isOn: true, isPrivateBrowsing: false)
+        }
         
         // Should be one for HTTP and one for HTTPS schemes
         XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
@@ -108,7 +119,9 @@ class DomainTests: CoreDataTestCase {
     /// Testing HTTPSE
     /// if setting an HTTPS scheme, that HTTP is also set
     func testHTTPSEforHTTPSsetter() {
-        Domain.setBraveShield(forUrl: url2HTTPS, shield: .HTTPSE, isOn: true, isPrivateBrowsing: false)
+        backgroundSaveAndWaitForExpectation {
+            Domain.setBraveShield(forUrl: url2HTTPS, shield: .HTTPSE, isOn: true, isPrivateBrowsing: false)
+        }
 
         // Should be one for HTTP and one for HTTPS schemes
         XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)

--- a/DataTests/DomainTests.swift
+++ b/DataTests/DomainTests.swift
@@ -4,19 +4,24 @@
 
 import XCTest
 import CoreData
+import BraveShared
 @testable import Data
 
 class DomainTests: CoreDataTestCase {
     let fetchRequest = NSFetchRequest<Domain>(entityName: String(describing: Domain.self))
+    
+    // Should match but with different schemes
+    let url = URL(string: "http://example.com")!
+    let urlHTTPS = URL(string: "https://example.com")!
+    
+    let url2 = URL(string: "http://brave.com")!
+    let url2HTTPS = URL(string: "https://brave.com")!
     
     private func entity(for context: NSManagedObjectContext) -> NSEntityDescription {
         return NSEntityDescription.entity(forEntityName: String(describing: Domain.self), in: context)!
     }
     
     func testGetOrCreate() {
-        let url = URL(string: "http://example.com")!
-        let url2 = URL(string: "http://brave.com")!
-        
         XCTAssertNotNil(Domain.getOrCreate(forUrl: url))
         XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 1)
         
@@ -28,6 +33,90 @@ class DomainTests: CoreDataTestCase {
         XCTAssertNotNil(Domain.getOrCreate(forUrl: url2))
         XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
     }
+    
+    func testGetOrCreateURLs() {
+        // This also validates that the schemes are being correctly saved
+        XCTAssertEqual(url.absoluteString, Domain.getOrCreate(forUrl: url).url)
+        XCTAssertEqual(url2.absoluteString, Domain.getOrCreate(forUrl: url2).url)
+        
+        let url3 = URL(string: "https://brave.com")!
+        let url4 = URL(string: "data://brave.com")!
+        XCTAssertEqual(url3.absoluteString, Domain.getOrCreate(forUrl: url3).url)
+        XCTAssertEqual(url4.absoluteString, Domain.getOrCreate(forUrl: url4).url)
+        XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 4)
+    }
+    
+    func testDefaultShieldSettings() {
+        
+        let domain = Domain.getOrCreate(forUrl: url)
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.AdblockAndTp, isPrivateBrowsing: true))
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.HTTPSE, isPrivateBrowsing: true))
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, isPrivateBrowsing: true))
+        XCTAssertFalse(domain.isShieldExpected(BraveShield.AllOff, isPrivateBrowsing: true))
+        XCTAssertFalse(domain.isShieldExpected(BraveShield.NoScript, isPrivateBrowsing: true))
+        XCTAssertFalse(domain.isShieldExpected(BraveShield.FpProtection, isPrivateBrowsing: true))
+        
+        XCTAssertEqual(domain.bookmarks?.count, 0)
+        XCTAssertEqual(domain.historyItems?.count, 0)
+        XCTAssertEqual(domain.url, url.domainURL.absoluteString)
+    }
+    
+    /// Tests non-HTTPSE shields
+    func testNormalShieldSettings() {
+        let url = url2HTTPS
+        let domain = Domain.getOrCreate(forUrl: url2HTTPS)
+        Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
+        Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: false, isPrivateBrowsing: false)
+        
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, isPrivateBrowsing: false))
+        // Not testing via isSheildExpected, since that adds default checks
+        XCTAssertFalse(domain.shield_adblockAndTp == 0)
+        
+        // These should be the same in this situation
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, isPrivateBrowsing: true))
+        // Not testing via isSheildExpected, since that adds default checks
+        XCTAssertFalse(domain.shield_adblockAndTp == 0)
+        
+        // Setting to "new" values
+        // Setting to same value
+        Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
+        Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: true, isPrivateBrowsing: false)
+        
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, isPrivateBrowsing: false))
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.AdblockAndTp, isPrivateBrowsing: false))
+        
+        // These should be the same in this situation
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, isPrivateBrowsing: true))
+        XCTAssertTrue(domain.isShieldExpected(BraveShield.AdblockAndTp, isPrivateBrowsing: true))
+    }
+    
+    /// Testing HTTPSE
+    /// if setting an HTTP scheme, that HTTPS is also set
+    func testHTTPSEforHTTPsetter() {
+        Domain.setBraveShield(forUrl: url, shield: .HTTPSE, isOn: true, isPrivateBrowsing: false)
+        
+        // Should be one for HTTP and one for HTTPS schemes
+        XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
+        
+        let domainRefetch1 = Domain.getOrCreate(forUrl: url)
+        XCTAssertEqual(domainRefetch1.isShieldExpected(.HTTPSE, isPrivateBrowsing: false), true)
+        
+        let domainRefetch2 = Domain.getOrCreate(forUrl: urlHTTPS)
+        XCTAssertEqual(domainRefetch2.isShieldExpected(.HTTPSE, isPrivateBrowsing: false), true)
+    }
+    
+    /// Testing HTTPSE
+    /// if setting an HTTPS scheme, that HTTP is also set
+    func testHTTPSEforHTTPSsetter() {
+        Domain.setBraveShield(forUrl: url2HTTPS, shield: .HTTPSE, isOn: true, isPrivateBrowsing: false)
 
-    // BRAVE TODO: Add shields unit tests after they are finished.
+        // Should be one for HTTP and one for HTTPS schemes
+        XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
+        
+        let domainRefetch1 = Domain.getOrCreate(forUrl: url2)
+        XCTAssertEqual(domainRefetch1.isShieldExpected(.HTTPSE, isPrivateBrowsing: false), true)
+        
+        let domainRefetch2 = Domain.getOrCreate(forUrl: url2HTTPS)
+        XCTAssertEqual(domainRefetch2.isShieldExpected(.HTTPSE, isPrivateBrowsing: false), true)
+    }
 }


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->
See https://github.com/brave/brave-ios/issues/1192
### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

