### PR TITLE
Fix #1651: Update Rewards UI based on if region is set to JP

### DIFF
--- a/BraveRewardsUI/Common/BATUSDPairView.swift
+++ b/BraveRewardsUI/Common/BATUSDPairView.swift
@@ -27,7 +27,7 @@ class BATUSDPairView: UIStackView {
     spacing = 5.0
     alignment = .bottom
     
-    batContainer.kindLabel.text = "BAT"
+    batContainer.kindLabel.text = Strings.BAT
     batContainer.amountLabel.text = "0"
     usdContainer.kindLabel.text = "USD"
     usdContainer.amountLabel.text = "0.00"

--- a/BraveRewardsUI/Common/DetailActionableRow.swift
+++ b/BraveRewardsUI/Common/DetailActionableRow.swift
@@ -18,7 +18,7 @@ class DetailActionableRow: Button {
     $0.font = .systemFont(ofSize: 14.0, weight: .semibold)
   }, kindLabelConfig: {
     $0.appearanceTextColor = Colors.grey200
-    $0.text = "BAT"
+    $0.text = Strings.BAT
     $0.font = .systemFont(ofSize: 13.0)
   })
   

--- a/BraveRewardsUI/Extensions/LocaleExtensions.swift
+++ b/BraveRewardsUI/Extensions/LocaleExtensions.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+extension Locale {
+  /// Whether or not the current users region and language is set to JP
+  var isJapan: Bool {
+    return regionCode == "JP"
+  }
+}

--- a/BraveRewardsUI/Grants/GrantsItemView.swift
+++ b/BraveRewardsUI/Grants/GrantsItemView.swift
@@ -25,7 +25,7 @@ class GrantsItemView: SettingsSectionView {
     }, kindLabelConfig: {
       $0.appearanceTextColor = Colors.grey200
       $0.font = .systemFont(ofSize: 13.0)
-      $0.text = "BAT"
+      $0.text = Strings.BAT
     })
     
     addSubview(stackView)

--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -2,7 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-internal struct Strings {}
+internal struct Strings {
+  /// "BAT" or "BAT Points" depending on the region
+  static var BAT: String {
+    if Locale.current.isJapan {
+      return NSLocalizedString("BATPoints", bundle: Bundle.RewardsUI, value: "BAT Points", comment: "The name of BAT in Japan")
+    }
+    return "BAT"
+  }
+}
 
 internal extension Strings {
   static let Open = NSLocalizedString("BraveRewardsOpen", bundle: Bundle.RewardsUI, value: "Open", comment: "")
@@ -111,7 +119,7 @@ internal extension Strings {
   static let AddFundsTokenWalletAddress = NSLocalizedString("BraveRewardsAddFundsTokenWalletAddress", bundle: Bundle.RewardsUI, value: "Wallet Address", comment: "")
   static let AutoContributeToVideos = NSLocalizedString("BraveRewardsAutoContributeToVideos", bundle: Bundle.RewardsUI, value: "Allow contribution to videos", comment: "")
   static let SettingsDisabledBody2 = NSLocalizedString("BraveRewardsSettingsDisabledBody2", bundle: Bundle.RewardsUI, value: "One where your time is valued, your personal data is kept private, and you actually get paid for your attention.", comment: "")
-  static let ContributingToUnverifiedSites = NSLocalizedString("BraveRewardsContributingToUnverifiedSites", bundle: Bundle.RewardsUI, value: "You've designated %@ BAT for creators who haven't yet signed up to recieve contributions. Your browser will keep trying to contribute until they verify, or until 90 days have passed.", comment: "")
+  static let ContributingToUnverifiedSites = NSLocalizedString("BraveRewardsContributingToUnverifiedSites", bundle: Bundle.RewardsUI, value: "You've designated %@ for creators who haven't yet signed up to recieve contributions. Your browser will keep trying to contribute until they verify, or until 90 days have passed.", comment: "")
   static let SettingsDisabledBody1 = NSLocalizedString("BraveRewardsSettingsDisabledBody1", bundle: Bundle.RewardsUI, value: "With your old browser, you paid to browse the web by viewing ads with your valuable attention. You spent your valuable time downloading invasive ad technology that transmitted your valuable private data to advertisers — without your consent.", comment: "")
   static let PanelTitle = NSLocalizedString("BraveRewardsPanelTitle", bundle: Bundle.RewardsUI, value: "Rewards", comment: "")
   static let CreatingWallet = NSLocalizedString("BraveRewardsCreatingWallet", bundle: Bundle.RewardsUI, value: "Creating wallet", comment: "")
@@ -178,5 +186,7 @@ internal extension Strings {
   static let MyFirstAdBody = NSLocalizedString("MyFirstAdBody", bundle: Bundle.RewardsUI, value: "Tap here to learn more.", comment: "")
   static let WalletCreationErrorTitle = NSLocalizedString("WalletCreationErrorTitle", bundle: Bundle.RewardsUI, value: "Error", comment: "")
   static let WalletCreationErrorBody = NSLocalizedString("WalletCreationErrorBody", bundle: Bundle.RewardsUI, value: "Oops! Something went wrong. Please try again.", comment: "")
+  static let BATPointsDisclaimer = NSLocalizedString("BATPointsDisclaimer", bundle: Bundle.RewardsUI, value: "BAT Points can be used to contribute to your favorite content creators. BAT Points cannot be exchanged for BAT.", comment: "Disclaimer about BAT Points for JP users")
+  static let BATPointsDisclaimerBoldedWords = NSLocalizedString("BATPointsBoldedWords", bundle: Bundle.RewardsUI, value: "BAT Points", comment: "Words that should be bolded in the BAT Points disclaimer")
 }
 

--- a/BraveRewardsUI/Rewards Summary/RewardsSummaryRowView.swift
+++ b/BraveRewardsUI/Rewards Summary/RewardsSummaryRowView.swift
@@ -72,7 +72,7 @@ import UIKit
                      batValue: String, usdDollarValue: String) {
       self.init(frame: .zero)
       titleLabel.text = title
-      cryptoCurrencyLabel.text = "BAT"
+      cryptoCurrencyLabel.text = Strings.BAT
       cryptoValueLabel.text = batValue
       cryptoValueLabel.appearanceTextColor = cryptoValueColor
       dollarValueLabel.text = usdDollarValue

--- a/BraveRewardsUI/Rewards Summary/RewardsSummaryView.swift
+++ b/BraveRewardsUI/Rewards Summary/RewardsSummaryView.swift
@@ -55,7 +55,7 @@ class RewardsSummaryView: UIView {
   
   /// A disclaimer view to show below the rows (Used when the user has auto-contribute enabled
   /// and has a portion of BAT designated to unverified publishers
-  var disclaimerView: LinkLabel? {
+  var disclaimerView: WalletDisclaimerView? {
     willSet {
       disclaimerView?.removeFromSuperview()
     }

--- a/BraveRewardsUI/Settings/SettingsViewController.swift
+++ b/BraveRewardsUI/Settings/SettingsViewController.swift
@@ -74,7 +74,7 @@ class SettingsViewController: UIViewController {
       $0.autoContributeSection.toggleSwitch.addTarget(self, action: #selector(autoContributeToggleValueChanged), for: .valueChanged)
       
       let dollarString = state.ledger.dollarStringForBATAmount(state.ledger.balance?.total ?? 0) ?? ""
-      $0.walletSection.setWalletBalance(state.ledger.balanceString, crypto: "BAT", dollarValue: dollarString)
+      $0.walletSection.setWalletBalance(state.ledger.balanceString, crypto: Strings.BAT, dollarValue: dollarString)
       
       if !BraveAds.isCurrentRegionSupported() {
          $0.adsSection.status = .unsupportedRegion
@@ -164,7 +164,7 @@ class SettingsViewController: UIViewController {
       guard let self = self else { return }
       self.settingsView.walletSection.setWalletBalance(
         self.state.ledger.balanceString,
-        crypto: "BAT",
+        crypto: Strings.BAT,
         dollarValue: self.state.ledger.usdBalanceString
       )
     }

--- a/BraveRewardsUI/Settings/Tips/Details/TipsSummaryTableCell.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsSummaryTableCell.swift
@@ -11,7 +11,7 @@ class TipsSummaryTableCell: UITableViewCell, TableViewReusable {
     $0.font = .systemFont(ofSize: 14.0, weight: .semibold)
   }, kindLabelConfig: {
     $0.appearanceTextColor = Colors.neutral200
-    $0.text = "BAT"
+    $0.text = Strings.BAT
     $0.font = .systemFont(ofSize: 13.0)
   })
   

--- a/BraveRewardsUI/Settings/Wallet/WalletActivityView.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletActivityView.swift
@@ -43,7 +43,7 @@ class WalletActivityView: SettingsSectionView {
   
   /// A disclaimer view to show below the rows (Used when the user has auto-contribute enabled
   /// and has a portion of BAT designated to unverified publishers
-  var disclaimerView: LinkLabel? {
+  var disclaimerView: WalletDisclaimerView? {
     willSet {
       disclaimerView?.removeFromSuperview()
     }

--- a/BraveRewardsUI/Settings/Wallet/WalletDetailsView.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletDetailsView.swift
@@ -24,7 +24,9 @@ extension WalletDetailsViewController {
       } else {
         stackView.addArrangedSubview(activityView)
       }
-      stackView.addArrangedSubview(PoweredByUpholdView())
+      if !Locale.current.isJapan {
+        stackView.addArrangedSubview(PoweredByUpholdView())
+      }
       
       scrollView.snp.makeConstraints {
         $0.edges.equalTo(self)

--- a/BraveRewardsUI/Settings/Wallet/WalletDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletDetailsViewController.swift
@@ -38,13 +38,17 @@ class WalletDetailsViewController: UIViewController, RewardsSummaryProtocol {
     
     detailsView.walletSection.setWalletBalance(
       state.ledger.balanceString,
-      crypto: "BAT",
+      crypto: Strings.BAT,
       dollarValue: state.ledger.usdBalanceString
     )
     
     detailsView.activityView.monthYearLabel.text = summaryPeriod
     detailsView.activityView.rows = summaryRows
-    detailsView.activityView.disclaimerView = disclaimerView
+    if !disclaimerLabels.isEmpty {
+      detailsView.activityView.disclaimerView = WalletDisclaimerView().then {
+        $0.labels = disclaimerLabels
+      }
+    }
   }
   
   // MARK: - Actions
@@ -60,7 +64,7 @@ class WalletDetailsViewController: UIViewController, RewardsSummaryProtocol {
       if let self = self {
         self.detailsView.walletSection.setWalletBalance(
           self.state.ledger.balanceString,
-          crypto: "BAT",
+          crypto: Strings.BAT,
           dollarValue: self.state.ledger.usdBalanceString
         )
       }

--- a/BraveRewardsUI/Settings/Wallet/WalletDisclaimerView.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletDisclaimerView.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+class WalletDisclaimerView: UIView {
+  
+  var labels: [LinkLabel] = [] {
+    willSet {
+      labels.forEach { $0.removeFromSuperview() }
+    }
+    didSet {
+      labels.forEach {
+        stackView.addArrangedSubview($0)
+      }
+    }
+  }
+  
+  private let stackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 10
+  }
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+  
+    addSubview(stackView)
+    
+    stackView.snp.makeConstraints {
+      $0.edges.equalTo(self).inset(8)
+    }
+    
+    backgroundColor = UIColor(white: 0.0, alpha: 0.04)
+    layer.cornerRadius = 4.0
+  }
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError()
+  }
+}

--- a/BraveRewardsUI/Tipping/TippingSelectionView.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionView.swift
@@ -24,7 +24,7 @@ class TippingOption: NSObject {
   class func batAmount(_ value: BATValue, dollarValue: String) -> TippingOption {
     return TippingOption(
       value: value,
-      crypto: "BAT",
+      crypto: "BAT", // Tipping page stays "BAT" regardless of locale
       cryptoImage: UIImage(frameworkResourceNamed: "bat-small"),
       dollarValue: dollarValue
     )

--- a/BraveRewardsUI/Tipping/TippingViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingViewController.swift
@@ -82,7 +82,7 @@ class TippingViewController: UIViewController, UIViewControllerTransitioningDele
     }
     
     tippingView.overviewView.disclaimerView.isHidden = publisherInfo.status == .verified
-    tippingView.optionSelectionView.setWalletBalance(state.ledger.balanceString, crypto: "BAT")
+    tippingView.optionSelectionView.setWalletBalance(state.ledger.balanceString, crypto: Strings.BAT)
     tippingView.optionSelectionView.options = TippingViewController.defaultTippingAmounts.map {
       TippingOption.batAmount(BATValue($0), dollarValue: state.ledger.dollarStringForBATAmount($0) ?? "")
     }

--- a/BraveRewardsUI/Wallet/RewardsSummaryProtocol.swift
+++ b/BraveRewardsUI/Wallet/RewardsSummaryProtocol.swift
@@ -16,7 +16,7 @@ protocol RewardsSummaryProtocol {
   var summaryRows: [RowView] { get }
   
   /// A view informing users about contributing to unverified publishers.
-  var disclaimerView: LinkLabel? { get }
+  var disclaimerLabels: [LinkLabel] { get }
 }
 
 private struct Activity {
@@ -71,21 +71,36 @@ extension RewardsSummaryProtocol {
     }
   }
   
-  var disclaimerView: LinkLabel? {
+  var disclaimerLabels: [LinkLabel] {
+    var labels: [LinkLabel] = []
+    
+    if Locale.current.isJapan {
+      labels.append(LinkLabel().then {
+        $0.attributedText = {
+          let str = NSMutableAttributedString(string: Strings.BATPointsDisclaimer, attributes: [.font: UIFont.systemFont(ofSize: 12.0)])
+          if let range = str.string.range(of: Strings.BATPointsDisclaimerBoldedWords) {
+            str.addAttribute(.font, value: UIFont.systemFont(ofSize: 12.0, weight: .semibold), range: NSRange(range, in: str.string))
+          }
+          return str
+        }()
+        $0.appearanceTextColor = Colors.grey200
+      })
+    }
+    
     let reservedAmount = BATValue(state.ledger.reservedAmount)
     // Don't show the view if there's no pending contributions.
-    if reservedAmount.doubleValue <= 0 { return nil }
-    
-    let text = String(format: Strings.ContributingToUnverifiedSites, reservedAmount.displayString)
-    
-    return LinkLabel().then {
-      $0.appearanceTextColor = Colors.grey200
-      $0.font = UIFont.systemFont(ofSize: 12.0)
-      $0.textContainerInset = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
-      $0.text = "\(text) \(Strings.DisclaimerLearnMore)"
-      $0.setURLInfo([Strings.DisclaimerLearnMore: "learn-more"])
-      $0.backgroundColor = UIColor(white: 0.0, alpha: 0.04)
-      $0.layer.cornerRadius = 4.0
+    if reservedAmount.doubleValue > 0 {
+      let batAmountText = "\(reservedAmount.displayString) \(Strings.BAT)"
+      let text = String(format: Strings.ContributingToUnverifiedSites, batAmountText)
+      
+      labels.append(LinkLabel().then {
+        $0.appearanceTextColor = Colors.grey200
+        $0.font = UIFont.systemFont(ofSize: 12.0)
+        $0.text = "\(text) \(Strings.DisclaimerLearnMore)"
+        $0.setURLInfo([Strings.DisclaimerLearnMore: "learn-more"])
+      })
     }
+    
+    return labels
   }
 }

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -88,7 +88,11 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
     navigationController?.setNavigationBarHidden(true, animated: false)
     
     rewardsSummaryView.rewardsSummaryButton.addTarget(self, action: #selector(tappedRewardsSummaryButton), for: .touchUpInside)
-    rewardsSummaryView.disclaimerView = disclaimerView
+    if !disclaimerLabels.isEmpty {
+      rewardsSummaryView.disclaimerView = WalletDisclaimerView().then {
+        $0.labels = disclaimerLabels
+      }
+    }
     
     walletView.headerView.addFundsButton.addTarget(self, action: #selector(tappedAddFunds), for: .touchUpInside)
     walletView.headerView.settingsButton.addTarget(self, action: #selector(tappedSettings), for: .touchUpInside)
@@ -190,9 +194,11 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
       self.state.delegate?.loadNewTabWithURL(url)
     }
     
-    walletView.rewardsSummaryView?.disclaimerView?.onLinkedTapped = { [weak self] _ in
-      guard let self = self, let url = URL(string: DisclaimerLinks.unclaimedFundsURL) else { return }
-      self.state.delegate?.loadNewTabWithURL(url)
+    walletView.rewardsSummaryView?.disclaimerView?.labels.forEach {
+      $0.onLinkedTapped = { [weak self] _ in
+        guard let self = self, let url = URL(string: DisclaimerLinks.unclaimedFundsURL) else { return }
+        self.state.delegate?.loadNewTabWithURL(url)
+      }
     }
     
     publisherView.onCheckAgainTapped = { [weak self] in
@@ -515,7 +521,7 @@ extension WalletViewController {
   func updateWalletHeader() {
     walletView.headerView.setWalletBalance(
       state.ledger.balanceString,
-      crypto: "BAT",
+      crypto: Strings.BAT,
       dollarValue: state.ledger.usdBalanceString
     )
   }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		271DED2B234CC7EF009DAC37 /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271DECC0234CC7EF009DAC37 /* BundleExtensions.swift */; };
 		271DED2C234CC7EF009DAC37 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271DECC1234CC7EF009DAC37 /* DateExtensions.swift */; };
 		272FCAA0225CF8F00091E645 /* OnePasswordExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 272FCA98225CF8F00091E645 /* OnePasswordExtension.framework */; };
+		27353FF2235F4E7300E42EBB /* WalletDisclaimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27353FF1235F4E7300E42EBB /* WalletDisclaimerView.swift */; };
 		2755AB7D23107BC600F0721F /* AdsReporting.js in Resources */ = {isa = PBXBuildFile; fileRef = 2755AB7C23107BC600F0721F /* AdsReporting.js */; };
 		2755AB8623107DBD00F0721F /* AdsMediaReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2755AB8523107DBD00F0721F /* AdsMediaReporting.swift */; };
 		2760D2BF215ACCE20068E131 /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2760D2BE215ACCE20068E131 /* BundleExtensions.swift */; };
@@ -285,6 +286,7 @@
 		279C756B219DDE3B001CD1CB /* FingerprintingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */; };
 		279C75C821A5B37D001CD1CB /* FingerprintingProtection.js in Resources */ = {isa = PBXBuildFile; fileRef = 279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */; };
 		27A586E1214C0DDD000CAE3C /* PreferencesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */; };
+		27B1E26D235E58190062E86F /* LocaleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B1E26C235E58190062E86F /* LocaleExtensions.swift */; };
 		27C461DE211B76500088A441 /* ShieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C461DD211B76500088A441 /* ShieldsView.swift */; };
 		27C46201211CD8D20088A441 /* DeferredTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A176323020CF2A6000126F25 /* DeferredTestUtils.swift */; };
 		27D114D42358FBBF00166534 /* BraveRewardsSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D114D32358FBBF00166534 /* BraveRewardsSettingsViewController.swift */; };
@@ -1477,6 +1479,7 @@
 		271DECC0234CC7EF009DAC37 /* BundleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
 		271DECC1234CC7EF009DAC37 /* DateExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
 		272FCA98225CF8F00091E645 /* OnePasswordExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OnePasswordExtension.framework; path = Carthage/Build/iOS/OnePasswordExtension.framework; sourceTree = "<group>"; };
+		27353FF1235F4E7300E42EBB /* WalletDisclaimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDisclaimerView.swift; sourceTree = "<group>"; };
 		2755AB7C23107BC600F0721F /* AdsReporting.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AdsReporting.js; sourceTree = "<group>"; };
 		2755AB8523107DBD00F0721F /* AdsMediaReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsMediaReporting.swift; sourceTree = "<group>"; };
 		2760D2BE215ACCE20068E131 /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
@@ -1497,6 +1500,7 @@
 		279C756A219DDE3B001CD1CB /* FingerprintingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintingProtection.swift; sourceTree = "<group>"; };
 		279C75C021A5B37D001CD1CB /* FingerprintingProtection.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = FingerprintingProtection.js; sourceTree = "<group>"; };
 		27A586E0214C0DDD000CAE3C /* PreferencesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTest.swift; sourceTree = "<group>"; };
+		27B1E26C235E58190062E86F /* LocaleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleExtensions.swift; sourceTree = "<group>"; };
 		27C461DD211B76500088A441 /* ShieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsView.swift; sourceTree = "<group>"; };
 		27D114D32358FBBF00166534 /* BraveRewardsSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveRewardsSettingsViewController.swift; sourceTree = "<group>"; };
 		27D114D52358FCA400166534 /* SettingsRowViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowViews.swift; sourceTree = "<group>"; };
@@ -3068,6 +3072,7 @@
 				271DEC8C234CC7EF009DAC37 /* WalletDetailsView.swift */,
 				271DEC8D234CC7EF009DAC37 /* WalletActivityView.swift */,
 				271DEC8E234CC7EF009DAC37 /* WalletSummaryView.swift */,
+				27353FF1235F4E7300E42EBB /* WalletDisclaimerView.swift */,
 			);
 			path = Wallet;
 			sourceTree = "<group>";
@@ -3160,6 +3165,7 @@
 				271DECBF234CC7EF009DAC37 /* UIImageExtensions.swift */,
 				271DECC0234CC7EF009DAC37 /* BundleExtensions.swift */,
 				271DECC1234CC7EF009DAC37 /* DateExtensions.swift */,
+				27B1E26C235E58190062E86F /* LocaleExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5511,6 +5517,7 @@
 				271DECDA234CC7EF009DAC37 /* TippingView.swift in Sources */,
 				271DECF1234CC7EF009DAC37 /* AdsDetailsViewController.swift in Sources */,
 				271DED0C234CC7EF009DAC37 /* EmptyTableCell.swift in Sources */,
+				27B1E26D235E58190062E86F /* LocaleExtensions.swift in Sources */,
 				271DECF3234CC7EF009DAC37 /* OptionsSelectionViewController.swift in Sources */,
 				271DED10234CC7EF009DAC37 /* CurrencyContainerView.swift in Sources */,
 				271DED12234CC7EF009DAC37 /* SeparatorView.swift in Sources */,
@@ -5518,6 +5525,7 @@
 				271DECF0234CC7EF009DAC37 /* SettingsAdSectionView.swift in Sources */,
 				271DECD3234CC7EF009DAC37 /* AdContentButton.swift in Sources */,
 				271DED1A234CC7EF009DAC37 /* ActionButton.swift in Sources */,
+				27353FF2235F4E7300E42EBB /* WalletDisclaimerView.swift in Sources */,
 				271DECC5234CC7EF009DAC37 /* PublisherView.swift in Sources */,
 				271DED03234CC7EF009DAC37 /* AutoContributeDetailsViewController.swift in Sources */,
 				271DED16234CC7EF009DAC37 /* BATUSDPairView.swift in Sources */,


### PR DESCRIPTION
- "BAT" becomes "BAT Points" in most scenarios
- An additional disclaimer message is shown in the rewards summary (when non-empty)
- Powered by Uphold message is not shown in wallet details screen

## Summary of Changes

This pull request fixes issue #1651 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Verify all is normal in non-JP region
- Set device **region** to JP (language doesn't matter)
- Verify most places that say "BAT" now say "BAT Points" (exclusions: Tipping screen options)
- Verify that in wallet details the footer "Powered by Uphold" message is not visible
- Send a one-time tip to a verified publisher
- Verify that the JP disclaimer shows up in wallet summary
- Send a tip to an unverified publisher
- Verify both disclaimers appear in wallet summary

## Screenshots:

| BAT Points | Powered By Uphold |
| --- | --- | 
| ![Simulator Screen Shot - iPhone Xs - 2019-10-22 at 11 25 17](https://user-images.githubusercontent.com/529104/67302766-6449cd80-f4bf-11e9-8b4e-8e1d0ff8d8ac.png) | ![Simulator Screen Shot - iPhone Xs - 2019-10-22 at 11 25 22](https://user-images.githubusercontent.com/529104/67302772-66ac2780-f4bf-11e9-9aea-43f6ccc0866d.png) |
| **JP Disclaimer** | **Both Disclaimers** |
| ![Simulator Screen Shot - iPhone Xs - 2019-10-22 at 11 26 22](https://user-images.githubusercontent.com/529104/67302818-76c40700-f4bf-11e9-83dc-a74d5123e25b.png) | ![Simulator Screen Shot - iPhone Xs - 2019-10-22 at 11 27 18](https://user-images.githubusercontent.com/529104/67302842-804d6f00-f4bf-11e9-8132-85edfdd9a88e.png) |

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).