### PR TITLE
Ref #1656: Update balance on claim grant after tokens are fetched

### DIFF
--- a/BraveRewards/BraveRewards.framework/Headers/BATBraveLedger.h
+++ b/BraveRewards/BraveRewards.framework/Headers/BATBraveLedger.h
@@ -173,6 +173,9 @@ NS_SWIFT_NAME(BraveLedger)
 
 @property (nonatomic, readonly) NSArray<BATPromotion *> *finishedPromotions;
 
+/// Updates `pendingPromotions` and `finishedPromotions` based on the database
+- (void)updatePromotions:(nullable void (^)())completion;
+
 - (void)fetchPromotions:(nullable void (^)(NSArray<BATPromotion *> *grants))completion;
 
 - (void)claimPromotion:(NSString *)deviceCheckPublicKey

--- a/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
+++ b/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
@@ -205,8 +205,7 @@ extension BraveLedger {
             
             self.attestPromotion(promotion.id, solution: solution) { result, promotion in
               if result == .ledgerOk {
-                self.fetchPromotions { _ in
-                  self.fetchBalance({ _ in })
+                self.updatePromotions {
                   completion(true)
                 }
               } else {

--- a/BraveRewardsUI/README.md
+++ b/BraveRewardsUI/README.md
@@ -6,5 +6,5 @@ The latest BraveRewards.framework was built on:
 
 ```
 brave-browser/5d5f18be463abaf9b5f23d5b7ec14be51f7fd412
-brave-core/96b0900380ed89472c8ad2a20e1c6bb728e75573
+brave-core/c4ddbe240f2b580f0c1c77e86d3b020b6988ae09
 ```


### PR DESCRIPTION
This also fixes the bug where promos sometimes mess up when claiming them during publisher list load

## Summary of Changes

This pull request references issue #1656

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Claim a grant
- Wait on panel
- Balance should update after 5s (if fetched tokens retry succeeds)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
