### PR TITLE
No Bug: Update "Auto-Contribute" to "Include in Auto-Contribute"

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -219,7 +219,7 @@ internal extension Strings {
   static let MonthlyTips = NSLocalizedString("BraveRewardsMonthlyTips", bundle: Bundle.RewardsUI, value: "Monthly Tips", comment: "")
   static let AdsUnsupportedRegion = NSLocalizedString("BraveRewardsAdsUnsupportedRegion", bundle: Bundle.RewardsUI, value: "Sorry! Ads are not yet available in your region.", comment: "")
   static let AdsUnsupportedDevice = NSLocalizedString("BraveRewardsAdsUnsupportedDvice", bundle: Bundle.RewardsUI, value: "Brave Rewards and Ads are not available on your device at this time.", comment: "")
-  static let AutoContributeSwitchLabel = NSLocalizedString("AutoContributeSwitchLabel", bundle: Bundle.RewardsUI, value: "Auto-Contribute", comment: "Label for auto-contribute toggle.")
+  static let AutoContributeSwitchLabel = NSLocalizedString("AutoContributeSwitchLabel", bundle: Bundle.RewardsUI, value: "Include in Auto-Contribute", comment: "Label for auto-contribute toggle.")
   static let TipSiteMonthly = NSLocalizedString("TipSiteMonthly", bundle: Bundle.RewardsUI, value: "Tip this site monthly", comment: "")
   static let OneTimeText = NSLocalizedString("OneTimeText", bundle: Bundle.RewardsUI, value: "One time ", comment: "Text describing the type of contribution")
   static let RecurringText = NSLocalizedString("RecurringText", bundle: Bundle.RewardsUI, value: "Recurring", comment: "Text describing the type of contribution")


### PR DESCRIPTION
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
