### PR TITLE
Fix #1891: Don't show insufficient funds when balance is tipping amount

### DIFF
--- a/BraveRewardsUI/Tipping/TippingViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingViewController.swift
@@ -68,7 +68,7 @@ class TippingViewController: UIViewController, UIViewControllerTransitioningDele
     tippingView.optionSelectionView.optionChanged = { [weak self] option in
       guard let self = self else { return }
       if let balanceTotal = self.state.ledger.balance?.total {
-        let hasEnoughBalanceForTip = option.value.doubleValue < balanceTotal
+        let hasEnoughBalanceForTip = option.value.doubleValue <= balanceTotal
         self.tippingView.optionSelectionView.setEnoughFundsAvailable(hasEnoughBalanceForTip)
       } else {
         self.tippingView.optionSelectionView.setEnoughFundsAvailable(false)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1891 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
