### PR TITLE
Fix #2155 - Clearing partial data destroys all tabs

### DIFF
--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -172,6 +172,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
             
             // Reset Webkit configuration to remove data from memory
             if clear.contains(where: { $0 is CookiesAndCacheClearable || $0 is CacheClearable }) {
+                self.tabManager.removeAll()
                 self.tabManager.resetConfiguration()
                 // Unlock the folders to allow clearing of data.
                 if Preferences.Privacy.blockAllCookies.value {
@@ -210,7 +211,6 @@ class ClearPrivateDataTableViewController: UITableViewController {
         let clearAction = UIAlertAction(title: Strings.ClearPrivateData, style: .destructive) { (_) in
             Preferences.Privacy.clearPrivateDataToggles.value = self.toggles
             self.clearButtonEnabled = false
-            self.tabManager.removeAll()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
                 if !self.gotNotificationDeathOfAllWebViews {
                     self.allWebViewsKilled()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

- Close tab only if Cache, Cookies and Site data option selected, for all other cases it will not close tabs.

For example,
- [x] **Cache** 
Or 
- [x] **Cookies and Site Data** 
Result :
**Close all tabs.** 

This pull request fixes issue #2155 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
