### PR TITLE
No Bug: Add an override for controlling the ads lifetime duration

### DIFF
--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -4,6 +4,8 @@
 
 import UIKit
 import BraveRewards
+import BraveShared
+import Shared
 import pop
 
 public class AdsViewController: UIViewController {
@@ -91,7 +93,11 @@ public class AdsViewController: UIViewController {
       // Invalidate and reschedule
       timer.invalidate()
     }
-    dismissTimers[adView] = Timer.scheduledTimer(withTimeInterval: automaticDismissalInterval, repeats: false, block: { [weak self] _ in
+    var dismissInterval = automaticDismissalInterval
+    if !AppConstants.BuildChannel.isRelease, let override = Preferences.Rewards.adsDurationOverride.value, override > 0 {
+      dismissInterval = TimeInterval(override)
+    }
+    dismissTimers[adView] = Timer.scheduledTimer(withTimeInterval: dismissInterval, repeats: false, block: { [weak self] _ in
       guard let self = self, let handler = self.displayedAds[adView] else { return }
       self.hide(adView: adView)
       handler.handler(handler.ad, .timedOut)

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -108,6 +108,9 @@ extension Preferences {
         /// In debug/beta, this is the overriden environment.
         public static let environmentOverride = Option<Int>(key: "rewards.environment-override",
                                                             default: EnvironmentOverride.none.rawValue)
+        
+        /// In debut/beta, the number of seconds before an ad should automatically dismiss
+        public static let adsDurationOverride = Option<Int?>(key: "rewards.ads.dismissal-override", default: nil)
     }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- View rewards debug menu and verify changing the override affects the duration that an ad remains visible before auto-dismissing

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-10-09 at 15 52 57](https://user-images.githubusercontent.com/529104/66515312-e0e6b000-eaac-11e9-8a71-61319fe4bf68.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
