### PR TITLE
Fix #2143: Removing bookmark on wrong context when using sync.

### DIFF
--- a/Data/models/Bookmark.swift
+++ b/Data/models/Bookmark.swift
@@ -531,7 +531,8 @@ extension Bookmark {
                 removeFolderAndSendSyncRecords(uuid: syncUUID)
             } else {
                 DataController.perform(context: context) { context in
-                    Sync.shared.sendSyncRecords(action: .delete, records: [self], context: context)
+                    guard let objectOnContext = context.object(with: self.objectID) as? Bookmark else { return }
+                    Sync.shared.sendSyncRecords(action: .delete, records: [objectOnContext], context: context)
                 }
             }
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2143 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Nothing should change for end user.
Just test if deleting bookmarks still works when connected to sync.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
