### PR TITLE
Fix #1587: Add second sorting descriptor "name" for sync device's frc.

### DIFF
--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -189,10 +189,15 @@ class SyncSettingsTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        configureCell(cell, atIndexPath: indexPath)
         
+        return cell
+    }
+    
+    private func configureCell(_ cell: UITableViewCell, atIndexPath indexPath: IndexPath) {
         guard let frc = frc else {
             log.error("FetchedResultsController is nil.")
-            return UITableViewCell()
+            return
         }
         
         switch indexPath.section {
@@ -210,8 +215,6 @@ class SyncSettingsTableViewController: UITableViewController {
         default:
             log.error("Section index out of bounds.")
         }
-        
-        return cell
     }
     
     private func setFullWidthSeparator(for cell: UITableViewCell) {
@@ -265,6 +268,14 @@ extension SyncSettingsTableViewController: NSFetchedResultsControllerDelegate {
         case .delete:
             guard let indexPath = indexPath else { return }
             tableView.deleteRows(at: [indexPath], with: .fade)
+        case .update:
+            if let indexPath = indexPath, let cell = tableView.cellForRow(at: indexPath) {
+              configureCell(cell, atIndexPath: indexPath)
+            }
+            
+            if let newIndexPath = newIndexPath, let cell = tableView.cellForRow(at: newIndexPath) {
+              configureCell(cell, atIndexPath: newIndexPath)
+            }
         default:
             log.info("Operation type: \(type) is not handled.")
         }

--- a/Data/models/Device.swift
+++ b/Data/models/Device.swift
@@ -32,7 +32,8 @@ public final class Device: NSManagedObject, Syncable, CRUD {
         fetchRequest.entity = Device.entity(context: context)
         
         let currentDeviceSort = NSSortDescriptor(key: "isCurrentDevice", ascending: false)
-        fetchRequest.sortDescriptors = [currentDeviceSort]
+        let nameSort = NSSortDescriptor(key: "name", ascending: true)
+        fetchRequest.sortDescriptors = [currentDeviceSort, nameSort]
         
         return NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: context,
                                           sectionNameKeyPath: nil, cacheName: nil)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1587 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
