### PR TITLE
Fix: #2155 - Reload tabs instead of destroying them.

### DIFF
--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -210,7 +210,9 @@ class ClearPrivateDataTableViewController: UITableViewController {
         let clearAction = UIAlertAction(title: Strings.ClearPrivateData, style: .destructive) { (_) in
             Preferences.Privacy.clearPrivateDataToggles.value = self.toggles
             self.clearButtonEnabled = false
-            self.tabManager.removeAll()
+            
+            self.tabManager.allTabs.forEach({ $0.reload() })
+            
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
                 if !self.gotNotificationDeathOfAllWebViews {
                     self.allWebViewsKilled()

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -212,9 +212,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
             self.clearButtonEnabled = false
             
             let shouldReloadTabs = self.clearables.contains { item in
-                return item.clearable is HistoryClearable ||
-                    item.clearable is CacheClearable ||
-                    item.clearable is CookiesAndCacheClearable
+                return item.clearable is CacheClearable || item.clearable is CookiesAndCacheClearable
             }
             
             if shouldReloadTabs {

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -211,7 +211,15 @@ class ClearPrivateDataTableViewController: UITableViewController {
             Preferences.Privacy.clearPrivateDataToggles.value = self.toggles
             self.clearButtonEnabled = false
             
-            self.tabManager.allTabs.forEach({ $0.reload() })
+            let shouldReloadTabs = self.clearables.contains { item in
+                return item.clearable is HistoryClearable ||
+                    item.clearable is CacheClearable ||
+                    item.clearable is CookiesAndCacheClearable
+            }
+            
+            if shouldReloadTabs {
+                self.tabManager.allTabs.forEach({ $0.reload() })
+            }
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
                 if !self.gotNotificationDeathOfAllWebViews {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Instead of destroying all tabs and recreating them, we reload them.

This pull request fixes issue #2155
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1. Open few tabs and visit different sites.
1. Open settings -> Clear browsing data -> Select Cache & Saved Logins -> Clear browsing data.
1. Tap on done all tabs should be retained (previously all opened tabs were lost).

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
