### PR TITLE
Always use light theme for Rewards UI.

### DIFF
--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import BraveShared
+import BraveRewardsUI
 
 extension Theme {
     func applyAppearanceProperties() {
@@ -72,8 +73,13 @@ extension Theme {
             UIView.appearance().appearanceOverrideUserInterfaceStyle = isDark ? .dark : .light
         } else {
             // iOS 12 fixes, many styling items do not work properly in iOS 12
-            UILabel.appearance().appearanceTextColor = colors.tints.home
+            let views = [ShieldsViewController.self, SyncViewController.self,
+                         BrowserViewController.self, BasePasscodeViewController.self]
             
+            views.forEach {
+                UILabel.appearance(whenContainedInInstancesOf: [$0]).appearanceTextColor = colors.tints.home
+            }
+
             // iOS 12 does not allow in-line color overrides :/
             // These UI components are currently non-themed
             // AlertPopupView
@@ -88,7 +94,43 @@ extension Theme {
             UISwitch.appearance().tintColor = #colorLiteral(red: 0.8392156863, green: 0.8392156863, blue: 0.8431372549, alpha: 1)
         }
         
+        // Brave Rewards
+        lightThemeOverridesForRewards()
+        
         (UIApplication.shared.delegate as? AppDelegate)?.window?.backgroundColor = colors.home
+    }
+    
+    // No theming exists for Brave Rewards at the moment, for appearance override, a default light
+    // theme should be used.
+    private func lightThemeOverridesForRewards() {
+        let lightTheme = Theme.from(id: DefaultTheme.light.rawValue)
+        let rewards = RewardsPanelController.self
+        
+        UIWindow.appearance(whenContainedInInstancesOf: [rewards]).appearanceOverrideUserInterfaceStyle = .light
+        UIView.appearance(whenContainedInInstancesOf: [rewards]).appearanceOverrideUserInterfaceStyle = .light
+        
+        UIToolbar.appearance(whenContainedInInstancesOf: [rewards]).tintColor = lightTheme.colors.accent
+        UIToolbar.appearance(whenContainedInInstancesOf: [rewards]).backgroundColor = lightTheme.colors.footer
+        
+        UINavigationBar.appearance(whenContainedInInstancesOf: [rewards]).tintColor = lightTheme.colors.accent
+        UINavigationBar.appearance(whenContainedInInstancesOf: [rewards])
+            .appearanceBarTintColor = lightTheme.colors.header
+        
+        UITableView.appearance(whenContainedInInstancesOf: [rewards])
+            .appearanceBackgroundColor = lightTheme.colors.home
+        UITableView.appearance(whenContainedInInstancesOf: [rewards]).appearanceSeparatorColor =
+            lightTheme.colors.border.withAlphaComponent(colors.transparencies.borderAlpha)
+        
+        UITableViewCell.appearance(whenContainedInInstancesOf: [rewards]).tintColor = lightTheme.colors.accent
+        UITableViewCell.appearance(whenContainedInInstancesOf: [rewards])
+            .backgroundColor = lightTheme.colors.header
+        
+        // Order of views is important here, it reads from right to left.
+        // That means all labels inside of UITableView within Rewards popup use light theme text.
+        //
+        // This is not pefect as it overrides values used in Brave Rewards repo but most if not all cell text
+        // uses one color. This should be good enough until we move rewards-ui into this repo.
+        UILabel.appearance(whenContainedInInstancesOf: [UITableView.self, RewardsPanelController.self]).appearanceTextColor = lightTheme.colors.tints.home
     }
 }
 

--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -125,6 +125,9 @@ extension Theme {
         UITableViewCell.appearance(whenContainedInInstancesOf: [rewards])
             .backgroundColor = lightTheme.colors.header
         
+        UILabel.appearance(whenContainedInInstancesOf: [AdView.self, BrowserViewController.self])
+            .appearanceTextColor = lightTheme.colors.tints.home
+        
         // Order of views is important here, it reads from right to left.
         // That means all labels inside of UITableView within Rewards popup use light theme text.
         //


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-rewards-ios/issues/229
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Look if the rewards popup UI looks good on all themes configuration both iOS 12 & 13

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Both iOS 12 & 13 use dark theme here

| iOS 12  |  iOS 13 |
|---|---|
| ![IMG_5095](https://user-images.githubusercontent.com/6950387/66140105-d4241100-e601-11e9-9b71-240955c354e7.PNG)  | <img width="544" alt="Zrzut ekranu 2019-10-3 o 17 14 10" src="https://user-images.githubusercontent.com/6950387/66140128-dbe3b580-e601-11e9-8fcf-fdcba064a291.png">  |
|  ![IMG_5096](https://user-images.githubusercontent.com/6950387/66140103-d4241100-e601-11e9-9458-96b7731a2b71.PNG) | <img width="544" alt="Zrzut ekranu 2019-10-3 o 17 14 19" src="https://user-images.githubusercontent.com/6950387/66140126-db4b1f00-e601-11e9-9e14-3df9e2140cb2.png">  |


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
