### PR TITLE
Fix #1499:  Use native context menu on iOS 13

### DIFF
--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -7,6 +7,9 @@ import WebKit
 
 class BraveWebView: WKWebView {
     
+    /// Stores last position when the webview was touched on.
+    private(set) var lastHitPoint = CGPoint(x: 0, y: 0)
+    
     private static var nonPersistentDataStore: WKWebsiteDataStore?
     private static func sharedNonPersistentStore() -> WKWebsiteDataStore {
         if let dataStore = nonPersistentDataStore {
@@ -36,5 +39,10 @@ class BraveWebView: WKWebView {
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError()
+    }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        lastHitPoint = point
+        return super.hitTest(point, with: event)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2446,22 +2446,26 @@ extension BrowserViewController: WKUIDelegate {
                 let tabType = currentTab.type
                 
                 if !tabType.isPrivate {
-                    let openNewTabAction = UIAction(title: Strings.OpenNewTabButtonTitle) { _ in
+                    let openNewTabAction = UIAction(title: Strings.OpenNewTabButtonTitle,
+                                                    image: UIImage(systemName: "plus")) { _ in
                         self.addTab(url: url, inPrivateMode: false, currentTab: currentTab)
                     }
+                    
                     openNewTabAction.accessibilityLabel = "linkContextMenu.openInNewTab"
                     
                     actions.append(openNewTabAction)
                 }
                 
-                let openNewPrivateTabAction = UIAction(title: Strings.OpenNewPrivateTabButtonTitle) { _ in
+                let openNewPrivateTabAction = UIAction(title: Strings.OpenNewPrivateTabButtonTitle,
+                                                       image: #imageLiteral(resourceName: "private_glasses").template) { _ in
                     self.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
                 }
                 openNewPrivateTabAction.accessibilityLabel = "linkContextMenu.openInNewPrivateTab"
                 
                 actions.append(openNewPrivateTabAction)
                 
-                let copyAction = UIAction(title: Strings.CopyLinkActionTitle) { _ in
+                let copyAction = UIAction(title: Strings.CopyLinkActionTitle,
+                                          image: UIImage(systemName: "doc.on.doc")) { _ in
                     UIPasteboard.general.url = url
                 }
                 copyAction.accessibilityLabel = "linkContextMenu.copyLink"
@@ -2469,7 +2473,8 @@ extension BrowserViewController: WKUIDelegate {
                 actions.append(copyAction)
                 
                 if let braveWebView = webView as? BraveWebView {
-                    let shareAction = UIAction(title: Strings.ShareLinkActionTitle) { _ in
+                    let shareAction = UIAction(title: Strings.ShareLinkActionTitle,
+                                               image: UIImage(systemName: "square.and.arrow.up")) { _ in
                         let touchPoint = braveWebView.lastHitPoint
                         let touchSize = CGSize(width: 0, height: 16)
                         let touchRect = CGRect(origin: touchPoint, size: touchSize)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -20,6 +20,7 @@ import SwiftKeychainWrapper
 import BraveRewardsUI
 import BraveRewards
 import StoreKit
+import SafariServices
 
 private let log = Logger.browserLogger
 
@@ -1972,9 +1973,13 @@ extension BrowserViewController: TabDelegate {
             tab.addContentScript(logins, name: LoginsHelper.name())
         }
 
-        let contextMenuHelper = ContextMenuHelper(tab: tab)
-        contextMenuHelper.delegate = self
-        tab.addContentScript(contextMenuHelper, name: ContextMenuHelper.name())
+        if #available(iOS 13, *) {
+            // Do nothing, native API is used.
+        } else {
+            let contextMenuHelper = ContextMenuHelper(tab: tab)
+            contextMenuHelper.delegate = self
+            tab.addContentScript(contextMenuHelper, name: ContextMenuHelper.name())
+        }
 
         let errorHelper = ErrorPageHelper()
         tab.addContentScript(errorHelper, name: ErrorPageHelper.name())
@@ -2428,6 +2433,82 @@ extension BrowserViewController: WKUIDelegate {
             self.tabManager.removeTab(tab)
         }
     }
+    
+    @available(iOS 13.0, *)
+    func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo, completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
+        
+        guard let url = elementInfo.linkURL else { return completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: nil)) }
+        
+        let actionProvider: UIContextMenuActionProvider = { _ -> UIMenu? in
+            var actions = [UIAction]()
+            
+            if let currentTab = self.tabManager.selectedTab {
+                let tabType = currentTab.type
+                
+                if !tabType.isPrivate {
+                    let openNewTabAction = UIAction(title: Strings.OpenNewTabButtonTitle) { _ in
+                        self.addTab(url: url, inPrivateMode: false, currentTab: currentTab)
+                    }
+                    openNewTabAction.accessibilityLabel = "linkContextMenu.openInNewTab"
+                    
+                    actions.append(openNewTabAction)
+                }
+                
+                let openNewPrivateTabAction = UIAction(title: Strings.OpenNewPrivateTabButtonTitle) { _ in
+                    self.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
+                }
+                openNewPrivateTabAction.accessibilityLabel = "linkContextMenu.openInNewPrivateTab"
+                
+                actions.append(openNewPrivateTabAction)
+                
+                let copyAction = UIAction(title: Strings.CopyLinkActionTitle) { _ in
+                    UIPasteboard.general.url = url
+                }
+                copyAction.accessibilityLabel = "linkContextMenu.copyLink"
+                
+                actions.append(copyAction)
+                
+                if let braveWebView = webView as? BraveWebView {
+                    let shareAction = UIAction(title: Strings.ShareLinkActionTitle) { _ in
+                        let touchPoint = braveWebView.lastHitPoint
+                        let touchSize = CGSize(width: 0, height: 16)
+                        let touchRect = CGRect(origin: touchPoint, size: touchSize)
+                        
+                        self.presentActivityViewController(url, sourceView: self.view,
+                                                           sourceRect: touchRect,
+                                                           arrowDirection: .any)
+                    }
+                    
+                    shareAction.accessibilityLabel = "linkContextMenu.share"
+                    
+                    actions.append(shareAction)
+                }
+            
+            }
+            
+            return UIMenu(title: url.absoluteString, children: actions)
+        }
+        
+        let config = UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: actionProvider)
+        
+        completionHandler(config)
+    }
+    
+    fileprivate func addTab(url: URL, inPrivateMode: Bool, currentTab: Tab) {
+        let tab = self.tabManager.addTab(URLRequest(url: url), afterTab: currentTab, isPrivate: inPrivateMode)
+        if inPrivateMode && !PrivateBrowsingManager.shared.isPrivateBrowsing {
+            self.tabManager.selectTab(tab)
+        } else {
+            // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
+            let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+                if buttonPressed {
+                    self.tabManager.selectTab(tab)
+                }
+            })
+            self.show(toast: toast)
+        }
+        self.scrollController.showToolbars(animated: true)
+    }
 }
 
 extension BrowserViewController: ReaderModeDelegate {
@@ -2642,31 +2723,15 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             dialogTitle = url.absoluteString
             let tabType = currentTab.type
 
-            let addTab = { (rURL: URL, isPrivate: Bool) in
-                let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)
-                if isPrivate && !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                    self.tabManager.selectTab(tab)
-                } else {
-                    // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                    let toast = ButtonToast(labelText: Strings.ContextMenuButtonToastNewTabOpenedLabelText, buttonText: Strings.ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
-                        if buttonPressed {
-                            self.tabManager.selectTab(tab)
-                        }
-                    })
-                    self.show(toast: toast)
-                }
-                self.scrollController.showToolbars(animated: true)
-            }
-
             if !tabType.isPrivate {
                 let openNewTabAction =  UIAlertAction(title: Strings.OpenNewTabButtonTitle, style: .default) { _ in
-                    addTab(url, false)
+                    self.addTab(url: url, inPrivateMode: false, currentTab: currentTab)
                 }
                 actionSheetController.addAction(openNewTabAction, accessibilityIdentifier: "linkContextMenu.openInNewTab")
             }
            
             let openNewPrivateTabAction =  UIAlertAction(title: Strings.OpenNewPrivateTabButtonTitle, style: .default) { _ in
-                addTab(url, true)
+                self.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
             }
             actionSheetController.addAction(openNewPrivateTabAction, accessibilityIdentifier: "linkContextMenu.openInNewPrivateTab")
 

--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -9,7 +9,7 @@ protocol ContextMenuHelperDelegate: AnyObject {
     func contextMenuHelper(_ contextMenuHelper: ContextMenuHelper, didCancelGestureRecognizer: UIGestureRecognizer)
 }
 
-class ContextMenuHelper: NSObject, UIGestureRecognizerDelegate {
+class ContextMenuHelper: NSObject {
     struct Elements {
         let link: URL?
         let image: URL?
@@ -22,12 +22,6 @@ class ContextMenuHelper: NSObject, UIGestureRecognizerDelegate {
     weak var delegate: ContextMenuHelperDelegate?
 
     fileprivate var nativeHighlightLongPressRecognizer: UILongPressGestureRecognizer?
-    fileprivate var elements: Elements?
-
-    required init(tab: Tab) {
-        super.init()
-        self.tab = tab
-    }
 
     lazy var gestureRecognizer: UILongPressGestureRecognizer = {
         let g = UILongPressGestureRecognizer(target: self, action: #selector(self.longPressGestureDetected))
@@ -35,6 +29,15 @@ class ContextMenuHelper: NSObject, UIGestureRecognizerDelegate {
         return g
     }()
 
+    fileprivate(set) var elements: Elements?
+
+    required init(tab: Tab) {
+        super.init()
+        self.tab = tab
+    }
+}
+
+extension ContextMenuHelper: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
     }
@@ -44,21 +47,14 @@ class ContextMenuHelper: NSObject, UIGestureRecognizerDelegate {
     // As of iOS 12, WKContentView gesture setup is async, but it has been called by the time
     // the webview is ready to load an URL. After this has happened, we can override the gesture.
     func replaceGestureHandlerIfNeeded() {
-        if #available(iOS 13.0, *) {
-            if !(tab?.webView?.gestureRecognizers?.contains(gestureRecognizer) ?? true) {
-                tab?.webView?.addGestureRecognizer(gestureRecognizer)
-            }
-        } else {
-            DispatchQueue.main.async {
-                if self.gestureRecognizerWithDescriptionFragment("ContextMenuHelper") == nil {
-                    self.replaceWebViewLongPress()
-                }
+        DispatchQueue.main.async {
+            if self.gestureRecognizerWithDescriptionFragment("ContextMenuHelper") == nil {
+                self.replaceWebViewLongPress()
             }
         }
     }
 
-    @available(iOS, obsoleted: 13.0)
-    func replaceWebViewLongPress() {
+    private func replaceWebViewLongPress() {
         // WebKit installs gesture handlers async. If `replaceWebViewLongPress` is called after a wkwebview in most cases a small delay is sufficient
         // See also https://bugs.webkit.org/show_bug.cgi?id=193366
 
@@ -70,7 +66,6 @@ class ContextMenuHelper: NSObject, UIGestureRecognizerDelegate {
         }
     }
 
-    @available(iOS, obsoleted: 13.0)
     private func gestureRecognizerWithDescriptionFragment(_ descriptionFragment: String) -> UILongPressGestureRecognizer? {
         let result = tab?.webView?.scrollView.subviews.compactMap({ $0.gestureRecognizers }).joined().first(where: {
             (($0 as? UILongPressGestureRecognizer) != nil) && $0.description.contains(descriptionFragment)
@@ -88,23 +83,15 @@ class ContextMenuHelper: NSObject, UIGestureRecognizerDelegate {
             return
         }
 
-        if #available(iOS 13, *), elements != nil {
-            tab?.webView?.scrollView.subviews.compactMap({ $0.gestureRecognizers }).joined().forEach { recognizer in
-                if recognizer.isEnabled {
-                    recognizer.isEnabled = false
-                    recognizer.isEnabled = true
-                }
-            }
-        } else {
-            // To prevent the tapped link from proceeding with navigation, "cancel" the native WKWebView
-            // `_highlightLongPressRecognizer`. This preserves the original behavior as seen here:
-            // https://github.com/WebKit/webkit/blob/d591647baf54b4b300ca5501c21a68455429e182/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm#L1600-L1614
-            if let nativeHighlightLongPressRecognizer = self.nativeHighlightLongPressRecognizer,
-                nativeHighlightLongPressRecognizer.isEnabled {
-                nativeHighlightLongPressRecognizer.isEnabled = false
-                nativeHighlightLongPressRecognizer.isEnabled = true
-            }
+        // To prevent the tapped link from proceeding with navigation, "cancel" the native WKWebView
+        // `_highlightLongPressRecognizer`. This preserves the original behavior as seen here:
+        // https://github.com/WebKit/webkit/blob/d591647baf54b4b300ca5501c21a68455429e182/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm#L1600-L1614
+        if let nativeHighlightLongPressRecognizer = self.nativeHighlightLongPressRecognizer,
+            nativeHighlightLongPressRecognizer.isEnabled {
+            nativeHighlightLongPressRecognizer.isEnabled = false
+            nativeHighlightLongPressRecognizer.isEnabled = true
         }
+
         if let elements = self.elements {
             delegate?.contextMenuHelper(self, didLongPressElements: elements, gestureRecognizer: sender)
             self.elements = nil

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -206,7 +206,11 @@ class Tab: NSObject {
 
             webView.accessibilityLabel = Strings.WebContentAccessibilityLabel
             webView.allowsBackForwardNavigationGestures = true
-            webView.allowsLinkPreview = false
+            if #available(iOS 13, *) {
+                webView.allowsLinkPreview = true
+            } else {
+                webView.allowsLinkPreview = false
+            }
 
             // Night mode enables this by toggling WKWebView.isOpaque, otherwise this has no effect.
             webView.backgroundColor = .black


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1499 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Check if long press action works well on iOS 12 and 13

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


<img width="544" alt="Zrzut ekranu 2019-10-8 o 11 44 13" src="https://user-images.githubusercontent.com/6950387/66385564-fbdbf600-e9c0-11e9-8b14-7a9ae4c91aa2.png">
<img width="544" alt="Zrzut ekranu 2019-10-8 o 11 43 56" src="https://user-images.githubusercontent.com/6950387/66385565-fbdbf600-e9c0-11e9-8974-1e30a9cebd23.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/internal/issues/new?assignees=&labels=security%2C+security-reviews&template=security-review.md&title=iOS:%20Security+Review+for) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
