### PR TITLE
Fixes Onboarding SafeAreaInsets: Fixes #1649

### DIFF
--- a/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownView.swift
@@ -110,14 +110,12 @@ extension OnboardingAdsCountdownViewController {
             addSubview(imageView)
             addSubview(mainStackView)
             mainStackView.snp.makeConstraints {
-                $0.leading.equalTo(self.safeArea.leading)
-                $0.trailing.equalTo(self.safeArea.trailing)
-                $0.bottom.equalTo(self.safeArea.bottom)
+                $0.leading.trailing.bottom.equalToSuperview()
             }
             
             descriptionView.addSubview(descriptionStackView)
             descriptionStackView.snp.makeConstraints {
-                $0.edges.equalToSuperview().inset(UX.descriptionContentInset)
+                $0.edges.equalTo(descriptionView.safeArea.edges).inset(UX.descriptionContentInset)
             }
             
             mainStackView.addArrangedSubview(descriptionView)

--- a/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
@@ -241,7 +241,7 @@ class CustomAnimator: NSObject, UIViewControllerAnimatedTransitioning {
         tDetails?.alpha = 0.0
         tDetailsContent?.alpha = 0.0
         
-        let inset = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0
+        let inset: CGFloat = 0.0
         var fDetailsFrame = (fDetails?.bounds ?? .zero)
         fDetailsFrame.origin.y = (container.frame.height - container.frame.origin.y) - fDetailsFrame.height
         fDetailsFrame = fDetailsFrame.offsetBy(dx: 0.0, dy: -inset)

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementView.swift
@@ -155,14 +155,12 @@ extension OnboardingRewardsAgreementViewController {
             addSubview(imageView)
             addSubview(mainStackView)
             mainStackView.snp.makeConstraints {
-                $0.leading.equalTo(self.safeArea.leading)
-                $0.trailing.equalTo(self.safeArea.trailing)
-                $0.bottom.equalTo(self.safeArea.bottom)
+                $0.leading.trailing.bottom.equalToSuperview()
             }
             
             descriptionView.addSubview(descriptionStackView)
             descriptionStackView.snp.makeConstraints {
-                $0.edges.equalToSuperview().inset(UX.descriptionContentInset)
+                $0.edges.equalTo(descriptionView.safeArea.edges).inset(UX.descriptionContentInset)
             }
             
             mainStackView.addArrangedSubview(descriptionView)

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
@@ -80,14 +80,12 @@ extension OnboardingRewardsViewController {
             addSubview(imageView)
             addSubview(mainStackView)
             mainStackView.snp.makeConstraints {
-                $0.leading.equalTo(self.safeArea.leading)
-                $0.trailing.equalTo(self.safeArea.trailing)
-                $0.bottom.equalTo(self.safeArea.bottom)
+                $0.leading.trailing.bottom.equalToSuperview()
             }
             
             descriptionView.addSubview(descriptionStackView)
             descriptionStackView.snp.makeConstraints {
-                $0.edges.equalToSuperview().inset(UX.descriptionContentInset)
+                $0.edges.equalTo(descriptionView.safeArea.edges).inset(UX.descriptionContentInset)
             }
             
             mainStackView.addArrangedSubview(descriptionView)

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
@@ -19,8 +19,8 @@ extension OnboardingRewardsViewController {
     
     class View: UIView {
         
-        let continueButton = CommonViews.primaryButton(text: Strings.OBJoinButton).then {
-            $0.accessibilityIdentifier = "OnboardingRewardsViewController.OBJoinButton"
+        let continueButton = CommonViews.primaryButton(text: Strings.OBTurnOnButton).then {
+            $0.accessibilityIdentifier = "OnboardingRewardsViewController.OBTurnOnButton"
         }
         
         let skipButton = CommonViews.secondaryButton().then {

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
@@ -19,8 +19,8 @@ extension OnboardingRewardsViewController {
     
     class View: UIView {
         
-        let continueButton = CommonViews.primaryButton(text: Strings.OBTurnOnButton).then {
-            $0.accessibilityIdentifier = "OnboardingRewardsViewController.OBTurnOnButton"
+        let continueButton = CommonViews.primaryButton(text: Strings.OBJoinButton).then {
+            $0.accessibilityIdentifier = "OnboardingRewardsViewController.OBJoinButton"
         }
         
         let skipButton = CommonViews.secondaryButton().then {

--- a/Client/Frontend/Browser/Onboarding/OnboardingShieldsView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingShieldsView.swift
@@ -84,14 +84,12 @@ extension OnboardingShieldsViewController {
             addSubview(imageView)
             addSubview(mainStackView)
             mainStackView.snp.makeConstraints {
-                $0.leading.equalTo(self.safeArea.leading)
-                $0.trailing.equalTo(self.safeArea.trailing)
-                $0.bottom.equalTo(self.safeArea.bottom)
+                $0.leading.trailing.bottom.equalToSuperview()
             }
             
             descriptionView.addSubview(descriptionStackView)
             descriptionStackView.snp.makeConstraints {
-                $0.edges.equalToSuperview().inset(UX.descriptionContentInset)
+                $0.edges.equalTo(descriptionView.safeArea.edges).inset(UX.descriptionContentInset)
             }
             
             mainStackView.addArrangedSubview(descriptionView)


### PR DESCRIPTION
- Extends the onboarding into the safe-area insets and fixes the animation to match.
- Verified Lottie Animations are 100% updated at this moment in time.. We might still get "new" ones for the `publisher-icon` not being round.. but that's out of the scope of this ticket.

## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-ios/issues/1649

![Simulator Screen Shot - iPhone 11 - 2019-10-15 at 13 00 10](https://user-images.githubusercontent.com/1530031/66852828-d95f5500-ef4b-11e9-9b6f-2167f3e5b032.png)
![Simulator Screen Shot - iPhone 11 - 2019-10-15 at 13 00 14](https://user-images.githubusercontent.com/1530031/66852830-d95f5500-ef4b-11e9-831d-6392a999a250.png)
![Simulator Screen Shot - iPhone 11 - 2019-10-15 at 13 00 19](https://user-images.githubusercontent.com/1530031/66852831-d95f5500-ef4b-11e9-916e-68e384db8542.png)


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
