### PR TITLE
Fix #1705: Fix incorrect title when changing monthly AC payment value

### DIFF
--- a/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
@@ -21,8 +21,6 @@ class BATValueOptionsSelectionViewController: OptionsSelectionViewController<BAT
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    
-    self.title = Strings.RecurringTipTitle
   }
   
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -365,6 +365,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
         }
       })
       
+      optionsVC.title = Strings.RecurringTipTitle
       self.navigationController?.pushViewController(optionsVC, animated: true)
     })
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1705 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- View the monthly payment setting screen in Auto Contribute settings, verify title is not recurring tips
- Setup a recurring tip on a user, verify when trying to edit said tip amount from the main wallet panel that it's title is "recurring tip" still

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).