### PR TITLE
Fix #1951: Present action sheets as a popover on iPads to fix crashes

### DIFF
--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -201,6 +201,12 @@ class ClearPrivateDataTableViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: false)
         
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            let cell = tableView.cellForRow(at: indexPath)
+            actionSheet.popoverPresentationController?.sourceView = cell
+            actionSheet.popoverPresentationController?.sourceRect = cell?.bounds ?? .zero
+            actionSheet.popoverPresentationController?.permittedArrowDirections = [.up, .down]
+        }
         let clearAction = UIAlertAction(title: Strings.ClearPrivateData, style: .destructive) { (_) in
             Preferences.Privacy.clearPrivateDataToggles.value = self.toggles
             self.clearButtonEnabled = false

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -108,7 +108,13 @@ class SyncSettingsTableViewController: UITableViewController {
         guard let frc = frc, let deviceCount = frc.fetchedObjects?.count else { return }
         let device = frc.object(at: indexPath)
         
-        let actionShet = UIAlertController(title: device.name, message: nil, preferredStyle: .actionSheet)
+        let actionSheet = UIAlertController(title: device.name, message: nil, preferredStyle: .actionSheet)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            let cell = tableView.cellForRow(at: indexPath)
+            actionSheet.popoverPresentationController?.sourceView = cell
+            actionSheet.popoverPresentationController?.sourceRect = cell?.bounds ?? .zero
+            actionSheet.popoverPresentationController?.permittedArrowDirections = [.up, .down]
+        }
         
         let removeAction = UIAlertAction(title: Strings.SyncRemoveDeviceAction, style: .destructive) { _ in
             if !DeviceInfo.hasConnectivity() {
@@ -129,10 +135,10 @@ class SyncSettingsTableViewController: UITableViewController {
         
         let cancelAction = UIAlertAction(title: Strings.CancelButtonTitle, style: .cancel, handler: nil)
         
-        actionShet.addAction(removeAction)
-        actionShet.addAction(cancelAction)
+        actionSheet.addAction(removeAction)
+        actionSheet.addAction(cancelAction)
         
-        present(actionShet, animated: true)
+        present(actionSheet, animated: true)
     }
     
     private func presentAlertPopup(for type: DeviceRemovalType, device: Device) {


### PR DESCRIPTION
Starting in iOS 13.2 there is a regression on iPads which causes action sheets to require presentation as a popover even when being presented within view controllers which have compact width size classes. In previous iOS versions they would present as an over-current-context iPhone action sheet

## Summary of Changes

This pull request fixes issue #1951 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- On an iPad attempt to clear private history _or_ click on a device in the sync chain settings screen
- Verify shows a popover now instead of crashing

## Screenshots:

![Simulator Screen Shot - iPad Pro (9 7-inch) - 2019-11-14 at 10 03 59](https://user-images.githubusercontent.com/529104/68869329-ff048900-06c6-11ea-8a25-ae39b3efabf4.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
