### PR TITLE
Fix #2181: Fix add funds text color on iOS 12

### DIFF
--- a/BraveRewardsUI/Wallet/WalletHeaderView.swift
+++ b/BraveRewardsUI/Wallet/WalletHeaderView.swift
@@ -72,6 +72,7 @@ class WalletHeaderView: UIView {
   
   let addFundsButton = Button(type: .system).then {
     $0.appearanceTintColor = UIColor(white: 1.0, alpha: 0.75)
+    $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.75)
     $0.setTitle(Strings.AddFunds, for: .normal)
     $0.setImage(UIImage(frameworkResourceNamed: "add-funds-icon").alwaysTemplate, for: .normal)
     $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2181

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

<img width="545" alt="image" src="https://user-images.githubusercontent.com/529104/72272946-79825400-35f7-11ea-80bb-5a2611d27bd3.png">

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
