### PR TITLE
Fix: #2124 - Fixes a bug where the gradient overflows the tabbar

### DIFF
--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -106,6 +106,18 @@ class TabsBarViewController: UIViewController {
         updateData()
     }
     
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        let offset = Float(collectionView.contentOffset.x)
+        let startFade = Float(30)
+        leftOverflowIndicator.opacity = min(1, offset / startFade)
+        
+        // all the way scrolled right
+        let offsetFromRight = collectionView.contentSize.width - CGFloat(offset) - collectionView.frame.width
+        rightOverflowIndicator.opacity = min(1, Float(offsetFromRight) / startFade)
+    }
+    
     deinit {
         NotificationCenter.default.removeObserver(self)
     }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -109,13 +109,7 @@ class TabsBarViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
-        let offset = Float(collectionView.contentOffset.x)
-        let startFade = Float(30)
-        leftOverflowIndicator.opacity = min(1, offset / startFade)
-        
-        // all the way scrolled right
-        let offsetFromRight = collectionView.contentSize.width - CGFloat(offset) - collectionView.frame.width
-        rightOverflowIndicator.opacity = min(1, Float(offsetFromRight) / startFade)
+        updateOverflowIndicatorsLayout()
     }
     
     deinit {
@@ -199,10 +193,7 @@ class TabsBarViewController: UIViewController {
         return max(overflow, 0)
     }
     
-    fileprivate func overflowIndicators() {
-        addScrollHint(for: .leftSide, maskLayer: leftOverflowIndicator)
-        addScrollHint(for: .rightSide, maskLayer: rightOverflowIndicator)
-        
+    private func updateOverflowIndicatorsLayout() {
         let offset = Float(collectionView.contentOffset.x)
         let startFade = Float(30)
         leftOverflowIndicator.opacity = min(1, offset / startFade)
@@ -210,6 +201,12 @@ class TabsBarViewController: UIViewController {
         // all the way scrolled right
         let offsetFromRight = collectionView.contentSize.width - CGFloat(offset) - collectionView.frame.width
         rightOverflowIndicator.opacity = min(1, Float(offsetFromRight) / startFade)
+    }
+    
+    fileprivate func overflowIndicators() {
+        addScrollHint(for: .leftSide, maskLayer: leftOverflowIndicator)
+        addScrollHint(for: .rightSide, maskLayer: rightOverflowIndicator)
+        updateOverflowIndicatorsLayout()
     }
     
     private enum HintSide { case leftSide, rightSide }


### PR DESCRIPTION
## Summary of Changes

Fixes a bug where minimizing the app completely through the app-switcher and then bringing it back into the foreground causes the gradient to overlap since it never gets updated when the layout updates.
To fix it, we override layoutSubviews and update the gradient accordingly.

This pull request fixes issue #2124
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
