### PR TITLE
Fix #1503: BVC responds dynamically to theme changes.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -328,6 +328,15 @@ class BrowserViewController: UIViewController {
             }
         })
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if #available(iOS 13.0, *) {
+            if UITraitCollection.current.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+                // Reload UI
+                applyTheme(Theme.of(tabManager.selectedTab))
+            }
+        }
+    }
 
     func dismissVisibleMenus() {
         displayedPopoverController?.dismiss(animated: true)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1503 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

This fix only applies for dynamic styling of the primary browser UI.
(#1506 is a follow up ticket for remaining UI menus/screens)

1. Must be on iOS 13 and have theme choice set to "Automatic"
1. It is also easiest to enable "Dark Mode" easy selection in the Control Center customization menus (iOS settings, not Brave). This enables an option on the control center:

(the bottom option changes the OS theme immediately, when toggled)
![Control Center OS theme switch](https://user-images.githubusercontent.com/2781690/64469351-3c97d500-d0cc-11e9-967e-76081084f798.jpeg)

3. On the new tab page or on a website (with no menus open), open control center and toggle the OS theme (see screenshot above).
1. The primary browser UI (NTP + top bar and bottom bar) should have updated colors.

Again, this does not work for settings page or other menus (shields panel, main menu). These _will_ be updated the next time the user opens them, but if they user has them opened, they are not automatically updated. (see #1506 for screenshots of these menus)

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
