### PR TITLE
Fixes #1263 Removed redundant check for loadQueue and moved the queue to deferred

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -57,7 +57,7 @@ class BrowserViewController: UIViewController {
     fileprivate let alertStackView = UIStackView() // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
     fileprivate var findInPageBar: FindInPageBar?
     
-    var loadQueue = DeferredCountable<Void>()
+    var loadQueue = Deferred<Void>()
 
     lazy var mailtoLinkHandler: MailtoLinkHandler = MailtoLinkHandler()
 
@@ -448,23 +448,21 @@ class BrowserViewController: UIViewController {
     
     fileprivate func setupTabs() {
         contentBlockListDeferred?.uponQueue(.main) { _ in
-            if self.loadQueue.isEmpty {
-                let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
-                let noTabsAdded = self.tabManager.tabsForCurrentMode.isEmpty
-                
-                var tabToSelect: Tab?
-                
-                if noTabsAdded {
-                    // Two scenarios if there are no tabs in tabmanager:
-                    // 1. We have not restored tabs yet, attempt to restore or make a new tab if there is nothing.
-                    // 2. We are in private browsing mode and need to add a new private tab.
-                    tabToSelect = isPrivate ? self.tabManager.addTab(isPrivate: true) : self.tabManager.restoreAllTabs()
-                } else {
-                    tabToSelect = self.tabManager.tabsForCurrentMode.last
-                }
-                self.tabManager.selectTab(tabToSelect)
+            let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
+            let noTabsAdded = self.tabManager.tabsForCurrentMode.isEmpty
+            
+            var tabToSelect: Tab?
+            
+            if noTabsAdded {
+                // Two scenarios if there are no tabs in tabmanager:
+                // 1. We have not restored tabs yet, attempt to restore or make a new tab if there is nothing.
+                // 2. We are in private browsing mode and need to add a new private tab.
+                tabToSelect = isPrivate ? self.tabManager.addTab(isPrivate: true) : self.tabManager.restoreAllTabs()
+            } else {
+                tabToSelect = self.tabManager.tabsForCurrentMode.last
             }
-            self.loadQueue.fill(())
+            self.tabManager.selectTab(tabToSelect)
+            self.loadQueue.fillIfUnfilled(())
         }
     }
 
@@ -2991,37 +2989,14 @@ extension BrowserViewController: PreferencesObserver {
 
 extension BrowserViewController {
     func openReferralLink(url: URL) {
-        self.loadQueue.upon {
+        self.loadQueue.uponQueue(.main) {
             self.openURLInNewTab(url, isPrivileged: false)
         }
     }
     
     func handleNavigationPath(path: NavigationPath) {
-        self.loadQueue.upon {
+        self.loadQueue.uponQueue(.main) {
             NavigationPath.handle(nav: path, with: self)
         }
-    }
-}
-
-//Provides a bool to query if tasks are pending on main queue.
-class DeferredCountable<T> {
-    private var count = 0
-    private var await = Deferred<T>()
-    
-    func upon(_ block: @escaping (T) -> Void) {
-        let executionBlock: (T) -> Void = { [unowned self] _ in
-            self.count -= 1
-            block(self.await.value)
-        }
-        count += 1
-        await.uponQueue(.main, block: executionBlock)
-    }
-    
-    func fill(_ value: T) {
-        await.fillIfUnfilled(value)
-    }
-    
-    var isEmpty: Bool {
-        return count == 0
     }
 }


### PR DESCRIPTION
Fixes: #1263 
The issue was caused by the `isEmpty` check. It was added for a logic that was obsolete after a review change.
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

