### PR TITLE
Fix #1553: Correct theme background color for empty downloads panel.

### DIFF
--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -58,6 +58,12 @@ extension Theme {
         
         InsetButton.appearance(whenContainedInInstancesOf: [SearchSuggestionPromptView.self]).appearanceTextColor = colors.tints.home
         
+        // Downloads
+        UIView.appearance(whenContainedInInstancesOf: [DownloadsPanel.self]).appearanceBackgroundColor = colors.home
+        
+        UIImageView.appearance(whenContainedInInstancesOf: [DownloadsPanel.self]).tintColor = colors.tints.home
+        UILabel.appearance(whenContainedInInstancesOf: [DownloadsPanel.self]).appearanceTextColor = colors.tints.home
+        
         if #available(iOS 13.0, *) {
             // Overrides all views inside of itself
             // According to docs, UIWindow override should be enough, but some labels on iOS 13 are still messed up without UIView override as well

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
@@ -250,8 +250,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
         let overlayView = UIView()
         overlayView.backgroundColor = UIColor.Photon.White100
         
-        let logoImageView = UIImageView(image: #imageLiteral(resourceName: "emptyDownloads"))
-        logoImageView.tintColor = UIColor.Photon.Grey60
+        let logoImageView = UIImageView(image: #imageLiteral(resourceName: "emptyDownloads").template)
         overlayView.addSubview(logoImageView)
         logoImageView.snp.makeConstraints { make in
             make.centerX.equalTo(overlayView)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1553 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="544" alt="Zrzut ekranu 2019-09-18 o 10 31 14" src="https://user-images.githubusercontent.com/6950387/65131650-e72ec280-d9ff-11e9-9176-2eeea8c4c720.png">

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
