### PR TITLE
Fixed #1397 by creating TabMO when opening popups.

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -298,6 +298,12 @@ class TabManager: NSObject {
 
     func addPopupForParentTab(_ parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
         let popup = Tab(configuration: configuration, type: parentTab.type)
+        if parentTab.isPrivate {
+            // Creating random tab id for private mode, as we don't want to save to database.
+            popup.id = UUID().uuidString
+        } else {
+            popup.id = TabMO.create()
+        }
         configureTab(popup, request: nil, afterTab: parentTab, flushToDisk: true, zombie: false, isPopup: true)
 
         // Wait momentarily before selecting the new tab, otherwise the parent tab


### PR DESCRIPTION
Fixes #1397 (Only in normal mode. TabMO will still not be created in private mode.)
TabMO was not created for popups. Hence when relaunching the app, the popups were not restored.

STR: Same as in the ticket #1397 

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
-->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.


## Test Plan:

<!-- Any useful notes for reviewer explaining how best to test and verify. -->

### Screenshots:

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

