### PR TITLE
Fix #2266: Make it easier to close NTP view by 'x' button.

### DIFF
--- a/Client/Frontend/NTP/ClaimRewardsNTPNotificationViewController.swift
+++ b/Client/Frontend/NTP/ClaimRewardsNTPNotificationViewController.swift
@@ -50,7 +50,7 @@ class ClaimRewardsNTPNotificationViewController: TranslucentBottomSheet {
                 text.attributedText(stringToChange: Strings.NTP.goodJob, font: font, color: .white)
         }
         
-        view.addSubview(mainView)
+        view.insertSubview(mainView, belowSubview: closeButton)
     }
     
     override func viewDidLayoutSubviews() {

--- a/Client/Frontend/NTP/NTPNotificationViewController.swift
+++ b/Client/Frontend/NTP/NTPNotificationViewController.swift
@@ -37,7 +37,7 @@ class NTPNotificationViewController: TranslucentBottomSheet {
         self.mainView = mainView
         
         mainView.setCustomSpacing(0, after: mainView.header)
-        view.addSubview(mainView)
+        view.insertSubview(mainView, belowSubview: closeButton)
     }
     
     override func viewDidLayoutSubviews() {

--- a/Client/Frontend/Widgets/TranslucentBottomSheet.swift
+++ b/Client/Frontend/Widgets/TranslucentBottomSheet.swift
@@ -12,7 +12,7 @@ class TranslucentBottomSheet: UIViewController {
     
     var closeHandler: (() -> Void)?
     
-    private let closeButton = UIButton().then {
+    let closeButton = UIButton().then {
         $0.setImage(#imageLiteral(resourceName: "close_translucent_popup").template, for: .normal)
         $0.appearanceTintColor = .white
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2266 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
