### PR TITLE
Rewards: Show My First Ad when the user enables ads the first time

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -87,6 +87,10 @@ extension Preferences {
         /// Version of downloaded data file for adblock stats.
         public static let adblockStatsDataVersion = Option<Int?>(key: "stats.adblock-data-version", default: nil)
     }
+    
+    public final class Rewards {
+        public static let myFirstAdShown = Option<Bool>(key: "rewards.ads.my-first-ad-shown", default: false)
+    }
 }
 
 extension Preferences {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -243,6 +243,22 @@ class BrowserViewController: UIViewController {
             self.updateRewardsButtonState()
         }
     }
+    
+    // Display first ad when the user gets back to this controller if they havent seen one before
+    func displayMyFirstAdIfAvailable() {
+        guard let rewards = rewards, rewards.ledger.isEnabled && rewards.ads.isEnabled else { return }
+        if Preferences.Rewards.myFirstAdShown.value { return }
+        // Check if ads are eligible
+        if BraveAds.isSupportedRegion(Locale.current.identifier) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                if Preferences.Rewards.myFirstAdShown.value { return }
+                Preferences.Rewards.myFirstAdShown.value = true
+                AdsViewController.displayFirstAd(on: self) { [weak self] url in
+                    self?.openInNewTab(url, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+                }
+            }
+        }
+    }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         let isDark = Theme.of(tabManager.selectedTab).isDark

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -75,11 +75,13 @@ extension BrowserViewController {
         let popover = PopoverController(contentController: braveRewardsPanel, contentSizeBehavior: .preferredContentSize)
         popover.addsConvenientDismissalMargins = false
         popover.present(from: topToolbar.locationView.rewardsButton, on: self)
-        popover.popoverDidDismiss = { _ in
+        popover.popoverDidDismiss = { [weak self] _ in
+            guard let self = self else { return }
             if let tabId = self.tabManager.selectedTab?.rewardsId, self.rewards?.ledger.selectedTabId == 0 {
                 // Show the tab currently visible
                 self.rewards?.ledger.selectedTabId = tabId
             }
+            self.displayMyFirstAdIfAvailable()
         }
         // Hide the current tab
         rewards.ledger.selectedTabId = 0


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#155

Shows the "My First Ad" ad whenever the user enables rewards/ads if they do so outside the initial onboarding (not done yet)

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Prefix: Enable rewards by removing the NO_REWARDS flag
- Open panel, enable rewards, dismiss panel, wait 3s, verify first ad shows. Click → should go too brave.com/my-first-ad
- Delete app, change region to one that isn't supported by Ads (one not in this list: https://github.com/brave/brave-core/blob/73e6b250b651c1a1f3b5165d7e25602c576c4e1c/vendor/bat-native-ads/src/bat/ads/internal/static_values.h#L43), repeat above steps, verify you don't see a first ad.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).