### PR TITLE
Fix #903: Puts more strict access on PhotoAlbum.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2860,6 +2860,21 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
 }
 
 extension BrowserViewController: ContextMenuHelperDelegate {
+    @objc
+    private func image(image: UIImage, didFinishSavingwithError error: NSError?, contextInfo: UnsafeRawPointer?) {
+        
+        if error != nil {
+            let accessDenied = UIAlertController(title: Strings.AccessPhotoDeniedAlertTitle, message: Strings.AccessPhotoDeniedAlertMessage, preferredStyle: .alert)
+            let dismissAction = UIAlertAction(title: Strings.CancelButtonTitle, style: .default, handler: nil)
+            accessDenied.addAction(dismissAction)
+            let settingsAction = UIAlertAction(title: Strings.OpenPhoneSettingsActionTitle, style: .default ) { _ in
+                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:])
+            }
+            accessDenied.addAction(settingsAction)
+            self.present(accessDenied, animated: true, completion: nil)
+        }
+    }
+    
     func contextMenuHelper(_ contextMenuHelper: ContextMenuHelper, didLongPressElements elements: ContextMenuHelper.Elements, gestureRecognizer: UIGestureRecognizer) {
         // locationInView can return (0, 0) when the long press is triggered in an invalid page
         // state (e.g., long pressing a link before the document changes, then releasing after a
@@ -2914,23 +2929,13 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
             actionSheetController.addAction(openInNewTabAction, accessibilityIdentifier: "linkContextMenu.openImageInNewTab")
 
-            let photoAuthorizeStatus = PHPhotoLibrary.authorizationStatus()
             let saveImageAction = UIAlertAction(title: Strings.SaveImageActionTitle, style: .default) { _ in
-                if photoAuthorizeStatus == .authorized || photoAuthorizeStatus == .notDetermined {
-                    self.getData(url) { data in
-                        PHPhotoLibrary.shared().performChanges({
-                            PHAssetCreationRequest.forAsset().addResource(with: .photo, data: data, options: nil)
-                        }, completionHandler: nil)
+                self.getData(url) { [weak self] data in
+                    guard let self = self, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
+                        return
                     }
-                } else {
-                    let accessDenied = UIAlertController(title: Strings.AccessPhotoDeniedAlertTitle, message: Strings.AccessPhotoDeniedAlertMessage, preferredStyle: .alert)
-                    let dismissAction = UIAlertAction(title: Strings.CancelButtonTitle, style: .default, handler: nil)
-                    accessDenied.addAction(dismissAction)
-                    let settingsAction = UIAlertAction(title: Strings.OpenPhoneSettingsActionTitle, style: .default ) { _ in
-                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:])
-                    }
-                    accessDenied.addAction(settingsAction)
-                    self.present(accessDenied, animated: true, completion: nil)
+                    
+                    UIImageWriteToSavedPhotosAlbum(image, self, #selector(self.image(image:didFinishSavingwithError:contextInfo:)), nil)
                 }
             }
             actionSheetController.addAction(saveImageAction, accessibilityIdentifier: "linkContextMenu.saveImage")

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2863,16 +2863,22 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     @objc
     private func image(image: UIImage, didFinishSavingwithError error: NSError?, contextInfo: UnsafeRawPointer?) {
         
-        if error != nil {
-            let accessDenied = UIAlertController(title: Strings.AccessPhotoDeniedAlertTitle, message: Strings.AccessPhotoDeniedAlertMessage, preferredStyle: .alert)
-            let dismissAction = UIAlertAction(title: Strings.CancelButtonTitle, style: .default, handler: nil)
-            accessDenied.addAction(dismissAction)
-            let settingsAction = UIAlertAction(title: Strings.OpenPhoneSettingsActionTitle, style: .default ) { _ in
-                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:])
-            }
-            accessDenied.addAction(settingsAction)
-            self.present(accessDenied, animated: true, completion: nil)
+        if error == nil {
+            return
         }
+        
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        
+        let accessDenied = UIAlertController(title: Strings.AccessPhotoDeniedAlertTitle, message: Strings.AccessPhotoDeniedAlertMessage, preferredStyle: .alert)
+        let dismissAction = UIAlertAction(title: Strings.CancelButtonTitle, style: .default, handler: nil)
+        accessDenied.addAction(dismissAction)
+        let settingsAction = UIAlertAction(title: Strings.OpenPhoneSettingsActionTitle, style: .default ) { _ in
+            UIApplication.shared.open(settingsUrl, options: [:])
+        }
+        accessDenied.addAction(settingsAction)
+        self.present(accessDenied, animated: true, completion: nil)
     }
     
     func contextMenuHelper(_ contextMenuHelper: ContextMenuHelper, didLongPressElements elements: ContextMenuHelper.Elements, gestureRecognizer: UIGestureRecognizer) {


### PR DESCRIPTION
Change Brave photos to only use write permissions. So we use iOS's built in writer for iOS 12 (already handled automatically on iOS 13).

## Steps to Reproduce
1. Go to a website like `https://imgur.com`
2. Long press on an image (not a video)
3. Should bring up context menu.
4. Hit Save/Add to Photos

**Expected:**
1. Should add to photos.
2. Should prompt if access is denied or changed from Settings->Privacy->Photos->Brave.
3. Should show "Write Only" in Settings->Privacy->Photos->Brave.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #903
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
