### PR TITLE
Rewards: Add rewards debug menu to debug section

### DIFF
--- a/BraveRewardsUI/QA Settings/QASettingsViewController.swift
+++ b/BraveRewardsUI/QA Settings/QASettingsViewController.swift
@@ -6,22 +6,61 @@ import UIKit
 import BraveRewards
 import BraveShared
 import Shared
+import Static
 
 private typealias EnvironmentOverride = Preferences.Rewards.EnvironmentOverride
 
 /// A special QA settings menu that allows them to adjust debug rewards features
-public class QASettingsViewController: UIViewController {
+public class QASettingsViewController: TableViewController, UITextFieldDelegate {
   
   public let rewards: BraveRewards
   
   public init(rewards: BraveRewards) {
     self.rewards = rewards
-    super.init(nibName: nil, bundle: nil)
+    super.init(style: .grouped)
   }
   
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
+  }
+  
+  private let segmentedControl = UISegmentedControl(items: EnvironmentOverride.allCases.map { $0.name })
+  
+  @objc private func environmentChanged() {
+    let value = segmentedControl.selectedSegmentIndex
+    guard let _ = EnvironmentOverride(rawValue: value) else { return }
+    Preferences.Rewards.environmentOverride.value = value
+    self.rewards.reset()
+    self.showResetRewardsAlert()
+  }
+  
+  private let reconcileTimeTextField = UITextField().then {
+    $0.borderStyle = .roundedRect
+    $0.autocorrectionType = .no
+    $0.autocapitalizationType = .none
+    $0.spellCheckingType = .no
+    $0.returnKeyType = .done
+    $0.textAlignment = .right
+    $0.text = "\(BraveLedger.reconcileTime)"
+    $0.placeholder = "0"
+  }
+  
+  @objc private func reconcileTimeEditingEnded() {
+    guard let value = Int32(reconcileTimeTextField.text ?? "") else {
+      let alert = UIAlertController(title: "Invalid value", message: "Time has been reset to 0 (no override)", preferredStyle: .alert)
+      alert.addAction(.init(title: "OK", style: .default, handler: nil))
+      self.present(alert, animated: true)
+      reconcileTimeTextField.text = "0"
+      BraveLedger.reconcileTime = 0
+      return
+    }
+    BraveLedger.reconcileTime = value
+  }
+  
+  public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    textField.resignFirstResponder()
+    return true
   }
   
   public override func viewDidLoad() {
@@ -31,99 +70,43 @@ public class QASettingsViewController: UIViewController {
     
     title = "Rewards QA Settings"
     
-    let scrollView = UIScrollView().then {
-      $0.alwaysBounceVertical = true
-    }
+    let isDefaultEnvironmentProd = AppConstants.BuildChannel != .developer
     
-    let stackView = UIStackView().then {
-      $0.axis = .vertical
-      $0.spacing = 12
-    }
+    segmentedControl.selectedSegmentIndex = Preferences.Rewards.environmentOverride.value
+    segmentedControl.addTarget(self, action: #selector(environmentChanged), for: .valueChanged)
+    reconcileTimeTextField.addTarget(self, action: #selector(reconcileTimeEditingEnded), for: .editingDidEnd)
+    reconcileTimeTextField.delegate = self
+    reconcileTimeTextField.frame = CGRect(x: 0, y: 0, width: 50, height: 32)
     
-    view.addSubview(scrollView)
-    scrollView.addSubview(stackView)
-    
-    scrollView.snp.makeConstraints {
-      $0.edges.equalTo(view)
-    }
-    
-    scrollView.contentLayoutGuide.snp.makeConstraints {
-      $0.width.equalTo(view)
-    }
-    
-    stackView.snp.makeConstraints {
-      $0.top.equalTo(scrollView.contentLayoutGuide.snp.top).offset(20)
-      $0.leading.trailing.equalTo(view).inset(12)
-      $0.bottom.equalTo(scrollView.contentLayoutGuide.snp.bottom).offset(-20)
-    }
-    
-    stackView.addStackViewItems(
-      .view(SwitchRow().then {
-        $0.textLabel.text = "Is Debug"
-        $0.toggleSwitch.isOn = BraveLedger.isDebug
-        $0.valueChanged = { value in
-          BraveLedger.isDebug = value
-          BraveAds.isDebug = value
-        }
-      }),
-      .view(UILabel().then {
-        let isDefaultEnvironmentProd = AppConstants.BuildChannel != .developer
-        $0.text = "Default Environment: \(isDefaultEnvironmentProd ? "Prod" : "Staging")"
-        $0.textColor = Colors.grey200
-        $0.numberOfLines = 0
-        $0.font = .systemFont(ofSize: 14)
-      }),
-      .view(EnvironmentRow().then {
-        $0.segmentedControl.selectedSegmentIndex = Preferences.Rewards.environmentOverride.value
-        $0.valueChanged = { value in
-          guard let _ = EnvironmentOverride(rawValue: value) else { return }
-          Preferences.Rewards.environmentOverride.value = value
-          self.rewards.reset()
-          self.showResetRewardsAlert()
-        }
-      }),
-      .view(SwitchRow().then {
-        $0.textLabel.text = "Use Short Retries"
-        $0.toggleSwitch.isOn = BraveLedger.useShortRetries
-        $0.valueChanged = { value in
-          BraveLedger.useShortRetries = value
-        }
-      }),
-      .view(ValueRow().then {
-        $0.textLabel.text = "Reconcile Time\n(0 = no override)"
-        $0.textField.text = "\(BraveLedger.reconcileTime)"
-        $0.textField.placeholder = "0"
-        let textField = $0.textField
-        $0.valueChanged = { value in
-          guard let value = Int32(value) else {
-            let alert = UIAlertController(title: "Invalid value", message: "Time has been reset to 0 (no override)", preferredStyle: .alert)
-            alert.addAction(.init(title: "OK", style: .default, handler: nil))
-            self.present(alert, animated: true)
-            textField.text = "0"
-            BraveLedger.reconcileTime = 0
-            return
-          }
-          BraveLedger.reconcileTime = value
-        }
-      }),
-      .customSpace(40),
-      .view(UILabel().then {
-        $0.text = "Changing the environment automatically resets Brave Rewards.\n\nIt is recommended you force-quit the app after Brave Rewards is reset"
-        $0.numberOfLines = 0
-        $0.textAlignment = .center
-        $0.font = .systemFont(ofSize: 14)
-      }),
-      .customSpace(40),
-      .view(UIButton(type: .roundedRect).then {
-        $0.setTitle("Reset Rewards", for: .normal)
-        $0.setTitleColor(.red, for: .normal)
-        $0.layer.cornerRadius = 8
-        $0.layer.borderWidth = 1.0 / UIScreen.main.scale
-        $0.layer.borderColor = UIColor.lightGray.cgColor
-        $0.snp.makeConstraints { $0.height.equalTo(44) }
-        $0.addTarget(self, action: #selector(tappedReset), for: .touchUpInside)
-      })
-    )
+    dataSource.sections = [
+      Section(
+        header: .title("Environment"),
+        rows: [
+          Row(text: "Default", detailText: isDefaultEnvironmentProd ? "Prod" : "Staging"),
+          Row(text: "Override", accessory: .view(segmentedControl)),
+        ],
+        footer: .title("Changing the environment automatically resets Brave Rewards.\n\nThe app must be force-quit after rewards is reset")
+      ),
+      Section(
+        rows: [
+          Row(text: "Is Debug", accessory: .switchToggle(value: BraveLedger.isDebug, { value in
+            BraveLedger.isDebug = value
+            BraveAds.isDebug = value
+          })),
+          Row(text: "Use Short Retries", accessory: .switchToggle(value: BraveLedger.useShortRetries, { value in
+            BraveLedger.useShortRetries = value
+          })),
+          Row(text: "Reconcile Time", detailText: "Number of minutes between reconciles. 0 = No Override", accessory: .view(reconcileTimeTextField), cellClass: MultilineSubtitleCell.self)
+        ]
+      ),
+      Section(
+        rows: [
+          Row(text: "Reset Rewards", selection: {
+            self.tappedReset()
+          }, cellClass: ButtonCell.self)
+        ]
+      )
+    ]
   }
   
   @objc private func tappedReset() {
@@ -133,8 +116,8 @@ public class QASettingsViewController: UIViewController {
   
   private func showResetRewardsAlert() {
     let alert = UIAlertController(
-      title: nil,
-      message: "Rewards has been reset. Force-quit the app to update the environment",
+      title: "Rewards Reset",
+      message: "Brave must be restarted to ensure expected Rewards behavior",
       preferredStyle: .alert
     )
     alert.addAction(UIAlertAction(title: "Exit Now", style: .destructive, handler: { _ in
@@ -145,91 +128,15 @@ public class QASettingsViewController: UIViewController {
   }
 }
 
-private class EnvironmentRow: UIStackView {
-  var valueChanged: ((Int) -> Void)?
+fileprivate class MultilineSubtitleCell: SubtitleCell {
   
-  private struct UX {
-    static let textColor = Colors.grey200
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    textLabel?.numberOfLines = 0
+    detailTextLabel?.numberOfLines = 0
   }
   
-  let textLabel = UILabel().then {
-    $0.text = "Environment Override"
-    $0.font = .systemFont(ofSize: 14.0)
-    $0.textColor = UX.textColor
-    $0.numberOfLines = 0
-  }
-  
-  let segmentedControl = UISegmentedControl(items: EnvironmentOverride.allCases.map { $0.name })
-  
-  override init(frame: CGRect) {
-    super.init(frame: frame)
-    
-    addArrangedSubview(textLabel)
-    addArrangedSubview(segmentedControl)
-    
-    segmentedControl.addTarget(self, action: #selector(selectedItemChanged), for: .valueChanged)
-  }
-  
-  @objc func selectedItemChanged() {
-    valueChanged?(segmentedControl.selectedSegmentIndex)
-  }
-  
-  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-    textField.resignFirstResponder()
-    return true
-  }
-  
-  @available(*, unavailable)
-  required init(coder: NSCoder) {
-    fatalError()
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
   }
 }
-
-private class ValueRow: UIStackView, UITextFieldDelegate {
-  
-  var valueChanged: ((String) -> Void)?
-  
-  private struct UX {
-    static let textColor = Colors.grey200
-  }
-  
-  let textLabel = UILabel().then {
-    $0.font = .systemFont(ofSize: 14.0)
-    $0.textColor = UX.textColor
-    $0.numberOfLines = 0
-  }
-  
-  let textField = UITextField().then {
-    $0.borderStyle = .roundedRect
-    $0.autocorrectionType = .no
-    $0.autocapitalizationType = .none
-    $0.spellCheckingType = .no
-    $0.returnKeyType = .done
-    $0.textAlignment = .right
-  }
-  
-  override init(frame: CGRect) {
-    super.init(frame: frame)
-    
-    addArrangedSubview(textLabel)
-    addArrangedSubview(textField)
-    
-    textField.addTarget(self, action: #selector(editingEnded), for: .editingDidEnd)
-    textField.delegate = self
-  }
-  
-  @objc func editingEnded() {
-    valueChanged?(textField.text ?? "")
-  }
-  
-  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-    textField.resignFirstResponder()
-    return true
-  }
-  
-  @available(*, unavailable)
-  required init(coder: NSCoder) {
-    fatalError()
-  }
-}
-

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -91,6 +91,23 @@ extension Preferences {
     public final class Rewards {
         public static let myFirstAdShown = Option<Bool>(key: "rewards.ads.my-first-ad-shown", default: false)
         public static let hideRewardsIcon = Option<Bool>(key: "rewards.hide-rewards-icon", default: false)
+        
+        public enum EnvironmentOverride: Int, CaseIterable {
+            case none
+            case staging
+            case prod
+            
+            public var name: String {
+                switch self {
+                case .none: return "None"
+                case .staging: return "Staging"
+                case .prod: return "Prod"
+                }
+            }
+        }
+        /// In debug/beta, this is the overriden environment.
+        public static let environmentOverride = Option<Int>(key: "rewards.environment-override",
+                                                            default: EnvironmentOverride.none.rawValue)
     }
 }
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -292,6 +292,8 @@
 		27FA2D4B234CC95A004D5D2D /* RewardsNotificationViewBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FA2D48234CC95A004D5D2D /* RewardsNotificationViewBuilderTests.swift */; };
 		27FA2D4C234CC95A004D5D2D /* DateExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FA2D49234CC95A004D5D2D /* DateExtensionsTests.swift */; };
 		27FA2D58234CDCEA004D5D2D /* BraveRewards.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FA2D4F234CC9FB004D5D2D /* BraveRewards.framework */; };
+		27FA2D65234E3222004D5D2D /* BraveShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DE7688420B3456C00FF5533 /* BraveShared.framework */; };
+		27FA2D69234E3222004D5D2D /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
 		27FD2CAB2146C31C00A5A779 /* RequestDesktopSiteActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FD2CA12146C31C00A5A779 /* RequestDesktopSiteActivity.swift */; };
 		27FD2CAC2146C31C00A5A779 /* FindInPageActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FD2CA92146C31C00A5A779 /* FindInPageActivity.swift */; };
 		27FD2CAD2146C31C00A5A779 /* AddToFavoritesActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FD2CAA2146C31C00A5A779 /* AddToFavoritesActivity.swift */; };
@@ -943,6 +945,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 27F443942135E11200296C58;
 			remoteInfo = BraveShareTo;
+		};
+		27FA2D67234E3222004D5D2D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5DE7688320B3456C00FF5533;
+			remoteInfo = BraveShared;
+		};
+		27FA2D6B234E3222004D5D2D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 288A2D851AB8B3260023ABC3;
+			remoteInfo = Shared;
 		};
 		288A2D9B1AB8B3260023ABC3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2286,6 +2302,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				27FA2D65234E3222004D5D2D /* BraveShared.framework in Frameworks */,
+				27FA2D69234E3222004D5D2D /* Shared.framework in Frameworks */,
 				27FA2D58234CDCEA004D5D2D /* BraveRewards.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4678,6 +4696,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				27FA2D68234E3222004D5D2D /* PBXTargetDependency */,
+				27FA2D6C234E3222004D5D2D /* PBXTargetDependency */,
 			);
 			name = BraveRewardsUI;
 			productName = BraveRewardsUI;
@@ -6101,6 +6121,16 @@
 			isa = PBXTargetDependency;
 			target = 27F443942135E11200296C58 /* BraveShareTo */;
 			targetProxy = 27F4439D2135E11200296C58 /* PBXContainerItemProxy */;
+		};
+		27FA2D68234E3222004D5D2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5DE7688320B3456C00FF5533 /* BraveShared */;
+			targetProxy = 27FA2D67234E3222004D5D2D /* PBXContainerItemProxy */;
+		};
+		27FA2D6C234E3222004D5D2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 288A2D851AB8B3260023ABC3 /* Shared */;
+			targetProxy = 27FA2D6B234E3222004D5D2D /* PBXContainerItemProxy */;
 		};
 		288A2D9C1AB8B3260023ABC3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -153,7 +153,15 @@ class BrowserViewController: UIViewController {
         rewardsObserver = nil
         #else
         RewardsHelper.configureRewardsLogs()
-        rewards = BraveRewards(configuration: .default)
+        if AppConstants.BuildChannel.isRelease {
+            rewards = BraveRewards(configuration: .production)
+        } else {
+            if let override = Preferences.Rewards.EnvironmentOverride(rawValue: Preferences.Rewards.environmentOverride.value), override != .none {
+                rewards = BraveRewards(configuration: override == .prod ? .production : .default)
+            } else {
+                rewards = BraveRewards(configuration: .default)
+            }
+        }
         rewardsObserver = LedgerObserver(ledger: rewards!.ledger)
         #endif
 

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -251,7 +251,7 @@ class MenuViewController: UITableViewController {
     }
     
     private func openSettings() {
-        let vc = SettingsViewController(profile: bvc.profile, tabManager: bvc.tabManager)
+        let vc = SettingsViewController(profile: bvc.profile, tabManager: bvc.tabManager, rewards: bvc.rewards)
         vc.settingsDelegate = bvc
         open(vc, doneButton: DoneButton(style: .done, position: .right),
              allowSwipeToDismiss: false)

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -104,12 +104,6 @@ class SettingsViewController: TableViewController {
         tableView.accessibilityIdentifier = "SettingsViewController.tableView"
         dataSource.sections = sections
         
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(triggerQAMenu))
-        tapGesture.numberOfTapsRequired = 7
-        tapGesture.cancelsTouchesInView = false
-        tapGesture.delaysTouchesEnded = false
-        navigationController?.navigationBar.addGestureRecognizer(tapGesture)
-        
         applyTheme(theme)
     }
     
@@ -119,27 +113,6 @@ class SettingsViewController: TableViewController {
         settings.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(tappedQADone))
         let container = UINavigationController(rootViewController: settings)
         present(container, animated: true)
-    }
-    
-    @objc private func triggerQAMenu() {
-        guard rewards != nil && navigationController?.visibleViewController === self else { return }
-        
-        let alert = UIAlertController(title: "Nothing to see here", message: "What's the secret password", preferredStyle: .alert)
-        alert.addTextField(configurationHandler: {
-            $0.returnKeyType = .go
-            $0.isSecureTextEntry = true
-            $0.autocorrectionType = .no
-            $0.autocapitalizationType = .none
-        })
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        alert.addAction(UIAlertAction(title: "Submit", style: .default, handler: { [unowned self] action in
-            guard let textField = alert.textFields?.first else { return }
-            let qaPassword = Bundle.main.infoDictionaryString(forKey: "QA_MENU_PW")
-            if !AppConstants.BuildChannel.isRelease || (!qaPassword.isEmpty && textField.text == qaPassword) {
-                self.displayRewardsDebugMenu()
-            }
-        }))
-        self.present(alert, animated: true)
     }
     
     @objc private func tappedQADone() {

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -11,6 +11,8 @@ import LocalAuthentication
 import SwiftyJSON
 import Data
 import WebKit
+import BraveRewards
+import BraveRewardsUI
 
 extension TabBarVisibility: RepresentableOptionType {
     public var displayString: String {
@@ -80,10 +82,12 @@ class SettingsViewController: TableViewController {
     
     private let profile: Profile
     private let tabManager: TabManager
+    private let rewards: BraveRewards?
     
-    init(profile: Profile, tabManager: TabManager) {
+    init(profile: Profile, tabManager: TabManager, rewards: BraveRewards? = nil) {
         self.profile = profile
         self.tabManager = tabManager
+        self.rewards = rewards
         
         super.init(style: .grouped)
     }
@@ -94,11 +98,52 @@ class SettingsViewController: TableViewController {
     }
     
     override func viewDidLoad() {
+        super.viewDidLoad()
+        
         navigationItem.title = Strings.Settings
         tableView.accessibilityIdentifier = "SettingsViewController.tableView"
         dataSource.sections = sections
         
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(triggerQAMenu))
+        tapGesture.numberOfTapsRequired = 7
+        tapGesture.cancelsTouchesInView = false
+        tapGesture.delaysTouchesEnded = false
+        navigationController?.navigationBar.addGestureRecognizer(tapGesture)
+        
         applyTheme(theme)
+    }
+    
+    private func displayRewardsDebugMenu() {
+        guard let rewards = rewards else { return }
+        let settings = QASettingsViewController(rewards: rewards)
+        settings.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(tappedQADone))
+        let container = UINavigationController(rootViewController: settings)
+        present(container, animated: true)
+    }
+    
+    @objc private func triggerQAMenu() {
+        guard rewards != nil && navigationController?.visibleViewController === self else { return }
+        
+        let alert = UIAlertController(title: "Nothing to see here", message: "What's the secret password", preferredStyle: .alert)
+        alert.addTextField(configurationHandler: {
+            $0.returnKeyType = .go
+            $0.isSecureTextEntry = true
+            $0.autocorrectionType = .no
+            $0.autocapitalizationType = .none
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "Submit", style: .default, handler: { [unowned self] action in
+            guard let textField = alert.textFields?.first else { return }
+            let qaPassword = Bundle.main.infoDictionaryString(forKey: "QA_MENU_PW")
+            if !AppConstants.BuildChannel.isRelease || (!qaPassword.isEmpty && textField.text == qaPassword) {
+                self.displayRewardsDebugMenu()
+            }
+        }))
+        self.present(alert, animated: true)
+    }
+    
+    @objc private func tappedQADone() {
+        dismiss(animated: true, completion: nil)
     }
     
     private var theme: Theme {
@@ -191,7 +236,7 @@ class SettingsViewController: TableViewController {
                 let optionsViewController = OptionSelectionViewController<TabBarVisibility>(
                     options: TabBarVisibility.allCases,
                     selectedOption: TabBarVisibility(rawValue: Preferences.General.tabBarVisibility.value),
-                    optionChanged: { [unowned self] _, option in
+                    optionChanged: { _, option in
                         Preferences.General.tabBarVisibility.value = option.rawValue
                         reloadCell(row, option.displayString)
                     }
@@ -449,6 +494,9 @@ class SettingsViewController: TableViewController {
                     self.navigationController?.pushViewController(UrpLogsViewController(), animated: true)
                 }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: "URP Code: \(UserReferralProgram.getReferralCode() ?? "--")"),
+                Row(text: "View Rewards Debug Menu", selection: {
+                    self.displayRewardsDebugMenu()
+                }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: "Load all QA Links", selection: {
                     let url = URL(string: "https://raw.githubusercontent.com/brave/qa-resources/master/testlinks.json")!
                     let string = try? String(contentsOf: url)

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -110,13 +110,7 @@ class SettingsViewController: TableViewController {
     private func displayRewardsDebugMenu() {
         guard let rewards = rewards else { return }
         let settings = QASettingsViewController(rewards: rewards)
-        settings.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(tappedQADone))
-        let container = UINavigationController(rootViewController: settings)
-        present(container, animated: true)
-    }
-    
-    @objc private func tappedQADone() {
-        dismiss(animated: true, completion: nil)
+        navigationController?.pushViewController(settings, animated: true)
     }
     
     private var theme: Theme {

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -90,6 +90,8 @@
 	<array>
 		<string>org.mozilla.ios.firefox.browsing</string>
 	</array>
+	<key>QA_MENU_PW</key>
+	<string>$(BRAVE_QA_MENU_PW)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>CharisSILB.ttf</string>

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -90,8 +90,6 @@
 	<array>
 		<string>org.mozilla.ios.firefox.browsing</string>
 	</array>
-	<key>QA_MENU_PW</key>
-	<string>$(BRAVE_QA_MENU_PW)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>CharisSILB.ttf</string>
@@ -154,7 +152,7 @@
 			<string></string>
 		</dict>
 	</array>
-    <key>UIFileSharingEnabled</key>
-    <true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#166

Draft PR state: Will replace Cartfile changes when https://github.com/brave/brave-rewards-ios/pull/213 has been merged

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Prefix: Enable reward by removing `NO_REWARDS` flag
- Access the rewards debug menu from the debug section while not in release mode
- Verify environment override works (The other flags may be harder to verify)

## Screenshots

![Simulator Screen Shot - iPhone 11 Pro - 2019-10-09 at 11 43 23](https://user-images.githubusercontent.com/529104/66497327-52613700-ea8a-11e9-918e-9bf5a6d9d75b.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).