### PR TITLE
Fix #1433: Don't show brackets for file downloads with unknown size.

### DIFF
--- a/Client/Frontend/Browser/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper.swift
@@ -85,7 +85,11 @@ class DownloadHelper: NSObject, OpenInHelper {
         
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         
-        let downloadActionText = Strings.Download + " (\(expectedSize ?? ""))"
+        var downloadActionText = Strings.Download
+        // The download can be of undetermined size, adding expected size only if it's available.
+        if let expectedSize = expectedSize {
+            downloadActionText += " (\(expectedSize))"
+        }
         
         let okAction = UIAlertAction(title: downloadActionText, style: .default) { _ in
             self.browserViewController.downloadQueue.enqueue(download)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1433 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Verify https://github.com/brave/brave-ios/archive/v1.11.3.zip doesn't show size or brackets
2. Verify https://github.com/brave/brave-ios/releases/download/v1.11.3/Brave1.11.3Prod.ipa does show expected size.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
