### PR TITLE
Fix #1360: Handle special characters in error descriptions

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/U2F.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F.js
@@ -119,7 +119,7 @@ Object.defineProperty($<webauthn>, 'postCreate', {
         return;
       }
       if (errorName) {
-        $<webauthn>.reject[handle](new DOMException(errorDescription, errorName))
+        $<webauthn>.reject[handle](new DOMException(atob(errorDescription), atob(errorName)))
         return
       }
       response = new $<attest>(attestationObject, clientDataJSON)
@@ -136,7 +136,7 @@ Object.defineProperty($<webauthn>, 'postGet', {
       return;
     }
     if (errorName) {
-      $<webauthn>.reject[handle](new DOMException(errorDescription, errorName))
+      $<webauthn>.reject[handle](new DOMException(atob(errorDescription), atob(errorName)))
       return
     }
     response = new $<assert>(authenticatorData, clientDataJSON, signature, userHandle)
@@ -155,7 +155,7 @@ Object.defineProperty($<u2f>, 'postSign', {
     if (errorCode > 1) {
       errorData = {
         'errorCode': errorCode,
-        'errorMessage': errorMessage
+        'errorMessage': atob(errorMessage)
       }
       $<u2f>.resolve[handle](errorData)
       return
@@ -175,7 +175,7 @@ Object.defineProperty($<u2f>, 'postRegister', {
     if (errorCode > 1) {
       errorData = {
         'errorCode': errorCode,
-        'errorMessage': errorMessage
+        'errorMessage': atob(errorMessage)
       }
       $<u2f>.resolve[handle](errorData)
       return

--- a/Client/U2FExtensions.swift
+++ b/Client/U2FExtensions.swift
@@ -404,7 +404,7 @@ class U2FExtensions: NSObject {
     private func sendFIDO2RegistrationError(handle: Int, errorName: String = FIDO2ErrorMessages.NotAllowedError.rawValue, errorDescription: String = Strings.U2FRegistrationError) {
         cleanupFIDO2Registration(handle: handle)
         ensureMainThread {
-            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postCreate('\(handle)', \(true),'', '', '', '\(errorName)', '\(errorDescription)')", completionHandler: { _, error in
+            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postCreate('\(handle)', \(true),'', '', '', '\(errorName.toBase64())', '\(errorDescription.toBase64())')", completionHandler: { _, error in
                 if error != nil {
                     let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
                     log.error(errorDescription)
@@ -576,7 +576,7 @@ class U2FExtensions: NSObject {
     private func sendFIDO2AuthenticationError(handle: Int, errorName: String = FIDO2ErrorMessages.NotAllowedError.rawValue, errorDescription: String = Strings.U2FAuthenticationError) {
         cleanupFIDO2Authentication(handle: handle)
         ensureMainThread {
-            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postGet('\(handle)', \(true), '', '', '', '', '\(errorName)', '\(errorDescription)')", completionHandler: { _, error in
+            self.tab?.webView?.evaluateJavaScript("navigator.credentials.postGet('\(handle)', \(true), '', '', '', '', '\(errorName.toBase64())', '\(errorDescription.toBase64())')", completionHandler: { _, error in
                 if error != nil {
                     let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
                     log.error(errorDescription)
@@ -730,7 +730,7 @@ class U2FExtensions: NSObject {
         cleanupFIDORegistration(handle: handle)
         if requestId >= 0 {
             ensureMainThread {
-                self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelRegister(\(requestId), \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+                self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelRegister(\(requestId), \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage.toBase64())')", completionHandler: { _, error in
                     if error != nil {
                         let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
                         log.error(errorDescription)
@@ -740,7 +740,7 @@ class U2FExtensions: NSObject {
         }
         
         ensureMainThread {
-            self.tab?.webView?.evaluateJavaScript("u2f.postRegister('\(handle)', \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+            self.tab?.webView?.evaluateJavaScript("u2f.postRegister('\(handle)', \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage.toBase64())')", completionHandler: { _, error in
                 if error != nil {
                     let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorRegistration.rawValue
                     log.error(errorDescription)
@@ -858,7 +858,7 @@ class U2FExtensions: NSObject {
         
         if requestId >= 0 {
             ensureMainThread {
-                self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelSign(\(requestId), \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+                self.tab?.webView?.evaluateJavaScript("u2f.postLowLevelSign(\(requestId), \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage.toBase64())')", completionHandler: { _, error in
                     if error != nil {
                         let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
                         log.error(errorDescription)
@@ -868,7 +868,7 @@ class U2FExtensions: NSObject {
         }
         
         ensureMainThread {
-            self.tab?.webView?.evaluateJavaScript("u2f.postSign('\(handle)', \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage)')", completionHandler: { _, error in
+            self.tab?.webView?.evaluateJavaScript("u2f.postSign('\(handle)', \(true), '', '', '', \(errorCode.rawValue), '\(errorMessage.toBase64())')", completionHandler: { _, error in
                 if error != nil {
                     let errorDescription = error?.localizedDescription ?? U2FErrorMessages.ErrorAuthentication.rawValue
                     log.error(errorDescription)
@@ -1082,4 +1082,11 @@ extension Strings {
     public static let pinLabel = NSLocalizedString("pinLabel", bundle: Bundle.shared, value: "Enter the PIN", comment: "Label for the text box when a security key with PIN is inserted.")
     public static let pinPlaceholder = NSLocalizedString("pinPlaceholder", bundle: Bundle.shared, value: "PIN", comment: "Placeholder text for PIN")
     public static let confirmPin = NSLocalizedString("confirmPin", bundle: Bundle.shared, value: "Confirm", comment: "Button text to confirm PIN")
+}
+
+extension String {
+    /// Encode a String to Base64
+    func toBase64() -> String {
+        return Data(self.utf8).base64EncodedString()
+    }
 }


### PR DESCRIPTION
fix #1360 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

1. Navigate to demo.yubico.com/u2f
2. Insert the security key and wait for the timeout interval
3. The page navigation should complete, and the error message should be displayed.

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

