### PR TITLE
Ref #1429 Use unique id for Beta app group id.

### DIFF
--- a/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -6,7 +6,7 @@
 	<string>production</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(MOZ_BUNDLE_ID)</string>
+		<string>group.$(MOZ_BUNDLE_ID).unique</string>
 	</array>
 </dict>
 </plist>

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -38,7 +38,11 @@ open class AppInfo {
     /// Return the shared container identifier (also known as the app group) to be used with for example background
     /// http requests. It is the base bundle identifier with a "group." prefix.
     public static var sharedContainerIdentifier: String {
-        let bundleIdentifier = baseBundleIdentifier
+        var bundleIdentifier = baseBundleIdentifier
+        if bundleIdentifier == "com.brave.ios.BrowserBeta" {
+            // com.brave.ios.BrowserBeta is taken and can't be used as an app group.
+            bundleIdentifier = "com.brave.ios.BrowserBeta.unique"
+        }
         return "group." + bundleIdentifier
     }
 


### PR DESCRIPTION
For some reason 'com.brave.ios.BrowserBeta' app group id is taken
and can't be used.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
