### PR TITLE
Fix #2121 - Shields not obeying their domain toggle.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -182,8 +182,7 @@ extension BrowserViewController: WKNavigationDelegate {
             if let urlHost = url.normalizedHost() {
                 if let mainDocumentURL = navigationAction.request.mainDocumentURL, url.scheme == "http" {
                     let domainForShields = Domain.getOrCreate(forUrl: mainDocumentURL, persistent: !isPrivateBrowsing)
-                    if !domainForShields.isAllShieldsOff() &&
-                        domainForShields.isShieldExpected(.HTTPSE) && HttpsEverywhereStats.shared.shouldUpgrade(url) {
+                    if domainForShields.isShieldExpected(.HTTPSE, considerAllShieldsOption: true) && HttpsEverywhereStats.shared.shouldUpgrade(url) {
                         // Check if HTTPSE is on and if it is, whether or not this http url would be upgraded
                         pendingHTTPUpgrades[urlHost] = navigationAction.request
                     }
@@ -216,15 +215,10 @@ extension BrowserViewController: WKNavigationDelegate {
               
                 if let tab = tabManager[webView] {
                     tab.userScriptManager?.isFingerprintingProtectionEnabled =
-                        !domainForShields.isAllShieldsOff()
-                        &&
-                        domainForShields.isShieldExpected(.FpProtection)
+                        domainForShields.isShieldExpected(.FpProtection, considerAllShieldsOption: true)
                 }
 
-                webView.configuration.preferences.javaScriptEnabled =
-                    domainForShields.isAllShieldsOff()
-                    ||
-                    !domainForShields.isShieldExpected(.NoScript)
+                webView.configuration.preferences.javaScriptEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
             }
             
             //Cookie Blocking code below

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -225,8 +225,6 @@ extension BrowserViewController: WKNavigationDelegate {
                     domainForShields.isAllShieldsOff()
                     ||
                     !domainForShields.isShieldExpected(.NoScript)
-                
-                print(webView.configuration.preferences.javaScriptEnabled)
             }
             
             //Cookie Blocking code below

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -28,7 +28,7 @@ class FaviconHandler {
             return deferMaybe(FaviconError())
         }
 
-        let deferred = Deferred<Maybe<(Favicon, Data?)>>()
+        let deferred = Deferred<Maybe<(Favicon, Data?)>>(value: nil, defaultQueue: .main)
 
         var imageOperation: SDWebImageOperation?
 

--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -67,7 +67,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
             
             if let domain = domain {
                 // site-specific shield has been overridden, update
-                view.toggleSwitch.isOn = domain.isShieldExpected(shield)
+                view.toggleSwitch.isOn = domain.isShieldExpected(shield, considerAllShieldsOption: false)
                 if shield == .AllOff {
                     // Reverse, as logic is inverted
                     view.toggleSwitch.isOn.toggle()

--- a/Client/WebFilters/ContentBlocker/BlocklistName.swift
+++ b/Client/WebFilters/ContentBlocker/BlocklistName.swift
@@ -61,8 +61,7 @@ class BlocklistName: CustomStringConvertible, ContentBlocker {
         
         var onList = Set<BlocklistName>()
         
-        if !domain.isAllShieldsOff() &&
-            domain.isShieldExpected(.AdblockAndTp) {
+        if domain.isShieldExpected(.AdblockAndTp, considerAllShieldsOption: true) {
             onList.formUnion([.ad, .tracker])
             
             if Preferences.Shields.useRegionAdBlock.value, let regionalBlocker = regionalBlocker {
@@ -74,8 +73,7 @@ class BlocklistName: CustomStringConvertible, ContentBlocker {
         
         // TODO #159: Setup image shield
         
-        if !domain.isAllShieldsOff() &&
-            domain.isShieldExpected(.HTTPSE) {
+        if domain.isShieldExpected(.HTTPSE, considerAllShieldsOption: true) {
             onList.insert(.https)
         }
         

--- a/Client/WebFilters/ContentBlocker/BlocklistName.swift
+++ b/Client/WebFilters/ContentBlocker/BlocklistName.swift
@@ -61,7 +61,8 @@ class BlocklistName: CustomStringConvertible, ContentBlocker {
         
         var onList = Set<BlocklistName>()
         
-        if domain.isShieldExpected(.AdblockAndTp) {
+        if !domain.isAllShieldsOff() &&
+            domain.isShieldExpected(.AdblockAndTp) {
             onList.formUnion([.ad, .tracker])
             
             if Preferences.Shields.useRegionAdBlock.value, let regionalBlocker = regionalBlocker {
@@ -73,7 +74,8 @@ class BlocklistName: CustomStringConvertible, ContentBlocker {
         
         // TODO #159: Setup image shield
         
-        if domain.isShieldExpected(.HTTPSE) {
+        if !domain.isAllShieldsOff() &&
+            domain.isShieldExpected(.HTTPSE) {
             onList.insert(.https)
         }
         

--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
@@ -39,7 +39,7 @@ extension ContentBlockerHelper: TabContentScript {
         
         let resourceType = TPStatsResourceType(rawValue: body["resourceType"] ?? "")
         
-        if resourceType == .script && domain.isShieldExpected(.NoScript) {
+        if resourceType == .script && domain.isShieldExpected(.NoScript, considerAllShieldsOption: true) {
             self.stats = self.stats.addingScriptBlock()
             BraveGlobalShieldStats.shared.scripts += 1
             return

--- a/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
+++ b/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
@@ -30,7 +30,7 @@ class SafeBrowsing {
         }
         let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
         let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivateBrowsing)
-        let isSafeBrowsingEnabled = domain.isShieldExpected(.SafeBrowsing)
+        let isSafeBrowsingEnabled = domain.isShieldExpected(.SafeBrowsing, considerAllShieldsOption: false)
         let isUrlBlacklisted = domainList.contains(baseDomain)
 
         return isSafeBrowsingEnabled && isUrlBlacklisted

--- a/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
+++ b/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
@@ -30,7 +30,7 @@ class SafeBrowsing {
         }
         let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
         let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivateBrowsing)
-        let isSafeBrowsingEnabled = !domain.isAllShieldsOff() && domain.isShieldExpected(.SafeBrowsing)
+        let isSafeBrowsingEnabled = domain.isShieldExpected(.SafeBrowsing)
         let isUrlBlacklisted = domainList.contains(baseDomain)
 
         return isSafeBrowsingEnabled && isUrlBlacklisted

--- a/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
+++ b/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
@@ -30,7 +30,7 @@ class SafeBrowsing {
         }
         let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
         let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivateBrowsing)
-        let isSafeBrowsingEnabled = domain.isShieldExpected(.SafeBrowsing)
+        let isSafeBrowsingEnabled = !domain.isAllShieldsOff() && domain.isShieldExpected(.SafeBrowsing)
         let isUrlBlacklisted = domainList.contains(baseDomain)
 
         return isSafeBrowsingEnabled && isUrlBlacklisted

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -67,6 +67,10 @@ public final class Domain: NSManagedObject, CRUD {
         setBraveShieldInternal(forUrl: url, shield: shield, isOn: isOn, context: _context)
     }
     
+    public func isAllShieldsOff() -> Bool {
+        return Bool(truncating: shield_allOff ?? NSNumber(value: 0))
+    }
+    
     /// Whether or not a given shield should be enabled based on domain exceptions and the users global preference
     public func isShieldExpected(_ shield: BraveShield) -> Bool {
         switch shield {

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -67,26 +67,28 @@ public final class Domain: NSManagedObject, CRUD {
         setBraveShieldInternal(forUrl: url, shield: shield, isOn: isOn, context: _context)
     }
     
-    public func isAllShieldsOff() -> Bool {
-        return Bool(truncating: shield_allOff ?? NSNumber(value: 0))
-    }
-    
     /// Whether or not a given shield should be enabled based on domain exceptions and the users global preference
-    public func isShieldExpected(_ shield: BraveShield) -> Bool {
-        switch shield {
-        case .AllOff:
-            return self.shield_allOff?.boolValue ?? false
-        case .AdblockAndTp:
-            return self.shield_adblockAndTp?.boolValue ?? Preferences.Shields.blockAdsAndTracking.value
-        case .HTTPSE:
-            return self.shield_httpse?.boolValue ?? Preferences.Shields.httpsEverywhere.value
-        case .SafeBrowsing:
-            return self.shield_safeBrowsing?.boolValue ?? Preferences.Shields.blockPhishingAndMalware.value
-        case .FpProtection:
-            return self.shield_fpProtection?.boolValue ?? Preferences.Shields.fingerprintingProtection.value
-        case .NoScript:
-            return self.shield_noScript?.boolValue ?? Preferences.Shields.blockScripts.value
+    public func isShieldExpected(_ shield: BraveShield, considerAllShieldsOption: Bool = false) -> Bool {
+        let isShieldOn = { () -> Bool in
+            switch shield {
+            case .AllOff:
+                return self.shield_allOff?.boolValue ?? false
+            case .AdblockAndTp:
+                return self.shield_adblockAndTp?.boolValue ?? Preferences.Shields.blockAdsAndTracking.value
+            case .HTTPSE:
+                return self.shield_httpse?.boolValue ?? Preferences.Shields.httpsEverywhere.value
+            case .SafeBrowsing:
+                return self.shield_safeBrowsing?.boolValue ?? Preferences.Shields.blockPhishingAndMalware.value
+            case .FpProtection:
+                return self.shield_fpProtection?.boolValue ?? Preferences.Shields.fingerprintingProtection.value
+            case .NoScript:
+                return self.shield_noScript?.boolValue ?? Preferences.Shields.blockScripts.value
+            }
         }
+        
+        let isAllShieldsOff = Bool(truncating: shield_allOff ?? NSNumber(value: 0))
+        let isSpecificShieldOn = isShieldOn()
+        return considerAllShieldsOption ? !isAllShieldsOff && isSpecificShieldOn : isSpecificShieldOn
     }
     
     public static func migrateShieldOverrides() {

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -68,7 +68,7 @@ public final class Domain: NSManagedObject, CRUD {
     }
     
     /// Whether or not a given shield should be enabled based on domain exceptions and the users global preference
-    public func isShieldExpected(_ shield: BraveShield, considerAllShieldsOption: Bool = false) -> Bool {
+    public func isShieldExpected(_ shield: BraveShield, considerAllShieldsOption: Bool) -> Bool {
         let isShieldOn = { () -> Bool in
             switch shield {
             case .AllOff:


### PR DESCRIPTION
**Security Review:**
- https://github.com/brave/security/issues/32

- Fixed shields not obeying their domain toggle.
- Fixed crash due to tabs being killed on a background thread.

**Steps to Reproduce:**
1. Turn on "Block Scripts" toggle.
2. Visit a website and notice some things don't load.
3. Turn OFF the site-shield toggle.
4. Notice that the page refreshed but scripts are still blocked!

**Fix:**
1. This PR fixes it so that if you turn off "All Toggles"/"Site Shield", it will disable all shields.
2. If you turn all toggles/site shield, it should show all your previous toggles with their previous settings.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2121
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
