### PR TITLE
No bug: Use single timezone for DAUTests.

### DIFF
--- a/BraveSharedTests/DAUTests.swift
+++ b/BraveSharedTests/DAUTests.swift
@@ -204,7 +204,7 @@ class DAUTests: XCTestCase {
         let format = "yyyy-MM-dd, HH:mm"
         
         pingWithDateAndCompare(dateString: "2019-12-31, 16:00", daily: true, weekly: true, monthly: true, first: true, dateFormat: format)
-        pingWithDateAndCompare(dateString: "2019-12-31, 23:00", daily: false, weekly: false, monthly: false, dateFormat: format)
+        pingWithDateAndCompare(dateString: "2019-12-31, 22:00", daily: false, weekly: false, monthly: false, dateFormat: format)
         pingWithDateAndCompare(dateString: "2020-01-01, 04:00", daily: true, weekly: false, monthly: true, dateFormat: format)
     }
     
@@ -246,6 +246,7 @@ class DAUTests: XCTestCase {
     private func dateFrom(string: String, format: String? = nil) -> Date {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = format ?? "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(abbreviation: "GMT")!
         
         return dateFormatter.date(from: string)!
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
