### PR TITLE
Fixes YubiKey presentation for "required" and "preferred"

### DIFF
--- a/Client/WebAuthN/U2FExtensions.swift
+++ b/Client/WebAuthN/U2FExtensions.swift
@@ -536,7 +536,7 @@ class U2FExtensions: NSObject {
             getAssertionRequest.clientDataHash = clientDataHash
             
             getAssertionRequest.options = [
-                YKFKeyFIDO2GetAssertionRequestOptionUP: request.userPresence,
+                YKFKeyFIDO2GetAssertionRequestOptionUP: request.userPresence
             ]
 
             var allowList = [YKFFIDO2PublicKeyCredentialDescriptor]()

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -37,7 +37,7 @@ extension WebAuthnAuthenticateRequest: Decodable {
         
         // userPresence is the inverse of userVerification, UP by default is true
         let userVerifcationString = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .userVerification) ?? "discouraged"
-        userPresence = userVerifcationString == "discouraged"
+        userPresence = userVerifcationString != "discouraged"
         
         let allowCredentialsArray = try publicKeyDictionary.decode([AllowCredentials].self, forKey: .allowCredentials)
     

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -36,7 +36,7 @@ extension WebAuthnAuthenticateRequest: Decodable {
         challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)
         
         // userPresence is the inverse of userVerification, UP by default is true
-        let userVerifcationString = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .userVerification) ?? "discouraged"
+        let userVerifcationString = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .userVerification) ?? "required"
         userPresence = userVerifcationString != "discouraged"
         
         let allowCredentialsArray = try publicKeyDictionary.decode([AllowCredentials].self, forKey: .allowCredentials)

--- a/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
+++ b/Client/WebAuthN/WebAuthnAuthenticateRequest.swift
@@ -3,11 +3,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import Shared
 
+enum WebAuthnUserVerification: String, Codable {
+    case required
+    case preferred
+    case discouraged
+}
+
 struct WebAuthnAuthenticateRequest {
     var rpID: String?
     var challenge: String
     var allowCredentials: [String] = []
-    var userPresence: Bool
+    let userPresence: Bool
+    var userVerification: WebAuthnUserVerification
 
     enum RequestKeys: String, CodingKey {
         case publicKey
@@ -35,9 +42,12 @@ extension WebAuthnAuthenticateRequest: Decodable {
         rpID = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .rpId)
         challenge = try publicKeyDictionary.decode(String.self, forKey: .challenge)
         
-        // userPresence is the inverse of userVerification, UP by default is true
-        let userVerifcationString = try publicKeyDictionary.decodeIfPresent(String.self, forKey: .userVerification) ?? "required"
-        userPresence = userVerifcationString != "discouraged"
+        // As of the latest spec changes, this valid will always be true!
+        // https://github.com/w3c/webauthn/pull/1140/files
+        userPresence = true
+        
+        // As a result of the above, we need to ensure that the default value is preferred
+        userVerification = try publicKeyDictionary.decodeIfPresent(WebAuthnUserVerification.self, forKey: .userVerification) ?? .preferred
         
         let allowCredentialsArray = try publicKeyDictionary.decode([AllowCredentials].self, forKey: .allowCredentials)
     

--- a/ClientTests/U2FTests.swift
+++ b/ClientTests/U2FTests.swift
@@ -57,7 +57,7 @@ class U2FTests: XCTestCase {
             XCTAssertEqual(request.challenge, "mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=", "request challenge is correct.")
             XCTAssertEqual(request.allowCredentials.count, 1, "request allowCredential count is correct")
             XCTAssertEqual(request.allowCredentials.first, "OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=", "request allowCredential is correct")
-            XCTAssertFalse(request.userPresence, "request userPresence is correct")
+            XCTAssertTrue(request.userPresence, "request userPresence is correct") //User presence must always be true now!
         } catch {
             XCTFail("\(error)")
         }

--- a/ClientTests/U2FTests.swift
+++ b/ClientTests/U2FTests.swift
@@ -57,7 +57,37 @@ class U2FTests: XCTestCase {
             XCTAssertEqual(request.challenge, "mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=", "request challenge is correct.")
             XCTAssertEqual(request.allowCredentials.count, 1, "request allowCredential count is correct")
             XCTAssertEqual(request.allowCredentials.first, "OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=", "request allowCredential is correct")
-            XCTAssertTrue(request.userPresence, "request userPresence is correct")
+            XCTAssertFalse(request.userPresence, "request userPresence is correct")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testWebAuthnUserPresence() {
+        do {
+            var payloads = [String]()
+            let presences = ["required", "preferred", "discouraged"]
+            let expected = [true, true, false, true]
+            
+            // Test expected presences
+            for presence in presences {
+                let payload = "{\"publicKey\":{\"allowCredentials\":[{\"type\":\"public-key\",\"id\":\"OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=\"}],\"rpId\":\"demo.brave.com\",\"timeout\":90000,\"userVerification\":\"\(presence)\",\"challenge\":\"mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=\"},\"signal\":{}}"
+                payloads.append(payload)
+            }
+            
+            // Test when userPresence is MISSING from the payload..
+        payloads.append("{\"publicKey\":{\"allowCredentials\":[{\"type\":\"public-key\",\"id\":\"OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=\"}],\"rpId\":\"demo.brave.com\",\"timeout\":90000,\"challenge\":\"mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=\"},\"signal\":{}}")
+            
+            for i in 0..<payloads.count {
+                guard let jsonData = payloads[i].data(using: String.Encoding.utf8) else {
+                    XCTFail("Failed parsing webauthn authentication data")
+                    return
+                }
+                
+                let request =  try JSONDecoder().decode(WebAuthnAuthenticateRequest.self, from: jsonData)
+                
+                XCTAssertTrue(request.userPresence == expected[i], "request userPresence is correct")
+            }
         } catch {
             XCTFail("\(error)")
         }

--- a/ClientTests/U2FTests.swift
+++ b/ClientTests/U2FTests.swift
@@ -63,15 +63,15 @@ class U2FTests: XCTestCase {
         }
     }
     
-    func testWebAuthnUserPresence() {
+    func testWebAuthnUserVerification() {
         do {
             var payloads = [String]()
-            let presences = ["required", "preferred", "discouraged"]
-            let expected = [true, true, false, true]
+            let verifications = ["required", "preferred", "discouraged"]
+            let expected: [WebAuthnUserVerification] = [.required, .preferred, .discouraged, .preferred]
             
-            // Test expected presences
-            for presence in presences {
-                let payload = "{\"publicKey\":{\"allowCredentials\":[{\"type\":\"public-key\",\"id\":\"OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=\"}],\"rpId\":\"demo.brave.com\",\"timeout\":90000,\"userVerification\":\"\(presence)\",\"challenge\":\"mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=\"},\"signal\":{}}"
+            // Test expected verifications
+            for verification in verifications {
+                let payload = "{\"publicKey\":{\"allowCredentials\":[{\"type\":\"public-key\",\"id\":\"OvQO5490o1w89Op/9dp4w7VvKuLEk5NHcfOnc2ZECtc=\"}],\"rpId\":\"demo.brave.com\",\"timeout\":90000,\"userVerification\":\"\(verification)\",\"challenge\":\"mdMbxTPACurawWFHqkoltSUwDear2OZQVl/uhBNqiaM=\"},\"signal\":{}}"
                 payloads.append(payload)
             }
             
@@ -86,7 +86,7 @@ class U2FTests: XCTestCase {
                 
                 let request =  try JSONDecoder().decode(WebAuthnAuthenticateRequest.self, from: jsonData)
                 
-                XCTAssertTrue(request.userPresence == expected[i], "request userPresence is correct")
+                XCTAssertTrue(request.userVerification == expected[i], "request userPresence is correct")
             }
         } catch {
             XCTFail("\(error)")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-ios/issues/1585

The boolean was flipped the wrong direction. This could have possibly been an enum instead but it doesn't matter as we only care if it's set to true or not.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
see https://github.com/brave/brave-ios/issues/1585

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
