### PR TITLE
Fix #2251: Make add funds button icon white

### DIFF
--- a/BraveRewardsUI/Wallet/WalletHeaderView.swift
+++ b/BraveRewardsUI/Wallet/WalletHeaderView.swift
@@ -71,6 +71,7 @@ class WalletHeaderView: UIView {
   }
   
   let addFundsButton = Button(type: .system).then {
+    $0.appearanceTintColor = UIColor(white: 1.0, alpha: 0.75)
     $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.75)
     $0.setTitle(Strings.addFunds, for: .normal)
     $0.setImage(UIImage(frameworkResourceNamed: "add-funds-icon").alwaysTemplate, for: .normal)


### PR DESCRIPTION
Looks like an accidental regression caused by the removal of this line in the camel case PR (#2172): https://github.com/brave/brave-ios/pull/2172/files#diff-df11de55a0f532a9aaf30c8fea7e6c7eL74

## Summary of Changes

This pull request fixes issue #2251

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
