### PR TITLE
Fix #1774: Don't allow ads to appear while the user is in overlay mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -228,8 +228,10 @@ class BrowserViewController: UIViewController {
         
         if let rewards = rewards {
             notificationsHandler = AdsNotificationHandler(ads: rewards.ads, presentingController: self)
-            notificationsHandler?.canShowNotifications = {
-                return !PrivateBrowsingManager.shared.isPrivateBrowsing
+            notificationsHandler?.canShowNotifications = { [weak self] in
+                guard let self = self else { return false }
+                return !PrivateBrowsingManager.shared.isPrivateBrowsing &&
+                    !self.topToolbar.inOverlayMode
             }
             notificationsHandler?.actionOccured = { [weak self] notification, action in
                 guard let self = self else { return }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1774 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable Ads
- Wait for ad to appear and click the URL bar to enter overlay mode
- Verify no ad is shown 

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
