### PR TITLE
Rewards: Update Rewards verified sign by fetching publisher info on url change

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1110,7 +1110,10 @@ class BrowserViewController: UIViewController {
     fileprivate func updateURLBar() {
         guard let tab = tabManager.selectedTab else { return }
         if let url = tab.url, !url.isLocal {
-            self.rewards?.ledger.fetchPublisherActivity(from: url, faviconURL: nil, publisherBlob: nil, tabId: UInt64(tab.rewardsId))
+            // Notify Rewards of new page load.
+            if let rewards = rewards {
+                tabManager.selectedTab?.reportPageLoad(to: rewards)
+            }
         } else {
             self.topToolbar.locationView.rewardsButton.isVerified = false
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1105,7 +1105,11 @@ class BrowserViewController: UIViewController {
             updateInContentHomePanel(url as URL)
         }
     }
+    
+    // This variable is used to keep track of current page. It is used to detect internal site navigation
+    // to report internal page load to Rewards lib
     var rewardsXHRLoadURL: URL?
+    
     /// Updates the URL bar security, text and button states.
     fileprivate func updateURLBar() {
         guard let tab = tabManager.selectedTab else { return }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1108,18 +1108,18 @@ class BrowserViewController: UIViewController {
 
     /// Updates the URL bar security, text and button states.
     fileprivate func updateURLBar() {
-        guard let tab = tabManager.selectedTab, let url = tab.url else { return }
-        if url.isLocal {
-            self.topToolbar.locationView.rewardsButton.isVerified = false
-        } else {
+        guard let tab = tabManager.selectedTab else { return }
+        if let url = tab.url, !url.isLocal {
             self.rewards?.ledger.fetchPublisherActivity(from: url, faviconURL: nil, publisherBlob: nil, tabId: UInt64(tab.rewardsId))
+        } else {
+            self.topToolbar.locationView.rewardsButton.isVerified = false
         }
         
-        topToolbar.currentURL = url.displayURL
+        topToolbar.currentURL = tab.url?.displayURL
         
         topToolbar.contentIsSecure = tab.contentIsSecure
         
-        let isPage = url.displayURL?.isWebPage() ?? false
+        let isPage = tab.url?.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isPage)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1105,13 +1105,16 @@ class BrowserViewController: UIViewController {
             updateInContentHomePanel(url as URL)
         }
     }
-
+    var rewardsXHRLoadURL: URL?
     /// Updates the URL bar security, text and button states.
     fileprivate func updateURLBar() {
         guard let tab = tabManager.selectedTab else { return }
         if let url = tab.url, !url.isLocal {
             // Notify Rewards of new page load.
-            if let rewards = rewards {
+            if let rewards = rewards, let rewardsURL = rewardsXHRLoadURL,
+                url.host == rewardsURL.host,
+                url.isMediaSiteURL {
+                tabManager.selectedTab?.reportPageNaviagtion(to: rewards)
                 tabManager.selectedTab?.reportPageLoad(to: rewards)
             }
         } else {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1108,16 +1108,18 @@ class BrowserViewController: UIViewController {
 
     /// Updates the URL bar security, text and button states.
     fileprivate func updateURLBar() {
-        guard let tab = tabManager.selectedTab else { return }
-        if let url = tab.url, url.isLocal {
+        guard let tab = tabManager.selectedTab, let url = tab.url else { return }
+        if url.isLocal {
             self.topToolbar.locationView.rewardsButton.isVerified = false
+        } else {
+            self.rewards?.ledger.fetchPublisherActivity(from: url, faviconURL: nil, publisherBlob: nil, tabId: UInt64(tab.rewardsId))
         }
         
-        topToolbar.currentURL = tab.url?.displayURL
+        topToolbar.currentURL = url.displayURL
         
         topToolbar.contentIsSecure = tab.contentIsSecure
         
-        let isPage = tab.url?.displayURL?.isWebPage() ?? false
+        let isPage = url.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isPage)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -123,6 +123,10 @@ extension Tab {
             rewards.reportLoadedPage(url: url, faviconUrl: faviconURL, tabId: self.rewardsId, html: htmlString, shouldClassifyForAds: shouldClassify)
         })
     }
+    
+    func reportPageNaviagtion(to rewards: BraveRewards) {
+        rewards.reportTabNavigation(tabId: self.rewardsId)
+    }
 }
 
 extension BrowserViewController: RewardsDataSource {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -379,6 +379,8 @@ extension BrowserViewController: WKNavigationDelegate {
             if webView.url?.isLocal == false {
                 // Reset should classify
                 tab.shouldClassifyLoadsForAds = true
+                // Set rewards inter site url as new page load url.
+                rewardsXHRLoadURL = webView.url
             }
             
             if tab === tabManager.selectedTab {

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -390,6 +390,8 @@ extension URL {
         return nil
     }
     
+    // This is a helper function for determining wetherr the url is a Media URL
+    // as handled in Rewards lib.
     public var isMediaSiteURL: Bool {
         // Don't need to include Github as it does a page load instead of XHR load.
         guard let domain = self.baseDomain else {

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -389,6 +389,14 @@ extension URL {
         }
         return nil
     }
+    
+    public var isMediaSiteURL: Bool {
+        // Don't need to include Github as it does a page load instead of XHR load.
+        guard let domain = self.baseDomain else {
+            return true
+        }
+        return ["youtube", "vimeo", "twitch", "twitter", "reddit"].contains(where: domain.contains)
+    }
 }
 
 // Helpers to deal with About URLs

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -572,4 +572,32 @@ class NSURLExtensionsTests: XCTestCase {
             XCTAssertNil($0.bookmarkletCodeComponent)
         }
     }
+    
+    func testMediaSiteURL() {
+        let goodURLs = [
+            "https://www.youtube.com",
+            "https://www.vimeo.com",
+            "https://m.youtube.com",
+            "https://m.twitch.tv",
+            "https://www.twitch.tv"
+        ]
+        
+        let badURLs = [
+            "https://youtube.xyz.com",
+            "https://www.google.com",
+            "https://www.you.tube.com"
+        ]
+        
+        func getURL(url: String) -> URL? {
+            return URL(string: url)
+        }
+        
+        goodURLs.forEach {
+            XCTAssertTrue(getURL(url: $0)?.isMediaSiteURL ?? true, "failed for \($0)")
+        }
+        
+        badURLs.forEach {
+            XCTAssertFalse((getURL(url: $0)?.isMediaSiteURL) ?? false, "failed for \($0)")
+        }
+    }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->
Fixes#: brave/brave-rewards-ios#225

The rewards verified sign was not updated when browsing sites without page load, example YouTube.
## Summary of Changes
A fetch publisher activity is done in delegate to update url. This internally checks if its media type or normal and does the required fetch -> call observer. We already have code in place to update the UI in observer.
This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Open a verified YouTube page and verify the rewards verified sign is displayed
Visit another video from the same page that is not verified and check that the rewards verified sign is removed.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
