### PR TITLE
FIx #1319: Clean documents directory folder.

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -31,11 +31,15 @@ class Migration {
     }
     
     /// Adblock files don't have to be moved, they now have a new directory and will be downloaded there.
-    /// Downloads folder was befer used before, it's a leftover from FF.
+    /// Downloads folder was nefer used before, it's a leftover from FF.
     private static func documentsDirectoryCleanup() {
         FileManager.default.removeFolder(withName: "abp-data", location: .documentDirectory)
         FileManager.default.removeFolder(withName: "https-everywhere-data", location: .documentDirectory)
         FileManager.default.removeFolder(withName: "Downloads", location: .documentDirectory)
+        
+        FileManager.default.moveFile(sourceName: "CookiesData.json", sourceLocation: .documentDirectory,
+                                     destinationName: "CookiesData.json",
+                                     destinationLocation: .applicationSupportDirectory)
     }
 }
 

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -18,11 +18,24 @@ class Migration {
             Bookmark.syncOrderMigration()
             Preferences.Migration.syncOrderCompleted.value = true
         }
+        
+        if !Preferences.Migration.documentsDirectoryCleanupCompleted.value {
+            documentsDirectoryCleanup()
+            Preferences.Migration.documentsDirectoryCleanupCompleted.value = true
+        }
     }
     
     static func moveDatabaseToApplicationDirectory() {
         //Moves Coredata sqlite file from Documents dir to application support dir.
         DataController.shared.migrateToNewPathIfNeeded()
+    }
+    
+    /// Adblock files don't have to be moved, they now have a new directory and will be downloaded there.
+    /// Downloads folder was befer used before, it's a leftover from FF.
+    private static func documentsDirectoryCleanup() {
+        FileManager.default.removeFolder(withName: "abp-data", location: .documentDirectory)
+        FileManager.default.removeFolder(withName: "https-everywhere-data", location: .documentDirectory)
+        FileManager.default.removeFolder(withName: "Downloads", location: .documentDirectory)
     }
 }
 
@@ -31,6 +44,11 @@ fileprivate extension Preferences {
     final class Migration {
         static let completed = Option<Bool>(key: "migration.completed", default: false)
         static let syncOrderCompleted = Option<Bool>(key: "migration.sync-order.completed", default: false)
+        /// Old app versions were using documents directory to store app files, database, adblock files.
+        /// These files are now moved to 'Application Support' folder, and documents directory is left
+        /// for user downloaded files.
+        static let documentsDirectoryCleanupCompleted =
+            Option<Bool>(key: "migration.documents-dir-completed", default: false)
     }
     
     /// Migrate the users preferences from prior versions of the app (<2.0)

--- a/Client/FileManagerExtension.swift
+++ b/Client/FileManagerExtension.swift
@@ -15,10 +15,6 @@ extension FileManager {
     }
     public typealias FolderLockObj = (folder: Folder, lock: Bool)
     
-    static var documentDirectoryURL: URL? {
-        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-    }
-    
     //Lock a folder using FolderLockObj provided.
     @discardableResult public func setFolderAccess(_ lockObjects: [FolderLockObj]) -> Bool {
         guard let baseDir = baseDirectory() else { return false }
@@ -99,6 +95,28 @@ extension FileManager {
         
         do {
             try removeItem(at: fileUrl)
+        } catch {
+            log.error(error)
+        }
+    }
+    
+    func moveFile(sourceName: String, sourceLocation: SearchPathDirectory,
+                  destinationName: String, destinationLocation: SearchPathDirectory) {
+        guard let sourceLocation = sourceLocation.url,
+            let destinationLocation = destinationLocation.url else {
+            return
+        }
+        
+        let sourceFileUrl = sourceLocation.appendingPathComponent(sourceName)
+        let destinationFileUrl = destinationLocation.appendingPathComponent(destinationName)
+        
+        if !fileExists(atPath: sourceFileUrl.path) {
+            log.debug("File \(sourceFileUrl) doesn't exist")
+            return
+        }
+        
+        do {
+            try moveItem(at: sourceFileUrl, to: destinationFileUrl)
         } catch {
             log.error(error)
         }

--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -82,7 +82,7 @@ extension Download: URLSessionTaskDelegate, URLSessionDownloadDelegate {
     }
 
     private func uniqueDownloadPathForFilename(_ filename: String) throws -> URL {
-        let downloadsPath = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false).appendingPathComponent("Downloads")
+        let downloadsPath = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
 
         let basePath = downloadsPath.appendingPathComponent(filename)
         let fileExtension = basePath.pathExtension

--- a/Client/Frontend/Settings/AdblockDebugMenuTableViewController.swift
+++ b/Client/Frontend/Settings/AdblockDebugMenuTableViewController.swift
@@ -57,7 +57,7 @@ class AdblockDebugMenuTableViewController: TableViewController {
                 return fm.contents(atPath: bundlePath)
             }
             
-            // Search in documents directory otherwise
+            // Search in application support directory otherwise
             let folderName = AdblockResourceDownloader.folderName
             guard let folderUrl = fm.getOrCreateFolder(name: folderName) else { return nil }
             

--- a/Client/HttpCookieExtension.swift
+++ b/Client/HttpCookieExtension.swift
@@ -15,6 +15,8 @@ public extension HTTPCookie {
         return "CookiesData.json"
     }
     
+    private static let directory = FileManager.SearchPathDirectory.applicationSupportDirectory.url
+    
     typealias Success = Bool
     class func saveToDisk(_ filename: String = HTTPCookie.locallySavedFile, completion: ((Success) -> Void)? = nil) {
         let cookieStore = WKWebsiteDataStore.default().httpCookieStore
@@ -31,7 +33,7 @@ public extension HTTPCookie {
          */
         WKWebsiteDataStore.default().fetchDataRecords(ofTypes: [WKWebsiteDataTypeCookies]) { _ in}
         cookieStore.getAllCookies { cookies in
-            guard let baseDir = FileManager.documentDirectoryURL else {
+            guard let baseDir = directory else {
                 completion?(false)
                 return
             }
@@ -47,7 +49,7 @@ public extension HTTPCookie {
     }
     
     class func loadFromDisk(_ filename: String = HTTPCookie.locallySavedFile, completion: ((Success) -> Void)? = nil) {
-        guard let baseDir = FileManager.documentDirectoryURL else {
+        guard let baseDir = directory else {
             completion?(false)
             return
         }
@@ -82,7 +84,7 @@ public extension HTTPCookie {
     }
     
     class func deleteLocalCookieFile(_ filename: String = HTTPCookie.locallySavedFile) {
-        guard let baseDir = FileManager.documentDirectoryURL else {
+        guard let baseDir = directory else {
             return
         }
         let url = baseDir.appendingPathComponent(filename)

--- a/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -45,10 +45,10 @@ class AdBlockStats: LocalAdblockResourceProtocol {
             self.setDataFile(data: data, id: bundledGeneralBlocklist)
         }
         
-        loadDatFilesFromDocumentsDirectory()
+        loadDatFilesFromApplicationSupportDirectory()
     }
     
-    private func loadDatFilesFromDocumentsDirectory() {
+    private func loadDatFilesFromApplicationSupportDirectory() {
         let fm = FileManager.default
 
         guard let folderUrl = fm.getOrCreateFolder(name: AdblockResourceDownloader.folderName) else {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -172,11 +172,6 @@ open class BrowserProfile: Profile {
         // This is the same as self.history.setTopSitesNeedsInvalidation, but without the
         // side-effect of instantiating SQLiteHistory (and thus BrowserDB) on the main thread.
         prefs.setBool(false, forKey: PrefsKeys.KeyTopSitesCacheIsValid)
-
-        // Create the "Downloads" folder in the documents directory.
-        if let downloadsPath = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false).appendingPathComponent("Downloads").path {
-            try? FileManager.default.createDirectory(atPath: downloadsPath, withIntermediateDirectories: true, attributes: nil)
-        }
     }
 
     func reopen() {


### PR DESCRIPTION
- Adblock files are moved to 'Application Support' folder
- `Downloads` folder is removed, it was used by Firefox, we will place
downloaded files directly into documents directory.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

