### PR TITLE
Fix 1413: excludeCredentials should return InvalidStateError if the credential is already created

### DIFF
--- a/Client/U2FExtensions.swift
+++ b/Client/U2FExtensions.swift
@@ -55,6 +55,7 @@ private enum U2FErrorMessages: String {
 private enum FIDO2ErrorMessages: String {
     case NotAllowedError = "NotAllowedError"
     case SecurityError = "SecurityError"
+    case InvalidStateError = "InvalidStateError"
 }
 
 private enum U2FMessageType: String {
@@ -433,6 +434,11 @@ class U2FExtensions: NSObject {
         }
         
         let makeCredentialError = error as NSError
+        
+        if makeCredentialError.code == YKFKeyFIDO2ErrorCode.CREDENTIAL_EXCLUDED.rawValue {
+            sendFIDO2RegistrationError(handle: handle, errorName: FIDO2ErrorMessages.InvalidStateError.rawValue, errorDescription: error.localizedDescription)
+            return
+        }
         
         guard makeCredentialError.code == YKFKeyFIDO2ErrorCode.PIN_REQUIRED.rawValue else {
             let errorDescription = error.localizedDescription


### PR DESCRIPTION
fix #1413 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Navigate to webauthntest.azurewebsites.net
2. Create a credential with `use excludeCredential` checked
3. Create a second credential with `use excludeCredential` checked
4. Should return an `InvalidStateError`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
