### PR TITLE
Fix #1767: Return missing decimal points while in JP region

### DIFF
--- a/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
+++ b/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
@@ -31,6 +31,7 @@ extension BraveLedger {
     let currencyFormatter = NumberFormatter()
     currencyFormatter.currencySymbol = ""
     currencyFormatter.numberStyle = .currency
+    currencyFormatter.locale = Locale(identifier: "en_US")
     let valueString = currencyFormatter.string(from: NSNumber(value: amount * conversionRate)) ?? "0.00"
     if includeCurrencyCode {
       return "\(valueString) \(currencyCode)"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1767 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-10-22 at 17 10 04](https://user-images.githubusercontent.com/529104/67333582-cc63d800-f4ee-11e9-9803-e7979f120aa9.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
