### PR TITLE
Fix #1698: Update Japanese translations for Rewards.

### DIFF
--- a/BraveRewardsUI/ja.lproj/Localizable.strings
+++ b/BraveRewardsUI/ja.lproj/Localizable.strings
@@ -1,0 +1,516 @@
+/* Label for auto-contribute toggle. */
+"AutoContributeSwitchLabel" = "自動支援";
+
+/* No comment provided by engineer. */
+"BraveRewards" = "Brave Rewards";
+
+/* No comment provided by engineer. */
+"BraveRewardsAddFunds" = "資金を追加する";
+
+/* No comment provided by engineer. */
+"BraveRewardsAddFundsBody" = "あなたが所有する仮想通貨に合ったアドレスを必ず使用してください。送られた仮想通貨はUpholdによってBATに自動的に変換され、Brave Rewards Wallet上に残高として追加されます。残高に反映されるまでに1時間ほどかかる可能性があります。";
+
+/* No comment provided by engineer. */
+"BraveRewardsAddFundsDisclaimer" = "Brave Walletは一方向です。つまりあなたのBATをパブリッシャーに送ることだけが可能です。Brave Walletについての詳しい情報はFAQをご確認ください。";
+
+/* No comment provided by engineer. */
+"BraveRewardsAddFundsShowQRCode" = "QRコードを表示する";
+
+/* No comment provided by engineer. */
+"BraveRewardsAddFundsTitle" = "外部アカウントからBrave Rewards Walletに仮想通貨を送信してください。";
+
+/* No comment provided by engineer. */
+"BraveRewardsAddFundsTokenWalletAddress" = "ウォレットアドレス";
+
+/* No comment provided by engineer. */
+"BraveRewardsAddFundsVCTitle" = "資金を追加する";
+
+/* No comment provided by engineer. */
+"BraveRewardsAdNotificationsReceived" = "今月受け取った広告通知";
+
+/* No comment provided by engineer. */
+"BraveRewardsAdNotificationTitle" = "Brave Rewards";
+
+/* No comment provided by engineer. */
+"BraveRewardsAdsEstimatedEarnings" = "保留中の推定報酬額";
+
+/* No comment provided by engineer. */
+"BraveRewardsAdsMaxPerDay" = "広告の最大表示件数";
+
+/* No comment provided by engineer. */
+"BraveRewardsAdsPayoutDateFormat" = "MMM d";
+
+/* No comment provided by engineer. */
+"BraveRewardsAdsUnsupportedDvice" = "現時点では、お使いのデバイスではBrave Rewardsと広告は利用できません。";
+
+/* No comment provided by engineer. */
+"BraveRewardsAdsUnsupportedRegion" = "申し訳ございません。お住まいの地域ではまだ広告を利用できません。";
+
+/* No comment provided by engineer. */
+"BraveRewardsAttention" = "アテンション";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContribute" = "自動支援";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeDateFormat" = "MMM d";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeMinimumLength" = "最小の長さ";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeMinimumLengthMessage" = "サイト訪問を記録する最小ページ数";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeMinimumVisits" = "最小訪問数";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeMinimumVisitsMessage" = "パブリッシャー関連度の計算に利用する最小訪問数";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeMonthlyPayment" = "月々の支払額";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeMonthlyPaymentTitle" = "月々の支払額";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeNextDate" = "次の支援支払日";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeRestoreExcludedSites" = "除外した%ldサイトを復元する";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeSupportedSites" = "支援中のサイト";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeToUnverifiedSites" = "未認証サイトへの支援を許可";
+
+/* No comment provided by engineer. */
+"BraveRewardsAutoContributeToVideos" = "動画への支援を許可する";
+
+/* No comment provided by engineer. */
+"BraveRewardsCheckAgain" = "ステータスを更新";
+
+/* No comment provided by engineer. */
+"BraveRewardsContributingToUnverifiedSites" = "支援の受取設定が完了していないクリエーターに％@ BATを送りました。彼らが設定を完了するか、90日が経過するまで送付を試みます。";
+
+/* No comment provided by engineer. */
+"BraveRewardsCreatingWallet" = "ウォレットを作成中";
+
+/* No comment provided by engineer. */
+"BraveRewardsDisabledBody" = "プライバシー重視型の広告を閲覧することで報酬を得て、あなたのお気に入りのサイトを支援することができます。";
+
+/* No comment provided by engineer. */
+"BraveRewardsDisabledEnableButton" = "Brave Rewardsを有効にする";
+
+/* No comment provided by engineer. */
+"BraveRewardsDisabledSubtitle" = "ウェブサイト閲覧で報酬を得よう！";
+
+/* No comment provided by engineer. */
+"BraveRewardsDisabledTitle" = "お帰りなさい！";
+
+/* No comment provided by engineer. */
+"BraveRewardsDisclaimerLearnMore" = "詳しく知る";
+
+/* No comment provided by engineer. */
+"BraveRewardsEarningFromAds" = "広告からの収益";
+
+/* No comment provided by engineer. */
+"BraveRewardsEmptyAutoContribution" = "サイトはブラウザをご利用いただいていると表示されるようになります。";
+
+/* No comment provided by engineer. */
+"BraveRewardsEmptyTipsText" = "今日はもうお気に入りのクリエイターにチップを送りましたか？";
+
+/* No comment provided by engineer. */
+"BraveRewardsEmptyWalletBulletHeader" = "ウォレットの残高を増やす3つの方法";
+
+/* No comment provided by engineer. */
+"BraveRewardsEmptyWalletBulletPoints" = "• 外部ウォレットから資金を追加する• 広告を表示して報酬を獲得する• Braveからの無料のトークン受け取る。通知をお見逃しなく！";
+
+/* No comment provided by engineer. */
+"BraveRewardsEmptyWalletTitle" = "残念、まだ獲得したトークンはありません。";
+
+/* No comment provided by engineer. */
+"BraveRewardsExclude" = "除外";
+
+/* No comment provided by engineer. */
+"BraveRewardsFiveAdsPerHour" = "広告を1時間に5件表示";
+
+/* No comment provided by engineer. */
+"BraveRewardsFourAdsPerHour" = "広告を1時間に4件表示";
+
+/* No comment provided by engineer. */
+"BraveRewardsGrantListExpiresOn" = "有効期限: %@";
+
+/* No comment provided by engineer. */
+"BraveRewardsGrants" = "付与トークン";
+
+/* No comment provided by engineer. */
+"BraveRewardsGrantsClaimedAmountTitle" = "無料の付与トークン";
+
+/* No comment provided by engineer. */
+"BraveRewardsGrantsClaimedExpirationDateTitle" = "付与トークンの有効期限";
+
+/* No comment provided by engineer. */
+"BraveRewardsGrantsClaimedSubtitle" = "あなたの付与トークンは送金中です。";
+
+/* No comment provided by engineer. */
+"BraveRewardsGrantsClaimedTitle" = "今日はラッキーデーです！";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreBody" = "あなたのアテンションは貴重です。 プライバシーを重視する画期的な広告を表示して報酬を獲得し、お気に入りのクリエイターを支援することが可能です。";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreBraveAdsBody" = "関連性が高くプライバシーを重視する広告を表示し報酬を獲得しましょう。";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreBraveAdsTitle" = "広告";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreCreateWallet1" = "参加します！";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreCreateWallet2" = "準備できました！";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreHowItWorks" = "仕組み";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreReady" = "準備はできましたか？";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreSubtitle" = "ウェブサイト閲覧で報酬を得よう！";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreTipsBody" = "ウェブサーフィン中に自動的にサイトを支援したり、好きなタイミングでチップを送ることが可能です。";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreTipsTitle" = "自動支援";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreTurnOnRewardsBody" = "広告と自動支援を有効にします。それぞれ個別にオンまたはオフにできます。";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreTurnOnRewardsTitle" = "Brave Rewardsを有効にする";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreWhyBody" = "従来のブラウザではその貴重なアテンションを広告に向けることで間接的にコンテンツに対価を支払っています。その際、不要な広告やスクリプトをダウンロードするためにあなたの貴重な時間が使われ、しかも個人情報を広告主へ送信してしまっているのです。あなたが知らないうちに。\n\nこれからBraveがあなたを新しいインターネットにご招待いたします。あなたの時間が尊重され、個人情報は守られ、関心に対して報酬が支払われます。";
+
+/* No comment provided by engineer. */
+"BraveRewardsLearnMoreWhyTitle" = "Brave Rewardsの利点";
+
+/* No comment provided by engineer. */
+"BraveRewardsMinimumLengthChoices0" = "5秒";
+
+/* No comment provided by engineer. */
+"BraveRewardsMinimumLengthChoices1" = "8秒";
+
+/* No comment provided by engineer. */
+"BraveRewardsMinimumLengthChoices2" = "1分";
+
+/* No comment provided by engineer. */
+"BraveRewardsMinimumVisitsChoices0" = "訪問数: 1";
+
+/* No comment provided by engineer. */
+"BraveRewardsMinimumVisitsChoices1" = "訪問数: 5";
+
+/* No comment provided by engineer. */
+"BraveRewardsMinimumVisitsChoices2" = "訪問数: 10";
+
+/* No comment provided by engineer. */
+"BraveRewardsMonthlyTips" = "月々のチップ";
+
+/* No comment provided by engineer. */
+"BraveRewardsNoActivitiesYet" = "まだアクティビティがありません…";
+
+/* No comment provided by engineer. */
+"BraveRewardsNotificationAdsTitle" = "Brave Ads";
+
+/* No comment provided by engineer. */
+"BraveRewardsNotificationAutoContributeTitle" = "自動支援";
+
+/* No comment provided by engineer. */
+"BraveRewardsNotificationRecurringTipTitle" = "定期チップ";
+
+/* No comment provided by engineer. */
+"BraveRewardsNotificationTokenGrantTitle" = "付与トークン";
+
+/* No comment provided by engineer. */
+"BraveRewardsNotYetVerified" = "未認証";
+
+/* No comment provided by engineer. */
+"BraveRewardsNumberOfAdsPerHourOptionsTitle" = "1時間あたりの広告表示件数";
+
+/* No comment provided by engineer. */
+"BraveRewardsOneAdPerHour" = "広告を1時間に1件表示";
+
+/* No comment provided by engineer. */
+"BraveRewardsOneTimeTips" = "1回限りのチップ";
+
+/* No comment provided by engineer. */
+"BraveRewardsOpen" = "開く";
+
+/* No comment provided by engineer. */
+"BraveRewardsPanelTitle" = "Rewards";
+
+/* No comment provided by engineer. */
+"BraveRewardsPaymentDate" = "次の支払日";
+
+/* No comment provided by engineer. */
+"BraveRewardsPoweredByUphold" = "Brave WalletはUpholdを使用しています";
+
+/* No comment provided by engineer. */
+"BraveRewardsPublisherSendTip" = "チップを送る";
+
+/* No comment provided by engineer. */
+"BraveRewardsRecurringTipTitle" = "定期チップ";
+
+/* No comment provided by engineer. */
+"BraveRewardsRemove" = "削除";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettings" = "設定";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsAdsBody" = "Braveで広告を見ることでトークンを獲得しましょう。広告はあなたのブラウザの利用履歴を元に推測されたものが表示されますが、全ての個人情報や閲覧履歴はブラウザの中だけに保存され外部に出ることはありません。";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsAdsComingSoonText" = "Coming soon.";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsAdsGrantAmountText" = "広告報酬  %@ 利用可能です";
+
+/* Example: <10 BAT> earned from ads */
+"BraveRewardsSettingsAdsGrantText" = "広告からの収益";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsAdsTitle" = "広告";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsAutoContributeBody" = "パブリッシャーやコンテンツ制作者を自動で支援する方法です。毎月の支払いを設定し、いつも通りにウェブ閲覧しましょう。あなたが訪問するサイトはBraveによって計測されたあなたのアテンションに基づき、あなたからの支援を自動的に受けとります。";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsAutoContributeTitle" = "自動支援";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsDisabledBody1" = "旧来のブラウザでは、 あなたの貴重なアテンションを広告に向けることでウェブ閲覧の支払いをしています。また不要な広告やスクリプトをダウンロードするためにあなたの貴重な時間を消費するだけでなく、個人情報を広告主へ送信しています — あなたの同意もなく。";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsDisabledBody2" = "あなたの時間が尊重され、プライバシーは守られ、更にあなたのアテンションに対して報酬が支払われます。";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsDisabledTitle1" = "Brave Rewardsの利点";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsDisabledTitle2" = "あなたを新しいインターネットへ招待します。";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsGrantClaimButtonTitle" = "受け取る";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsGrantText" = "無料のトークンを受け取ることが可能です";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsTipsBody" = "コンテンツ制作者にチップを送りましょう。毎月定期的に支払われるチップを設定することで、継続的にサイトを支援することができます。";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsTipsTitle" = "チップ";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsTitle" = "設定";
+
+/* No comment provided by engineer. */
+"BraveRewardsSettingsViewDetails" = "詳細を表示";
+
+/* No comment provided by engineer. */
+"BraveRewardsSite" = "サイト";
+
+/* No comment provided by engineer. */
+"BraveRewardsSummaryTitle" = "Rewardsのサマリ";
+
+/* No comment provided by engineer. */
+"BraveRewardsThreeAdsPerHour" = "広告を1時間に3件表示";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingAmountTitle" = "チップする金額";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingConfirmation" = "ありがとうございます";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingMakeMonthly" = "毎月支払う";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingMonthlyTitle" = "次の宛先に自動的にチップを送信しています: ";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingNotEnoughTokens" = "トークンが不足しています。資金を追加してください。";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingOneTimeTitle" = "次の宛先にチップを送信しました:";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingOverviewBody" = "チップを送ることで、このクリエイターをサポートできます。 すばらしいコンテンツを作成してくれたクリエイターに感謝の気持ちを届けましょう。クリエイターは受取設定が完了していれば毎月第1週にチップを受け取ることができます。\n\n毎月の自動的にチップを送り継続的にサポートすることも可能です。";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingOverviewTitle" = "ようこそ！";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingRecurring" = "毎月";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingRecurringDetails" = "初回の定期チップ支払いは次の日付に行われます : ";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingSendMonthlyTip" = "毎月定期チップ支払いを設定する";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingSendTip" = "チップを送る";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingTitle" = "チップを送る";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingUnverifiedDisclaimer" = "注: このクリエイターは、まだBraveユーザーからの支援を受諾する手続きを行っていません。クリエイターが確認するまで、または90日間が経過するまで、支援の送信を継続します。";
+
+/* No comment provided by engineer. */
+"BraveRewardsTippingWalletBalanceTitle" = "ウォレット残高";
+
+/* No comment provided by engineer. */
+"BraveRewardsTips" = "チップ";
+
+/* No comment provided by engineer. */
+"BraveRewardsTipsTotalThisMonth" = "今月のチップ総額";
+
+/* No comment provided by engineer. */
+"BraveRewardsTokens" = "トークン";
+
+/* No comment provided by engineer. */
+"BraveRewardsTotalGrantsClaimed" = "受け取り済みのトークン";
+
+/* No comment provided by engineer. */
+"BraveRewardsTotalSites" = "合計 %Id";
+
+/* No comment provided by engineer. */
+"BraveRewardsTwoAdsPerHour" = "広告を1時間に2件表示";
+
+/* No comment provided by engineer. */
+"BraveRewardsUnverifiedPublisherDisclaimer" = "このクリエイターは、まだBraveユーザーからの支援を受諾する手続きを行っていません。クリエイターの認証確認が終了するまで、送信されたチップはあなたのウォレット内に維持されます。";
+
+/* No comment provided by engineer. */
+"BraveRewardsVerified" = "Brave認証済みパブリッシャー";
+
+/* No comment provided by engineer. */
+"BraveRewardsWalletDetailsTitle" = "ウォレット詳細";
+
+/* No comment provided by engineer. */
+"BraveRewardsWalletHeaderGrants" = "付与トークン";
+
+/* No comment provided by engineer. */
+"BraveRewardsWalletHeaderTitle" = "あなたのウォレット";
+
+/* No comment provided by engineer. */
+"Cancel" = "キャンセル";
+
+/* No comment provided by engineer. */
+"CLAIM" = "受け取る";
+
+/* No comment provided by engineer. */
+"DisclaimerInformation" = "「Brave Rewardsに参加」をクリックすると、利用規約とプライバシーポリシーに同意したと見なされます。";
+
+/* No comment provided by engineer. */
+"MyFirstAdBody" = "詳しくはこちら";
+
+/* No comment provided by engineer. */
+"MyFirstAdTitle" = "これが初めてのBrave Ads(広告)です。";
+
+/* Body for a no network notification */
+"NoNetworkBody" = "Braveリワードサーバーが応答していません。修復作業が終了するまで少々お待ちください。";
+
+/* Title for a no network notification */
+"NoNetworkTitle" = "おっと！";
+
+/* We show this string in the notification when you don't have enough funds for contribution */
+"NotificationAutoContributeNotEnoughFundsBody" = "資金が不十分なため、予定されていたサイトへの自動支援と設定されている毎月支払いチップの支払いを完了できませんでした。30日後に再試行します。";
+
+/* Message for ads launch notification */
+"NotificationBraveAdsLaunchMsg" = "これで今後広告を閲覧することで報酬を獲得できるようになりました。";
+
+/* We show this string in notification when contribution fails */
+"NotificationContributeError" = "支援の処理中にエラーが発生しました。もう一度お試しください。";
+
+/* We show this string in notification when contribution fails */
+"NotificationContributeNotificationError" = "支援の処理中にエラーが発生しました。もう一度お試しください。";
+
+/* We show this string in the notification when contribution is successful */
+"NotificationContributeSuccess" = "%@ BATを支援しました。";
+
+/* We show this string in notification when tip fails */
+"NotificationContributeTipError" = "チップを送信することができませんでした。後ほどもう一度お試しください。";
+
+/* Panel notification text for Ads grant */
+"NotificationEarningsClaimDefault" = "広告閲覧の報酬を受け取りました！";
+
+/* Title for an error notification */
+"NotificationErrorTitle" = "おっと！";
+
+/* Description for new grant notification */
+"NotificationGrantNotification" = "受け取り可能な付与トークンがあります。";
+
+/* Description for new insufficient funds notification */
+"NotificationinsufficientFunds" = "あなたのBrave Rewardsアカウントはデポジットが必要です。";
+
+/* Title for insufficient funds notification */
+"NotificationInsufficientFundsTitle" = "資金不足";
+
+/* Notification title for pending contribution type */
+"NotificationPendingContributionTitle" = "保留中の支援";
+
+/* Notification text that tells user his wallet is under funded for pending contribution to complete */
+"NotificationPendingNotEnoughFunds" = "資金不足のため保留中のチップがあります";
+
+/* Message for monthly tips processed notification */
+"NotificationTipsProcessedBody" = "毎月の定期チップ支払いが処理が完了しました！";
+
+/* Notification text that tells user which publisher just verified */
+"NotificationVerifiedPublisherBody" = "クリエイター : %@ の認証手続きが完了しました";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
+
+/* Text describing the type of contribution */
+"OneTimeText" = "1回限り";
+
+/* This is a suffix statement. example: SomeChannel on Twitter */
+"OnProviderText" = "on %@";
+
+/* No comment provided by engineer. */
+"PrivacyPolicyURL" = "プライバシーポリシー";
+
+/* Text describing the type of contribution */
+"RecurringText" = "定期支払い";
+
+/* No comment provided by engineer. */
+"RewardsOptInDescription" = "プライバシーに配慮した広告を見ると\nトークンを獲得できます。";
+
+/* No comment provided by engineer. */
+"RewardsOptInJoinTitle" = "Rewardsに参加する";
+
+/* No comment provided by engineer. */
+"RewardsOptInLearnMore" = "詳しく知る";
+
+/* No comment provided by engineer. */
+"RewardsOptInPrefix" = "未来のインターネット体験をする準備はできましたか？";
+
+/* No comment provided by engineer. */
+"TermsOfServiceURL" = "利用規約";
+
+/* No comment provided by engineer. */
+"TipSiteMonthly" = "毎月定期支払いチップを設定";
+
+/* Prompt to turn on Ads via notification */
+"TurnOnAds" = "Brave AdsをOnにする";
+
+/* No comment provided by engineer. */
+"WelcomeDisclaimerInformation" = "「参加します」をクリックすると、利用規約とプライバシーポリシーに同意したと見なされます。";
+

--- a/BraveShared/de.lproj/BraveShared.strings
+++ b/BraveShared/de.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Einen Computer hinzufügen";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "QR-Code der Kette scannen";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Navigieren Sie auf Ihrem zweiten mobilen Gerät im Einstellungsbereich zu Synchronisieren und tippen Sie auf den Button \"Synchronisierungscode scannen\". Scannen Sie den untenstehenden QR-Code mit Ihrer Kamera.\nBehandeln Sie diesen Code wie ein Passwort. Wenn eine Person ihn erfährt, kann sie Ihre synchronisierten Daten lesen und ändern.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Dunkel";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Display & Helligkeit";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Diese Einstellungen werden nicht im Privatmodus des Browsers verwendet.";

--- a/BraveShared/es.lproj/BraveShared.strings
+++ b/BraveShared/es.lproj/BraveShared.strings
@@ -188,7 +188,7 @@
 "BraveShieldDefaults" = "Opciones por defecto de Brave Shield";
 
 /* Sync page title */
-"BraveSync" = "Sincroniza";
+"BraveSync" = "Sincronización";
 
 /* Sync settings welcome */
 "BraveSyncWelcome" = "Lo primero que tendrás que hacer es instalar Brave en todos los dispositivos que quieras sincronizar. Para conectarlos entre sí, inicia una cadena de sincronización con la que vincular todos tus dispositivos de forma segura.";
@@ -263,7 +263,7 @@
 "Copied" = "¡Copiado!";
 
 /* Copied codewords title */
-"CopiedToClipboard" = "¡Copiado al portapapeles!";
+"CopiedToClipboard" = "¡Copiado en el portapapeles!";
 
 /* Copy app info to clipboard action sheet action. */
 "CopyAppInfoToClipboard" = "Copiar información de la aplicación en el portapapeles.";
@@ -275,7 +275,7 @@
 "CopyLinkActionTitle" = "Copiar enlace";
 
 /* Copy codewords title */
-"CopyToClipboard" = "Copiar al portapapeles";
+"CopyToClipboard" = "Copiar en el portapapeles";
 
 /* Currently usedd search engines section name. */
 "CurrentlyUsedSearchEngines" = "Utilizado actualmente en buscadores";
@@ -359,10 +359,10 @@
 "EditFolderTitle" = "Editar carpeta";
 
 /* Sync enter code words */
-"EnterCodeWords" = "Ingresa las palabras clave";
+"EnterCodeWords" = "Introduce las palabras clave";
 
 /* Enter sync code words below */
-"EnterCodeWordsBelow" = "Ingresa las palabras clave abajo";
+"EnterCodeWordsBelow" = "Introduce las palabras clave abajo";
 
 /* Description for new folder popup */
 "EnterFolderName" = "Editar nombre de carpeta";
@@ -404,7 +404,7 @@
 "FavoritesRootLevelCellTitle" = "Favoritos";
 
 /* Share action title */
-"FindInPage" = "Encontrar en la página";
+"FindInPage" = "Buscar en página";
 
 /* Done button in Find in Page Toolbar. */
 "FindInPageDoneButtonAccessibilityLabel" = "Listo";
@@ -836,7 +836,7 @@
 "SuppressAlertsActionTitle" = "Suprimir alertas";
 
 /* Sync settings section title */
-"Sync" = "Sincroniza";
+"Sync" = "Sincronización";
 
 /* Add another device cell button. */
 "SyncAddAnotherDevice" = "Añadir otro dispositivo";
@@ -844,14 +844,11 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Añadir un ordenador";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Escanear el código QR de la cadena";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "En su segundo aparato móvil, navega hacia el panel de settings (ajustes) y presione el botón “scan sync code”. Use su camera para escanear el código QR debajo.\nTrate este código como una contraseña. So alguien lo obtiene, lo pueden leer y modificar sus datos sincronizados.";
 
 /* Add device to sync with code words */
-"SyncAddDeviceWords" = "Ingresar el código de sincronización";
+"SyncAddDeviceWords" = "Introduce el código de sincronización";
 
 /* Sync add device description */
 "SyncAddDeviceWordsDescription" = "En su aparato, navega hacia sincroniza en el panel de ajustes y presione el botón “%@” Entre la palabra clave en la cadena de sincronización mostrada debajo.\nTrate este código como una contraseña. So alguien lo obtiene, lo pueden leer y modificar sus datos sincronizados.";
@@ -875,10 +872,10 @@
 "SyncDevices" = "Dispositivos y ajustes";
 
 /* Message for sync initialization error alert */
-"SyncInitErrorMessage" = "El agente de sincronización está actualmente desconectado o no alcanzable. Intente de nuevo más tarde.";
+"SyncInitErrorMessage" = "El agente de sincronización está desconectado u ocupado. Inténtalo de nuevo más tarde.";
 
 /* Title for sync initialization error alert */
-"SyncInitErrorTitle" = "Error de comunicación de sincronización";
+"SyncInitErrorTitle" = "Error de comunicación en la sincronización";
 
 /* No internet connection alert body. */
 "SyncNoConnectionBody" = "Comprueba tu conexión a Internet y vuelve a intentarlo.";
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Oscuro";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Pantalla y brillo";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Estos ajustes no se aplican en el modo de navegación privada.";

--- a/BraveShared/fr.lproj/BraveShared.strings
+++ b/BraveShared/fr.lproj/BraveShared.strings
@@ -404,7 +404,7 @@
 "FavoritesRootLevelCellTitle" = "Favoris";
 
 /* Share action title */
-"FindInPage" = "Rechercher dans la page";
+"FindInPage" = "Rechercher sur la page";
 
 /* Done button in Find in Page Toolbar. */
 "FindInPageDoneButtonAccessibilityLabel" = "Terminé";
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Ajouter un ordinateur";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Scanner le code QR de la chaîne";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Sur votre deuxième appareil mobile, sélectionnez Synchronisation dans le volet des paramètres et appuyez sur le bouton « Scanner un code de synchronisation ». Utilisez votre appareil photo pour scanner le code QR ci-dessous.\nCe code fait office de mot de passe. Si quelqu'un réussit à l'obtenir, cela signifie qu'il pourra lire et modifier vos données synchronisées.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Sombre";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Présentation et luminosité";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Ces réglages ne seront pas appliqués en navigation privée.";

--- a/BraveShared/id-ID.lproj/BraveShared.strings
+++ b/BraveShared/id-ID.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Tambahkan Komputer";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Pindai Kode QR Rantai";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Pada perangkat Anda, navigasilah ke Sinkronisasi di panel Pengaturan, lalu ketuk tombol \"Pindai Kode Sinkronisasi\". Gunakan kamera Anda untuk memindai Kode QR di bawah ini.\nPerlakukan kode ini layaknya kata sandi. Jika seseorang mengetahuinya, mereka dapat membaca dan mengubah data Anda yang telah disinkronisasi.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Gelap";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Tampilan & Kecerahan";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Pengaturan ini tidak diterapkan dalam mode penjelajahan pribadi.";

--- a/BraveShared/it.lproj/BraveShared.strings
+++ b/BraveShared/it.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Aggiungi un computer";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Scansiona il codice QR della catena";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Sul tuo secondo dispositivo mobile, vai a Sincronizza nel pannello Impostazioni e premi il pulsante “Scansiona codice di sincronizzazione”. Usa la fotocamera per scansionare il codice QR sottostante. \nTratta questo codice come una password. Se qualcuno ne entra in possesso, può leggere e modificare i tuoi dati sincronizzati.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Scuro";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Display e luminosità";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Queste impostazioni non vengono applicate nella modalità di navigazione privata.";

--- a/BraveShared/ja.lproj/BraveShared.strings
+++ b/BraveShared/ja.lproj/BraveShared.strings
@@ -8,7 +8,7 @@
 "AccessPhotoDeniedAlertTitle" = "Brave が写真にアクセスしようとしています";
 
 /* Button to add a bookmark */
-"AddBookmark" = "ブックマークを追加";
+"AddBookmark" = "ブックマーク追加";
 
 /* Cell title for add folder action */
 "AddFolderActionCellTitle" = "新しいフォルダ";
@@ -17,7 +17,7 @@
 "AddToFavorites" = "お気に入りに追加";
 
 /* Title for the button to add a new website bookmark. */
-"AddToMenuItem" = "ブックマークに追加";
+"AddToMenuItem" = "ブックマーク追加";
 
 /* individual blocking statistic title */
 "AdsAndTrackers" = "広告とトラッカー";
@@ -322,6 +322,9 @@
 /* Current device model and iOS version copied to clipboard. */
 "DeviceTemplate" = "デバイス %1$@ (%2$@)";
 
+/* Section name for display preferences. */
+"DisplaySettingsSection" = "ディスプレイ";
+
 /* No comment provided by engineer. */
 "Done" = "完了";
 
@@ -425,13 +428,22 @@
 "FingerprintingMethods" = "フィンガープリント";
 
 /* blocking stat title */
-"FingerprintingnProtection" = "指紋\n認証";
+"FingerprintingnProtection" = "フィンガー\nプリント対策";
 
 /* No comment provided by engineer. */
 "FingerprintingProtection" = "フィンガープリント対策";
 
 /* Grand camera access */
 "GrantCameraAccess" = "カメラを有効にする";
+
+/* Context menu item for hiding link previews */
+"HideLinkPreviewsActionTitle" = "リンクプレビューを非表示にする";
+
+/* Hides the rewards icon */
+"HideRewardsIcon" = "Brave Rewardsのアイコンを非表示にする";
+
+/* Hide the rewards icon explination. */
+"HideRewardsIconSubtitle" = "Brave Rewardsが対応していないページでBrave Rewardsのアイコンを非表示にする";
 
 /* Title for history menu item */
 "HistortMenuItem" = "履歴";
@@ -814,6 +826,9 @@
 /* Setting preference to only show the browser tabs bar when the device is in the landscape orientation. */
 "ShowInLandscapeOnly" = "横持ちのときだけ表示";
 
+/* Context menu item for showing link previews */
+"ShowLinkPreviewsActionTitle" = "リンクプレビューを表示する";
+
 /* Accessibility Label for the tabs button in the browser toolbar */
 "ShowTabs" = "タブを表示";
 
@@ -845,7 +860,7 @@
 "SyncAddComputerTitle" = "コンピュータを追加";
 
 /* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "チェーンのQRコードをスキャン";
+"SyncAddDeviceScan" = "同期チェーン用QRコード";
 
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "他のスマートフォンまたはタブレットでBraveを開き、[設定] > [Brave Sync] > {スキャン} と移動します。\nカメラを使って下のQRコードを読み込んでください。\nこのコードをパスワードのように扱ってください。何者かがコードを手に入れた場合、コードを入手した者はあなたが同期したデータを読んだり、変更を加えたりすることができます。";
@@ -1031,7 +1046,7 @@
 "ThemesDarkOption" = "ダーク";
 
 /* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "ディスプレイと明るさの設定";
+"ThemesDisplayBrightness" = "外観";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "これらの設定はプライベートモードには適用されません。";

--- a/BraveShared/ja.lproj/Localizable.strings
+++ b/BraveShared/ja.lproj/Localizable.strings
@@ -1,8 +1,50 @@
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "いいえ";
 
+/* Title for ads onboarding screen */
+"OBAdsTitle" = "この後、初めての広告を表示します";
+
+/* Button to agree to Brave's Terms of Service. */
+"OBAgreeButton" = "同意する";
+
+/* Title for when the user completes onboarding */
+"OBCompleteTitle" = "準備が完了しました。";
+
+/* Button to show information on how to enable ads */
+"OBDidntSeeAdButton" = "広告が表示されませんでした。";
+
+/* A generic error body for onboarding */
+"OBErrorDetails" = "ウォレット作成中にエラーが発生しました。もう一度お試しください。";
+
+/* No comment provided by engineer. */
+"OBErrorOkay" = "OK";
+
+/* A generic error title for onboarding */
+"OBErrorTitle" = "申し訳ございません";
+
 /* Button to finish onboarding and start using the app. */
 "OBFinishButton" = "ブラウジングを開始する";
+
+/* Button to join Brave Rewards. */
+"OBJoinButton" = "参加する";
+
+/* Detail text for rewards agreement onboarding screen */
+"OBRewardsAgreementDetail" = "Brave Rewardsに同意する";
+
+/* Detail text for rewards agreement onboarding screen */
+"OBRewardsAgreementDetailLink" = "利用規約";
+
+/* Title for rewards agreement onboarding screen */
+"OBRewardsAgreementTitle" = "Brave Rewardsの利用規約に同意する";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetailInAdRegion" = "プライバシー重視型の広告を閲覧することで報酬を得て、あなたのお気に入りのクリエイターやサイトを支援することができます。";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetailOutsideAdRegion" = "ウェブサーフィン中に自動的にサイトを支援したり、好きなタイミングでチップを送ることが可能です。";
+
+/* Title for rewards onboarding screen */
+"OBRewardsTitle" = "Brave Rewards";
 
 /* Save button to save current selection */
 "OBSaveButton" = "保存";
@@ -18,6 +60,9 @@
 
 /* Title for shields onboarding screen */
 "OBShieldsTitle" = "Brave Shields";
+
+/* Button to show Brave Rewards. */
+"OBShowMeButton" = "表示する";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "続ける";

--- a/BraveShared/ko-KR.lproj/BraveShared.strings
+++ b/BraveShared/ko-KR.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "컴퓨터 추가";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "체인 QR 코드 스캔";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "두 번째 기기에서 설정 패널에 있는 동기화로 이동한 다음 \"동기화 코드 스캔\" 버튼을 탭합니다. 카메라를 사용하여 아래 QR 코드를 스캔합니다.\n 이 코드는 일종의 비밀번호로 취급하십시오. 이 코드를 확보한 사람은 귀하의 동기화 데이터를 읽고 변조할 수 있습니다.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "어두움";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "디스플레이 및 밝기";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "이 설정은 비공개 브라우징 모드에는 적용되지 않습니다.";

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Tambah satu Komputer";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Imbas Kod QR Rantai";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Pada peranti mudah alih kedua anda, navigasi ke Segerak dalam panel Tetapan dan ketik butang \"Imbas Kod Segerak\". Gunakan kamera anda untuk mengimbas Kod QR di bawah.\nAnggapkan kod ini sebagai kata laluan. Jika orang lain mendapat kod ini, mereka boleh membaca dan mengubah suai data anda yang disegerakkan. ";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Gelap";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Paparan & Kecerahan";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Tetapan ini tidak terpakai dalam mod pelayaran peribadi.";

--- a/BraveShared/nb.lproj/BraveShared.strings
+++ b/BraveShared/nb.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Legg til en datamaskin";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Skann kjedens QR-kode";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "På den andre mobilenheten går du til Sync på panelet Innstillinger på enheten og trykker på knappen «Skann synkkode». Bruk kameraet til å skanne QR-koden som er vist nedenfor.\nDu må behandle koden som et passord. Hvis noen får tak i den, kan de lese og endre de synkroniserte dataene.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Mørk";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Skjerm og lysstyrke";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Disse innstillingene brukes ikke i privat nettlesermodus.";

--- a/BraveShared/pl.lproj/BraveShared.strings
+++ b/BraveShared/pl.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Dodaj komputer";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Skanuj kod QR łańcucha";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Na drugim urządzeniu mobilnym przejdź do obszaru Synchronizacja w panelu Ustawienia i dotknij przycisku „Skanuj kod synchronizacji”. Skorzystaj z aparatu, aby zeskanować poniższy kod QR.\n Traktuj ten kod jak hasło. Jeśli ktoś go pozna, będzie mógł odczytać i zmodyfikować synchronizowane dane.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Ciemny";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Wyświetlanie i jasność";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Ustawienia te nie są stosowane w trybie przeglądania prywatnego.";

--- a/BraveShared/pt-BR.lproj/BraveShared.strings
+++ b/BraveShared/pt-BR.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Adicionar um computador";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Ler código QR da cadeia";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "No seu segundo dispositivo móvel, navegue até a opção \"Sincronizar\" do painel \"Configurações\" e toque no botão \"Ler código de sincronização\". Use sua câmera para ler o código QR abaixo.\n Trate esse código como uma senha. Se outra pessoa tiver acesso a ele, ela poderá ler e modificar seus dados sincronizados.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Escuro";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Exibição e brilho";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Essas configurações não são aplicadas no modo de navegação privada.";

--- a/BraveShared/ru.lproj/BraveShared.strings
+++ b/BraveShared/ru.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Добавьте компьютер";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Сканируйте QR-код цепочки";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Запустите Brave на втором мобильном устройстве и откройте настройки. Перейдите в раздел «Синхронизация» и нажмите «Сканировать код синхронизации». Сканируйте QR-код ниже с помощью камеры.\nОтноситесь к этому коду как к паролю. Не сообщайте его никому, иначе другие пользователи смогут просматривать и изменять ваши синхронизированные данные.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Тёмная тема";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Экран и яркость";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Эти настройки не применяются в приватном режиме.";

--- a/BraveShared/sv.lproj/BraveShared.strings
+++ b/BraveShared/sv.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Lägg till en dator";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Skanna kedje-QR-kod";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "På din andra mobila enhet navigerar du till synkronisering på panelen för inställningar och trycker på knappen \"Skanna synkroniseringskod\". Använd din kamera för att skanna QR koden nedan.\nBehandla den här koden som ett lösenord. Om någon får tag i den kan de läsa och ändra dina synkroniserade data.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Mörk";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Skärm och ljusstyrka";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Dessa inställningar tillämpas inte i privat surfläge.";

--- a/BraveShared/uk.lproj/BraveShared.strings
+++ b/BraveShared/uk.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "Додавання комп’ютера";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "Сканування QR-коду ланцюжка";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "На другому мобільному пристрої перейдіть до меню «Синхронізація» в панелі налаштувань і торкніться кнопки «Сканувати код синхронізації». Відскануйте наведений нижче QR-код за допомогою камери.\n Цей код виконує функції пароля. Якщо хтось дізнається його, то зможе переглядати та змінювати ваші синхронізовані дані.";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "Темна";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "Відображення та яскравість";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "Ці налаштування не застосовуються в приватному режимі.";

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "新增電腦";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "掃瞄鏈接 QR 碼";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "在第二部行動裝置上導向至設定面板中的同步並點選「掃描同步代碼」按鈕。使用相機掃描下方的 QR 碼。\n將此代碼視為密碼。如某人取得該密碼，其可讀取並修改您同步的資料。";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "暗";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "顯示及亮度";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "這些設定不適用於私密瀏覽模式。";

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -844,9 +844,6 @@
 /* Add a Computer title */
 "SyncAddComputerTitle" = "添加计算机";
 
-/* Add mobile device to sync with scan */
-"SyncAddDeviceScan" = "扫描链接二维码";
-
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "在您的第二个移动设备上，导航到设置面板中的“同步”，点击“扫描同步代码”按钮。用您的摄像头扫描下面的二维码。\n 将此代码视作密码。如果有人得到它，他们可以读取和修改您的同步数据。";
 
@@ -1029,9 +1026,6 @@
 
 /* Selection to color/style the user interface with a dark theme */
 "ThemesDarkOption" = "暗";
-
-/* Setting to choose the user interface theme for normal browsing mode, contains choices like 'light' or 'dark' themes */
-"ThemesDisplayBrightness" = "显示和亮度";
 
 /* Text specifying that the above setting does not impact the user interface while they user is in private browsing mode. */
 "ThemesDisplayBrightnessFooter" = "这些设置未应用到私有浏览模式。";

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0A0D3D6121A596BE00BEE65B /* MalwareList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0D3D6021A596BE00BEE65B /* MalwareList.swift */; };
 		0A19362F234D44DB002E2B81 /* AppearanceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19362E234D44DB002E2B81 /* AppearanceAttributes.swift */; };
 		0A19365423508756002E2B81 /* LinkPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19365323508756002E2B81 /* LinkPreviewViewController.swift */; };
+		0A1CBCFD23571EFA004DA73F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0A1CBCFB23571EFA004DA73F /* Localizable.strings */; };
 		0A1E842D21909CA70042F782 /* crypto.js in Resources */ = {isa = PBXBuildFile; fileRef = 0A1E842C21909CA70042F782 /* crypto.js */; };
 		0A1E842F21909CBC0042F782 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 0A1E842E21909CBB0042F782 /* bundle.js */; };
 		0A1E843121909CC40042F782 /* fetch.js in Resources */ = {isa = PBXBuildFile; fileRef = 0A1E843021909CC30042F782 /* fetch.js */; };
@@ -1172,6 +1173,7 @@
 		03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelativeDatesTests.swift; sourceTree = "<group>"; };
 		0A063D4A22EB2945001CE50B /* libadblock.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libadblock.a; sourceTree = "<group>"; };
 		0A063D4B22EB2945001CE50B /* ablock_rust_lib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ablock_rust_lib.h; sourceTree = "<group>"; };
+		0A0B951123571EF200E6543A /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A0D3D3821A4BD0600BEE65B /* SafeBrowsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeBrowsing.swift; sourceTree = "<group>"; };
 		0A0D3D3B21A4BE6400BEE65B /* adblock-list.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "adblock-list.txt"; sourceTree = "<group>"; };
 		0A0D3D3D21A4BE6C00BEE65B /* simple_malware.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = simple_malware.txt; sourceTree = "<group>"; };
@@ -1180,6 +1182,8 @@
 		0A0D3D6021A596BE00BEE65B /* MalwareList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareList.swift; sourceTree = "<group>"; };
 		0A19362E234D44DB002E2B81 /* AppearanceAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceAttributes.swift; sourceTree = "<group>"; };
 		0A19365323508756002E2B81 /* LinkPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewViewController.swift; sourceTree = "<group>"; };
+		0A1CBCFC23571EFA004DA73F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0A1CBCFE23571EFA004DA73F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A1E841B219095410042F782 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		0A1E842C21909CA70042F782 /* crypto.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = crypto.js; path = "node_modules/brave-sync/node_modules/brave-crypto/browser/crypto.js"; sourceTree = SOURCE_ROOT; };
 		0A1E842E21909CBB0042F782 /* bundle.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = bundle.js; path = "node_modules/brave-sync/bundles/bundle.js"; sourceTree = SOURCE_ROOT; };
@@ -1215,6 +1219,7 @@
 		0A24F845233EB5B5004D2F3A /* BundleId.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BundleId.xcconfig; sourceTree = "<group>"; };
 		0A24F846233EB5B5004D2F3A /* Fennec.enterprise.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Fennec.enterprise.xcconfig; sourceTree = "<group>"; };
 		0A24F847233EB5B5004D2F3A /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
+		0A2D5DF623571F02001ED889 /* ko-KR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ko-KR"; path = "ko-KR.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0A2F921B22146B7700304249 /* FrecencyQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrecencyQuery.swift; sourceTree = "<group>"; };
 		0A38EA7F216532DB00142710 /* CRUDProtocolsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRUDProtocolsTests.swift; sourceTree = "<group>"; };
 		0A39D56C21930B89008B2772 /* ScriptOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptOpener.swift; sourceTree = "<group>"; };
@@ -1239,15 +1244,19 @@
 		0A4BEFD7221EE78E0005551A /* CachedNetworkResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedNetworkResource.swift; sourceTree = "<group>"; };
 		0A4BEFD9221EF3360005551A /* NetworkResourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResourceType.swift; sourceTree = "<group>"; };
 		0A4BEFDD221F03C80005551A /* NetworkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerTests.swift; sourceTree = "<group>"; };
+		0A529EBB23571F1800DDAFDD /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A53F3E621E6560A0086E80C /* InMemoryDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryDataController.swift; sourceTree = "<group>"; };
 		0A6112AB230B00E7001BBC45 /* OnboardingNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNavigationController.swift; sourceTree = "<group>"; };
 		0A6112BC230B4306001BBC45 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
+		0A67500A23571F21006A6D00 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A6E095E230E05BC00AB3F19 /* onboarding-shields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-shields.json"; sourceTree = "<group>"; };
+		0A75A3BD23571F2B00013540 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0A764F30230EE5CA003A1D9B /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
 		0A771D34218C8FDC00336E0D /* Bookmark+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmark+Sync.swift"; sourceTree = "<group>"; };
 		0A7B5D6622689C5D00AADF22 /* AddEditHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditHeaderView.swift; sourceTree = "<group>"; };
 		0A7B5D6F2269E72C00AADF22 /* BookmarkSaveLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSaveLocation.swift; sourceTree = "<group>"; };
 		0A7B5D712269E7AD00AADF22 /* BookmarkEditMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkEditMode.swift; sourceTree = "<group>"; };
+		0A86268423571F3300FD4C11 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A8C6992225BC7B100988715 /* ToolbarUrlActionsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarUrlActionsProtocol.swift; sourceTree = "<group>"; };
 		0A8C69AA225CFCAF00988715 /* AddEditBookmarkTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkTableViewController.swift; sourceTree = "<group>"; };
 		0A8C69B4225DE99700988715 /* BookmarkDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkDetailsView.swift; sourceTree = "<group>"; };
@@ -1257,11 +1266,13 @@
 		0A917390231D173C0069A08B /* AppReviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReviewTests.swift; sourceTree = "<group>"; };
 		0A93F17F2264C2D200A3571B /* FolderDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderDetailsView.swift; sourceTree = "<group>"; };
 		0A93F1882264C72000A3571B /* BookmarkFormFieldsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFormFieldsProtocol.swift; sourceTree = "<group>"; };
+		0A95EF7A23571F3A001385A3 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A9B6A3420E6453400712BC9 /* Model8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model8.xcdatamodel; sourceTree = "<group>"; };
 		0AA029F7222E899400D6B535 /* Bookmark+Reorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmark+Reorder.swift"; sourceTree = "<group>"; };
 		0AA21E472302C4CC00358988 /* webauth_verify_key.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = webauth_verify_key.json; sourceTree = "<group>"; };
 		0AA21E482302C4CC00358988 /* webauth_insert_key.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = webauth_insert_key.json; sourceTree = "<group>"; };
 		0AA21E492302C4CC00358988 /* webauth_touch_key.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = webauth_touch_key.json; sourceTree = "<group>"; };
+		0AA490CD23571F440098D1FF /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Storage.strings; sourceTree = "<group>"; };
 		0AA4AA98231849440009AAEF /* ABPFilterParserData.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = ABPFilterParserData.dat; sourceTree = "<group>"; };
 		0AA4FC382109D685000B173A /* CRUDProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRUDProtocols.swift; sourceTree = "<group>"; };
 		0AAAAC962249174A009A8763 /* SyncAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAlerts.swift; sourceTree = "<group>"; };
@@ -1273,11 +1284,14 @@
 		0AADC4D120D2A6A200FDE368 /* PreloadedFavorites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreloadedFavorites.swift; sourceTree = "<group>"; };
 		0AADC4D620D2B03900FDE368 /* BraveShieldStatsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BraveShieldStatsView.swift; sourceTree = "<group>"; };
 		0AB2442B22AA789B00B4D9DD /* ReaderModeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeButton.swift; sourceTree = "<group>"; };
+		0AB70C6A23571F4C00E9C2C8 /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/Storage.strings; sourceTree = "<group>"; };
 		0AC0D399233E7CAF0091EFA5 /* ObjcExceptionBridging.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ObjcExceptionBridging.framework; path = Carthage/Build/iOS/ObjcExceptionBridging.framework; sourceTree = "<group>"; };
 		0AC0D3A9233E86E50091EFA5 /* sqlcipher.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = sqlcipher.xcodeproj; sourceTree = "<group>"; };
 		0AC0D3BF233E889D0091EFA5 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/Storage.strings; sourceTree = "<group>"; };
 		0AC0D3C1233E889D0091EFA5 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0AC8E23A22A6C56D0064F3FA /* libYubiKit.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libYubiKit.a; path = ThirdParty/YubiKit/libYubiKit.a; sourceTree = "<group>"; };
+		0ACB38EA23571F5600DDC245 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/Storage.strings"; sourceTree = "<group>"; };
+		0ACB3BF723571ED1000AC688 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Storage.strings; sourceTree = "<group>"; };
 		0AD4FEE9223A9A5500E00C05 /* BundledJSProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledJSProtocol.swift; sourceTree = "<group>"; };
 		0AD4FEEB223A9C1300E00C05 /* BrowserifiedJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserifiedJS.swift; sourceTree = "<group>"; };
 		0AD4FEED223AA09D00E00C05 /* BrowserifyExposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserifyExposable.swift; sourceTree = "<group>"; };
@@ -1288,9 +1302,11 @@
 		0AD5E9C32200591F00D0D91B /* BraveShield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveShield.swift; sourceTree = "<group>"; };
 		0AD9F88022F049E5008B4D95 /* AdblockRustEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdblockRustEngine.swift; sourceTree = "<group>"; };
 		0AD9F88D22F05376008B4D95 /* AdblockRustTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdblockRustTests.swift; sourceTree = "<group>"; };
+		0ADAFD9223571ED700C8669B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Storage.strings; sourceTree = "<group>"; };
 		0ADCD4512319640F0078CC67 /* UserAgentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentBuilder.swift; sourceTree = "<group>"; };
 		0ADCD45A231973650078CC67 /* UserAgentBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentBuilderTests.swift; sourceTree = "<group>"; };
 		0AE5C09822CAA01E00DFF3EE /* RewardsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsButton.swift; sourceTree = "<group>"; };
+		0AE885BC23571EE1006951A8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Storage.strings; sourceTree = "<group>"; };
 		0AEF99A822E22C5E00294C76 /* DownloadsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsViewController.swift; sourceTree = "<group>"; };
 		0AEF99B122E22D2200294C76 /* DateGroupedTableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateGroupedTableData.swift; sourceTree = "<group>"; };
 		0AEFB84822244135007AF600 /* AdblockDebugMenuTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdblockDebugMenuTableViewController.swift; sourceTree = "<group>"; };
@@ -1306,6 +1322,7 @@
 		0AF3B4EB213D8E3300695962 /* DeviceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceTests.swift; sourceTree = "<group>"; };
 		0AF3B4EC213D8E3300695962 /* TabMOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabMOTests.swift; sourceTree = "<group>"; };
 		0AF6845A2191D6470079EC77 /* bookmark_util.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = bookmark_util.js; sourceTree = "<group>"; };
+		0AF89E5A23571EE80074E1EF /* id-ID */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "id-ID"; path = "id-ID.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0B3E7D931B27A7CE00E2E84D /* AboutHomeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutHomeHandler.swift; sourceTree = "<group>"; };
 		0B3E7DB91B27AB4C00E2E84D /* MockLogins.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MockLogins.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0B54BD181B698B7C004C822C /* SuggestedSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuggestedSites.swift; sourceTree = "<group>"; };
@@ -2779,6 +2796,7 @@
 				271DEC3B234CC7ED009DAC37 /* Welcome */,
 				271DEC1B234CC75F009DAC37 /* BraveRewardsUI.h */,
 				271DEC1C234CC75F009DAC37 /* Info.plist */,
+				0A1CBCFB23571EFA004DA73F /* Localizable.strings */,
 			);
 			indentWidth = 2;
 			path = BraveRewardsUI;
@@ -5105,6 +5123,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				271DED0A234CC7EF009DAC37 /* Images.xcassets in Resources */,
+				0A1CBCFD23571EFA004DA73F /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6233,10 +6252,33 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		0A1CBCFB23571EFA004DA73F /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0A1CBCFC23571EFA004DA73F /* ja */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 		0AC0D3BE233E889D0091EFA5 /* Storage.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
 				0AC0D3BF233E889D0091EFA5 /* ms */,
+				0ACB3BF723571ED1000AC688 /* de */,
+				0ADAFD9223571ED700C8669B /* es */,
+				0AE885BC23571EE1006951A8 /* fr */,
+				0AF89E5A23571EE80074E1EF /* id-ID */,
+				0A0B951123571EF200E6543A /* it */,
+				0A1CBCFE23571EFA004DA73F /* ja */,
+				0A2D5DF623571F02001ED889 /* ko-KR */,
+				0A529EBB23571F1800DDAFDD /* nb */,
+				0A67500A23571F21006A6D00 /* pl */,
+				0A75A3BD23571F2B00013540 /* pt-BR */,
+				0A86268423571F3300FD4C11 /* ru */,
+				0A95EF7A23571F3A001385A3 /* sv */,
+				0AA490CD23571F440098D1FF /* uk */,
+				0AB70C6A23571F4C00E9C2C8 /* zh */,
+				0ACB38EA23571F5600DDC245 /* zh-TW */,
 			);
 			name = Storage.strings;
 			sourceTree = "<group>";

--- a/Client/es.lproj/Localizable.strings
+++ b/Client/es.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "touchKeyCancel" = "Cancelar";
 
 /* Message for touch key modal. */
-"touchKeyMessage" = "Pulsa la clave para finalizar la solicitud de";
+"touchKeyMessage" = "Pulsa la clave para finalizar la solicitud de ";
 
 /* Title when PIN code is being verified. */
 "verificationPending" = "Verificando tu PIN de";

--- a/Client/fr.lproj/InfoPlist.strings
+++ b/Client/fr.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
 /* (No Comment) */
-"1Password Fill Browser Action" = "1Password Fill Browser Action";
+"1Password Fill Browser Action" = "Remplir les mots de passe avec 1Password";
 
 /* (No Comment) */
 "NSCameraUsageDescription" = "Cette option vous permet de prendre des photos et de les importer.";


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1698 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Set device's region and language to Japanese, test out Rewards UI

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="544" alt="Zrzut ekranu 2019-10-16 o 14 58 02" src="https://user-images.githubusercontent.com/6950387/66921640-eb152b00-f025-11e9-8554-c43f07927013.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
