### PR TITLE
Fix #1903: Present action sheets as popovers on iPads

### DIFF
--- a/BraveRewardsUI/QA Settings/QASettingsViewController.swift
+++ b/BraveRewardsUI/QA Settings/QASettingsViewController.swift
@@ -141,6 +141,8 @@ public class QASettingsViewController: TableViewController {
           Row(text: "Recovery Key", detailText: obfuscatedPassphrase ?? "—", selection: {
             if let passphrase = self.rewards.ledger.walletPassphrase {
               let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+              sheet.popoverPresentationController?.sourceView = self.view
+              sheet.popoverPresentationController?.sourceRect = self.view.bounds
               sheet.addAction(UIAlertAction(title: "Copy Wallet Passphrase", style: .default, handler: { _ in
                 UIPasteboard.general.string = passphrase
               }))

--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -71,6 +71,8 @@ class BraveRewardsSettingsViewController: TableViewController {
                 Section(rows: [
                     Row(text: Strings.WalletCreationDate, detailText: walletCreatedDate, selection: {
                         let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+                        sheet.popoverPresentationController?.sourceView = self.view
+                        sheet.popoverPresentationController?.sourceRect = self.view.bounds
                         sheet.addAction(UIAlertAction(title: Strings.CopyWalletSupportInfo, style: .default, handler: { [unowned self] _ in
                             self.rewards.ledger.rewardsInternalInfo { info in
                                 guard let info = info else { return }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -400,6 +400,8 @@ class SettingsViewController: TableViewController {
                 Row(text: version, selection: { [unowned self] in
                     let device = UIDevice.current
                     let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+                    actionSheet.popoverPresentationController?.sourceView = self.view
+                    actionSheet.popoverPresentationController?.sourceRect = self.view.bounds
                     let iOSVersion = "\(device.systemName) \(UIDevice.current.systemVersion)"
                     
                     let deviceModel = String(format: Strings.Device_template, device.modelName, iOSVersion)


### PR DESCRIPTION
The place where it appears is a bit goofy at the moment, until we can find a way to force UIAlertController to appear the same on iPad as it does on iPhone

## Summary of Changes

This pull request fixes issue #1903 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Test iPhone builds that action sheets appear normal for copy version & brave rewards > copy wallet info
- Test iPad builds that they don't crash clicking the same buttons

## Screenshots:

![Simulator Screen Shot - iPad Pro (9 7-inch) - 2019-11-05 at 17 55 42](https://user-images.githubusercontent.com/529104/68253286-8e3ddc80-fff5-11e9-9335-f8705ac5a396.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).