### PR TITLE
Rewards: Change Brave Ads title from "Advertisement" to "BRAVE REWARDS"

### DIFF
--- a/BraveRewardsUI/Ads/AdContentButton.swift
+++ b/BraveRewardsUI/Ads/AdContentButton.swift
@@ -21,7 +21,7 @@ class AdContentButton: UIControl {
   private let appNameLabel = UILabel().then {
     $0.appearanceTextColor = .black
     $0.font = .systemFont(ofSize: 14.0, weight: .medium)
-    $0.text = Strings.AdNotificationTitle
+    $0.text = Strings.AdNotificationTitle.uppercased()
   }
   
   private let backgroundView: UIVisualEffectView = {

--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -6,7 +6,7 @@ internal struct Strings {}
 
 internal extension Strings {
   static let Open = NSLocalizedString("BraveRewardsOpen", bundle: Bundle.RewardsUI, value: "Open", comment: "")
-  static let AdNotificationTitle = NSLocalizedString("BraveRewardsAdNotificationTitle", bundle: Bundle.RewardsUI, value: "Advertisement", comment: "")
+  static let AdNotificationTitle = NSLocalizedString("BraveRewardsAdNotificationTitle", bundle: Bundle.RewardsUI, value: "Brave Rewards", comment: "")
   static let Verified = NSLocalizedString("BraveRewardsVerified", bundle: Bundle.RewardsUI, value: "Brave Verified Publisher", comment: "")
   static let CheckAgain = NSLocalizedString("BraveRewardsCheckAgain", bundle: Bundle.RewardsUI, value: "Refresh Status", comment: "")
   static let RewardsOptInLearnMore = NSLocalizedString("RewardsOptInLearnMore", bundle: Bundle.RewardsUI, value: "Learn More", comment: "")


### PR DESCRIPTION
Fixes brave/brave-rewards-ios#243

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- See the first ad/any ad, verify top label says "BRAVE REWARDS"

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-10-11 at 15 21 40](https://user-images.githubusercontent.com/529104/66678862-d5c18a80-ec3a-11e9-99f9-3a00be01ece3.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
