### PR TITLE
Fix #1409: Cleanup Swift 5 build warnings

### DIFF
--- a/Client/Extensions/NSURLExtensionsMailTo.swift
+++ b/Client/Extensions/NSURLExtensionsMailTo.swift
@@ -27,7 +27,7 @@ public extension URL {
 
         // Extract 'to' value
         let toStart = urlString.index(urlString.startIndex, offsetBy: "mailto:".count)
-        let toEnd = urlString.index(of: "?") ?? urlString.endIndex
+        let toEnd = urlString.firstIndex(of: "?") ?? urlString.endIndex
 
         let to = String(urlString[toStart..<toEnd])
 

--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -95,6 +95,8 @@ extension UIView {
                 make.height.equalTo(amount)
             case .horizontal:
                 make.width.equalTo(amount)
+            @unknown default:
+                assertionFailure()
             }
         }
         return spacer

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -25,7 +25,7 @@ private extension TrayToBrowserAnimator {
         let tabManager = bvc.tabManager
         let displayedTabs = tabManager.tabsForCurrentMode
         
-        guard let selectedTab = bvc.tabManager.selectedTab, let expandFromIndex = displayedTabs.index(of: selectedTab) else {
+        guard let selectedTab = bvc.tabManager.selectedTab, let expandFromIndex = displayedTabs.firstIndex(of: selectedTab) else {
             fatalError("No tab selected for transition.")
         }
         bvc.view.frame = transitionContext.finalFrame(for: bvc)
@@ -148,7 +148,7 @@ private extension BrowserToTrayAnimator {
         let container = transitionContext.containerView
         let tabManager = bvc.tabManager
         let displayedTabs = tabManager.tabsForCurrentMode
-        guard let selectedTab = bvc.tabManager.selectedTab, let scrollToIndex = displayedTabs.index(of: selectedTab) else {
+        guard let selectedTab = bvc.tabManager.selectedTab, let scrollToIndex = displayedTabs.firstIndex(of: selectedTab) else {
             fatalError("No tab selected for transition.")
         }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1597,7 +1597,7 @@ extension BrowserViewController: TopToolbarDelegate {
 
         // We couldn't build a URL, so check for a matching search keyword.
         let trimmedText = text.trimmingCharacters(in: .whitespaces)
-        guard let possibleKeywordQuerySeparatorSpace = trimmedText.index(of: " ") else {
+        guard let possibleKeywordQuerySeparatorSpace = trimmedText.firstIndex(of: " ") else {
             submitSearchText(text)
             return
         }

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -31,6 +31,9 @@ struct RewardsHelper {
             case .logInfo, .logResponse, .logRequest: logger.info(logOutput)
             case .logWarning: logger.warning(logOutput)
             case .logError: logger.error(logOutput)
+            @unknown default:
+                assertionFailure()
+                logger.debug(logOutput)
             }
         }, withFlush: nil)
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -59,7 +59,7 @@ extension BrowserViewController {
         }
 
         let tabs = tabManager.tabsForCurrentMode
-        if let index = tabs.index(of: currentTab), index + 1 < tabs.count {
+        if let index = tabs.firstIndex(of: currentTab), index + 1 < tabs.count {
             tabManager.selectTab(tabs[index + 1])
         } else if let firstTab = tabs.first {
             tabManager.selectTab(firstTab)
@@ -72,7 +72,7 @@ extension BrowserViewController {
         }
 
         let tabs = tabManager.tabsForCurrentMode
-        if let index = tabs.index(of: currentTab), index - 1 < tabs.count && index != 0 {
+        if let index = tabs.firstIndex(of: currentTab), index - 1 < tabs.count && index != 0 {
             tabManager.selectTab(tabs[index - 1])
         } else if let lastTab = tabs.last {
             tabManager.selectTab(lastTab)

--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -156,7 +156,7 @@ class DownloadQueue {
 
 extension DownloadQueue: DownloadDelegate {
     func download(_ download: Download, didCompleteWithError error: Error?) {
-        guard let error = error, let index = downloads.index(of: download) else {
+        guard let error = error, let index = downloads.firstIndex(of: download) else {
             return
         }
 
@@ -174,7 +174,7 @@ extension DownloadQueue: DownloadDelegate {
     }
 
     func download(_ download: Download, didFinishDownloadingTo location: URL) {
-        guard let index = downloads.index(of: download) else {
+        guard let index = downloads.firstIndex(of: download) else {
             return
         }
 

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -139,7 +139,7 @@ class ErrorPageHelper {
                 return GCDWebServerResponse(statusCode: 404)
             }
 
-            guard let index = self.redirecting.index(of: url) else {
+            guard let index = self.redirecting.firstIndex(of: url) else {
                 return GCDWebServerDataResponse(redirect: url, permanent: false)
             }
 
@@ -241,7 +241,7 @@ class ErrorPageHelper {
                     return
                 }
 
-                if let index = ErrorPageHelper.redirecting.index(of: previousURL) {
+                if let index = ErrorPageHelper.redirecting.firstIndex(of: previousURL) {
                     ErrorPageHelper.redirecting.remove(at: index)
                 }
             }

--- a/Client/Frontend/Browser/FormPostHelper.swift
+++ b/Client/Frontend/Browser/FormPostHelper.swift
@@ -85,7 +85,7 @@ class FormPostHelper: TabContentScript {
         
         let request = formPostData.urlRequestWithHeaders(navigationAction.request.allHTTPHeaderFields)
         
-        if let index = blankTargetFormPosts.index(where: { $0.matchesNavigationAction(navigationAction) }) {
+        if let index = blankTargetFormPosts.firstIndex(where: { $0.matchesNavigationAction(navigationAction) }) {
             blankTargetFormPosts.remove(at: index)
         }
         

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -101,6 +101,9 @@ extension FavoritesDataSource: NSFetchedResultsControllerDelegate {
             }
         case .move:
             break
+        @unknown default:
+            assertionFailure()
+            break
         }
     }
 }

--- a/Client/Frontend/Browser/ImageCache/WebImageCache.swift
+++ b/Client/Frontend/Browser/ImageCache/WebImageCache.swift
@@ -112,6 +112,9 @@ extension WebImageCache {
             
         case .disk:
             return ImageCacheType.disk
+
+        @unknown default:
+            return ImageCacheType.none
         }
     }
     

--- a/Client/Frontend/Browser/Punycode.swift
+++ b/Client/Frontend/Browser/Punycode.swift
@@ -19,7 +19,7 @@ extension String {
     }
 
     fileprivate func toIndex(_ value: Character) -> Int {
-        return asciiPunycode.index(of: value)!
+        return asciiPunycode.firstIndex(of: value)!
     }
 
     fileprivate func adapt(_ delta: Int, numPoints: Int, firstTime: Bool) -> Int {

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -163,7 +163,7 @@ class SearchEngines {
             return
         }
 
-        customEngines.remove(at: customEngines.index(of: engine)!)
+        customEngines.remove(at: customEngines.firstIndex(of: engine)!)
         saveCustomEngines()
         orderedEngines = getOrderedEngines()
     }
@@ -275,8 +275,8 @@ class SearchEngines {
         // (if the user changed locales or added a new engine); these engines
         // will be appended to the end of the list.
         return unorderedEngines.sorted { engine1, engine2 in
-            let index1 = orderedEngineNames.index(of: engine1.shortName)
-            let index2 = orderedEngineNames.index(of: engine2.shortName)
+            let index1 = orderedEngineNames.firstIndex(of: engine1.shortName)
+            let index2 = orderedEngineNames.firstIndex(of: engine2.shortName)
 
             if index1 == nil && index2 == nil {
                 return engine1.shortName < engine2.shortName

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -306,7 +306,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     @objc func didSelectEngine(_ sender: UIButton) {
         // The UIButtons are the same cardinality and order as the array of quick search engines.
         // Subtract 1 from index to account for magnifying glass accessory.
-        guard let index = searchEngineScrollViewContent.subviews.index(of: sender) else {
+        guard let index = searchEngineScrollViewContent.subviews.firstIndex(of: sender) else {
             assertionFailure()
             return
         }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -462,7 +462,7 @@ class Tab: NSObject {
     }
 
     func removeSnackbar(_ bar: SnackBar) {
-        if let index = bars.index(of: bar) {
+        if let index = bars.firstIndex(of: bar) {
             bars.remove(at: index)
             tabDelegate?.tab(self, didRemoveSnackbar: bar)
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -148,7 +148,7 @@ class TabManager: NSObject {
             return nil
         }
         
-        return tabsForCurrentMode.index(of: selectedTab)
+        return tabsForCurrentMode.firstIndex(of: selectedTab)
     }
     
     // What the users sees displayed based on current private browsing mode
@@ -226,7 +226,7 @@ class TabManager: NSObject {
         }
 
         if let tab = tab {
-            _selectedIndex = allTabs.index(of: tab) ?? -1
+            _selectedIndex = allTabs.firstIndex(of: tab) ?? -1
         } else {
             _selectedIndex = -1
         }
@@ -387,7 +387,7 @@ class TabManager: NSObject {
 
         let toTab = currentTabs[visibleToIndex]
 
-        guard let fromIndex = allTabs.index(of: tab), let toIndex = allTabs.index(of: toTab) else {
+        guard let fromIndex = allTabs.firstIndex(of: tab), let toIndex = allTabs.firstIndex(of: toTab) else {
             return
         }
         
@@ -397,7 +397,7 @@ class TabManager: NSObject {
         let tab = allTabs.remove(at: fromIndex)
         allTabs.insert(tab, at: toIndex)
 
-        if let previouslySelectedTab = previouslySelectedTab, let previousSelectedIndex = allTabs.index(of: previouslySelectedTab) {
+        if let previouslySelectedTab = previouslySelectedTab, let previousSelectedIndex = allTabs.firstIndex(of: previouslySelectedTab) {
             _selectedIndex = previousSelectedIndex
         }
 
@@ -417,7 +417,7 @@ class TabManager: NSObject {
 
         if parent == nil || parent?.type != tab.type {
             allTabs.append(tab)
-        } else if let parent = parent, var insertIndex = allTabs.index(of: parent) {
+        } else if let parent = parent, var insertIndex = allTabs.firstIndex(of: parent) {
             insertIndex += 1
             while insertIndex < allTabs.count && allTabs[insertIndex].isDescendentOf(parent) {
                 insertIndex += 1
@@ -534,7 +534,7 @@ class TabManager: NSObject {
         
         hideNetworkActivitySpinner()
 
-        guard let removalIndex = allTabs.index(where: { $0 === tab }) else {
+        guard let removalIndex = allTabs.firstIndex(where: { $0 === tab }) else {
             log.debug("Could not find index of tab to remove")
             return
         }
@@ -563,7 +563,7 @@ class TabManager: NSObject {
 
         var tabIndex: Int = -1
         if let oldTab = oldSelectedTab {
-            tabIndex = currentTabs.index(of: oldTab) ?? -1
+            tabIndex = currentTabs.firstIndex(of: oldTab) ?? -1
         }
 
         let prevCount = count
@@ -579,7 +579,7 @@ class TabManager: NSObject {
         if let oldTab = oldSelectedTab, tab !== oldTab {
             // If it wasn't the selected tab we removed, then keep it like that.
             // It might have changed index, so we look it up again.
-            _selectedIndex = allTabs.index(of: oldTab) ?? -1
+            _selectedIndex = allTabs.firstIndex(of: oldTab) ?? -1
         } else if let parentTab = tab.parent,
             currentTabs.count > 1,
             let newTab = currentTabs.reduce(currentTabs.first, { currentBestTab, tab2 in
@@ -593,7 +593,7 @@ class TabManager: NSObject {
             }
         }), parentTab == newTab, tab !== newTab, newTab.lastExecutedTime != nil {
             // We select the most recently visited tab, only if it is also the parent tab of the closed tab.
-            _selectedIndex = allTabs.index(of: newTab) ?? -1
+            _selectedIndex = allTabs.firstIndex(of: newTab) ?? -1
         } else {
             // By now, we've just removed the selected one, and no previously loaded
             // tabs. So let's load the final one in the tab tray.
@@ -602,7 +602,7 @@ class TabManager: NSObject {
             }
 
             if let currentTab = currentTabs[safe: tabIndex] {
-                _selectedIndex = allTabs.index(of: currentTab) ?? -1
+                _selectedIndex = allTabs.firstIndex(of: currentTab) ?? -1
             } else {
                 _selectedIndex = -1
             }
@@ -658,7 +658,7 @@ class TabManager: NSObject {
         
         // Remove the current tab last to prevent switching tabs while removing tabs
         if let selectedTab = selectedTab {
-            if let selectedIndex = tabsCopy.index(of: selectedTab) {
+            if let selectedIndex = tabsCopy.firstIndex(of: selectedTab) {
                 let removed = tabsCopy.remove(at: selectedIndex)
                 removeTabs(tabsCopy)
                 removeTab(removed)

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -66,7 +66,7 @@ extension TabTrayController {
         let tabs = self.tabs
         let currentIndex: Int
         if let selected = tabManager.selectedTab {
-            currentIndex = tabs.index(of: selected) ?? 0
+            currentIndex = tabs.firstIndex(of: selected) ?? 0
         } else {
             currentIndex = 0
         }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -611,7 +611,7 @@ extension TabTrayController: TabManagerDelegate {
 
         let updated = [ selected, previous ]
             .compactMap { $0 }
-            .compactMap { tabs.index(of: $0) }
+            .compactMap { tabs.firstIndex(of: $0) }
             .map { IndexPath(item: $0, section: 0) }
 
         assertIsMainThread("Changing selected tab is on main thread")
@@ -634,7 +634,7 @@ extension TabTrayController: TabManagerDelegate {
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {
         // Get the index of the added tab from it's set (private or normal)
-        guard let index = tabManager.tabsForCurrentMode.index(of: tab) else { return }
+        guard let index = tabManager.tabsForCurrentMode.firstIndex(of: tab) else { return }
         if !privateTabsAreEmpty() {
             emptyPrivateTabsView.isHidden = true
         }
@@ -858,7 +858,7 @@ extension TabManagerDataSource: UICollectionViewDragDelegate {
 @available(iOS 11.0, *)
 extension TabManagerDataSource: UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
-        guard isDragging, let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = tabs.index(of: tab) else {
+        guard isDragging, let destinationIndexPath = coordinator.destinationIndexPath, let dragItem = coordinator.items.first?.dragItem, let tab = dragItem.localObject as? Tab, let sourceIndex = tabs.firstIndex(of: tab) else {
             return
         }
 
@@ -878,7 +878,7 @@ extension TabManagerDataSource: UICollectionViewDropDelegate {
 
         // If the tab doesn't exist by the time we get here, we must return a
         // `.cancel` operation continuously until `isDragging` can be reset.
-        guard isDragging, tabs.index(of: tab) != nil else {
+        guard isDragging, tabs.firstIndex(of: tab) != nil else {
             isDragging = false
             return UICollectionViewDropProposal(operation: .cancel)
         }
@@ -1057,7 +1057,7 @@ extension TabTrayController: TabPeekDelegate {
     }
 
     func tabPeekDidCloseTab(_ tab: Tab) {
-        if let index = self.tabDataSource.tabs.index(of: tab),
+        if let index = self.tabDataSource.tabs.firstIndex(of: tab),
             let cell = self.collectionView?.cellForItem(at: IndexPath(item: index, section: 0)) as? TabCell {
             cell.close()
         }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -299,7 +299,7 @@ extension TabsBarViewController: UICollectionViewDataSource {
         
         // Find original from/to index... we need to target the full list not partial.
         let tabs = manager.tabsForCurrentMode
-        guard let to = tabs.index(where: {$0 === toTab}) else { return }
+        guard let to = tabs.firstIndex(where: {$0 === toTab}) else { return }
         
         manager.moveTab(fromTab, toIndex: to)
         updateData()

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -417,6 +417,9 @@ extension BookmarksViewController: NSFetchedResultsControllerDelegate {
       tableView.deleteRows(at: [indexPath], with: .automatic)
     case .move:
       break
+    @unknown default:
+        assertionFailure()
+        break
     }
   }
 }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -218,6 +218,8 @@ extension HistoryViewController: NSFetchedResultsControllerDelegate {
       if let newIndexPath = newIndexPath {
         tableView.insertRows(at: [newIndexPath], with: .automatic)
       }
+    @unknown default:
+        assertionFailure()
     }
     updateEmptyPanelState()
   }

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -387,7 +387,7 @@ fileprivate class ListSelectionController: NSObject {
 
     func deselectIndexPath(_ indexPath: IndexPath) {
         guard let foundSelectedPath = (selectedIndexPaths.filter { $0.row == indexPath.row && $0.section == indexPath.section }).first,
-              let indexToRemove = selectedIndexPaths.index(of: foundSelectedPath) else {
+            let indexToRemove = selectedIndexPaths.firstIndex(of: foundSelectedPath) else {
             return
         }
 
@@ -465,7 +465,7 @@ class LoginDataSource: NSObject, UITableViewDataSource {
     }
 
     @objc func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
-        return titles.index(of: Character(title)) ?? 0
+        return titles.firstIndex(of: Character(title)) ?? 0
     }
 
     @objc func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/Client/Frontend/Settings/PasscodeSettingsViewController.swift
+++ b/Client/Frontend/Settings/PasscodeSettingsViewController.swift
@@ -111,6 +111,8 @@ class PasscodeSettingsViewController: TableViewController {
             navigationItem.title = Strings.AuthenticationTouchIDPasscodeSetting
         case .none:
             navigationItem.title = Strings.AuthenticationPasscode
+        @unknown default:
+            assertionFailure()
         }
     }
 }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -61,8 +61,8 @@ extension DataSource {
     /// Since they are structs we cannot obtain references to them to alter them, we must directly access them
     /// from `sections[x].rows[y]`
     func indexPath(rowUUID: String, sectionUUID: String) -> IndexPath? {
-        guard let section = sections.index(where: { $0.uuid == sectionUUID }),
-            let row = sections[section].rows.index(where: { $0.uuid == rowUUID }) else {
+        guard let section = sections.firstIndex(where: { $0.uuid == sectionUUID }),
+            let row = sections[section].rows.firstIndex(where: { $0.uuid == rowUUID }) else {
                 return nil
         }
         return IndexPath(row: row, section: section)

--- a/Client/Frontend/Sync/SyncPairCameraViewController.swift
+++ b/Client/Frontend/Sync/SyncPairCameraViewController.swift
@@ -182,6 +182,7 @@ extension AVCaptureVideoOrientation {
             case .landscapeRight:       return .landscapeRight
             case .portrait:             return .portrait
             case .portraitUpsideDown:   return .portraitUpsideDown
+            @unknown default:           assertionFailure(); return .portrait
             }
         }
     }

--- a/Client/WebAuthN/WebAuthnRegisterRequest.swift
+++ b/Client/WebAuthN/WebAuthnRegisterRequest.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 struct PublicKeyCredentialDescriptor: Decodable {
     let type: String
     let id: String

--- a/Data/models/History.swift
+++ b/Data/models/History.swift
@@ -16,7 +16,7 @@ private var ignoredSchemes = ["about"]
 public func isIgnoredURL(_ url: URL) -> Bool {
     guard let scheme = url.scheme else { return false }
 
-    if let _ = ignoredSchemes.index(of: scheme) {
+    if let _ = ignoredSchemes.firstIndex(of: scheme) {
         return true
     }
 

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -427,7 +427,7 @@ extension URL {
         
         guard let scheme = self.scheme else { return false }
         
-        if let _ = ignoredSchemes.index(of: scheme) {
+        if let _ = ignoredSchemes.firstIndex(of: scheme) {
             return false
         }
         

--- a/Shared/WeakList.swift
+++ b/Shared/WeakList.swift
@@ -59,7 +59,7 @@ open class WeakList<T: AnyObject>: Sequence {
     }
     
     open func index(of object: T) -> Int? {
-        return self.items.index(where: { $0.value === object })
+        return self.items.firstIndex(where: { $0.value === object })
     }
     
     open subscript(index: Int) -> T? {

--- a/Storage/MockLogins.swift
+++ b/Storage/MockLogins.swift
@@ -77,7 +77,7 @@ open class MockLogins: BrowserLogins, SyncableLogins {
     }
 
     open func addLogin(_ login: LoginData) -> Success {
-        if let _ = cache.index(of: login as! Login) {
+        if let _ = cache.firstIndex(of: login as! Login) {
             return deferMaybe(LoginDataError(description: "Already in the cache"))
         }
         cache.append(login as! Login)
@@ -100,7 +100,7 @@ open class MockLogins: BrowserLogins, SyncableLogins {
     }
 
     open func updateLogin(_ login: LoginData) -> Success {
-        if let index = cache.index(of: login as! Login) {
+        if let index = cache.firstIndex(of: login as! Login) {
             cache[index].timePasswordChanged = Date.nowMicroseconds()
             return succeed()
         }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -25,7 +25,7 @@ private var ignoredSchemes = ["about"]
 public func isIgnoredURL(_ url: URL) -> Bool {
     guard let scheme = url.scheme else { return false }
 
-    if let _ = ignoredSchemes.index(of: scheme) {
+    if let _ = ignoredSchemes.firstIndex(of: scheme) {
         return true
     }
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -1242,7 +1242,7 @@ open class SDRow: Sequence {
     // the columns array passed into this Row to find the correct index.
     public subscript(key: String) -> Any? {
         get {
-            if let index = columnNames.index(of: key) {
+            if let index = columnNames.firstIndex(of: key) {
                 return getValue(index)
             }
             return nil


### PR DESCRIPTION
Remaining warnings are related to `withUnsafeMutableBytes`/`withUnsafeBytes` deprecations which might need a better look.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-ios/issues) for my issue if one did not already exist.
- [x] My patch or PR title has a standard commit message that looks like `Fix #123: This fixes the shattered coffee cup!` (or `No Bug: <message>` if no relevant ticket)
- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New files have MPL-2.0 license header.

## Test Plan:

Sanity test

## Reviewer Checklist:

- [ ] PR is linked to an issue via [Zenhub](https://www.zenhub.com/extension).
- [ ] Issues are assigned to at least one epic.
- [ ] Issues include necessary QA labels:
  - [ ] `QA/(Yes|No)`
  - [ ] `release-notes/(include|exclude)`
  - [ ] `bug` / `enhancement`
- [ ] Necessary security reviews have taken place.
- [ ] Adequate test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable)

