### PR TITLE
Fix #1753 - Create wallet and move on immediately.

### DIFF
--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
@@ -9,8 +9,6 @@ import BraveRewards
 
 class OnboardingRewardsAgreementViewController: OnboardingViewController {
 
-    private var loadingView = UIActivityIndicatorView(style: .white)
-
     private var contentView: View {
         return view as! View // swiftlint:disable:this force_cast
     }
@@ -51,37 +49,11 @@ class OnboardingRewardsAgreementViewController: OnboardingViewController {
     
     @objc
     private func onTurnOn() {
-        if loadingView.superview != nil || loadingView.isAnimating {
-            return
+        rewards?.ledger.createWalletAndFetchDetails { _ in
+            //TODO: Handle errors at a later date and possibly elsewhere..
         }
         
-        let titleColour = contentView.turnOnButton.titleColor(for: .normal)
-        contentView.turnOnButton.setTitleColor(.clear, for: .normal)
-        contentView.turnOnButton.isUserInteractionEnabled = false
-        contentView.skipButton.isUserInteractionEnabled = false
-        contentView.turnOnButton.addSubview(loadingView)
-        loadingView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
-        
-        loadingView.startAnimating()
-        rewards?.ledger.createWalletAndFetchDetails { [weak self] success in
-            guard let self = self else { return }
-
-            self.loadingView.stopAnimating()
-            self.loadingView.removeFromSuperview()
-            self.contentView.turnOnButton.setTitleColor(titleColour, for: .normal)
-            self.contentView.turnOnButton.isUserInteractionEnabled = true
-            self.contentView.skipButton.isUserInteractionEnabled = true
-            
-            if success {
-                self.continueTapped()
-            } else {
-                let alert = UIAlertController(title: Strings.OBErrorTitle, message: Strings.OBErrorDetails, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: Strings.OBErrorOkay, style: .default, handler: nil))
-                self.present(alert, animated: true, completion: nil)
-            }
-        }
+        self.continueTapped()
     }
     
     override func applyTheme(_ theme: Theme) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

When we are on onboarding, we will create the wallet and fetch the details. Whether it fails or not, we do not handle it here. We will handle that elsewhere in the future. This is so the user doesn't get stuck during onboarding waiting for wallet to finish creating and they can move on with the flow.

This pull request fixes issue https://github.com/brave/brave-ios/issues/1753
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
