### PR TITLE
Added New Private Tab QuickAction.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -511,3 +511,12 @@ extension Strings {
     public static let AddToMenuItem = NSLocalizedString("AddToMenuItem", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add to...", comment: "Title for adding new bookmark menu item")
     public static let ShareWithMenuItem = NSLocalizedString("ShareWithMenuItem", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Share with...", comment: "Title for sharing url menu item")
 }
+
+// MARK: - Quick Actions
+extension Strings {
+    public static let QuickActionNewTab = NSLocalizedString("ShortcutItemTitleNewTab", tableName: "BraveShared", bundle: Bundle.braveShared, value: "New Tab", comment: "Quick Action for 3D-Touch on the Application Icon")
+    
+    public static let QuickActionNewPrivateTab = NSLocalizedString("ShortcutItemTitleNewPrivateTab", tableName: "BraveShared", bundle: Bundle.braveShared, value: "New Private Tab", comment: "Quick Action for 3D-Touch on the Application Icon")
+    
+    public static let QuickActionScanQRCode = NSLocalizedString("ShortcutItemTitleQRCode", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Scan QR Code", comment: "Quick Action for 3D-Touch on the Application Icon")
+}

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -515,8 +515,6 @@ extension Strings {
 // MARK: - Quick Actions
 extension Strings {
     public static let QuickActionNewTab = NSLocalizedString("ShortcutItemTitleNewTab", tableName: "BraveShared", bundle: Bundle.braveShared, value: "New Tab", comment: "Quick Action for 3D-Touch on the Application Icon")
-    
     public static let QuickActionNewPrivateTab = NSLocalizedString("ShortcutItemTitleNewPrivateTab", tableName: "BraveShared", bundle: Bundle.braveShared, value: "New Private Tab", comment: "Quick Action for 3D-Touch on the Application Icon")
-    
     public static let QuickActionScanQRCode = NSLocalizedString("ShortcutItemTitleQRCode", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Scan QR Code", comment: "Quick Action for 3D-Touch on the Application Icon")
 }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -64,6 +64,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         
         HttpsEverywhereStats.shared.startLoading()
         
+        updateShortcutItems(application)
+        
         // Passcode checking, must happen on immediate launch
         if !DataController.shared.storeExists() {
             // Since passcode is stored in keychain it persists between installations.
@@ -185,6 +187,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let p = BrowserProfile(localName: "profile")
         self.profile = p
         return p
+    }
+    
+    func updateShortcutItems(_ application: UIApplication) {
+        let newTabItem = UIMutableApplicationShortcutItem(type: "\(Bundle.main.bundleIdentifier ?? "").NewTab",
+            localizedTitle: NSLocalizedString("ShortcutItemTitleNewTab",
+                                              tableName: "InfoPlist",
+                                              bundle: Bundle.main,
+                                              comment: "New Tab"),
+            localizedSubtitle: nil,
+            icon: UIApplicationShortcutIcon(templateImageName: "quick_action_new_tab"),
+            userInfo: [:])
+        
+        let privateTabItem = UIMutableApplicationShortcutItem(type: "\(Bundle.main.bundleIdentifier ?? "").NewPrivateTab",
+            localizedTitle: NSLocalizedString("ShortcutItemTitleNewPrivateTab",
+                                              tableName: "InfoPlist",
+                                              bundle: Bundle.main,
+                                              comment: "New Private Tab"),
+            localizedSubtitle: nil,
+            icon: UIApplicationShortcutIcon(templateImageName: "quick_action_new_private_tab"),
+            userInfo: [:])
+        
+        application.shortcutItems = Preferences.Privacy.privateBrowsingOnly.value ? [privateTabItem] : [newTabItem, privateTabItem]
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -191,19 +191,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     
     func updateShortcutItems(_ application: UIApplication) {
         let newTabItem = UIMutableApplicationShortcutItem(type: "\(Bundle.main.bundleIdentifier ?? "").NewTab",
-            localizedTitle: NSLocalizedString("ShortcutItemTitleNewTab",
-                                              tableName: "InfoPlist",
-                                              bundle: Bundle.main,
-                                              comment: "New Tab"),
+            localizedTitle: Strings.QuickActionNewTab,
             localizedSubtitle: nil,
             icon: UIApplicationShortcutIcon(templateImageName: "quick_action_new_tab"),
             userInfo: [:])
         
         let privateTabItem = UIMutableApplicationShortcutItem(type: "\(Bundle.main.bundleIdentifier ?? "").NewPrivateTab",
-            localizedTitle: NSLocalizedString("ShortcutItemTitleNewPrivateTab",
-                                              tableName: "InfoPlist",
-                                              bundle: Bundle.main,
-                                              comment: "New Private Tab"),
+            localizedTitle: Strings.QuickActionNewPrivateTab,
             localizedSubtitle: nil,
             icon: UIApplicationShortcutIcon(templateImageName: "quick_action_new_private_tab"),
             userInfo: [:])

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -10,6 +10,7 @@ import XCGLogger
 
 enum ShortcutType: String {
     case newTab = "NewTab"
+    case newPrivateTab = "NewPrivateTab"
 
     init?(fullType: String) {
         guard let last = fullType.components(separatedBy: ".").last else { return nil }
@@ -57,6 +58,8 @@ class QuickActions: NSObject {
         switch type {
         case .newTab:
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
+        case .newPrivateTab:
+            handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -843,6 +843,12 @@ class BrowserViewController: UIViewController {
             tabsBar.view.isHidden = !shouldShow
         }
     }
+    
+    private func updateApplicationShortcuts() {
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            delegate.updateShortcutItems(UIApplication.shared)
+        }
+    }
 
     fileprivate func hideSearchController() {
         if let searchController = searchController {
@@ -2956,6 +2962,7 @@ extension BrowserViewController: PreferencesObserver {
             PrivateBrowsingManager.shared.isPrivateBrowsing = isPrivate
             setupTabs()
             updateTabsBarVisibility()
+            updateApplicationShortcuts()
         case Preferences.Shields.blockAdsAndTracking.key,
              Preferences.Shields.httpsEverywhere.key,
              Preferences.Shields.blockScripts.key,

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -545,12 +545,19 @@ class TabTrayController: UIViewController, Themeable {
     func updatePrivateModeButtonVisibility() {
         toolbar.privateModeButton.isHidden = Preferences.Privacy.privateBrowsingOnly.value
     }
+    
+    private func updateApplicationShortcuts() {
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            delegate.updateShortcutItems(UIApplication.shared)
+        }
+    }
 }
 
 extension TabTrayController: PreferencesObserver {
     func preferencesDidChange(for key: String) {
         if key == Preferences.Privacy.privateBrowsingOnly.key {
             updatePrivateModeButtonVisibility()
+            updateApplicationShortcuts()
         }
     }
 }

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -106,25 +106,6 @@
 		<string>FiraSans-SemiBold.ttf</string>
 		<string>FiraSans-UltraLight.ttf</string>
 	</array>
-	<key>UIApplicationShortcutItems</key>
-	<array>
-        <dict>
-            <key>UIApplicationShortcutItemIconFile</key>
-            <string>quick_action_new_tab</string>
-            <key>UIApplicationShortcutItemTitle</key>
-            <string>ShortcutItemTitleNewTab</string>
-            <key>UIApplicationShortcutItemType</key>
-            <string>$(PRODUCT_BUNDLE_IDENTIFIER).NewTab</string>
-        </dict>
-        <dict>
-            <key>UIApplicationShortcutItemIconFile</key>
-            <string>quick_action_new_private_tab</string>
-            <key>UIApplicationShortcutItemTitle</key>
-            <string>ShortcutItemTitleNewPrivateTab</string>
-            <key>UIApplicationShortcutItemType</key>
-            <string>$(PRODUCT_BUNDLE_IDENTIFIER).NewPrivateTab</string>
-        </dict>
-	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -108,14 +108,22 @@
 	</array>
 	<key>UIApplicationShortcutItems</key>
 	<array>
-		<dict>
-			<key>UIApplicationShortcutItemIconFile</key>
-			<string>quick_action_new_tab</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>ShortcutItemTitleNewTab</string>
-			<key>UIApplicationShortcutItemType</key>
-			<string>$(PRODUCT_BUNDLE_IDENTIFIER).NewTab</string>
-		</dict>
+        <dict>
+            <key>UIApplicationShortcutItemIconFile</key>
+            <string>quick_action_new_tab</string>
+            <key>UIApplicationShortcutItemTitle</key>
+            <string>ShortcutItemTitleNewTab</string>
+            <key>UIApplicationShortcutItemType</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER).NewTab</string>
+        </dict>
+        <dict>
+            <key>UIApplicationShortcutItemIconFile</key>
+            <string>quick_action_new_private_tab</string>
+            <key>UIApplicationShortcutItemTitle</key>
+            <string>ShortcutItemTitleNewPrivateTab</string>
+            <key>UIApplicationShortcutItemType</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER).NewPrivateTab</string>
+        </dict>
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-ios/issues/1258

Added New Private Tab quick action:

![image](https://user-images.githubusercontent.com/1530031/61302090-33b51200-a7b3-11e9-9bf5-95cb4f60a827.png)

Quick actions are dynamic.

If the application has NEVER launched, the actions will only show "Share Brave".
However, after the first launch, the actions will depend on what mode you're browsing in:

**Private Browsing Only Mode:**
New Private Tab -> Launches only private tabs.

**Any Other Mode:**
New Tab -> Launches a regular tab.
New Private Tab -> Launches a new private tab.


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

