### PR TITLE
Fix #1890: Only display current reconcile's AC publishers in AC table

### DIFF
--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -73,6 +73,7 @@ class AutoContributeDetailViewController: UIViewController {
       $0.percent = 1 //exclude 0% sites.
       $0.orderBy = [sort]
       $0.nonVerified = state.ledger.allowUnverifiedPublishers
+      $0.reconcileStamp = state.ledger.autoContributeProps.reconcileStamp
     }
     
     state.ledger.listActivityInfo(fromStart: UInt32(start), limit: UInt32(limit), filter: filter) { publishersList in


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1890 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
