### PR TITLE
Fix #1653: Focus on an existing tab if the URL matches from rewards

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -168,9 +168,13 @@ extension BrowserViewController: RewardsUIDelegate {
     func loadNewTabWithURL(_ url: URL) {
         self.presentedViewController?.dismiss(animated: true)
         
-        let request = URLRequest(url: url)
-        let isPrivate = PrivateBrowsingManager.shared.isPrivateBrowsing
-        tabManager.addTabAndSelect(request, isPrivate: isPrivate)
+        if let tab = tabManager.getTabForURL(url) {
+            tabManager.selectTab(tab)
+        } else {
+            let request = URLRequest(url: url)
+            let isPrivate = PrivateBrowsingManager.shared.isPrivateBrowsing
+            tabManager.addTabAndSelect(request, isPrivate: isPrivate)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #1653

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open rewards panel on any web page, tap learn more in the discliamer, verify it creates a new tab
- Open rewards panel, tap same learn more, verify it does not open a new tab
- Switch tabs, repeat, verify it switches to learn more tab instead of creating a new one

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
