### PR TITLE
Fix #1864, ref #1553: Fix styling of edit buttons in downloads panel.

### DIFF
--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -60,12 +60,6 @@ extension Theme {
         
         InsetButton.appearance(whenContainedInInstancesOf: [SearchSuggestionPromptView.self]).appearanceTextColor = colors.tints.home
         
-        // Downloads
-        UIView.appearance(whenContainedInInstancesOf: [DownloadsPanel.self]).appearanceBackgroundColor = colors.home
-        
-        UIImageView.appearance(whenContainedInInstancesOf: [DownloadsPanel.self]).tintColor = colors.tints.home
-        UILabel.appearance(whenContainedInInstancesOf: [DownloadsPanel.self]).appearanceTextColor = colors.tints.home
-        
         if #available(iOS 13.0, *) {
             // Overrides all views inside of itself
             // According to docs, UIWindow override should be enough, but some labels on iOS 13 are still messed up without UIView override as well

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -52,8 +52,10 @@ extension BrowserViewController: DownloadQueueDelegate {
                 let downloadCompleteToast = ButtonToast(labelText: download.filename, imageName: "check", buttonText: Strings.DownloadsButtonTitle, completion: { buttonPressed in
                     guard buttonPressed else { return }
                     
-                    let nav = SettingsNavigationController(rootViewController:
-                        DownloadsPanel(profile: self.profile))
+                    let downloadsPanel = DownloadsPanel(profile: self.profile)
+                    let currentTheme = Theme.of(self.tabManager.selectedTab)
+                    downloadsPanel.applyTheme(currentTheme)
+                    let nav = SettingsNavigationController(rootViewController: downloadsPanel)
                     nav.modalPresentationStyle = .formSheet
                     nav.navigationBar.topItem?.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: nav, action: #selector(nav.done))
                     

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
@@ -55,6 +55,10 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     private var groupedDownloadedFiles = DateGroupedTableData<DownloadedFile>()
     private var fileExtensionIcons: [String: UIImage] = [:]
     
+    let welcomeLabel = UILabel()
+    let overlayView = UIView()
+    let logoImageView = UIImageView(image: #imageLiteral(resourceName: "emptyDownloads").template)
+    
     // MARK: - Lifecycle
     init(profile: Profile) {
         self.profile = profile
@@ -247,10 +251,8 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     fileprivate func createEmptyStateOverlayView() -> UIView {
-        let overlayView = UIView()
         overlayView.backgroundColor = UIColor.Photon.White100
         
-        let logoImageView = UIImageView(image: #imageLiteral(resourceName: "emptyDownloads").template)
         overlayView.addSubview(logoImageView)
         logoImageView.snp.makeConstraints { make in
             make.centerX.equalTo(overlayView)
@@ -262,7 +264,6 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
             make.top.greaterThanOrEqualTo(overlayView).offset(50)
         }
         
-        let welcomeLabel = UILabel()
         overlayView.addSubview(welcomeLabel)
         welcomeLabel.text = Strings.DownloadsPanelEmptyStateTitle
         welcomeLabel.textAlignment = .center
@@ -386,6 +387,10 @@ extension DownloadsPanel: Themeable {
         emptyStateOverlayView.removeFromSuperview()
         emptyStateOverlayView = createEmptyStateOverlayView()
         updateEmptyPanelState()
+        
+        welcomeLabel.appearanceTextColor = theme.colors.tints.home
+        overlayView.appearanceBackgroundColor = theme.colors.home
+        logoImageView.tintColor = theme.colors.tints.home
         
         tableView.reloadData()
     }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -226,6 +226,8 @@ class MenuViewController: UITableViewController {
     
     private func openDownloads() {
         let vc = DownloadsPanel(profile: bvc.profile)
+        let currentTheme = Theme.of(bvc.tabManager.selectedTab)
+        vc.applyTheme(currentTheme)
         
         open(vc, doneButton: DoneButton(style: .done, position: .right))
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
As this is a regression from 1.12 and a small fix, we may want to merge it into 1.13

This pull request fixes issue #1864 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
