### PR TITLE
Fix #2001: Sync code warning text highlight on iOS 12.

### DIFF
--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -135,7 +135,7 @@ class SyncAddDeviceViewController: SyncViewController {
         }
     }
     
-    func setupVisuals() {
+    private func setupVisuals() {
         modeControl = UISegmentedControl(items: [Strings.QRCode, Strings.CodeWords])
         modeControl.translatesAutoresizingMaskIntoConstraints = false
         modeControl.selectedSegmentIndex = 0
@@ -220,11 +220,14 @@ class SyncAddDeviceViewController: SyncViewController {
         if deviceType == .computer {
             SEL_showCodewords()
         }
-        
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         updateLabels()
     }
     
-    func updateLabels() {
+    private func updateLabels() {
         let isFirstIndex = modeControl.selectedSegmentIndex == 0
         
         titleLabel.text = isFirstIndex ? Strings.SyncAddDeviceScan : Strings.SyncAddDeviceWords


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2001 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
