### PR TITLE
Fix #2260: Don't show second NTP notification if Rewards enabled via …

### DIFF
--- a/BraveRewardsUI/Settings/SettingsViewController.swift
+++ b/BraveRewardsUI/Settings/SettingsViewController.swift
@@ -137,14 +137,13 @@ class SettingsViewController: UIViewController {
   @objc private func rewardsSwitchValueChanged() {
     state.ledger.isEnabled = settingsView.rewardsToggleSection.toggleSwitch.isOn
     updateVisualStateOfSections(animated: true)
+    NotificationCenter.default.post(name: .adsOrRewardsToggledInSettings, object: nil)
   }
   
   @objc private func adsToggleValueChanged() {
     state.ads.isEnabled = settingsView.adsSection.toggleSwitch.isOn
     updateVisualStateOfSections(animated: true)
-    // This is to notify BVC that ad setting was toggled.
-    // At the moment there is no ledger observer for ads status, must use notification.
-    NotificationCenter.default.post(name: .adsToggled, object: nil)
+    NotificationCenter.default.post(name: .adsOrRewardsToggledInSettings, object: nil)
   }
   
   @objc private func autoContributeToggleValueChanged() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -286,7 +286,6 @@ class BrowserViewController: UIViewController {
             self.updateRewardsButtonState()
         }
         rewardsObserver.rewardsEnabledStateUpdated = { [weak self] _ in
-            self?.resetNTPNotification()
             self?.updateRewardsButtonState()
         }
     }
@@ -467,7 +466,7 @@ class BrowserViewController: UIViewController {
             $0.addObserver(self, selector: #selector(appDidEnterBackgroundNotification),
                            name: UIApplication.didEnterBackgroundNotification, object: nil)
             $0.addObserver(self, selector: #selector(resetNTPNotification),
-                           name: .adsToggled, object: nil)
+                           name: .adsOrRewardsToggledInSettings, object: nil)
             
         }
         

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -56,5 +56,5 @@ extension Notification.Name {
     public static let topSitesConversion = Notification.Name("TopSitesConversion")
     
     // MARK: - Rewards
-    public static let adsToggled = Notification.Name("adsToggled")
+    public static let adsOrRewardsToggledInSettings = Notification.Name("adsOrRewardsToggledInSettings")
 }


### PR DESCRIPTION
…NTP.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2260 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
