### PR TITLE
Fix #2145: Crash with Sync.getExistingObjects

### DIFF
--- a/Data/models/Device.swift
+++ b/Data/models/Device.swift
@@ -63,7 +63,12 @@ extension Device {
             return device
         }
         
-        return context.object(with: deviceId) as? Device
+        do {
+            return try context.existingObject(with: deviceId) as? Device
+        } catch {
+            log.error("Failed to fetch device: \(error)")
+            return nil
+        }
     }
     
     class func add(name: String?, isCurrent: Bool = false) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Call `context.object` can throw a fault sometimes. Changing it to `existingObject` so we can fail silently.
Not 100% sure this is going to help, doesn't hurt to add it though.

Please note that we use `context.object` in other places and never had problems, in the future we might consider replacing it with safer approach, using either `existingObject` or `registeredObject` methods

This pull request fixes issue #2145 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
