### PR TITLE
Fix #1995: Rewards notification text now display correctly on iOS 12

### DIFF
--- a/BraveRewardsUI/Wallet/Notifications/WalletActionNotificationView.swift
+++ b/BraveRewardsUI/Wallet/Notifications/WalletActionNotificationView.swift
@@ -64,6 +64,7 @@ class WalletActionNotificationView: WalletNotificationView {
     let bodyLabel = UILabel().then {
       $0.numberOfLines = 0
       $0.textAlignment = .center
+      $0.appearanceTextColor = nil
       $0.attributedText = bodyAttributedString()
     }
     actionButton.do {

--- a/BraveRewardsUI/Wallet/Notifications/WalletAlertNotificationView.swift
+++ b/BraveRewardsUI/Wallet/Notifications/WalletAlertNotificationView.swift
@@ -43,6 +43,7 @@ class WalletAlertNotificationView: WalletNotificationView {
     
     let label = UILabel().then {
       $0.numberOfLines = 0
+      $0.appearanceTextColor = nil
       $0.attributedText = bodyAttributedString()
 //      $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1995 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Install Brave on an iOS 12 device and enable rewards
- Open panel, promotion should come and the notification text should be more readable
- Please verify it also looks nice on iOS 13

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).