### PR TITLE
Fix #1942: Show correct copy & icon for ads grant notifications

### DIFF
--- a/BraveRewardsUI/Wallet/Notifications/RewardsNotificationViewBuilder.swift
+++ b/BraveRewardsUI/Wallet/Notifications/RewardsNotificationViewBuilder.swift
@@ -70,7 +70,7 @@ struct RewardsNotificationViewBuilder {
       category = .grant
     case .grantAds:
       body = Strings.NotificationEarningsClaimDefault
-      category = .grant
+      category = .adGrant
     case .tipsProcessed:
       body = Strings.NotificationTipsProcessedBody
       category = .tipsProcessed

--- a/BraveRewardsUI/Wallet/Notifications/WalletActionNotificationView.swift
+++ b/BraveRewardsUI/Wallet/Notifications/WalletActionNotificationView.swift
@@ -16,6 +16,12 @@ struct WalletActionNotification {
       action: Strings.CLAIM.uppercased()
     )
     
+    static let adGrant = Category(
+      icon: UIImage(frameworkResourceNamed: "icn-ads"),
+      title: Strings.NotificationAdsTitle,
+      action: Strings.CLAIM.uppercased()
+    )
+    
     static let tipsProcessed = Category(
       icon: UIImage(frameworkResourceNamed: "icn-contribute"),
       title: Strings.NotificationRecurringTipTitle,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1942 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
