### PR TITLE
Fix #2080: Update translations, fix '%@/d' placeholders for Chinese.

### DIFF
--- a/BraveRewardsUI/zh-TW.lproj/Localizable.strings
+++ b/BraveRewardsUI/zh-TW.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "BraveRewardsAutoContributeNextDate" = "下一個贊助日期";
 
 /* No comment provided by engineer. */
-"BraveRewardsAutoContributeRestoreExcludedSites" = "還原 ％ld 個已排除的站點";
+"BraveRewardsAutoContributeRestoreExcludedSites" = "還原 %ld 個已排除的站點";
 
 /* No comment provided by engineer. */
 "BraveRewardsAutoContributeSupportedSites" = "支持的站點";
@@ -113,7 +113,7 @@
 "BraveRewardsCheckAgain" = "重新整理狀態";
 
 /* No comment provided by engineer. */
-"BraveRewardsContributingToUnverifiedSites" = "您已將 ％@ 指定給尚未註冊接受贊助的創作者。 您的瀏覽器將繼續嘗試贊助，直到他們通過驗證或 90 天期滿為止。";
+"BraveRewardsContributingToUnverifiedSites" = "您已將 %@ 指定給尚未註冊接受贊助的創作者。 您的瀏覽器將繼續嘗試贊助，直到他們通過驗證或 90 天期滿為止。";
 
 /* No comment provided by engineer. */
 "BraveRewardsCreatingWallet" = "建立錢包";
@@ -158,7 +158,7 @@
 "BraveRewardsFourAdsPerHour" = "每小時 4 則廣告";
 
 /* No comment provided by engineer. */
-"BraveRewardsGrantListExpiresOn" = "於 ％@ 到期";
+"BraveRewardsGrantListExpiresOn" = "於 %@ 到期";
 
 /* No comment provided by engineer. */
 "BraveRewardsGrants" = "獎金";
@@ -314,7 +314,7 @@
 "BraveRewardsSettingsAdsComingSoonText" = "即將推出。";
 
 /* No comment provided by engineer. */
-"BraveRewardsSettingsAdsGrantAmountText" = "您的廣告收入，共計 ％@。";
+"BraveRewardsSettingsAdsGrantAmountText" = "您的廣告收入，共計 %@。";
 
 /* Example: <10 BAT> earned from ads */
 "BraveRewardsSettingsAdsGrantText" = "獲得的廣告收入";
@@ -437,7 +437,7 @@
 "BraveRewardsTotalGrantsClaimedJapan" = "已領取點數贈與";
 
 /* No comment provided by engineer. */
-"BraveRewardsTotalSites" = "總計 ％ld";
+"BraveRewardsTotalSites" = "總計 %ld";
 
 /* No comment provided by engineer. */
 "BraveRewardsTwoAdsPerHour" = "每小時 2 則廣告";
@@ -497,7 +497,7 @@
 "NotificationContributeNotificationError" = "處理您的贊助時出現問題。";
 
 /* We show this string in the notification when contribution is successful */
-"NotificationContributeSuccess" = "您已贊助 ％@";
+"NotificationContributeSuccess" = "您已贊助 %@";
 
 /* We show this string in notification when tip fails */
 "NotificationContributeTipError" = "無法發送您的小費。 請稍後再試。";
@@ -527,7 +527,7 @@
 "NotificationTipsProcessedBody" = "您的每月小費已處理！";
 
 /* Notification text that tells user which publisher just verified */
-"NotificationVerifiedPublisherBody" = "最近通過驗證的創作者 ％@ ";
+"NotificationVerifiedPublisherBody" = "最近通過驗證的創作者 %@ ";
 
 /* No comment provided by engineer. */
 "OK" = "好";
@@ -536,7 +536,7 @@
 "OneTimeText" = "一次性";
 
 /* This is a suffix statement. example: SomeChannel on Twitter */
-"OnProviderText" = "於 ％@";
+"OnProviderText" = "於 %@";
 
 /* No comment provided by engineer. */
 "PrivacyPolicyURL" = "隱私政策";

--- a/BraveRewardsUI/zh.lproj/Localizable.strings
+++ b/BraveRewardsUI/zh.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "BraveRewardsAutoContributeNextDate" = "下一次捐款日期";
 
 /* No comment provided by engineer. */
-"BraveRewardsAutoContributeRestoreExcludedSites" = "恢复 ％ld 个排除的站点";
+"BraveRewardsAutoContributeRestoreExcludedSites" = "恢复 %ld 个排除的站点";
 
 /* No comment provided by engineer. */
 "BraveRewardsAutoContributeSupportedSites" = "支持的网站";
@@ -113,7 +113,7 @@
 "BraveRewardsCheckAgain" = "刷新状态";
 
 /* No comment provided by engineer. */
-"BraveRewardsContributingToUnverifiedSites" = "您已将 ％@ 指定给尚未注册要接收捐款的创建者。您的浏览器会继续尝试进行捐款，直到他们通过验证或直到90天为止。";
+"BraveRewardsContributingToUnverifiedSites" = "您已将 %@ 指定给尚未注册要接收捐款的创建者。您的浏览器会继续尝试进行捐款，直到他们通过验证或直到90天为止。";
 
 /* No comment provided by engineer. */
 "BraveRewardsCreatingWallet" = "创建钱包";
@@ -158,7 +158,7 @@
 "BraveRewardsFourAdsPerHour" = "每小时 4 个广告";
 
 /* No comment provided by engineer. */
-"BraveRewardsGrantListExpiresOn" = "％@到期";
+"BraveRewardsGrantListExpiresOn" = "%@到期";
 
 /* No comment provided by engineer. */
 "BraveRewardsGrants" = "赠款";
@@ -314,7 +314,7 @@
 "BraveRewardsSettingsAdsComingSoonText" = "即将推出。";
 
 /* No comment provided by engineer. */
-"BraveRewardsSettingsAdsGrantAmountText" = "您的广告收入，％@ 可用。";
+"BraveRewardsSettingsAdsGrantAmountText" = "您的广告收入，%@ 可用。";
 
 /* Example: <10 BAT> earned from ads */
 "BraveRewardsSettingsAdsGrantText" = "广告收入";
@@ -437,7 +437,7 @@
 "BraveRewardsTotalGrantsClaimedJapan" = "赠予的积分已被领取";
 
 /* No comment provided by engineer. */
-"BraveRewardsTotalSites" = "总计％ld";
+"BraveRewardsTotalSites" = "总计%ld";
 
 /* No comment provided by engineer. */
 "BraveRewardsTwoAdsPerHour" = "每小时 2 个广告";
@@ -497,7 +497,7 @@
 "NotificationContributeNotificationError" = "处理您的捐款时出现问题。";
 
 /* We show this string in the notification when contribution is successful */
-"NotificationContributeSuccess" = "您已捐赠了 ％@。";
+"NotificationContributeSuccess" = "您已捐赠了 %@。";
 
 /* We show this string in notification when tip fails */
 "NotificationContributeTipError" = "无法发送您的酬谢费。请稍后再试。";
@@ -527,7 +527,7 @@
 "NotificationTipsProcessedBody" = "您的每月酬谢费已处理！";
 
 /* Notification text that tells user which publisher just verified */
-"NotificationVerifiedPublisherBody" = "创作者 ％@ 最近已通过验证。";
+"NotificationVerifiedPublisherBody" = "创作者 %@ 最近已通过验证。";
 
 /* No comment provided by engineer. */
 "OK" = "好";
@@ -536,7 +536,7 @@
 "OneTimeText" = "一次性";
 
 /* This is a suffix statement. example: SomeChannel on Twitter */
-"OnProviderText" = "日期：％@";
+"OnProviderText" = "日期：%@";
 
 /* No comment provided by engineer. */
 "PrivacyPolicyURL" = "隐私政策";

--- a/BraveShared/de.lproj/BraveShared.strings
+++ b/BraveShared/de.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Brave Shield-Standardeinstellungen";
-
 /* Sync page title */
 "BraveSync" = "Synchronisieren";
 

--- a/BraveShared/de.lproj/Localizable.strings
+++ b/BraveShared/de.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Überspringen";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Wiederhergestellte Lesezeichen";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Wiederhergestellte Favoriten";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Sollen Suchvorschläge aktiviert werden?";
 

--- a/BraveShared/es.lproj/BraveShared.strings
+++ b/BraveShared/es.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Opciones por defecto de Brave Shield";
-
 /* Sync page title */
 "BraveSync" = "Sincronización";
 

--- a/BraveShared/es.lproj/Localizable.strings
+++ b/BraveShared/es.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Omitir";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Marcadores restaurados";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Favoritos restaurados";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "¿Activar las sugerencias de búsqueda?";
 

--- a/BraveShared/fr.lproj/BraveShared.strings
+++ b/BraveShared/fr.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Réglages par défaut de Brave Shield";
-
 /* Sync page title */
 "BraveSync" = "Synchronisation";
 

--- a/BraveShared/fr.lproj/Localizable.strings
+++ b/BraveShared/fr.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Ignorer";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Marque-pages restaurés";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Favoris restaurés";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Activer les suggestions de recherche ?";
 

--- a/BraveShared/id-ID.lproj/BraveShared.strings
+++ b/BraveShared/id-ID.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Default Perisai Brave";
-
 /* Sync page title */
 "BraveSync" = "Sinkronisasi";
 

--- a/BraveShared/id-ID.lproj/Localizable.strings
+++ b/BraveShared/id-ID.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Lewati";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Penanda Halaman Dikembalikan";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Pilihan Favorit Dikembalikan";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Aktifkan saran pencarian?";
 

--- a/BraveShared/it.lproj/BraveShared.strings
+++ b/BraveShared/it.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Impostazioni predefinite Brave Shield";
-
 /* Sync page title */
 "BraveSync" = "Sincronizza";
 

--- a/BraveShared/it.lproj/Localizable.strings
+++ b/BraveShared/it.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Salta";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Segnalibri ripristinati";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Preferiti ripristinati";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Attivare i suggerimenti di ricerca?";
 

--- a/BraveShared/ja.lproj/BraveShared.strings
+++ b/BraveShared/ja.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Brave Shieldのデフォルト設定";
-
 /* Sync page title */
 "BraveSync" = "Brave Sync";
 

--- a/BraveShared/ja.lproj/Localizable.strings
+++ b/BraveShared/ja.lproj/Localizable.strings
@@ -65,7 +65,7 @@
 "OBSaveButton" = "保存";
 
 /* Detail text for search engine onboarding screen */
-"OBSearchEngineDetail" = "デフフォルトの検索エンジンを設定する";
+"OBSearchEngineDetail" = "デフォルトの検索エンジンを設定する";
 
 /* Title for search engine onboarding screen */
 "OBSearchEngineTitle" = "Braveブラウザにようこそ！";
@@ -87,6 +87,12 @@
 
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "スキップ";
+
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "復元されたブックマーク";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "復元されたお気に入り";
 
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "検索候補をオンにしますか？";

--- a/BraveShared/ko-KR.lproj/BraveShared.strings
+++ b/BraveShared/ko-KR.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Brave Shield 기본값";
-
 /* Sync page title */
 "BraveSync" = "동기화";
 

--- a/BraveShared/ko-KR.lproj/Localizable.strings
+++ b/BraveShared/ko-KR.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "건너뛰기";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "복원된 북마크";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "복원된 즐겨찾기";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "추천 검색어를 사용하시겠습니까?";
 

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Lalai Perisai Brave";
-
 /* Sync page title */
 "BraveSync" = "Segerak";
 

--- a/BraveShared/ms.lproj/Localizable.strings
+++ b/BraveShared/ms.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Langkau";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Penanda Halaman yang Dipulihkan";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Kegemaran yang Dipulihkan";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Hidupkan cadangan carian?";
 

--- a/BraveShared/nb.lproj/BraveShared.strings
+++ b/BraveShared/nb.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Brave Shield standardinnstillinger";
-
 /* Sync page title */
 "BraveSync" = "Synk";
 

--- a/BraveShared/nb.lproj/Localizable.strings
+++ b/BraveShared/nb.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Hopp over";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Gjenopprettede bokmerker";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Gjenopprettede favoritter";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Slå på søkeforslag?";
 

--- a/BraveShared/pl.lproj/BraveShared.strings
+++ b/BraveShared/pl.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Domyślne ustawienia Brave Shield";
-
 /* Sync page title */
 "BraveSync" = "Synchronizuj";
 

--- a/BraveShared/pl.lproj/Localizable.strings
+++ b/BraveShared/pl.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Pomiń";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Przywrócone zakładki";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Przywrócone ulubione";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Czy włączyć sugestie wyszukiwania?";
 

--- a/BraveShared/pt-BR.lproj/BraveShared.strings
+++ b/BraveShared/pt-BR.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Configurações da proteção do Brave";
-
 /* Sync page title */
 "BraveSync" = "Sincronizar";
 

--- a/BraveShared/pt-BR.lproj/Localizable.strings
+++ b/BraveShared/pt-BR.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Pular";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Favoritos restaurados";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Favoritos em destaque restaurados";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Ativar as sugestões de pesquisa?";
 

--- a/BraveShared/ru.lproj/BraveShared.strings
+++ b/BraveShared/ru.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Настройки Brave Shield по умолчанию";
-
 /* Sync page title */
 "BraveSync" = "Синхронизация";
 

--- a/BraveShared/ru.lproj/Localizable.strings
+++ b/BraveShared/ru.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Пропустить";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Восстановленные закладки";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Восстановленное избранное";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Включить подсказки при поиске?";
 

--- a/BraveShared/sv.lproj/BraveShared.strings
+++ b/BraveShared/sv.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Standardinställningar för Braves sköldar";
-
 /* Sync page title */
 "BraveSync" = "Synkronisera";
 

--- a/BraveShared/sv.lproj/Localizable.strings
+++ b/BraveShared/sv.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Hoppa över";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Återställda bokmärken";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Återställda favoriter";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Sätt på sökförslag?";
 

--- a/BraveShared/uk.lproj/BraveShared.strings
+++ b/BraveShared/uk.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Екрани Brave за замовчуванням";
-
 /* Sync page title */
 "BraveSync" = "Синхронізація";
 

--- a/BraveShared/uk.lproj/Localizable.strings
+++ b/BraveShared/uk.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "Пропустити";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "Відновлені закладки";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "Відновлений список вибраного";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Увімкнути пошукові підказки?";
 

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Brave Shield 預設";
-
 /* Sync page title */
 "BraveSync" = "同步";
 
@@ -1136,7 +1133,7 @@
 "VersionTemplate" = "%1$@ 版 (%2$@)";
 
 /* Label that says where to view an item. '%@' is a placeholder and will include things like 'Instagram', 'unsplash'. The full label will look like 'View  on Instagram'. */
-"ViewOn" = "瀏覽於 ％@";
+"ViewOn" = "瀏覽於 %@";
 
 /* The date your wallet was created */
 "WalletCreationDate" = "錢包建立日期";

--- a/BraveShared/zh-TW.lproj/Localizable.strings
+++ b/BraveShared/zh-TW.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "跳過";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "恢復的書籤";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "恢復的最愛";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "開啟搜尋建議？";
 

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -190,9 +190,6 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
-/* Section title for adbblock, tracking protection, HTTPS-E, and cookies */
-"BraveShieldDefaults" = "Brave 默认保护";
-
 /* Sync page title */
 "BraveSync" = "同步";
 

--- a/BraveShared/zh.lproj/Localizable.strings
+++ b/BraveShared/zh.lproj/Localizable.strings
@@ -88,6 +88,12 @@
 /* Skip button to skip onboarding and start using the app. */
 "OnboardingSkipButton" = "跳过";
 
+/* Name of folder where restored bookmarks are retrieved */
+"RestoredBookmarksFolderName" = "恢复的书签";
+
+/* Name of folder where restored favorites are retrieved */
+"RestoredFavoritesFolderName" = "恢复的收藏夹";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "开启搜索建议功能？";
 

--- a/Client/de.lproj/InfoPlist.strings
+++ b/Client/de.lproj/InfoPlist.strings
@@ -7,9 +7,7 @@
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Brave benötigt Face-ID für den Zugriff auf Ihre gespeicherten Anmeldedaten.";
 
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* (No Comment) */
 "NSLocationWhenInUseUsageDescription" = "Von Ihnen besuchte Websites können Ihren Standort anfordern.";
 
 /* (No Comment) */


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

User wallets etc. aren't translated yet, there is another ticket for it https://github.com/brave/brave-ios/issues/2166

This PR aims to fix the issue with Chinese placeholders with minimal changes to other strings.

## Summary of Changes

This pull request fixes issue #2080 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
