### PR TITLE
Fix #1750: Don't double push wallet controllers from welcome screen

### DIFF
--- a/BraveRewardsUI/Create Wallet/CreateWalletViewController.swift
+++ b/BraveRewardsUI/Create Wallet/CreateWalletViewController.swift
@@ -89,6 +89,7 @@ class CreateWalletViewController: UIViewController {
   }
   
   @objc private func tappedLearnMore() {
+    state.ledger.remove(observer) // No way to come back to this screen anyways
     let controller = WelcomeViewController(state: state)
     navigationController?.pushViewController(controller, animated: true)
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1750 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- See #1750 STR

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
