### PR TITLE
Fix #1330-DataTheorem - NSSecureCoding used instead of NSCoding

### DIFF
--- a/BraveShared/Analytics/CustomHeaderData.swift
+++ b/BraveShared/Analytics/CustomHeaderData.swift
@@ -68,7 +68,7 @@ class CustomHeaderData: NSObject {
     }
 }
 
-extension CustomHeaderData: NSCoding {
+extension CustomHeaderData: NSSecureCoding {
     struct CodingKeys {
         static let domain = "customHeaderDataDomain"
         static let headerKey = "customHeaderDataHeaderKey"
@@ -79,5 +79,9 @@ extension CustomHeaderData: NSCoding {
         aCoder.encode(domainList, forKey: CodingKeys.domain)
         aCoder.encode(headerField, forKey: CodingKeys.headerKey)
         aCoder.encode(headerValue, forKey: CodingKeys.headerValue)
+    }
+    
+    static var supportsSecureCoding: Bool {
+        return true
     }
 }

--- a/BraveShared/Analytics/CustomHeaderData.swift
+++ b/BraveShared/Analytics/CustomHeaderData.swift
@@ -18,9 +18,10 @@ class CustomHeaderData: NSObject {
 
     // Initializer can't be placed in extension.
     required init?(coder aDecoder: NSCoder) {
-        guard let domainList = aDecoder.decodeObject(forKey: CodingKeys.domain) as? [String],
-            let headerKey = aDecoder.decodeObject(forKey: CodingKeys.headerKey) as? String,
-            let headerValue = aDecoder.decodeObject(forKey: CodingKeys.headerValue) as? String
+        guard let domainList = aDecoder.decodeObject(of: [NSString.self], forKey: CodingKeys.domain) as? [String],
+            let headerKey = aDecoder.decodeObject(of: NSString.self, forKey: CodingKeys.headerKey) as String?,
+            let headerValue = aDecoder.decodeObject(of: NSString.self, forKey: CodingKeys.headerValue) as String?
+            
             else { return nil }
 
         self.domainList = domainList

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -42,10 +42,10 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
         // this catches the cases where bool encoded in Swift 2 needs to be decoded with decodeObject, but a Bool encoded in swift 3 needs
         // to be decoded using decodeBool. This catches the upgrade case to ensure that we are always able to fetch a keyed valye for isCustomEngine
         // http://stackoverflow.com/a/40034694
-        let isCustomEngine = aDecoder.decodeAsBool(forKey: "isCustomEngine")
-        guard let searchTemplate = aDecoder.decodeObject(forKey: "searchTemplate") as? String,
-              let shortName = aDecoder.decodeObject(forKey: "shortName") as? String,
-              let image = aDecoder.decodeObject(forKey: "image") as? UIImage else {
+        let isCustomEngine = aDecoder.decodeBool(forKey: "isCustomEngine")
+        guard let searchTemplate = aDecoder.decodeObject(of: NSString.self, forKey: "searchTemplate") as String?,
+            let shortName = aDecoder.decodeObject(of: NSString.self, forKey: "shortName") as String?,
+            let image = aDecoder.decodeObject(of: UIImage.self, forKey: "image") else {
                 assertionFailure()
                 return nil
         }
@@ -54,7 +54,7 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
         self.shortName = shortName
         self.isCustomEngine = isCustomEngine
         self.image = image
-        self.engineID = aDecoder.decodeObject(forKey: "engineID") as? String
+        self.engineID = aDecoder.decodeObject(of: NSString.self, forKey: "engineID") as String?
         self.suggestTemplate = nil
     }
 

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -7,7 +7,7 @@ import Foundation
 import Shared
 import Data
 
-class SessionData: NSObject, NSCoding {
+class SessionData: NSObject, NSSecureCoding {
     let currentPage: Int
     let urls: [URL]
     let lastUsedTime: Timestamp
@@ -62,5 +62,9 @@ class SessionData: NSObject, NSCoding {
         let currentURL = urlStrings[(currentPage < 0 ? max(urlStrings.count-1, 0) : currentPage)]
         
         return SavedTab(id: "InvalidId", title: nil, url: currentURL, isSelected: false, order: -1, screenshot: nil, history: urlStrings, historyIndex: Int16(currentPage))
+    }
+    
+    static var supportsSecureCoding: Bool {
+        return true
     }
 }

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -45,9 +45,9 @@ class SessionData: NSObject, NSSecureCoding {
     }
 
     required init?(coder: NSCoder) {
-        self.currentPage = coder.decodeAsInt(forKey: SessionData.Keys.currentPage)
-        self.urls = coder.decodeObject(forKey: "urls") as? [URL] ?? []
-        self.lastUsedTime = coder.decodeAsUInt64(forKey: SessionData.Keys.lastUsedTime)
+        self.currentPage = coder.decodeInteger(forKey: SessionData.Keys.currentPage)
+        self.urls = coder.decodeObject(of: [NSURL.self], forKey: "urls") as? [URL] ?? []
+        self.lastUsedTime = UInt64(coder.decodeInt64(forKey: SessionData.Keys.lastUsedTime))
     }
 
     func encode(with coder: NSCoder) {

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -29,9 +29,9 @@ public class PushRegistration: NSObject, NSSecureCoding {
     }
 
     @objc public convenience required init?(coder aDecoder: NSCoder) {
-        guard let uaid = aDecoder.decodeObject(forKey: "uaid") as? String,
-            let secret = aDecoder.decodeObject(forKey: "secret") as? String,
-            let subscriptions = aDecoder.decodeObject(forKey: "subscriptions") as? [String: PushSubscription] else {
+        guard let uaid = aDecoder.decodeObject(of: NSString.self, forKey: "uaid") as String?,
+            let secret = aDecoder.decodeObject(of: NSString.self, forKey: "secret") as String?,
+            let subscriptions = aDecoder.decodeObject(of: NSDictionary.self, forKey: "subscriptions") as [String: PushSubscription]? else {
                 fatalError("Cannot decode registration")
         }
         self.init(uaid: uaid, secret: secret, subscriptions: subscriptions)
@@ -95,12 +95,12 @@ public class PushSubscription: NSObject, NSSecureCoding {
     }
 
     @objc public convenience required init?(coder aDecoder: NSCoder) {
-        guard let channelID = aDecoder.decodeObject(forKey: "channelID") as? String,
-            let urlString = aDecoder.decodeObject(forKey: "endpoint") as? String,
+        guard let channelID = aDecoder.decodeObject(of: NSString.self, forKey: "channelID") as String?,
+            let urlString = aDecoder.decodeObject(of: NSString.self, forKey: "endpoint") as String?,
             let endpoint = URL(string: urlString),
-            let p256dhPrivateKey = aDecoder.decodeObject(forKey: "p256dhPrivateKey") as? String,
-            let p256dhPublicKey = aDecoder.decodeObject(forKey: "p256dhPublicKey") as? String,
-            let authKey = aDecoder.decodeObject(forKey: "authKey") as? String else {
+            let p256dhPrivateKey = aDecoder.decodeObject(of: NSString.self, forKey: "p256dhPrivateKey") as String?,
+            let p256dhPublicKey = aDecoder.decodeObject(of: NSString.self, forKey: "p256dhPublicKey") as String?,
+            let authKey = aDecoder.decodeObject(of: NSString.self, forKey: "authKey") as String? else {
             return nil
         }
 

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 import SwiftyJSON
 
-public class PushRegistration: NSObject, NSCoding {
+public class PushRegistration: NSObject, NSSecureCoding {
     let uaid: String
     let secret: String
     // We don't need to have more than one subscription until WebPush is exposed to content Javascript
@@ -56,12 +56,16 @@ public class PushRegistration: NSObject, NSCoding {
         }
         return PushRegistration(uaid: uaid, secret: secret, subscriptions: [defaultSubscriptionID: defaultSubscription])
     }
+    
+    public static var supportsSecureCoding: Bool {
+        return true
+    }
 }
 
 fileprivate let defaultSubscriptionID = "defaultSubscription"
 /// Small NSCodable class for persisting a channel subscription.
 /// We use NSCoder because we expect it to be stored in the profile.
-public class PushSubscription: NSObject, NSCoding {
+public class PushSubscription: NSObject, NSSecureCoding {
     let channelID: String
     let endpoint: URL
 
@@ -113,6 +117,10 @@ public class PushSubscription: NSObject, NSCoding {
         aCoder.encode(p256dhPrivateKey, forKey: "p256dhPrivateKey")
         aCoder.encode(p256dhPublicKey, forKey: "p256dhPublicKey")
         aCoder.encode(authKey, forKey: "authKey")
+    }
+    
+    public static var supportsSecureCoding: Bool {
+        return true
     }
 }
 

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -25,7 +25,7 @@ public extension KeychainWrapper {
     }
 }
 
-open class AuthenticationKeychainInfo: NSObject, NSCoding {
+open class AuthenticationKeychainInfo: NSObject, NSSecureCoding {
     fileprivate(set) open var passcode: String?
     open var isPasscodeRequiredImmediately: Bool
     fileprivate(set) open var lockOutInterval: TimeInterval?
@@ -70,6 +70,10 @@ open class AuthenticationKeychainInfo: NSObject, NSCoding {
         } else {
             self.isPasscodeRequiredImmediately = true
         }
+    }
+    
+    public static var supportsSecureCoding: Bool {
+        return true
     }
 }
 

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -55,15 +55,15 @@ open class AuthenticationKeychainInfo: NSObject, NSSecureCoding {
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        if let lockOutInterval = aDecoder.decodeObject(forKey: "lockOutInterval") as? NSNumber {
+        if let lockOutInterval = aDecoder.decodeObject(of: NSNumber.self, forKey: "lockOutInterval") as NSNumber? {
             self.lockOutInterval = lockOutInterval.doubleValue
         }
-        self.passcode = aDecoder.decodeObject(forKey: "passcode") as? String
-        self.failedAttempts = aDecoder.decodeAsInt(forKey: "failedAttempts")
-        self.useTouchID = aDecoder.decodeAsBool(forKey: "useTouchID")
+        self.passcode = aDecoder.decodeObject(of: NSString.self, forKey: "passcode") as String?
+        self.failedAttempts = aDecoder.decodeInteger(forKey: "failedAttempts")
+        self.useTouchID = aDecoder.decodeBool(forKey: "useTouchID")
         if aDecoder.containsValue(forKey: "isPasscodeRequiredImmediately") {
-            self.isPasscodeRequiredImmediately = aDecoder.decodeAsBool(forKey: "isPasscodeRequiredImmediately")
-        } else if let interval = aDecoder.decodeObject(forKey: "requiredPasscodeInterval") as? NSNumber {
+            self.isPasscodeRequiredImmediately = aDecoder.decodeBool(forKey: "isPasscodeRequiredImmediately")
+        } else if let interval = aDecoder.decodeObject(of: NSNumber.self, forKey: "requiredPasscodeInterval") as NSNumber? {
             // This is solely used for 1.6.6 -> 1.7 migration
             //  `requiredPasscodeInterval` is not re-encoded on this object
             self.isPasscodeRequiredImmediately = (interval == 2)

--- a/Storage/RecentlyClosedTabs.swift
+++ b/Storage/RecentlyClosedTabs.swift
@@ -64,12 +64,12 @@ open class ClosedTab: NSObject, NSSecureCoding {
     }
 
     required convenience public init?(coder: NSCoder) {
-        guard let url = coder.decodeObject(forKey: "url") as? URL else { return nil }
+        guard let url = coder.decodeObject(of: NSURL.self, forKey: "url") as URL? else { return nil }
 
         self.init(
             url: url,
-            title: coder.decodeObject(forKey: "title") as? String,
-            faviconURL: coder.decodeObject(forKey: "faviconURL") as? String
+            title: coder.decodeObject(of: NSString.self, forKey: "title") as String?,
+            faviconURL: coder.decodeObject(of: NSString.self, forKey: "faviconURL") as String?
         )
     }
 


### PR DESCRIPTION
Conform to NSSecureCoding instead due to security vulnerability on #003831-DataTheorem.
Fixes #1330 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

