### PR TITLE
Fixes #1255: WebView becomes blank when showing PDF on Tab-Tray

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -113,12 +113,18 @@ private extension TrayToBrowserAnimator {
     /// Bug is present in FireFox iOS: https://stackoverflow.com/questions/52735158/wkwebview-shows-gray-background-and-pdf-content-gets-invisible-on-viewcontroller
     /// Although, they solve it differently..
     /// Confirmed by WebKit that it's an iOS bug: https://bugs.webkit.org/show_bug.cgi?id=193281
-    private func WKWebViewPDFNotRenderingBugFix(for controller: UIViewController) {
-        let fakeController = UIViewController()
-        if let navController = controller.navigationController {
-            navController.present(fakeController, animated: false, completion: {
-                fakeController.dismiss(animated: false, completion: nil)
-            })
+    private func WKWebViewPDFNotRenderingBugFix(for controller: BrowserViewController) {
+        guard let mimeType = controller.tabManager.selectedTab?.mimeType, !mimeType.isKindOfHTML else {
+            return
+        }
+        
+        if mimeType.lowercased().contains("pdf") {
+            let fakeController = UIViewController()
+            if let navController = controller.navigationController {
+                navController.present(fakeController, animated: false, completion: {
+                    fakeController.dismiss(animated: false, completion: nil)
+                })
+            }
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -109,6 +109,10 @@ private extension TrayToBrowserAnimator {
     /// 7. Verify PDF re-rendered.
     /// Note: This only happens when a UINavigationController ".push".
     ///       It does not happen for `.present`
+    
+    /// Bug is present in FireFox iOS: https://stackoverflow.com/questions/52735158/wkwebview-shows-gray-background-and-pdf-content-gets-invisible-on-viewcontroller
+    /// Although, they solve it differently..
+    /// Confirmed by WebKit that it's an iOS bug: https://bugs.webkit.org/show_bug.cgi?id=193281
     private func WKWebViewPDFNotRenderingBugFix(for controller: UIViewController) {
         let fakeController = UIViewController()
         if let navController = controller.navigationController {

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -94,7 +94,28 @@ private extension TrayToBrowserAnimator {
             bvc.topToolbar.isTransitioning = false
             bvc.updateTabsBarVisibility()
             transitionContext.completeTransition(true)
+            
+            self.WKWebViewPDFNotRenderingBugFix(for: bvc)
         })
+    }
+    
+    /// Fixes a Bug in iOS 12.2 where:
+    /// 1. Have Navigation Controller
+    /// 2. Set a ViewController with a WKWebView as root controller
+    /// 3. Push any other controller
+    /// 4. Dismiss the controller
+    /// 5. Verify that PDF not rendering.
+    /// 6. Present any controller and dismiss it
+    /// 7. Verify PDF re-rendered.
+    /// Note: This only happens when a UINavigationController ".push".
+    ///       It does not happen for `.present`
+    private func WKWebViewPDFNotRenderingBugFix(for controller: UIViewController) {
+        let fakeController = UIViewController()
+        if let navController = controller.navigationController {
+            navController.present(fakeController, animated: false, completion: {
+                fakeController.dismiss(animated: false, completion: nil)
+            })
+        }
     }
 }
 


### PR DESCRIPTION
Fixes PDFs not rendering when UINavigationController `pushes` the WKWebView controller to the tab tray and back. Even happens in a brand new project that contains only a WKWebView (with a PDF loaded) and embedded in a NavigationController)..

Can be reproduced using this code: https://gist.github.com/Brandon-T/6ef3a15498ecf7ec7d5ce170e5533934

OR

Following the steps in Ticket: #1255

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

