### PR TITLE
Fix #1284: Support password-less logins for security keys

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/U2F.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F.js
@@ -86,10 +86,11 @@ class $<attest> {
 }
 
 class $<assert> {
-  constructor (authenticatorData, clientDataJSON, signature) {
+  constructor (authenticatorData, clientDataJSON, signature, userHandle) {
     this.authenticatorData = window.base64ToArrayBuffer(authenticatorData)
     this.clientDataJSON = window.base64ToArrayBuffer(clientDataJSON)
     this.signature = window.base64ToArrayBuffer(signature)
+    this.userHandle = window.base64ToArrayBuffer(userHandle)
   }
 }
 
@@ -128,17 +129,17 @@ Object.defineProperty($<webauthn>, 'postCreate', {
 })
 
 Object.defineProperty($<webauthn>, 'postGet', {
-  value: function (handle, fromNative, id, authenticatorData, clientDataJSON, signature, errorName, errorDescription) {
+  value: function (handle, fromNative, id, authenticatorData, clientDataJSON, signature, userHandle, errorName, errorDescription) {
     if (fromNative) {
       caller = window.top.$<webauthn>.caller[handle]
-      caller.$<webauthn>.postGet(handle, false, id, authenticatorData, clientDataJSON, signature, errorName, errorDescription);
+      caller.$<webauthn>.postGet(handle, false, id, authenticatorData, clientDataJSON, signature, userHandle, errorName, errorDescription);
       return;
     }
     if (errorName) {
       $<webauthn>.reject[handle](new DOMException(errorDescription, errorName))
       return
     }
-    response = new $<assert>(authenticatorData, clientDataJSON, signature)
+    response = new $<assert>(authenticatorData, clientDataJSON, signature, userHandle)
     data = new $<pkc>(id, response)
     $<webauthn>.resolve[handle](data)
   }

--- a/Client/U2FExtensions.swift
+++ b/Client/U2FExtensions.swift
@@ -340,11 +340,6 @@ class U2FExtensions: NSObject {
         let clientData = WebAuthnClientData(type: WebAuthnClientDataType.get.rawValue, challenge: request.challenge, origin: url)
         do {
             let clientDataJSON = try JSONEncoder().encode(clientData)
-            guard let allowCredential = request.allowCredentials.first else {
-                sendFIDO2AuthenticationError(handle: handle)
-                return
-            }
-            let requestId = allowCredential
             
             if let rpId = request.rpID {
                 getAssertionRequest.rpId = rpId
@@ -366,23 +361,29 @@ class U2FExtensions: NSObject {
                 return
             }
             getAssertionRequest.clientDataHash = clientDataHash
+            
+            getAssertionRequest.options = [
+                YKFKeyFIDO2GetAssertionRequestOptionUP: request.userPresence,
+            ]
 
             var allowList = [YKFFIDO2PublicKeyCredentialDescriptor]()
-            for credentialId in request.allowCredentials {
-                let credentialDescriptor = YKFFIDO2PublicKeyCredentialDescriptor()
-                
-                guard let credentialIdData = Data(base64Encoded: credentialId) else {
-                    sendFIDO2AuthenticationError(handle: handle)
-                    return
+            if request.allowCredentials.count > 0 {
+                for credentialId in request.allowCredentials {
+                    let credentialDescriptor = YKFFIDO2PublicKeyCredentialDescriptor()
+                    
+                    guard let credentialIdData = Data(base64Encoded: credentialId) else {
+                        sendFIDO2AuthenticationError(handle: handle)
+                        return
+                    }
+                    
+                    credentialDescriptor.credentialId = credentialIdData
+                    let credType = YKFFIDO2PublicKeyCredentialType()
+                    credType.name = "public-key"
+                    credentialDescriptor.credentialType = credType
+                    allowList.append(credentialDescriptor)
                 }
-                
-                credentialDescriptor.credentialId = credentialIdData
-                let credType = YKFFIDO2PublicKeyCredentialType()
-                credType.name = "public-key"
-                credentialDescriptor.credentialType = credType
-                allowList.append(credentialDescriptor)
+                getAssertionRequest.allowList = allowList
             }
-            getAssertionRequest.allowList = allowList
             
             guard let fido2Service = YubiKitManager.shared.keySession.fido2Service else {
                 sendFIDO2AuthenticationError(handle: handle)
@@ -405,14 +406,14 @@ class U2FExtensions: NSObject {
                     self.sendFIDO2AuthenticationError(handle: handle)
                     return
                 }
-                self.finalizeFIDO2Authentication(handle: handle, response: response, requestId: requestId, clientDataJSON: clientDataJSON, error: nil)
+                self.finalizeFIDO2Authentication(handle: handle, response: response, clientDataJSON: clientDataJSON, error: nil)
             }
         } catch {
             sendFIDO2AuthenticationError(handle: handle, errorDescription: error.localizedDescription)
         }
     }
     
-    private func finalizeFIDO2Authentication(handle: Int, response: YKFKeyFIDO2GetAssertionResponse, requestId: String, clientDataJSON: Data, error: NSErrorPointer) {
+    private func finalizeFIDO2Authentication(handle: Int, response: YKFKeyFIDO2GetAssertionResponse, clientDataJSON: Data, error: NSErrorPointer) {
         guard error == nil else {
             let errorDescription = error?.pointee?.localizedDescription ?? Strings.U2FAuthenticationError
             sendFIDO2AuthenticationError(handle: handle, errorDescription: errorDescription)
@@ -422,10 +423,17 @@ class U2FExtensions: NSObject {
         let authenticatorData = response.authData.base64EncodedString()
         let clientDataJSONString = clientDataJSON.base64EncodedString()
         let sig = response.signature.base64EncodedString()
+
+       let userHandle = response.user?.userId.base64EncodedString() ?? ""
+        
+        guard let requestId = response.credential?.credentialId.base64EncodedString() else {
+            sendFIDO2AuthenticationError(handle: handle)
+            return
+        }
         
         cleanupFIDO2Authentication(handle: handle)
         ensureMainThread {
-            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postGet('\(handle)', \(true), '\(requestId)', '\(authenticatorData)', '\(clientDataJSONString)', '\(sig)', '')", completionHandler: { _, error in
+            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postGet('\(handle)', \(true), '\(requestId)', '\(authenticatorData)', '\(clientDataJSONString)', '\(sig)', '\(userHandle)', '')", completionHandler: { _, error in
                 if error != nil {
                     let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
                     log.error(errorDescription)

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -7,6 +7,7 @@ struct WebAuthnAuthenticateRequest {
     var rpID: String?
     var challenge: String
     var allowCredentials: [String] = []
+    var userPresence: Bool
 
     enum RequestKeys: String, CodingKey {
         case publicKey
@@ -17,6 +18,7 @@ struct WebAuthnAuthenticateRequest {
         case challenge
         case allowCredentials
         case authenticatorSelection
+        case userVerification
     }
 }
 
@@ -32,6 +34,10 @@ extension WebAuthnAuthenticateRequest: Decodable {
         
         rpID = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .rpId)
         challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)
+        
+        // userPresence is the inverse of userVerification
+        let userVerifcationString = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .userVerification) ?? ""
+        userPresence = userVerifcationString == "discouraged"
         
         let allowCredentialsArray = try publicKeyDictionary.decode([AllowCredentials].self, forKey: .allowCredentials)
     

--- a/ClientTests/U2FTests.swift
+++ b/ClientTests/U2FTests.swift
@@ -58,6 +58,7 @@ class U2FTests: XCTestCase {
             XCTAssertEqual(request.challenge, "mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=", "request challenge is correct.")
             XCTAssertEqual(request.allowCredentials.count, 1, "request allowCredential count is correct")
             XCTAssertEqual(request.allowCredentials.first, "OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=", "request allowCredential is correct")
+            XCTAssertTrue(request.userPresence, "request userPresence is correct")
         } catch {
             XCTFail("\(error)")
         }


### PR DESCRIPTION
fix #1284 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

1. Navigate to https://yubico.com/playground
2. Create an account and add a security key with password-less login enabled
3. Sign-Out
4. On the login page, click on `If you have password-less login, click here to sign in`
5. With the key plugged in, you should login without entering any username and password.

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

