### PR TITLE
Fix #2010 - Progressive Onboarding

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -738,6 +738,7 @@ class BrowserViewController: UIViewController {
         
         // The user either skipped or didn't complete onboarding.
         let isRewardsEnabled = rewards.ledger.isEnabled
+        let currentProgress = OnboardingProgress(rawValue: Preferences.General.basicOnboardingProgress.value) ?? .none
         
         // 1. Existing user.
         // 2. The user skipped onboarding before.
@@ -752,7 +753,7 @@ class BrowserViewController: UIViewController {
             if daysUntilNextPrompt <= Date() {
                 guard let onboarding = OnboardingNavigationController(
                     profile: profile,
-                    onboardingType: rewards.ledger.isEnabled ? .existingUserRewardsOn : .existingUserRewardsOff,
+                    onboardingType: rewards.ledger.isEnabled ? .existingUserRewardsOn(currentProgress) : .existingUserRewardsOff(currentProgress),
                     rewards: rewards,
                     theme: Theme.of(tabManager.selectedTab)
                     ) else { return }
@@ -774,7 +775,7 @@ class BrowserViewController: UIViewController {
             
             guard let onboarding = OnboardingNavigationController(
                 profile: profile,
-                onboardingType: isRewardsEnabled ? .existingUserRewardsOn : .existingUserRewardsOff,
+                onboardingType: isRewardsEnabled ? .existingUserRewardsOn(currentProgress) : .existingUserRewardsOff(currentProgress),
                 rewards: rewards,
                 theme: Theme.of(tabManager.selectedTab)
                 ) else { return }
@@ -792,7 +793,7 @@ class BrowserViewController: UIViewController {
             
             guard let onboarding = OnboardingNavigationController(
                 profile: profile,
-                onboardingType: isRewardsEnabled ? .existingUserRewardsOn : .existingUserRewardsOff,
+                onboardingType: isRewardsEnabled ? .existingUserRewardsOn(currentProgress) : .existingUserRewardsOff(currentProgress),
                 rewards: rewards,
                 theme: Theme.of(tabManager.selectedTab)
                 ) else { return }
@@ -813,7 +814,7 @@ class BrowserViewController: UIViewController {
             
             guard let onboarding = OnboardingNavigationController(
                 profile: profile,
-                onboardingType: isRewardsEnabled ? .existingUserRewardsOn : .existingUserRewardsOff,
+                onboardingType: isRewardsEnabled ? .existingUserRewardsOn(currentProgress) : .existingUserRewardsOff(currentProgress),
                 rewards: rewards,
                 theme: Theme.of(tabManager.selectedTab)
                 ) else { return }
@@ -831,7 +832,7 @@ class BrowserViewController: UIViewController {
             
             guard let onboarding = OnboardingNavigationController(
                 profile: profile,
-                onboardingType: .newUser,
+                onboardingType: .newUser(currentProgress),
                 rewards: rewards,
                 theme: Theme.of(tabManager.selectedTab)
                 ) else { return }

--- a/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingNavigationController.swift
@@ -41,9 +41,9 @@ class OnboardingNavigationController: UINavigationController {
     weak var onboardingDelegate: OnboardingControllerDelegate?
     
     enum OnboardingType {
-        case newUser
-        case existingUserRewardsOff
-        case existingUserRewardsOn
+        case newUser(OnboardingProgress)
+        case existingUserRewardsOff(OnboardingProgress)
+        case existingUserRewardsOn(OnboardingProgress)
         
         /// Returns a list of onboarding screens for given type.
         /// Screens should be sorted in order of which they are presented to the user.
@@ -55,9 +55,24 @@ class OnboardingNavigationController: UINavigationController {
             }
             #else
             switch self {
-            case .newUser: return BraveAds.isCurrentLocaleSupported() ? [.searchEnginePicker, .shieldsInfo, .rewardsAgreement, .adsCountdown] : [.searchEnginePicker, .shieldsInfo, .rewardsAgreement]
-            case .existingUserRewardsOff: return BraveAds.isCurrentLocaleSupported() ? [.rewardsAgreement, .adsCountdown] : [.rewardsAgreement]
-            case .existingUserRewardsOn: return BraveAds.isCurrentLocaleSupported() ? [.existingRewardsTurnOnAds, .adsCountdown] : []
+            case .newUser(let progress):
+                //The user already made it to rewards and agreed so they should only see ads countdown
+                if progress == .rewards || progress == .ads {
+                    return BraveAds.isCurrentLocaleSupported() ? [.adsCountdown] : [.rewardsAgreement]
+                }
+                return BraveAds.isCurrentLocaleSupported() ? [.searchEnginePicker, .shieldsInfo, .rewardsAgreement, .adsCountdown] : [.searchEnginePicker, .shieldsInfo, .rewardsAgreement]
+            case .existingUserRewardsOff(let progress):
+                //The user already made it to rewards and agreed so they should only see ads countdown
+                if progress == .rewards || progress == .ads {
+                    return BraveAds.isCurrentLocaleSupported() ? [.adsCountdown] : []
+                }
+                return BraveAds.isCurrentLocaleSupported() ? [.rewardsAgreement, .adsCountdown] : [.rewardsAgreement]
+            case .existingUserRewardsOn(let progress):
+                //The user already made it to rewards and agreed so they should only see ads countdown
+                if progress == .rewards || progress == .ads {
+                    return BraveAds.isCurrentLocaleSupported() ? [.adsCountdown] : []
+                }
+                return BraveAds.isCurrentLocaleSupported() ? [.existingRewardsTurnOnAds, .adsCountdown] : []
             }
             #endif
         }


### PR DESCRIPTION
Keeps track of the user's progress to NOT allow them to recreate the wallet during onboarding.
Example:

User hits "Join Rewards"/"Turn On" and a wallet is created. But then they kill the app before seeing the ads and finishing onboarding. The next time they launch, it should take them straight to `ads` controllers instead of showing "Join" or "Turn On" again.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2010 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
