### PR TITLE
Fix #1876: Revert `domainUrl`, add new method to strip www from url.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3034,7 +3034,7 @@ extension BrowserViewController {
         guard searchQuery != "",
             let iconURL = URL(string: favicon.url),
             let url = URL(string: searchQuery.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed)!),
-            let shortName = url.domainURL().host else {
+            let shortName = url.domainURL.host else {
                 let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
                 self.present(alert, animated: true, completion: nil)
                 return

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -73,7 +73,7 @@ class FaviconHandler {
             guard let image = image else {
                 // If we failed to download a page-level icon, try getting the domain-level icon
                 // instead before ultimately failing.
-                let siteIconURL = currentURL.domainURL().appendingPathComponent("favicon.ico")
+                let siteIconURL = currentURL.domainURL.appendingPathComponent("favicon.ico")
                 imageOperation = webImageCache.load(from: siteIconURL, options: [.lowPriority], progress: onProgress, completion: onCompletedSiteFavicon)
 
                 return

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -321,7 +321,7 @@ class TabLocationView: UIView {
 
     fileprivate func updateTextWithURL() {
         (urlTextField as? DisplayTextField)?.hostString = url?.host ?? ""
-        urlTextField.text = url?.domainURL(stripWWWSubdomainOnly: true).schemelessAbsoluteString.trim("/")
+        urlTextField.text = url?.withoutWWW.schemelessAbsoluteString.trim("/")
     }
 }
 

--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -207,7 +207,7 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
     // Returns a single Favicon UIImage for a given URL
     class func fetchFavImageForURL(forURL url: URL, profile: Profile) -> Deferred<Maybe<UIImage>> {
         let deferred = Deferred<Maybe<UIImage>>()
-        FaviconFetcher.getForURL(url.domainURL()).uponQueue(.main) { result in
+        FaviconFetcher.getForURL(url.domainURL).uponQueue(.main) { result in
             guard let favicons = result.successValue, let favicon = favicons.first, let faviconURL = favicon.url.asURL else {
                 return deferred.fill(Maybe(failure: FaviconError()))
             }

--- a/Client/WebAuthN/U2FExtensions.swift
+++ b/Client/WebAuthN/U2FExtensions.swift
@@ -236,7 +236,7 @@ class U2FExtensions: NSObject {
         guard let url = self.tab?.url else {
             return nil
         }
-        return url.domainURL().absoluteString
+        return url.domainURL.absoluteString
     }
     
     private func setCurrentTabId() {

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -106,7 +106,7 @@ extension Domain {
     class func getOrCreateInternal(_ url: URL,
                                    context: NSManagedObjectContext = DataController.viewContext,
                                    save: Bool = true) -> Domain {
-        let domainString = url.domainURL().absoluteString
+        let domainString = url.domainURL.absoluteString
         if let domain = Domain.first(where: NSPredicate(format: "url == %@", domainString), context: context) {
             return domain
         }
@@ -158,7 +158,7 @@ extension Domain {
     }
     
     class func getForUrl(_ url: URL) -> Domain? {
-        let domainString = url.domainURL().absoluteString
+        let domainString = url.domainURL.absoluteString
         return Domain.first(where: NSPredicate(format: "url == %@", domainString))
     }
     

--- a/DataTests/DomainTests.swift
+++ b/DataTests/DomainTests.swift
@@ -58,7 +58,7 @@ class DomainTests: CoreDataTestCase {
         
         XCTAssertEqual(domain.bookmarks?.count, 0)
         XCTAssertEqual(domain.historyItems?.count, 0)
-        XCTAssertEqual(domain.url, url.domainURL().absoluteString)
+        XCTAssertEqual(domain.url, url.domainURL.absoluteString)
     }
     
     /// Tests non-HTTPSE shields

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -357,22 +357,22 @@ class NSURLExtensionsTests: XCTestCase {
         badurls.forEach { XCTAssertFalse(URL(string:$0)!.isWebPage(), $0) }
     }
 
-    func testdomainURL() {
+    func testdomainWithoutWWW() {
         let urls = [
             ("https://www.example.com/index.html", "https://example.com/index.html"),
             ("https://mail.example.com/index.html", "https://mail.example.com/index.html"),
             ("https://mail.example.co.uk/index.html", "https://mail.example.co.uk/index.html"),
         ]
-        urls.forEach { XCTAssertEqual(URL(string:$0.0)!.domainURL().absoluteString, $0.1) }
+        urls.forEach { XCTAssertEqual(URL(string:$0.0)!.withoutWWW.absoluteString, $0.1) }
     }
     
-    func testdomainURLStrippingOnlyWWW() {
+    func testdomainUrl() {
         let urls = [
-            ("https://www.example.com/index.html", "https://example.com/index.html"),
-            ("https://m.example.com/index.html", "https://m.example.com/index.html"),
-            ("https://mobile.example.co.uk/index.html", "https://mobile.example.co.uk/index.html"),
+            ("https://www.example.com/index.html", "https://example.com"),
+            ("https://mail.example.com/index.html", "https://mail.example.com"),
+            ("https://mail.example.co.uk/index.html", "https://mail.example.co.uk"),
         ]
-        urls.forEach { XCTAssertEqual(URL(string:$0.0)!.domainURL(stripWWWSubdomainOnly: true).absoluteString, $0.1) }
+        urls.forEach { XCTAssertEqual(URL(string:$0.0)!.domainURL.absoluteString, $0.1) }
     }
 
     func testdisplayURL() {

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -62,7 +62,7 @@ open class Site: Identifiable, Hashable {
     var guid: String?
 
     open var tileURL: URL {
-        return URL(string: url)?.domainURL() ?? URL(string: "about:blank")!
+        return URL(string: url)?.domainURL ?? URL(string: "about:blank")!
     }
 
     public let url: String


### PR DESCRIPTION
#ref 1533

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This commit:
https://github.com/brave/brave-ios/commit/d482ffbe4c638734a49b5b25f67711cea26bf718

had a bug where `domainURL` wasn't stripping url parameters.
Now there are two methods, one to strip `www` only and leave params, 
and old `domainURL` which keeps the scheme without params

This pull request fixes issue #1876 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
