### PR TITLE
Fix #2246: Show correct toggle state on AC settings

### DIFF
--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -51,6 +51,9 @@ class AutoContributeDetailViewController: UIViewController {
     contentView.tableView.delegate = self
     contentView.tableView.dataSource = self
     
+    contentView.allowVideoContributionsSwitch.addTarget(self, action: #selector(allowVideoValueChanged), for: .valueChanged)
+    contentView.allowUnverifiedContributionsSwitch.addTarget(self, action: #selector(allowUnverifiedValueChanged), for: .valueChanged)
+    
     title = Strings.autoContribute
   }
   
@@ -72,6 +75,9 @@ class AutoContributeDetailViewController: UIViewController {
   }
   
   private func reloadData() {
+    contentView.allowUnverifiedContributionsSwitch.isOn = state.ledger.allowUnverifiedPublishers
+    contentView.allowVideoContributionsSwitch.isOn = state.ledger.allowVideoContributions
+    
     let filter = state.ledger.supportedPublishersFilter
     state.ledger.listActivityInfo(fromStart: 0, limit: 0, filter: filter) { pubs in
       self.publishersCount = UInt(pubs.count)
@@ -79,6 +85,16 @@ class AutoContributeDetailViewController: UIViewController {
     }
     excludedPublishersCount = state.ledger.numberOfExcludedPublishers
     contentView.tableView.reloadData()
+  }
+  
+  // MARK: - Actions
+  
+  @objc private func allowUnverifiedValueChanged() {
+    state.ledger.allowUnverifiedPublishers = contentView.allowUnverifiedContributionsSwitch.isOn
+  }
+  
+  @objc private func allowVideoValueChanged() {
+    state.ledger.allowVideoContributions = contentView.allowVideoContributionsSwitch.isOn
   }
 }
 


### PR DESCRIPTION
Missed these action hookups when I moved the settings up a level in #2217 

## Summary of Changes

This pull request fixes issue #2246 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
