### PR TITLE
No Bug: Replace missed hard-coded BAT in Auto-Contribute settings screen

### DIFF
--- a/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
@@ -160,7 +160,7 @@ extension AutoContributeSettingsViewController: UITableViewDelegate, UITableView
     case .monthlyPayment:
       cell.label.text = Strings.AutoContributeMonthlyPayment
       if let dollarAmount = ledger.dollarStringForBATAmount(ledger.contributionAmount) {
-        cell.accessoryLabel?.text = "\(ledger.contributionAmount) BAT (\(dollarAmount))"
+        cell.accessoryLabel?.text = "\(ledger.contributionAmount) \(Strings.BAT) (\(dollarAmount))"
       }
     case .minimumLength:
       cell.label.text = Strings.AutoContributeMinimumLengthMessage


### PR DESCRIPTION
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
