### PR TITLE
Added support for Exclusion List for WebAuthN.

### DIFF
--- a/Client/U2FExtensions.swift
+++ b/Client/U2FExtensions.swift
@@ -243,18 +243,16 @@ class U2FExtensions: NSObject {
             ]
             makeCredentialRequest.options = makeOptions
             
-            let exclusionList: [Any] = publicKey.excludeCredentials.compactMap({
+            let exclusionList: [YKFFIDO2PublicKeyCredentialDescriptor] = publicKey.excludeCredentials.compactMap({
                 let credentialDescriptor = YKFFIDO2PublicKeyCredentialDescriptor()
                 guard let credentialIdData = Data(base64Encoded: $0.id) else {
                     return nil
                 }
                 
                 credentialDescriptor.credentialId = credentialIdData
-                credentialDescriptor.credentialType = {
-                    let credType = YKFFIDO2PublicKeyCredentialType()
-                    credType.name = "public-key"
-                    return credType
-                }()
+                credentialDescriptor.credentialType = YKFFIDO2PublicKeyCredentialType().then {
+                    $0.name = "public-key"
+                }
                 
                 return credentialDescriptor
             })

--- a/Client/WebAuthN/WebAuthnRegisterRequest.swift
+++ b/Client/WebAuthN/WebAuthnRegisterRequest.swift
@@ -2,6 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+struct PublicKeyCredentialDescriptor: Decodable {
+    let type: String
+    let id: String
+}
+
 struct WebAuthnRegisterRequest: Decodable {
     struct PublicKey: Decodable {
         struct PubKeyCredParams: Decodable {
@@ -31,6 +37,7 @@ struct WebAuthnRegisterRequest: Decodable {
         let user: User
         let rp: Rp
         let challenge: String
+        let excludeCredentials: [PublicKeyCredentialDescriptor]
     }
     let publicKey: PublicKey
 }


### PR DESCRIPTION
- Added support for Exclusion List for WebAuthN.
- Fixes #1285
- Screenshot below added showing "Valid Credential found in exclusion list".

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

![IMG_3196](https://user-images.githubusercontent.com/1530031/62151933-6ee53400-b2cf-11e9-8763-197f13ee62bf.PNG)
