### PR TITLE
Fix #1911 - Clear Enrollment data when restoring a wallet

### DIFF
--- a/BraveRewardsUI/QA Settings/QASettingsViewController.swift
+++ b/BraveRewardsUI/QA Settings/QASettingsViewController.swift
@@ -214,6 +214,7 @@ public class QASettingsViewController: TableViewController {
         let message = error?.localizedDescription ?? "Restore Complete. Brave must be restarted to ensure expected Rewards behavior"
         let completionAlert = UIAlertController(title: "Restore Wallet", message: message, preferredStyle: .alert)
         if error == nil {
+          DeviceCheckClient.resetDeviceEnrollment()
           completionAlert.addAction(UIAlertAction(title: "Exit Now", style: .destructive, handler: { _ in
             fatalError()
           }))

--- a/Client/DeviceCheck/Cryptography.swift
+++ b/Client/DeviceCheck/Cryptography.swift
@@ -62,20 +62,7 @@ public struct CryptographicKey {
   /// Deletes the key from the secure-enclave and keychain
   @discardableResult
   public func delete() -> Error? {
-    guard let keyId = keyId.data(using: .utf8) else {
-      return CryptographyError(description: "Invalid KeyId")
-    }
-    
-    let error = SecItemDelete([
-      kSecClass: kSecClassKey,
-      kSecAttrApplicationTag: keyId
-    ] as CFDictionary)
-    
-    if error == errSecSuccess || error == errSecItemNotFound {
-      return nil
-    }
-    
-    return CryptographyError(code: error)
+    return Cryptography.delete(id: keyId)
   }
   
   /// Signs "message" with the key and returns the signature
@@ -267,6 +254,25 @@ public class Cryptography {
     }
     
     return CryptographicKey(key: pKey, keyId: id)
+  }
+  
+  /// Deletes the key with the specified ID from the secure-enclave and keychain
+  @discardableResult
+  public class func delete(id: String) -> Error? {
+    guard let keyId = id.data(using: .utf8) else {
+      return CryptographyError(description: "Invalid KeyId")
+    }
+    
+    let error = SecItemDelete([
+      kSecClass: kSecClassKey,
+      kSecAttrApplicationTag: keyId
+    ] as CFDictionary)
+    
+    if error == errSecSuccess || error == errSecItemNotFound {
+      return nil
+    }
+    
+    return CryptographyError(code: error)
   }
   
   /// Retrieve a key's properties without retrieving the actual key itself

--- a/Client/DeviceCheck/DeviceCheck.swift
+++ b/Client/DeviceCheck/DeviceCheck.swift
@@ -6,6 +6,7 @@ import Foundation
 import DeviceCheck
 import BraveRewards
 import BraveShared
+import Shared
 
 private let log = Logger.browserLogger
 

--- a/Client/DeviceCheck/DeviceCheck.swift
+++ b/Client/DeviceCheck/DeviceCheck.swift
@@ -7,6 +7,8 @@ import DeviceCheck
 import BraveRewards
 import BraveShared
 
+private let log = Logger.browserLogger
+
 /// A structure used to register a device for Brave's DeviceCheck enrollment
 public struct DeviceCheckRegistration: Codable {
   // The enrollment blob is a Base64 Encoded `DeviceCheckEnrollment` structure
@@ -148,6 +150,13 @@ public class DeviceCheckClient {
     let hasPrivateKey = Cryptography.keyExists(id: DeviceCheckClient.privateKeyId)
     let didEnrollSuccessfully = Preferences.Rewards.didEnrollDeviceCheck.value
     return hasPrivateKey && didEnrollSuccessfully
+  }
+  
+  public class func resetDeviceEnrollment() {
+    Preferences.Rewards.didEnrollDeviceCheck.value = false
+    if let error = Cryptography.delete(id: DeviceCheckClient.privateKeyId) {
+      log.error(error)
+    }
   }
   
   // MARK: - Server calls for DeviceCheck


### PR DESCRIPTION
When a wallet is successfully restored, remove the old private-key and enrollment preferences. This will cause it to generate a new private key during re-enrollment when claiming a grant.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1911
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->
- Delete the existing private key and preference when you restore a wallet.
- We can optionally keep the same private-key and just set the preference but I opted for both just in case someone decides to mess with their info.plist somehow.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
