### PR TITLE
Fix #2237: Show 'my first ad' after tapping on Rewards button on NTP.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -263,6 +263,10 @@ class BrowserViewController: UIViewController {
             guard let self = self, let client = self.deviceCheckClient else { return }
             if result == .walletCreated {
                 self.rewards.ledger.setupDeviceCheckEnrollment(client) { }
+                
+                if self.notificationsHandler?.shouldShowNotifications() == true {
+                    self.displayMyFirstAdIfAvailable()
+                }
             }
         }
         rewardsObserver.fetchedPanelPublisher = { [weak self] publisher, tabId in


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2237 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
