### PR TITLE
Sync screens UI fixes

### DIFF
--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -53,6 +53,8 @@ extension Theme {
         // Sync items
         SyncViewController.SyncView.appearance(whenContainedInInstancesOf: [UINavigationController.self]).appearanceBackgroundColor = colors.home
         SyncDeviceTypeButton.appearance().appearanceBackgroundColor = colors.header
+        UIButton.appearance(
+            whenContainedInInstancesOf: [SyncViewController.self]).appearanceTextColor = colors.tints.home
         
         // Search
         UIView.appearance(whenContainedInInstancesOf: [SearchViewController.self]).appearanceBackgroundColor = colors.home

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -190,7 +190,7 @@ class SyncAddDeviceViewController: SyncViewController {
         doneButton.translatesAutoresizingMaskIntoConstraints = false
         doneButton.setTitle(Strings.Done, for: .normal)
         doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
-        doneButton.setTitleColor(UIColor.white, for: .normal)
+        doneButton.appearanceTextColor = .white
         doneButton.backgroundColor = BraveUX.BraveOrange
         doneButton.addTarget(self, action: #selector(SEL_done), for: .touchUpInside)
 

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -82,8 +82,8 @@ class SyncAddDeviceViewController: SyncViewController {
 
         view.addSubview(stackView)
         stackView.snp.makeConstraints { make in
-            make.top.equalTo(self.view.safeArea.top)
-            make.left.right.equalTo(self.view)
+            make.top.equalTo(self.view.safeArea.top).inset(10)
+            make.left.right.equalTo(self.view).inset(16)
             make.bottom.equalTo(self.view.safeArea.bottom).inset(24)
         }
         
@@ -142,8 +142,8 @@ class SyncAddDeviceViewController: SyncViewController {
         modeControl.selectedSegmentIndex = 0
         modeControl.addTarget(self, action: #selector(SEL_changeMode), for: .valueChanged)
         modeControl.isHidden = deviceType == .computer
-        controlContainerView.addSubview(modeControl)
-        stackView.addArrangedSubview(controlContainerView)
+        modeControl.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        stackView.addArrangedSubview(modeControl)
         
         let titleDescriptionStackView = UIStackView()
         titleDescriptionStackView.axis = .vertical
@@ -153,6 +153,7 @@ class SyncAddDeviceViewController: SyncViewController {
         titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.semibold)
+        titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         titleDescriptionStackView.addArrangedSubview(titleLabel)
 
         descriptionLabel = UILabel()
@@ -162,29 +163,21 @@ class SyncAddDeviceViewController: SyncViewController {
         descriptionLabel.textAlignment = .center
         descriptionLabel.adjustsFontSizeToFitWidth = true
         descriptionLabel.minimumScaleFactor = 0.5
+        descriptionLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         titleDescriptionStackView.addArrangedSubview(descriptionLabel)
 
-        let textStackView = UIStackView(arrangedSubviews: [UIView.spacer(.horizontal, amount: 32),
-                                                           titleDescriptionStackView,
-                                                           UIView.spacer(.horizontal, amount: 32)])
-        textStackView.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 100), for: .vertical)
-
-        stackView.addArrangedSubview(textStackView)
+        stackView.addArrangedSubview(titleDescriptionStackView)
         
         codewordsView.isHidden = true
         containerView.addSubview(codewordsView)
-        
         stackView.addArrangedSubview(containerView)
         
-        let copyPasteStackView = UIStackView()
-        copyPasteStackView.axis = .vertical
-        copyPasteStackView.spacing = 1
-        copyPasteStackView.addArrangedSubview(copyPasteButton)
-        stackView.addArrangedSubview(copyPasteStackView)
-
         let doneEnterWordsStackView = UIStackView()
         doneEnterWordsStackView.axis = .vertical
         doneEnterWordsStackView.spacing = 4
+        doneEnterWordsStackView.distribution = .fillEqually
+        
+        doneEnterWordsStackView.addArrangedSubview(copyPasteButton)
 
         doneButton = RoundInterfaceButton(type: .roundedRect)
         doneButton.translatesAutoresizingMaskIntoConstraints = false
@@ -203,31 +196,12 @@ class SyncAddDeviceViewController: SyncViewController {
         enterWordsButton.setTitleColor(BraveUX.GreyH, for: .normal)
         enterWordsButton.addTarget(self, action: #selector(SEL_showCodewords), for: .touchUpInside)
 
-        let buttonsStackView = UIStackView(arrangedSubviews: [UIView.spacer(.horizontal, amount: 16),
-                                                              doneEnterWordsStackView,
-                                                              UIView.spacer(.horizontal, amount: 16)])
-        buttonsStackView.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .vertical)
+        doneEnterWordsStackView.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .vertical)
 
-        stackView.addArrangedSubview(buttonsStackView)
-        
-        controlContainerView.snp.makeConstraints { (make) in
-            make.top.equalTo(0)
-            make.left.right.equalTo(self.view)
-            make.height.greaterThanOrEqualTo(44)
-        }
+        stackView.addArrangedSubview(doneEnterWordsStackView)
 
-        modeControl.snp.makeConstraints { (make) in
-            make.top.equalTo(0).offset(10)
-            make.left.right.equalTo(self.controlContainerView).inset(8)
-        }
-        
-        containerView.snp.makeConstraints { (make) in
-            make.left.right.equalTo(self.view).inset(22)
-        }
-
-        codewordsView.snp.makeConstraints { (make) in
-            make.top.bottom.equalTo(self.containerView).inset(8)
-            make.left.right.equalTo(self.containerView).inset(22)
+        codewordsView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
 
         doneButton.snp.makeConstraints { (make) in

--- a/Client/Frontend/Sync/SyncCameraView.swift
+++ b/Client/Frontend/Sync/SyncCameraView.swift
@@ -12,6 +12,8 @@ class SyncCameraView: UIView, AVCaptureMetadataOutputObjectsDelegate {
     private lazy var cameraAccessButton: RoundInterfaceButton = {
         let button = self.createCameraButton()
         button.setTitle(Strings.GrantCameraAccess, for: .normal)
+        button.tintColor = .white
+        button.appearanceTextColor = .white
         button.addTarget(self, action: #selector(SEL_cameraAccess), for: .touchUpInside)
         return button
     }()
@@ -28,7 +30,7 @@ class SyncCameraView: UIView, AVCaptureMetadataOutputObjectsDelegate {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        cameraOverlayView = UIImageView(image: UIImage(named: "camera-overlay")?.withRenderingMode(.alwaysTemplate))
+        cameraOverlayView = UIImageView(image: UIImage(named: "camera-overlay"))
         cameraOverlayView.contentMode = .center
         addSubview(cameraOverlayView)
         addSubview(cameraAccessButton)

--- a/Client/Frontend/Sync/SyncCodewordsView.swift
+++ b/Client/Frontend/Sync/SyncCodewordsView.swift
@@ -11,6 +11,7 @@ class SyncCodewordsView: UIView, UITextViewDelegate {
         textView.autocorrectionType = .yes
         textView.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.medium)
         textView.textColor = BraveUX.GreyJ
+        textView.backgroundColor = .white
         return textView
     }()
     
@@ -18,7 +19,7 @@ class SyncCodewordsView: UIView, UITextViewDelegate {
         let label = UILabel()
         label.text = Strings.CodeWordInputHelp
         label.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.regular)
-        label.textColor = BraveUX.GreyE
+        label.appearanceTextColor = BraveUX.GreyE
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         return label

--- a/Client/Frontend/Sync/SyncPairCameraViewController.swift
+++ b/Client/Frontend/Sync/SyncPairCameraViewController.swift
@@ -91,14 +91,12 @@ class SyncPairCameraViewController: SyncViewController {
         titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.semibold)
-        titleLabel.textColor = BraveUX.GreyJ
         titleLabel.text = Strings.SyncToDevice
         titleDescriptionStackView.addArrangedSubview(titleLabel)
 
         descriptionLabel = UILabel()
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         descriptionLabel.font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.regular)
-        descriptionLabel.textColor = BraveUX.GreyH
         descriptionLabel.numberOfLines = 0
         descriptionLabel.lineBreakMode = .byWordWrapping
         descriptionLabel.textAlignment = .center
@@ -115,7 +113,6 @@ class SyncPairCameraViewController: SyncViewController {
         enterWordsButton.translatesAutoresizingMaskIntoConstraints = false
         enterWordsButton.setTitle(Strings.EnterCodeWords, for: .normal)
         enterWordsButton.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.semibold)
-        enterWordsButton.setTitleColor(BraveUX.GreyH, for: .normal)
         enterWordsButton.addTarget(self, action: #selector(SEL_enterWords), for: .touchUpInside)
         stackView.addArrangedSubview(enterWordsButton)
         

--- a/Client/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/Client/Frontend/Sync/SyncPairWordsViewController.swift
@@ -17,7 +17,7 @@ class SyncPairWordsViewController: SyncViewController {
     lazy var wordCountLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 13, weight: UIFont.Weight.regular)
-        label.textColor = BraveUX.GreyE
+        label.appearanceTextColor = BraveUX.GreyE
         label.text = String(format: Strings.WordCount, 0)
         return label
     }()

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -41,13 +41,13 @@ class SyncSettingsTableViewController: UITableViewController {
         
         let text = UITextView().then {
             $0.text = Strings.SyncSettingsHeader
-            $0.textContainerInset = UIEdgeInsets(top: 36, left: 16, bottom: 16, right: 16)
+            $0.textContainerInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
             $0.isEditable = false
             $0.isSelectable = false
             $0.textColor = BraveUX.GreyH
             $0.textAlignment = .center
             $0.font = UIFont.systemFont(ofSize: 15)
-            $0.sizeToFit()
+            $0.isScrollEnabled = false
             $0.backgroundColor = UIColor.clear
         }
         
@@ -56,6 +56,8 @@ class SyncSettingsTableViewController: UITableViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        tableView.tableHeaderView?.sizeToFit()
         
         if disableBackButton {
             navigationController?.interactivePopGestureRecognizer?.isEnabled = false
@@ -214,32 +216,25 @@ class SyncSettingsTableViewController: UITableViewController {
             
             cell.textLabel?.text = deviceName
         case Sections.buttons.rawValue:
-            // By default all cells have separators with left inset. Our buttons are based on table cells,
-            // we need to style them so they look more like buttons with full width separator between them.
-            setFullWidthSeparator(for: cell)
-            configureButtonCell(cell, buttonIndex: indexPath.row)
+            configureButtonCell(cell)
         default:
             log.error("Section index out of bounds.")
         }
     }
     
-    private func setFullWidthSeparator(for cell: UITableViewCell) {
+    private func configureButtonCell(_ cell: UITableViewCell) {
+        // By default all cells have separators with left inset. Our buttons are based on table cells,
+        // we need to style them so they look more like buttons with full width separator between them.
         cell.preservesSuperviewLayoutMargins = false
         cell.separatorInset = UIEdgeInsets.zero
         cell.layoutMargins = UIEdgeInsets.zero
-    }
-    
-    private func configureButtonCell(_ cell: UITableViewCell, buttonIndex: Int) {
-        func attributedString(for text: String, color: UIColor) -> NSAttributedString {
-            return NSAttributedString(string: text, attributes:
-                [NSAttributedString.Key.foregroundColor: color,
-                 NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.regular)])
+        
+        cell.textLabel?.do {
+            $0.text = Strings.SyncAddAnotherDevice
+            $0.textAlignment = .center
+            $0.appearanceTextColor = BraveUX.BraveOrange
+            $0.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.regular)
         }
-        
-        let decoratedText = attributedString(for: Strings.SyncAddAnotherDevice, color: BraveUX.BraveOrange)
-        
-        cell.textLabel?.attributedText = decoratedText
-        cell.textLabel?.textAlignment = .center
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -73,7 +73,7 @@ class SyncWelcomeViewController: SyncViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(Strings.NewSyncCode, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
-        button.setTitleColor(UIColor.white, for: .normal)
+        button.appearanceTextColor = .white
         button.backgroundColor = BraveUX.BraveOrange
         button.addTarget(self, action: #selector(newToSyncAction), for: .touchUpInside)
 

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -102,19 +102,6 @@ extension String {
         return cleaned.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: string)
     }
     
-    /// Makes a part of the string bold and returns a NSAttributedString.
-    /// Text size must be provided for bold system font and to make font size the same as rest of the string.
-    public func makePartiallyBoldAttributedString(stringToBold text: String, boldTextSize: CGFloat) -> NSAttributedString? {
-        let addWordsDescriptionBolded = NSMutableAttributedString(string: self)
-        guard let rangeOfBoldedText = self.range(of: text) else { return nil }
-        // NSMutableAttributedString still uses NSRange, a conversion from Swift's range is required.
-        let nsRangeOfBoldedText = NSRange(rangeOfBoldedText, in: self)
-        // Make sure we use the same font size for the bolded text.
-        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.boldSystemFont(ofSize: boldTextSize)]
-        addWordsDescriptionBolded.setAttributes(attributes, range: nsRangeOfBoldedText)
-        return addWordsDescriptionBolded
-    }
-    
     /*
      Truncates the string to the specified length number of characters and appends an optional trailing string if longer.
      - Parameter length: Desired maximum lengths of a string


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Please use rebase-merge strategy, this PR solves few issues at once.

<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Check how all sync screens look like with both light and dark themes.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="544" alt="Zrzut ekranu 2019-11-18 o 18 48 08" src="https://user-images.githubusercontent.com/6950387/69140020-f5fa2a00-0ac1-11ea-8a8a-f218d94252ac.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
