### PR TITLE
Fix #2034: Don't show server error after wallet creation incorrectly

### DIFF
--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -494,10 +494,13 @@ extension WalletViewController {
       guard let self = self else {
         return
       }
-      if path.status == .satisfied && (self.state.ledger.balance != nil && self.state.ledger.walletInfo != nil) {
-        //hide network not available banner
-        self.walletView.setNotificationView(nil, animated: true)
-        self.loadNextNotification()
+      if path.status == .satisfied {
+        if self.state.ledger.balance != nil &&
+          self.state.ledger.walletInfo != nil {
+          //hide network not available banner
+          self.walletView.setNotificationView(nil, animated: true)
+          self.loadNextNotification()
+        }
       } else {
         //Show network not available banner
         self.showServerErrorNotification()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2034 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
