### PR TITLE
Fix: #1869 - Onboarding not showing up for really old versions of the app

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -758,6 +758,25 @@ class BrowserViewController: UIViewController {
             
             onboarding.onboardingDelegate = self
             present(onboarding, animated: true)
+            return
+        }
+        
+        // 1. Rewards are on/off (existing user)
+        // 2. User hasn't seen the rewards part of the onboarding yet because their version of the app is insanely OLD and somehow the progress value doesn't exist.
+        if (Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue)
+            &&
+            (Preferences.General.basicOnboardingProgress.value == OnboardingProgress.none.rawValue) {
+            
+            guard let onboarding = OnboardingNavigationController(
+                profile: profile,
+                onboardingType: isRewardsEnabled ? .existingUserRewardsOn : .existingUserRewardsOff,
+                rewards: rewards,
+                theme: Theme.of(tabManager.selectedTab)
+                ) else { return }
+            
+            onboarding.onboardingDelegate = self
+            present(onboarding, animated: true)
+            return
         }
         
         // 1. Rewards are on/off (existing user)
@@ -778,6 +797,7 @@ class BrowserViewController: UIViewController {
             
             onboarding.onboardingDelegate = self
             present(onboarding, animated: true)
+            return
         }
         
         // 1. User is brand new
@@ -795,6 +815,7 @@ class BrowserViewController: UIViewController {
             
             onboarding.onboardingDelegate = self
             present(onboarding, animated: true)
+            return
         }
     }
 


### PR DESCRIPTION
I'm hoping this fixes onboarding not showing up for OLD versions of the app.. Because otherwise there's no way this should even be possible.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1869

I added code that I THINK will fix it. I have no way of knowing because stuff is somehow working for me and I don't know why. However, I suspect that it's because this preference value does NOT exist and since its default value upon upgrade should be "none", I am now checking if onboarding WAS completed and this value is NONE. If this is true, we show `.existingUser`.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
