### PR TITLE
Rewards#201: Use os.log for Brave Rewards logs.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -9,7 +9,6 @@ import Data
 import BraveShared
 
 private let log = Logger.browserLogger
-private let rewardsLog = Logger.rewardsLogger
 
 extension WKNavigationAction {
     /// Allow local requests only if the request is privileged.

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -10,9 +10,9 @@ import BraveShared
 import XCGLogger
 import Data
 import CoreData
+import os.log
 
 private let log = Logger.browserLogger
-private let rewardsLog = Logger.rewardsLogger
 
 protocol TabManagerDelegate: class {
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?)
@@ -259,13 +259,16 @@ class TabManager: NSObject {
         if !PrivateBrowsingManager.shared.isPrivateBrowsing {
             let previousFaviconURL = URL(string: previousTab.displayFavicon?.url ?? "")
             if previousFaviconURL == nil {
-                rewardsLog.warning("No favicon found in \(previousTab) to report to rewards panel")
+                os_log(.error, log: Logger.rewards, "No favicon found in tab with url %{public}s to report to rewards panel",
+                       previousTab.url?.absoluteString ?? "nil")
+                
             }
             rewards.reportTabUpdated(Int(previousTab.rewardsId), url: previousTabUrl, faviconURL: previousFaviconURL, isSelected: false,
                                      isPrivate: previousTab.isPrivate)
             let faviconURL = URL(string: newSelectedTab.displayFavicon?.url ?? "")
             if faviconURL == nil {
-                rewardsLog.warning("No favicon found in \(newSelectedTab) to report to rewards panel")
+                os_log(.error, log: Logger.rewards, "No favicon found in tab with url %{public}s to report to rewards panel",
+                newSelectedTab.url?.absoluteString ?? "nil")
             }
             rewards.reportTabUpdated(Int(newSelectedTab.rewardsId), url: newTabUrl, faviconURL: faviconURL, isSelected: true,
                                      isPrivate: newSelectedTab.isPrivate)

--- a/Client/Rewards/RewardsReporting.swift
+++ b/Client/Rewards/RewardsReporting.swift
@@ -5,10 +5,8 @@
 import Foundation
 import WebKit
 import BraveRewards
-import XCGLogger
 import Shared
-
-private let log = Logger.rewardsLogger
+import os.log
 
 class RewardsReporting: TabContentScript {
     let rewards: BraveRewards
@@ -64,7 +62,8 @@ class RewardsReporting: TabContentScript {
                 }
             }
         } catch {
-            log.error("Failed to parse message from rewards reporting JS: \(error)")
+            os_log(.error, log: Logger.rewards, "Failed to parse message from rewards reporting JS: %{public}s",
+                error.localizedDescription)
         }
     }
 }

--- a/Shared/Logger.swift
+++ b/Shared/Logger.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import XCGLogger
+import os.log
 
 public struct Logger {}
 
@@ -17,14 +18,6 @@ public extension Logger {
     /// Logger used for recording frontend/browser happenings
     static let browserLogger = RollingFileLogger(filenameRoot: "browser", logDirectoryPath: Logger.logFileDirectoryPath())
     
-    /// Logger used for things recorded on BraveRewards framework.
-    static let rewardsLogger: RollingFileLogger = {
-        let logger = RollingFileLogger(filenameRoot: "rewards", logDirectoryPath: Logger.logFileDirectoryPath())
-        logger.setup(showFunctionName: false, showFileNames: false, showLineNumbers: false)
-        
-        return logger
-    }()
-    
     static let braveSyncLogger = RollingFileLogger(filenameRoot: "bravesync", logDirectoryPath: Logger.logFileDirectoryPath())
 
     /// Logger used for recording interactions with the keychain
@@ -36,6 +29,8 @@ public extension Logger {
         logger.newLogWithDate(Date())
         return logger
     }()
+    
+    static let rewards = OSLog(subsystem: "com.brave.ios.logs", category: "rewards")
 
     /**
     Return the log file directory path. If the directory doesn't exist, make sure it exist first before returning the path.


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-rewards-ios/issues/201
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See if you can see the logs in Console.app


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
