### PR TITLE
Fix #1808, Fix #1809: Fix tipping screen rotation & multitasking layout

### DIFF
--- a/BraveRewardsUI/Tipping/TippingOverviewView.swift
+++ b/BraveRewardsUI/Tipping/TippingOverviewView.swift
@@ -152,6 +152,7 @@ class TippingOverviewView: UIView {
       $0.leading.trailing.equalTo(self).inset(25.0)
       $0.bottom.equalTo(self.scrollView.contentLayoutGuide).inset(25.0)
     }
+    updateForTraits()
   }
   
   @available(*, unavailable)
@@ -161,6 +162,10 @@ class TippingOverviewView: UIView {
   
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
+    updateForTraits()
+  }
+  
+  func updateForTraits() {
     grabberView.isHidden = traitCollection.horizontalSizeClass == .regular
   }
 }

--- a/BraveRewardsUI/Tipping/TippingSelectionView.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionView.swift
@@ -172,10 +172,15 @@ class TippingSelectionView: UIView {
     insufficientFundsButton.snp.makeConstraints {
       $0.edges.equalTo(self.sendTipButton)
     }
+    updateForTraits()
   }
   
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
+    updateForTraits()
+  }
+  
+  func updateForTraits() {
     let isWideLayout = traitCollection.horizontalSizeClass == .regular
     layoutGuide.snp.remakeConstraints {
       if isWideLayout {

--- a/BraveRewardsUI/Tipping/TippingView.swift
+++ b/BraveRewardsUI/Tipping/TippingView.swift
@@ -138,11 +138,11 @@ extension TippingViewController {
         $0.top.leading.trailing.equalTo(contentView)
         $0.bottom.equalTo(self.optionSelectionView.snp.top)
       }
+      
+      updateForTraits()
     }
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-      super.traitCollectionDidChange(previousTraitCollection)
-      
+    func updateForTraits() {
       let isWideLayout = traitCollection.horizontalSizeClass == .regular
       contentView.snp.remakeConstraints {
         if isWideLayout {
@@ -160,6 +160,11 @@ extension TippingViewController {
       optionSelectionView.clipsToBounds = isWideLayout
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      super.traitCollectionDidChange(previousTraitCollection)
+      updateForTraits()
+    }
+    
     @available(*, unavailable)
     required init(coder: NSCoder) {
       fatalError()
@@ -173,6 +178,9 @@ extension TippingViewController {
 extension TippingViewController.View: BasicAnimationControllerDelegate {
   func animatePresentation(context: UIViewControllerContextTransitioning) {
     context.containerView.addSubview(self)
+    snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
     frame = context.containerView.bounds
     let isWideLayout = context.containerView.traitCollection.horizontalSizeClass == .regular
     


### PR DESCRIPTION
In iOS 13, `traitCollectionDidChange` no longer is called on `init` and instead is given a predicted trait collection therefore we need to make sure to use that predicted trait collection on `init` in case it never changes.

## Summary of Changes

This pull request fixes issue #1808 
This pull request fixes issue #1809 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).