### PR TITLE
Fix #1570: Rotate the popover during dismissal to avoid crazy animations

### DIFF
--- a/Client/Frontend/Popover/PopoverController.swift
+++ b/Client/Frontend/Popover/PopoverController.swift
@@ -502,6 +502,8 @@ extension PopoverController: BasicAnimationControllerDelegate {
         }
         
         let oldTransform = containerView.transform
+        let rotationAngle = atan2(oldTransform.b, oldTransform.a)
+        
         containerView.transform = .identity // Reset to get unaltered frame
         let translationDelta = anchorPointDelta(from: popoverContext, popoverRect: containerView.frame)
         containerView.transform = oldTransform // Make sure to animate transform from a possibly altered transform
@@ -509,6 +511,7 @@ extension PopoverController: BasicAnimationControllerDelegate {
         UIView.animate(withDuration: 0.15, delay: 0, options: [.beginFromCurrentState, .allowUserInteraction], animations: {
             self.containerView.transform = CGAffineTransform(translationX: translationDelta.x, y: translationDelta.y)
                 .scaledBy(x: 0.001, y: 0.001)
+                .rotated(by: rotationAngle)
                 .translatedBy(x: -translationDelta.x, y: -translationDelta.y)
         }) { finished in
             context.completeTransition(finished)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1570 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Dismiss the shield or rewards popover with the gesture in all sorts of rotations

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
