### PR TITLE
Fix #1451: Set DuckDuckGo search engine for certain countries.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -49,8 +49,11 @@ class SearchEngines {
     fileprivate let fileAccessor: FileAccessor
 
     static let defaultRegionSearchEngines = [
-        "DE": OpenSearchEngine.EngineNames.qwant,
-        "FR": OpenSearchEngine.EngineNames.qwant
+        "DE": OpenSearchEngine.EngineNames.duckDuckGo,
+        "FR": OpenSearchEngine.EngineNames.qwant,
+        "AU": OpenSearchEngine.EngineNames.duckDuckGo,
+        "NZ": OpenSearchEngine.EngineNames.duckDuckGo,
+        "IE": OpenSearchEngine.EngineNames.duckDuckGo,
     ]
     
     init(files: FileAccessor) {


### PR DESCRIPTION
DDG will be set as default for:
- Australia
- Germany
- Ireland
- New Zealand

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1451 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Change your device's *region* to new countries and verify that the new search engine is preselected on onboarding screen.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
