### PR TITLE
Rewards: Don't show the Brave Rewards icon while in Private Mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1211,6 +1211,8 @@ class BrowserViewController: UIViewController {
             self.topToolbar.locationView.rewardsButton.isVerified = false
         }
         
+        self.topToolbar.locationView.rewardsButton.isHidden = PrivateBrowsingManager.shared.isPrivateBrowsing
+        
         topToolbar.currentURL = tab.url?.displayURL
         
         topToolbar.contentIsSecure = tab.contentIsSecure

--- a/Client/Frontend/Browser/Toolbars/UrlBar/RewardsButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/RewardsButton.swift
@@ -16,11 +16,6 @@ class RewardsButton: UIButton {
         didSet { updateView() }
     }
     
-    /// Disabled state shows grayscale icon but still allows interaction.
-    var isDisabled: Bool = false {
-        didSet { updateView() }
-    }
-    
     private let notificationsBadgeView = UIView().then {
         $0.backgroundColor = BraveUX.BraveOrange
         $0.frame = CGRect(x: 19, y: 5, width: 12, height: 12)
@@ -51,11 +46,6 @@ class RewardsButton: UIButton {
     private func updateView() {
         checkmarkView.isHidden = true
         notificationsBadgeView.isHidden = true
-        
-        if isDisabled {
-            setImage(#imageLiteral(resourceName: "brave_rewards_button_disabled"), for: .normal)
-            return
-        }
         
         setImage(#imageLiteral(resourceName: "brave_rewards_button_enabled"), for: .normal)
         

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -184,7 +184,6 @@ class TabLocationView: UIView {
     lazy var rewardsButton: RewardsButton = {
         let button = RewardsButton()
         button.addTarget(self, action: #selector(didClickBraveRewardsButton), for: .touchUpInside)
-        button.isDisabled = PrivateBrowsingManager.shared.isPrivateBrowsing
         return button
     }()
     
@@ -257,7 +256,7 @@ class TabLocationView: UIView {
     
     @objc private func privateBrowsingModeChanged() {
         #if !NO_REWARDS
-        rewardsButton.isDisabled = PrivateBrowsingManager.shared.isPrivateBrowsing
+        rewardsButton.isHidden = PrivateBrowsingManager.shared.isPrivateBrowsing
         #endif
     }
 


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#238

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- In normal mode verify icon is visible
- Switch to private mode, verify icon is hidden
- Turn on Private Browsing Only mode, relaunch app and verify icon is still hidden

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).