### PR TITLE
Fix #580 - Removing of history when going from normal tabs to PBO.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1120,16 +1120,16 @@ class BrowserViewController: UIViewController {
         
         guard let webView = object as? WKWebView else {
             log.error("An object of type: \(String(describing: object)) is being observed instead of a WKWebView")
-            return  //False alarm.. the source MUST be a web view.
+            return  // False alarm.. the source MUST be a web view.
         }
         
-        //WebView is a zombie and somehow still has an observer attached to it
+        // WebView is a zombie and somehow still has an observer attached to it
         guard let tab = tabManager[webView] else {
             log.error("WebView: \(webView) has been removed from TabManager but still has attached observers")
             return
         }
         
-        //Must handle ALL keypaths
+        // Must handle ALL keypaths
         guard let kp = keyPath, let path = KVOConstants(rawValue: kp) else {
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
             return
@@ -3336,7 +3336,7 @@ extension BrowserViewController: PreferencesObserver {
                 
                 // Clear ALL data when going from normal mode to private
                 // The other way around is handled in `removeTab`
-                let clearables: [Clearable] = [HistoryClearable(), CookiesAndCacheClearable()]
+                let clearables: [Clearable] = [CookiesAndCacheClearable()]
                 _ = ClearPrivateDataTableViewController.clearPrivateData(clearables)
             }
         case Preferences.General.alwaysRequestDesktopSite.key:


### PR DESCRIPTION
One line fix. Removed the history clearable.

## Summary of Changes

This pull request fixes issue #580
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
