### PR TITLE
Fix #2147: Hide tipping panel social media icons

### DIFF
--- a/BraveRewardsUI/Tipping/TippingOverviewView.swift
+++ b/BraveRewardsUI/Tipping/TippingOverviewView.swift
@@ -46,6 +46,10 @@ class TippingOverviewView: UIView {
   
   let socialStackView = UIStackView().then {
     $0.spacing = 20.0
+    // Hide these icons until a later date (ref: https://github.com/brave/brave-ios/issues/2147) when we
+    // can make the icons actual buttons that lead to their social media sites (ref:
+    // https://github.com/brave/brave-ios/issues/1712)
+    $0.isHidden = true
   }
   
   private let bodyStackView = UIStackView().then {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2147 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable Rewards on prod
- Visit neowin.net
- Verify no icons show

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-06 at 12 53 18](https://user-images.githubusercontent.com/529104/71837087-94971600-3083-11ea-9cf9-f24fd9dd6bb3.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
