### PR TITLE
Fix #1746 - Show confirmation screen without delay on OnboardingAds.

### DIFF
--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -92,6 +92,10 @@ public class AdsViewController: UIViewController {
     }
   }
   
+  deinit {
+    dismissTimers.forEach({ $0.value.invalidate() })
+  }
+  
   // MARK: - Actions
   
   private var dismissTimers: [AdView: Timer] = [:]

--- a/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownView.swift
@@ -38,6 +38,7 @@ extension OnboardingAdsCountdownViewController {
         let finishedButton = CommonViews.primaryButton(text: Strings.OBFinishButton).then {
             $0.accessibilityIdentifier = "OnboardingAdsCountdownViewController.StartBrowsing"
             $0.backgroundColor = BraveUX.BraveOrange
+            $0.isExclusiveTouch = true
         }
         
         private let mainStackView = UIStackView().then {

--- a/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownViewController.swift
@@ -43,11 +43,12 @@ class OnboardingAdsCountdownViewController: OnboardingViewController, UNUserNoti
         contentView.resetAnimation()
         contentView.animate(from: 0.0, to: 1.0, duration: UX.animationTime) { [weak self] in
             guard let self = self else { return }
+            
+            //Show the confirmation screen no matter what..
+            self.contentView.setState(.finished)
+            
             self.displayMyFirstAdIfAvailable { action in
-                if action == .timedOut {
-                    //User possibly missed the ad.. show them confirmation screen.
-                    self.contentView.setState(.finished)
-                } else {
+                if action == .opened {
                     //User saw the ad.. they interacted with it.. onboarding is finished.
                     self.continueTapped()
                 }

--- a/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingAdsCountdownViewController.swift
@@ -44,8 +44,10 @@ class OnboardingAdsCountdownViewController: OnboardingViewController, UNUserNoti
         contentView.animate(from: 0.0, to: 1.0, duration: UX.animationTime) { [weak self] in
             guard let self = self else { return }
             
-            //Show the confirmation screen no matter what..
-            self.contentView.setState(.finished)
+            //Show the confirmation screen no matter what.. after 1 second delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.contentView.setState(.finished)
+            }
             
             self.displayMyFirstAdIfAvailable { action in
                 if action == .opened {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-ios/issues/1746
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
