### PR TITLE
No Bug: Add non breaking space for "Learn more" strings.

### DIFF
--- a/Client/Frontend/NTP/NTPNotificationViewController.swift
+++ b/Client/Frontend/NTP/NTPNotificationViewController.swift
@@ -77,9 +77,9 @@ class NTPNotificationViewController: TranslucentBottomSheet {
         
         switch state {
         case .getPaidTurnRewardsOn, .getPaidTurnAdsOn:
-            let learnMore = Strings.learnMore
+            let learnMore = Strings.learnMore.withNonBreakingSpace
             config.bodyText =
-                (text: "\(Strings.NTP.getPaidToSeeThisImage)\n\(learnMore)",
+                (text: "\(Strings.NTP.getPaidToSeeThisImage) \(learnMore)",
                     urlInfo: [learnMore: "learn-more"],
                     action: { [weak self] action in
                         self?.learnMoreHandler?()
@@ -100,10 +100,10 @@ class NTPNotificationViewController: TranslucentBottomSheet {
                     self?.close()
                 })
         case .gettingPaidAlready:
-            let learnMore = Strings.learnMore
+            let learnMore = Strings.learnMore.withNonBreakingSpace
             
             config.bodyText =
-                (text: "\(Strings.NTP.youArePaidToSeeThisImage)\n\(learnMore)",
+                (text: "\(Strings.NTP.youArePaidToSeeThisImage) \(learnMore)",
                     urlInfo: [learnMore: "learn-more"],
                     action: { [weak self] action in
                         self?.learnMoreHandler?()

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -127,4 +127,8 @@ extension String {
         attributedString.addAttributes(boldFontAttribute, range: range)
         return attributedString
     }
+    
+    public var withNonBreakingSpace: String {
+        self.replacingOccurrences(of: " ", with: "\u{00a0}")
+    }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->



<img width="544" alt="Zrzut ekranu 2020-01-24 o 20 17 57" src="https://user-images.githubusercontent.com/6950387/73097102-a5021a00-3ee6-11ea-9907-5b61c851c09f.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
