### PR TITLE
Fix #1773: Make ad auto-dismissal time 30 seconds

### DIFF
--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -18,7 +18,7 @@ public class AdsViewController: UIViewController {
   }
   
   /// The number of seconds until the ad is automatically dismissed
-  private let automaticDismissalInterval: TimeInterval = 8
+  private let automaticDismissalInterval: TimeInterval = 30
   
   private var displayedAds: [AdView: DisplayedAd] = [:]
   private(set) var visibleAdView: AdView?

--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -17,14 +17,6 @@ public class AdsViewController: UIViewController {
     let animatedOut: () -> Void
   }
   
-  /// Whether or not this ads container is being used to display "my first ad"
-  ///
-  /// Setting this to true disables the debug ads override and uses a shorter dismissal duration
-  private var isFirstAd = false
-  
-  /// The number of seconds until the "my first ad" is automatically dismissed
-  private let myFirstAdDismissalInterval: TimeInterval = 3
-  
   /// The number of seconds until the ad is automatically dismissed
   private let automaticDismissalInterval: TimeInterval = 8
   
@@ -105,8 +97,8 @@ public class AdsViewController: UIViewController {
       // Invalidate and reschedule
       timer.invalidate()
     }
-    var dismissInterval = isFirstAd ? myFirstAdDismissalInterval : automaticDismissalInterval
-    if !AppConstants.BuildChannel.isRelease && !isFirstAd, let override = Preferences.Rewards.adsDurationOverride.value, override > 0 {
+    var dismissInterval = automaticDismissalInterval
+    if !AppConstants.BuildChannel.isRelease, let override = Preferences.Rewards.adsDurationOverride.value, override > 0 {
       dismissInterval = TimeInterval(override)
     }
     dismissTimers[adView] = Timer.scheduledTimer(withTimeInterval: dismissInterval, repeats: false, block: { [weak self] _ in
@@ -310,7 +302,6 @@ extension AdsViewController {
   /// Display a "My First Ad" on a presenting controller and be notified if they tap it
   public static func displayFirstAd(on presentingController: UIViewController, completion: @escaping (AdsNotificationHandler.Action, URL) -> Void) {
     let adsViewController = AdsViewController()
-    adsViewController.isFirstAd = true
     
     presentingController.addChild(adsViewController)
     presentingController.view.addSubview(adsViewController.view)


### PR DESCRIPTION
Please use rebase merge strategy

## Summary of Changes

This pull request fixes issue #1773 
This pull request reverts #1703

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Go through onboarding, verify my first ad remains on screen for 30s before timing out
- With ads enabled, browse and when an ad comes up, verify it remains on screen for 30s before timing out

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).