### PR TITLE
Fix #1725: Force URLSession's to use main thread for completion block

### DIFF
--- a/BraveShared/Analytics/UrpService.swift
+++ b/BraveShared/Analytics/UrpService.swift
@@ -30,7 +30,7 @@ struct UrpService {
         // Certificate pinning
         certificateEvaluator = PinningCertificateEvaluator(hosts: [normalizedHost])
         
-        sessionManager = URLSession(configuration: .default, delegate: certificateEvaluator, delegateQueue: nil)
+        sessionManager = URLSession(configuration: .default, delegate: certificateEvaluator, delegateQueue: .main)
     }
 
     func referralCodeLookup(completion: @escaping (ReferralData?, UrpError?) -> Void) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2838,7 +2838,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                     application.endBackgroundTask(taskId)
                 })
                 
-                URLSession(configuration: .default).dataTask(with: url, completionHandler: { data, response, error in
+                URLSession(configuration: .default, delegate: nil, delegateQueue: .main).dataTask(with: url, completionHandler: { data, response, error in
                     
                     if let response = response as? HTTPURLResponse {
                         if !(200..<300).contains(response.statusCode) {
@@ -2882,7 +2882,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     }
 
     private func getData(_ url: URL, success: @escaping (Data) -> Void) {
-        URLSession(configuration: .default).dataTask(with: url) { data, response, _ in
+        URLSession(configuration: .default, delegate: nil, delegateQueue: .main).dataTask(with: url) { data, response, _ in
             if let response = response as? HTTPURLResponse {
                 if !(200..<300).contains(response.statusCode) {
                     return

--- a/Client/Frontend/Browser/Search/SearchSuggestClient.swift
+++ b/Client/Frontend/Browser/Search/SearchSuggestClient.swift
@@ -23,7 +23,7 @@ class SearchSuggestClient {
     lazy fileprivate var session: URLSession = {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpAdditionalHeaders = ["User-Agent": self.userAgent]
-        return URLSession(configuration: configuration)
+        return URLSession(configuration: configuration, delegate: nil, delegateQueue: .main)
     }()
 
     init(searchEngine: OpenSearchEngine, userAgent: String) {

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -102,7 +102,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = ["User-Agent": FaviconFetcher.userAgent]
         configuration.timeoutIntervalForRequest = 5
-        return URLSession(configuration: configuration)
+        return URLSession(configuration: configuration, delegate: nil, delegateQueue: .main)
     }()
 
     fileprivate func fetchDataForURL(_ url: URL) -> Deferred<Maybe<Data>> {

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -96,7 +96,7 @@ class ClientTests: XCTestCase {
 
         request.setValue("Basic \(credentials)", forHTTPHeaderField: "Authorization")
 
-        URLSession(configuration: .ephemeral).dataTask(with: request) { data, resp, error in
+        URLSession(configuration: .ephemeral, delegate: nil, delegateQueue: .main).dataTask(with: request) { data, resp, error in
             response = resp as? HTTPURLResponse
             expectation.fulfill()
         }.resume()


### PR DESCRIPTION
Force the sessions to be on the main queue. This is what Alamofire does automatically.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
