### PR TITLE
Fix #1707: Configure popover on iPad for restoring excluded publishers

### DIFF
--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -196,6 +196,11 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       case SummaryRows.excludedSites.rawValue:
         let numberOfExcludedSites = state.ledger.numberOfExcludedPublishers
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        if let presenter = alert.popoverPresentationController, let cell = tableView.cellForRow(at: indexPath) {
+          presenter.sourceView = cell
+          presenter.sourceRect = cell.bounds
+          presenter.permittedArrowDirections = [.up, .down]
+        }
         alert.addAction(UIAlertAction(title: String(format: Strings.AutoContributeRestoreExcludedSites, numberOfExcludedSites), style: .default, handler: { _ in
           self.state.ledger.restoreAllExcludedPublishers()
         }))


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1707 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards, create a wallet
- Stay on a site long enough for and navigate away to add it to the AC table
- Open AC table (rewards settings > AC details). Swipe to exclude the entry
- Tap restore 1 excluded site and verify that it doesn't crash

## Screenshots:

![Simulator Screen Shot - iPad Pro (9 7-inch) - 2019-10-18 at 11 01 10](https://user-images.githubusercontent.com/529104/67105340-9a710f80-f196-11e9-899d-f00a2e3137ac.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).