### PR TITLE
Fix #1786: Don't use probi value for USD conversion on one-time tips

### DIFF
--- a/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
@@ -195,16 +195,19 @@ extension TipsDetailViewController: UITableViewDataSource, UITableViewDelegate {
       let contribution = tip.weight
       switch tip.rewardsCategory {
       case .oneTimeTip:
+        let value = BATValue(probi: "\(contribution)")
         cell.typeNameLabel.text = Strings.OneTimeText + Date.stringFrom(reconcileStamp: tip.reconcileStamp)
-        cell.tokenView.batContainer.amountLabel.text = BATValue(probi: "\(contribution)")?.displayString
+        cell.tokenView.batContainer.amountLabel.text = value?.displayString
+        cell.tokenView.usdContainer.amountLabel.text = state.ledger.dollarStringForBATAmount(value?.doubleValue ?? 0, includeCurrencyCode: false)
       case .recurringTip:
         cell.tokenView.batContainer.amountLabel.text = BATValue(contribution).displayString
+        cell.tokenView.usdContainer.amountLabel.text = state.ledger.dollarStringForBATAmount(contribution, includeCurrencyCode: false)
         cell.typeNameLabel.text = Strings.RecurringText
       default:
         cell.tokenView.batContainer.amountLabel.text = ""
+        cell.tokenView.usdContainer.amountLabel.text = ""
         cell.typeNameLabel.text = ""
       }
-      cell.tokenView.usdContainer.amountLabel.text = state.ledger.dollarStringForBATAmount(contribution, includeCurrencyCode: false)
       return cell
     }
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1786 and  #1689 (again)  

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
