### PR TITLE
Fix: #1840 - Pub favicon is only shown for the first entry on tips details.

### DIFF
--- a/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
+++ b/BraveRewardsUI/Settings/Tips/Details/TipsDetailViewController.swift
@@ -288,14 +288,21 @@ extension TipsDetailViewController {
     if let pageURL = URL(string: pageURL) {
       state.dataSource?.retrieveFavicon(for: pageURL, faviconURL: URL(string: faviconURL ?? ""), completion: {[weak self] favData in
         guard let self = self,
-          let image = favData?.image,
-          let index = self.tipsList.firstIndex(where: {$0.id == identifier}) else {
+          let image = favData?.image  else {
             return
         }
+        
+        let indices = self.tipsList.enumerated().compactMap({ $0.element.id == identifier ? $0.offset : nil })
+        if indices.isEmpty {
+          return
+        }
 
-        if let tableView = (self.view as? View)?.tableView,
-          let cell = tableView.cellForRow(at: IndexPath(row: index, section: Section.tips.rawValue)) as? TipsTableCell {
-          cell.siteImageView.image = image
+        if let tableView = (self.view as? View)?.tableView {
+          for index in indices {
+            if let cell = tableView.cellForRow(at: IndexPath(row: index, section: Section.tips.rawValue)) as? TipsTableCell {
+              cell.siteImageView.image = image
+            }
+          }
         }
       })
     }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue https://github.com/brave/brave-ios/issues/1840
- Issue happens because the code originally only checked for the first cell that matches the tip identifier. - However, user/qa would tip the same publisher twice so we can now have duplicate matching identifiers instead of limiting it to just one.
- Solution is to update ALL cells where the identifier matches.
- Tested and works.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
