### PR TITLE
Fix #2068: Prefix auto-contribute BAT value selections with "Up to"

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -41,6 +41,7 @@ internal extension Strings {
   static let SettingsTitle = NSLocalizedString("BraveRewardsSettingsTitle", bundle: Bundle.RewardsUI, value: "Settings", comment: "")
   static let Tips = NSLocalizedString("BraveRewardsTips", bundle: Bundle.RewardsUI, value: "Tips", comment: "")
   static let SettingsAutoContributeTitle = NSLocalizedString("BraveRewardsSettingsAutoContributeTitle", bundle: Bundle.RewardsUI, value: "Auto-Contribute", comment: "")
+  static let SettingsAutoContributeUpToValue = NSLocalizedString("BraveRewardsSettingsAutoContributeUpToValue", bundle: Bundle.RewardsUI, value: "Up to %@", comment: "The maximum amount of BAT to auto-contribute. E.g. 'Up to 20.0 BAT'")
   static let NotYetVerified = NSLocalizedString("BraveRewardsNotYetVerified", bundle: Bundle.RewardsUI, value: "Not yet verified", comment: "")
   static let GrantsClaimedTitle = NSLocalizedString("BraveRewardsGrantsClaimedTitle", bundle: Bundle.RewardsUI, value: "It's your lucky day!", comment: "")
   static let AdsGrantsClaimedTitle = NSLocalizedString("BraveRewardsAdsGrantsClaimedTitle", bundle: Bundle.RewardsUI, value: "Brave Ads Rewards!", comment: "")

--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -174,23 +174,20 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
         // Monthly payment
         guard let wallet = state.ledger.walletInfo else { break }
         let monthlyPayment = state.ledger.contributionAmount
-        let choices = wallet.parametersChoices.map { $0.doubleValue }
-        let selectedIndex = choices.firstIndex(of: monthlyPayment) ?? 0
-        let stringChoices = choices.map { choice -> String in
-          var amount = "\(choice) \(Strings.BAT)"
-          if let dollarRate = state.ledger.dollarStringForBATAmount(choice) {
-            amount.append(" (\(dollarRate))")
+        let choices = wallet.parametersChoices.map { BATValue($0.doubleValue) }
+        let selectedIndex = choices.map({ $0.doubleValue }).firstIndex(of: monthlyPayment) ?? 0
+        
+        let controller = BATValueOptionsSelectionViewController(
+          ledger: state.ledger,
+          options: choices,
+          isSelectionPrecise: false,
+          selectedOptionIndex: selectedIndex
+        ) { [weak self] selectedIndex in
+          guard let self = self else { return }
+          if selectedIndex < choices.count {
+            self.state.ledger.contributionAmount = choices[selectedIndex].doubleValue
           }
-          return amount
-        }
-        let controller = OptionsSelectionViewController(
-          options: stringChoices,
-          selectedOptionIndex: selectedIndex) { [weak self] (selectedIndex) in
-            guard let self = self else { return }
-            if selectedIndex < choices.count {
-              self.state.ledger.contributionAmount = choices[selectedIndex]
-            }
-            self.navigationController?.popViewController(animated: true)
+          self.navigationController?.popViewController(animated: true)
         }
         controller.title = Strings.AutoContributeMonthlyPaymentTitle
         navigationController?.pushViewController(controller, animated: true)

--- a/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
@@ -99,7 +99,12 @@ extension AutoContributeSettingsViewController: UITableViewDelegate, UITableView
       let choices = wallet.parametersChoices.map { BATValue($0.doubleValue) }
       let selectedIndex = choices.map({ $0.doubleValue }).firstIndex(of: monthlyPayment) ?? 0
       
-      let controller = BATValueOptionsSelectionViewController(ledger: ledger, options: choices, selectedOptionIndex: selectedIndex) { [weak self] (selectedIndex) in
+      let controller = BATValueOptionsSelectionViewController(
+        ledger: ledger,
+        options: choices,
+        isSelectionPrecise: false,
+        selectedOptionIndex: selectedIndex
+      ) { [weak self] selectedIndex in
         guard let self = self else { return }
         if selectedIndex < choices.count {
           self.ledger.contributionAmount = choices[selectedIndex].doubleValue

--- a/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
@@ -8,13 +8,18 @@ import BraveRewards
 
 /// A controller for displaying BATValue options with their equivalent dollar value.
 /// When the user selects an option, the selected index is returned in the completion block.
+/// If you pass false for `isSelectionPrecise`, the value will be prefixed with "Up to"
 class BATValueOptionsSelectionViewController: OptionsSelectionViewController<BATValue> {
   
   private let ledger: BraveLedger?
+  private var isSelectionPrecise: Bool
   
-  init(ledger: BraveLedger, options: [BATValue],
+  init(ledger: BraveLedger,
+       options: [BATValue],
+       isSelectionPrecise: Bool = true,
        selectedOptionIndex: Int = 0,
        optionSelected: @escaping (_ selectedIndex: Int) -> Void) {
+    self.isSelectionPrecise = isSelectionPrecise
     self.ledger = ledger
     super.init(options: options, selectedOptionIndex: selectedOptionIndex, optionSelected: optionSelected)
   }
@@ -26,7 +31,10 @@ class BATValueOptionsSelectionViewController: OptionsSelectionViewController<BAT
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = super.tableView(tableView, cellForRowAt: indexPath)
 
-    let displayString = options[indexPath.row].displayString
+    var displayString = options[indexPath.row].displayString
+    if !isSelectionPrecise {
+      displayString = String.localizedStringWithFormat(Strings.SettingsAutoContributeUpToValue, displayString)
+    }
     let dollarAmount = ledger?.dollarStringForBATAmount(options[indexPath.row].doubleValue) ?? ""
     
     let attributedText = NSMutableAttributedString(string: displayString, attributes: [


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2068 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable Rewards
- Go to Auto-Contribute details, tap monthly amount, verify amounts are prefixed with "Up to"
- Go to Auto-Contribute settings, repeat previous verification
- Enable a monthly tip for a publisher, verify tapping on monthly amount from rewards panel does not prefix amounts with "Up to"

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-03 at 14 34 52](https://user-images.githubusercontent.com/529104/71744909-a89a0800-2e36-11ea-84f9-cdd163ec97ff.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).