### PR TITLE
Revert "No Bug: Hide Rewards User Wallets unless compiler flag is used (#2205)"

### DIFF
--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -641,7 +641,6 @@ extension WalletViewController {
       crypto: Strings.walletBalanceType,
       dollarValue: state.ledger.usdBalanceString
     )
-    #if REWARDS_USER_WALLET
     if let publisher = publisher {
       publisherSummaryView.publisherView.setStatus(
         publisher.status,
@@ -666,19 +665,16 @@ extension WalletViewController {
       }
       self.walletView.headerView.addFundsButton.isHidden = wallet.status != .verified
     }
-    #endif
   }
   
   /// Fetch an updated external wallet from ledger if the user isn't in JP
   func updateExternalWallet() {
-    #if REWARDS_USER_WALLET
     if Preferences.Rewards.isUsingBAP.value == true { return }
     
     // If we can show Uphold, grab verification status of the wallet
     state.ledger.fetchExternalWallet(forType: .uphold) { _ in
       self.updateWalletHeader()
     }
-    #endif
   }
   
   func setupLedgerObservers() {


### PR DESCRIPTION
## Summary of Changes

This pull request reverts PR #2205 

Since user wallets will once again be in 1.15