### PR TITLE
Fix #1512: Long press brings up 2 context menus at once.

### DIFF
--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -87,8 +87,15 @@ class ContextMenuHelper: NSObject, UIGestureRecognizerDelegate {
         guard sender.state == .began else {
             return
         }
-        
-        if #available(iOS 13, *) {} else {
+
+        if #available(iOS 13, *) {
+            tab?.webView?.scrollView.subviews.compactMap({ $0.gestureRecognizers }).joined().forEach { recognizer in
+                if recognizer.isEnabled {
+                    recognizer.isEnabled = false
+                    recognizer.isEnabled = true
+                }
+            }
+        } else {
             // To prevent the tapped link from proceeding with navigation, "cancel" the native WKWebView
             // `_highlightLongPressRecognizer`. This preserves the original behavior as seen here:
             // https://github.com/WebKit/webkit/blob/d591647baf54b4b300ca5501c21a68455429e182/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm#L1600-L1614


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Another fix from FF
https://github.com/mozilla-mobile/firefox-ios/commit/e139c9dba54da8cb1690f5a7666fd7c8809baed9

This pull request fixes issue #1512 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
