### PR TITLE
Fix #1751: Show a badge on the rewards button until first usage

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -91,6 +91,7 @@ extension Preferences {
     public final class Rewards {
         public static let myFirstAdShown = Option<Bool>(key: "rewards.ads.my-first-ad-shown", default: false)
         public static let hideRewardsIcon = Option<Bool>(key: "rewards.hide-rewards-icon", default: false)
+        public static let panelOpened = Option<Bool>(key: "rewards.rewards-panel-opened", default: false)
         
         public enum EnvironmentOverride: Int, CaseIterable {
             case none

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -57,9 +57,13 @@ extension BrowserViewController {
         let isVerifiedBadgeVisible = self.publisher?.status == .verified || self.publisher?.status == .connected
         self.topToolbar.locationView.rewardsButton.isVerified = isVerifiedBadgeVisible
         self.topToolbar.locationView.rewardsButton.notificationCount = self.rewards?.ledger.notifications.count ?? 0
+        self.topToolbar.locationView.rewardsButton.forceShowBadge = !Preferences.Rewards.panelOpened.value
     }
 
     func showBraveRewardsPanel() {
+        Preferences.Rewards.panelOpened.value = true
+        updateRewardsButtonState()
+        
         if UIDevice.current.userInterfaceIdiom != .pad && UIApplication.shared.statusBarOrientation.isLandscape {
             let value = UIInterfaceOrientation.portrait.rawValue
             UIDevice.current.setValue(value, forKey: "orientation")

--- a/Client/Frontend/Browser/Toolbars/UrlBar/RewardsButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/RewardsButton.swift
@@ -16,6 +16,10 @@ class RewardsButton: UIButton {
         didSet { updateView() }
     }
     
+    var forceShowBadge = false {
+        didSet { updateView() }
+    }
+    
     private let notificationsBadgeView = UIView().then {
         $0.backgroundColor = BraveUX.BraveOrange
         $0.frame = CGRect(x: 19, y: 5, width: 12, height: 12)
@@ -49,7 +53,7 @@ class RewardsButton: UIButton {
         
         setImage(#imageLiteral(resourceName: "brave_rewards_button_enabled"), for: .normal)
         
-        if notificationCount > 0 {
+        if notificationCount > 0 || forceShowBadge {
             notificationsBadgeView.isHidden = false
         } else if isVerified {
             checkmarkView.isHidden = false


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1751 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open app, verify rewards button has a visible badge. 
- Tap rewards button to display panel, verify rewards button badge disappears

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-10-22 at 15 27 25](https://user-images.githubusercontent.com/529104/67323445-74be7000-f4e0-11e9-9b47-297b6bc2d7ed.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
