### PR TITLE
Fix #1689: Display the correct BAT value for one-time-tips

### DIFF
--- a/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
@@ -192,17 +192,19 @@ extension TipsDetailViewController: UITableViewDataSource, UITableViewDelegate {
       cell.siteImageView.image = UIImage(frameworkResourceNamed: "defaultFavicon")
       setFavicon(identifier: tip.id, pageURL: tip.url, faviconURL: tip.faviconUrl)
       cell.verifiedStatusImageView.isHidden = tip.status != .verified
+      let contribution = tip.weight
       switch tip.rewardsCategory {
       case .oneTimeTip:
         cell.typeNameLabel.text = Strings.OneTimeText + Date.stringFrom(reconcileStamp: tip.reconcileStamp)
+        cell.tokenView.batContainer.amountLabel.text = BATValue(probi: "\(contribution)")?.displayString
       case .recurringTip:
+        cell.tokenView.batContainer.amountLabel.text = BATValue(contribution).displayString
         cell.typeNameLabel.text = Strings.RecurringText
       default:
+        cell.tokenView.batContainer.amountLabel.text = ""
         cell.typeNameLabel.text = ""
       }
-      let contribution = tip.weight
-      cell.tokenView.batContainer.amountLabel.text = "\(contribution)"
-      cell.tokenView.usdContainer.amountLabel.text = state.ledger.dollarStringForBATAmount(contribution)
+      cell.tokenView.usdContainer.amountLabel.text = state.ledger.dollarStringForBATAmount(contribution, includeCurrencyCode: false)
       return cell
     }
   }


### PR DESCRIPTION
Also fixes the duplication of "USD" in the tips list

## Summary of Changes

This pull request fixes issue #1689 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- Add a recurring tip for a publisher
- Add a one time tip for a publisher
- Verify in the rewards settings → tips details that the list displays all BAT values as regular decimals amounts (i.e. "1.0 BAT")
- Verify that USD is not repeated

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).