### PR TITLE
Ref #2151: At least one notification must show before we lock showing…

### DIFF
--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -104,6 +104,10 @@ extension Preferences {
         /// Whether the iOS keyboard auto-opens on a NTP or not
         static let autoOpenKeyboard = Option<Bool>(key: "newtabpage.auto-open-keyboard", default: false)
         
+        /// At least one notification must show before we lock showing subsequent notifications.
+        static let atleastOneNTPNotificationWasShowed = Option<Bool>(key: "newtabpage.one-notificaiton-showed",
+                                                                     default: false)
+        
         /// Whether the callout to use branded image was shown.
         static let brandedImageShowed = Option<Bool>(key: "newtabpage.branded-image-callout-showed",
                                                      default: false)

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -153,6 +153,7 @@ extension BrowserViewController {
     
     @objc func resetNTPNotification() {
         Preferences.NewTabPage.brandedImageShowed.value = false
+        Preferences.NewTabPage.atleastOneNTPNotificationWasShowed.value = false
     }
 }
 

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -181,8 +181,10 @@ class FavoritesViewController: UIViewController, Themeable {
             $0.removeObserver(self, name: .privacyModeChanged, object: nil)
         }
         
-        // Navigating away from NTP counts the current notification as showed.
-        Preferences.NewTabPage.brandedImageShowed.value = true
+        if Preferences.NewTabPage.atleastOneNTPNotificationWasShowed.value {
+            // Navigating away from NTP counts the current notification as showed.
+            Preferences.NewTabPage.brandedImageShowed.value = true
+        }
     }
     
     override func viewDidLoad() {
@@ -297,6 +299,7 @@ class FavoritesViewController: UIViewController, Themeable {
             }
             
             vc = notificationVC
+            Preferences.NewTabPage.atleastOneNTPNotificationWasShowed.value = true
         case .claimRewards:
             if !Preferences.NewTabPage.attemptToShowClaimRewardsNotification.value { return }
             


### PR DESCRIPTION
… subsequent notifications.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
