### PR TITLE
Fix #1791: Use correct "MMM, d" date format for tips detail screen

### DIFF
--- a/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
@@ -46,7 +46,11 @@ class TipsDetailViewController: UIViewController {
   
   private var nextContributionDateView: LabelAccessoryView {
     let view = LabelAccessoryView()
-    view.label.text = Date.stringFrom(reconcileStamp: state.ledger.autoContributeProps.reconcileStamp)
+    let dateFormatter = DateFormatter().then {
+      $0.dateFormat = Strings.AutoContributeDateFormat
+    }
+    let date = Date(timeIntervalSince1970: TimeInterval(state.ledger.autoContributeProps.reconcileStamp))
+    view.label.text = dateFormatter.string(from: date)
     view.bounds = CGRect(origin: .zero, size: view.systemLayoutSizeFitting(UIView.layoutFittingExpandedSize))
     return view
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1791 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
