### PR TITLE
Fix #1849: Update channel param for DAU release pings.

### DIFF
--- a/BraveSharedTests/DAUTests.swift
+++ b/BraveSharedTests/DAUTests.swift
@@ -20,7 +20,7 @@ class DAUTests: XCTestCase {
     private let dau = DAU(date: Date(timeIntervalSince1970: 1183809600))
     
     func testChannelParam() {
-        let releaseExpected = URLQueryItem(name: "channel", value: "stable")
+        let releaseExpected = URLQueryItem(name: "channel", value: "release")
         XCTAssertEqual(dau.channelParam(for: .release), releaseExpected)
         
         let externalBetaExpected = URLQueryItem(name: "channel", value: "beta")

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -26,7 +26,7 @@ public enum AppBuildChannel: String {
     public var serverChannelParam: String {
         switch self {
         case .release:
-            return "stable"
+            return "release"
         case .beta:
             return "beta"
          case .enterprise:


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1849 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
No test plan for QA

Should upload production binary (with API key), and hit server. Have backend team validate iOS has submitted a channel=release ping successfully and it is being counted.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
