### PR TITLE
Fix #1268: Fix YubiKey workflow for fw 5.2.1

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -95,8 +95,8 @@ class UserScriptManager {
         
         var alteredSource = source
         let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
-        alteredSource = alteredSource.replacingOccurrences(of: "$<webauthn>", with: "W\(token)", options: .literal)
-        alteredSource = alteredSource.replacingOccurrences(of: "$<u2f>", with: "U\(token)", options: .literal)
+        alteredSource = alteredSource.replacingOccurrences(of: "$<webauthn>", with: "fido2\(token)", options: .literal)
+        alteredSource = alteredSource.replacingOccurrences(of: "$<u2f>", with: "fido\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<pkc>", with: "pkp\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<assert>", with: "assert\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<attest>", with: "attest\(token)", options: .literal)

--- a/Client/U2FExtensions.swift
+++ b/Client/U2FExtensions.swift
@@ -238,10 +238,8 @@ class U2FExtensions: NSObject {
             param.alg = publicKeyCred.alg
             makeCredentialRequest.pubKeyCredParams = [param]
             
-            let userVerification = publicKey.authenticatorSelection?.userVerification ?? ""
             let makeOptions = [
-                YKFKeyFIDO2MakeCredentialRequestOptionRK: publicKey.authenticatorSelection?.requireResidentKey ?? false,
-                YKFKeyFIDO2MakeCredentialRequestOptionUV: userVerification == "required"
+                YKFKeyFIDO2MakeCredentialRequestOptionRK: publicKey.authenticatorSelection?.requireResidentKey ?? false
             ]
             makeCredentialRequest.options = makeOptions
             
@@ -368,14 +366,7 @@ class U2FExtensions: NSObject {
                 return
             }
             getAssertionRequest.clientDataHash = clientDataHash
-            
-            // userPresence is set to the inverse of userVerification
-            // https://www.w3.org/TR/webauthn/#user-verification
-            getAssertionRequest.options = [
-                YKFKeyFIDO2GetAssertionRequestOptionUP: !request.userVerification,
-                YKFKeyFIDO2GetAssertionRequestOptionUV: request.userVerification
-            ]
-            
+
             var allowList = [YKFFIDO2PublicKeyCredentialDescriptor]()
             for credentialId in request.allowCredentials {
                 let credentialDescriptor = YKFFIDO2PublicKeyCredentialDescriptor()

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -7,8 +7,7 @@ struct WebAuthnAuthenticateRequest {
     var rpID: String?
     var challenge: String
     var allowCredentials: [String] = []
-    var userVerification: Bool
-    
+
     enum RequestKeys: String, CodingKey {
         case publicKey
     }
@@ -18,7 +17,6 @@ struct WebAuthnAuthenticateRequest {
         case challenge
         case allowCredentials
         case authenticatorSelection
-        case userVerification
     }
 }
 
@@ -34,8 +32,6 @@ extension WebAuthnAuthenticateRequest: Decodable {
         
         rpID = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .rpId)
         challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)
-        let userVerifcationString = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .userVerification) ?? ""
-        userVerification = userVerifcationString == "required"
         
         let allowCredentialsArray = try publicKeyDictionary.decode([AllowCredentials].self, forKey: .allowCredentials)
     

--- a/Client/WebAuthN/WebAuthnRegisterRequest.swift
+++ b/Client/WebAuthN/WebAuthnRegisterRequest.swift
@@ -24,7 +24,6 @@ struct WebAuthnRegisterRequest: Decodable {
         // If present the two keys may or may not be present
         struct AuthenticatorSelection: Decodable {
             var requireResidentKey: Bool?
-            var userVerification: String?
         }
         
         let authenticatorSelection: AuthenticatorSelection?


### PR DESCRIPTION
fix https://github.com/brave/brave-ios/issues/1268

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

1. Using the YubiKey with fw 5.2.1, navigate to demo.yubico.com/u2f
2. Complete the registration/login workflow

<!-- Any useful notes for reviewer explaining how best to test and verify. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)