### PR TITLE
Fix #1551: Better text color for tab tray cells on iOS 12 devices.

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -194,6 +194,8 @@ class TabCell: UICollectionViewCell, Themeable {
     func applyTheme(_ theme: Theme) {
         styleChildren(theme: theme)
         
+        // TabCell doesn't use much theming atm, using non-themable values for some views here.
+        titleText.appearanceTextColor = .black
         backgroundHolder.backgroundColor = theme.colors.home
         screenshotView.backgroundColor = backgroundHolder.backgroundColor
         favicon.tintColor = theme.colors.tints.home


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1551 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

iOS 12 with dark theme
![IMG_5079](https://user-images.githubusercontent.com/6950387/65134915-6246a780-da05-11e9-81b6-c56d98483235.PNG)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
