### PR TITLE
Fixes: #1290. iPad will now have Desktop UA as default in iOS 13 with a setting to disable it

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -393,6 +393,7 @@ extension Strings {
     public static let Privacy = NSLocalizedString("Privacy", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Privacy", comment: "Settings privacy section title")
     public static let Security = NSLocalizedString("Security", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Security", comment: "Settings security section title")
     public static let Save_Logins = NSLocalizedString("SaveLogins", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Save Logins", comment: "Setting to enable the built-in password manager")
+    public static let AlwaysRequestDesktopSite = NSLocalizedString("AlwaysRequestDesktopSite", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Always request desktop site", comment: "Setting to always request desktop site")
     public static let ShieldsAdStats = NSLocalizedString("AdsrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Ads \nBlocked", comment: "Shields Ads Stat")
     public static let ShieldsAdAndTrackerStats = NSLocalizedString("AdsAndTrackersrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Ads & Trackers \nBlocked", comment: "Shields Ads Stat")
     public static let ShieldsTrackerStats = NSLocalizedString("TrackersrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Trackers \nBlocked", comment: "Shields Trackers Stat")

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -441,7 +441,6 @@
 		4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */; };
 		4F97573B1AFA6F37006ECC24 /* readerContent.html in Resources */ = {isa = PBXBuildFile; fileRef = 4F9757391AFA6F37006ECC24 /* readerContent.html */; };
 		55A747171DC46FC400CE1B57 /* HomePageUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A747161DC46FC400CE1B57 /* HomePageUITest.swift */; };
-		5925CC0C2304B08F006C8BDD /* SwiftAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5925CC0B2304B08F006C8BDD /* SwiftAttributes.swift */; };
 		5925CC152304DBEF006C8BDD /* UserAgentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5925CC142304DBEF006C8BDD /* UserAgentExtension.swift */; };
 		592F521E2217327C0078395E /* HttpCookieExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592F521D2217327B0078395E /* HttpCookieExtension.swift */; };
 		59350AFB22612D95004D7445 /* DisplayTextFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59350AFA22612D95004D7445 /* DisplayTextFieldTest.swift */; };
@@ -1597,7 +1596,6 @@
 		4F9757391AFA6F37006ECC24 /* readerContent.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = readerContent.html; sourceTree = "<group>"; };
 		55A747161DC46FC400CE1B57 /* HomePageUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageUITest.swift; sourceTree = "<group>"; };
 		5902D2FF22DCD681002232FB /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/BraveShared.strings; sourceTree = "<group>"; };
-		5925CC0B2304B08F006C8BDD /* SwiftAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftAttributes.swift; sourceTree = "<group>"; };
 		5925CC142304DBEF006C8BDD /* UserAgentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentExtension.swift; sourceTree = "<group>"; };
 		5929A9E421B6AEB5005ECF8D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Storage.strings; sourceTree = "<group>"; };
 		5929A9EC21B6AEBB005ECF8D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1952,6 +1950,7 @@
 		A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeHelper.swift; sourceTree = "<group>"; };
 		A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightModeHelper.swift; sourceTree = "<group>"; };
 		AB1B097921F2F00400E0DD51 /* FavoritesViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewControllerTests.swift; sourceTree = "<group>"; };
+		B0373FF7229D1493006F78B4 /* PreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewViewController.swift; sourceTree = "<group>"; };
 		C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListViewController.swift; sourceTree = "<group>"; };
 		C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListAnimator.swift; sourceTree = "<group>"; };
 		C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabTrayButtonExtensions.swift; path = ../Browser/TabTrayButtonExtensions.swift; sourceTree = "<group>"; };
@@ -3877,7 +3876,6 @@
 				5925CC142304DBEF006C8BDD /* UserAgentExtension.swift */,
 				E65075911E37F7AB006961AC /* WeakList.swift */,
 				2760D2BE215ACCE20068E131 /* BundleExtensions.swift */,
-				5925CC0B2304B08F006C8BDD /* SwiftAttributes.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -5376,7 +5374,6 @@
 				E65075C01E37F7AB006961AC /* WeakList.swift in Sources */,
 				E65075AE1E37F7AB006961AC /* UIImageExtensions.swift in Sources */,
 				E65075A71E37F7AB006961AC /* ScannerExtensions.swift in Sources */,
-				5925CC0C2304B08F006C8BDD /* SwiftAttributes.swift in Sources */,
 				E65075A21E37F7AB006961AC /* HexExtensions.swift in Sources */,
 				288A2DB61AB8B38D0023ABC3 /* Result.swift in Sources */,
 				E65075AD1E37F7AB006961AC /* UIColorExtensions.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -441,6 +441,8 @@
 		4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */; };
 		4F97573B1AFA6F37006ECC24 /* readerContent.html in Resources */ = {isa = PBXBuildFile; fileRef = 4F9757391AFA6F37006ECC24 /* readerContent.html */; };
 		55A747171DC46FC400CE1B57 /* HomePageUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A747161DC46FC400CE1B57 /* HomePageUITest.swift */; };
+		5925CC0C2304B08F006C8BDD /* SwiftAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5925CC0B2304B08F006C8BDD /* SwiftAttributes.swift */; };
+		5925CC152304DBEF006C8BDD /* UserAgentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5925CC142304DBEF006C8BDD /* UserAgentExtension.swift */; };
 		592F521E2217327C0078395E /* HttpCookieExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592F521D2217327B0078395E /* HttpCookieExtension.swift */; };
 		59350AFB22612D95004D7445 /* DisplayTextFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59350AFA22612D95004D7445 /* DisplayTextFieldTest.swift */; };
 		5953AAEF2226E9D800A92DE1 /* HttpCookieExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5953AAEE2226E9D800A92DE1 /* HttpCookieExtensionTest.swift */; };
@@ -1595,6 +1597,8 @@
 		4F9757391AFA6F37006ECC24 /* readerContent.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = readerContent.html; sourceTree = "<group>"; };
 		55A747161DC46FC400CE1B57 /* HomePageUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageUITest.swift; sourceTree = "<group>"; };
 		5902D2FF22DCD681002232FB /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/BraveShared.strings; sourceTree = "<group>"; };
+		5925CC0B2304B08F006C8BDD /* SwiftAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftAttributes.swift; sourceTree = "<group>"; };
+		5925CC142304DBEF006C8BDD /* UserAgentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentExtension.swift; sourceTree = "<group>"; };
 		5929A9E421B6AEB5005ECF8D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Storage.strings; sourceTree = "<group>"; };
 		5929A9EC21B6AEBB005ECF8D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5929A9ED21B6AED0005ECF8D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1948,7 +1952,6 @@
 		A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeHelper.swift; sourceTree = "<group>"; };
 		A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightModeHelper.swift; sourceTree = "<group>"; };
 		AB1B097921F2F00400E0DD51 /* FavoritesViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewControllerTests.swift; sourceTree = "<group>"; };
-		B0373FF7229D1493006F78B4 /* PreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewViewController.swift; sourceTree = "<group>"; };
 		C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListViewController.swift; sourceTree = "<group>"; };
 		C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackForwardListAnimator.swift; sourceTree = "<group>"; };
 		C4E3984B1D21F2FD004E89BA /* TabTrayButtonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabTrayButtonExtensions.swift; path = ../Browser/TabTrayButtonExtensions.swift; sourceTree = "<group>"; };
@@ -3871,8 +3874,10 @@
 				E650758E1E37F7AB006961AC /* SystemUtils.swift */,
 				E650758F1E37F7AB006961AC /* TimeConstants.swift */,
 				E65075901E37F7AB006961AC /* UserAgent.swift */,
+				5925CC142304DBEF006C8BDD /* UserAgentExtension.swift */,
 				E65075911E37F7AB006961AC /* WeakList.swift */,
 				2760D2BE215ACCE20068E131 /* BundleExtensions.swift */,
+				5925CC0B2304B08F006C8BDD /* SwiftAttributes.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -5355,6 +5360,7 @@
 				A1510DDF20E51EF4008BF1F4 /* UIDeviceExtensions.swift in Sources */,
 				E65075B81E37F7AB006961AC /* NotificationConstants.swift in Sources */,
 				E65075AC1E37F7AB006961AC /* StringExtensions.swift in Sources */,
+				5925CC152304DBEF006C8BDD /* UserAgentExtension.swift in Sources */,
 				E65075951E37F7AB006961AC /* GeneralUtils.swift in Sources */,
 				E683F0C21E93D4E90035D990 /* DictionaryExtensions.swift in Sources */,
 				E650759B1E37F7AB006961AC /* CrashSimulator.m in Sources */,
@@ -5370,6 +5376,7 @@
 				E65075C01E37F7AB006961AC /* WeakList.swift in Sources */,
 				E65075AE1E37F7AB006961AC /* UIImageExtensions.swift in Sources */,
 				E65075A71E37F7AB006961AC /* ScannerExtensions.swift in Sources */,
+				5925CC0C2304B08F006C8BDD /* SwiftAttributes.swift in Sources */,
 				E65075A21E37F7AB006961AC /* HexExtensions.swift in Sources */,
 				288A2DB61AB8B38D0023ABC3 /* Result.swift in Sources */,
 				E65075AD1E37F7AB006961AC /* UIColorExtensions.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -416,12 +416,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
     fileprivate func setUserAgent() {
         let firefoxUA = UserAgent.defaultUserAgent()
-
-        // Set the UA for WKWebView (via defaults), the favicon fetcher, and the image loader.
-        // This only needs to be done once per runtime. Note that we use defaults here that are
-        // readable from extensions, so they can just use the cached identifier.
-        let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
-        defaults.register(defaults: ["UserAgent": firefoxUA])
+        
+        // For iOS 13 and above WKWebpagePreferences.preferredContentMode & applicationNameForUserAgent are used to manage UA.
+        if lessThaniOS13 {
+            // Set the UA for WKWebView (via defaults), the favicon fetcher, and the image loader.
+            // This only needs to be done once per runtime. Note that we use defaults here that are
+            // readable from extensions, so they can just use the cached identifier.
+            let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
+            defaults.register(defaults: ["UserAgent": firefoxUA])
+        }
 
         SDWebImageDownloader.shared().setValue(firefoxUA, forHTTPHeaderField: "User-Agent")
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -418,7 +418,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let firefoxUA = UserAgent.defaultUserAgent()
         
         // For iOS 13 and above WKWebpagePreferences.preferredContentMode & applicationNameForUserAgent are used to manage UA.
-        if lessThaniOS13 {
+        if #available(iOS 13.0, *) {
+            //No change required here
+        } else {
             // Set the UA for WKWebView (via defaults), the favicon fetcher, and the image loader.
             // This only needs to be done once per runtime. Note that we use defaults here that are
             // readable from extensions, so they can just use the cached identifier.

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -41,6 +41,8 @@ extension Preferences {
         static let blockPopups = Option<Bool>(key: "general.block-popups", default: true)
         /// Controls how the tab bar should be shown (or not shown)
         static let tabBarVisibility = Option<Int>(key: "general.tab-bar-visiblity", default: TabBarVisibility.always.rawValue)
+        /// Sets Desktop UA for iPad by default (iOS 13+ & iPad only)
+        static let alwaysRequestDesktopSite = Option<Bool>(key: "general.always-request-desktop-site", default: UIDevice.isIpad)
         
         /// Whether or not a user has enabled Night Mode.
         ///

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1277,8 +1277,9 @@ class BrowserViewController: UIViewController {
             }
         }
         
-        // Remember whether or not a desktop site was requested
-        tab.desktopSite = webView.customUserAgent?.isEmpty == false
+        // Remember whether or not a desktop/mobile site was requested
+        let isCustomUserAgentEmpty = webView.customUserAgent?.isEmpty == true
+        tab.desktopSite = isCustomUserAgentEmpty ? UIDevice.isIpad : !UIDevice.isIpad
     }
     
     // MARK: - Browser PIN Callout

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1284,7 +1284,7 @@ class BrowserViewController: UIViewController {
         
         // Remember whether or not a desktop/mobile site was requested
         if #available(iOS 13.0, *) {
-            if let customUA = webView.customUserAgent, customUA.isEmpty == false {
+            if let customUA = webView.customUserAgent, !customUA.isEmpty {
                 tab.desktopSite = UserAgent.isDesktopUA(uaString: customUA)
             } else {
                 tab.desktopSite = Preferences.General.alwaysRequestDesktopSite.value

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -64,6 +64,16 @@ extension BrowserViewController: WKNavigationDelegate {
         return false
     }
 
+    // This is the iOS 13 delegate callback which is similar to the delegate below it
+    // except that a WKWebpagePreferences is provided, Setting the type of contentMode loads the site accordingly.
+    @available(iOS 13.0, *)
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
+        self.webView(webView, decidePolicyFor: navigationAction) {
+            preferences.preferredContentMode = Preferences.General.alwaysRequestDesktopSite.value ? .desktop :. mobile
+            decisionHandler($0, preferences)
+        }
+    }
+    
     // This is the place where we decide what to do with a new navigation action. There are a number of special schemes
     // and http(s) urls that need to be handled in a different way. All the logic for that is inside this delegate
     // method.

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -123,7 +123,7 @@ class Tab: NSObject {
 
     /// Whether or not the desktop site was requested with the last request, reload or navigation. Note that this property needs to
     /// be managed by the web view's navigation delegate.
-    var desktopSite: Bool = false
+    var desktopSite: Bool = UIDevice.isIpad ? true : false
     
     var readerModeAvailableOrActive: Bool {
         if let readerMode = self.getContentScript(name: "ReaderMode") as? ReaderMode {
@@ -399,7 +399,13 @@ class Tab: NSObject {
     }
 
     func reload() {
-        let userAgent: String? = desktopSite ? UserAgent.desktopUserAgent() : nil
+        
+        var userAgent: String?
+        if UIDevice.isIpad && !desktopSite {
+            userAgent = UserAgent.mobileUserAgent()
+        } else if !UIDevice.isIpad && desktopSite {
+            userAgent = UserAgent.desktopUserAgent()
+        }
         if (userAgent ?? "") != webView?.customUserAgent,
            let currentItem = webView?.backForwardList.currentItem {
             webView?.customUserAgent = userAgent

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -123,7 +123,7 @@ class Tab: NSObject {
 
     /// Whether or not the desktop site was requested with the last request, reload or navigation. Note that this property needs to
     /// be managed by the web view's navigation delegate.
-    var desktopSite: Bool = Preferences.General.alwaysRequestDesktopSite.value ? true : false
+    var desktopSite: Bool = Preferences.General.alwaysRequestDesktopSite.value
     
     var readerModeAvailableOrActive: Bool {
         if let readerMode = self.getContentScript(name: "ReaderMode") as? ReaderMode {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -165,6 +165,11 @@ class TabManager: NSObject {
     private class func getNewConfiguration() -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
+        // Setting the Unique applicationName for the user agent to identify Brave.
+        if #available(iOS 13.0, *) {
+            configuration.applicationNameForUserAgent = Preferences.General.alwaysRequestDesktopSite.value ?
+            UserAgent.desktopUAApplicationName() : UserAgent.mobileUAApplicationName()
+        }
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !Preferences.General.blockPopups.value
         UserReferralProgram.shared?.insertCookies(intoStore: configuration.websiteDataStore.httpCookieStore)
         return configuration

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -166,7 +166,10 @@ class SettingsViewController: TableViewController {
             }
             general.rows.append(row)
         }
-        
+        if #available(iOS 13.0, *), UIDevice.isIpad {
+            general.rows.append(BoolRow(title: Strings.AlwaysRequestDesktopSite,
+            option: Preferences.General.alwaysRequestDesktopSite))
+        }
         return general
     }()
     

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -14,13 +14,12 @@ import Alamofire
 class ClientTests: XCTestCase {
 
     // Simple test to make sure the WKWebView UA matches the expected FxiOS pattern.
-    func testUserAgent() {
+    func testMobileUserAgent() {
         let compare: (String) -> Bool = { ua in
             let range = ua.range(of: "^Mozilla/5\\.0 \\(.+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) FxiOS/[0-9\\.]+b[0-9\\.]* Mobile/[A-Za-z0-9]+ Safari/[0-9\\.]+$", options: .regularExpression)
             return range != nil
         }
-
-        XCTAssertTrue(compare(UserAgent.defaultUserAgent()), "User agent computes correctly.")
+        XCTAssertTrue(compare(UserAgent.mobileUserAgent()), "User agent computes correctly.")
         XCTAssertTrue(compare(UserAgent.cachedUserAgent(checkiOSVersion: true)!), "User agent is cached correctly.")
 
         let expectation = self.expectation(description: "Found Firefox user agent")

--- a/Shared/SwiftAttributes.swift
+++ b/Shared/SwiftAttributes.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+public var lessThaniOS13: Bool {
+    if #available(iOS 13.0, *) {
+        return false
+    }
+    return true
+}

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -4,7 +4,6 @@
 
 import AVFoundation
 import UIKit
-import JavaScriptCore
 
 open class UserAgent {
     private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -4,6 +4,7 @@
 
 import AVFoundation
 import UIKit
+import JavaScriptCore
 
 open class UserAgent {
     private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
@@ -45,59 +46,51 @@ open class UserAgent {
                 return firefoxUA
             }
         }
-
         return nil
     }
 
+    private static var systemDefaultUA: String = ""
     /**
      * This will typically return quickly, but can require creation of a UIWebView.
      * As a result, it must be called on the UI thread.
      */
     public static func defaultUserAgent() -> String {
         assert(Thread.current.isMainThread, "This method must be called on the main thread.")
-
         if let firefoxUA = UserAgent.cachedUserAgent(checkiOSVersion: true) {
             return firefoxUA
         }
-
-        let webView = UIWebView()
-
+        defaults.removeObject(forKey: "UserAgent")
         let currentiOSVersion = UIDevice.current.systemVersion
         defaults.set(currentiOSVersion, forKey: "LastDeviceSystemVersionNumber")
         defaults.set(appVersion, forKey: "LastFirefoxVersionNumber")
         defaults.set(buildNumber, forKey: "LastFirefoxBuildNumber")
-
-        let userAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent")!
-
-        // Extract the WebKit version and use it as the Safari version.
-        let webKitVersionRegex = try? NSRegularExpression(pattern: "AppleWebKit/([^ ]+) ", options: [])
-        guard let match = webKitVersionRegex?.firstMatch(in: userAgent, options: [], range: NSRange(location: 0, length: userAgent.count)) else {
-            print("Error: Unable to determine WebKit version in UA.")
-            return userAgent     // Fall back to Safari's.
+        systemDefaultUA = UIWebView().stringByEvaluatingJavaScript(from: "navigator.userAgent")!
+        if UIDevice.isIpad {
+            return desktopUserAgent()
         }
-
-        let webKitVersion = (userAgent as NSString).substring(with: match.range(at: 1))
-
+        return mobileUserAgent()
+    }
+    
+    public static func mobileUserAgent() -> String {
+        // Extract the WebKit version and use it as the Safari version.
+        guard let webKitVersion = systemDefaultUA.webkitVersion() else {
+            return systemDefaultUA
+        }
+        
         // Insert "FxiOS/<version>" before the Mobile/ section.
-        let mobileRange = (userAgent as NSString).range(of: "Mobile/")
+        let mobileRange = (systemDefaultUA as NSString).range(of: "Mobile/")
         if mobileRange.location == NSNotFound {
             print("Error: Unable to find Mobile section in UA.")
-            return userAgent     // Fall back to Safari's.
+            return systemDefaultUA     // Fall back to Safari's.
         }
-
-        let mutableUA = NSMutableString(string: userAgent)
+        
+        let mutableUA = NSMutableString(string: systemDefaultUA)
         mutableUA.insert("FxiOS/\(appVersion)b\(buildNumber) ", at: mobileRange.location)
-
-        let firefoxUA = "\(mutableUA) Safari/\(webKitVersion)"
-
-        defaults.set(firefoxUA, forKey: "UserAgent")
-
-        return firefoxUA
+        return "\(mutableUA) Safari/\(webKitVersion)"
     }
 
     public static func desktopUserAgent() -> String {
-        let userAgent = NSMutableString(string: defaultUserAgent())
-
+        let userAgent = NSMutableString(string: systemDefaultUA)
         // Spoof platform section
         let platformRegex = try? NSRegularExpression(pattern: "\\([^\\)]+\\)", options: [])
         guard let platformMatch = platformRegex?.firstMatch(in: userAgent as String, options: [], range: NSRange(location: 0, length: userAgent.length)) else {
@@ -107,13 +100,28 @@ open class UserAgent {
         userAgent.replaceCharacters(in: platformMatch.range, with: "(Macintosh; Intel Mac OS X 10_11_1)")
 
         // Strip mobile section
-        let mobileRegex = try? NSRegularExpression(pattern: " FxiOS/[^ ]+ Mobile/[^ ]+", options: [])
+        let mobileRegex = try? NSRegularExpression(pattern: " Mobile/[^ ]+", options: [])
         guard let mobileMatch = mobileRegex?.firstMatch(in: userAgent as String, options: [], range: NSRange(location: 0, length: userAgent.length)) else {
             print("Error: Unable to find Mobile section in UA.")
             return String(userAgent)
         }
         userAgent.replaceCharacters(in: mobileMatch.range, with: "")
+        
+        // Extract the WebKit version and use it as the Safari version.
+        guard let webKitVersion = systemDefaultUA.webkitVersion() else {
+            return systemDefaultUA
+        }
+        return "\(userAgent) Safari/\(webKitVersion)"
+    }
+}
 
-        return String(userAgent)
+private extension String {
+    func webkitVersion() -> String? {
+        let webKitVersionRegex = try? NSRegularExpression(pattern: "AppleWebKit/([^ ]+) ", options: [])
+        guard let match = webKitVersionRegex?.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.count)) else {
+            return nil
+        }
+        
+        return (self as NSString).substring(with: match.range(at: 1))
     }
 }

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -59,7 +59,10 @@ open class UserAgent {
         if let firefoxUA = UserAgent.cachedUserAgent(checkiOSVersion: true) {
             return firefoxUA
         }
-        defaults.removeObject(forKey: "UserAgent")
+        // Reset UA
+        var dict = UserDefaults.standard.volatileDomain(forName: UserDefaults.registrationDomain)
+        dict.removeValue(forKey: "UserAgent")
+        UserDefaults.standard.setVolatileDomain(dict, forName: UserDefaults.registrationDomain)
         let currentiOSVersion = UIDevice.current.systemVersion
         defaults.set(currentiOSVersion, forKey: "LastDeviceSystemVersionNumber")
         defaults.set(appVersion, forKey: "LastFirefoxVersionNumber")

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -67,9 +67,6 @@ open class UserAgent {
         defaults.set(appVersion, forKey: "LastFirefoxVersionNumber")
         defaults.set(buildNumber, forKey: "LastFirefoxBuildNumber")
         systemDefaultUA = UIWebView().stringByEvaluatingJavaScript(from: "navigator.userAgent")!
-        if UIDevice.isIpad {
-            return desktopUserAgent()
-        }
         return mobileUserAgent()
     }
     

--- a/Shared/UserAgentExtension.swift
+++ b/Shared/UserAgentExtension.swift
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import WebKit
+
+extension UserAgent {
+    // Application names are used for default behaviour while custom UA's for user intiated toggle.
+    public static func mobileUAApplicationName() -> String? {
+        let mobileUA = mobileUserAgent()
+        // Extract the WebKit version and use it as the Safari version.
+        let mobileRegex = try? NSRegularExpression(pattern: "FxiOS(.*)$", options: [])
+        guard let match = mobileRegex?.firstMatch(in: mobileUA, options: [], range: NSRange(location: 0, length: mobileUA.count)) else {
+            return nil     // Fall back to Safari's.
+        }
+        return (mobileUA as NSString).substring(with: match.range)
+    }
+    
+    public static func desktopUAApplicationName() -> String? {
+        let desktopUA = desktopUserAgent()
+        // Extract the WebKit version and use it as the Safari version.
+        let mobileRegex = try? NSRegularExpression(pattern: "Safari(.*)$", options: [])
+        guard let match = mobileRegex?.firstMatch(in: desktopUA, options: [], range: NSRange(location: 0, length: desktopUA.count)) else {
+            return nil     // Fall back to Safari's.
+        }
+        return (desktopUA as NSString).substring(with: match.range)
+    }
+    
+    // Check if mobile UA
+    public static func isDesktopUA(uaString: String) -> Bool {
+        return !uaString.lowercased().contains("mobile")
+    }
+    
+}


### PR DESCRIPTION
Fixes: #1290, iPad will use Desktop UA by default.
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->
To test please visit https://www.whatsmyua.info
and load the page in iPad/iPhone (iOS 12 & 13) and also try changing the mode from share option

On iOS 12 (iPhone & Pad)& iOS 13 (iPhone), there should be no change and should be same as older versions,
while on iOS 13 iPad the launch should be. in desktop and the setting will be available 
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

