### PR TITLE
Fix #1959 -  Unable to exit fullscreen when watching videos

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/FullscreenHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/FullscreenHelper.js
@@ -28,7 +28,7 @@ var $<documentHasFullscreenFunctions> = document.documentElement.requestFullscre
 
 var $<videosSupportFullscreen> = HTMLVideoElement.prototype.webkitEnterFullscreen !== undefined;
 
-if (!$<isFullscreenSupportedNatively> && $<videosSupportFullscreen>) {
+if (!$<isFullscreenSupportedNatively> && $<videosSupportFullscreen> && !/mobile/i.test(navigator.userAgent)) {
     
     HTMLElement.prototype.requestFullscreen = function() {
         if (this.webkitRequestFullscreen !== undefined) {


### PR DESCRIPTION
When watching videos on YOUTUBE only, they request that a DIV tag become fullscreen instead of a video tag. When exiting fullscreen, it does NOT request that the DIV tag exit. Instead, it calls exit on the video tag which is wrong behaviour but technically allowed and it's up to WebKit to exit.


Real issue is actually because `fullscreenEnabled` returns false no matter what in `WKWebView` even if Fullscreen is actually a supported feature (works in Safari, and works in WKWebView for video tags)..  In other words, even though the boolean returns false, the webView actually supports the feature so the boolean is returning the WRONG value (possibly on purpose).

When requesting a Mobile Site, youtube doesn't discriminate. It will always request fullscreen without a check and it will trigger the native player.

However, when requesting a Desktop site, it checks if it's supported and if it returns false, it will NOT allow you to play videos in fullscreen (iPad Desktop UA for example).

To fix this, we spoof the boolean to be true but only when requesting DesktopUA since mobile already works 100% of the time.

Now we can enter and exit fullscreen on a MobileUA and DesktopUA. This is a condition fix meaning that if a newer version of iOS fixes the boolean itself, then our fix won't be injected and would only be used for older versions of iOS.

## Summary of Changes

This pull request fixes issue #1959
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
