### PR TITLE
Fix #2156: Don't crash the app when no tab found for tab tray transition.

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -5,6 +5,8 @@
 import UIKit
 import Shared
 
+private let log = Logger.browserLogger
+
 class TrayToBrowserAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         if let bvc = transitionContext.viewController(forKey: .to) as? BrowserViewController,
@@ -26,7 +28,9 @@ private extension TrayToBrowserAnimator {
         let displayedTabs = tabManager.tabsForCurrentMode
         
         guard let selectedTab = bvc.tabManager.selectedTab, let expandFromIndex = displayedTabs.firstIndex(of: selectedTab) else {
-            fatalError("No tab selected for transition.")
+            log.error("No tab selected for transition.")
+            transitionContext.completeTransition(true)
+            return
         }
         bvc.view.frame = transitionContext.finalFrame(for: bvc)
 
@@ -149,7 +153,9 @@ private extension BrowserToTrayAnimator {
         let tabManager = bvc.tabManager
         let displayedTabs = tabManager.tabsForCurrentMode
         guard let selectedTab = bvc.tabManager.selectedTab, let scrollToIndex = displayedTabs.firstIndex(of: selectedTab) else {
-            fatalError("No tab selected for transition.")
+            log.error("No tab selected for transition.")
+            transitionContext.completeTransition(true)
+            return
         }
 
         tabTray.view.frame = transitionContext.finalFrame(for: tabTray)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Ref #636
See https://github.com/brave/brave-ios/pull/963 for more context.
I replaced fatal errors with regular returns. As per ticket above I skipped calling `completeTransition(false)`

I couldn't reproduce the crash so we should monitor it in xcode after next version with this fix included is released.

This pull request fixes issue #2156 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Look for str in #636 and confirm it hasn't regressed

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
