### PR TITLE
Fix wrong String name in TabMOTests

### DIFF
--- a/DataTests/TabMOTests.swift
+++ b/DataTests/TabMOTests.swift
@@ -21,7 +21,7 @@ class TabMOTests: CoreDataTestCase {
         XCTAssertNotNil(object.syncUUID)
         XCTAssertNotNil(object.imageUrl)
         XCTAssertNil(object.url)
-        XCTAssertEqual(object.title, Strings.new_Tab)
+        XCTAssertEqual(object.title, Strings.newTab)
         
         // Testing default values
         XCTAssertEqual(object.order, 0)


### PR DESCRIPTION
I guess we missed this while working on #2197. CI is failing right now. #trivial