### PR TITLE
Fix #1834: Update "Next contribution date" to "Next monthly tip date"

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -50,7 +50,7 @@ internal extension Strings {
   static let RewardsOptInPrefix = NSLocalizedString("RewardsOptInPrefix", bundle: Bundle.RewardsUI, value: "Get ready to experience the next Internet.", comment: "")
   static let DisclaimerLearnMore = NSLocalizedString("BraveRewardsDisclaimerLearnMore", bundle: Bundle.RewardsUI, value: "Learn More", comment: "")
   static let CLAIM = NSLocalizedString("CLAIM", bundle: Bundle.RewardsUI, value: "CLAIM", comment: "")
-  static let AutoContributeNextDate = NSLocalizedString("BraveRewardsAutoContributeNextDate", bundle: Bundle.RewardsUI, value: "Next contribution date", comment: "")
+  static let AutoContributeNextDate = NSLocalizedString("BraveRewardsAutoContributeNextDate", bundle: Bundle.RewardsUI, value: "Next monthly tip date", comment: "")
   static let TippingMakeMonthly = NSLocalizedString("BraveRewardsTippingMakeMonthly", bundle: Bundle.RewardsUI, value: "Make this monthly", comment: "")
   static let OK = NSLocalizedString("OK", bundle: Bundle.RewardsUI, value: "OK", comment: "")
   static let LearnMoreHowItWorks = NSLocalizedString("BraveRewardsLearnMoreHowItWorks", bundle: Bundle.RewardsUI, value: "How it works…", comment: "")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1834

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
