### PR TITLE
Fix #661: Open in Brave now opens the first URL found in share content

### DIFF
--- a/BraveShareTo/ShareToBraveViewController.swift
+++ b/BraveShareTo/ShareToBraveViewController.swift
@@ -13,6 +13,19 @@ class ShareToBraveViewController: SLComposeServiceViewController {
         return URL(string: "brave://open-url?url=\(url)")
     }
     
+    private func firstURL(in string: String) -> URL? {
+        do {
+            let detector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+            if let match = detector.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.count)),
+                let range = Range(match.range, in: string) {
+                return URL(string: String(string[range]))
+            }
+        } catch {
+            return nil
+        }
+        return nil
+    }
+    
     override func configurationItems() -> [Any]! {
         guard let inputItems = extensionContext?.inputItems as? [NSExtensionItem] else {
             return []
@@ -33,19 +46,22 @@ class ShareToBraveViewController: SLComposeServiceViewController {
         }
         
         provider.loadItem(of: provider.isUrl ? kUTTypeURL : kUTTypeText) { item, error in
-            var urlItem: URL!
+            var urlItem: URL?
             
             // We can get urls from other apps as a kUTTypeText type, for example from Apple's mail.app.
             if let text = item as? String {
-                urlItem = URL(string: text)
+                urlItem = self.firstURL(in: text)
             } else if let url = item as? URL {
-                urlItem = url
+                urlItem = self.firstURL(in: url.absoluteString)
             } else {
                 self.cancel()
                 return
             }
             
-            if let braveUrl = urlItem.absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics).flatMap(self.urlScheme) {
+            // Just open the app if we don't find a url. In the future we could
+            // use this entry point to search instead of open a given URL
+            let urlString = urlItem?.absoluteString ?? ""
+            if let braveUrl = urlString.addingPercentEncoding(withAllowedCharacters: .alphanumerics).flatMap(self.urlScheme) {
                 self.handleUrl(braveUrl)
             }
         }

--- a/BraveShareTo/ShareToBraveViewController.swift
+++ b/BraveShareTo/ShareToBraveViewController.swift
@@ -5,25 +5,13 @@
 import UIKit
 import Social
 import MobileCoreServices
+import BraveShared
 
 class ShareToBraveViewController: SLComposeServiceViewController {
     
     // TODO: Separate scheme for debug builds, so it can be tested without need to uninstall production app.
     private func urlScheme(for url: String) -> URL? {
         return URL(string: "brave://open-url?url=\(url)")
-    }
-    
-    private func firstURL(in string: String) -> URL? {
-        do {
-            let detector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-            if let match = detector.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.count)),
-                let range = Range(match.range, in: string) {
-                return URL(string: String(string[range]))
-            }
-        } catch {
-            return nil
-        }
-        return nil
     }
     
     override func configurationItems() -> [Any]! {
@@ -50,9 +38,9 @@ class ShareToBraveViewController: SLComposeServiceViewController {
             
             // We can get urls from other apps as a kUTTypeText type, for example from Apple's mail.app.
             if let text = item as? String {
-                urlItem = self.firstURL(in: text)
+                urlItem = text.firstURL
             } else if let url = item as? URL {
-                urlItem = self.firstURL(in: url.absoluteString)
+                urlItem = url.absoluteString.firstURL
             } else {
                 self.cancel()
                 return

--- a/BraveShared/Extensions/StringExtensions.swift
+++ b/BraveShared/Extensions/StringExtensions.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+extension String {
+    /// The first URL found within this String, or nil if no URL is found
+    public var firstURL: URL? {
+        if let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue),
+            let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.count)),
+            let range = Range(match.range, in: self) {
+            return URL(string: String(self[range]))
+        }
+        return nil
+    }
+}

--- a/BraveSharedTests/StringExtensionTests.swift
+++ b/BraveSharedTests/StringExtensionTests.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import BraveShared
+
+class StringExtensionTests: XCTestCase {
+
+    func testFirstURL() {
+        let urlString = "https://brave.com"
+        let url = URL(string: urlString)!
+        XCTAssertEqual(urlString, url.absoluteString)
+        
+        let prefixedString = "Prefixed Text then the URL: \(urlString)"
+        XCTAssertEqual(url, prefixedString.firstURL)
+        
+        let postfixedString = "\(urlString) The url is before this text"
+        XCTAssertEqual(url, postfixedString.firstURL)
+        
+        let stringWithMultipleURLs = "\(urlString) This one has more than one url https://duckduckgo.com"
+        XCTAssertEqual(url, stringWithMultipleURLs.firstURL)
+        
+        let stringWithNoURLs = "This one is just text"
+        XCTAssertNil(stringWithNoURLs.firstURL)
+        
+        let schemelessURL = "brave.com"
+        XCTAssertNotNil(schemelessURL.firstURL)
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -144,6 +144,9 @@
 		27658271217130D900754B2F /* GlobalSign_r1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2765826E217130D900754B2F /* GlobalSign_r1.cer */; };
 		27658272217130D900754B2F /* GlobalSign_r3.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2765826F217130D900754B2F /* GlobalSign_r3.cer */; };
 		27658273217130D900754B2F /* DigiCertHighAssurance.cer in Resources */ = {isa = PBXBuildFile; fileRef = 27658270217130D900754B2F /* DigiCertHighAssurance.cer */; };
+		2777273722EB43A100F0214C /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777273622EB43A100F0214C /* StringExtensions.swift */; };
+		2777274022EB44B300F0214C /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777273F22EB44B300F0214C /* StringExtensionTests.swift */; };
+		2777275A22EB4C7700F0214C /* BraveShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DE7688420B3456C00FF5533 /* BraveShared.framework */; };
 		2795274A21A890EB00921AA1 /* FingerprintingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */; };
 		2798E01D213EFC3F003EDBB1 /* FavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */; };
 		279C756B219DDE3B001CD1CB /* FingerprintingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */; };
@@ -512,9 +515,9 @@
 		5DE768B120B4713000FF5533 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		5E3477E922D7771700B0D5F8 /* ResourceDownloader.js in Resources */ = {isa = PBXBuildFile; fileRef = 5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */; };
 		5E34781022D7A1D200B0D5F8 /* ResourceDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */; };
-		5E9288CA22DF864C007BE7A6 /* TabSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9288C922DF864C007BE7A6 /* TabSessionTests.swift */; };
 		5E4845C022DE381200372022 /* WindowRenderHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 5E4845BF22DE381200372022 /* WindowRenderHelper.js */; };
 		5E4845C222DE3DF800372022 /* WindowRenderHelperScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4845C122DE3DF800372022 /* WindowRenderHelperScript.swift */; };
+		5E9288CA22DF864C007BE7A6 /* TabSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9288C922DF864C007BE7A6 /* TabSessionTests.swift */; };
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
 		744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */; };
 		7479B4EF1C5306A200DF000B /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7479B4ED1C5306A200DF000B /* Reachability.swift */; };
@@ -1292,6 +1295,8 @@
 		2765826E217130D900754B2F /* GlobalSign_r1.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = GlobalSign_r1.cer; sourceTree = "<group>"; };
 		2765826F217130D900754B2F /* GlobalSign_r3.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = GlobalSign_r3.cer; sourceTree = "<group>"; };
 		27658270217130D900754B2F /* DigiCertHighAssurance.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = DigiCertHighAssurance.cer; sourceTree = "<group>"; };
+		2777273622EB43A100F0214C /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+		2777273F22EB44B300F0214C /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintingProtectionTests.swift; sourceTree = "<group>"; };
 		2798E015213EFC3F003EDBB1 /* FavoriteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteTests.swift; sourceTree = "<group>"; };
 		279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintingProtection.swift; sourceTree = "<group>"; };
@@ -1882,9 +1887,9 @@
 		5DE768AF20B4601600FF5533 /* UIColorExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
 		5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ResourceDownloader.js; sourceTree = "<group>"; };
 		5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManager.swift; sourceTree = "<group>"; };
-		5E9288C922DF864C007BE7A6 /* TabSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSessionTests.swift; sourceTree = "<group>"; };
 		5E4845BF22DE381200372022 /* WindowRenderHelper.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = WindowRenderHelper.js; sourceTree = "<group>"; };
 		5E4845C122DE3DF800372022 /* WindowRenderHelperScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowRenderHelperScript.swift; sourceTree = "<group>"; };
+		5E9288C922DF864C007BE7A6 /* TabSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSessionTests.swift; sourceTree = "<group>"; };
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MailtoLinkHandler.swift; sourceTree = "<group>"; };
 		7479B4ED1C5306A200DF000B /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ThirdParty/Reachability.swift; sourceTree = "<group>"; };
@@ -2266,6 +2271,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2777275A22EB4C7700F0214C /* BraveShared.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2630,6 +2636,7 @@
 				A1510DA020E409E9008BF1F4 /* URLCacheExtensions.swift */,
 				0A4214F621AC0AFF006B8E39 /* TimeExtensions.swift */,
 				0AAAACAC22491CC7009A8763 /* ErrorExtensions.swift */,
+				2777273622EB43A100F0214C /* StringExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3449,6 +3456,7 @@
 				0A42150021AC0E8E006B8E39 /* TimeExtensionTests.swift */,
 				5DE7689520B3456E00FF5533 /* Info.plist */,
 				5965CA212215D4A0000B9EC1 /* CustomHeaderDataTests.swift */,
+				2777273F22EB44B300F0214C /* StringExtensionTests.swift */,
 			);
 			path = BraveSharedTests;
 			sourceTree = "<group>";
@@ -3651,7 +3659,6 @@
 				D0C95DF9200EAE5E00E4E51C /* NoImageModeHelper.js */,
 				D0C95E03200FCA8800E4E51C /* ReaderMode.js */,
 				D0006623204728A8009BA6F6 /* TrackingProtectionStats.js */,
-				5E4845BF22DE381200372022 /* WindowRenderHelper.js */,
 			);
 			path = AtDocumentStart;
 			sourceTree = "<group>";
@@ -5593,6 +5600,7 @@
 				0AD5E9C42200591F00D0D91B /* BraveShield.swift in Sources */,
 				5DE768A920B3461300FF5533 /* BraveUX.swift in Sources */,
 				2765825D2171263A00754B2F /* UserReferralProgram.swift in Sources */,
+				2777273722EB43A100F0214C /* StringExtensions.swift in Sources */,
 				276582692171266900754B2F /* ReferralData.swift in Sources */,
 				5DE768B020B4601700FF5533 /* UIColorExtensions.swift in Sources */,
 				5DE768AE20B443E500FF5533 /* JSONSerializationExtensions.swift in Sources */,
@@ -5612,6 +5620,7 @@
 			files = (
 				A176323C20CF2AF900126F25 /* DeferredTestUtils.swift in Sources */,
 				5DE7689420B3456E00FF5533 /* BraveSharedTests.swift in Sources */,
+				2777274022EB44B300F0214C /* StringExtensionTests.swift in Sources */,
 				27A586E1214C0DDD000CAE3C /* PreferencesTest.swift in Sources */,
 				5965CA222215D4A0000B9EC1 /* CustomHeaderDataTests.swift in Sources */,
 				5D6DDF0021428CF0001FF0AE /* DAUTests.swift in Sources */,

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -47,7 +47,8 @@ enum NavigationPath: Equatable {
         if urlString.starts(with: "\(scheme)://deep-link"), let deepURL = components.valueForQuery("url"), let link = DeepLink(urlString: deepURL) {
             self = .deepLink(link)
         } else if urlString.starts(with: "\(scheme)://open-url") {
-            let url = components.valueForQuery("url")?.asURL
+            let urlText = components.valueForQuery("url")
+            let url = URIFixup.getURL(urlText ?? "") ?? urlText?.asURL
             let forcedPrivate = Preferences.Privacy.privateBrowsingOnly.value || PrivateBrowsingManager.shared.isPrivateBrowsing
             let isPrivate = Bool(components.valueForQuery("private") ?? "") ?? forcedPrivate
             self = .url(webURL: url, isPrivate: isPrivate)


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.

## Test Plan:

- Test that regular shared links work (Safari > Share button > Open In Brave)
- Test that sharing non-URL's fails silently (Safari > Select text on page > Share… > Open In Brave). In the future this can be used to _search_ for said text instead of just open a new tab
- Test that opening text that _contains_ a link in it works (example apps that share both title & URL: Feedly, Reeder)

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

