### PR TITLE
Fix: #1129 Disable Auto-Play Toggle added.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -451,6 +451,7 @@ extension Strings {
 
 extension Strings {
     public static let Block_Popups = NSLocalizedString("BlockPopups", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Block Popups", comment: "Setting to enable popup blocking")
+    public static let Media_Auto_Plays = NSLocalizedString("MediaAutoPlays", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Enable background video autoplay", comment: "Setting to allow media to play automatically")
     public static let Show_Tabs_Bar = NSLocalizedString("ShowTabsBar", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Show Tabs Bar", comment: "Setting to show/hide the tabs bar")
     public static let Private_Browsing_Only = NSLocalizedString("PrivateBrowsingOnly", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Private Browsing Only", comment: "Setting to keep app in private mode")
     public static let Brave_Shield_Defaults = NSLocalizedString("BraveShieldDefaults", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Brave Shield Defaults", comment: "Section title for adbblock, tracking protection, HTTPS-E, and cookies")

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -49,6 +49,9 @@ extension Preferences {
         static let showBookmarkToolbarShortcut = Option<Bool>(key: "general.show-bookmark-toolbar-shortcut", default: UIDevice.isIpad)
         /// Sets Desktop UA for iPad by default (iOS 13+ & iPad only)
         static let alwaysRequestDesktopSite = Option<Bool>(key: "general.always-request-desktop-site", default: UIDevice.isIpad)
+        /// Controls whether or not media auto-plays
+        static let mediaAutoPlays = Option<Bool>(key: "general.media-auto-plays", default: true)
+        
         /// Whether or not a user has enabled Night Mode.
         ///
         /// Currently unused

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -50,7 +50,7 @@ extension Preferences {
         /// Sets Desktop UA for iPad by default (iOS 13+ & iPad only)
         static let alwaysRequestDesktopSite = Option<Bool>(key: "general.always-request-desktop-site", default: UIDevice.isIpad)
         /// Controls whether or not media auto-plays
-        static let mediaAutoPlays = Option<Bool>(key: "general.media-auto-plays", default: true)
+        static let mediaAutoPlays = Option<Bool>(key: "general.media-auto-plays", default: false)
         
         /// Whether or not a user has enabled Night Mode.
         ///

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -200,8 +200,6 @@ class Tab: NSObject {
             }
             // Enables Zoom in website by ignoring their javascript based viewport Scale limits.
             configuration!.ignoresViewportScaleLimits = true
-            // Enables media auto-play based on the current preference setting (default is false)
-            configuration!.mediaTypesRequiringUserActionForPlayback = Preferences.General.mediaAutoPlays.value ? [] : .all
             let webView = TabWebView(frame: .zero, configuration: configuration!, isPrivate: isPrivate)
             webView.delegate = self
             configuration = nil

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -200,6 +200,8 @@ class Tab: NSObject {
             }
             // Enables Zoom in website by ignoring their javascript based viewport Scale limits.
             configuration!.ignoresViewportScaleLimits = true
+            // Enables media auto-play based on the current preference setting (default is false)
+            configuration!.mediaTypesRequiringUserActionForPlayback = Preferences.General.mediaAutoPlays.value ? [] : .all
             let webView = TabWebView(frame: .zero, configuration: configuration!, isPrivate: isPrivate)
             webView.delegate = self
             configuration = nil

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -1105,6 +1105,14 @@ extension TabManager: PreferencesObserver {
         case Preferences.General.mediaAutoPlays.key:
             let allowsMediaAutoPlay = Preferences.General.mediaAutoPlays.value
             configuration.mediaTypesRequiringUserActionForPlayback = allowsMediaAutoPlay ? [] : .all
+            
+            reloadSelectedTab()
+            for tab in allTabs where tab != selectedTab {
+                tab.createWebview()
+                if let url = tab.webView?.url {
+                    tab.loadRequest(PrivilegedRequest(url: url) as URLRequest)
+                }
+            }
         default:
             break
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -94,6 +94,7 @@ class TabManager: NSObject {
 
         Preferences.Shields.blockImages.observe(from: self)
         Preferences.General.blockPopups.observe(from: self)
+        Preferences.General.mediaAutoPlays.observe(from: self)
     }
 
     func addNavigationDelegate(_ delegate: WKNavigationDelegate) {
@@ -161,6 +162,7 @@ class TabManager: NSObject {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !Preferences.General.blockPopups.value
+        configuration.mediaTypesRequiringUserActionForPlayback = Preferences.General.mediaAutoPlays.value ? [] : .all
         UserReferralProgram.shared?.insertCookies(intoStore: configuration.websiteDataStore.httpCookieStore)
         return configuration
     }
@@ -1100,6 +1102,9 @@ extension TabManager: PreferencesObserver {
             }
             // The default tab configurations also need to change.
             configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+        case Preferences.General.mediaAutoPlays.key:
+            let allowsMediaAutoPlay = Preferences.General.mediaAutoPlays.value
+            configuration.mediaTypesRequiringUserActionForPlayback = allowsMediaAutoPlay ? [] : .all
         default:
             break
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -1103,9 +1103,6 @@ extension TabManager: PreferencesObserver {
             // The default tab configurations also need to change.
             configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
         case Preferences.General.mediaAutoPlays.key:
-            let allowsMediaAutoPlay = Preferences.General.mediaAutoPlays.value
-            configuration.mediaTypesRequiringUserActionForPlayback = allowsMediaAutoPlay ? [] : .all
-            
             reset()
             reloadSelectedTab()
             for tab in allTabs where tab != selectedTab {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -1105,12 +1105,6 @@ extension TabManager: PreferencesObserver {
         case Preferences.General.mediaAutoPlays.key:
             reset()
             reloadSelectedTab()
-            for tab in allTabs where tab != selectedTab {
-                tab.createWebview()
-                if let url = tab.webView?.url {
-                    tab.loadRequest(PrivilegedRequest(url: url) as URLRequest)
-                }
-            }
         default:
             break
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -1106,6 +1106,7 @@ extension TabManager: PreferencesObserver {
             let allowsMediaAutoPlay = Preferences.General.mediaAutoPlays.value
             configuration.mediaTypesRequiringUserActionForPlayback = allowsMediaAutoPlay ? [] : .all
             
+            reset()
             reloadSelectedTab()
             for tab in allTabs where tab != selectedTab {
                 tab.createWebview()

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -151,6 +151,7 @@ class SettingsViewController: TableViewController {
                 }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 BoolRow(title: Strings.Save_Logins, option: Preferences.General.saveLogins),
                 BoolRow(title: Strings.Block_Popups, option: Preferences.General.blockPopups),
+                BoolRow(title: Strings.Media_Auto_Plays, option: Preferences.General.mediaAutoPlays)
             ]
         )
         


### PR DESCRIPTION
- Disable Auto-Play Toggle added.
- Fixes: https://github.com/brave/brave-ios/issues/1129

URLs to test:

https://www.cnn.com/2019/08/10/europe/russia-jet-propulsion-blast-radiation-intl/index.html
https://videojs.github.io/autoplay-tests/plain/attr/autoplay.html
https://videojs.github.io/autoplay-tests/

URLs known for auto-play 100% of the time:
https://www.youtube.com/watch?v=JASUsVY5YJ8

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

