### PR TITLE
Hide the auto-play toggle until 1.13 #1738

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -163,9 +163,9 @@ class TabManager: NSObject {
         configuration.processPool = WKProcessPool()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !Preferences.General.blockPopups.value
         
-        if !Preferences.General.mediaAutoPlays.value {
-            configuration.mediaTypesRequiringUserActionForPlayback = .all
-        }
+//        if !Preferences.General.mediaAutoPlays.value {
+//            configuration.mediaTypesRequiringUserActionForPlayback = .all
+//        }
         
         UserReferralProgram.shared?.insertCookies(intoStore: configuration.websiteDataStore.httpCookieStore)
         return configuration

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -219,7 +219,9 @@ class SettingsViewController: TableViewController {
                 }
                 }, accessory: .disclosureIndicator,
                    cellClass: MultilineValue1Cell.self),
-            BoolRow(title: Strings.Media_Auto_Plays, option: Preferences.General.mediaAutoPlays)
+            
+            //Disabled until 1.13
+            //BoolRow(title: Strings.Media_Auto_Plays, option: Preferences.General.mediaAutoPlays)
         ]
         return section
     }()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Related: https://github.com/brave/brave-ios/issues/1738

Hide the auto-play toggle until `1.13`
Decision made here: https://bravesoftware.slack.com/archives/C06UXF3KJ/p1571420762123200

Once we feel like we're ready to test it, we should open a ticket to reenable it. @srirambv 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
