### PR TITLE
Fix #1631: Give Rewards notifications a clear background

### DIFF
--- a/BraveRewardsUI/Wallet/Notifications/WalletNotificationView.swift
+++ b/BraveRewardsUI/Wallet/Notifications/WalletNotificationView.swift
@@ -19,7 +19,7 @@ class WalletNotificationView: UIView {
   
   override init(frame: CGRect) {
     super.init(frame: frame)
-    backgroundColor = .white
+    backgroundColor = .clear
     
     closeButton.do {
       $0.setImage(UIImage(frameworkResourceNamed: "close-icon").alwaysTemplate, for: .normal)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1631 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
