### PR TITLE
Rewards: Update date formatting in Auto Contribute to match ads

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -145,6 +145,7 @@ internal extension Strings {
   static let FourAdsPerHour = NSLocalizedString("BraveRewardsFourAdsPerHour", bundle: Bundle.RewardsUI, value: "4 ads per hour", comment: "")
   static let FiveAdsPerHour = NSLocalizedString("BraveRewardsFiveAdsPerHour", bundle: Bundle.RewardsUI, value: "5 ads per hour", comment: "")
   static let AdsPayoutDateFormat = NSLocalizedString("BraveRewardsAdsPayoutDateFormat", bundle: Bundle.RewardsUI, value: "MMM d", comment: "")
+  static let AutoContributeDateFormat = NSLocalizedString("BraveRewardsAutoContributeDateFormat", bundle: Bundle.RewardsUI, value: "MMM d", comment: "")
   static let TotalGrantsClaimed = NSLocalizedString("BraveRewardsTotalGrantsClaimed", bundle: Bundle.RewardsUI, value: "Token Grants Claimed", comment: "")
   static let EarningFromAds = NSLocalizedString("BraveRewardsEarningFromAds", bundle: Bundle.RewardsUI, value: "Earnings from Ads", comment: "")
   static let OneTimeTips = NSLocalizedString("BraveRewardsOneTimeTips", bundle: Bundle.RewardsUI, value: "One-time Tips", comment: "")

--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -131,8 +131,7 @@ class AutoContributeDetailViewController: UIViewController {
   private var nextContributionDateView: LabelAccessoryView {
     let view = LabelAccessoryView()
     let dateFormatter = DateFormatter().then {
-      $0.dateStyle = .short
-      $0.timeStyle = .none
+      $0.dateFormat = Strings.AutoContributeDateFormat
     }
     let reconcileDate = Date(timeIntervalSince1970: TimeInterval(state.ledger.autoContributeProps.reconcileStamp))
     view.label.text = dateFormatter.string(from: reconcileDate)


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#234

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- Go to Rewards > Settings > Auto-Contribute View Details and verify that the date matches "Nov 8" style

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-10-10 at 11 21 57](https://user-images.githubusercontent.com/529104/66582688-2e682900-eb50-11e9-8b04-c922bfbf2bab.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
