### PR TITLE
Fix: #2128 - New-Tab-Page under settings showing wrong options

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -159,14 +159,13 @@ class SettingsViewController: TableViewController {
         }
         display.rows.append(row)
         
-        row = Row(text: Strings.NewTabPageSettingsTitle,
+        display.rows.append(Row(text: Strings.NewTabPageSettingsTitle,
             selection: { [unowned self] in
                 self.navigationController?.pushViewController(NewTabPageTableViewController(), animated: true)
             },
             accessory: .disclosureIndicator,
             cellClass: MultilineValue1Cell.self
-        )
-        display.rows.append(row)
+        ))
         
         if UIDevice.current.userInterfaceIdiom == .pad {
             display.rows.append(


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixed an issue where New-Tab-Page under settings menu was changing the reference to a struct captured by a lambda. Therefore when the lambda updated the struct, it also modified New-Tab-Page display.

This pull request fixes issue #2128
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
