### PR TITLE
No Bug: Update Travis Xcode to 11.3, fix error 65 with Sync initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode11
+osx_image: xcode11.3
 cache:
   directories:
     - Carthage

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -5226,6 +5226,7 @@
 					5DE7688B20B3456E00FF5533 = {
 						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
+						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					E6F9650B1B2F1CF20034B023 = {
 						CreatedOnToolsVersion = 6.3.2;

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -575,8 +575,10 @@ class BrowserViewController: UIViewController {
         present(alert, animated: true, completion: nil)
         #endif
         
-        sync.webView.alpha = 0.01
-        UIApplication.shared.keyWindow?.insertSubview(Sync.shared.webView, at: 0)
+        DispatchQueue.main.async {
+            sync.webView.alpha = 0.01
+            UIApplication.shared.keyWindow?.insertSubview(Sync.shared.webView, at: 0)
+        }
     }
     
     fileprivate func setupTabs() {

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -161,9 +161,11 @@ public class Sync: JSInjector {
         self.maximumDelayAttempts = 15
         self.delayLengthInSeconds = Int64(3.0)
         
-        webView = WKWebView(frame: CGRect(x: 30, y: 30, width: 300, height: 500), configuration: webConfig)
-        // Attempt sync setup
-        initializeSync()
+        DispatchQueue.main.async {
+            self.webView = WKWebView(frame: CGRect(x: 30, y: 30, width: 300, height: 500), configuration: self.webConfig)
+            // Attempt sync setup
+            self.initializeSync()
+        }
     }
     
     public func leaveSyncGroup(sendToSync: Bool = true) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This should finally help with our CI.
The problem was calling Sync code from background thread, this happened only in async tests somewhere it seems.

<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
