### PR TITLE
Fix #2049: sharedSyncDevice race condition.

### DIFF
--- a/Data/models/Device.swift
+++ b/Data/models/Device.swift
@@ -10,7 +10,7 @@ private let log = Logger.browserLogger
 public final class Device: NSManagedObject, Syncable, CRUD {
     
     // Check if this can be nested inside the method
-    static var sharedCurrentDevice: Device?
+    static var sharedCurrentDeviceId: NSManagedObjectID?
     
     // Assign on parent model via CD
     @NSManaged public var isSynced: Bool
@@ -56,14 +56,14 @@ extension Device {
     
     /// Returns a current device and assings it to a shared variable.
     static func currentDevice(context: NSManagedObjectContext = DataController.viewContext) -> Device? {
-        if sharedCurrentDevice == nil {
+        guard let deviceId = sharedCurrentDeviceId else {
             let predicate = NSPredicate(format: "isCurrentDevice == true")
-            sharedCurrentDevice = first(where: predicate, context: context)
-        } else if let sharedDevice = sharedCurrentDevice {
-            sharedCurrentDevice = context.object(with: sharedDevice.objectID) as? Device
+            let device = first(where: predicate, context: context)
+            sharedCurrentDeviceId = device?.objectID
+            return device
         }
         
-        return sharedCurrentDevice
+        return context.object(with: deviceId) as? Device
     }
     
     class func add(name: String?, isCurrent: Bool = false) {

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -181,7 +181,7 @@ public class Sync: JSInjector {
                 self.sendSyncRecords(action: .delete, records: [device], context: context)
             }
             
-            Device.sharedCurrentDevice = nil
+            Device.sharedCurrentDeviceId = nil
             Device.deleteAll(context: .existing(context))
         }
         

--- a/DataTests/CoreDataTestCase.swift
+++ b/DataTests/CoreDataTestCase.swift
@@ -21,7 +21,7 @@ class CoreDataTestCase: XCTestCase {
     override func tearDown() {
         NotificationCenter.default.removeObserver(self)
         DataController.viewContext.reset()
-        Device.sharedCurrentDevice = nil
+        Device.sharedCurrentDeviceId = nil
         contextSaveCompletion = nil
         super.tearDown()
     }


### PR DESCRIPTION
Shared sync device was kept as a static variable. 
The thing is that NSManagedObjects are not thread safe.
This commit changes the implementation so the thread safe object id is used to access the object.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2049 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Hard to test because this never crashed for me or the QA team.
The changes touches sync device stuff so please test basic sync chain creation.

Verify that connected sync devices are showing. 
I would like to just avoid regressions and see if this will also get rid of app crashes after we ship it to users

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
