### PR TITLE
Fix #2162 - Fixes a crash when javascript's `window.open` creates a new tab.

### DIFF
--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -25,7 +25,6 @@ class BraveWebView: WKWebView {
         if isPrivate {
             configuration.websiteDataStore = BraveWebView.sharedNonPersistentStore()
         } else {
-            BraveWebView.nonPersistentDataStore = nil
             configuration.websiteDataStore = WKWebsiteDataStore.default()
         }
         


### PR DESCRIPTION
There is no need to nil the persistent store when a webView of a different kind is created. We only need to nil it in `removeNonPersistentStore` when all tabs or all private tabs are killed.

## Steps To Reproduce
1. On a real device, enter Private Browsing Mode
2. Open https://www.w3schools.com/jsref/met_win_open.asp
3. Open settings, and enable block all cookies
4. Confirm blocking all cookies.
4. Disable block all cookies from settings.
5. Tap on the try it yourself button on the w3 website
6. It crashes when a new tab is opened from the old tab (popup).

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2162
Related to: https://github.com/brave/brave-ios/pull/1237

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
