### PR TITLE
Fix #2022: Don't mark ads as unavailable when using custom calendars

### DIFF
--- a/BraveRewardsUI/README.md
+++ b/BraveRewardsUI/README.md
@@ -5,6 +5,6 @@ A UI framework for consuming Brave Rewards. The core logic around BraveRewards r
 The latest BraveRewards.framework was built on:
 
 ```
-brave-browser/3c18ec6742623aa1c83fbd2550434d7c0fc26f12
-brave-core/9dfc26db88b4231838dbc3ac913b8cb600a7fa4d
+brave-browser/b08ea58f46fc531f6abe9dca41f4381815d58372
+brave-core/62dfd8e87c339a4947b08c511c3e41fb16e351f8
 ```


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #2022

This updates the brave-core library with the following changes:

- Support OS level targeting for ads (https://github.com/brave/brave-core/pull/4068)
- Allow multiple matched segments to trigger ads (https://github.com/brave/brave-core/pull/4073)
- Use correct locale identifier when iOS user has custom calendar set (https://github.com/brave/brave-core/pull/4069)

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Go to Settings > general > language & Region and change your calendar to japanese
- Enable rewards and verify that it is still enabled and working

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
