### PR TITLE
Fix #2027 - Notification Orientation only stabled on SOME iPads

### DIFF
--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -10,6 +10,7 @@ import pop
 
 public class AdsViewController: UIViewController {
   public typealias ActionHandler = (AdsNotification, AdsNotificationHandler.Action) -> Void
+  private var widthAnchor: NSLayoutConstraint?
   
   private struct DisplayedAd {
     let ad: AdsNotification
@@ -44,13 +45,17 @@ public class AdsViewController: UIViewController {
       $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
       $0.top.greaterThanOrEqualTo(view).offset(4) // Makes sure in landscape its at least 4px from the top
       
-      if UIDevice.current.userInterfaceIdiom == .pad {
-        let isWidthLarger = UIScreen.main.bounds.width > UIScreen.main.bounds.height
-        $0.width.equalTo(isWidthLarger ? view.snp.width : view.snp.height).multipliedBy(0.40).priority(.high)
-      } else {
+      if UIDevice.current.userInterfaceIdiom != .pad {
         $0.width.equalTo(view).priority(.high)
       }
     }
+    
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      widthAnchor = adView.widthAnchor.constraint(equalToConstant: 0.0)
+      widthAnchor?.priority = .defaultHigh
+      widthAnchor?.isActive = true
+    }
+    
     view.layoutIfNeeded()
     
     animateIn(adView: adView)
@@ -74,6 +79,15 @@ public class AdsViewController: UIViewController {
     swipePanGesture.name = swipeGestureName
     swipePanGesture.delegate = self
     adView.addGestureRecognizer(swipePanGesture)
+  }
+  
+  public override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      let isWidthLarger = view.bounds.width > view.bounds.height
+      widthAnchor?.constant = isWidthLarger ? view.bounds.width * 0.40 : view.bounds.height * 0.40
+    }
   }
   
   public func hide(adView: AdView) {

--- a/BraveRewardsUI/Ads/AdsViewController.swift
+++ b/BraveRewardsUI/Ads/AdsViewController.swift
@@ -85,8 +85,8 @@ public class AdsViewController: UIViewController {
     super.viewWillLayoutSubviews()
     
     if UIDevice.current.userInterfaceIdiom == .pad {
-      let isWidthLarger = view.bounds.width > view.bounds.height
-      widthAnchor?.constant = isWidthLarger ? view.bounds.width * 0.40 : view.bounds.height * 0.40
+      let constant = max(view.bounds.width, view.bounds.height) * 0.40
+      widthAnchor?.constant = ceil(constant * UIScreen.main.scale) / UIScreen.main.scale
     }
   }
   


### PR DESCRIPTION
Switch to using a constraint constant and manual calculation because `.multiplier(0.40).priority(.high)` doesn't work on ALL iPads (only some).

This makes the notification width on ALL iPads ALWAYS 40% of the longest side of the view/screen if possible.
Prior to this PR, it somehow only worked for SOME iPads and I really don't know why. IE: Sri was seeing small notifications but other QAs saw large ones. I saw large ones.

With this fix, I have tested iPad Pro 12.9in, 9.7in, iPad Air 2 and 3rd Gen.. iOS 12 and 13.
I have tested split screen and multi-tasking and rotation with all of the former.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2027
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
