### PR TITLE
Fix #1944: Hook up learn more button in settings wallet details

### DIFF
--- a/BraveRewardsUI/Settings/Wallet/WalletDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Wallet/WalletDetailsViewController.swift
@@ -49,6 +49,12 @@ class WalletDetailsViewController: UIViewController, RewardsSummaryProtocol {
         $0.labels = disclaimerLabels
       }
     }
+    detailsView.activityView.disclaimerView?.labels.forEach {
+      $0.onLinkedTapped = { [weak self] _ in
+        guard let self = self, let url = URL(string: DisclaimerLinks.unclaimedFundsURL) else { return }
+        self.state.delegate?.loadNewTabWithURL(url)
+      }
+    }
   }
   
   // MARK: - Actions


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1944 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Tip a non-verified publisher
- Go to brave rewards settings > wallet detail > click the learn more button on the unverified contribution disclaimer

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).