### PR TITLE
Dismiss popover when the user clicks a link in the rewards panel

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -94,6 +94,8 @@ extension BrowserViewController: RewardsUIDelegate {
     }
     
     func loadNewTabWithURL(_ url: URL) {
+        self.presentedViewController?.dismiss(animated: true)
+        
         let request = URLRequest(url: url)
         let isPrivate = PrivateBrowsingManager.shared.isPrivateBrowsing
         tabManager.addTabAndSelect(request, isPrivate: isPrivate)


### PR DESCRIPTION
fixes https://github.com/brave/brave-rewards-ios/issues/161

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Prefix: Enable rewards by removing NO_REWARDS build flag
- Click on a ToS/Privacy link, should dismiss panel and open link
- Same for clicking on auto-contribute table row

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).