### PR TITLE
Fix #1763 Subtitle theme not updating when switching to DarkMode

### DIFF
--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementView.swift
@@ -103,10 +103,10 @@ extension OnboardingRewardsAgreementViewController {
             $0.spacing = 15.0
         }
         
-        private func updateDescriptionLabel() {
+        private func updateDescriptionLabel(for theme: Theme) {
             descriptionLabel.attributedText = {
                 let fontSize: CGFloat = 14.0
-                let titleLabelColor = titleLabel.textColor ?? .black
+                let titleLabelColor = theme.colors.tints.home
                 
                 let text = NSMutableAttributedString(string: Strings.OBRewardsAgreementDetail, attributes: [
                     .font: UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular),
@@ -144,8 +144,12 @@ extension OnboardingRewardsAgreementViewController {
             descriptionLabel.isAccessibilityElement = true
         }
         
-        func updateSubtitleText(_ text: String, boldWords: Int) {
-            self.subtitleLabel.attributedText = text.boldWords(with: self.subtitleLabel.font, amount: boldWords)
+        func updateSubtitleText(_ text: String, boldWords: Int, for theme: Theme) {
+            let subTitle = text.boldWords(with: self.subtitleLabel.font, amount: boldWords)
+            subTitle.addAttribute(.foregroundColor,
+                                  value: theme.colors.tints.home,
+                                  range: NSRange(location: 0, length: subTitle.length))
+            self.subtitleLabel.attributedText = subTitle
         }
         
         init(theme: Theme) {
@@ -182,7 +186,14 @@ extension OnboardingRewardsAgreementViewController {
         func applyTheme(_ theme: Theme) {
             descriptionView.backgroundColor = OnboardingViewController.colorForTheme(theme)
             titleLabel.appearanceTextColor = theme.colors.tints.home
-            updateDescriptionLabel()
+            updateDescriptionLabel(for: theme)
+            
+            if let text = (subtitleLabel.attributedText?.mutableCopy() as? NSMutableAttributedString) {
+                text.addAttribute(.foregroundColor,
+                                  value: theme.colors.tints.home,
+                                  range: NSRange(location: 0, length: text.length))
+                subtitleLabel.attributedText = text
+            }
         }
         
         override func layoutSubviews() {

--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
@@ -23,7 +23,10 @@ class OnboardingRewardsAgreementViewController: OnboardingViewController {
         let isAdsRegionSupported = BraveAds.isCurrentLocaleSupported()
         
         let adSupportedRegionText = Preferences.Rewards.isUsingBAP.value == true ? Strings.OBRewardsDetailInAdRegionJapan : Strings.OBRewardsDetailInAdRegion
-        contentView.updateSubtitleText(isAdsRegionSupported ? adSupportedRegionText : Strings.OBRewardsDetailOutsideAdRegion, boldWords: isAdsRegionSupported ? 2 : 1)
+        contentView.updateSubtitleText(isAdsRegionSupported ?
+            adSupportedRegionText : Strings.OBRewardsDetailOutsideAdRegion,
+                                       boldWords: isAdsRegionSupported ? 2 : 1,
+                                       for: theme)
         
         contentView.turnOnButton.addTarget(self, action: #selector(onTurnOn), for: .touchUpInside)
         contentView.skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)


### PR DESCRIPTION
Updated the theme of the sub-title whenever its text changes. It's an attributed text so it doesn't support appearanceTextColor and it contains links.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1763
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
