### PR TITLE
Fix #2257: Always use current locale for downloading branded assets.

### DIFF
--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -18,10 +18,6 @@ class NTPDownloader {
     private static let ntpDownloadsFolder = "NTPDownloads"
     private static let baseURL = "https://brave-ntp-crx-input-dev.s3-us-west-2.amazonaws.com/"
     
-    private let defaultLocale = "US"
-    private let supportedLocales: [String] = []
-    private let currentLocale = Locale.current.regionCode
-    
     private var timer: Timer?
     private var backgroundObserver: NSObjectProtocol?
     private var foregroundObserver: NSObjectProtocol?
@@ -275,23 +271,11 @@ class NTPDownloader {
     }
     
     private func getBaseURL() -> URL? {
-        guard let url = URL(string: NTPDownloader.baseURL) else {
+        guard let url = URL(string: NTPDownloader.baseURL), let region = Locale.current.regionCode else {
             return nil
         }
         
-        return url.appendingPathComponent(getSupportedLocale())
-    }
-    
-    private func getSupportedLocale() -> String {
-        guard let region = Locale.current.regionCode else {
-            return self.defaultLocale
-        }
-        
-        if supportedLocales.contains(region) {
-            return region
-        }
-        
-        return self.defaultLocale
+        return url.appendingPathComponent(region)
     }
     
     //MARK: - Download & Unpacking


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2257 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
