### PR TITLE
Fix #2188: Add "up to" on preview amounts in AC details & settings

### DIFF
--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -295,7 +295,8 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
         cell.label.text = Strings.AutoContributeMonthlyPayment
         cell.accessoryType = .disclosureIndicator
         if let dollarAmount = state.ledger.dollarStringForBATAmount(state.ledger.contributionAmount) {
-          cell.accessoryLabel?.text = "\(state.ledger.contributionAmount) \(Strings.BAT) (\(dollarAmount))"
+          let amount = "\(state.ledger.contributionAmount) \(Strings.BAT) (\(dollarAmount))"
+          cell.accessoryLabel?.text = String(format: Strings.SettingsAutoContributeUpToValue, amount)
         }
         cell.selectionStyle = .default
       case .nextContribution:

--- a/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
@@ -165,7 +165,8 @@ extension AutoContributeSettingsViewController: UITableViewDelegate, UITableView
     case .monthlyPayment:
       cell.label.text = Strings.AutoContributeMonthlyPayment
       if let dollarAmount = ledger.dollarStringForBATAmount(ledger.contributionAmount) {
-        cell.accessoryLabel?.text = "\(ledger.contributionAmount) \(Strings.BAT) (\(dollarAmount))"
+        let amount = "\(ledger.contributionAmount) \(Strings.BAT) (\(dollarAmount))"
+        cell.accessoryLabel?.text = String(format: Strings.SettingsAutoContributeUpToValue, amount)
       }
     case .minimumLength:
       cell.label.text = Strings.AutoContributeMinimumLengthMessage


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2188 

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-13 at 17 37 13](https://user-images.githubusercontent.com/529104/72298249-a6505e80-362b-11ea-9e2e-f97ac8a8854a.png)

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-13 at 17 37 12](https://user-images.githubusercontent.com/529104/72298258-a81a2200-362b-11ea-8fa5-02c59843f723.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
