### PR TITLE
Fix #1429: Correct App Group id for Beta/TestFlight builds.

### DIFF
--- a/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -6,7 +6,7 @@
 	<string>production</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(MOZ_BUNDLE_ID).unique</string>
+		<string>group.$(MOZ_BUNDLE_ID)</string>
 	</array>
 </dict>
 </plist>

--- a/ClientTests/AuthenticatorTests.swift
+++ b/ClientTests/AuthenticatorTests.swift
@@ -11,7 +11,7 @@ import Deferred
 
 class MockFiles: FileAccessor {
     init() {
-        let docPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+        let docPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0]
         super.init(rootPath: (docPath as NSString).appendingPathComponent("testing"))
     }
 }

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -67,6 +67,25 @@ class ClientTests: XCTestCase {
             "0x7f.0x0.0x0.0x1"
             ].forEach { XCTAssertFalse(hostIsValid($0), "\($0) host should not be valid.") }
     }
+    
+    func testEmptyDocumentsDirectory() {
+        let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        XCTAssertNotNil(url)
+        
+        let emptyDirectoryExpectation = expectation(description: "empty documents directory")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            do {
+                if try FileManager.default.contentsOfDirectory(atPath: url!.path).isEmpty {
+                    emptyDirectoryExpectation.fulfill()
+                }
+            } catch {
+                XCTFail("Crash at FileManager.contentsOfDirectory")
+            }
+        }
+        
+        wait(for: [emptyDirectoryExpectation], timeout: 4)
+    }
 
     fileprivate func hostIsValid(_ host: String) -> Bool {
         let expectation = self.expectation(description: "Validate host for \(host)")

--- a/ClientTests/FileAccessorTests.swift
+++ b/ClientTests/FileAccessorTests.swift
@@ -11,7 +11,7 @@ class FileAccessorTests: XCTestCase {
     fileprivate var files: FileAccessor!
 
     override func setUp() {
-        let docPath: NSString = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString
+        let docPath: NSString = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0] as NSString
         files = FileAccessor(rootPath: docPath.appendingPathComponent("filetest"))
 
         testDir = try! files.getAndEnsureDirectory()

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -36,8 +36,9 @@ class ProfileFileAccessor: FileAccessor {
         if let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: sharedContainerIdentifier) {
             rootPath = url.path
         } else {
-            log.error("Unable to find the shared container. Defaulting profile location to ~/Documents instead.")
-            rootPath = (NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0])
+            log.error("Unable to find the shared container. Defaulting profile location to ~/Library/Application Support/ instead.")
+            rootPath = (NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory,
+                                                            .userDomainMask, true)[0])
         }
 
         super.init(rootPath: URL(fileURLWithPath: rootPath).appendingPathComponent(profileDirName).path)
@@ -81,7 +82,6 @@ extension Profile {
 }
 
 open class BrowserProfile: Profile {
-    
     
     fileprivate let name: String
     fileprivate let keychain: KeychainWrapper

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -38,12 +38,7 @@ open class AppInfo {
     /// Return the shared container identifier (also known as the app group) to be used with for example background
     /// http requests. It is the base bundle identifier with a "group." prefix.
     public static var sharedContainerIdentifier: String {
-        var bundleIdentifier = baseBundleIdentifier
-        if bundleIdentifier == "com.brave.ios.FennecEnterprise" {
-            // Bug 1373726 - Base bundle identifier incorrectly generated for Nightly builds
-            // This can be removed when we are able to fix the app group in the developer portal
-            bundleIdentifier = "com.brave.ios.Fennec.enterprise"
-        }
+        let bundleIdentifier = baseBundleIdentifier
         return "group." + bundleIdentifier
     }
 

--- a/StoragePerfTests/StoragePerfTests.swift
+++ b/StoragePerfTests/StoragePerfTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class MockFiles: FileAccessor {
     init() {
-        let docPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+        let docPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0]
         super.init(rootPath: (docPath as NSString).appendingPathComponent("testing"))
     }
 }

--- a/StorageTests/MockFiles.swift
+++ b/StorageTests/MockFiles.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class MockFiles: FileAccessor {
     init() {
-        let docPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+        let docPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0]
         super.init(rootPath: (docPath as NSString).appendingPathComponent("testing"))
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
1. We fix the app group id for beta builds
2. If it fails we will save profile folder to `Library/Application Support`

This pull request fixes issue #1429 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
