### PR TITLE
Ref #2151: NTP Behavioral Refactor Work

### DIFF
--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -205,7 +205,7 @@ class FavoritesViewController: UIViewController, Themeable {
         collection.addSubview(braveShieldStatsView)
         collection.addSubview(favoritesOverflowButton)
         collection.addSubview(ddgButton)
-        collection.addSubview(imageCreditButton)
+        view.addSubview(imageCreditButton)
         
         ddgButton.addSubview(ddgLogo)
         ddgButton.addSubview(ddgLabel)

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -189,6 +189,8 @@ class FavoritesViewController: UIViewController, Themeable {
             self?.favoritesOverflowButton.isHidden = self?.dataSource.hasOverflow == false
         }
         
+        collection.bounces = false
+        
         // Could setup as section header but would need to use flow layout,
         // Auto-layout subview within collection doesn't work properly,
         // Quick-and-dirty layout here.

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -578,10 +578,3 @@ extension FavoritesViewController: PreferencesObserver {
         self.resetBackground()
     }
 }
-
-extension CGSize {
-    public func widthLargerOrEqualThanHalfIPad() -> Bool {
-        let halfIPadSize: CGFloat = 507
-        return width >= halfIPadSize
-    }
-}

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -174,13 +174,6 @@ class FavoritesViewController: UIViewController, Themeable {
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongGesture(gesture:)))
         collection.addGestureRecognizer(longPressGesture)
         
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(gesture:)))
-        // Adding a clear background for tap gestures, otherwise impossible to tap other buttons / icons on NTP
-        let background = UIView()
-        background.backgroundColor = .clear
-        background.addGestureRecognizer(tapGesture)
-        collection.backgroundView = background
-        
         view.addSubview(collection)
         collection.dataSource = dataSource
         dataSource.collectionView = collection
@@ -274,7 +267,6 @@ class FavoritesViewController: UIViewController, Themeable {
         switch gesture.state {
         case .began:
             guard let selectedIndexPath = collection.indexPathForItem(at: gesture.location(in: collection)) else {
-                handleLongGestureForBackground(gesture: gesture)
                 break
             }
             
@@ -287,21 +279,6 @@ class FavoritesViewController: UIViewController, Themeable {
         default:
             collection.cancelInteractiveMovement()
         }
-    }
-    
-    @objc func handleTapGesture(gesture: UITapGestureRecognizer) {
-        // Tap gesture only actionable with sponsored images.
-        if gesture.state == .ended && backgroundImage.info?.isSponsored == true {
-            showImageCredit()
-        }
-    }
-    
-    /// Handles long press gesture for background credit
-    func handleLongGestureForBackground(gesture: UILongPressGestureRecognizer) {
-        if gesture.state != .began {
-            return
-        }
-        showImageCredit()
     }
     
     @objc fileprivate func showImageCredit() {

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -231,6 +231,10 @@ class FavoritesViewController: UIViewController, Themeable {
     
     private var collectionContentSizeObservation: NSKeyValueObservation?
     
+    override func viewWillLayoutSubviews() {
+        updateConstraints()
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
@@ -377,8 +381,30 @@ class FavoritesViewController: UIViewController, Themeable {
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        
+
+        updateConstraints()
         collection.collectionViewLayout.invalidateLayout()
+    }
+    
+    private func updateConstraints() {
+        let isIpad = UIDevice.isIpad
+        let isLandscape = view.frame.width > view.frame.height
+        
+        var right: ConstraintRelatableTarget = self.view.safeAreaLayoutGuide
+        var left: ConstraintRelatableTarget = self.view.safeAreaLayoutGuide
+        if isLandscape {
+            if isIpad {
+                right = self.view.snp.centerX
+            } else {
+                left = self.view.snp.centerX
+            }
+        }
+        
+        collection.snp.remakeConstraints { make in
+            make.right.equalTo(right)
+            make.left.equalTo(left)
+            make.top.bottom.equalTo(self.view)
+        }
     }
     
     private func setupImageCredit() {

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -50,7 +50,7 @@ class FavoritesDataSource: NSObject, UICollectionViewDataSource {
         /// 2. trait collection
         
         let icons = (less: 4, more: 6)
-        let minIconPoints = 80 as CGFloat
+        let minIconPoints: CGFloat = 80
         
         // If icons fall below a certain size, then use less icons.
         if (collection.frame.width / CGFloat(icons.more)) < minIconPoints {

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -41,11 +41,23 @@ class FavoritesDataSource: NSObject, UICollectionViewDataSource {
     
     /// The number of times that each row contains
     var columnsPerRow: Int {
-        guard let traitCollection = collectionView?.traitCollection else {
+        guard let collection = collectionView else {
             return 0
         }
         
-        let cols = traitCollection.horizontalSizeClass == .compact ? 4 : 6
+        /// Two considerations:
+        /// 1. icon size minimum
+        /// 2. trait collection
+        
+        let icons = (less: 4, more: 6)
+        let minIconPoints = 80 as CGFloat
+        
+        // If icons fall below a certain size, then use less icons.
+        if (collection.frame.width / CGFloat(icons.more)) < minIconPoints {
+            return icons.less
+        }
+        
+        let cols = collection.traitCollection.horizontalSizeClass == .compact ? icons.less : icons.more
         return cols
     }
     

--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -41,36 +41,12 @@ class FavoritesDataSource: NSObject, UICollectionViewDataSource {
     
     /// The number of times that each row contains
     var columnsPerRow: Int {
-        guard let size = collectionView?.bounds.size,
-            let traitCollection = collectionView?.traitCollection else {
-                return 0
+        guard let traitCollection = collectionView?.traitCollection else {
+            return 0
         }
         
-        var cols = 0
-        if traitCollection.horizontalSizeClass == .compact {
-            // Landscape iPhone
-            if traitCollection.verticalSizeClass == .compact {
-                cols = 5
-            }
-                // Split screen iPad width
-            else if size.widthLargerOrEqualThanHalfIPad() {
-                cols = 4
-            }
-                // iPhone portrait
-            else {
-                cols = 3
-            }
-        } else {
-            // Portrait iPad
-            if size.height > size.width {
-                cols = 4
-            }
-                // Landscape iPad
-            else {
-                cols = 5
-            }
-        }
-        return cols + 1
+        let cols = traitCollection.horizontalSizeClass == .compact ? 4 : 6
+        return cols
     }
     
     /// If there are more favorites than are being shown


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

This fixes:

- Landscape redesign
> - [ ] Verify iPhone landscape moves favorites to righthand side
> - [ ] Verify iPad landscape moves favorites to top lefthand side

- Remove background long-press
> - [ ] Pressing or holding on the image background should _not_ bring up image credit information / website

- Remove sponsored background tap
> No QA

- Disable vertical bouncing
> Basically if all of the NTP contents fit on the screen, it should not be scrollable 
> - [ ] With normal, portrait usage, verify NTP is not scrollable.
> - [ ] Disable background images, save a ton of favorites, so they do not all fit on screen, and verify scrolling work with the overflow.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
