### PR TITLE
Fix #2171 - User Agent is incorrect on iOS 13 iPads

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1399,6 +1399,12 @@ class BrowserViewController: UIViewController {
         // Reset the UA when a different domain is being loaded
         if webView.url?.host != newURL.host {
             webView.customUserAgent = nil
+            
+            //iOS 13 - iPad Only.. Does NOT read the User-Agent from `UserDefaults`!!
+            //So setting it to nil, NEVER actually sets the default UA.
+            if #available(iOS 13, *), UIDevice.isIpad {
+                webView.customUserAgent = Preferences.General.alwaysRequestDesktopSite.value ? UserAgent.desktopUserAgent() : UserAgent.defaultUserAgent()
+            }
         }
     }
 
@@ -1407,7 +1413,7 @@ class BrowserViewController: UIViewController {
         let ua = newRequest.value(forHTTPHeaderField: "User-Agent")
         
         if #available(iOS 13.0, *) {
-            webView.customUserAgent = Preferences.General.alwaysRequestDesktopSite.value == UserAgent.isDesktopUA(ua) ? nil : ua
+            webView.customUserAgent = Preferences.General.alwaysRequestDesktopSite.value == UserAgent.isDesktopUA(ua) ? UserAgent.desktopUserAgent() : ua
         } else {
             webView.customUserAgent = ua == UserAgent.defaultUserAgent() ? nil : ua
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -359,7 +359,6 @@ extension BrowserViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
         
         self.webView(webView, decidePolicyFor: navigationAction) {
-            preferences.preferredContentMode = Preferences.General.alwaysRequestDesktopSite.value ? .desktop : .mobile
             decisionHandler($0, preferences)
         }
     }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -195,9 +195,6 @@ class Tab: NSObject {
             configuration!.preferences = WKPreferences()
             configuration!.preferences.javaScriptCanOpenWindowsAutomatically = false
             configuration!.allowsInlineMediaPlayback = true
-            if #available(iOS 13.0, *) {
-                configuration!.defaultWebpagePreferences.preferredContentMode = Preferences.General.alwaysRequestDesktopSite.value ? .desktop : .mobile
-            }
             // Enables Zoom in website by ignoring their javascript based viewport Scale limits.
             configuration!.ignoresViewportScaleLimits = true
             let webView = TabWebView(frame: .zero, configuration: configuration!, isPrivate: isPrivate)
@@ -219,6 +216,10 @@ class Tab: NSObject {
             // which allows the content appear beneath the toolbars in the BrowserViewController
             webView.scrollView.layer.masksToBounds = false
             webView.navigationDelegate = navigationDelegate
+            
+            if #available(iOS 13, *), UIDevice.isIpad {
+                webView.customUserAgent = Preferences.General.alwaysRequestDesktopSite.value ? UserAgent.desktopUserAgent() : UserAgent.defaultUserAgent()
+            }
 
             restore(webView, restorationData: self.sessionData?.savedTabData)
 
@@ -386,12 +387,7 @@ class Tab: NSObject {
     }
 
     func reload() {
-        var mobileUA: String?
-        if #available(iOS 13.0, *) {
-            mobileUA = UserAgent.defaultUserAgent()
-        }
-
-        let userAgent: String? = desktopSite ? UserAgent.desktopUserAgent() : mobileUA
+        let userAgent: String? = desktopSite ? UserAgent.desktopUserAgent() : UserAgent.defaultUserAgent()
         
         if (userAgent ?? "") != webView?.customUserAgent,
            let currentItem = webView?.backForwardList.currentItem {

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -110,13 +110,7 @@ open class UserAgent {
         if let userAgent = userAgent, !userAgent.isEmpty {
             return !userAgent.lowercased().contains("mobile")
         }
-        
-        //on iOS 13 iPad, we do not require a custom user-agent for Desktop
-        if #available(iOS 13.0, *), UIDevice.isIpad {
-            return true
-        }
-        
-        //However, for iPhone we do..
+
         return false
     }
 }

--- a/Shared/UserAgentBuilder.swift
+++ b/Shared/UserAgentBuilder.swift
@@ -8,6 +8,7 @@ public struct UserAgentBuilder {
     struct UAVersions {
         let safariVersion: String
         let webkitVersion: String
+        let iOSVersion: String
     }
     
     struct OSVersionMap {
@@ -18,9 +19,13 @@ public struct UserAgentBuilder {
     
     public init() {}
     
-    public func build(appendSafariVersion: Bool = false) -> String {
+    public func build(appendSafariVersion: Bool = false, appendiOSVersion: Bool = false) -> String {
         let uaVersions = webkitVersion
         var ua = "Mozilla/5.0 (\(cpuInfo)) AppleWebKit/\(uaVersions.webkitVersion) (KHTML, like Gecko) Mobile/\(kernelVersion)"
+        
+        if appendiOSVersion {
+            ua += " Version/\(uaVersions.iOSVersion)"
+        }
         
         if appendSafariVersion {
             ua += " Safari/\(uaVersions.safariVersion)"
@@ -51,7 +56,8 @@ public struct UserAgentBuilder {
     var webkitVersion: UAVersions {
         let _12_0 = OSVersionMap(majorVersion: 12, minorVersion: 0,
                               uaVersions: UAVersions(safariVersion: "605.1",
-                                                     webkitVersion: "605.1.15"))
+                                                     webkitVersion: "605.1.15",
+                                                     iOSVersion: iOSVersion))
         
         var uaVersions: UAVersions?
         
@@ -80,5 +86,9 @@ public struct UserAgentBuilder {
     var kernelVersion: String {
         // Kernel version is frozen for iOS 11.3 and later.
         return "15E148"
+    }
+    
+    var iOSVersion: String {
+        return UIDevice.current.systemVersion
     }
 }


### PR DESCRIPTION
## Summary of Changes

- Explicitly setting UA on all devices regardless of iOS13's `preferredContentMode` which doesn't contain the version in the UA and doesn't read the UserDefaults UA.
- Reason for changes: We were relying on code from a long time ago where setting the UA to nil causes the WKWebView to read from UserDefaults the registered UA. On iOS 13 iPad only, preferred content-mode is supposed to be used. However, there's a bug where it doesn't send the VERSION or `Safari` in the UA so we are forced to avoid setting `nil` to the UA for UserDefaults AND we must always set the UA manually.

This pull request fixes issue #2171
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
