### PR TITLE
Fix #1908: Correct message for claiming ads earning view.

### DIFF
--- a/BraveRewardsUI/Settings/Grants/SettingsGrantSectionView.swift
+++ b/BraveRewardsUI/Settings/Grants/SettingsGrantSectionView.swift
@@ -50,10 +50,11 @@ class SettingsGrantSectionView: SettingsSectionView {
     switch type {
     case .ads(let amount):
       iconImageView.image = UIImage(frameworkResourceNamed: "icn-ads")
+      
       if let amount = amount {
-        textLabel.text = String(format: Strings.SettingsAdsGrantText, "\(amount) \(Strings.BAT) ")
+        textLabel.text = "\(amount) \(Strings.BAT) \(Strings.SettingsAdsGrantText)"
       } else {
-        textLabel.text = Strings.SettingsAdsGrantText
+        textLabel.text = Strings.NotificationEarningsClaimDefault
       }
     case .ugp:
       iconImageView.image = UIImage(frameworkResourceNamed: "icn-grant")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Note: Sriram marked this ticket for 1.14, if we want to get it in along with other more important tickets to 1.13 the milestone needs to be updated.

This pull request fixes issue #1908 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
