### PR TITLE
Fixes: #902 - Feature/media background playback

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -470,6 +470,7 @@ extension Strings {
     public static let Block_Popups = NSLocalizedString("BlockPopups", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Block Popups", comment: "Setting to enable popup blocking")
     public static let Media_Auto_Plays = NSLocalizedString("MediaAutoPlays", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Enable background video autoplay", comment: "Setting to allow media to play automatically")
     public static let Show_Tabs_Bar = NSLocalizedString("ShowTabsBar", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Show Tabs Bar", comment: "Setting to show/hide the tabs bar")
+    public static let AllowBackgroundMediaPlayback = NSLocalizedString("AllowBackgroundMediaPlayback", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Allow background media playback", comment: "Setting to enable Background media playback")
     public static let Private_Browsing_Only = NSLocalizedString("PrivateBrowsingOnly", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Private Browsing Only", comment: "Setting to keep app in private mode")
     public static let Brave_Shield_Defaults = NSLocalizedString("BraveShieldDefaults", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Brave Shield Defaults", comment: "Section title for adbblock, tracking protection, HTTPS-E, and cookies")
     public static let Block_Ads_and_Tracking = NSLocalizedString("BlockAdsAndTracking", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Block Ads & Tracking", comment: "")

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -674,6 +674,8 @@
 		5EC594F1232C697200922111 /* OnboardingAdsCountdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC594F0232C697200922111 /* OnboardingAdsCountdownView.swift */; };
 		5EE5918123A290E000E8E8DE /* CoreNFC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F926647A234D4EF400359492 /* CoreNFC.framework */; };
 		5EEB25DE234E667700279091 /* CertificatePinningTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EEB25DD234E667700279091 /* CertificatePinningTest.swift */; };
+		5EB0606022EB4EDF001BE9CA /* BackgroundMediaPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB0605F22EB4EDF001BE9CA /* BackgroundMediaPlayback.swift */; };
+		5EB0606222EB5322001BE9CA /* BackgroundPlay.js in Resources */ = {isa = PBXBuildFile; fileRef = 5EB0606122EB5322001BE9CA /* BackgroundPlay.js */; };
 		744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */; };
 		7479B4EF1C5306A200DF000B /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7479B4ED1C5306A200DF000B /* Reachability.swift */; };
 		74821FFE1DB6D3AC00EEEA72 /* MailSchemes.plist in Resources */ = {isa = PBXBuildFile; fileRef = 74821FFD1DB6D3AC00EEEA72 /* MailSchemes.plist */; };
@@ -2108,6 +2110,8 @@
 		5EC594EE232C68FC00922111 /* OnboardingAdsCountdownViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAdsCountdownViewController.swift; sourceTree = "<group>"; };
 		5EC594F0232C697200922111 /* OnboardingAdsCountdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAdsCountdownView.swift; sourceTree = "<group>"; };
 		5EEB25DD234E667700279091 /* CertificatePinningTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatePinningTest.swift; sourceTree = "<group>"; };
+        5EB0605F22EB4EDF001BE9CA /* BackgroundMediaPlayback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMediaPlayback.swift; sourceTree = "<group>"; };
+		5EB0606122EB5322001BE9CA /* BackgroundPlay.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = BackgroundPlay.js; sourceTree = "<group>"; };
 		610967E5236B41C9000F10EA /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6117A72C236B41D000921BFB /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		6129BC4D236B417A004CAD4D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -4147,6 +4151,7 @@
 				5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */,
 				5E4845BF22DE381200372022 /* WindowRenderHelper.js */,
 				5EB57D0122FDC0CB00A07325 /* FullscreenHelper.js */,
+				5EB0606122EB5322001BE9CA /* BackgroundPlay.js */,
 			);
 			path = UserScripts;
 			sourceTree = "<group>";
@@ -4327,6 +4332,7 @@
 				5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */,
 				5E4845C122DE3DF800372022 /* WindowRenderHelperScript.swift */,
 				0A19365323508756002E2B81 /* LinkPreviewViewController.swift */,
+				5EB0605F22EB4EDF001BE9CA /* BackgroundMediaPlayback.swift */,
 			);
 			indentWidth = 4;
 			path = Browser;
@@ -5512,6 +5518,7 @@
 				E4B7B7781A793CF20022C5E0 /* FiraSans-Italic.ttf in Resources */,
 				5D53749D23846FFC00A2B587 /* dc-cavalleri.jpg in Resources */,
 				5EC1DDBD2356888000CA4028 /* onboarding-rewards.json in Resources */,
+				5EB0606222EB5322001BE9CA /* BackgroundPlay.js in Resources */,
 				0BA1E00E1B03FB0B007675AF /* NetError.html in Resources */,
 				5DE5250E218CE92C000DFAA6 /* block-images.json in Resources */,
 				5D5374A823846FFC00A2B587 /* annie-spratt.jpg in Resources */,
@@ -6054,6 +6061,7 @@
 				A13AC72520EC12360040D4BB /* Migration.swift in Sources */,
 				27FD2CAB2146C31C00A5A779 /* RequestDesktopSiteActivity.swift in Sources */,
 				3BCE6D3C1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift in Sources */,
+				5EB0606022EB4EDF001BE9CA /* BackgroundMediaPlayback.swift in Sources */,
 				4422D55A21BFFB7F00BF1855 /* regexp.cc in Sources */,
 				0A7B5D722269E7AD00AADF22 /* BookmarkEditMode.swift in Sources */,
 				4422D4DC21BFFB7600BF1855 /* block_builder.cc in Sources */,

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -39,6 +39,8 @@ extension Preferences {
         static let saveLogins = Option<Bool>(key: "general.save-logins", default: true)
         /// Whether or not to block popups from websites automaticaly
         static let blockPopups = Option<Bool>(key: "general.block-popups", default: true)
+        /// Control whether or not to allow media to play in the background
+        static let allowBackgroundMediaPlayback = Option<Bool>(key: "general.allow-background-media-playback", default: false)
         /// Controls how the tab bar should be shown (or not shown)
         static let tabBarVisibility = Option<Int>(key: "general.tab-bar-visiblity", default: TabBarVisibility.always.rawValue)
         /// Defines the user's normal browsing theme

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     var rootViewController: UIViewController!
     weak var profile: Profile?
     var tabManager: TabManager!
+    var backgroundMediaHandler: BackgroundMediaHandler?
 
     weak var application: UIApplication?
     var launchOptions: [AnyHashable: Any]?
@@ -122,6 +123,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             class_addMethod(clazz, MenuHelper.SelectorFindInPage, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
         }
 
+        backgroundMediaHandler = BackgroundMediaHandler(profile: profile)
         self.tabManager = TabManager(prefs: profile.prefs, imageStore: imageStore)
 
         // Make sure current private browsing flag respects the private browsing only user preference
@@ -162,6 +164,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         self.tabManager = nil
         self.browserViewController = nil
         self.rootViewController = nil
+        self.backgroundMediaHandler = nil
     }
 
     /**
@@ -338,7 +341,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 //                application.endBackgroundTask(taskId)
 //            }
 //        } else {
-            profile.shutdown()
+            self.backgroundMediaHandler?.requestShutdown()
             application.endBackgroundTask(taskId)
 //        }
     }
@@ -349,7 +352,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             return
         }
 
-        profile?.shutdown()
+        self.backgroundMediaHandler?.requestShutdown()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -90,6 +90,7 @@ fileprivate extension Preferences {
         migrate(key: "blockPopups", to: Preferences.General.blockPopups)
         migrate(key: "kPrefKeyTabsBarShowPolicy", to: Preferences.General.tabBarVisibility)
         migrate(key: "NightModeStatus", to: Preferences.General.nightMode)
+        migrate(key: "allowBackgroundMediaPlayback", to: Preferences.General.allowBackgroundMediaPlayback)
         
         // Search
         migrate(key: "search.orderedEngineNames", to: Preferences.Search.orderedEngines)

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -90,7 +90,6 @@ fileprivate extension Preferences {
         migrate(key: "blockPopups", to: Preferences.General.blockPopups)
         migrate(key: "kPrefKeyTabsBarShowPolicy", to: Preferences.General.tabBarVisibility)
         migrate(key: "NightModeStatus", to: Preferences.General.nightMode)
-        migrate(key: "allowBackgroundMediaPlayback", to: Preferences.General.allowBackgroundMediaPlayback)
         
         // Search
         migrate(key: "search.orderedEngineNames", to: Preferences.Search.orderedEngines)

--- a/Client/Frontend/Browser/BackgroundMediaPlayback.swift
+++ b/Client/Frontend/Browser/BackgroundMediaPlayback.swift
@@ -84,7 +84,6 @@ class BackgroundMediaPlayback: TabContentScript {
     
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
         if let response = message.body as? String {
-            debugPrint(response)
             log.info(response)
         } else {
             log.info(message.description)

--- a/Client/Frontend/Browser/BackgroundMediaPlayback.swift
+++ b/Client/Frontend/Browser/BackgroundMediaPlayback.swift
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import AVFoundation
+import Shared
+import WebKit
+
+private let log = Logger.browserLogger
+
+class BackgroundMediaHandler {
+    private var canCleanup = false
+    private var isActive = false
+    private var shutdownRequested = false
+    private weak var profile: Profile?
+    
+    init(profile: Profile) {
+        self.profile = profile
+        
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, options: [.allowAirPlay, .allowBluetooth, .allowBluetoothA2DP, .duckOthers])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            log.error(error)
+        }
+    }
+    
+    deinit {
+        deactivateBackgroundPlayback()
+    }
+    
+    func activateBackgroundPlayback() {
+        if isActive {
+            return
+        }
+        
+        isActive = true
+    }
+    
+    func deactivateBackgroundPlayback() {
+        if !isActive {
+            return
+        }
+        
+        isActive = false
+        
+        if shutdownRequested {
+            shutdownRequested = false
+            
+            profile?.shutdown()
+        }
+    }
+    
+    func requestShutdown() {
+        defer { shutdownRequested = true }
+        if isActive {
+            return
+        }
+        
+        if UIApplication.shared.applicationState == .background {
+            return
+        }
+        
+        profile?.shutdown()
+    }
+}
+
+class BackgroundMediaPlayback: TabContentScript {
+    fileprivate weak var tab: Tab?
+    
+    init(tab: Tab) {
+        self.tab = tab
+    }
+    
+    static func name() -> String {
+        return "BackgroundMediaPlayback"
+    }
+    
+    func scriptMessageHandlerName() -> String? {
+        return "backgroundMediaPlayback"
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        if let response = message.body as? String {
+            debugPrint(response)
+            log.info(response)
+        } else {
+            log.info(message.description)
+        }
+    }
+}

--- a/Client/Frontend/Browser/BackgroundMediaPlayback.swift
+++ b/Client/Frontend/Browser/BackgroundMediaPlayback.swift
@@ -5,6 +5,7 @@
 import Foundation
 import AVFoundation
 import Shared
+import BraveShared
 import WebKit
 
 private let log = Logger.browserLogger
@@ -67,7 +68,7 @@ class BackgroundMediaHandler {
 }
 
 class BackgroundMediaPlayback: TabContentScript {
-    fileprivate weak var tab: Tab?
+    private weak var tab: Tab?
     
     init(tab: Tab) {
         self.tab = tab
@@ -88,5 +89,22 @@ class BackgroundMediaPlayback: TabContentScript {
         } else {
             log.info(message.description)
         }
+    }
+    
+    static func pauseAllMedia(for webview: WKWebView) {
+        let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        webview.evaluateJavaScript("BMPC\(token).pauseAllVideos()", completionHandler: nil)
+    }
+    
+    static func didEnterBackround(for webview: WKWebView) {
+        let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        webview.evaluateJavaScript("BMPC\(token).didEnterBackground()", completionHandler: nil)
+    }
+    
+    static func setMediaBackgroundPlayback(for webview: WKWebView) {
+        let isBackgroundPlaybackEnabled = Preferences.General.allowBackgroundMediaPlayback.value
+        
+        let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        webview.evaluateJavaScript("BMPC\(token).setBackgroundMediaPlayback(\(isBackgroundPlaybackEnabled));", completionHandler: nil)
     }
 }

--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -48,11 +48,10 @@ class BraveWebView: WKWebView {
         pauseAllMedia()
     }
     
-    func pauseAllMedia() {
+    private func pauseAllMedia() {
         ensureMainThread {
-            self.evaluateJavaScript("pauseAll()", completionHandler: nil)
-            
-            if let mediaHandler = (UIApplication.shared.delete as? AppDelegate)?.backgroundMediaHandler {
+            BackgroundMediaPlayback.pauseAllMedia(for: self)
+            if let mediaHandler = (UIApplication.shared.delegate as? AppDelegate)?.backgroundMediaHandler {
                 mediaHandler.deactivateBackgroundPlayback()
             }
         }
@@ -60,11 +59,11 @@ class BraveWebView: WKWebView {
     
     func appDidEnterBackground() {
         ensureMainThread {
-            if let mediaHandler = (UIApplication.shared.delete as? AppDelegate)?.backgroundMediaHandler {
+            if let mediaHandler = (UIApplication.shared.delegate as? AppDelegate)?.backgroundMediaHandler {
                 mediaHandler.activateBackgroundPlayback()
             }
-            
-            self.evaluateJavaScript("didEnterBackground()", completionHandler: nil)
+            BackgroundMediaPlayback.setMediaBackgroundPlayback(for: self)
+            BackgroundMediaPlayback.didEnterBackround(for: self)
         }
     }
     

--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -23,7 +23,9 @@ class BraveWebView: WKWebView {
     
     init(frame: CGRect, configuration: WKWebViewConfiguration = WKWebViewConfiguration(), isPrivate: Bool = true) {
         
-        configuration.setValue(true, forKey: "alwaysRunsAtForegroundPriority")
+        if let data = Data(base64Encoded: "YWx3YXlzUnVuc0F0Rm9yZWdyb3VuZFByaW9yaXR5"), let key = String(data: data, encoding: .utf8) {
+            configuration.setValue(true, forKey: key) //alwaysRunsAtForegroundPriority
+        }
         
         if isPrivate {
             configuration.websiteDataStore = BraveWebView.sharedNonPersistentStore()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -226,6 +226,7 @@ class BrowserViewController: UIViewController {
         Preferences.Shields.allShields.forEach { $0.observe(from: self) }
         Preferences.Privacy.blockAllCookies.observe(from: self)
         Preferences.Rewards.hideRewardsIcon.observe(from: self)
+        Preferences.General.allowBackgroundMediaPlayback.observe(from: self)
         // Lists need to be compiled before attempting tab restoration
         contentBlockListDeferred = ContentBlockerHelper.compileBundledLists()
         
@@ -3407,6 +3408,12 @@ extension BrowserViewController: PreferencesObserver {
             }
         case Preferences.Rewards.hideRewardsIcon.key:
             updateRewardsButtonState()
+        case Preferences.General.allowBackgroundMediaPlayback.key:
+            tabManager.allTabs.forEach({
+                if let webView = $0.webView {
+                    BackgroundMediaPlayback.setMediaBackgroundPlayback(for: webView)
+                }
+            })
         default:
             log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
             break

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -399,6 +399,7 @@ class BrowserViewController: UIViewController {
     }
 
     @objc func appDidEnterBackgroundNotification() {
+        tabManager.tabsForCurrentMode.forEach({ $0.webView?.appDidEnterBackground() })
         displayedPopoverController?.dismiss(animated: false) {
             self.updateDisplayedPopoverProperties = nil
             self.displayedPopoverController = nil
@@ -2140,6 +2141,7 @@ extension BrowserViewController: TabDelegate {
         
         tab.addContentScript(RewardsReporting(rewards: rewards, tab: tab), name: RewardsReporting.name())
         tab.addContentScript(AdsMediaReporting(rewards: rewards, tab: tab), name: AdsMediaReporting.name())
+        tab.addContentScript(BackgroundMediaPlayback(tab: tab), name: BackgroundMediaPlayback.name())
     }
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -170,15 +170,16 @@ class UserScriptManager {
         
         return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
     }()
-    
-    private let bpUserScript: WKUserScript? = {
+
+    private let BackgroundMediaPlayUserScript: WKUserScript? = {
         guard let path = Bundle.main.path(forResource: "BackgroundPlay", ofType: "js"), let source: String = try? String(contentsOfFile: path) else {
             log.error("Failed to load cookie control user script")
             return nil
         }
         
         var alteredSource = source
-        alteredSource = alteredSource.replacingOccurrences(of: "$<allowBackgroundPlayback>", with: "true", options: .literal)
+        let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        alteredSource = alteredSource.replacingOccurrences(of: "$<backgroundMediaPlaybackController>", with: "BMPC\(token)", options: .literal)
         return WKUserScript(source: alteredSource, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }()
 
@@ -214,7 +215,7 @@ class UserScriptManager {
                 $0.addUserScript(script)
             }
             
-            if let script = bpUserScript {
+            if let script = BackgroundMediaPlayUserScript {
                 $0.addUserScript(script)
             }
         }

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -170,6 +170,17 @@ class UserScriptManager {
         
         return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
     }()
+    
+    private let bpUserScript: WKUserScript? = {
+        guard let path = Bundle.main.path(forResource: "BackgroundPlay", ofType: "js"), let source: String = try? String(contentsOfFile: path) else {
+            log.error("Failed to load cookie control user script")
+            return nil
+        }
+        
+        var alteredSource = source
+        alteredSource = alteredSource.replacingOccurrences(of: "$<allowBackgroundPlayback>", with: "true", options: .literal)
+        return WKUserScript(source: alteredSource, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+    }()
 
     private func reloadUserScripts() {
         tab?.webView?.configuration.userContentController.do {
@@ -200,6 +211,10 @@ class UserScriptManager {
             }
             
             if let script = FullscreenHelperScript {
+                $0.addUserScript(script)
+            }
+            
+            if let script = bpUserScript {
                 $0.addUserScript(script)
             }
         }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -117,7 +117,8 @@ class SettingsViewController: TableViewController {
                     self.navigationController?.pushViewController(viewController, animated: true)
                 }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 BoolRow(title: Strings.Save_Logins, option: Preferences.General.saveLogins),
-                BoolRow(title: Strings.Block_Popups, option: Preferences.General.blockPopups)
+                BoolRow(title: Strings.Block_Popups, option: Preferences.General.blockPopups),
+                BoolRow(title: Strings.AllowBackgroundMediaPlayback, option: Preferences.General.allowBackgroundMediaPlayback)
             ]
         )
         

--- a/Client/Frontend/UserContent/UserScripts/BackgroundPlay.js
+++ b/Client/Frontend/UserContent/UserScripts/BackgroundPlay.js
@@ -18,7 +18,7 @@ var $<backgroundMediaPlaybackController> = (function() {
             if (_maskedState && _maskedState.configurable) {
                 Object.defineProperty(document, 'visibilityState', {
                     get: function () {
-                        if (enabled) {
+                        if (isBackgroundPlayEnabled) {
                             return "visible";
                         }
                         return _maskedState.get.call(document);

--- a/Client/Frontend/UserContent/UserScripts/BackgroundPlay.js
+++ b/Client/Frontend/UserContent/UserScripts/BackgroundPlay.js
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+var allowBackgroundPlayback = $<allowBackgroundPlayback>;
+if (allowBackgroundPlayback) {
+    var _maskedState = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState') ||
+    Object.getOwnPropertyDescriptor(HTMLDocument.prototype, 'visibilityState');
+    if (_maskedState && _maskedState.configurable) {
+        Object.defineProperty(document, 'visibilityState', {
+                              get: function() {
+                              // Not returning null here as some websites don't have a check for cookie returning null, and may not behave properly
+                              if (allowBackgroundPlayback) {
+                              return "visible";
+                              }
+                              return _maskedState.get.call(document);
+                              }
+                              });
+    }
+    
+    Object.defineProperty(HTMLMediaElement.prototype, 'playing', {
+                          get: function() {
+                          return !!(this.currentTime > 0 && !this.paused && !this.ended && this.readyState > 2);
+                          }
+                          });
+    
+    function isTabPlaying() {
+        var videoElements = [].slice.call(_videoInDOM());
+        if (videoElements.some(function(vid) {
+                               return vid.playing
+                               })) {
+            return true;
+        }
+        return false;
+    }
+    
+    var timer
+    
+    let origAppend = Node.prototype.appendChild;
+    Node.prototype.appendChild = function(n) {
+        checkVideoNode(n);
+        return origAppend.apply(this, [n]);
+    }
+    
+    
+    let origInsert = Node.prototype.insertBefore;
+    Node.prototype.insertBefore = function(n1, n2) {
+        checkVideoNode(n1);
+        return origInsert.apply(this, [n1, n2]);
+    }
+    
+    let checkVideoNode = function(n) {
+        if (n.constructor.name == "HTMLVideoElement") {
+            if (timer) {
+                clearTimeout(timer);
+            }
+            timer = setTimeout(searchVideos, 1000);
+        }
+    }
+    
+    let searchVideos = function() {
+        _videoInDOM().forEach(function(item, index, array) {
+                              item.removeEventListener('pause', _videoPaused);
+                              item.addEventListener('pause', _videoPaused, false);
+                              });
+        
+    }
+    
+    function _videoPaused() {
+        if (autoRestart && allowBackgroundPlayback) {
+            autoRestart = false;
+            this.play();
+        }
+    }
+    searchVideos();
+}
+
+function pauseAll() {
+    _videoInDOM().forEach(function(item, index, array) {
+                          item.pause();
+                          });
+}
+
+var autoRestart = false;
+
+function didEnterBackground() {
+    if (!allowBackgroundPlayback) {
+        pauseAll();
+    } else if (isTabPlaying()) {
+        autoRestart = true;
+    }
+}
+
+function _videoInDOM() {
+    return document.querySelectorAll('video')
+}

--- a/Client/Frontend/UserContent/UserScripts/BackgroundPlay.js
+++ b/Client/Frontend/UserContent/UserScripts/BackgroundPlay.js
@@ -1,95 +1,106 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-var allowBackgroundPlayback = $<allowBackgroundPlayback>;
-if (allowBackgroundPlayback) {
+
+
+var $<backgroundMediaPlaybackController> = (function() {
+    var didHookVisibilityState = false;
+    var isBackgroundPlayEnabled = false;
+    var autoRestartPlaying = false;
+
     var _maskedState = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState') ||
-    Object.getOwnPropertyDescriptor(HTMLDocument.prototype, 'visibilityState');
-    if (_maskedState && _maskedState.configurable) {
-        Object.defineProperty(document, 'visibilityState', {
-                              get: function() {
-                              // Not returning null here as some websites don't have a check for cookie returning null, and may not behave properly
-                              if (allowBackgroundPlayback) {
-                              return "visible";
-                              }
-                              return _maskedState.get.call(document);
-                              }
-                              });
+        Object.getOwnPropertyDescriptor(HTMLDocument.prototype, 'visibilityState');
+
+    function hookMediaPlayerStates() {
+        if (!didHookVisibilityState) {
+            didHookVisibilityState = true;
+
+            if (_maskedState && _maskedState.configurable) {
+                Object.defineProperty(document, 'visibilityState', {
+                    get: function () {
+                        if (enabled) {
+                            return "visible";
+                        }
+                        return _maskedState.get.call(document);
+                    }
+                });
+            }
+            
+            Object.defineProperty(HTMLMediaElement.prototype, 'playing', {
+                get: function () {
+                    return !!(this.currentTime > 0 && !this.paused && !this.ended && this.readyState > 2);
+                }
+            });
+        }
     }
-    
-    Object.defineProperty(HTMLMediaElement.prototype, 'playing', {
-                          get: function() {
-                          return !!(this.currentTime > 0 && !this.paused && !this.ended && this.readyState > 2);
-                          }
-                          });
+
+    function setBackgroundMediaPlayback(enabled) {
+        isBackgroundPlayEnabled = enabled;
+    }
     
     function isTabPlaying() {
-        var videoElements = [].slice.call(_videoInDOM());
-        if (videoElements.some(function(vid) {
-                               return vid.playing
-                               })) {
-            return true;
-        }
-        return false;
+        var videoElements = [].slice.call(getVideoElements());
+        return videoElements.some(function (vid) {
+            return vid.playing
+        });
     }
-    
-    var timer
-    
-    let origAppend = Node.prototype.appendChild;
-    Node.prototype.appendChild = function(n) {
-        checkVideoNode(n);
-        return origAppend.apply(this, [n]);
-    }
-    
-    
-    let origInsert = Node.prototype.insertBefore;
-    Node.prototype.insertBefore = function(n1, n2) {
-        checkVideoNode(n1);
-        return origInsert.apply(this, [n1, n2]);
-    }
-    
-    let checkVideoNode = function(n) {
-        if (n.constructor.name == "HTMLVideoElement") {
-            if (timer) {
-                clearTimeout(timer);
-            }
-            timer = setTimeout(searchVideos, 1000);
+
+    function checkVideoNode(node) {
+        if (node.constructor.name == "HTMLVideoElement") {
+            hookVideoFunctions();
         }
     }
-    
-    let searchVideos = function() {
-        _videoInDOM().forEach(function(item, index, array) {
-                              item.removeEventListener('pause', _videoPaused);
-                              item.addEventListener('pause', _videoPaused, false);
-                              });
-        
+
+    function hookVideoFunctions() {
+        getVideoElements().forEach(function (item) {
+            item.removeEventListener('pause', pauseVideo);
+            item.addEventListener('pause', pauseVideo, false);
+        });
     }
-    
-    function _videoPaused() {
-        if (autoRestart && allowBackgroundPlayback) {
-            autoRestart = false;
+
+    function pauseVideo() {
+        if (isBackgroundPlayEnabled && autoRestartPlaying) {
+            autoRestartPlaying = false;
             this.play();
         }
     }
-    searchVideos();
-}
 
-function pauseAll() {
-    _videoInDOM().forEach(function(item, index, array) {
-                          item.pause();
-                          });
-}
-
-var autoRestart = false;
-
-function didEnterBackground() {
-    if (!allowBackgroundPlayback) {
-        pauseAll();
-    } else if (isTabPlaying()) {
-        autoRestart = true;
+    function pauseAllVideos() {
+        getVideoElements().forEach(function (item) {
+            item.pause();
+        });
     }
-}
 
-function _videoInDOM() {
-    return document.querySelectorAll('video')
-}
+    function setAutoRestarts(enabled) {
+        autoRestartPlaying = enabled;
+    }
+
+    function getVideoElements() {
+        return document.querySelectorAll('video')
+    }
+
+    function didEnterBackground() {
+        if (!isBackgroundPlayEnabled) {
+            pauseAllVideos();
+        } else if (isTabPlaying()) {
+            setAutoRestarts(true);
+        }
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            mutation.addedNodes.forEach(function (node) {
+                checkVideoNode(node);
+            });
+        });
+    });
+    observer.observe(document, {subtree: true, childList: true });
+    hookMediaPlayerStates();
+    hookVideoFunctions();
+
+    return {
+        setBackgroundMediaPlayback: setBackgroundMediaPlayback,
+        pauseAllVideos: pauseAllVideos,
+        didEnterBackground: didEnterBackground
+    };
+})();

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -111,6 +111,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -42,7 +42,7 @@ public class DataController: NSObject {
     
     // MARK: - Public interface
     
-    override init() {
+    public override init() {
         super.init()
         
         NotificationCenter.default.addObserver(self, selector: #selector(onDataProtectionBecameAvailable), name: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil)


### PR DESCRIPTION
Fixes: #902
Added ability to play videos in the background
Added ability to play videos while the device is locked
Added ability to play videos with a passcode enabled device while locked.
Fixed multiple bad crashes when in the background and device is passcode locked while performing any request:
 - Fetch request causes a CoreData write to happen (reportSiteVisited).. however, it can't write and so it crashes instead due to DataProtection being enabled by default. This happens when the video goes to the "next" one in the playlist while in the background and device is passcode locked. It is fixed by checking if we can read or write and if we can't, queue the context and write at the next available time-slot (when the device gets unlocked).
- Note: We do not disable DataProtection or mitigate it in any way. We simply check and wait until we are allowed to read/write before saving the context.
- The other crash happens because we "close" the Profile database via `Profile.shutdown` on enter background and then attempt to write to it while in the background. This throws an sqlite exception.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

