### PR TITLE
Fix #1647, Fix #1650: Only enable ads by default when current region is supported

### DIFF
--- a/BraveRewards/BraveRewards.framework/Headers/BATBraveAds.h
+++ b/BraveRewards/BraveRewards.framework/Headers/BATBraveAds.h
@@ -41,7 +41,12 @@ NS_SWIFT_NAME(BraveAds)
 
 #pragma mark - Global
 
+/// Whether or not a given region is supported. The region should be a standard
+/// locale identifier, i.e. "en_US"
 + (BOOL)isSupportedRegion:(NSString *)region;
+
+/// Whether or not the users current region (by `NSLocale`) is supported
++ (BOOL)isCurrentRegionSupported;
 
 /// Whether or not to use staging servers. Defaults to false
 @property (nonatomic, class, getter=isDebug) BOOL debug;

--- a/BraveRewardsUI/README.md
+++ b/BraveRewardsUI/README.md
@@ -6,5 +6,5 @@ The latest BraveRewards.framework was built on:
 
 ```
 brave-browser/51350aa972b4df31081360db71bc7cb4f36275b7
-brave-core/f413e099815d86431b9bea8633ce02dc5262446d
+brave-core/dc5776e4409cf53d2a19357d8a546f59a961ceaa
 ```

--- a/BraveRewardsUI/Settings/SettingsViewController.swift
+++ b/BraveRewardsUI/Settings/SettingsViewController.swift
@@ -76,7 +76,7 @@ class SettingsViewController: UIViewController {
       let dollarString = state.ledger.dollarStringForBATAmount(state.ledger.balance?.total ?? 0) ?? ""
       $0.walletSection.setWalletBalance(state.ledger.balanceString, crypto: "BAT", dollarValue: dollarString)
       
-      if !BraveAds.isSupportedRegion(Locale.current.identifier) {
+      if !BraveAds.isCurrentRegionSupported() {
          $0.adsSection.status = .unsupportedRegion
       }
       $0.adsSection.toggleSwitch.isOn = state.ads.isEnabled

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -550,7 +550,7 @@ extension Strings {
     public static let OBSaveButton = NSLocalizedString("OBSaveButton", bundle: Bundle.braveShared, value: "Save", comment: "Save button to save current selection")
     public static let OBFinishButton = NSLocalizedString("OBFinishButton", bundle: Bundle.braveShared, value: "Start browsing", comment: "Button to finish onboarding and start using the app.")
     public static let OBJoinButton = NSLocalizedString("OBJoinButton", bundle: Bundle.braveShared, value: "Join", comment: "Button to join Brave Rewards.")
-    public static let OBShowMeButton = NSLocalizedString("OBShowMeButton", bundle: Bundle.braveShared, value: "Show Me", comment: "Button to show Brave Rewards.")
+    public static let OBTurnOnButton = NSLocalizedString("OBTurnOnButton", bundle: Bundle.braveShared, value: "Turn On", comment: "Button to show Brave Rewards.")
     public static let OBAgreeButton = NSLocalizedString("OBAgreeButton", bundle: Bundle.braveShared, value: "Agree", comment: "Button to agree to Brave's Terms of Service.")
     public static let OBDidntSeeAdButton = NSLocalizedString("OBDidntSeeAdButton", bundle: Bundle.braveShared, value: "I didn't see an ad", comment: "Button to show information on how to enable ads")
     public static let OBSearchEngineTitle = NSLocalizedString("OBSearchEngineTitle", bundle: Bundle.braveShared, value: "Welcome to Brave Browser", comment: "Title for search engine onboarding screen")

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -265,7 +265,7 @@ class BrowserViewController: UIViewController {
         guard let rewards = rewards, rewards.ledger.isEnabled && rewards.ads.isEnabled else { return }
         if Preferences.Rewards.myFirstAdShown.value { return }
         // Check if ads are eligible
-        if BraveAds.isSupportedRegion(Locale.current.identifier) {
+        if BraveAds.isCurrentRegionSupported() {
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 if Preferences.Rewards.myFirstAdShown.value { return }
                 Preferences.Rewards.myFirstAdShown.value = true
@@ -734,7 +734,7 @@ class BrowserViewController: UIViewController {
         // 1. Rewards are on/off (existing user)
         // 2. Ads are now available
         // 3. User hasn't seen the ads part of onboarding yet
-        if BraveAds.isSupportedRegion(Locale.current.identifier)
+        if BraveAds.isCurrentRegionSupported()
             &&
             (Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue)
             &&

--- a/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownViewController.swift
@@ -69,7 +69,7 @@ class OnboardingAdsCountdownViewController: OnboardingViewController, UNUserNoti
 extension OnboardingAdsCountdownViewController {
     
     private func displayMyFirstAdIfAvailable(_ completion: ((AdsNotificationHandler.Action) -> Void)? = nil) {
-        if BraveAds.isSupportedRegion(Locale.current.identifier) {
+        if BraveAds.isCurrentRegionSupported() {
             Preferences.Rewards.myFirstAdShown.value = true
             AdsViewController.displayFirstAd(on: self) { [weak self] action, url  in
                 if action == .opened {

--- a/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
@@ -55,9 +55,9 @@ class OnboardingNavigationController: UINavigationController {
             }
             #else
             switch self {
-            case .newUser: return BraveAds.isSupportedRegion(Locale.current.identifier) ? [.searchEnginePicker, .shieldsInfo, .rewardsInfo, .rewardsAgreement, .adsCountdown] : [.searchEnginePicker, .shieldsInfo, .rewardsInfo, .rewardsAgreement]
-            case .existingUserRewardsOff: return BraveAds.isSupportedRegion(Locale.current.identifier) ? [.rewardsInfo, .rewardsAgreement, .adsCountdown] : []
-            case .existingUserRewardsOn: return BraveAds.isSupportedRegion(Locale.current.identifier) ? [.rewardsInfo, .adsCountdown] : []
+            case .newUser: return BraveAds.isCurrentRegionSupported() ? [.searchEnginePicker, .shieldsInfo, .rewardsInfo, .rewardsAgreement, .adsCountdown] : [.searchEnginePicker, .shieldsInfo, .rewardsInfo, .rewardsAgreement]
+            case .existingUserRewardsOff: return BraveAds.isCurrentRegionSupported() ? [.rewardsInfo, .rewardsAgreement, .adsCountdown] : []
+            case .existingUserRewardsOn: return BraveAds.isCurrentRegionSupported() ? [.rewardsInfo, .adsCountdown] : []
             }
             #endif
         }

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsView.swift
@@ -53,7 +53,7 @@ extension OnboardingRewardsViewController {
         private let titleLabel = CommonViews.primaryText(Strings.OBRewardsTitle)
         
         private let descriptionLabel = CommonViews.secondaryText("").then {
-            $0.attributedText = BraveAds.isSupportedRegion(Locale.current.identifier) ?  Strings.OBRewardsDetailInAdRegion.boldWords(with: $0.font, amount: 2) : Strings.OBRewardsDetailOutsideAdRegion.boldWords(with: $0.font, amount: 1)
+            $0.attributedText = BraveAds.isCurrentRegionSupported() ?  Strings.OBRewardsDetailInAdRegion.boldWords(with: $0.font, amount: 2) : Strings.OBRewardsDetailOutsideAdRegion.boldWords(with: $0.font, amount: 1)
         }
         
         private lazy var textStackView = UIStackView().then { stackView in

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsViewController.swift
@@ -20,7 +20,7 @@ class OnboardingRewardsViewController: OnboardingViewController {
         super.viewDidLoad()
         
         let isRewardsEnabled = rewards?.ledger.isEnabled == true
-        let isAdsRegionSupported = BraveAds.isSupportedRegion(Locale.current.identifier)
+        let isAdsRegionSupported = BraveAds.isCurrentRegionSupported()
         
         // The user is not new..
         if Preferences.General.basicOnboardingProgress.value != OnboardingProgress.none.rawValue || isRewardsEnabled {
@@ -42,5 +42,11 @@ class OnboardingRewardsViewController: OnboardingViewController {
     override func applyTheme(_ theme: Theme) {
         styleChildren(theme: theme)
         contentView.applyTheme(theme)
+    }
+    
+    override func continueTapped() {
+        rewards?.ads.isEnabled = true
+        
+        super.continueTapped()
     }
 }

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsViewController.swift
@@ -30,9 +30,9 @@ class OnboardingRewardsViewController: OnboardingViewController {
             contentView.updateDetailsText(isAdsRegionSupported ? Strings.OBRewardsDetailInAdRegion : Strings.OBRewardsDetailOutsideAdRegion, boldWords: isAdsRegionSupported ? 2 : 1)
         }
         
-        // Last flow has been modified to show "Show Me" instead of "Join"
+        // Last flow has been modified to show "Turn On" instead of "Join"
         if isRewardsEnabled && isAdsRegionSupported {
-            contentView.continueButton.setTitle(Strings.OBShowMeButton, for: .normal)
+            contentView.continueButton.setTitle(Strings.OBTurnOnButton, for: .normal)
         }
         
         contentView.continueButton.addTarget(self, action: #selector(continueTapped), for: .touchUpInside)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Please choose "Rebase" for merge strategy

## Summary of Changes

This pull request fixes issue #1647 
This pull request fixes issue #1650 

Relevant brave-core changes for #1647: https://github.com/brave/brave-core/pull/3701

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- Set region to non-supported ad region, go through onboarding
- Verify ads is disabled due to unsupported region
- Set region to supported ad region, ads onboarding should show "Turn On" button instead of "Show Me"
- After completing onboarding verify that ads is enabled in Brave Rewards settings

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).