### PR TITLE
Rewards: Don't show ads while private browsing

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -227,6 +227,9 @@ class BrowserViewController: UIViewController {
         
         if let rewards = rewards {
             notificationsHandler = AdsNotificationHandler(ads: rewards.ads, presentingController: self)
+            notificationsHandler?.canShowNotifications = {
+                return !PrivateBrowsingManager.shared.isPrivateBrowsing
+            }
             notificationsHandler?.actionOccured = { [weak self] notification, action in
                 guard let self = self else { return }
                 if action == .opened {


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#237

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- Enable private browsing
- Verify no ads are shown (my first ad doesn't count)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
