### PR TITLE
Rewards: Add "Hide Rewards Icon" setting to new Display settings section

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -296,7 +296,10 @@ extension Strings {
 // MARK:- Settings.
 extension Strings {
     public static let ClearPrivateData = NSLocalizedString("ClearPrivateData", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items. Also used as section title in settings panel")
+    public static let DisplaySettingsSection = NSLocalizedString("DisplaySettingsSection", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Display", comment: "Section name for display preferences.")
     public static let OtherSettingsSection = NSLocalizedString("OtherSettingsSection", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Other Settings", comment: "Section name for other settings.")
+    public static let HideRewardsIcon = NSLocalizedString("HideRewardsIcon", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Hide Brave Rewards Icon", comment: "Hides the rewards icon")
+    public static let HideRewardsIconSubtitle = NSLocalizedString("HideRewardsIconSubtitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Hides the Brave Rewards icon when Brave Rewards is not enabled", comment: "Hide the rewards icon explination.")
 }
 
 // MARK:- Error pages.
@@ -524,7 +527,7 @@ extension Strings {
     
     // MARK: - Themes
     
-    public static let ThemesDisplayBrightness = NSLocalizedString("ThemesDisplayBrightness", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Display & Brightness", comment: "Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes")
+    public static let ThemesDisplayBrightness = NSLocalizedString("ThemesDisplayBrightness", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Appearance", comment: "Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes")
     public static let ThemesDisplayBrightnessFooter = NSLocalizedString("ThemesDisplayBrightnessFooter", tableName: "BraveShared", bundle: Bundle.braveShared, value: "These settings are not applied in private browsing mode.", comment: "Text specifying that the above setting does not impact the user interface while they user is in private browsing mode.")
     public static let ThemesAutomaticOption = NSLocalizedString("ThemesAutomaticOption", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Automatic", comment: "Selection to automatically color/style the user interface.")
     public static let ThemesLightOption = NSLocalizedString("ThemesLightOption", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Light", comment: "Selection to color/style the user interface with a light theme.")

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -90,6 +90,7 @@ extension Preferences {
     
     public final class Rewards {
         public static let myFirstAdShown = Option<Bool>(key: "rewards.ads.my-first-ad-shown", default: false)
+        public static let hideRewardsIcon = Option<Bool>(key: "rewards.hide-rewards-icon", default: false)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -210,6 +210,7 @@ class BrowserViewController: UIViewController {
         Preferences.General.alwaysRequestDesktopSite.observe(from: self)
         Preferences.Shields.allShields.forEach { $0.observe(from: self) }
         Preferences.Privacy.blockAllCookies.observe(from: self)
+        Preferences.Rewards.hideRewardsIcon.observe(from: self)
         // Lists need to be compiled before attempting tab restoration
         contentBlockListDeferred = ContentBlockerHelper.compileBundledLists()
         
@@ -3058,6 +3059,8 @@ extension BrowserViewController: PreferencesObserver {
             } else {
                 tabManager.reloadSelectedTab()
             }
+        case Preferences.Rewards.hideRewardsIcon.key:
+            updateRewardsButtonState()
         default:
             log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
             break

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -7,6 +7,7 @@ import BraveRewards
 import BraveRewardsUI
 import Data
 import Shared
+import BraveShared
 
 private let log = Logger.rewardsLogger
 
@@ -52,6 +53,7 @@ extension RewardsPanelController: PopoverContentComponent {
 extension BrowserViewController {
     func updateRewardsButtonState() {
         if !isViewLoaded { return }
+        self.topToolbar.locationView.rewardsButton.isHidden = self.rewards?.ledger.isEnabled == false && Preferences.Rewards.hideRewardsIcon.value
         self.topToolbar.locationView.rewardsButton.isVerified = self.publisher?.verified ?? false
         self.topToolbar.locationView.rewardsButton.notificationCount = self.rewards?.ledger.notifications.count ?? 0
     }


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#203

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Prefix: Enable rewards by removing the NO_REWARDS build flag
- Verify that rewards is disabled/wallet not created
- Open settings, verify that new display section looks correct and settings within it work as usual
- Turn on Hide Brave Rewards Icon and close settings, verify that the icon is no longer in the toolbar
- Verify that icon stays hidden through app launches
- Turn off Hide Brave Rewards Icon and enable Brave Rewards in the panel
- Turn on Hide Brave Rewards Icon again and verify that the icon is still visible in the toolbar since BR is enabled

## Screenshots:

![Simulator Screen Shot - iPhone Xs - 2019-09-19 at 11 07 11](https://user-images.githubusercontent.com/529104/65256706-f7ad6e80-dacd-11e9-9a26-607afec5efd8.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).