### PR TITLE
Fix #2264: Show banner again if the first one didn't have time to appear

### DIFF
--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -323,7 +323,6 @@ class FavoritesViewController: UIViewController, Themeable {
             }
             
             vc = notificationVC
-            Preferences.NewTabPage.atleastOneNTPNotificationWasShowed.value = true
         case .claimRewards:
             if !Preferences.NewTabPage.attemptToShowClaimRewardsNotification.value { return }
             
@@ -340,6 +339,11 @@ class FavoritesViewController: UIViewController, Themeable {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
             guard let self = self else { return }
+            
+            if case .brandedImages = type {
+                Preferences.NewTabPage.atleastOneNTPNotificationWasShowed.value = true
+            }
+            
             self.ntpNotificationShowing = true
             self.addChild(viewController)
             self.view.addSubview(viewController.view)


### PR DESCRIPTION
on screen.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2264 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
