### PR TITLE
Fix #2153: Don't reset the user wallet button when balance updates

### DIFF
--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -628,31 +628,33 @@ extension WalletViewController {
       crypto: Strings.WalletBalanceType,
       dollarValue: state.ledger.usdBalanceString
     )
-    // Hidden by default
-    walletView.headerView.setUserWalletStatus(.hidden)
-    if Preferences.Rewards.isUsingBAP.value != true {
-      // If we can show Uphold, grab verification status of the wallet
-      state.ledger.externalWallet(forType: .uphold) { wallet in
-        guard let wallet = wallet else { return }
-        
-        self.userWallet = wallet
-        
-        switch wallet.status {
-        case .notConnected:
-          self.walletView.headerView.setUserWalletStatus(.notConnected)
-        case .connected,
-             .pending:
-          self.walletView.headerView.setUserWalletStatus(.connectedNotVerified)
-        case .disconnectedVerified,
-             .disconnectedNotVerified:
-          self.walletView.headerView.setUserWalletStatus(.disconnected)
-        case .verified:
-          self.walletView.headerView.setUserWalletStatus(.verified)
-        @unknown default:
-          break
+    if userWallet == nil {
+      // Hidden by default
+      walletView.headerView.setUserWalletStatus(.hidden)
+      if Preferences.Rewards.isUsingBAP.value != true {
+        // If we can show Uphold, grab verification status of the wallet
+        state.ledger.externalWallet(forType: .uphold) { wallet in
+          guard let wallet = wallet else { return }
+          
+          self.userWallet = wallet
+          
+          switch wallet.status {
+          case .notConnected:
+            self.walletView.headerView.setUserWalletStatus(.notConnected)
+          case .connected,
+               .pending:
+            self.walletView.headerView.setUserWalletStatus(.connectedNotVerified)
+          case .disconnectedVerified,
+               .disconnectedNotVerified:
+            self.walletView.headerView.setUserWalletStatus(.disconnected)
+          case .verified:
+            self.walletView.headerView.setUserWalletStatus(.verified)
+          @unknown default:
+            break
+          }
+          
+          self.walletView.headerView.addFundsButton.isHidden = wallet.status != .verified
         }
-        
-        self.walletView.headerView.addFundsButton.isHidden = wallet.status != .verified
       }
     }
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2153 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).