### PR TITLE
Fix #2013: Don't crash when page html contains UTF16/chunked encoding

### DIFF
--- a/BraveRewardsUI/README.md
+++ b/BraveRewardsUI/README.md
@@ -6,5 +6,5 @@ The latest BraveRewards.framework was built on:
 
 ```
 brave-browser/3c18ec6742623aa1c83fbd2550434d7c0fc26f12
-brave-core/99fe6b1539119739b98d2910f65dd9262589850c
+brave-core/9dfc26db88b4231838dbc3ac913b8cb600a7fa4d
 ```


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #2013 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
