### PR TITLE
Fix #1643: Add Brave Rewards settings in Other Settings section 

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -300,8 +300,11 @@ extension Strings {
     public static let ClearPrivateData = NSLocalizedString("ClearPrivateData", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Clear Private Data", comment: "Button in settings that clears private data for the selected items. Also used as section title in settings panel")
     public static let DisplaySettingsSection = NSLocalizedString("DisplaySettingsSection", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Display", comment: "Section name for display preferences.")
     public static let OtherSettingsSection = NSLocalizedString("OtherSettingsSection", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Other Settings", comment: "Section name for other settings.")
+    public static let BraveRewardsTitle = NSLocalizedString("BraveRewardsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Brave Rewards", comment: "Brave Rewards settings title")
     public static let HideRewardsIcon = NSLocalizedString("HideRewardsIcon", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Hide Brave Rewards Icon", comment: "Hides the rewards icon")
     public static let HideRewardsIconSubtitle = NSLocalizedString("HideRewardsIconSubtitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Hides the Brave Rewards icon when Brave Rewards is not enabled", comment: "Hide the rewards icon explination.")
+    public static let WalletCreationDate = NSLocalizedString("WalletCreationDate", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Wallet Creation Date", comment: "The date your wallet was created")
+    public static let CopyWalletSupportInfo = NSLocalizedString("CopyWalletSupportInfo", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Copy Support Info", comment: "Copy rewards internals info for support")
 }
 
 // MARK:- Error pages.

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -285,6 +285,8 @@
 		27A586E1214C0DDD000CAE3C /* PreferencesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */; };
 		27C461DE211B76500088A441 /* ShieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C461DD211B76500088A441 /* ShieldsView.swift */; };
 		27C46201211CD8D20088A441 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
+		27D114D42358FBBF00166534 /* BraveRewardsSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D114D32358FBBF00166534 /* BraveRewardsSettingsViewController.swift */; };
+		27D114D62358FCA400166534 /* SettingsRowViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D114D52358FCA400166534 /* SettingsRowViews.swift */; };
 		27D87C2E2152B50200FB55C6 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D87C2D2152B50200FB55C6 /* GradientView.swift */; };
 		27F4439F2135E11200296C58 /* BraveShareTo.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 27F443952135E11200296C58 /* BraveShareTo.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		27F443AD2135E25300296C58 /* ShareToBraveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F443AC2135E25300296C58 /* ShareToBraveViewController.swift */; };
@@ -1492,6 +1494,8 @@
 		279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = FingerprintingProtection.js; sourceTree = "<group>"; };
 		27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTest.swift; sourceTree = "<group>"; };
 		27C461DD211B76500088A441 /* ShieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsView.swift; sourceTree = "<group>"; };
+		27D114D32358FBBF00166534 /* BraveRewardsSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveRewardsSettingsViewController.swift; sourceTree = "<group>"; };
+		27D114D52358FCA400166534 /* SettingsRowViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowViews.swift; sourceTree = "<group>"; };
 		27D87C2D2152B50200FB55C6 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		27D922B221C9830F00345BF3 /* Model9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model9.xcdatamodel; sourceTree = "<group>"; };
 		27F443952135E11200296C58 /* BraveShareTo.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BraveShareTo.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3267,6 +3271,8 @@
 				A1CA29C320E1746A00CB9126 /* OptionSelectionViewController.swift */,
 				A16DC67E20E585D90069C8E1 /* PasscodeSettingsViewController.swift */,
 				0AEFB84822244135007AF600 /* AdblockDebugMenuTableViewController.swift */,
+				27D114D32358FBBF00166534 /* BraveRewardsSettingsViewController.swift */,
+				27D114D52358FCA400166534 /* SettingsRowViews.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -5832,6 +5838,7 @@
 				5E4845C222DE3DF800372022 /* WindowRenderHelperScript.swift in Sources */,
 				27F94A3A21909A5900F4FADF /* SearchSuggestionsPromptView.swift in Sources */,
 				C690C208212FF35100E6EEE9 /* WebImageCacheWithNoPrivacyProtectionManager.swift in Sources */,
+				27D114D42358FBBF00166534 /* BraveRewardsSettingsViewController.swift in Sources */,
 				0A4BEFDA221EF3360005551A /* NetworkResourceType.swift in Sources */,
 				4422D4B921BFFB7600BF1855 /* crc32c.cc in Sources */,
 				592F521E2217327C0078395E /* HttpCookieExtension.swift in Sources */,
@@ -6145,6 +6152,7 @@
 				D3E8EF101B97BE69001900FB /* ClearPrivateDataTableViewController.swift in Sources */,
 				4422D4B421BFFB7600BF1855 /* hash.cc in Sources */,
 				5E612A8E234B7FC8007D12B5 /* OnboardingRewardsView.swift in Sources */,
+				27D114D62358FCA400166534 /* SettingsRowViews.swift in Sources */,
 				4422D56621BFFB7F00BF1855 /* tostring.cc in Sources */,
 				4422D54821BFFB7E00BF1855 /* pcre.cc in Sources */,
 				C8F457AA1F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift in Sources */,

--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Static
+import Shared
+import BraveShared
+import BraveRewards
+import BraveRewardsUI
+
+private extension ContributionRetry {
+    var name: String {
+        switch self {
+        case .stepCurrent: return "Current"
+        case .stepFinal: return "Final"
+        case .stepNo: return "No"
+        case .stepPayload: return "Payload"
+        case .stepPrepare: return "Prepare"
+        case .stepProof: return "Proof"
+        case .stepReconcile: return "Reconcile"
+        case .stepRegister: return "Register"
+        case .stepViewing: return "Viewing"
+        case .stepVote: return "Vote"
+        case .stepWinners: return "Winners"
+        default: return "Unknown"
+        }
+    }
+}
+
+class BraveRewardsSettingsViewController: TableViewController {
+    
+    let rewards: BraveRewards
+    
+    init(_ rewards: BraveRewards) {
+        self.rewards = rewards
+        super.init(style: .grouped)
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        title = Strings.BraveRewardsTitle
+        
+        var hideIconRow = BoolRow(title: Strings.HideRewardsIcon, option: Preferences.Rewards.hideRewardsIcon)
+        hideIconRow.detailText = Strings.HideRewardsIconSubtitle
+        hideIconRow.cellClass = MultilineSubtitleCell.self
+        
+        dataSource.sections = [
+            Section(rows: [
+                hideIconRow
+            ])
+        ]
+        
+        if rewards.ledger.isWalletCreated {
+            let dateFormatter = DateFormatter().then {
+                $0.dateStyle = .short
+            }
+            var walletCreatedDate: String = "-"
+            self.rewards.ledger.rewardsInternalInfo { info in
+                guard let info = info else { return }
+                walletCreatedDate = dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(info.bootStamp)))
+            }
+            
+            dataSource.sections += [
+                Section(rows: [
+                    Row(text: Strings.WalletCreationDate, detailText: walletCreatedDate, selection: {
+                        let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+                        sheet.addAction(UIAlertAction(title: Strings.CopyWalletSupportInfo, style: .default, handler: { [unowned self] _ in
+                            self.rewards.ledger.rewardsInternalInfo { info in
+                                guard let info = info else { return }
+                                var supportInfo = """
+                                Key Info Seed: \(info.isKeyInfoSeedValid ? "Valid" : "Invalid")
+                                Wallet Payment ID: \(info.paymentId)
+                                Persona ID: \(info.personaId)
+                                User ID: \(info.userId)
+                                Wallet created: \(walletCreatedDate)
+                                """
+                                if info.currentReconciles.count > 0 {
+                                    supportInfo += "\nReconciles:"
+                                    for (viewingId, reconcile) in info.currentReconciles {
+                                        supportInfo += """
+                                        
+                                        \t\(viewingId):
+                                        \t\tAmount: \(reconcile.amount)
+                                        \t\tRetry Step: \(reconcile.retryStep.name)
+                                        \t\tRetry Level: \(reconcile.retryLevel)
+                                        """
+                                    }
+                                }
+                                UIPasteboard.general.string = supportInfo
+                            }
+                        }))
+                        sheet.addAction(UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: nil))
+                        self.present(sheet, animated: true)
+                    })
+                ])
+            ]
+        }
+    }
+}

--- a/Client/Frontend/Settings/SettingsRowViews.swift
+++ b/Client/Frontend/Settings/SettingsRowViews.swift
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Static
+import BraveShared
+
+/// The same style switch accessory view as in Static framework, except will not be recreated each time the Cell
+/// is configured, since it will be stored as is in `Row.Accessory.view`
+class SwitchAccessoryView: UISwitch {
+    typealias ValueChange = (Bool) -> Void
+    
+    init(initialValue: Bool, valueChange: (ValueChange)? = nil) {
+        self.valueChange = valueChange
+        super.init(frame: .zero)
+        isOn = initialValue
+        addTarget(self, action: #selector(valueChanged), for: .valueChanged)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    var valueChange: ValueChange?
+    
+    @objc func valueChanged() {
+        valueChange?(self.isOn)
+    }
+}
+
+/// Just creates a switch toggle `Row` which updates a `Preferences.Option<Bool>`
+func BoolRow(title: String, option: Preferences.Option<Bool>, onValueChange: SwitchAccessoryView.ValueChange? = nil) -> Row {
+    return Row(
+        text: title,
+        accessory: .view(SwitchAccessoryView(initialValue: option.value, valueChange: onValueChange ?? { option.value = $0 })),
+        cellClass: MultilineValue1Cell.self,
+        uuid: option.key
+    )
+}
+
+class MultilineButtonCell: ButtonCell {
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        textLabel?.numberOfLines = 0
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class MultilineValue1Cell: Value1Cell {
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        textLabel?.numberOfLines = 0
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class MultilineSubtitleCell: SubtitleCell {
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        textLabel?.numberOfLines = 0
+        detailTextLabel?.numberOfLines = 0
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -122,7 +122,7 @@ class SettingsViewController: TableViewController {
         list.append(generalSection)
         list.append(displaySection)
         #if !NO_SYNC
-            list.append(syncSection)
+            list.append(otherSettingsSection)
         #endif
         list.append(contentsOf: [privacySection,
                                  securitySection,
@@ -150,8 +150,7 @@ class SettingsViewController: TableViewController {
                     self.navigationController?.pushViewController(viewController, animated: true)
                 }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 BoolRow(title: Strings.Save_Logins, option: Preferences.General.saveLogins),
-                BoolRow(title: Strings.Block_Popups, option: Preferences.General.blockPopups),
-                BoolRow(title: Strings.Media_Auto_Plays, option: Preferences.General.mediaAutoPlays)
+                BoolRow(title: Strings.Block_Popups, option: Preferences.General.blockPopups)
             ]
         )
         
@@ -231,7 +230,7 @@ class SettingsViewController: TableViewController {
         return display
     }()
     
-    private lazy var syncSection: Section = {
+    private lazy var otherSettingsSection: Section = {
         
         return Section(
             // BRAVE TODO: Change it once we finalize our decision how to name the section.(#385)
@@ -254,7 +253,8 @@ class SettingsViewController: TableViewController {
                         self.navigationController?.pushViewController(view, animated: true)
                     }
                 }, accessory: .disclosureIndicator,
-                   cellClass: MultilineValue1Cell.self)
+                   cellClass: MultilineValue1Cell.self),
+                BoolRow(title: Strings.Media_Auto_Plays, option: Preferences.General.mediaAutoPlays)
             ]
         )
     }()


### PR DESCRIPTION
Tapping the Wallet Creation date (only visible when rewards is enabled and wallet is created) will rewards internals (including payment ID) to pasteboard

Also updates the location of the "background video auto-play" setting to be in the proper place in Other Settings

## Summary of Changes

This pull request fixes issue #1643

Checked with Anthony, the support info string doesn't need to be localized

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable Rewards by removing NO_REWARDS
- Check settings → Brave Rewards → verify there is no "Wallet Creation Date" row
- Go out and join rewards
- Check settings → Brave Rewards → verify "wallet creation date" row is there (and should be today)
- Click on wallet creation date, copy support info and verify that there is information that matches `brave://rewards-internals` 

## Screenshots:

| Root | Brave Rewards |
| --- | --- |
| ![Simulator Screen Shot - iPhone 11 Pro - 2019-10-17 at 17 04 42](https://user-images.githubusercontent.com/529104/67048448-3a308e00-f102-11e9-8bc2-49e37f36bff9.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-10-17 at 17 04 44](https://user-images.githubusercontent.com/529104/67048453-3d2b7e80-f102-11e9-8a70-a42de3d77f97.png) |

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
