### PR TITLE
Fix #1515: Don't show DDG promo in regions with different search engine.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -85,8 +85,10 @@ class SearchEngines {
     /// Whether or not we should show DuckDuckGo related promotions based on the users current region
     static var shouldShowDuckDuckGoPromo: Bool {
         // We want to show ddg promo in most cases so guard returns true.
-        guard let region = Locale.current.regionCode else { return true }
-        return !defaultRegionSearchEngines.keys.contains(region)
+        guard let region = Locale.current.regionCode,
+            let searchEngine = defaultRegionSearchEngines[region] else { return true }
+        
+        return searchEngine == OpenSearchEngine.EngineNames.duckDuckGo
     }
 
     func setDefaultEngine(_ engine: String, forType type: DefaultEngineType) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1515 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify the bug with STR from the issue.
Additionally verify, that the DDG prompt doesn't show in France region.(ddg popup should not show  in regions where different non-google search is set)

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
