### PR TITLE
Fix #1893: Correct woi param for non-gregorian calendars.

### DIFF
--- a/BraveShared/Analytics/DAU.swift
+++ b/BraveShared/Analytics/DAU.swift
@@ -270,7 +270,7 @@ extension Date {
         
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
-        
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
         return dateFormatter.string(from: monday)
     }
     

--- a/BraveSharedTests/DAUTests.swift
+++ b/BraveSharedTests/DAUTests.swift
@@ -140,6 +140,16 @@ class DAUTests: XCTestCase {
         XCTAssertNil(params2)
     }
     
+    func testMondayOfCurrentWeekFormatted() {
+        // Making sure gregorian year is showing
+        let yearString = Date().mondayOfCurrentWeekFormatted?.truncate(length: 4, trailing: "")
+        let year = Int(yearString!)!
+        
+        // There is no easy way to mock a different calendar in unit tests, just checking if
+        // year we get looks 'correct' should be good enough.
+        XCTAssert(year > 2018 && year < 2025)
+    }
+    
     func testNonDefaultWoiExplicitDate() {
         let correctWoi = "2018-02-26"
         


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1893 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Can't really by tested by QA

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
