### PR TITLE
Fix #1388: Cancel queued key sessions on cleanup

### DIFF
--- a/Client/U2FExtensions.swift
+++ b/Client/U2FExtensions.swift
@@ -477,6 +477,7 @@ class U2FExtensions: NSObject {
         }
         fido2RegHandles.remove(at: index)
         fido2RegisterRequest.removeValue(forKey: handle)
+        YubiKitManager.shared.keySession.cancelCommands()
     }
     
     // FIDO2 Authentication
@@ -728,6 +729,7 @@ class U2FExtensions: NSObject {
         }
         fido2AuthHandles.remove(at: index)
         fido2AuthRequest.removeValue(forKey: handle)
+        YubiKitManager.shared.keySession.cancelCommands()
     }
     
     // FIDO Registration
@@ -841,6 +843,7 @@ class U2FExtensions: NSObject {
         fidoRegHandles.remove(at: index)
         fidoRegisterRequest.removeValue(forKey: handle)
         requestId.removeValue(forKey: handle)
+        YubiKitManager.shared.keySession.cancelCommands()
     }
     
     // FIDO Authetication
@@ -972,6 +975,7 @@ class U2FExtensions: NSObject {
         fidoSignHandles.remove(at: index)
         fidoSignRequests.removeValue(forKey: handle)
         requestId.removeValue(forKey: handle)
+        YubiKitManager.shared.keySession.cancelCommands()
     }
     
     private func handleSessionStateChange() {


### PR DESCRIPTION
Fix #1388 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.

## Test Plan:

1. Navigate to demo.yubico.com
2. Try the cancel/retry workflow with registration and authentication
3. App should not crash

## Reviewer Checklist:

- [x] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [x] Issues are assigned to at least one epic.
- [x] Issues include necessary QA labels:
  - [x] `QA/(Yes|No)`
  - [x] `release-notes/(include|exclude)`
  - [x] `bug` / `enhancement`
- [x] Necessary security reviews have taken place.
- [x] Adequate test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable)

