### PR TITLE
Fix #1871: Change grant claimed copy for ads grants

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -41,6 +41,7 @@ internal extension Strings {
   static let SettingsAutoContributeTitle = NSLocalizedString("BraveRewardsSettingsAutoContributeTitle", bundle: Bundle.RewardsUI, value: "Auto-Contribute", comment: "")
   static let NotYetVerified = NSLocalizedString("BraveRewardsNotYetVerified", bundle: Bundle.RewardsUI, value: "Not yet verified", comment: "")
   static let GrantsClaimedTitle = NSLocalizedString("BraveRewardsGrantsClaimedTitle", bundle: Bundle.RewardsUI, value: "It's your lucky day!", comment: "")
+  static let AdsGrantsClaimedTitle = NSLocalizedString("BraveRewardsAdsGrantsClaimedTitle", bundle: Bundle.RewardsUI, value: "Brave Ads Rewards!", comment: "")
   static let NotificationAdsTitle = NSLocalizedString("BraveRewardsNotificationAdsTitle", bundle: Bundle.RewardsUI, value: "Brave Ads", comment: "")
   static let MinimumVisitsChoices2 = NSLocalizedString("BraveRewardsMinimumVisitsChoices2", bundle: Bundle.RewardsUI, value: "10 visits", comment: "")
   static let MinimumVisitsChoices1 = NSLocalizedString("BraveRewardsMinimumVisitsChoices1", bundle: Bundle.RewardsUI, value: "5 visits", comment: "")
@@ -123,6 +124,7 @@ internal extension Strings {
     }
     return NSLocalizedString("BraveRewardsGrantsClaimedSubtitle", bundle: Bundle.RewardsUI, value: "Your token grant is on its way.", comment: "")
   }
+  static let AdsGrantsClaimedSubtitle = NSLocalizedString("BraveRewardsAdsGrantsClaimedSubtitle", bundle: Bundle.RewardsUI, value: "Your rewards grant from Brave Ads is on its way.", comment: "")
   static let AutoContributeRestoreExcludedSites = NSLocalizedString("BraveRewardsAutoContributeRestoreExcludedSites", bundle: Bundle.RewardsUI, value: "Restore %ld excluded sites", comment: "")
   static let SettingsViewDetails = NSLocalizedString("BraveRewardsSettingsViewDetails", bundle: Bundle.RewardsUI, value: "View Details", comment: "")
   static let AutoContributeMonthlyPaymentTitle = NSLocalizedString("BraveRewardsAutoContributeMonthlyPaymentTitle", bundle: Bundle.RewardsUI, value: "Monthly Payment", comment: "")
@@ -191,6 +193,12 @@ internal extension Strings {
       return NSLocalizedString("BraveRewardsGrantsClaimedAmountTitleJapan", bundle: Bundle.RewardsUI, value: "Free Points Grant", comment: "")
     }
     return NSLocalizedString("BraveRewardsGrantsClaimedAmountTitle", bundle: Bundle.RewardsUI, value: "Free Token Grant", comment: "")
+  }
+  static var AdsGrantsClaimedAmountTitle: String {
+    if Locale.current.isJapan {
+      return NSLocalizedString("BraveRewardsAdsGrantsClaimedAmountTitleJapan", bundle: Bundle.RewardsUI, value: "Your Brave Ads Point Grant", comment: "")
+    }
+    return NSLocalizedString("BraveRewardsAdsGrantsClaimedAmountTitle", bundle: Bundle.RewardsUI, value: "Your Brave Ads Token Grant", comment: "")
   }
   static let SettingsAdsComingSoonText = NSLocalizedString("BraveRewardsSettingsAdsComingSoonText", bundle: Bundle.RewardsUI, value: "Coming soon.", comment: "")
   static let SettingsTipsTitle = NSLocalizedString("BraveRewardsSettingsTipsTitle", bundle: Bundle.RewardsUI, value: "Tips", comment: "")

--- a/BraveRewardsUI/Settings/SettingsViewController.swift
+++ b/BraveRewardsUI/Settings/SettingsViewController.swift
@@ -185,7 +185,7 @@ class SettingsViewController: UIViewController {
       
       let claimedVC = GrantClaimedViewController(
         grantAmount: amount,
-        expirationDate: isAdGrant ? nil : Date(timeIntervalSince1970: TimeInterval(promotion.expiresAt))
+        kind: isAdGrant ? .ads : .ugp(expirationDate: Date(timeIntervalSince1970: TimeInterval(promotion.expiresAt)))
       )
       self.present(claimedVC, animated: true)
     }

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -335,7 +335,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
       let isAdGrant = promotion.type == .ads
       let claimedVC = GrantClaimedViewController(
         grantAmount: grantAmount,
-        expirationDate: isAdGrant ? nil : Date(timeIntervalSince1970: TimeInterval(promotion.expiresAt))
+        kind: isAdGrant ? .ads : .ugp(expirationDate: Date(timeIntervalSince1970: TimeInterval(promotion.expiresAt)))
       )
       self.present(claimedVC, animated: true) {
         self.tappedNotificationClose()


### PR DESCRIPTION
Needs translations pushed to transifex after

## Summary of Changes

This pull request fixes issue #1871

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- At the moment, easiest way is to fake the grant type at `GrantClaimedViewController` creation.

## Screenshots:

| Regular Grant | Ads Grant |
| --- | --- |
| ![IMG_4401](https://user-images.githubusercontent.com/529104/68620929-8a4e0680-049c-11ea-9197-e7d8b8ac8c96.png) | ![IMG_4402](https://user-images.githubusercontent.com/529104/68620933-8d48f700-049c-11ea-9405-8e06f7baf9b7.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).