### PR TITLE
Fix #2185: `loadPersistentStore` crash.

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -107,6 +107,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let profilePrefix = profile.prefs.getBranchPrefix()
         Migration.launchMigrations(keyPrefix: profilePrefix)
         
+        // An attempt to fix #2185.
+        // There's an unknown crash related to database creation, which happens when tabs are being restored.
+        // Our DataControllers uses a mix of static and lazy properties, there is a chance that some
+        // concurrency problems are occuring.
+        // This forces the database to initialize most important lazy properties before doing any other
+        // database related code.
+        // Please note that this is called after bookmark and keychain restoration processes.
+        DataController.shared.lazyInitialization()
         setUpWebServer(profile)
         
         var imageStore: DiskImageStore?

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -45,6 +45,11 @@ public class DataController: NSObject {
     public static var shared: DataController = DataController()
     public static var sharedInMemory: DataController = InMemoryDataController()
     
+    /// A possible hacky solution to prevent  #2185 crashes.
+    public func lazyInitialization() {
+        _ = DataController.shared.container
+    }
+    
     public func storeExists() -> Bool {
         return FileManager.default.fileExists(atPath: storeURL.path)
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Another blind guess of what is causing the crash. This doesn't change app logic at all, just attempt to initialize database container at earlier point.

This pull request fixes issue #2185 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
