### PR TITLE
Fix #443: Display time out details for incorrect passcode lockdown

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -288,7 +288,9 @@ extension Strings {
     
     public static let AuthenticationIncorrectAttemptsRemaining = NSLocalizedString("AuthenticationIncorrectAttemptsRemaining", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Incorrect passcode. Try again (Attempts remaining: %d).", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining")
     
-    public static let AuthenticationMaximumAttemptsReached = NSLocalizedString("AuthenticationMaximumAttemptsReached", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Maximum attempts reached. Please try again in an hour.", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
+    public static let AuthenticationMaximumAttemptsReached = NSLocalizedString("AuthenticationMaximumAttemptsReached", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Too many failed attempts. Please try again in %d minutes.", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
+    
+    public static let AuthenticationMaximumAttemptsReachedOneMinute = NSLocalizedString("AuthenticationMaximumAttemptsReachedOneMinute", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Too many failed attempts. Please try again in 1 minute.", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
     
     public static let AuthenticationMaximumAttemptsReachedNoTime = NSLocalizedString("AuthenticationMaximumAttemptsReachedNoTime", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Maximum attempts reached. Please try again later.", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
     

--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -62,7 +62,16 @@ extension BasePasscodeViewController {
     }
 
     func displayLockoutError() {
-        displayError(Strings.AuthenticationMaximumAttemptsReachedNoTime)
+        if let timeLeft = authenticationInfo?.lockoutTimeLeft {
+            let inMinutes = Int(ceil(timeLeft / 60))
+            if inMinutes == 1 {
+                displayError(Strings.AuthenticationMaximumAttemptsReachedOneMinute)
+            } else {
+                displayError(String.localizedStringWithFormat(Strings.AuthenticationMaximumAttemptsReached, inMinutes))
+            }
+        } else {
+            displayError(Strings.AuthenticationMaximumAttemptsReachedNoTime)
+        }
     }
 
     func failMismatchPasscode() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #443 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable browser PIN, get locked out, verify minutes left is shown

## Screenshots:

| 1 Minute | Many Minutes |
| --- | --- |
| ![Simulator Screen Shot - iPhone 8 - 2019-11-18 at 11 41 35](https://user-images.githubusercontent.com/529104/69072510-c7b11780-09f9-11ea-9097-0dd751d02b04.png) | ![Simulator Screen Shot - iPhone 8 - 2019-11-18 at 11 43 42](https://user-images.githubusercontent.com/529104/69072525-ced82580-09f9-11ea-9fa1-6828fc7fff2e.png) |

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
