### PR TITLE
Fix #1986, Fix #1987 - PBO crash and clearing of PBO data from Normal to Private.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1121,7 +1121,20 @@ class BrowserViewController: UIViewController {
     }
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-        guard let webView = object as? WKWebView, let tab = tabManager[webView], let kp = keyPath, let path = KVOConstants(rawValue: kp) else {
+        
+        guard let webView = object as? WKWebView else {
+            log.error("An object of type: \(String(describing: object)) is being observed instead of a WKWebView")
+            return  //False alarm.. the source MUST be a web view.
+        }
+        
+        //WebView is a zombie and somehow still has an observer attached to it
+        guard let tab = tabManager[webView] else {
+            log.error("WebView: \(webView) has been removed from TabManager but still has attached observers")
+            return
+        }
+        
+        //Must handle ALL keypaths
+        guard let kp = keyPath, let path = KVOConstants(rawValue: kp) else {
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
             return
         }
@@ -3320,6 +3333,11 @@ extension BrowserViewController: PreferencesObserver {
             if isPrivate { //When PBO is turned ON, we remove all tabs and configurations.
                 tabManager.removeAll()
                 tabManager.resetConfiguration()
+                
+                // Clear ALL data when going from normal mode to private
+                // The other way around is handled in `removeTab`
+                let clearables: [Clearable] = [HistoryClearable(), CookiesAndCacheClearable()]
+                _ = ClearPrivateDataTableViewController.clearPrivateData(clearables)
             }
         case Preferences.General.alwaysRequestDesktopSite.key:
             tabManager.reset()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -665,9 +665,9 @@ extension TabTrayController: TabManagerDelegate {
         // through the Close All Tabs feature (which will close tabs that are not in our current privacy mode)
         // check this before removing the item from the collection
         let removedIndex = tabDataSource.removeTab(tab)
-        if removedIndex > -1 {
-            self.collectionView.performBatchUpdates({
-                self.collectionView.deleteItems(at: [IndexPath(item: removedIndex, section: 0)])
+        if removedIndex > -1, let collectionView = self.collectionView {
+            collectionView.performBatchUpdates({
+                collectionView.deleteItems(at: [IndexPath(item: removedIndex, section: 0)])
             }, completion: { finished in
                 guard self.privateTabsAreEmpty() else { return }
                 self.emptyPrivateTabsView.isHidden = false


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

- Fix crash in PBO when a zombie tab still has an observer attached to it which gets released in deinit. However, if the tab is loading data while it is being killed (IE: a large PDF, or inbox or webpage), then the observer can trigger `estimatedProgress` or any other keyPath causing a crash because the webView was already killed. Solution is to guard in the observer and let the deinit run its course naturally.

- Fix PBO not clearing data when going from Normal to PBO. Going from PBO to Normal already worked from previous PR. This seems like a regression fix :S Pretty sure I had already done this exact same thing.

This pull request fixes issue #1987 && #1986
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
