### PR TITLE
Fix #1438: Save files to 'Downloads' folder.

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -35,7 +35,6 @@ class Migration {
     private static func documentsDirectoryCleanup() {
         FileManager.default.removeFolder(withName: "abp-data", location: .documentDirectory)
         FileManager.default.removeFolder(withName: "https-everywhere-data", location: .documentDirectory)
-        FileManager.default.removeFolder(withName: "Downloads", location: .documentDirectory)
         
         FileManager.default.moveFile(sourceName: "CookiesData.json", sourceLocation: .documentDirectory,
                                      destinationName: "CookiesData.json",

--- a/Client/FileManagerExtension.swift
+++ b/Client/FileManagerExtension.swift
@@ -15,6 +15,15 @@ extension FileManager {
     }
     public typealias FolderLockObj = (folder: Folder, lock: Bool)
     
+    /// URL where files downloaded by user are stored.
+    /// If the download folder doesn't exists it creates a new one
+    func downloadsPath() throws -> URL {
+        FileManager.default.getOrCreateFolder(name: "Downloads", excludeFromBackups: true, location: .documentDirectory)
+        
+        return try FileManager.default.url(for: .documentDirectory, in: .userDomainMask,
+                                       appropriateFor: nil, create: false).appendingPathComponent("Downloads")
+    }
+    
     //Lock a folder using FolderLockObj provided.
     @discardableResult public func setFolderAccess(_ lockObjects: [FolderLockObj]) -> Bool {
         guard let baseDir = baseDirectory() else { return false }
@@ -60,6 +69,7 @@ extension FileManager {
     
     /// Creates a folder at given location and returns its URL.
     /// If folder already exists, returns its URL as well.
+    @discardableResult
     func getOrCreateFolder(name: String, excludeFromBackups: Bool = true,
                            location: SearchPathDirectory = .applicationSupportDirectory) -> URL? {
         guard let documentsDir = location.url else { return nil }

--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -37,8 +37,7 @@ class Download: NSObject {
     func resume() {}
     
     fileprivate func uniqueDownloadPathForFilename(_ filename: String) throws -> URL {
-        let downloadsPath = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-        
+        let downloadsPath = try FileManager.default.downloadsPath()
         let basePath = downloadsPath.appendingPathComponent(filename)
         let fileExtension = basePath.pathExtension
         let filenameWithoutExtension = fileExtension.count > 0 ? String(filename.dropLast(fileExtension.count + 1)) : filename

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
@@ -141,7 +141,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     private func fetchData() -> [DownloadedFile] {
         var downloadedFiles: [DownloadedFile] = []
         do {
-            let downloadsPath = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            let downloadsPath = try FileManager.default.downloadsPath()
             let files = try FileManager.default.contentsOfDirectory(at: downloadsPath, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles, .skipsPackageDescendants, .skipsSubdirectoryDescendants])
             
             for file in files {

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -141,8 +141,7 @@ class DownloadsClearable: Clearable {
     func clear() -> Success {
         do {
             let fileManager = FileManager.default
-            let downloadsLocation = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-            
+            let downloadsLocation = try FileManager.default.downloadsPath()
             let filePaths = try fileManager.contentsOfDirectory(atPath: downloadsLocation.path)
             
             try filePaths.forEach {

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -68,23 +68,21 @@ class ClientTests: XCTestCase {
             ].forEach { XCTAssertFalse(hostIsValid($0), "\($0) host should not be valid.") }
     }
     
-    func testEmptyDocumentsDirectory() {
-        let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        XCTAssertNotNil(url)
+    func testDownloadsFolder() {
+        let path = try? FileManager.default.downloadsPath()
+        XCTAssertNotNil(path)
         
-        let emptyDirectoryExpectation = expectation(description: "empty documents directory")
+        XCTAssert(FileManager.default.fileExists(atPath: path!.path))
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            do {
-                if try FileManager.default.contentsOfDirectory(atPath: url!.path).isEmpty {
-                    emptyDirectoryExpectation.fulfill()
-                }
-            } catch {
-                XCTFail("Crash at FileManager.contentsOfDirectory")
-            }
-        }
+        // Let's pretend user deletes downloads folder via files.app
+        XCTAssertNoThrow(try FileManager.default.removeItem(at: path!))
         
-        wait(for: [emptyDirectoryExpectation], timeout: 4)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path!.path))
+        
+        // Calling downloads path should recreate the deleted folder
+        XCTAssertNoThrow(try FileManager.default.downloadsPath())
+        
+        XCTAssert(FileManager.default.fileExists(atPath: path!.path))
     }
 
     fileprivate func hostIsValid(_ host: String) -> Bool {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -42,6 +42,9 @@ class ProfileFileAccessor: FileAccessor {
         }
 
         super.init(rootPath: URL(fileURLWithPath: rootPath).appendingPathComponent(profileDirName).path)
+        
+        // Create the "Downloads" folder in the documents directory if doesn't exist.
+        FileManager.default.getOrCreateFolder(name: "Downloads", excludeFromBackups: true, location: .documentDirectory)
     }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1438 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify the `Downloads` folder is visible in Files.app and files are downloaded there

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
