### PR TITLE
Fix rewards#229: Theme fixes for Rewards UI.

### DIFF
--- a/BraveRewardsUI/Add Funds/AddFundsView.swift
+++ b/BraveRewardsUI/Add Funds/AddFundsView.swift
@@ -34,14 +34,14 @@ extension AddFundsViewController {
       }
       
       let titleLabel = UILabel().then {
-        $0.textColor = SettingsUX.headerTextColor
+        $0.appearanceTextColor = SettingsUX.headerTextColor
         $0.font = .systemFont(ofSize: 22.0, weight: .medium)
         $0.text = Strings.AddFundsTitle
         $0.numberOfLines = 0
       }
       
       let bodyLabel = UILabel().then {
-        $0.textColor = SettingsUX.bodyTextColor
+        $0.appearanceTextColor = SettingsUX.bodyTextColor
         $0.font = .systemFont(ofSize: 14.0)
         $0.text = Strings.AddFundsBody
         $0.numberOfLines = 0

--- a/BraveRewardsUI/Add Funds/TokenAddressView.swift
+++ b/BraveRewardsUI/Add Funds/TokenAddressView.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import CoreImage
+import BraveShared
 
 class TokenAddressView: UIView {
   
@@ -63,7 +64,7 @@ class TokenAddressView: UIView {
     $0.layer.borderWidth = 1.0 / UIScreen.main.scale
     $0.textContainerInset = UIEdgeInsets(top: 8, left: 4, bottom: 8, right: 4)
     $0.layer.cornerRadius = 4.0
-    $0.textColor = Colors.grey100
+    $0.appearanceTextColor = Colors.grey100
     $0.font = UIFont(name: "Menlo-Regular", size: 13.0)
   }
   
@@ -107,7 +108,7 @@ class TokenAddressView: UIView {
       .view(UILabel().then {
         $0.text = Strings.AddFundsTokenWalletAddress
         $0.font = .systemFont(ofSize: 12.0, weight: .medium)
-        $0.textColor = Colors.grey100
+        $0.appearanceTextColor = Colors.grey100
       }),
       .customSpace(4.0),
       .view(addressTextView),

--- a/BraveRewardsUI/Ads/AdContentButton.swift
+++ b/BraveRewardsUI/Ads/AdContentButton.swift
@@ -9,17 +9,17 @@ import pop
 /// The main ads view. Mimics a system notification in that it shows an icon, "app name" (always will be "Brave Rewards"), title and body.
 class AdContentButton: UIControl {
   let titleLabel = UILabel().then {
-    $0.textColor = .black
+    $0.appearanceTextColor = .black
     $0.font = .systemFont(ofSize: 15.0, weight: .semibold)
     $0.numberOfLines = 2
   }
   let bodyLabel = UILabel().then {
-    $0.textColor = UIColor(white: 0.0, alpha: 0.5)
+    $0.appearanceTextColor = UIColor(white: 0.0, alpha: 0.5)
     $0.font = .systemFont(ofSize: 15.0)
     $0.numberOfLines = 3
   }
   private let appNameLabel = UILabel().then {
-    $0.textColor = .black
+    $0.appearanceTextColor = .black
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
     $0.text = Strings.AdNotificationTitle
   }
@@ -112,9 +112,9 @@ class AdContentButton: UIControl {
   }
   
   func applyTheme() {
-    appNameLabel.textColor = isDarkMode ? .white : .black
-    titleLabel.textColor = isDarkMode ? .white : .black
-    bodyLabel.textColor = UIColor(white: isDarkMode ? 1.0 : 0.0, alpha: 0.5)
+    appNameLabel.appearanceTextColor = isDarkMode ? .white : .black
+    titleLabel.appearanceTextColor = isDarkMode ? .white : .black
+    bodyLabel.appearanceTextColor = UIColor(white: isDarkMode ? 1.0 : 0.0, alpha: 0.5)
     backgroundView.contentView.backgroundColor = isDarkMode ? UIColor.black.withAlphaComponent(0.3) : UIColor.white.withAlphaComponent(0.7)
   }
   

--- a/BraveRewardsUI/Ads/AdSwipeButton.swift
+++ b/BraveRewardsUI/Ads/AdSwipeButton.swift
@@ -42,7 +42,7 @@ class AdSwipeButton: UIControl {
     case .text(let text, let textColor):
       let label = UILabel()
       label.text = text
-      label.textColor = textColor
+      label.appearanceTextColor = textColor
       label.textAlignment = .center
       label.font = .systemFont(ofSize: 14.0, weight: .semibold)
       clippedView.addSubview(label)

--- a/BraveRewardsUI/Common/ActionButton.swift
+++ b/BraveRewardsUI/Common/ActionButton.swift
@@ -27,7 +27,7 @@ class ActionButton: Button {
   
   override var tintColor: UIColor! {
     didSet {
-      setTitleColor(tintColor, for: .normal)
+      appearanceTextColor = tintColor
       layer.borderColor = tintColor.withAlphaComponent(0.5).cgColor
     }
   }

--- a/BraveRewardsUI/Common/BATUSDPairView.swift
+++ b/BraveRewardsUI/Common/BATUSDPairView.swift
@@ -38,13 +38,13 @@ class BATUSDPairView: UIStackView {
                    usdFontSize: CGFloat = 13.0) {
     self.init(batAmountConfig: {
       $0.font = .systemFont(ofSize: amountFontSize, weight: .medium)
-      $0.textColor = Colors.grey100
+      $0.appearanceTextColor = Colors.grey100
     }, batKindConfig: {
       $0.font = .systemFont(ofSize: kindFontSize)
-      $0.textColor = Colors.grey100
+      $0.appearanceTextColor = Colors.grey100
     }, usdConfig: {
       $0.font = .systemFont(ofSize: usdFontSize)
-      $0.textColor = Colors.grey200
+      $0.appearanceTextColor = Colors.grey200
     })
   }
   

--- a/BraveRewardsUI/Common/DetailActionableRow.swift
+++ b/BraveRewardsUI/Common/DetailActionableRow.swift
@@ -9,15 +9,15 @@ class DetailActionableRow: Button {
   
   let textLabel = UILabel().then {
     $0.font = .systemFont(ofSize: 14.0)
-    $0.textColor = Colors.grey200
+    $0.appearanceTextColor = Colors.grey200
     $0.numberOfLines = 0
   }
   
   let batValueView = CurrencyContainerView(amountLabelConfig: {
-    $0.textColor = Colors.purple300
+    $0.appearanceTextColor = Colors.purple300
     $0.font = .systemFont(ofSize: 14.0, weight: .semibold)
   }, kindLabelConfig: {
-    $0.textColor = Colors.grey200
+    $0.appearanceTextColor = Colors.grey200
     $0.text = "BAT"
     $0.font = .systemFont(ofSize: 13.0)
   })

--- a/BraveRewardsUI/Common/SwitchRow.swift
+++ b/BraveRewardsUI/Common/SwitchRow.swift
@@ -14,7 +14,7 @@ class SwitchRow: UIStackView {
   
   let textLabel = UILabel().then {
     $0.font = .systemFont(ofSize: 14.0)
-    $0.textColor = UX.textColor
+    $0.appearanceTextColor = UX.textColor
     $0.numberOfLines = 0
   }
   

--- a/BraveRewardsUI/Common/Tables/EmptyTableCell.swift
+++ b/BraveRewardsUI/Common/Tables/EmptyTableCell.swift
@@ -13,7 +13,7 @@ class EmptyTableCell: UITableViewCell, TableViewReusable {
   }
   
   let label = UILabel().then {
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.textAlignment = .center
     $0.font = SettingsUX.bodyFont
     $0.numberOfLines = 0
@@ -21,6 +21,9 @@ class EmptyTableCell: UITableViewCell, TableViewReusable {
   
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
+    
+    backgroundColor = .white
+    
     contentView.addSubview(label)
     label.snp.makeConstraints {
       $0.leading.trailing.equalTo(contentView).inset(45)

--- a/BraveRewardsUI/Common/Tables/LabelAccessoryView.swift
+++ b/BraveRewardsUI/Common/Tables/LabelAccessoryView.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A view with a label in it with a rounded colored background
 class LabelAccessoryView: UIView {
   let label = UILabel().then {
-    $0.textColor = Colors.grey100
+    $0.appearanceTextColor = Colors.grey100
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
   }
   override init(frame: CGRect) {

--- a/BraveRewardsUI/Common/Tables/TableHeaderRowView.swift
+++ b/BraveRewardsUI/Common/Tables/TableHeaderRowView.swift
@@ -44,7 +44,7 @@ class TableHeaderRowView: UIView {
     for c in columns {
       let label = UILabel().then {
         $0.text = c.title
-        $0.textColor = tintColor
+        $0.appearanceTextColor = tintColor
         $0.font = .systemFont(ofSize: 13.0, weight: .medium)
         $0.textAlignment = c.align
         $0.isAccessibilityElement = !c.title.isEmpty

--- a/BraveRewardsUI/Common/Tables/TableViewCell.swift
+++ b/BraveRewardsUI/Common/Tables/TableViewCell.swift
@@ -45,6 +45,9 @@ class TableViewCell: UITableViewCell, TableViewReusable {
     
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     
+    label.appearanceTextColor = .black
+    backgroundColor = .white
+    
     contentView.addSubview(label)
     if let accessoryLabel = accessoryLabel {
       contentView.addSubview(accessoryLabel)

--- a/BraveRewardsUI/Common/Then.swift
+++ b/BraveRewardsUI/Common/Then.swift
@@ -61,7 +61,7 @@ extension Then where Self: AnyObject {
   ///
   ///     let label = UILabel().then {
   ///       $0.textAlignment = .Center
-  ///       $0.textColor = UIColor.blackColor()
+  ///       $0.appearanceTextColor = UIColor.blackColor()
   ///       $0.text = "Hello, World!"
   ///     }
   func then(_ block: (Self) throws -> Void) rethrows -> Self {

--- a/BraveRewardsUI/Create Wallet/CreateWalletView.swift
+++ b/BraveRewardsUI/Create Wallet/CreateWalletView.swift
@@ -29,7 +29,7 @@ extension CreateWalletViewController {
     private let watermarkImageView = UIImageView(image: UIImage(frameworkResourceNamed: "bat-watermark"))
     
     private let prefixLabel = UILabel().then {
-      $0.textColor = UX.prefixTextColor
+      $0.appearanceTextColor = UX.prefixTextColor
       $0.font = .systemFont(ofSize: 16.0)
       $0.textAlignment = .center
       $0.text = Strings.RewardsOptInPrefix
@@ -39,7 +39,7 @@ extension CreateWalletViewController {
     private let batLogoImageView = UIImageView(image: UIImage(frameworkResourceNamed: "bat-logo"))
     
     private let titleLabel = UILabel().then {
-      $0.textColor = UX.titleTextColor
+      $0.appearanceTextColor = UX.titleTextColor
       $0.font = .systemFont(ofSize: 28.0, weight: .medium)
       $0.textAlignment = .center
       $0.attributedText = {
@@ -58,7 +58,7 @@ extension CreateWalletViewController {
     }
     
     private let descriptionLabel = UILabel().then {
-      $0.textColor = UX.bodyTextColor
+      $0.appearanceTextColor = UX.bodyTextColor
       $0.font = .systemFont(ofSize: 16.0)
       $0.textAlignment = .center
       $0.text = Strings.RewardsOptInDescription
@@ -67,7 +67,7 @@ extension CreateWalletViewController {
     
     let termsOfServiceLabel = LinkLabel().then {
       $0.font = .systemFont(ofSize: 12.0)
-      $0.textColor = Colors.grey900
+      $0.appearanceTextColor = Colors.grey900
       $0.textAlignment = .center
       $0.text = Strings.DisclaimerInformation
       $0.setURLInfo([Strings.TermsOfServiceURL: "terms", Strings.PrivacyPolicyURL: "policy"])

--- a/BraveRewardsUI/Disabled Brave Rewards/RewardsDisabledView.swift
+++ b/BraveRewardsUI/Disabled Brave Rewards/RewardsDisabledView.swift
@@ -75,14 +75,14 @@ extension RewardsDisabledView {
     
     let titleLabel = UILabel().then {
       $0.font = .systemFont(ofSize: 28.0)
-      $0.textColor = UX.titleColor
+      $0.appearanceTextColor = UX.titleColor
       $0.textAlignment = .center
       $0.text = Strings.DisabledTitle
     }
     
     let subtitleLabel = UILabel().then {
       $0.font = .systemFont(ofSize: 18.0, weight: .semibold)
-      $0.textColor = UX.subtitleColor
+      $0.appearanceTextColor = UX.subtitleColor
       $0.textAlignment = .center
       $0.numberOfLines = 0
       $0.text = Strings.DisabledSubtitle
@@ -90,7 +90,7 @@ extension RewardsDisabledView {
     
     let bodyLabel = UILabel().then {
       $0.font = .systemFont(ofSize: 16.0)
-      $0.textColor = UX.bodyColor
+      $0.appearanceTextColor = UX.bodyColor
       $0.textAlignment = .center
       $0.numberOfLines = 0
       $0.text = Strings.DisabledBody
@@ -108,7 +108,7 @@ extension RewardsDisabledView {
     
     let termsOfServiceLabel = LinkLabel().then {
       $0.font = .systemFont(ofSize: 12.0)
-      $0.textColor = Colors.grey100
+      $0.appearanceTextColor = Colors.grey100
       $0.textAlignment = .center
       $0.text = Strings.DisclaimerInformation
       $0.setURLInfo([Strings.TermsOfServiceURL: "terms", Strings.PrivacyPolicyURL: "policy"])

--- a/BraveRewardsUI/Grants/GrantsItemView.swift
+++ b/BraveRewardsUI/Grants/GrantsItemView.swift
@@ -19,11 +19,11 @@ class GrantsItemView: SettingsSectionView {
       $0.spacing = 5.0
     }
     let amountView = CurrencyContainerView(amountLabelConfig: {
-      $0.textColor = Colors.grey100
+      $0.appearanceTextColor = Colors.grey100
       $0.font = .systemFont(ofSize: 16.0, weight: .medium)
       $0.text = amount
     }, kindLabelConfig: {
-      $0.textColor = Colors.grey200
+      $0.appearanceTextColor = Colors.grey200
       $0.font = .systemFont(ofSize: 13.0)
       $0.text = "BAT"
     })
@@ -33,7 +33,7 @@ class GrantsItemView: SettingsSectionView {
     
     if let date = expirationDate {
       let expirationLabel = UILabel().then {
-        $0.textColor = Colors.grey300
+        $0.appearanceTextColor = Colors.grey300
         $0.font = .systemFont(ofSize: 14.0)
         $0.numberOfLines = 0
         $0.text = String(

--- a/BraveRewardsUI/Publisher/PublisherAttentionView.swift
+++ b/BraveRewardsUI/Publisher/PublisherAttentionView.swift
@@ -7,13 +7,13 @@ import UIKit
 class PublisherAttentionView: UIView {
   
   let titleLabel = UILabel().then {
-    $0.textColor = Colors.grey000
+    $0.appearanceTextColor = Colors.grey000
     $0.text = Strings.Attention
     $0.font = .systemFont(ofSize: 14.0)
   }
   /// Either "X%" or "–"
   let valueLabel = UILabel().then {
-    $0.textColor = Colors.grey000
+    $0.appearanceTextColor = Colors.grey000
     $0.font = .systemFont(ofSize: 14.0, weight: .semibold)
     $0.textAlignment = .right
     $0.setContentHuggingPriority(.required, for: .horizontal)

--- a/BraveRewardsUI/Publisher/PublisherView.swift
+++ b/BraveRewardsUI/Publisher/PublisherView.swift
@@ -48,7 +48,7 @@ class PublisherView: UIStackView {
   let faviconImageView = PublisherIconCircleImageView(size: UX.faviconSize)
   
   private let publisherNameLabel = UILabel().then {
-    $0.textColor = UX.publisherNameColor
+    $0.appearanceTextColor = UX.publisherNameColor
     $0.font = .systemFont(ofSize: 18.0, weight: .medium)
     $0.numberOfLines = 2
   }
@@ -102,13 +102,13 @@ class PublisherView: UIStackView {
   
   // "Brave Verified Publisher" / "Not yet verified"
   private let verifiedLabel = UILabel().then {
-    $0.textColor = UX.verifiedStatusColor
+    $0.appearanceTextColor = UX.verifiedStatusColor
     $0.font = .systemFont(ofSize: 12.0)
     $0.adjustsFontSizeToFitWidth = true
   }
   
   let checkAgainButton = Button(type: .system).then {
-    $0.setTitleColor(Colors.blue500, for: .normal)
+    $0.appearanceTextColor = Colors.blue500
     $0.titleLabel?.font = .systemFont(ofSize: 12.0)
     $0.setTitle(Strings.CheckAgain, for: .normal)
     $0.setContentHuggingPriority(.required, for: .horizontal)
@@ -120,7 +120,7 @@ class PublisherView: UIStackView {
   
   // Only shown when unverified
   private let unverifiedDisclaimerView = LinkLabel().then {
-    $0.textColor = Colors.grey200
+    $0.appearanceTextColor = Colors.grey200
     $0.font = UIFont.systemFont(ofSize: 12.0)
     $0.textContainerInset = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
     $0.text = "\(Strings.UnverifiedPublisherDisclaimer) \(Strings.DisclaimerLearnMore)"

--- a/BraveRewardsUI/Rewards Summary/RewardsSummaryButton.swift
+++ b/BraveRewardsUI/Rewards Summary/RewardsSummaryButton.swift
@@ -14,7 +14,7 @@ import UIKit
     
     let titleLabel = UILabel().then {
       $0.text = Strings.SummaryTitle.uppercased()
-      $0.textColor = UX.titleTextColor
+      $0.appearanceTextColor = UX.titleTextColor
       $0.font = .systemFont(ofSize: 14.0, weight: .bold)
     }
     

--- a/BraveRewardsUI/Rewards Summary/RewardsSummaryRowView.swift
+++ b/BraveRewardsUI/Rewards Summary/RewardsSummaryRowView.swift
@@ -19,7 +19,7 @@ import UIKit
     }
     
     let titleLabel = UILabel().then {
-      $0.textColor = UX.titleColor
+      $0.appearanceTextColor = UX.titleColor
       $0.font = .systemFont(ofSize: 15.0)
       $0.numberOfLines = 0
       $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -31,13 +31,13 @@ import UIKit
     }
     
     let cryptoCurrencyLabel = UILabel().then {
-      $0.textColor = UX.cryptoCurrencyColor
+      $0.appearanceTextColor = UX.cryptoCurrencyColor
       $0.font = .systemFont(ofSize: 12.0)
       $0.setContentHuggingPriority(.required, for: .horizontal)
     }
     
     let dollarValueLabel = UILabel().then {
-      $0.textColor = UX.dollarValueColor
+      $0.appearanceTextColor = UX.dollarValueColor
       $0.font = .systemFont(ofSize: 10.0)
       $0.textAlignment = .right
       $0.setContentHuggingPriority(.required, for: .horizontal)
@@ -74,7 +74,7 @@ import UIKit
       titleLabel.text = title
       cryptoCurrencyLabel.text = "BAT"
       cryptoValueLabel.text = batValue
-      cryptoValueLabel.textColor = cryptoValueColor
+      cryptoValueLabel.appearanceTextColor = cryptoValueColor
       dollarValueLabel.text = usdDollarValue
     }
     

--- a/BraveRewardsUI/Rewards Summary/RewardsSummaryView.swift
+++ b/BraveRewardsUI/Rewards Summary/RewardsSummaryView.swift
@@ -14,7 +14,7 @@ class RewardsSummaryView: UIView {
   
   let rewardsSummaryButton = RewardsSummaryViewButton()
   let monthYearLabel = UILabel().then {
-    $0.textColor = UX.monthYearColor
+    $0.appearanceTextColor = UX.monthYearColor
     $0.font = .systemFont(ofSize: 22.0)
   }
   let scrollView = UIScrollView()

--- a/BraveRewardsUI/RewardsPanelController.swift
+++ b/BraveRewardsUI/RewardsPanelController.swift
@@ -24,7 +24,10 @@ public class RewardsPanelController: PopoverNavigationController {
   public override func viewDidLoad() {
     super.viewDidLoad()
     
+    navigationBar.appearanceBarTintColor = navigationBar.barTintColor
     navigationBar.tintColor = Colors.blurple400
+    navigationBar.titleTextAttributes = [.foregroundColor: UIColor.black]
+    
     if #available(iOS 13.0, *) {
       overrideUserInterfaceStyle = .light
     }

--- a/BraveRewardsUI/Settings/Ads/AdsUnsupportedView.swift
+++ b/BraveRewardsUI/Settings/Ads/AdsUnsupportedView.swift
@@ -19,7 +19,7 @@ class AdsUnsupportedView: UIView {
     $0.numberOfLines = 0
     $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     $0.font = .systemFont(ofSize: 13.0, weight: .medium)
-    $0.textColor = Colors.neutral200
+    $0.appearanceTextColor = Colors.neutral200
   }
   
   override init(frame: CGRect) {

--- a/BraveRewardsUI/Settings/Ads/Details/AdsDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Ads/Details/AdsDetailsViewController.swift
@@ -126,7 +126,7 @@ extension AdsDetailsViewController: UITableViewDelegate, UITableViewDataSource {
     cell.label.font = SettingsUX.bodyFont
     cell.label.numberOfLines = 0
     cell.label.lineBreakMode = .byWordWrapping
-    cell.accessoryLabel?.textColor = Colors.grey100
+    cell.accessoryLabel?.appearanceTextColor = Colors.grey100
     cell.accessoryLabel?.font = SettingsUX.bodyFont
     cell.accessoryType = .none
     switch row {

--- a/BraveRewardsUI/Settings/Ads/SettingsAdSectionView.swift
+++ b/BraveRewardsUI/Settings/Ads/SettingsAdSectionView.swift
@@ -65,7 +65,7 @@ class SettingsAdSectionView: SettingsSectionView {
       bodyLabel.alpha = alpha
       titleLabel.alpha = alpha
       
-      titleLabel.textColor = isSupported ? BraveUX.adsTintColor : Colors.grey200
+      titleLabel.appearanceTextColor = isSupported ? BraveUX.adsTintColor : Colors.grey200
     }
   }
   
@@ -119,13 +119,13 @@ class SettingsAdSectionView: SettingsSectionView {
   
   private let titleLabel = UILabel().then {
     $0.text = Strings.SettingsAdsTitle
-    $0.textColor = BraveUX.adsTintColor
+    $0.appearanceTextColor = BraveUX.adsTintColor
     $0.font = SettingsUX.titleFont
   }
 
   private let bodyLabel = UILabel().then {
     $0.text = Strings.SettingsAdsBody
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.numberOfLines = 0
     $0.font = SettingsUX.bodyFont
   }

--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeCell.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeCell.swift
@@ -25,13 +25,13 @@ class AutoContributeCell: UITableViewCell, TableViewReusable {
     $0.isHidden = true
   }
   let siteNameLabel = UILabel().then {
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.font = SettingsUX.bodyFont
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     $0.numberOfLines = 0
   }
   private let attentionLabel = UILabel().then {
-    $0.textColor = Colors.grey200
+    $0.appearanceTextColor = Colors.grey200
     $0.font = SettingsUX.bodyFont
     $0.textAlignment = .right
   }
@@ -40,6 +40,8 @@ class AutoContributeCell: UITableViewCell, TableViewReusable {
     super.init(style: style, reuseIdentifier: nil)
     
     siteStackView.spacing = verifiedStatusImageView.image?.size.width ?? 10.0
+    
+    backgroundColor = .white
     
     insertSubview(attentionBackgroundFillView, belowSubview: contentView)
     contentView.addSubview(siteStackView)

--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -276,9 +276,9 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       let cell = row.dequeuedCell(from: tableView, indexPath: indexPath)
       cell.manualSeparators = []
       cell.label.font = SettingsUX.bodyFont
-      cell.label.textColor = .black
+      cell.label.appearanceTextColor = .black
       cell.label.numberOfLines = 0
-      cell.accessoryLabel?.textColor = Colors.grey100
+      cell.accessoryLabel?.appearanceTextColor = Colors.grey100
       cell.accessoryLabel?.font = SettingsUX.bodyFont
       cell.accessoryType = .none
       cell.selectionStyle = .none
@@ -305,7 +305,7 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       case .excludedSites:
         let numberOfExcludedSites = state.ledger.numberOfExcludedPublishers
         cell.label.text = String(format: Strings.AutoContributeRestoreExcludedSites, numberOfExcludedSites)
-        cell.label.textColor = Colors.blurple400
+        cell.label.appearanceTextColor = Colors.blurple400
         cell.selectionStyle = .default
       }
       return cell
@@ -373,6 +373,7 @@ extension AutoContributeDetailViewController {
       tableView.register(Value1TableViewCell.self)
       tableView.register(EmptyTableCell.self)
       tableView.layoutMargins = UIEdgeInsets(top: 15.0, left: 15.0, bottom: 15.0, right: 15.0)
+      tableView.appearanceSeparatorColor = UIColor(white: 0.85, alpha: 1.0)
       
       addSubview(tableView)
       tableView.snp.makeConstraints {

--- a/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
@@ -153,7 +153,7 @@ extension AutoContributeSettingsViewController: UITableViewDelegate, UITableView
     cell.label.font = SettingsUX.bodyFont
     cell.label.numberOfLines = 0
     cell.label.lineBreakMode = .byWordWrapping
-    cell.accessoryLabel?.textColor = Colors.grey100
+    cell.accessoryLabel?.appearanceTextColor = Colors.grey100
     cell.accessoryLabel?.font = SettingsUX.bodyFont
     cell.accessoryType = row.accessoryType
     switch row {

--- a/BraveRewardsUI/Settings/Auto-Contribute/SettingsAutoContributeSectionView.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/SettingsAutoContributeSectionView.swift
@@ -59,13 +59,13 @@ class SettingsAutoContributeSectionView: SettingsSectionView {
   
   private let titleLabel = UILabel().then {
     $0.text = Strings.SettingsAutoContributeTitle
-    $0.textColor = BraveUX.autoContributeTintColor
+    $0.appearanceTextColor = BraveUX.autoContributeTintColor
     $0.font = SettingsUX.titleFont
   }
   
   private let bodyLabel = UILabel().then {
     $0.text = Strings.SettingsAutoContributeBody
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.numberOfLines = 0
     $0.font = SettingsUX.bodyFont
   }

--- a/BraveRewardsUI/Settings/Grants/GrantClaimedViewController.swift
+++ b/BraveRewardsUI/Settings/Grants/GrantClaimedViewController.swift
@@ -78,14 +78,14 @@ extension GrantClaimedViewController {
       let imageView = UIImageView(image: UIImage(frameworkResourceNamed: "bat-reward-graphic"))
       let titleLabel = UILabel().then {
         $0.numberOfLines = 0
-        $0.textColor = BraveUX.braveOrange
+        $0.appearanceTextColor = BraveUX.braveOrange
         $0.text = Strings.GrantsClaimedTitle
         $0.font = .systemFont(ofSize: 20.0)
         $0.textAlignment = .center
       }
       let subtitleLabel = UILabel().then {
         $0.numberOfLines = 0
-        $0.textColor = SettingsUX.subtitleTextColor
+        $0.appearanceTextColor = SettingsUX.subtitleTextColor
         $0.text = Strings.GrantsClaimedSubtitle
         $0.font = .systemFont(ofSize: 12.0)
         $0.textAlignment = .center
@@ -138,7 +138,7 @@ extension GrantClaimedViewController {
     
     override init(frame: CGRect) {
       let infoLabelConfig: (UILabel) -> Void = {
-        $0.textColor = UX.infoAccentTextColor
+        $0.appearanceTextColor = UX.infoAccentTextColor
         $0.font = .systemFont(ofSize: 14.0)
       }
       
@@ -158,12 +158,12 @@ extension GrantClaimedViewController {
       }
       let amountTitleLabel = UILabel().then {
         $0.text = Strings.GrantsClaimedAmountTitle
-        $0.textColor = SettingsUX.subtitleTextColor
+        $0.appearanceTextColor = SettingsUX.subtitleTextColor
         $0.font = .systemFont(ofSize: 13.0)
       }
       let expirdationDateTitleLabel = UILabel().then {
         $0.text = Strings.GrantsClaimedExpirationDateTitle
-        $0.textColor = SettingsUX.subtitleTextColor
+        $0.appearanceTextColor = SettingsUX.subtitleTextColor
         $0.font = .systemFont(ofSize: 13.0)
       }
       

--- a/BraveRewardsUI/Settings/Grants/SettingsGrantSectionView.swift
+++ b/BraveRewardsUI/Settings/Grants/SettingsGrantSectionView.swift
@@ -83,7 +83,7 @@ class SettingsGrantSectionView: SettingsSectionView {
   }
   
   private let textLabel = UILabel().then {
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.font = SettingsUX.bodyFont
     $0.numberOfLines = 0
   }

--- a/BraveRewardsUI/Settings/Options/OptionsSelectionViewController.swift
+++ b/BraveRewardsUI/Settings/Options/OptionsSelectionViewController.swift
@@ -76,9 +76,11 @@ class OptionsSelectionViewController<OptionType: DisplayableOption>: UIViewContr
   
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(withIdentifier: "OptionCell", for: indexPath)
+    cell.backgroundColor = .white
+    cell.textLabel?.appearanceTextColor = .black
     cell.textLabel?.text = options[indexPath.row].displayString
     cell.textLabel?.font = .systemFont(ofSize: 14.0)
-    cell.textLabel?.textColor = Colors.grey100
+    cell.textLabel?.appearanceTextColor = Colors.grey100
     cell.textLabel?.numberOfLines = 0
     cell.accessoryType = selectedOptionIndex == indexPath.row ? .checkmark : .none
     return cell
@@ -94,7 +96,7 @@ extension OptionsSelectionViewController {
       
       tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: CGFloat.leastNormalMagnitude))
       tableView.backgroundView = UIView().then { $0.backgroundColor = SettingsUX.backgroundColor }
-      tableView.separatorColor = UIColor(white: 0.85, alpha: 1.0)
+      tableView.appearanceSeparatorColor = UIColor(white: 0.85, alpha: 1.0)
       tableView.register(UITableViewCell.self, forCellReuseIdentifier: "OptionCell")
       
       addSubview(tableView)

--- a/BraveRewardsUI/Settings/Rewards Toggle/BraveRewardsToggleView.swift
+++ b/BraveRewardsUI/Settings/Rewards Toggle/BraveRewardsToggleView.swift
@@ -41,7 +41,7 @@ class BraveRewardsToggleView: UIView {
   }
   
   private let titleLabel = UILabel().then {
-    $0.textColor = Colors.grey100
+    $0.appearanceTextColor = Colors.grey100
     $0.text = Strings.BraveRewards
   }
   

--- a/BraveRewardsUI/Settings/Rewards Toggle/SettingsRewardsSectionView.swift
+++ b/BraveRewardsUI/Settings/Rewards Toggle/SettingsRewardsSectionView.swift
@@ -79,25 +79,25 @@ private class DisabledRewardsLabelsView: UIView {
   
   let labels = [
     UILabel().then {
-      $0.textColor = SettingsUX.headerTextColor
+      $0.appearanceTextColor = SettingsUX.headerTextColor
       $0.text = Strings.SettingsDisabledTitle1
       $0.numberOfLines = 0
       $0.font = .systemFont(ofSize: 15.0)
     },
     UILabel().then {
-      $0.textColor = SettingsUX.bodyTextColor
+      $0.appearanceTextColor = SettingsUX.bodyTextColor
       $0.text = Strings.SettingsDisabledBody1
       $0.numberOfLines = 0
       $0.font = .systemFont(ofSize: 13.0)
     },
     UILabel().then {
-      $0.textColor = SettingsUX.headerTextColor
+      $0.appearanceTextColor = SettingsUX.headerTextColor
       $0.text = Strings.SettingsDisabledTitle2
       $0.numberOfLines = 0
       $0.font = .systemFont(ofSize: 15.0)
     },
     UILabel().then {
-      $0.textColor = SettingsUX.bodyTextColor
+      $0.appearanceTextColor = SettingsUX.bodyTextColor
       $0.text = Strings.SettingsDisabledBody2
       $0.numberOfLines = 0
       $0.font = .systemFont(ofSize: 13.0)

--- a/BraveRewardsUI/Settings/SettingsViewDetailsButton.swift
+++ b/BraveRewardsUI/Settings/SettingsViewDetailsButton.swift
@@ -11,7 +11,7 @@ class SettingsViewDetailsButton: Button {
     
     tintColor = Colors.purple300
     setTitle(Strings.SettingsViewDetails, for: .normal)
-    setTitleColor(Colors.purple300, for: .normal)
+    appearanceTextColor = Colors.purple300
     setImage(UIImage(frameworkResourceNamed: "right-arrow").alwaysTemplate, for: .normal)
     titleLabel?.font = .systemFont(ofSize: 14.0, weight: .medium)
     titleEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 3)

--- a/BraveRewardsUI/Settings/Tips/Details/TipsSummaryTableCell.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsSummaryTableCell.swift
@@ -7,16 +7,16 @@ import UIKit
 class TipsSummaryTableCell: UITableViewCell, TableViewReusable {
   
   let batValueView = CurrencyContainerView(amountLabelConfig: {
-    $0.textColor = Colors.neutral200
+    $0.appearanceTextColor = Colors.neutral200
     $0.font = .systemFont(ofSize: 14.0, weight: .semibold)
   }, kindLabelConfig: {
-    $0.textColor = Colors.neutral200
+    $0.appearanceTextColor = Colors.neutral200
     $0.text = "BAT"
     $0.font = .systemFont(ofSize: 13.0)
   })
   
   let usdValueView = CurrencyContainerView(uniformLabelConfig: {
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.font = .systemFont(ofSize: 13.0)
   }).then {
     $0.kindLabel.text = "USD"
@@ -25,9 +25,11 @@ class TipsSummaryTableCell: UITableViewCell, TableViewReusable {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     
+    backgroundColor = .white
+    
     let totalTipsThisMonthLabel = UILabel().then {
       $0.text = Strings.TipsTotalThisMonth
-      $0.textColor = Colors.neutral200
+      $0.appearanceTextColor = Colors.neutral200
       $0.font = .systemFont(ofSize: 14.0, weight: .medium)
       $0.numberOfLines = 0
       $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)

--- a/BraveRewardsUI/Settings/Tips/Details/TipsTableCell.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsTableCell.swift
@@ -16,13 +16,13 @@ class TipsTableCell: UITableViewCell, TableViewReusable {
   }
   
   let tokenView = BATUSDPairView(batAmountConfig: {
-    $0.textColor = Colors.grey100
+    $0.appearanceTextColor = Colors.grey100
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
   }, batKindConfig: {
-    $0.textColor = Colors.grey100
+    $0.appearanceTextColor = Colors.grey100
     $0.font = .systemFont(ofSize: 12.0)
   }, usdConfig: {
-    $0.textColor = Colors.grey200
+    $0.appearanceTextColor = Colors.grey200
     $0.font = .systemFont(ofSize: 10.0)
   }).then {
     $0.axis = .vertical
@@ -46,13 +46,13 @@ class TipsTableCell: UITableViewCell, TableViewReusable {
     $0.alignment = .leading
   }
   let siteNameLabel = UILabel().then {
-    $0.textColor = Colors.grey100
+    $0.appearanceTextColor = Colors.grey100
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     $0.numberOfLines = 0
   }
   let typeNameLabel = UILabel().then {
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.font = .systemFont(ofSize: 13.0, weight: .medium)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     $0.numberOfLines = 0
@@ -60,6 +60,8 @@ class TipsTableCell: UITableViewCell, TableViewReusable {
   
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: nil)
+    
+    backgroundColor = .white
     
     insertSubview(attentionBackgroundFillView, belowSubview: contentView)
     contentView.addSubview(siteStackView)

--- a/BraveRewardsUI/Settings/Tips/SettingsTipsSectionView.swift
+++ b/BraveRewardsUI/Settings/Tips/SettingsTipsSectionView.swift
@@ -47,13 +47,13 @@ class SettingsTipsSectionView: SettingsSectionView {
   
   private let titleLabel = UILabel().then {
     $0.text = Strings.SettingsTipsTitle
-    $0.textColor = BraveUX.tipsTintColor
+    $0.appearanceTextColor = BraveUX.tipsTintColor
     $0.font = SettingsUX.titleFont
   }
   
   private let bodyLabel = UILabel().then {
     $0.text = Strings.SettingsTipsBody
-    $0.textColor = SettingsUX.bodyTextColor
+    $0.appearanceTextColor = SettingsUX.bodyTextColor
     $0.numberOfLines = 0
     $0.font = SettingsUX.bodyFont
   }

--- a/BraveRewardsUI/Settings/Wallet/WalletActivityView.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletActivityView.swift
@@ -15,7 +15,7 @@ class WalletActivityView: SettingsSectionView {
   }
   
   let monthYearLabel = UILabel().then {
-    $0.textColor = UX.monthYearColor
+    $0.appearanceTextColor = UX.monthYearColor
     $0.font = .systemFont(ofSize: 22.0, weight: .medium)
   }
   

--- a/BraveRewardsUI/Settings/Wallet/WalletDetailsView.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletDetailsView.swift
@@ -65,7 +65,7 @@ extension WalletDetailsViewController.View {
       let imageView = UIImageView(image: UIImage(frameworkResourceNamed: "icn-blankslate-statement"))
       let titleLabel = UILabel().then {
         $0.text = Strings.EmptyWalletTitle
-        $0.textColor = SettingsUX.bodyTextColor
+        $0.appearanceTextColor = SettingsUX.bodyTextColor
         $0.font = .systemFont(ofSize: 22.0)
         $0.textAlignment = .center
         $0.numberOfLines = 0
@@ -81,12 +81,12 @@ extension WalletDetailsViewController.View {
           
           addArrangedSubview(UILabel().then {
             $0.font = .systemFont(ofSize: 15.0, weight: .medium)
-            $0.textColor = SettingsUX.subtitleTextColor
+            $0.appearanceTextColor = SettingsUX.subtitleTextColor
             $0.text = Strings.EmptyWalletBulletHeader
           })
           addArrangedSubview(UILabel().then {
             $0.font = .systemFont(ofSize: 15.0)
-            $0.textColor = SettingsUX.bodyTextColor
+            $0.appearanceTextColor = SettingsUX.bodyTextColor
             $0.text = Strings.EmptyWalletBulletPoints
             $0.numberOfLines = 0
           })
@@ -134,7 +134,7 @@ extension WalletDetailsViewController.View {
       })
       stackView.addArrangedSubview(UILabel().then {
         $0.setContentCompressionResistancePriority(.required, for: .horizontal)
-        $0.textColor = Colors.grey300
+        $0.appearanceTextColor = Colors.grey300
         $0.font = .systemFont(ofSize: 14.0)
         $0.textAlignment = .center
         $0.numberOfLines = 0

--- a/BraveRewardsUI/Settings/Wallet/WalletSummaryView.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletSummaryView.swift
@@ -17,11 +17,11 @@ class SettingsWalletSectionView: SettingsSectionView {
   
   private(set) lazy var viewDetailsButton = SettingsViewDetailsButton(type: .system).then {
     $0.tintColor = .white
-    $0.setTitleColor(.white, for: .normal)
+    $0.appearanceTextColor = .white
   }
   
   private(set) lazy var addFundsButton = Button(type: .system).then {
-    $0.setTitleColor(.white, for: .normal)
+    $0.appearanceTextColor = .white
     $0.setTitle(Strings.AddFunds, for: .normal)
     $0.setImage(UIImage(frameworkResourceNamed: "wallet-icon").alwaysOriginal, for: .normal)
     $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8.0)
@@ -48,7 +48,7 @@ class SettingsWalletSectionView: SettingsSectionView {
   
   private let titleLabel = UILabel().then {
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
-    $0.textColor = UIColor(white: 1.0, alpha: 0.65)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.65)
     $0.text = Strings.WalletHeaderTitle
   }
   
@@ -58,18 +58,18 @@ class SettingsWalletSectionView: SettingsSectionView {
   }
   
   let balanceLabel = UILabel().then {
-    $0.textColor = .white
+    $0.appearanceTextColor = .white
     $0.font = .systemFont(ofSize: 30.0)
   }
   
   let altcurrencyTypeLabel = UILabel().then {
-    $0.textColor = UIColor(white: 1.0, alpha: 0.65)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.65)
     $0.font = .systemFont(ofSize: 16.0)
   }
   
   let usdBalanceLabel = UILabel().then {
     $0.textAlignment = .center
-    $0.textColor = UIColor(white: 1.0, alpha: 0.65)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.65)
     $0.font = .systemFont(ofSize: 12.0)
   }
   

--- a/BraveRewardsUI/Tipping/InsufficientFundsButton.swift
+++ b/BraveRewardsUI/Tipping/InsufficientFundsButton.swift
@@ -22,7 +22,7 @@ class InsufficientFundsButton: UIControl {
   }
   
   private let textLabel = UILabel().then {
-    $0.textColor = .white
+    $0.appearanceTextColor = .white
     $0.font = .systemFont(ofSize: 13.0)
     $0.numberOfLines = 0
     $0.text = Strings.TippingNotEnoughTokens

--- a/BraveRewardsUI/Tipping/SendTipButton.swift
+++ b/BraveRewardsUI/Tipping/SendTipButton.swift
@@ -23,7 +23,7 @@ class SendTipButton: UIControl {
   }
   
   private let textLabel = UILabel().then {
-    $0.textColor = .white
+    $0.appearanceTextColor = .white
     $0.font = .systemFont(ofSize: 13.0, weight: .semibold)
     $0.text = Strings.TippingSendTip.uppercased()
   }

--- a/BraveRewardsUI/Tipping/TippingConfirmationView.swift
+++ b/BraveRewardsUI/Tipping/TippingConfirmationView.swift
@@ -28,28 +28,28 @@ class TippingConfirmationView: UIView {
   
   let titleLabel = UILabel().then {
     $0.text = Strings.TippingConfirmation
-    $0.textColor = UX.confirmationTextColor
+    $0.appearanceTextColor = UX.confirmationTextColor
     $0.font = .systemFont(ofSize: 28.0, weight: .bold)
     $0.textAlignment = .center
     $0.numberOfLines = 0
   }
   
   let subtitleLabel = UILabel().then {
-    $0.textColor = UX.confirmationTextColor
+    $0.appearanceTextColor = UX.confirmationTextColor
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
     $0.textAlignment = .center
     $0.numberOfLines = 0
   }
   
   let infoLabel = UILabel().then {
-    $0.textColor = UX.confirmationTextColor
+    $0.appearanceTextColor = UX.confirmationTextColor
     $0.font = .systemFont(ofSize: 20.0, weight: .medium)
     $0.textAlignment = .center
     $0.numberOfLines = 0
   }
   
   let monthlyTipLabel = UILabel().then {
-    $0.textColor = UX.confirmationTextColor
+    $0.appearanceTextColor = UX.confirmationTextColor
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
     $0.textAlignment = .center
     $0.numberOfLines = 0

--- a/BraveRewardsUI/Tipping/TippingOptionView.swift
+++ b/BraveRewardsUI/Tipping/TippingOptionView.swift
@@ -37,17 +37,17 @@ class TippingOptionView: UIControl {
   }
   
   let valueLabel = UILabel().then {
-    $0.textColor = UX.textColor
+    $0.appearanceTextColor = UX.textColor
     $0.font = .systemFont(ofSize: 13.0, weight: .bold)
   }
   
   let cryptoLabel = UILabel().then {
-    $0.textColor = UX.textColor
+    $0.appearanceTextColor = UX.textColor
     $0.font = .systemFont(ofSize: 12.0)
   }
   
   let dollarLabel = UILabel().then {
-    $0.textColor = UX.unselectedDollarTextColor
+    $0.appearanceTextColor = UX.unselectedDollarTextColor
     $0.font = .systemFont(ofSize: 12.0)
     $0.textAlignment = .center
   }
@@ -90,7 +90,7 @@ class TippingOptionView: UIControl {
       amountView.layer.borderWidth = isSelected ? 0 : 1
       UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 1000, initialSpringVelocity: 0, options: [], animations: {
         self.amountView.backgroundColor = self.isSelected ? UX.borderColor : .clear
-        self.dollarLabel.textColor = self.isSelected ? UX.selectedDollarTextColor : UX.unselectedDollarTextColor
+        self.dollarLabel.appearanceTextColor = self.isSelected ? UX.selectedDollarTextColor : UX.unselectedDollarTextColor
       }, completion: nil)
     }
   }

--- a/BraveRewardsUI/Tipping/TippingOverviewView.swift
+++ b/BraveRewardsUI/Tipping/TippingOverviewView.swift
@@ -47,7 +47,7 @@ class TippingOverviewView: UIView {
   }
   
   let disclaimerView = LinkLabel().then {
-    $0.textColor = Colors.grey200
+    $0.appearanceTextColor = Colors.grey200
     $0.font = UIFont.systemFont(ofSize: 12.0)
     $0.textContainerInset = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
     $0.text = "\(Strings.TippingUnverifiedDisclaimer) \(Strings.DisclaimerLearnMore)"
@@ -59,14 +59,14 @@ class TippingOverviewView: UIView {
   
   let titleLabel = UILabel().then {
     $0.text = Strings.TippingOverviewTitle
-    $0.textColor = UX.titleColor
+    $0.appearanceTextColor = UX.titleColor
     $0.font = .systemFont(ofSize: 23.0, weight: .semibold)
     $0.numberOfLines = 0
   }
   
   let bodyLabel = UILabel().then {
     $0.text = Strings.TippingOverviewBody 
-    $0.textColor = UX.bodyColor
+    $0.appearanceTextColor = UX.bodyColor
     $0.font = .systemFont(ofSize: 17.0)
     $0.numberOfLines = 0
   }

--- a/BraveRewardsUI/Tipping/TippingSelectionView.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionView.swift
@@ -102,7 +102,7 @@ class TippingSelectionView: UIView {
   // MARK: - Private UI
   
   private let titleLabel = UILabel().then {
-    $0.textColor = .white
+    $0.appearanceTextColor = .white
     $0.font = .systemFont(ofSize: 18.0, weight: .bold)
     $0.text = Strings.TippingAmountTitle
   }
@@ -210,16 +210,16 @@ extension TippingSelectionView {
   // "wallet balance X BAT"
   fileprivate class WalletBalanceView: UIStackView {
     let titleLabel = UILabel().then {
-      $0.textColor = Colors.blurple700
+      $0.appearanceTextColor = Colors.blurple700
       $0.font = .systemFont(ofSize: 12.0)
       $0.text = Strings.TippingWalletBalanceTitle
     }
     let valueLabel = UILabel().then {
-      $0.textColor = .white
+      $0.appearanceTextColor = .white
       $0.font = .systemFont(ofSize: 12.0, weight: .medium)
     }
     let cryptoLabel = UILabel().then {
-      $0.textColor = .white
+      $0.appearanceTextColor = .white
       $0.font = .systemFont(ofSize: 12.0, weight: .medium)
     }
     

--- a/BraveRewardsUI/Wallet/EmptyWalletSummaryView.swift
+++ b/BraveRewardsUI/Wallet/EmptyWalletSummaryView.swift
@@ -13,7 +13,7 @@ class EmptyWalletSummaryView: UIView {
     let label = UILabel().then {
       $0.text = Strings.NoActivitiesYet
       $0.textAlignment = .center
-      $0.textColor = Colors.grey400
+      $0.appearanceTextColor = Colors.grey400
       $0.font = .systemFont(ofSize: 20.0)
       $0.numberOfLines = 0
     }

--- a/BraveRewardsUI/Wallet/RewardsSummaryProtocol.swift
+++ b/BraveRewardsUI/Wallet/RewardsSummaryProtocol.swift
@@ -79,7 +79,7 @@ extension RewardsSummaryProtocol {
     let text = String(format: Strings.ContributingToUnverifiedSites, reservedAmount.displayString)
     
     return LinkLabel().then {
-      $0.textColor = Colors.grey200
+      $0.appearanceTextColor = Colors.grey200
       $0.font = UIFont.systemFont(ofSize: 12.0)
       $0.textContainerInset = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
       $0.text = "\(text) \(Strings.DisclaimerLearnMore)"

--- a/BraveRewardsUI/Wallet/WalletHeaderView.swift
+++ b/BraveRewardsUI/Wallet/WalletHeaderView.swift
@@ -11,9 +11,9 @@ class WalletHeaderView: UIView {
     $0.clipsToBounds = true
   }
   
-  private let titleLabel = UILabel().then {
+  let titleLabel = UILabel().then {
     $0.font = .systemFont(ofSize: 16.0, weight: .medium)
-    $0.textColor = UIColor(white: 1.0, alpha: 0.65)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.65)
     $0.text = Strings.WalletHeaderTitle
   }
   
@@ -23,18 +23,18 @@ class WalletHeaderView: UIView {
   }
   
   let balanceLabel = UILabel().then {
-    $0.textColor = .white
+    $0.appearanceTextColor = .white
     $0.font = .systemFont(ofSize: 36.0)
   }
   
   let altcurrencyTypeLabel = UILabel().then {
-    $0.textColor = UIColor(white: 1.0, alpha: 0.65)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.65)
     $0.font = .systemFont(ofSize: 18.0)
   }
   
   let usdBalanceLabel = UILabel().then {
     $0.textAlignment = .center
-    $0.textColor = UIColor(white: 1.0, alpha: 0.65)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.65)
     $0.font = .systemFont(ofSize: 12.0)
   }
   
@@ -43,13 +43,13 @@ class WalletHeaderView: UIView {
     $0.titleLabel?.font = .systemFont(ofSize: 10.0, weight: .semibold)
     $0.setImage(UIImage(frameworkResourceNamed: "right-arrow-small").alwaysTemplate, for: .normal)
     $0.setTitle(Strings.WalletHeaderGrants, for: .normal)
-    $0.setTitleColor(UIColor(white: 1.0, alpha: 0.75), for: .normal)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.75)
     $0.titleEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5.0)
     $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10.0)
   }
   
   let addFundsButton = UIButton(type: .system).then {
-    $0.setTitleColor(UIColor(white: 1.0, alpha: 0.75), for: .normal)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.75)
     $0.setTitle(Strings.AddFunds, for: .normal)
     $0.setImage(UIImage(frameworkResourceNamed: "wallet-icon").alwaysOriginal, for: .normal)
     $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8.0)
@@ -60,7 +60,7 @@ class WalletHeaderView: UIView {
   }
   
   let settingsButton = UIButton(type: .system).then {
-    $0.setTitleColor(UIColor(white: 1.0, alpha: 0.75), for: .normal)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.75)
     $0.setTitle(Strings.Settings, for: .normal)
     $0.setImage(UIImage(frameworkResourceNamed: "bat-small").alwaysOriginal, for: .normal)
     $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8.0)

--- a/BraveRewardsUI/Welcome/WelcomeView.swift
+++ b/BraveRewardsUI/Welcome/WelcomeView.swift
@@ -15,7 +15,7 @@ extension WelcomeViewController {
     
     let termsOfServiceLabel = LinkLabel().then {
       $0.font = .systemFont(ofSize: 12.0)
-      $0.textColor = Colors.grey900
+      $0.appearanceTextColor = Colors.grey900
       $0.textAlignment = .center
       $0.text = Strings.WelcomeDisclaimerInformation
       $0.setURLInfo([Strings.TermsOfServiceURL: "terms", Strings.PrivacyPolicyURL: "policy"])
@@ -39,7 +39,7 @@ extension WelcomeViewController {
         .view(UIImageView(image: UIImage(frameworkResourceNamed: "bat-dragable"))),
         .customSpace(20.0),
         .view(UILabel().then {
-          $0.textColor = .white
+          $0.appearanceTextColor = .white
           $0.font = .systemFont(ofSize: 28.0, weight: .medium)
           $0.textAlignment = .center
           $0.attributedText = {
@@ -57,7 +57,7 @@ extension WelcomeViewController {
           }()
         }),
         .view(UILabel().then {
-          $0.textColor = Colors.blue500
+          $0.appearanceTextColor = Colors.blue500
           $0.font = .systemFont(ofSize: 22.0)
           $0.textAlignment = .center
           $0.numberOfLines = 0
@@ -65,7 +65,7 @@ extension WelcomeViewController {
         }),
         .customSpace(15.0),
         .view(UILabel().then {
-          $0.textColor = .white
+          $0.appearanceTextColor = .white
           $0.font = .systemFont(ofSize: 16.0)
           $0.textAlignment = .center
           $0.numberOfLines = 0
@@ -78,7 +78,7 @@ extension WelcomeViewController {
         .customSpace(25.0),
         .view(UILabel().then {
           $0.text = Strings.LearnMoreHowItWorks
-          $0.textColor = UIColor(white: 1.0, alpha: 0.5)
+          $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.5)
           $0.textAlignment = .center
           $0.font = .systemFont(ofSize: 16.0)
         }),
@@ -147,14 +147,14 @@ extension WelcomeViewController {
       stackView.addArrangedSubview(UIImageView(image: icon))
       stackView.addArrangedSubview(UILabel().then {
         $0.text = title
-        $0.textColor = .black
+        $0.appearanceTextColor = .black
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.font = .systemFont(ofSize: 18, weight: .medium)
       })
       stackView.addArrangedSubview(UILabel().then {
         $0.text = body
-        $0.textColor = Colors.grey200
+        $0.appearanceTextColor = Colors.grey200
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.font = .systemFont(ofSize: 16)
@@ -188,7 +188,7 @@ extension WelcomeViewController {
     
     let termsOfServiceLabel = LinkLabel().then {
       $0.font = .systemFont(ofSize: 12.0)
-      $0.textColor = Colors.grey200
+      $0.appearanceTextColor = Colors.grey200
       $0.linkColor = .black
       $0.textAlignment = .center
       $0.text = Strings.WelcomeDisclaimerInformation
@@ -239,14 +239,14 @@ extension WelcomeViewController {
         .view(UILabel().then {
           $0.text = Strings.LearnMoreWhyTitle
           $0.font = .systemFont(ofSize: 24.0)
-          $0.textColor = .black
+          $0.appearanceTextColor = .black
           $0.numberOfLines = 0
         }),
         .customSpace(10.0),
         .view(UILabel().then {
           $0.text = Strings.LearnMoreWhyBody
           $0.font = .systemFont(ofSize: 16.0)
-          $0.textColor = Colors.grey200
+          $0.appearanceTextColor = Colors.grey200
           $0.numberOfLines = 0
         }),
         .customSpace(20.0),
@@ -270,7 +270,7 @@ extension WelcomeViewController {
           $0.text = Strings.LearnMoreReady
           $0.font = .systemFont(ofSize: 20.0)
           $0.textAlignment = .center
-          $0.textColor = Colors.blurple400
+          $0.appearanceTextColor = Colors.blurple400
           $0.numberOfLines = 0
         }),
         .customSpace(20.0),

--- a/BraveShared/AppearanceAttributes.swift
+++ b/BraveShared/AppearanceAttributes.swift
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+public extension UILabel {
+    @objc dynamic var appearanceTextColor: UIColor! {
+        get { return self.textColor }
+        set { self.textColor = newValue }
+    }
+}
+
+public extension UITableView {
+    @objc dynamic var appearanceSeparatorColor: UIColor? {
+        get { return self.separatorColor }
+        set { self.separatorColor = newValue }
+    }
+}
+
+public extension UITextView {
+    @objc dynamic var appearanceTextColor: UIColor? {
+        get { return self.textColor }
+        set { self.textColor = newValue }
+    }
+}
+
+public extension UIView {
+    @objc dynamic var appearanceBackgroundColor: UIColor? {
+        get { return self.backgroundColor }
+        set { self.backgroundColor = newValue }
+    }
+}
+
+public extension UITextField {
+    @objc dynamic var appearanceTextColor: UIColor? {
+        get { return self.textColor }
+        set { self.textColor = newValue }
+    }
+}
+
+public extension UIView {
+    @objc dynamic var appearanceOverrideUserInterfaceStyle: UIUserInterfaceStyle {
+        get {
+            if #available(iOS 13.0, *) {
+                return self.overrideUserInterfaceStyle
+            }
+            return .unspecified
+        }
+        set {
+            if #available(iOS 13.0, *) {
+                self.overrideUserInterfaceStyle = newValue
+            }
+            // Ignore
+        }
+    }
+}
+
+public extension UINavigationBar {
+    @objc dynamic var appearanceBarTintColor: UIColor? {
+        get { return self.barTintColor }
+        set { self.barTintColor = newValue }
+    }
+}
+
+public extension UIButton {
+    @objc dynamic var appearanceTextColor: UIColor! {
+        get { return self.titleColor(for: .normal) }
+        set {
+            self.setTitleColor(newValue, for: .normal)
+            // iOS 12 has many problems with overwriting color values.
+            // We have to set text color directly to the label as well.
+            if #available(iOS 13.0, *) { } else { titleLabel?.appearanceTextColor = newValue }
+        }
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		0A0D3D5021A5609600BEE65B /* SafeBrowsingError.html in Resources */ = {isa = PBXBuildFile; fileRef = 0A0D3D4821A5609500BEE65B /* SafeBrowsingError.html */; };
 		0A0D3D5221A565C300BEE65B /* SafeBrowsingHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0D3D5121A565C300BEE65B /* SafeBrowsingHandler.swift */; };
 		0A0D3D6121A596BE00BEE65B /* MalwareList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0D3D6021A596BE00BEE65B /* MalwareList.swift */; };
+		0A19362F234D44DB002E2B81 /* AppearanceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19362E234D44DB002E2B81 /* AppearanceAttributes.swift */; };
+		0A193631234D4C4C002E2B81 /* BraveShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DE7688420B3456C00FF5533 /* BraveShared.framework */; platformFilter = ios; };
+		0A193632234D4C4C002E2B81 /* BraveShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5DE7688420B3456C00FF5533 /* BraveShared.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0A193635234D4C4C002E2B81 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; platformFilter = ios; };
+		0A193636234D4C4C002E2B81 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0A1E842D21909CA70042F782 /* crypto.js in Resources */ = {isa = PBXBuildFile; fileRef = 0A1E842C21909CA70042F782 /* crypto.js */; };
 		0A1E842F21909CBC0042F782 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 0A1E842E21909CBB0042F782 /* bundle.js */; };
 		0A1E843121909CC40042F782 /* fetch.js in Resources */ = {isa = PBXBuildFile; fileRef = 0A1E843021909CC30042F782 /* fetch.js */; };
@@ -911,6 +916,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0A193633234D4C4C002E2B81 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5DE7688320B3456C00FF5533;
+			remoteInfo = BraveShared;
+		};
+		0A193637234D4C4C002E2B81 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 288A2D851AB8B3260023ABC3;
+			remoteInfo = Shared;
+		};
 		0AC0D3B1233E86E50091EFA5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0AC0D3A9233E86E50091EFA5 /* sqlcipher.xcodeproj */;
@@ -1089,6 +1108,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		0A193639234D4C4D002E2B81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				0A193632234D4C4C002E2B81 /* BraveShared.framework in Embed Frameworks */,
+				0A193636234D4C4C002E2B81 /* Shared.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		0AC0D387233BD77B0091EFA5 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1176,6 +1207,7 @@
 		0A0D3D4821A5609500BEE65B /* SafeBrowsingError.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SafeBrowsingError.html; sourceTree = "<group>"; };
 		0A0D3D5121A565C300BEE65B /* SafeBrowsingHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeBrowsingHandler.swift; sourceTree = "<group>"; };
 		0A0D3D6021A596BE00BEE65B /* MalwareList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareList.swift; sourceTree = "<group>"; };
+		0A19362E234D44DB002E2B81 /* AppearanceAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceAttributes.swift; sourceTree = "<group>"; };
 		0A1E841B219095410042F782 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		0A1E842C21909CA70042F782 /* crypto.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = crypto.js; path = "node_modules/brave-sync/node_modules/brave-crypto/browser/crypto.js"; sourceTree = SOURCE_ROOT; };
 		0A1E842E21909CBB0042F782 /* bundle.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = bundle.js; path = "node_modules/brave-sync/bundles/bundle.js"; sourceTree = SOURCE_ROOT; };
@@ -3775,6 +3807,7 @@
 				0AD4FED9223A8AF800E00C05 /* Extensions */,
 				0AD5E9BB2200590C00D0D91B /* Shields */,
 				5D6DDEDF214003A6001FF0AE /* Analytics */,
+				0A19362E234D44DB002E2B81 /* AppearanceAttributes.swift */,
 				5D6DDEF62141B6A0001FF0AE /* Preferences.swift */,
 				5DE7687C20B342E600FF5533 /* BraveStrings.swift */,
 				5DE768A820B3461200FF5533 /* BraveUX.swift */,
@@ -4692,6 +4725,7 @@
 				271DEC15234CC75F009DAC37 /* Sources */,
 				271DEC16234CC75F009DAC37 /* Frameworks */,
 				271DEC17234CC75F009DAC37 /* Resources */,
+				0A193639234D4C4D002E2B81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -5672,6 +5706,7 @@
 				2765825D2171263A00754B2F /* UserReferralProgram.swift in Sources */,
 				2777273722EB43A100F0214C /* StringExtensions.swift in Sources */,
 				276582692171266900754B2F /* ReferralData.swift in Sources */,
+				0A19362F234D44DB002E2B81 /* AppearanceAttributes.swift in Sources */,
 				5DE768B020B4601700FF5533 /* UIColorExtensions.swift in Sources */,
 				5DE768AE20B443E500FF5533 /* JSONSerializationExtensions.swift in Sources */,
 				0AAAACAD22491CC7009A8763 /* ErrorExtensions.swift in Sources */,
@@ -6102,6 +6137,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0A193634234D4C4C002E2B81 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 5DE7688320B3456C00FF5533 /* BraveShared */;
+			targetProxy = 0A193633234D4C4C002E2B81 /* PBXContainerItemProxy */;
+		};
+		0A193638234D4C4C002E2B81 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 288A2D851AB8B3260023ABC3 /* Shared */;
+			targetProxy = 0A193637234D4C4C002E2B81 /* PBXContainerItemProxy */;
+		};
 		271DEC24234CC760009DAC37 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 271DEC18234CC75F009DAC37 /* BraveRewardsUI */;
@@ -7421,6 +7468,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -7434,6 +7482,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(FRAMEWORK_BASE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Shared/Shared-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
@@ -8086,6 +8135,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -8118,6 +8168,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -8164,6 +8215,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -8189,6 +8241,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -8236,6 +8289,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -8261,6 +8315,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -8308,6 +8363,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -8333,6 +8389,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -8759,6 +8816,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -8773,6 +8831,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(FRAMEWORK_BASE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Shared/Shared-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
@@ -8967,6 +9026,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -8980,6 +9040,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(FRAMEWORK_BASE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Shared/Shared-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
@@ -9252,6 +9313,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -9266,6 +9328,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(FRAMEWORK_BASE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Shared/Shared-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};

--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import BraveShared
+import BraveRewardsUI
 
 extension Theme {
     func applyAppearanceProperties() {
@@ -88,66 +89,17 @@ extension Theme {
             UISwitch.appearance().tintColor = #colorLiteral(red: 0.8392156863, green: 0.8392156863, blue: 0.8431372549, alpha: 1)
         }
         
+        // Brave Rewards
+        
+        // on iOS 12 global UILabel appearance takes over `barTint` and other properties for some reason.
+        // Adding a more specific proxy resolves it.
+        if #available(iOS 13, *) { } else {
+            UILabel.appearance(whenContainedInInstancesOf: [UINavigationBar.self, RewardsPanelController.self]).appearanceTextColor = .black
+        }
+        
+        // This solves bunch of small theming problems like disclosure indicators color, cell highlight color..
+        UIView.appearance(whenContainedInInstancesOf: [RewardsPanelController.self]).appearanceOverrideUserInterfaceStyle = .light
+        
         (UIApplication.shared.delegate as? AppDelegate)?.window?.backgroundColor = colors.home
     }
 }
-
-extension UILabel {
-    @objc dynamic var appearanceTextColor: UIColor! {
-        get { return self.textColor }
-        set { self.textColor = newValue }
-    }
-}
-
-extension InsetButton {
-    @objc dynamic var appearanceTextColor: UIColor! {
-        get { return self.titleColor(for: .normal) }
-        set { self.setTitleColor(newValue, for: .normal) }
-    }
-}
-
-extension UITableView {
-    @objc dynamic var appearanceSeparatorColor: UIColor? {
-        get { return self.separatorColor }
-        set { self.separatorColor = newValue }
-    }
-}
-
-extension UIView {
-    @objc dynamic var appearanceBackgroundColor: UIColor? {
-        get { return self.backgroundColor }
-        set { self.backgroundColor = newValue }
-    }
-}
-
-extension UITextField {
-    @objc dynamic var appearanceTextColor: UIColor? {
-        get { return self.textColor }
-        set { self.textColor = newValue }
-    }
-}
-
-extension UIView {
-    @objc dynamic var appearanceOverrideUserInterfaceStyle: UIUserInterfaceStyle {
-        get {
-            if #available(iOS 13.0, *) {
-                return self.overrideUserInterfaceStyle
-            }
-            return .unspecified
-        }
-        set {
-            if #available(iOS 13.0, *) {
-                self.overrideUserInterfaceStyle = newValue
-            }
-            // Ignore
-        }
-    }
-}
-
-extension UINavigationBar {
-    @objc dynamic var appearanceBarTintColor: UIColor? {
-        get { return self.barTintColor }
-        set { self.barTintColor = newValue }
-    }
-}
-


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
I tried to make as many changes as possible directly in RewardsUI classes.

There are two global appearance workarounds
1. Navigation's bar text color can't be set on iOS 12
2. Globally setting `UserInterfaceStyle` for all views in the Rewards popup to prevent minor theming bugs.

This pull request fixes issue brave/brave-rewards-ios#229
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that all screens and displayed ads are looking good on both iOS 12 & 13

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Too many screenshots to attach, please run this branch and see for yourself

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
