### PR TITLE
Fix #1941: Add App Store scheme handling for new App Store redirects

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2137,6 +2137,7 @@ extension BrowserViewController: TabDelegate {
 
     func showBar(_ bar: SnackBar, animated: Bool) {
         view.layoutIfNeeded()
+        self.view.bringSubviewToFront(self.alertStackView)
         UIView.animate(withDuration: animated ? 0.25 : 0, animations: {
             self.alertStackView.insertArrangedSubview(bar, at: 0)
             self.view.layoutIfNeeded()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -62,6 +62,9 @@ extension BrowserViewController: WKNavigationDelegate {
                 return true
             }
         }
+        if url.scheme == "itms-appss" || url.scheme == "itmss" {
+            return true
+        }
         return false
     }
 


### PR DESCRIPTION
Also make sure snack bar alerts show above new tab overlay

Note: Snackbar UI is currently broken (possible regression of #1736), but otherwise works

## Summary of Changes

This pull request fixes issue #1941 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

Additional test plan other than what's found in issue:

- Open an empty new tab
- Paste `https://apps.apple.com/us/app/brave-fast-privacy-web-browser/id1052879175` into the URL bar and go
- Verify that the "Open in App Store" snack bar alert thing shows up at the bottom of the tab

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).