### PR TITLE
Fix #1092: Don't assign a color background to `brave.com` favicon

### DIFF
--- a/Client/Utils/FaviconFetcher.swift
+++ b/Client/Utils/FaviconFetcher.swift
@@ -33,7 +33,8 @@ open class FaviconFetcher: NSObject, XMLParserDelegate {
         return #imageLiteral(resourceName: "defaultFavicon")
     }()
 
-    static var colors: [String: UIColor] = [:] //An in-Memory data store that stores background colors domains. Stored using url.baseDomain.
+    // An in-Memory data store that stores background colors domains. Stored using url.baseDomain.
+    static var colors: [String: UIColor] = ["brave.com": UIColor.Photon.White100]
 
     // Sites can be accessed via their baseDomain.
     static var defaultIcons: [String: (color: UIColor, url: String)] = {


### PR DESCRIPTION
There's really no other way of doing this since our favicon's background colors are auto-generated. So basically whitelisting `brave.com` by giving it a cached background color to pull.

# Summary of Changes

This pull request fixes issue #1092

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-11-20 at 17 23 26](https://user-images.githubusercontent.com/529104/69283616-b95e2980-0bba-11ea-8467-dada95778fbf.png)
![Simulator Screen Shot - iPhone 11 Pro - 2019-11-20 at 17 23 32](https://user-images.githubusercontent.com/529104/69283620-bbc08380-0bba-11ea-91aa-cb402d97a1c4.png)
![Simulator Screen Shot - iPhone 11 Pro - 2019-11-20 at 17 23 39](https://user-images.githubusercontent.com/529104/69283623-bd8a4700-0bba-11ea-9478-c6b48b643a03.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).