### PR TITLE
Rewards: Show notification badge on Brave Rewards icon when needed

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/RewardsButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/RewardsButton.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Shared
+import BraveShared
 
 class RewardsButton: UIButton {
     
@@ -18,6 +19,12 @@ class RewardsButton: UIButton {
     /// Disabled state shows grayscale icon but still allows interaction.
     var isDisabled: Bool = false {
         didSet { updateView() }
+    }
+    
+    private let notificationsBadgeView = UIView().then {
+        $0.backgroundColor = BraveUX.BraveOrange
+        $0.frame = CGRect(x: 19, y: 5, width: 12, height: 12)
+        $0.layer.cornerRadius = 6
     }
     
     private var checkmarkView = UIImageView().then {
@@ -37,12 +44,13 @@ class RewardsButton: UIButton {
         accessibilityIdentifier = "urlBar-rewardsButton"
         
         addSubview(checkmarkView)
+        addSubview(notificationsBadgeView)
         updateView()
     }
     
     private func updateView() {
         checkmarkView.isHidden = true
-        // notificationView.isHidden = true
+        notificationsBadgeView.isHidden = true
         
         if isDisabled {
             setImage(#imageLiteral(resourceName: "brave_rewards_button_disabled"), for: .normal)
@@ -51,9 +59,9 @@ class RewardsButton: UIButton {
         
         setImage(#imageLiteral(resourceName: "brave_rewards_button_enabled"), for: .normal)
         
-        // if notificationCount > 0 { show badge with number }
-        
-        if isVerified {
+        if notificationCount > 0 {
+            notificationsBadgeView.isHidden = false
+        } else if isVerified {
             checkmarkView.isHidden = false
         }
     }


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#208

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Prefix: Enable rewards by removing NO_REWARDS build flag
2. Join rewards if not already joined
3. Wait for a notification to be added and verify a badge is shown in the URL bar until the notification is dismissed.

There are a few types of notifications that you can get:
1. Grant available
2. Failed reconcile (insufficient funds for instance)
3. Insufficient funds 3 days before reconcile
4. Tips processed (Reconcile completed)

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-09-25 at 16 17 32](https://user-images.githubusercontent.com/529104/65636277-fdb0bd00-dfaf-11e9-84a2-7159f3a9b228.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
