### PR TITLE
Fix #1898: Hide rewards summary when leaving main wallet screen

### DIFF
--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -124,6 +124,10 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
     if presentedViewController == nil {
       navigationController?.setNavigationBarHidden(false, animated: animated)
     }
+    
+    if rewardsSummaryView.transform.ty != 0 {
+      tappedRewardsSummaryButton()
+    }
   }
   
   deinit {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1898 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable Rewards
- Visit a website so the publisher info comes up in panel
- In rewards panel click rewards summary button
- Click settings
- Go back, verify UI layout is correct

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
