### PR TITLE
Fix #1475: Update passcode screen after completion.

### DIFF
--- a/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PagingPasscodeViewController.swift
@@ -7,6 +7,8 @@ private let PaneSwipeDuration: TimeInterval = 0.3
 
 /// Base class for implementing a Passcode configuration screen with multiple 'panes'.
 class PagingPasscodeViewController: BasePasscodeViewController {
+    var completion: (() -> Void)?
+    
     fileprivate lazy var pager: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.isPagingEnabled = true
@@ -46,6 +48,7 @@ class PagingPasscodeViewController: BasePasscodeViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.view.endEditing(true)
+        completion?()
     }
 }
 

--- a/Client/Frontend/Settings/PasscodeSettingsViewController.swift
+++ b/Client/Frontend/Settings/PasscodeSettingsViewController.swift
@@ -41,6 +41,7 @@ class PasscodeSettingsViewController: TableViewController {
                     Row(text: Strings.AuthenticationTurnOffPasscode,
                         selection: { [unowned self] in
                             let setupPasscodeController = RemovePasscodeViewController()
+                            setupPasscodeController.completion = self.reloadSections
                             let container = UINavigationController(rootViewController: setupPasscodeController)
                             self.present(container, animated: true)
                         },
@@ -49,6 +50,7 @@ class PasscodeSettingsViewController: TableViewController {
                     Row(text: Strings.AuthenticationChangePasscode,
                         selection: { [unowned self] in
                             let changePasscodeController = ChangePasscodeViewController()
+                            changePasscodeController.completion = self.reloadSections
                             let container = UINavigationController(rootViewController: changePasscodeController)
                             self.present(container, animated: true)
                         }
@@ -80,6 +82,7 @@ class PasscodeSettingsViewController: TableViewController {
                     Row(text: Strings.AuthenticationTurnOnPasscode,
                         selection: { [unowned self] in
                             let setupPasscodeController = SetupPasscodeViewController()
+                            setupPasscodeController.completion = self.reloadSections
                             let container = UINavigationController(rootViewController: setupPasscodeController)
                             self.present(container, animated: true)
                         },


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This is caused due to how iOS 13 handles presentation. Now the modal VCs are showing as a popup, which makes the parent vc to not call `viewDisappear`

This pull request fixes issue #1475 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
