### PR TITLE
Rewards: Support new connected publisher status

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -4,7 +4,7 @@ github "Sidetalker/onepassword-app-extension" "68a9d932a6373ca045984fbf4fb9a25ae
 github "SnapKit/SnapKit" "5.0.1"
 github "SwiftyJSON/SwiftyJSON" "5.0.0"
 github "airbnb/lottie-ios" "531eb22d47a9439a2344fdaf96832189f2c6e925"
-github "brave/brave-rewards-ios" "b86a6e9b66277bc64c8f628e2a85317b31a155d4"
+github "brave/brave-rewards-ios" "a89694050213317416cb42879dbbf1be2ffd4a79"
 github "cezheng/Fuzi" "3.1.0"
 github "facebook/pop" "1.0.12"
 github "garvankeeley/Deferred" "9.9.2"

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -54,7 +54,8 @@ extension BrowserViewController {
     func updateRewardsButtonState() {
         if !isViewLoaded { return }
         self.topToolbar.locationView.rewardsButton.isHidden = self.rewards?.ledger.isEnabled == false && Preferences.Rewards.hideRewardsIcon.value
-        self.topToolbar.locationView.rewardsButton.isVerified = self.publisher?.verified ?? false
+        let isVerifiedBadgeVisible = self.publisher?.status == .verified || self.publisher?.status == .connected
+        self.topToolbar.locationView.rewardsButton.isVerified = isVerifiedBadgeVisible
         self.topToolbar.locationView.rewardsButton.notificationCount = self.rewards?.ledger.notifications.count ?? 0
     }
 


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#197

~Draft PR status: waiting on merge of https://github.com/brave/brave-rewards-ios/pull/219 to update Cartfile.resolved~

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Prefix: Enable rewards by removing NO_REWARDS build flag
2. Visit unverified publisher site & verify no badge
3. Visit verified publisher site & verify badge
4. Visit connected publisher site & verify badge

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).