### PR TITLE
Added Desktop UA for iPad toggle.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -393,6 +393,7 @@ extension Strings {
     public static let Privacy = NSLocalizedString("Privacy", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Privacy", comment: "Settings privacy section title")
     public static let Security = NSLocalizedString("Security", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Security", comment: "Settings security section title")
     public static let Save_Logins = NSLocalizedString("SaveLogins", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Save Logins", comment: "Setting to enable the built-in password manager")
+    public static let AlwaysRequestDesktopSite = NSLocalizedString("AlwaysRequestDesktopSite", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Always request desktop site", comment: "Setting to always request desktop site")
     public static let ShieldsAdStats = NSLocalizedString("AdsrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Ads \nBlocked", comment: "Shields Ads Stat")
     public static let ShieldsAdAndTrackerStats = NSLocalizedString("AdsAndTrackersrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Ads & Trackers \nBlocked", comment: "Shields Ads Stat")
     public static let ShieldsTrackerStats = NSLocalizedString("TrackersrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Trackers \nBlocked", comment: "Shields Trackers Stat")

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -421,7 +421,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         // This only needs to be done once per runtime. Note that we use defaults here that are
         // readable from extensions, so they can just use the cached identifier.
         
-        if #available(iOS 13.0, *), UIDevice.isIpad {
+        if #available(iOS 13.0, *) {
             //iOS 13 iPad UA is the same as Safari's..
         } else {
             let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -420,8 +420,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         // Set the UA for WKWebView (via defaults), the favicon fetcher, and the image loader.
         // This only needs to be done once per runtime. Note that we use defaults here that are
         // readable from extensions, so they can just use the cached identifier.
-        let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
-        defaults.register(defaults: ["UserAgent": firefoxUA])
+        
+        if #available(iOS 13.0, *), UIDevice.isIpad {
+            //iOS 13 iPad UA is the same as Safari's..
+        } else {
+            let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
+            defaults.register(defaults: ["UserAgent": firefoxUA])
+        }
 
         SDWebImageDownloader.shared().setValue(firefoxUA, forHTTPHeaderField: "User-Agent")
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -421,12 +421,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         // This only needs to be done once per runtime. Note that we use defaults here that are
         // readable from extensions, so they can just use the cached identifier.
         
-        if #available(iOS 13.0, *) {
-            //iOS 13 iPad UA is the same as Safari's..
-        } else {
-            let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
-            defaults.register(defaults: ["UserAgent": firefoxUA])
-        }
+        let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
+        defaults.register(defaults: ["UserAgent": firefoxUA])
 
         SDWebImageDownloader.shared().setValue(firefoxUA, forHTTPHeaderField: "User-Agent")
 

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -41,6 +41,8 @@ extension Preferences {
         static let blockPopups = Option<Bool>(key: "general.block-popups", default: true)
         /// Controls how the tab bar should be shown (or not shown)
         static let tabBarVisibility = Option<Int>(key: "general.tab-bar-visiblity", default: TabBarVisibility.always.rawValue)
+        /// Sets Desktop UA for iPad by default (iOS 13+ & iPad only)
+        static let alwaysRequestDesktopSite = Option<Bool>(key: "general.always-request-desktop-site", default: UIDevice.isIpad)
         
         /// Whether or not a user has enabled Night Mode.
         ///

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -201,6 +201,7 @@ class BrowserViewController: UIViewController {
         // Observe some user preferences
         Preferences.Privacy.privateBrowsingOnly.observe(from: self)
         Preferences.General.tabBarVisibility.observe(from: self)
+        Preferences.General.alwaysRequestDesktopSite.observe(from: self)
         Preferences.Shields.allShields.forEach { $0.observe(from: self) }
         Preferences.Privacy.blockAllCookies.observe(from: self)
         // Lists need to be compiled before attempting tab restoration
@@ -1092,7 +1093,12 @@ class BrowserViewController: UIViewController {
     func restoreSpoofedUserAgentIfRequired(_ webView: WKWebView, newRequest: URLRequest) {
         // Restore any non-default UA from the request's header
         let ua = newRequest.value(forHTTPHeaderField: "User-Agent")
-        webView.customUserAgent = ua != UserAgent.defaultUserAgent() ? ua : nil
+        
+        if #available(iOS 13.0, *) {
+            webView.customUserAgent = Preferences.General.alwaysRequestDesktopSite.value == UserAgent.isDesktopUA(ua) ? nil : ua
+        } else {
+            webView.customUserAgent = ua != UserAgent.defaultUserAgent() ? ua : nil
+        }
     }
 
     fileprivate func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {
@@ -1224,7 +1230,13 @@ class BrowserViewController: UIViewController {
         }
         
         // Remember whether or not a desktop site was requested
-        tab.desktopSite = webView.customUserAgent?.isEmpty == false
+        tab.desktopSite = UserAgent.isDesktopUA(webView.customUserAgent)
+        
+        if #available(iOS 13.0, *), UIDevice.isIpad {
+            if webView.customUserAgent?.isEmpty == true {
+                tab.desktopSite = Preferences.General.alwaysRequestDesktopSite.value
+            }
+        }
     }
     
     // MARK: - Browser PIN Callout
@@ -2951,6 +2963,15 @@ extension BrowserViewController: PreferencesObserver {
             setupTabs()
             updateTabsBarVisibility()
             updateApplicationShortcuts()
+        case Preferences.General.alwaysRequestDesktopSite.key:
+            tabManager.reset()
+            self.tabManager.reloadSelectedTab()
+            for tab in self.tabManager.allTabs where tab != self.tabManager.selectedTab {
+                tab.createWebview()
+                if let url = tab.webView?.url {
+                    tab.loadRequest(PrivilegedRequest(url: url) as URLRequest)
+                }
+            }
         case Preferences.Shields.blockAdsAndTracking.key,
              Preferences.Shields.httpsEverywhere.key,
              Preferences.Shields.blockScripts.key,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1097,7 +1097,7 @@ class BrowserViewController: UIViewController {
         if #available(iOS 13.0, *) {
             webView.customUserAgent = Preferences.General.alwaysRequestDesktopSite.value == UserAgent.isDesktopUA(ua) ? nil : ua
         } else {
-            webView.customUserAgent = ua != UserAgent.defaultUserAgent() ? ua : nil
+            webView.customUserAgent = ua == UserAgent.defaultUserAgent() ? nil : ua
         }
     }
 
@@ -2966,12 +2966,6 @@ extension BrowserViewController: PreferencesObserver {
         case Preferences.General.alwaysRequestDesktopSite.key:
             tabManager.reset()
             self.tabManager.reloadSelectedTab()
-            for tab in self.tabManager.allTabs where tab != self.tabManager.selectedTab {
-                tab.createWebview()
-                if let url = tab.webView?.url {
-                    tab.loadRequest(PrivilegedRequest(url: url) as URLRequest)
-                }
-            }
         case Preferences.Shields.blockAdsAndTracking.key,
              Preferences.Shields.httpsEverywhere.key,
              Preferences.Shields.blockScripts.key,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -272,6 +272,15 @@ extension BrowserViewController: WKNavigationDelegate {
         // just let the webview handle it as normal.
         decisionHandler(.allow)
     }
+    
+    @available(iOS 13.0, *)
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
+        
+        self.webView(webView, decidePolicyFor: navigationAction) {
+            preferences.preferredContentMode = Preferences.General.alwaysRequestDesktopSite.value ? .desktop : .mobile
+            decisionHandler($0, preferences)
+        }
+    }
 
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -1034,16 +1034,34 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-            var res = WKNavigationActionPolicy.allow
-            for delegate in delegates {
-                delegate.webView?(webView, decidePolicyFor: navigationAction, decisionHandler: { policy in
-                    if policy == .cancel {
-                        res = policy
-                    }
-                })
-            }
+        var res = WKNavigationActionPolicy.allow
+        for delegate in delegates {
+            delegate.webView?(webView, decidePolicyFor: navigationAction, decisionHandler: { policy in
+                if policy == .cancel {
+                    res = policy
+                }
+            })
+        }
 
-            decisionHandler(res)
+        decisionHandler(res)
+    }
+    
+    @available(iOS 13.0, *)
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
+        
+        var res = WKNavigationActionPolicy.allow
+        var pref = preferences
+        for delegate in delegates {
+            delegate.webView?(webView, decidePolicyFor: navigationAction, preferences: preferences, decisionHandler: { policy, preference  in
+                if policy == .cancel {
+                    res = policy
+                }
+                
+                pref = preference
+            })
+        }
+
+        decisionHandler(res, pref)
     }
 
     func webView(_ webView: WKWebView,

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -167,6 +167,11 @@ class SettingsViewController: TableViewController {
             general.rows.append(row)
         }
         
+        if #available(iOS 13.0, *), UIDevice.isIpad {
+            general.rows.append(BoolRow(title: Strings.AlwaysRequestDesktopSite,
+            option: Preferences.General.alwaysRequestDesktopSite))
+        }
+        
         return general
     }()
     

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -104,7 +104,7 @@ open class UserAgent {
             print("Error: Unable to determine platform in UA.")
             return String(userAgent)
         }
-        userAgent.replaceCharacters(in: platformMatch.range, with: "(Macintosh; Intel Mac OS X 10_11_1)")
+        userAgent.replaceCharacters(in: platformMatch.range, with: "(Macintosh; Intel Mac OS X 10_15)")
 
         // Strip mobile section
         let mobileRegex = try? NSRegularExpression(pattern: " FxiOS/[^ ]+ Mobile/[^ ]+", options: [])
@@ -115,5 +115,27 @@ open class UserAgent {
         userAgent.replaceCharacters(in: mobileMatch.range, with: "")
 
         return String(userAgent)
+    }
+    
+    public static func mobileApplicationName() -> String? {
+        return "FxiOS"
+    }
+    
+    public static func desktopApplicationName() -> String? {
+        return nil
+    }
+    
+    public static func isDesktopUA(_ userAgent: String?) -> Bool {
+        if let userAgent = userAgent {
+            return !userAgent.lowercased().contains("mobile")
+        }
+        
+        //on iOS 13 iPad, we do not require a custom user-agent for Desktop
+        if #available(iOS 13.0, *), UIDevice.isIpad {
+            return true
+        }
+        
+        //However, for iPhone we do..
+        return false
     }
 }

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -117,16 +117,8 @@ open class UserAgent {
         return String(userAgent)
     }
     
-    public static func mobileApplicationName() -> String? {
-        return "FxiOS"
-    }
-    
-    public static func desktopApplicationName() -> String? {
-        return nil
-    }
-    
     public static func isDesktopUA(_ userAgent: String?) -> Bool {
-        if let userAgent = userAgent {
+        if let userAgent = userAgent, !userAgent.isEmpty {
             return !userAgent.lowercased().contains("mobile")
         }
         


### PR DESCRIPTION
Fixes: #1290 .
Uses same UA as Firefox (on mobile it will contain: "FxiOS/Version Mobile/OSVersion".. with Desktop UA, it will be the same but without that string included (IE: Same as Safari which is what FF does).
Note: I do not do any UA modifications (The only one I did was to change from 10_11 to 10_15 which is what Safari on iOS 13 does.. but leaving it at 10_11 is the same anyway.. neither have any effects).


## Summary of Changes

This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
