### PR TITLE
No Bug: Use BAT Points on tipping confirmation screen in JP region

### DIFF
--- a/BraveRewardsUI/Tipping/TippingView.swift
+++ b/BraveRewardsUI/Tipping/TippingView.swift
@@ -19,7 +19,7 @@ extension TippingViewController {
       confirmationView.faviconImageView.backgroundColor = overviewView.faviconImageView.backgroundColor
       confirmationView.subtitleLabel.text = isMonthly ? Strings.TippingMonthlyTitle : Strings.TippingOneTimeTitle
       
-      confirmationView.infoLabel.text = "\(name)\n\(tipAmount) BAT\(isMonthly ? ", \(Strings.TippingRecurring)" : "")"
+      confirmationView.infoLabel.text = "\(name)\n\(tipAmount) \(Strings.BAT)\(isMonthly ? ", \(Strings.TippingRecurring)" : "")"
       
       if isMonthly, let recurringDate = recurringDate {
         confirmationView.monthlyTipLabel.attributedText = {


### PR DESCRIPTION
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Tip a user, on the confirmation screen make sure it says BAT in non-JP regions, and BAT Points in JP region

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
