### PR TITLE
Fix #1129 - Match iOS 13's auto-play WebKit Policies

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -162,7 +162,11 @@ class TabManager: NSObject {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !Preferences.General.blockPopups.value
-        configuration.mediaTypesRequiringUserActionForPlayback = Preferences.General.mediaAutoPlays.value ? [] : .all
+        
+        if !Preferences.General.mediaAutoPlays.value {
+            configuration.mediaTypesRequiringUserActionForPlayback = .all
+        }
+        
         UserReferralProgram.shared?.insertCookies(intoStore: configuration.websiteDataStore.httpCookieStore)
         return configuration
     }


### PR DESCRIPTION
Change the default value to match the iOS 13 WebKit policies. If a video has an audio channel, it shall NOT auto play! The default value as of iOS 13 is `.audio`. It's better to NOT specify this value because if it changes again, our code will automatically have the applied effect instead of a bug. Setting it to either [] or .audio breaks it even though the default is .audio. Why? I don't know but the solution is to leave the default value as is.

However, this change doesn't have any side-effects on iOS 12 as I tested.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-ios/issues/1129

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
