### PR TITLE
Fix #2026 - Context Menu Helper throw exceptions on iOS13.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2084,13 +2084,9 @@ extension BrowserViewController: TabDelegate {
             tab.addContentScript(logins, name: LoginsHelper.name())
         }
 
-        if #available(iOS 13, *) {
-            // Do nothing, native API is used.
-        } else {
-            let contextMenuHelper = ContextMenuHelper(tab: tab)
-            contextMenuHelper.delegate = self
-            tab.addContentScript(contextMenuHelper, name: ContextMenuHelper.name())
-        }
+        let contextMenuHelper = ContextMenuHelper(tab: tab)
+        contextMenuHelper.delegate = self
+        tab.addContentScript(contextMenuHelper, name: ContextMenuHelper.name())
 
         let errorHelper = ErrorPageHelper()
         tab.addContentScript(errorHelper, name: ErrorPageHelper.name())

--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -23,7 +23,7 @@ class ContextMenuHelper: NSObject {
 
     fileprivate var nativeHighlightLongPressRecognizer: UILongPressGestureRecognizer?
 
-    lazy var gestureRecognizer: UILongPressGestureRecognizer = {
+    fileprivate lazy var gestureRecognizer: UILongPressGestureRecognizer = {
         let g = UILongPressGestureRecognizer(target: self, action: #selector(self.longPressGestureDetected))
         g.delegate = self
         return g
@@ -47,6 +47,10 @@ extension ContextMenuHelper: UIGestureRecognizerDelegate {
     // As of iOS 12, WKContentView gesture setup is async, but it has been called by the time
     // the webview is ready to load an URL. After this has happened, we can override the gesture.
     func replaceGestureHandlerIfNeeded() {
+        if #available(iOS 13, *) {
+            return
+        }
+        
         DispatchQueue.main.async {
             if self.gestureRecognizerWithDescriptionFragment("ContextMenuHelper") == nil {
                 self.replaceWebViewLongPress()
@@ -55,6 +59,10 @@ extension ContextMenuHelper: UIGestureRecognizerDelegate {
     }
 
     private func replaceWebViewLongPress() {
+        if #available(iOS 13, *) {
+            return
+        }
+        
         // WebKit installs gesture handlers async. If `replaceWebViewLongPress` is called after a wkwebview in most cases a small delay is sufficient
         // See also https://bugs.webkit.org/show_bug.cgi?id=193366
 
@@ -109,6 +117,10 @@ extension ContextMenuHelper: TabContentScript {
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        if #available(iOS 13, *) {
+            return
+        }
+        
         guard let data = message.body as? [String: AnyObject] else {
             return
         }


### PR DESCRIPTION
On iOS 13, the ContextMenuHelper message handler is not added to the WebView, therefore we get an error when trying to access it's webkit handler from scripts.

To fix this, we inject the handler anyway, but we do nothing in the callback.

## Steps to Reproduce:
1. Load Brave on iOS 12.XX simulator or device
2. Go to https://imgur.com
3. Long press an image
4. Check the console using Safari Development Tools
5. See NO errors related to `undefined` or `contextMenuHelper`
-
1. Load Brave on iOS 13.XX simulator or device
2. Go to https://imgur.com
3. Long press an image
4. Check the console using Safari Development Tools
5. See errors related to `undefined` or `contextMenuHelper`

Verify that this PR fixes it and that ContextMenu still works on iOS 13 :)

## Summary of Changes

This pull request fixes issue #2026
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Long press on link in both iOS 12 & 13, verify they are still working correctly

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
