### PR TITLE
Fixed issue #1280 by creating a stackView for tab buttons

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -188,11 +188,9 @@ class TabLocationView: UIView {
         return button
     }()
     
-    lazy var separatorLine: UIView = {
-        let line = UIView()
-        line.layer.cornerRadius = 2
-        return line
-    }()
+    lazy var separatorLine: UIView = CustomSeparatorView(lineSize: .init(width: 1, height: 26), cornerRadius: 2)
+    
+    lazy var tabOptionsStackView = UIStackView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -208,33 +206,25 @@ class TabLocationView: UIView {
         addGestureRecognizer(longPressRecognizer)
         addGestureRecognizer(tapRecognizer)
         
-        let buttonContentEdgeInsets = UIEdgeInsets(top: 6, left: 6, bottom: 6, right: 6)
+        var optionSubviews = [readerModeButton, reloadButton, separatorLine, shieldsButton]
+        separatorLine.isUserInteractionEnabled = false
         
-        #if NO_REWARDS
-        [readerModeButton, reloadButton, separatorLine, shieldsButton].forEach {
-            $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-            $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        }
-        
-        let buttonsStackview = UIStackView(arrangedSubviews: [shieldsButton])
-        
-        shieldsButton.contentEdgeInsets = buttonContentEdgeInsets
-        #else
-        [readerModeButton, reloadButton, separatorLine, shieldsButton, rewardsButton].forEach {
-            $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-            $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        }
-        
-        let buttonsStackview = UIStackView(arrangedSubviews: [shieldsButton, rewardsButton])
-        
-        shieldsButton.contentEdgeInsets = buttonContentEdgeInsets
-        rewardsButton.contentEdgeInsets = buttonContentEdgeInsets
-        
+        #if !NO_REWARDS
+        optionSubviews.append(rewardsButton)
         #endif
         
+        let buttonContentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+        optionSubviews.forEach {
+            ($0 as? CustomSeparatorView)?.layoutMargins = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: 2)
+            ($0 as? UIButton)?.contentEdgeInsets = buttonContentEdgeInsets
+            $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+            $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        }
+        optionSubviews.forEach(tabOptionsStackView.addArrangedSubview)
+        
         urlTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
-
-        let subviews = [lockImageView, urlTextField, readerModeButton, reloadButton, separatorLine, buttonsStackview]
+        
+        let subviews = [lockImageView, urlTextField, tabOptionsStackView]
         contentView = UIStackView(arrangedSubviews: subviews)
         contentView.distribution = .fill
         contentView.alignment = .center
@@ -242,28 +232,18 @@ class TabLocationView: UIView {
         contentView.isLayoutMarginsRelativeArrangement = true
         contentView.insetsLayoutMarginsFromSafeArea = false
         contentView.spacing = 10
+        contentView.setCustomSpacing(5, after: urlTextField)
+        
+        tabOptionsStackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 6)
+        tabOptionsStackView.isLayoutMarginsRelativeArrangement = true
         addSubview(contentView)
         
-        // Reduce spacing after separator to make space for shields button tappable area.
-        contentView.setCustomSpacing(2, after: separatorLine)
-
         contentView.snp.makeConstraints { make in
-            make.leading.top.bottom.equalTo(self)
-            make.trailing.equalTo(self).inset(6)
+            make.leading.trailing.top.bottom.equalTo(self)
         }
         
-        lockImageView.snp.makeConstraints { make in
-            make.height.equalTo(TabLocationViewUX.ButtonSize)
-        }
-        
-        separatorLine.snp.makeConstraints { make in
-            make.width.equalTo(1)
-            make.height.equalTo(26)
-        }
-        
-        readerModeButton.snp.makeConstraints { make in
-            make.size.width.equalTo(TabLocationViewUX.ButtonSize.width)
-            make.size.height.equalTo(TabLocationViewUX.ButtonSize.height)
+        tabOptionsStackView.snp.makeConstraints { make in
+            make.top.bottom.equalTo(contentView)
         }
 
         // Setup UIDragInteraction to handle dragging the location
@@ -365,6 +345,13 @@ extension TabLocationView: UIGestureRecognizerDelegate {
         // If the longPressRecognizer is active, fail the tap recognizer to avoid conflicts.
         return gestureRecognizer == longPressRecognizer && otherGestureRecognizer == tapRecognizer
     }
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if gestureRecognizer == tapRecognizer && touch.view == tabOptionsStackView {
+            return false
+        }
+        return true
+    }
 }
 
 // MARK: - UIDragInteractionDelegate
@@ -441,5 +428,35 @@ private class DisplayTextField: UITextField {
 
     fileprivate override var canBecomeFirstResponder: Bool {
         return false
+    }
+}
+
+private class CustomSeparatorView: UIView {
+    
+    private let innerView: UIView
+    init(lineSize: CGSize, cornerRadius: CGFloat = 0) {
+        innerView = UIView(frame: .init(origin: .zero, size: lineSize))
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        innerView.layer.cornerRadius = cornerRadius
+        addSubview(innerView)
+        innerView.snp.makeConstraints {
+            $0.width.height.equalTo(lineSize)
+            $0.centerY.equalTo(self)
+            $0.leading.trailing.equalTo(self.layoutMarginsGuide)
+        }
+    }
+    
+    override var backgroundColor: UIColor? {
+        get {
+            return innerView.backgroundColor
+        }
+        set {
+            innerView.backgroundColor = newValue
+        }
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }


### PR DESCRIPTION
Added a stack view to hold all the tab options, doing this any touch in the stack view is handled in `UIGestureRecognizerDelegate-> shouldReceive` if not tapped on a UIControl.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:
Tap on edges of the buttons to try to replicate the bug reported in #1280 
<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:
Various states:
<img width="376" alt="Screenshot 2019-07-25 at 10 53 55 PM" src="https://user-images.githubusercontent.com/5398557/61895108-7c956500-af2f-11e9-9c36-c5f2f0ef210c.png">
<img width="374" alt="Screenshot 2019-07-25 at 10 54 35 PM" src="https://user-images.githubusercontent.com/5398557/61895109-7c956500-af2f-11e9-82f1-29afb27714fa.png">
<img width="373" alt="Screenshot 2019-07-25 at 10 55 18 PM" src="https://user-images.githubusercontent.com/5398557/61895110-7c956500-af2f-11e9-96a5-bc3d376f5495.png">
<img width="372" alt="Screenshot 2019-07-25 at 10 55 52 PM" src="https://user-images.githubusercontent.com/5398557/61895111-7c956500-af2f-11e9-82a9-4514172aecd0.png">

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

