### PR TITLE
Fix #2039: Use app-styled alert for external URL prompts

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -32,16 +32,22 @@ extension URL {
 
 extension BrowserViewController {
     fileprivate func handleExternalURL(_ url: URL, openedURLCompletionHandler: ((Bool) -> Void)? = nil) {
-        let alertController = UIAlertController(
+        self.view.endEditing(true)
+        let popup = AlertPopupView(
+            imageView: nil,
             title: Strings.OpenExternalAppURLTitle,
             message: String(format: Strings.OpenExternalAppURLMessage, url.relativeString),
-            preferredStyle: .alert
+            titleWeight: .semibold,
+            titleSize: 21
         )
-        alertController.addAction(UIAlertAction(title: Strings.OpenExternalAppURLDontAllow, style: .cancel))
-        alertController.addAction(UIAlertAction(title: Strings.OpenExternalAppURLAllow, style: .default) { result in
+        popup.addButton(title: Strings.OpenExternalAppURLDontAllow, fontSize: 16) { () -> PopupViewDismissType in
+            return .flyDown
+        }
+        popup.addButton(title: Strings.OpenExternalAppURLAllow, type: .primary, fontSize: 16) { () -> PopupViewDismissType in
             UIApplication.shared.open(url, options: [:], completionHandler: openedURLCompletionHandler)
-        })
-        self.present(alertController, animated: true)
+            return .flyDown
+        }
+        popup.showWithType(showType: .flyUp)
     }
 }
 


### PR DESCRIPTION
Font sizes/colors may want to be adjusted, @jamesmudgett to verify design below

## Summary of Changes

This pull request fixes issue #2039 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2019-11-28 at 16 00 45](https://user-images.githubusercontent.com/529104/69831683-71fa1d80-11f8-11ea-856f-2d422d3574a9.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).