### PR TITLE
Fix #1757: Show rewards onboarding to existing users when not in an ad-supported region

### DIFF
--- a/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
@@ -56,7 +56,7 @@ class OnboardingNavigationController: UINavigationController {
             #else
             switch self {
             case .newUser: return BraveAds.isCurrentRegionSupported() ? [.searchEnginePicker, .shieldsInfo, .rewardsAgreement, .adsCountdown] : [.searchEnginePicker, .shieldsInfo, .rewardsAgreement]
-            case .existingUserRewardsOff: return BraveAds.isCurrentRegionSupported() ? [.rewardsAgreement, .adsCountdown] : []
+            case .existingUserRewardsOff: return BraveAds.isCurrentRegionSupported() ? [.rewardsAgreement, .adsCountdown] : [.rewardsAgreement]
             case .existingUserRewardsOn: return BraveAds.isCurrentRegionSupported() ? [.existingRewards, .adsCountdown] : []
             }
             #endif


### PR DESCRIPTION
When the user is OUT of ads region, and existing user, we can show rewards agreement.. There is no way for me to tell if rewards are available though :S 

Which means, if the user is new, they complete onboarding up to shields. After some time, they upgrade or kill the app, now they are existing, and rewards show up which didn't show up previously.


<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1757 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
