### PR TITLE
Fix #1664: Make the join rewards loader state independent from the panel

### DIFF
--- a/BraveRewardsUI/Common/LoaderView.swift
+++ b/BraveRewardsUI/Common/LoaderView.swift
@@ -4,6 +4,18 @@
 
 import UIKit
 
+private class LoaderLayer: CALayer {
+  weak var parent: LoaderView?
+  
+  override func action(forKey event: String) -> CAAction? {
+    if event == kCAOnOrderIn && parent?.isAnimating == true {
+      // Resume animation
+      parent?.start()
+    }
+    return super.action(forKey: event)
+  }
+}
+
 /// A Brave styled activity indicator view
 class LoaderView: UIView {
   /// The size of the indicator
@@ -30,11 +42,19 @@ class LoaderView: UIView {
     }
   }
   
+  override class var layerClass: AnyClass {
+    return LoaderLayer.self
+  }
+  
+  private(set) var isAnimating: Bool = false
+  
   func start() {
+    isAnimating = true
     loaderLayer.add(rotateAnimation, forKey: "rotation")
   }
   
   func stop() {
+    isAnimating = false
     loaderLayer.removeAnimation(forKey: "rotation")
   }
   
@@ -46,6 +66,7 @@ class LoaderView: UIView {
     super.init(frame: CGRect(origin: .zero, size: size.size))
     
     layer.addSublayer(loaderLayer)
+    (layer as? LoaderLayer)?.parent = self
   }
   
   override var tintColor: UIColor! {

--- a/BraveRewardsUI/Create Wallet/CreateWalletViewController.swift
+++ b/BraveRewardsUI/Create Wallet/CreateWalletViewController.swift
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
+import BraveRewards
+import BraveShared
 
 class CreateWalletViewController: UIViewController {
   
@@ -14,7 +16,9 @@ class CreateWalletViewController: UIViewController {
   
   init(state: RewardsState) {
     self.state = state
+    self.observer = LedgerObserver(ledger: state.ledger)
     super.init(nibName: nil, bundle: nil)
+    setupLedgerObserver()
   }
   
   @available(*, unavailable)
@@ -34,6 +38,7 @@ class CreateWalletViewController: UIViewController {
     createWalletView.createWalletButton.addTarget(self, action: #selector(tappedCreateWallet), for: .touchUpInside)
     createWalletView.learnMoreButton.addTarget(self, action: #selector(tappedLearnMore), for: .touchUpInside)
     createWalletView.termsOfServiceLabel.onLinkedTapped = tappedDisclaimerLink
+    createWalletView.createWalletButton.isCreatingWallet = state.ledger.isInitializingWallet
     
     let size = CGSize(width: RewardsUX.preferredPanelSize.width, height: UIScreen.main.bounds.height)
     preferredContentSize = view.systemLayoutSizeFitting(
@@ -52,25 +57,35 @@ class CreateWalletViewController: UIViewController {
     }
   }
   
+  let observer: LedgerObserver
+  
+  func setupLedgerObserver() {
+    state.ledger.add(observer)
+    observer.walletInitalized = { [weak self] result in
+      guard let self = self else { return }
+      self.createWalletView.createWalletButton.isCreatingWallet = false
+      if result == .ledgerOk || result == .walletCreated {
+        self.show(WalletViewController(state: self.state), sender: self)
+      } else {
+        self.showFailureAlert()
+      }
+    }
+  }
+  
   // MARK: - Actions
+  
+  func showFailureAlert() {
+    let alertController = UIAlertController(title: Strings.WalletCreationErrorTitle, message: Strings.WalletCreationErrorBody, preferredStyle: .alert)
+    alertController.addAction(UIAlertAction(title: Strings.OK, style: .default, handler: nil))
+    self.present(alertController, animated: true)
+  }
   
   @objc private func tappedCreateWallet() {
     if createWalletView.createWalletButton.isCreatingWallet {
       return
     }
     createWalletView.createWalletButton.isCreatingWallet = true
-    state.ledger.createWalletAndFetchDetails { [weak self] success in
-      guard let self = self else { return }
-      if !success {
-        let alertController = UIAlertController(title: "Error", message: "Oops! Something went wrong. Please try again.", preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        self.present(alertController, animated: true)
-        self.createWalletView.createWalletButton.isCreatingWallet = false
-        return
-      }
-      defer { self.createWalletView.createWalletButton.isCreatingWallet = false }
-      self.show(WalletViewController(state: self.state), sender: self)
-    }
+    state.ledger.createWalletAndFetchDetails { _ in }
   }
   
   @objc private func tappedLearnMore() {

--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -177,5 +177,7 @@ internal extension Strings {
   static let NoNetworkBody = NSLocalizedString("NoNetworkBody", bundle: Bundle.RewardsUI, value: "The Brave Rewards server is not responding. We will fix this as soon as possible.", comment: "Body for a no network notification")
   static let MyFirstAdTitle = NSLocalizedString("MyFirstAdTitle", bundle: Bundle.RewardsUI, value: "This is your first Brave ad", comment: "")
   static let MyFirstAdBody = NSLocalizedString("MyFirstAdBody", bundle: Bundle.RewardsUI, value: "Tap here to learn more.", comment: "")
+  static let WalletCreationErrorTitle = NSLocalizedString("WalletCreationErrorTitle", bundle: Bundle.RewardsUI, value: "Error", comment: "")
+  static let WalletCreationErrorBody = NSLocalizedString("WalletCreationErrorBody", bundle: Bundle.RewardsUI, value: "Oops! Something went wrong. Please try again.", comment: "")
 }
 

--- a/BraveRewardsUI/README.md
+++ b/BraveRewardsUI/README.md
@@ -6,5 +6,5 @@ The latest BraveRewards.framework was built on:
 
 ```
 brave-browser/9bfe756147e525a3355ad84b0d760f031d7b9d53
-brave-core/9b8c9c2a6a5f504c1378dac23f8a920dbd133bd7
+brave-core/ba1db25ae0128f4d27d6603ae946051494164a3b
 ```


### PR DESCRIPTION
Fixes #1664 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- Open panel, click join rewards. Verify the regular flow still works
- Reset rewards/Delete & reinstall
- Open panel, click join rewards, close panel quickly, reopen panel. Verify it is animating the loader, you can't click on it again and that when it finishes it moves to the next page
- Reset rewards/Delete & reinstall
- Open panel, click join rewards, click "Learn more". Verify both buttons within the welcome/learn more screen are loading, and you can't click them again and when it finishes, it moves to the next page.

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).