### PR TITLE
Fixed Popups showing the wrong size in Split-Screen-View on iPad.

### DIFF
--- a/Client/Frontend/Popup/PopupView.swift
+++ b/Client/Frontend/Popup/PopupView.swift
@@ -87,6 +87,9 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
     
     var dialogWidth: CGFloat {
         get {
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                return min((applicationWindow?.bounds.width ?? UIScreen.main.bounds.width) - padding * 2.0, kPopupDialogMaxWidth)
+            }
             return min(UIScreen.main.bounds.width - padding * 2.0, kPopupDialogMaxWidth)
         }
     }
@@ -243,7 +246,11 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
         
         dialogView.removeFromSuperview()
         
-        frame = UIScreen.main.bounds
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            frame = applicationWindow?.bounds ?? UIScreen.main.bounds
+        } else {
+            frame = UIScreen.main.bounds
+        }
         addSubview(dialogView)
         setNeedsLayout()
         layoutIfNeeded()

--- a/Client/Frontend/Popup/PopupView.swift
+++ b/Client/Frontend/Popup/PopupView.swift
@@ -91,10 +91,7 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
                 return min(superview.bounds.width - padding * 2.0, kPopupDialogMaxWidth)
             }
             
-            if UIDevice.current.userInterfaceIdiom == .pad {
-                return min((applicationWindow?.bounds.width ?? UIScreen.main.bounds.width) - padding * 2.0, kPopupDialogMaxWidth)
-            }
-            return min(UIScreen.main.bounds.width - padding * 2.0, kPopupDialogMaxWidth)
+            return 0.0
         }
     }
     
@@ -250,11 +247,21 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
         
         dialogView.removeFromSuperview()
         
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            frame = applicationWindow?.bounds ?? UIScreen.main.bounds
+        if presentsOverWindow {
+            UIApplication.shared.keyWindow?.addSubview(self)
         } else {
-            frame = UIScreen.main.bounds
+            let currentViewController: AnyObject = (applicationWindow?.rootViewController)!
+            if currentViewController is UINavigationController {
+                let navigationController: UINavigationController? = currentViewController as? UINavigationController
+                navigationController?.visibleViewController?.view.addSubview(self)
+            } else if currentViewController is UIViewController {
+                let viewController: UIViewController? = currentViewController as? UIViewController
+                viewController?.view.addSubview(self)
+            }
         }
+        
+        frame = superview?.bounds ?? UIScreen.main.bounds
+        
         addSubview(dialogView)
         setNeedsLayout()
         layoutIfNeeded()
@@ -285,19 +292,6 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
         }
         
         overlayView.alpha = 0.0
-        
-        if presentsOverWindow {
-            UIApplication.shared.keyWindow?.addSubview(self)
-        } else {
-            let currentViewController: AnyObject = (applicationWindow?.rootViewController)!
-            if currentViewController is UINavigationController {
-                let navigationController: UINavigationController? = currentViewController as? UINavigationController
-                navigationController?.visibleViewController?.view.addSubview(self)
-            } else if currentViewController is UIViewController {
-                let viewController: UIViewController? = currentViewController as? UIViewController
-                viewController?.view.addSubview(self)
-            }
-        }
         
         UIView.animate(withDuration: 0.2, delay: 0.0, options: [.curveEaseOut], animations: {
             self.overlayView.alpha = self.kPopupBackgroundAlpha

--- a/Client/Frontend/Popup/PopupView.swift
+++ b/Client/Frontend/Popup/PopupView.swift
@@ -85,8 +85,12 @@ class PopupView: UIView, UIGestureRecognizerDelegate {
     var showHandler: (() -> Void)?
     var dismissHandler: (() -> Void)?
     
-    var dialogWidth: CGFloat {
+    var dialogWidth: CGFloat {        
         get {
+            if let superview = self.superview {
+                return min(superview.bounds.width - padding * 2.0, kPopupDialogMaxWidth)
+            }
+            
             if UIDevice.current.userInterfaceIdiom == .pad {
                 return min((applicationWindow?.bounds.width ?? UIScreen.main.bounds.width) - padding * 2.0, kPopupDialogMaxWidth)
             }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-ios/issues/1583
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

On iPad, for popup views, they present on the main window and uses frames instead of constraints. However, for iPad with Multi-Tasking and Split-Screen, the `UIScreen.main.bounds` will actually return the size of the device's screen (as expected).. Therefore we should have been using the size of the `UIWindow` instead because the window is smaller than the screen in split-view.

![Simulator Screen Shot - iPad Air (3rd generation) - 2019-10-15 at 10 10 17](https://user-images.githubusercontent.com/1530031/66839240-1e778d00-ef34-11e9-9ce2-affa93beebfa.png)


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
