### PR TITLE
Fix #2224: Make ntp notification centered on landscape phones and iPads.

### DIFF
--- a/Client/Frontend/NTP/NTPNotificationViewController.swift
+++ b/Client/Frontend/NTP/NTPNotificationViewController.swift
@@ -24,6 +24,8 @@ class NTPNotificationViewController: TranslucentBottomSheet {
         if state == .dontShow { return nil }
     }
     
+    private var mainView: UIStackView?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -32,13 +34,37 @@ class NTPNotificationViewController: TranslucentBottomSheet {
             return
         }
         
-        mainView.setCustomSpacing(0, after: mainView.header)
+        self.mainView = mainView
         
+        mainView.setCustomSpacing(0, after: mainView.header)
         view.addSubview(mainView)
+    }
+    
+    override func viewDidLayoutSubviews() {
+        updateMainViewConstraints()
+    }
+    
+    private func updateMainViewConstraints() {
+        guard let mainView = mainView else { return }
+
+        mainView.alignment = isPortraitIphone ? .fill : .center
+
         mainView.snp.remakeConstraints {
             $0.top.equalToSuperview().inset(28)
-            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
+
+            if isPortraitIphone {
+                $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(16)
+            } else {
+                let width = min(view.frame.width, 400)
+                $0.width.equalTo(width)
+                $0.centerX.equalToSuperview()
+            }
         }
+    }
+    
+    private var isPortraitIphone: Bool {
+        traitCollection.userInterfaceIdiom == .phone && UIApplication.shared.statusBarOrientation.isPortrait
     }
     
     override func close(immediately: Bool = false) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2224 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="950" alt="Zrzut ekranu 2020-01-23 o 22 29 50" src="https://user-images.githubusercontent.com/6950387/73028664-4aa98080-3e36-11ea-8e88-3d19a3bd0e80.png">
<img width="538" alt="Zrzut ekranu 2020-01-23 o 22 29 43" src="https://user-images.githubusercontent.com/6950387/73028665-4aa98080-3e36-11ea-81f8-813a815d6531.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
