### PR TITLE
Fix #1783: Show verified badge for connected publishers in AC/Tips table

### DIFF
--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -333,7 +333,7 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
         }
       }
       
-      cell.verifiedStatusImageView.isHidden = publisher.status != .verified
+      cell.verifiedStatusImageView.isHidden = publisher.status == .notVerified
       let provider = " \(publisher.provider.isEmpty ? "" : String(format: Strings.OnProviderText, publisher.providerDisplayString))"
       let attrName = NSMutableAttributedString(string: publisher.name).then {
         $0.append(NSMutableAttributedString(string: provider, attributes: [.font: UIFont.boldSystemFont(ofSize: 14.0),

--- a/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
@@ -191,7 +191,7 @@ extension TipsDetailViewController: UITableViewDataSource, UITableViewDelegate {
       
       cell.siteImageView.image = UIImage(frameworkResourceNamed: "defaultFavicon")
       setFavicon(identifier: tip.id, pageURL: tip.url, faviconURL: tip.faviconUrl)
-      cell.verifiedStatusImageView.isHidden = tip.status != .verified
+      cell.verifiedStatusImageView.isHidden = tip.status == .notVerified
       let contribution = tip.weight
       switch tip.rewardsCategory {
       case .oneTimeTip:


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1783 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit connected (but not verified) publisher (e.g. KhanAcademy)
- After 8s, visit another page, then open panel
- Verify wallet panel has verified badge but also sees the disclaimer
- Open AC table list, verify that badge is displayed there as well
- Tip one-time/recurring for same connected publisher
- Open Tips list, verify that badge is displayed there as well

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-10-24 at 10 29 27](https://user-images.githubusercontent.com/529104/67495889-95560980-f649-11e9-8b62-0788c2958c51.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).