### PR TITLE
No Bug: Use "BAT Points" for wallet balance, keep BAP everywhere else

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -13,6 +13,12 @@ internal struct Strings {
 }
 
 internal extension Strings {
+  static var WalletBalanceType: String {
+    if Locale.current.isJapan {
+      return NSLocalizedString("BATPoints", bundle: Bundle.RewardsUI, value: "BAT Points", comment: "")
+    }
+    return Strings.BAT
+  }
   static let Open = NSLocalizedString("BraveRewardsOpen", bundle: Bundle.RewardsUI, value: "Open", comment: "")
   static let AdNotificationTitle = NSLocalizedString("BraveRewardsAdNotificationTitle", bundle: Bundle.RewardsUI, value: "Brave Rewards", comment: "")
   static let Verified = NSLocalizedString("BraveRewardsVerified", bundle: Bundle.RewardsUI, value: "Brave Verified Creator", comment: "")

--- a/BraveRewardsUI/Settings/SettingsViewController.swift
+++ b/BraveRewardsUI/Settings/SettingsViewController.swift
@@ -74,7 +74,7 @@ class SettingsViewController: UIViewController {
       $0.autoContributeSection.toggleSwitch.addTarget(self, action: #selector(autoContributeToggleValueChanged), for: .valueChanged)
       
       let dollarString = state.ledger.dollarStringForBATAmount(state.ledger.balance?.total ?? 0) ?? ""
-      $0.walletSection.setWalletBalance(state.ledger.balanceString, crypto: Strings.BAT, dollarValue: dollarString)
+      $0.walletSection.setWalletBalance(state.ledger.balanceString, crypto: Strings.WalletBalanceType, dollarValue: dollarString)
       
       if !BraveAds.isCurrentRegionSupported() {
          $0.adsSection.status = .unsupportedRegion
@@ -164,7 +164,7 @@ class SettingsViewController: UIViewController {
       guard let self = self else { return }
       self.settingsView.walletSection.setWalletBalance(
         self.state.ledger.balanceString,
-        crypto: Strings.BAT,
+        crypto: Strings.WalletBalanceType,
         dollarValue: self.state.ledger.usdBalanceString
       )
     }

--- a/BraveRewardsUI/Settings/Wallet/WalletDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletDetailsViewController.swift
@@ -38,7 +38,7 @@ class WalletDetailsViewController: UIViewController, RewardsSummaryProtocol {
     
     detailsView.walletSection.setWalletBalance(
       state.ledger.balanceString,
-      crypto: Strings.BAT,
+      crypto: Strings.WalletBalanceType,
       dollarValue: state.ledger.usdBalanceString
     )
     
@@ -64,7 +64,7 @@ class WalletDetailsViewController: UIViewController, RewardsSummaryProtocol {
       if let self = self {
         self.detailsView.walletSection.setWalletBalance(
           self.state.ledger.balanceString,
-          crypto: Strings.BAT,
+          crypto: Strings.WalletBalanceType,
           dollarValue: self.state.ledger.usdBalanceString
         )
       }

--- a/BraveRewardsUI/Tipping/TippingViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingViewController.swift
@@ -83,7 +83,7 @@ class TippingViewController: UIViewController, UIViewControllerTransitioningDele
     }
     
     tippingView.overviewView.disclaimerView.isHidden = publisherInfo.status == .verified
-    tippingView.optionSelectionView.setWalletBalance(state.ledger.balanceString, crypto: Strings.BAT)
+    tippingView.optionSelectionView.setWalletBalance(state.ledger.balanceString, crypto: Strings.WalletBalanceType)
     tippingView.optionSelectionView.options = TippingViewController.defaultTippingAmounts.map {
       TippingOption.batAmount(BATValue($0), dollarValue: state.ledger.dollarStringForBATAmount($0) ?? "")
     }

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -541,7 +541,7 @@ extension WalletViewController {
   func updateWalletHeader() {
     walletView.headerView.setWalletBalance(
       state.ledger.balanceString,
-      crypto: Strings.BAT,
+      crypto: Strings.WalletBalanceType,
       dollarValue: state.ledger.usdBalanceString
     )
   }


### PR DESCRIPTION
Wallet balances show as BAT Points, everything else is BAP

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
