### PR TITLE
Fix: #1916, Fix: #1904 - Makes notifications wider on iPad.

### DIFF
--- a/BraveRewardsUI/Ads/AdsNotificationHandler.swift
+++ b/BraveRewardsUI/Ads/AdsNotificationHandler.swift
@@ -47,12 +47,14 @@ public class AdsNotificationHandler: BraveAdsNotificationHandler {
   private func displayAd(notification: AdsNotification) {
     guard let presentingController = presentingController else { return }
     
+    guard let window = presentingController.view.window else {
+      return
+    }
+    
     if adsViewController.parent == nil {
-      presentingController.addChild(adsViewController)
-      presentingController.view.addSubview(adsViewController.view)
-      adsViewController.didMove(toParent: presentingController)
+      window.addSubview(adsViewController.view)
       adsViewController.view.snp.makeConstraints {
-        $0.edges.equalToSuperview()
+        $0.edges.equalTo(window.safeAreaLayoutGuide.snp.edges)
       }
     }
     

--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -45,7 +45,8 @@ public class AdsViewController: UIViewController {
       $0.top.greaterThanOrEqualTo(view).offset(4) // Makes sure in landscape its at least 4px from the top
       
       if UIDevice.current.userInterfaceIdiom == .pad {
-        $0.width.equalTo(max(view.bounds.width, view.bounds.height) * 0.40).priority(.high)
+        let isWidthLarger = UIScreen.main.bounds.width > UIScreen.main.bounds.height
+        $0.width.equalTo(isWidthLarger ? view.snp.width : view.snp.height).multipliedBy(0.40).priority(.high)
       } else {
         $0.width.equalTo(view).priority(.high)
       }

--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -41,7 +41,7 @@ public class AdsViewController: UIViewController {
       $0.leading.greaterThanOrEqualTo(view).inset(8)
       $0.trailing.lessThanOrEqualTo(view).inset(8)
       $0.centerX.equalTo(view)
-      $0.width.equalTo(400).priority(.high)
+      $0.width.equalTo(view).priority(.high)
       $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
       $0.top.greaterThanOrEqualTo(view).offset(4) // Makes sure in landscape its at least 4px from the top
     }
@@ -299,15 +299,24 @@ extension AdsViewController: UIGestureRecognizerDelegate {
 }
 
 extension AdsViewController {
+  
   /// Display a "My First Ad" on a presenting controller and be notified if they tap it
   public static func displayFirstAd(on presentingController: UIViewController, completion: @escaping (AdsNotificationHandler.Action, URL) -> Void) {
     let adsViewController = AdsViewController()
     
-    presentingController.addChild(adsViewController)
-    presentingController.view.addSubview(adsViewController.view)
-    adsViewController.didMove(toParent: presentingController)
+    guard let window = presentingController.view.window else {
+      return
+    }
+    
+    window.addSubview(adsViewController.view)
     adsViewController.view.snp.makeConstraints {
-      $0.edges.equalToSuperview()
+      $0.edges.top.bottom.equalToSuperview()
+      
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        $0.edges.width.equalTo(max(window.bounds.width, window.bounds.height)).multipliedBy(0.40)
+      } else {
+        $0.edges.width.equalTo(400.0).priority(.high)
+      }
     }
     
     let notification = AdsNotification.customAd(
@@ -319,9 +328,7 @@ extension AdsViewController {
     adsViewController.display(ad: notification, handler: { (notification, action) in
       completion(action, notification.url)
     }, animatedOut: {
-      adsViewController.willMove(toParent: nil)
       adsViewController.view.removeFromSuperview()
-      adsViewController.removeFromParent()
     })
   }
 }

--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -41,9 +41,14 @@ public class AdsViewController: UIViewController {
       $0.leading.greaterThanOrEqualTo(view).inset(8)
       $0.trailing.lessThanOrEqualTo(view).inset(8)
       $0.centerX.equalTo(view)
-      $0.width.equalTo(view).priority(.high)
       $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
       $0.top.greaterThanOrEqualTo(view).offset(4) // Makes sure in landscape its at least 4px from the top
+      
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        $0.width.equalTo(max(view.bounds.width, view.bounds.height) * 0.40).priority(.high)
+      } else {
+        $0.width.equalTo(view).priority(.high)
+      }
     }
     view.layoutIfNeeded()
     
@@ -310,13 +315,7 @@ extension AdsViewController {
     
     window.addSubview(adsViewController.view)
     adsViewController.view.snp.makeConstraints {
-      $0.edges.top.bottom.equalToSuperview()
-      
-      if UIDevice.current.userInterfaceIdiom == .pad {
-        $0.edges.width.equalTo(max(window.bounds.width, window.bounds.height)).multipliedBy(0.40)
-      } else {
-        $0.edges.width.equalTo(400.0).priority(.high)
-      }
+      $0.edges.equalTo(window.safeAreaLayoutGuide.snp.edges)
     }
     
     let notification = AdsNotification.customAd(


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1916 & #1904
- Makes notifications wider on iPad and presents them on top of everything else just like system notifications by rendering them on the window instead of the controller's view.
- This ticket includes two fixes because the only way for me to make it wider was to put it on the window which inherently fixes the notification stacking below the panel bug.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
