### PR TITLE
Prevent iTunes from backing up our Logins.db and our CoreData databases.

### DIFF
--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -193,6 +193,27 @@ public class DataController: NSObject {
         storeDescription.setOption(completeProtection, forKey: NSPersistentStoreFileProtectionKey)
         
         container.persistentStoreDescriptions = [storeDescription]
+
+        // Set the security policy to exclude the database from backup
+        do {
+            var store = store
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            try store.setResourceValues(resourceValues)
+        } catch {
+            log.error("Could not set security policy on url for: \(store)")
+        }
+        
+        // Set the security policy to exclude the ApplicationSupportDirectory from backup
+        var url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+        
+        do {
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            try url?.setResourceValues(resourceValues)
+        } catch {
+            log.error("Could not set security policy on url for: \(url?.absoluteString ?? "Application Support Directory")")
+        }
     }
     
     // MARK: - Private

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -144,6 +144,16 @@ open class BrowserProfile: Profile {
 
         // Set up our database handles.
         self.loginsDB = BrowserDB(filename: "logins.db", secretKey: BrowserProfile.loginsKey, schema: LoginsSchema(), files: files)
+        
+        // Set security policy on the database
+        do {
+            var databasePath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory())).appendingPathComponent("logins.db")
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            try databasePath.setResourceValues(resourceValues)
+        } catch {
+            log.error("Couldn't exclude logins.db from iTunes Backup")
+        }
 
         if isNewProfile {
             log.info("New profile. Removing old account metadata.")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Security Review: https://github.com/brave/security/issues/8

I don't know where the ticket is. I can't find it :S at all.. But the fix is to prevent the databases from being backed-up with iTunes and iCloud.


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
