### PR TITLE
Fix #1536: Correct shields stats color for iOS12 devices.

### DIFF
--- a/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
+++ b/Client/Frontend/Browser/HomePanel/BraveShieldStatsView.swift
@@ -118,7 +118,7 @@ class BraveShieldStatsView: UIView, Themeable {
 class StatView: UIView {
     var color: UIColor = UX.GreyJ {
         didSet {
-            statLabel.textColor = color
+            statLabel.appearanceTextColor = color
         }
     }
     

--- a/Client/Frontend/Shields/ShieldsView.swift
+++ b/Client/Frontend/Shields/ShieldsView.swift
@@ -191,12 +191,12 @@ extension ShieldsViewController {
                 httpsUpgradesStatView: stats.httpse,
                 scriptsBlockedStatView: stats.trackers
             ].forEach {
-                $0.0.valueLabel.textColor = $0.1
+                $0.0.valueLabel.appearanceTextColor = $0.1
             }
             
             let faddedColor = hostLabel.textColor.withAlphaComponent(0.8)
-            statsHeaderLabel.textColor = faddedColor
-            settingsHeaderLabel.textColor = faddedColor
+            statsHeaderLabel.appearanceTextColor = faddedColor
+            settingsHeaderLabel.appearanceTextColor = faddedColor
         }
     }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1536 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Check on both iOS 12 & 13. Check new tab page stats and stats in Brave Shields menu

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
