### PR TITLE
No Bug: Add a way to export rewards database files from beta builds

### DIFF
--- a/BraveRewardsUI/QA Settings/QASettingsViewController.swift
+++ b/BraveRewardsUI/QA Settings/QASettingsViewController.swift
@@ -178,6 +178,9 @@ public class QASettingsViewController: TableViewController {
       ),
       Section(
         rows: [
+          Row(text: "Share Rewards Database", selection: {
+            self.tappedShareRewardsDatabase()
+          }, cellClass: ButtonCell.self),
           Row(text: "Reset Rewards", selection: {
             self.tappedReset()
           }, cellClass: ButtonCell.self)
@@ -192,6 +195,13 @@ public class QASettingsViewController: TableViewController {
       alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
       self.present(alert, animated: true, completion: nil)
     }
+  }
+  
+  private func tappedShareRewardsDatabase() {
+    guard let appSupportPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first else { return }
+    let dbPath = (appSupportPath as NSString).appendingPathComponent("rewards")
+    let activity = UIActivityViewController(activityItems: [URL(fileURLWithPath: dbPath)], applicationActivities: nil)
+    self.present(activity, animated: true)
   }
   
   @objc private func tappedRestoreWallet() {


### PR DESCRIPTION
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards
- Go to rewards debug menu, click share rewards database, airdrop it to yourself
- Verify that the database files are intact and readable

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
