### PR TITLE
Fix #1963, Fix #1964 - URL bar alignment is off and secure page icon not showing

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1266,17 +1266,17 @@ class BrowserViewController: UIViewController {
                     if url.isAboutHomeURL || url.isAboutURL {
                         tab.secureContentState = .localHost
                         topToolbar.secureContentState = .localHost
-                    } else if url.isErrorPageURL {
-                        topToolbar.secureContentState = tab.secureContentState
-                    } else if url.isReaderModeURL || url.isLocal {
+                        break
+                    }
+                    
+                    if url.isReaderModeURL || url.isLocal {
                         tab.secureContentState = .unknown
                         topToolbar.secureContentState = .unknown
-                    } else {
-                        topToolbar.secureContentState = tab.secureContentState
+                        break
                     }
-                } else {
-                    topToolbar.secureContentState = tab.secureContentState
                 }
+                
+                topToolbar.secureContentState = tab.secureContentState
                 break
             }
             

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1269,6 +1269,14 @@ class BrowserViewController: UIViewController {
                         break
                     }
                     
+                    if url.isErrorPageURL {
+                        if ErrorPageHelper.certificateError(for: url) != 0 {
+                            tab.secureContentState = .insecure
+                            topToolbar.secureContentState = .insecure
+                            break
+                        }
+                    }
+                    
                     if url.isReaderModeURL || url.isLocal {
                         tab.secureContentState = .unknown
                         topToolbar.secureContentState = .unknown

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1262,9 +1262,18 @@ class BrowserViewController: UIViewController {
             tab.secureContentState = .insecure
             
             guard let serverTrust = tab.webView?.serverTrust else {
-                if tab.webView?.url?.isLocal == true {
-                    tab.secureContentState = .unknown
-                    topToolbar.secureContentState = .unknown
+                if let url = tab.webView?.url {
+                    if url.isAboutHomeURL || url.isAboutURL {
+                        tab.secureContentState = .secure
+                        topToolbar.secureContentState = .secure
+                    } else if url.isErrorPageURL {
+                        topToolbar.secureContentState = tab.secureContentState
+                    } else if url.isReaderModeURL || url.isLocal {
+                        tab.secureContentState = .unknown
+                        topToolbar.secureContentState = .unknown
+                    } else {
+                        topToolbar.secureContentState = tab.secureContentState
+                    }
                 } else {
                     topToolbar.secureContentState = tab.secureContentState
                 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1265,7 +1265,13 @@ class BrowserViewController: UIViewController {
             guard let serverTrust = tab.webView?.serverTrust else {
                 break
             }
-
+            
+            let policies = [
+                SecPolicyCreateBasicX509(),
+                SecPolicyCreateSSL(true, tab.webView?.url?.host as CFString?)
+            ]
+            
+            SecTrustSetPolicies(serverTrust, policies as CFTypeRef)
             SecTrustEvaluateAsync(serverTrust, DispatchQueue.global()) { _, secTrustResult in
                 switch secTrustResult {
                 case .proceed, .unspecified:

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1264,8 +1264,8 @@ class BrowserViewController: UIViewController {
             guard let serverTrust = tab.webView?.serverTrust else {
                 if let url = tab.webView?.url {
                     if url.isAboutHomeURL || url.isAboutURL {
-                        tab.secureContentState = .secure
-                        topToolbar.secureContentState = .secure
+                        tab.secureContentState = .localHost
+                        topToolbar.secureContentState = .localHost
                     } else if url.isErrorPageURL {
                         topToolbar.secureContentState = tab.secureContentState
                     } else if url.isReaderModeURL || url.isLocal {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1260,9 +1260,9 @@ class BrowserViewController: UIViewController {
             }
 
             tab.contentIsSecure = false
-            topToolbar.contentIsSecure = tab.contentIsSecure
-
+            
             guard let serverTrust = tab.webView?.serverTrust else {
+                topToolbar.contentIsSecure = tab.contentIsSecure
                 break
             }
             

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -303,11 +303,11 @@ class ErrorPageHelper {
                 return errCode
             }
             
-            if ErrorPageHelper.CertErrors.contains(errCode) {
+            if ErrorPageHelper.certErrors.contains(errCode) {
                 return errCode
             }
             
-            if ErrorPageHelper.CertErrorCodes[errCode] != nil {
+            if ErrorPageHelper.certErrorCodes[errCode] != nil {
                 return errCode
             }
             return 0

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -307,7 +307,7 @@ class ErrorPageHelper {
                 return errCode
             }
             
-            if let _ = ErrorPageHelper.CertErrorCodes[errCode] {
+            if ErrorPageHelper.CertErrorCodes[errCode] != nil {
                 return errCode
             }
             return 0

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -280,6 +280,40 @@ class ErrorPageHelper {
         components.queryItems = queryItems
         webView.load(PrivilegedRequest(url: components.url!) as URLRequest)
     }
+    
+    public static func certificateError(for url: URL) -> Int {
+        if url.isErrorPageURL {
+            let query = url.getQuery()
+            
+            let cfErrors: [CFNetworkErrors] = [
+                .cfurlErrorSecureConnectionFailed,
+                .cfurlErrorServerCertificateHasBadDate,
+                .cfurlErrorServerCertificateUntrusted,
+                .cfurlErrorServerCertificateHasUnknownRoot,
+                .cfurlErrorServerCertificateNotYetValid,
+                .cfurlErrorClientCertificateRejected,
+                .cfurlErrorClientCertificateRequired
+            ]
+            
+            guard let code = query["code"], let errCode = Int(code) else {
+                return 0
+            }
+            
+            if let code = CFNetworkErrors(rawValue: Int32(errCode)), cfErrors.contains(code) {
+                return errCode
+            }
+            
+            if ErrorPageHelper.CertErrors.contains(errCode) {
+                return errCode
+            }
+            
+            if let _ = ErrorPageHelper.CertErrorCodes[errCode] {
+                return errCode
+            }
+            return 0
+        }
+        return 0
+    }
 }
 
 extension ErrorPageHelper: TabContentScript {

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
@@ -34,7 +34,7 @@ class OnboardingRewardsAgreementViewController: OnboardingViewController {
         (view as! View).onTermsOfServicePressed = { [weak self] in  // swiftlint:disable:this force_cast
             guard let self = self else { return }
             
-            self.present(OnboardingWebViewController(), animated: true, completion: nil)
+            self.present(OnboardingWebViewController(profile: self.profile), animated: true, completion: nil)
         }
     }
     

--- a/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
@@ -112,9 +112,12 @@ class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
         if let trust = webView.serverTrust {
             toolbar.secureIcon.isHidden = false
             
-            let x509 = SecPolicyCreateBasicX509()
-            let sslPolicy = SecPolicyCreateSSL(true, (webView.url?.host ?? "") as CFString)
-            SecTrustSetPolicies(trust, [x509, sslPolicy] as CFTypeRef)
+            let policies = [
+                SecPolicyCreateBasicX509(),
+                SecPolicyCreateSSL(true, webView.url?.host as CFString?)
+            ]
+            
+            SecTrustSetPolicies(trust, policies as CFTypeRef)
             
             var result: SecTrustResultType = .invalid
             SecTrustEvaluate(trust, &result)

--- a/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
@@ -9,6 +9,8 @@ import Shared
 class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
     
     private let url = URL(string: "https://brave.com/terms-of-use/")
+    private var helpers = [String: TabContentScript]()
+    private var profile: Profile
     
     private let KVOs: [KVOConstants] = [
         .loading,
@@ -22,12 +24,11 @@ class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
     private let toolbar = Toolbar().then {
         $0.snp.makeConstraints {
             $0.height.greaterThanOrEqualTo(45.0)
-            //$0.height.equalTo(45.0)
         }
     }
     
     private let webView = { () -> WKWebView in
-       let configuration: WKWebViewConfiguration = {
+        let configuration: WKWebViewConfiguration = {
             let configuration = WKWebViewConfiguration()
             configuration.processPool = WKProcessPool()
             configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
@@ -40,6 +41,15 @@ class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
     
     deinit {
         KVOs.forEach { webView.removeObserver(self, forKeyPath: $0.rawValue) }
+    }
+    
+    init(profile: Profile) {
+        self.profile = profile
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func viewDidLoad() {
@@ -59,11 +69,17 @@ class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
         KVOs.forEach { webView.addObserver(self, forKeyPath: $0.rawValue, options: .new, context: nil) }
         
         webView.navigationDelegate = self
-        webView.load(URLRequest(url: url!))
+        setupScripts()
+        webView.load(PrivilegedRequest(url: url!) as URLRequest)
         
         toolbar.exitButton.addTarget(self, action: #selector(onExit), for: .touchUpInside)
         toolbar.backButton.addTarget(self, action: #selector(onBack), for: .touchUpInside)
         toolbar.forwardButton.addTarget(self, action: #selector(onForward), for: .touchUpInside)
+    }
+    
+    private func setupScripts() {
+        let errorHelper = ErrorPageHelper()
+        addScript(errorHelper, for: ErrorPageHelper.name())
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
@@ -143,13 +159,60 @@ class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
         toolbar.forwardButton.tintColor = webView.canGoForward ? UX.buttonEnabledColor : UX.buttonDisabledColor
     }
     
-    func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         
-        if let trust = challenge.protectionSpace.serverTrust {
+        let error = error as NSError
+        if error.domain == "WebKitErrorDomain" && error.code == 102 {
+            return
+        }
+
+        if error.code == WKError.webContentProcessTerminated.rawValue && error.domain == "WebKitErrorDomain" {
+            webView.reload()
+            return
+        }
+
+        if error.code == Int(CFNetworkErrors.cfurlErrorCancelled.rawValue) {
+            return
+        }
+
+        if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+            ErrorPageHelper().showPage(error, forUrl: url, inWebView: webView)
+        }
+    }
+    
+    func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        if challenge.protectionSpace.host == "localhost" && challenge.protectionSpace.port == Int(WebServer.sharedInstance.server.port) {
+            return completionHandler(.useCredential, WebServer.sharedInstance.credentials)
+        }
+        
+        let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+            let trust = challenge.protectionSpace.serverTrust,
+            let cert = SecTrustGetCertificateAtIndex(trust, 0), profile.certStore.containsCertificate(cert, forOrigin: origin) {
             return completionHandler(.useCredential, URLCredential(trust: trust))
         }
         
-        return completionHandler(.performDefaultHandling, nil)
+        completionHandler(.performDefaultHandling, nil)
+    }
+}
+
+extension OnboardingWebViewController: WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        
+        for helper in helpers.values {
+            if let scriptMessageHandlerName = helper.scriptMessageHandlerName(),
+                scriptMessageHandlerName == message.name {
+                return helper.userContentController(userContentController, didReceiveScriptMessage: message)
+            }
+        }
+    }
+    
+    private func addScript(_ helper: TabContentScript, for name: String) {
+        helpers[name] = helper
+        
+        if let scriptMessageHandlerName = helper.scriptMessageHandlerName() {
+            webView.configuration.userContentController.add(self, name: scriptMessageHandlerName)
+        }
     }
 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -34,6 +34,12 @@ protocol URLChangeDelegate {
     func tab(_ tab: Tab, urlDidChangeTo url: URL)
 }
 
+enum TabSecureContentState {
+    case secure
+    case insecure
+    case unknown
+}
+
 class Tab: NSObject {
     var id: String?
     
@@ -46,8 +52,8 @@ class Tab: NSObject {
     var isPrivate: Bool {
         return type.isPrivate
     }
-    
-    var contentIsSecure = false
+
+    var secureContentState: TabSecureContentState = .insecure
 
     // PageMetadata is derived from the page content itself, and as such lags behind the
     // rest of the tab.

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -35,6 +35,7 @@ protocol URLChangeDelegate {
 }
 
 enum TabSecureContentState {
+    case localHost
     case secure
     case insecure
     case unknown

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -74,9 +74,13 @@ class TabLocationView: UIView {
     }
     
     private func updateLockImageView() {
+        lockImageView.isHidden = false
+        
         switch secureContentState {
+        case .localHost:
+            lockImageView.isHidden = true
         case .secure:
-            lockImageView.tintColor = #colorLiteral(red: 0, green: 0.6860338449, blue: 0, alpha: 1)
+            lockImageView.tintColor = #colorLiteral(red: 0.3764705882, green: 0.3843137255, blue: 0.4, alpha: 1)
         case .insecure:
             lockImageView.tintColor = .red
         case .unknown:
@@ -140,7 +144,7 @@ class TabLocationView: UIView {
 
     fileprivate lazy var lockImageView: UIImageView = {
         let lockImageView = UIImageView(image: #imageLiteral(resourceName: "lock_verified").template)
-        lockImageView.isHidden = false
+        lockImageView.isHidden = true
         lockImageView.tintColor = #colorLiteral(red: 0.3764705882, green: 0.3843137255, blue: 0.4, alpha: 1)
         lockImageView.isAccessibilityElement = true
         lockImageView.contentMode = .center

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -55,7 +55,7 @@ class TabLocationView: UIView {
         }
     }
 
-    var contentIsSecure = false {
+    var secureContentState: TabSecureContentState = .insecure {
         didSet {
             updateLockImageView()
         }
@@ -74,10 +74,13 @@ class TabLocationView: UIView {
     }
     
     private func updateLockImageView() {
-        if contentIsSecure {
+        switch secureContentState {
+        case .secure:
             lockImageView.tintColor = #colorLiteral(red: 0, green: 0.6860338449, blue: 0, alpha: 1)
-        } else {
+        case .insecure:
             lockImageView.tintColor = .red
+        case .unknown:
+            lockImageView.tintColor = #colorLiteral(red: 0.3764705882, green: 0.3843137255, blue: 0.4, alpha: 1)
         }
     }
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -79,11 +79,9 @@ class TabLocationView: UIView {
         switch secureContentState {
         case .localHost:
             lockImageView.isHidden = true
-        case .secure:
-            lockImageView.tintColor = #colorLiteral(red: 0.3764705882, green: 0.3843137255, blue: 0.4, alpha: 1)
         case .insecure:
             lockImageView.tintColor = .red
-        case .unknown:
+        case .secure, .unknown:
             lockImageView.tintColor = #colorLiteral(red: 0.3764705882, green: 0.3843137255, blue: 0.4, alpha: 1)
         }
     }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -74,11 +74,10 @@ class TabLocationView: UIView {
     }
     
     private func updateLockImageView() {
-        let wasHidden = lockImageView.isHidden
-        lockImageView.isHidden = !contentIsSecure
-
-        if wasHidden != lockImageView.isHidden {
-            UIAccessibility.post(notification: .layoutChanged, argument: nil)
+        if contentIsSecure {
+            lockImageView.tintColor = #colorLiteral(red: 0, green: 0.6860338449, blue: 0, alpha: 1)
+        } else {
+            lockImageView.tintColor = .red
         }
     }
 
@@ -138,7 +137,7 @@ class TabLocationView: UIView {
 
     fileprivate lazy var lockImageView: UIImageView = {
         let lockImageView = UIImageView(image: #imageLiteral(resourceName: "lock_verified").template)
-        lockImageView.isHidden = true // Hidden by default
+        lockImageView.isHidden = false
         lockImageView.tintColor = #colorLiteral(red: 0.3764705882, green: 0.3843137255, blue: 0.4, alpha: 1)
         lockImageView.isAccessibilityElement = true
         lockImageView.contentMode = .center
@@ -401,7 +400,7 @@ extension TabLocationView: TabEventHandler {
 class DisplayTextField: UITextField {
     weak var accessibilityActionsSource: AccessibilityActionsSource?
     var hostString: String = ""
-    let pathPadding: CGFloat = 20.0
+    let pathPadding: CGFloat = 5.0
 
     override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
         get {

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -86,9 +86,9 @@ class TopToolbarView: UIView, ToolbarProtocol {
         }
     }
     
-    var contentIsSecure: Bool {
-        get { return locationView.contentIsSecure }
-        set { locationView.contentIsSecure = newValue }
+    var secureContentState: TabSecureContentState {
+        get { return locationView.secureContentState }
+        set { locationView.secureContentState = newValue }
     }
     
     // MARK: - Views


### PR DESCRIPTION
## Security Review:
- https://github.com/brave/security/issues/28

## Summary of Changes
- Fixes URL bar alignment due to security bug #552 
- Fixes URL bar secure webpage icon not showing 100% of the time
- Like Android, added green and red colours to the icon.
- Fixes 4 security flaws in the validation of the `SecTrust` for `WKWebView` (calling `SecTrustEvaluate` was not enough.. I have added a list of policies to validate.. can be tested with https://badssl.com)
   - Now validates expired certificates
   - Now validates wrong host
   - Now validates CRL (Certificate Revocation)
   - Now validates x509 (SHA1, Subject, KeyLength, etc)..
      - In iOS 13, any certificate with SHA1 or weak algorithms will fail.
      - Any non TLS1.2 cert will fail.
      - Any certificate with invalid SubjectInfo or any invalid fields will fail.

Prior to these "small" changes, all tests against `badssl.com` would fail and show the page was secure when it wasn't.

**WIP**: 
- Still waiting on the real icons for iOS to be uploaded to the ticket.
- Unit tests for security.

This pull request fixes issue #1964 & #1963 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
