### PR TITLE
No Bug: Add DeviceCheck status and enrollment state to rewards internal

### DIFF
--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -8,6 +8,7 @@ import Shared
 import BraveShared
 import BraveRewards
 import BraveRewardsUI
+import DeviceCheck
 
 private extension ContributionRetry {
     var name: String {
@@ -77,6 +78,8 @@ class BraveRewardsSettingsViewController: TableViewController {
                             self.rewards.ledger.rewardsInternalInfo { info in
                                 guard let info = info else { return }
                                 var supportInfo = """
+                                Device Status: \(DCDevice.current.isSupported ? "Supported" : "Not supported")
+                                Enrollment State: \(DeviceCheckClient.isDeviceEnrolled() ? "Enrolled" : "Not enrolled")
                                 Key Info Seed: \(info.isKeyInfoSeedValid ? "Valid" : "Invalid")
                                 Wallet Payment ID: \(info.paymentId)
                                 Persona ID: \(info.personaId)


### PR DESCRIPTION
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
