### PR TITLE
Fixes #1309 by making sure NSBatchDeleteRequest is not run on In-Memory store

### DIFF
--- a/Data/models/CRUDProtocols.swift
+++ b/Data/models/CRUDProtocols.swift
@@ -44,9 +44,14 @@ extension Deletable where Self: NSManagedObject {
             request.includesPropertyValues = includesPropertyValues
             
             do {
-                // NSBatchDeleteRequest can't be used for in-memory store we use in tests.
+                // NSBatchDeleteRequest can't be used for in-memory store we use in tests and PBM.
                 // Have to delete objects one by one.
-                if AppConstants.IsRunningTest {
+                var isInMemoryContext: Bool = false
+                if let currentCoordinator = context.persistentStoreCoordinator,
+                    let inMemoryCoordinator = DataController.viewContextInMemory.persistentStoreCoordinator {
+                    isInMemoryContext = currentCoordinator == inMemoryCoordinator
+                }
+                if AppConstants.IsRunningTest || isInMemoryContext {
                     let results = try context.fetch(request) as? [NSManagedObject]
                     results?.forEach {
                         context.delete($0)

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -42,7 +42,8 @@ public class DataController: NSObject {
             // called at higher level when a `.new` WriteContext is passed.
             task(existingContext)
         case .new(let inMemory):
-            let queue = DataController.shared.operationQueue
+            // Though keeping same queue does not make a difference but kept them diff for independent processing.
+            let queue = inMemory ? DataController.sharedInMemory.operationQueue :  DataController.shared.operationQueue
             
             queue.addOperation({
                 let backgroundContext = inMemory ? DataController.newBackgroundContextInMemory() : DataController.newBackgroundContext()
@@ -79,7 +80,7 @@ public class DataController: NSObject {
             return
         }
         
-        if context == DataController.viewContext {
+        if context.concurrencyType == .mainQueueConcurrencyType {
             log.warning("Writing to view context, this should be avoided.")
         }
         


### PR DESCRIPTION
Fixes #1309 by making sure NSBatchDeleteRequest is not run on In-Memory store. And other cleanups.
The issue was caused due to calling NSBatchDeleteRequest for an in-memory store.
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

