### PR TITLE
Fix #2174: Cache last updated external wallet between panel opens

### DIFF
--- a/BraveRewards/BraveRewards.framework/Headers/BATBraveLedger.h
+++ b/BraveRewards/BraveRewards.framework/Headers/BATBraveLedger.h
@@ -100,8 +100,11 @@ NS_SWIFT_NAME(BraveLedger)
 
 #pragma mark - User Wallets
 
-- (void)externalWalletForType:(BATExternalWalletType)walletType
-                   completion:(void (^)(BATExternalWallet * _Nullable wallet))completion;
+/// The last updated external wallet if a user has hooked one up
+@property (nonatomic, readonly) NSDictionary<BATExternalWalletType, BATExternalWallet *> *externalWallets;
+
+- (void)fetchExternalWalletForType:(BATExternalWalletType)walletType
+                        completion:(void (^)(BATExternalWallet * _Nullable wallet))completion;
 
 - (void)disconnectWalletOfType:(BATExternalWalletType)walletType
                     completion:(nullable void (^)(BATResult result))completion;

--- a/BraveRewardsUI/README.md
+++ b/BraveRewardsUI/README.md
@@ -6,5 +6,5 @@ The latest BraveRewards.framework was built on:
 
 ```
 brave-browser/b08ea58f46fc531f6abe9dca41f4381815d58372
-brave-core/e4d28710b19bb79f288c9de98de36f507c90b774
+brave-core/323811f8fe9eb8248ff1146353d931dff06b8d1b
 ```

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -103,14 +103,17 @@ extension BrowserViewController {
             queryItems: items) { result, redirectURL in
                 switch result {
                 case .ledgerOk:
-                    if let redirectURL = redirectURL {
-                        // Requires verification
-                        let request = URLRequest(url: redirectURL)
-                        tab.loadRequest(request)
-                    } else {
-                        // Done
-                        self.tabManager.removeTab(tab)
-                        self.showBraveRewardsPanel()
+                    // Fetch the wallet
+                    self.rewards.ledger.fetchExternalWallet(forType: .uphold) { _ in
+                        if let redirectURL = redirectURL {
+                            // Requires verification
+                            let request = URLRequest(url: redirectURL)
+                            tab.loadRequest(request)
+                        } else {
+                            // Done
+                            self.tabManager.removeTab(tab)
+                            self.showBraveRewardsPanel()
+                        }
                     }
                 case .batNotAllowed:
                     // Uphold account doesn't support BAT...


### PR DESCRIPTION
Also fetches the external wallet before showing the panel when logging into a KYC'd account, so the panel is showing the correct UI immediately

## Summary of Changes

This pull request fixes issue #2174

Relevant brave-core commit: https://github.com/brave/brave-core/commit/323811f8fe9eb8248ff1146353d931dff06b8d1b

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable rewards, link KYC'd uphold account
- Verify when panel appears it already says "wallet verified"
- Verify subsequent panel opens don't ever show "Your wallet" temporarily until it fetches the wallet info
- Go to uphold.com, log out. Disconnect wallet via panel, verify user sees grey "disconnected" button immediately on coming back
- Tap "disconnected" button, login to non-KYC'd account, open panel. Should show "Verify Wallet" button (not disconnected) immediately

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).