### PR TITLE
No Bug: Add loader & proper call to "Claim" grant button in notification

### DIFF
--- a/BraveRewardsUI/QA Settings/QASettingsViewController.swift
+++ b/BraveRewardsUI/QA Settings/QASettingsViewController.swift
@@ -29,8 +29,9 @@ public class QASettingsViewController: TableViewController {
   
   @objc private func environmentChanged() {
     let value = segmentedControl.selectedSegmentIndex
-    guard let _ = EnvironmentOverride(rawValue: value) else { return }
-    Preferences.Rewards.environmentOverride.value = value
+    guard value < EnvironmentOverride.sortedCases.count else { return }
+    let overrideForIndex = EnvironmentOverride.sortedCases[value]
+    Preferences.Rewards.environmentOverride.value = overrideForIndex.rawValue
     self.rewards.reset()
     self.showResetRewardsAlert()
   }
@@ -98,7 +99,8 @@ public class QASettingsViewController: TableViewController {
     
     let isDefaultEnvironmentProd = AppConstants.BuildChannel != .developer
     
-    segmentedControl.selectedSegmentIndex = Preferences.Rewards.environmentOverride.value
+    let override: EnvironmentOverride = EnvironmentOverride(rawValue: Preferences.Rewards.environmentOverride.value) ?? .none
+    segmentedControl.selectedSegmentIndex = EnvironmentOverride.sortedCases.firstIndex(of: override) ?? 0
     segmentedControl.addTarget(self, action: #selector(environmentChanged), for: .valueChanged)
     reconcileTimeTextField.addTarget(self, action: #selector(reconcileTimeEditingEnded), for: .editingDidEnd)
     reconcileTimeTextField.frame = CGRect(x: 0, y: 0, width: 50, height: 32)


### PR DESCRIPTION
Also fixes the environment picker

This is basically preemptive work for grant claiming when it comes next week

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
