### PR TITLE
Fix #1739 -  Fix AdsNotification not dynamically supporting DarkMode

### DIFF
--- a/BraveRewardsUI/Ads/AdContentButton.swift
+++ b/BraveRewardsUI/Ads/AdContentButton.swift
@@ -38,10 +38,6 @@ class AdContentButton: UIControl {
     return backgroundView
   }()
   
-  private var isDarkMode: Bool {
-    return traitCollection.userInterfaceStyle == .dark
-  }
-  
   override public init(frame: CGRect) {
     super.init(frame: frame)
     
@@ -86,7 +82,7 @@ class AdContentButton: UIControl {
     layer.shadowOffset = CGSize(width: 0, height: 1)
     layer.shadowRadius = 2
     
-    applyTheme()
+    applyTheme(for: traitCollection)
   }
   
   public override func layoutSubviews() {
@@ -111,7 +107,8 @@ class AdContentButton: UIControl {
     }
   }
   
-  func applyTheme() {
+  func applyTheme(for traitCollection: UITraitCollection) {
+    let isDarkMode = traitCollection.userInterfaceStyle == .dark
     appNameLabel.appearanceTextColor = (isDarkMode ? UIColor.white : UIColor.black).withAlphaComponent(0.5)
     titleLabel.appearanceTextColor = isDarkMode ? .white : .black
     bodyLabel.appearanceTextColor = isDarkMode ? .white : .black
@@ -120,6 +117,6 @@ class AdContentButton: UIControl {
   
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
-    applyTheme()
+    applyTheme(for: traitCollection)
   }
 }

--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -332,3 +332,13 @@ extension AdsViewController {
     })
   }
 }
+
+extension AdsViewController {
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    if #available(iOS 13.0, *) {
+        if UITraitCollection.current.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+          visibleAdView?.adContentButton.applyTheme(for: traitCollection)
+        }
+    }
+  }
+}

--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -335,6 +335,8 @@ extension AdsViewController {
 
 extension AdsViewController {
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    
     if #available(iOS 13.0, *) {
         if UITraitCollection.current.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
           visibleAdView?.adContentButton.applyTheme(for: traitCollection)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -383,6 +383,8 @@ class BrowserViewController: UIViewController {
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
         if #available(iOS 13.0, *) {
             if UITraitCollection.current.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
                 // Reload UI

--- a/Client/Frontend/Browser/Onboarding/OnboardingViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingViewController.swift
@@ -106,6 +106,8 @@ class OnboardingViewController: UIViewController, Themeable {
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
         if #available(iOS 13.0, *) {
             if UITraitCollection.current.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
                 theme = OnboardingViewController.getUpdatedTheme()


### PR DESCRIPTION
Fix Trait collection not updating on iOS13 for Ads Notification views when DarkMode is dynamically changed.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1739
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
