### PR TITLE
Fix #2016: Don't hide the keyboard when we take a screenshot of the page

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1500,6 +1500,11 @@ class BrowserViewController: UIViewController {
             // forward/backward. Strange, but LayoutChanged fixes that.
             UIAccessibility.post(notification: .layoutChanged, argument: nil)
         } else if let webView = tab.webView {
+            // Ref #2016: Keyboard auto hides while typing
+            // For some reason the web view will steal first responder as soon
+            // as its added to the view heirarchy below. This line fixes that...
+            // somehow...
+            webView.resignFirstResponder()
             // To Screenshot a tab that is hidden we must add the webView,
             // then wait enough time for the webview to render.
             view.insertSubview(webView, at: 0)


### PR DESCRIPTION
Another solution is not doing a screenshot if the tab is backgrounded, as it almost never produces a proper screenshot anyways

## Summary of Changes

This pull request fixes issue #2016 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
