### PR TITLE
Fix #1966: Show open rewards settings button in settings

### DIFF
--- a/BraveRewardsUI/RewardsPanelController.swift
+++ b/BraveRewardsUI/RewardsPanelController.swift
@@ -7,9 +7,14 @@ import BraveRewards
 
 public class RewardsPanelController: PopoverNavigationController {
   
+  public enum InitialPage {
+    case `default`
+    case settings
+  }
+
   public static let batLogoImage = UIImage(frameworkResourceNamed: "bat-small")
   
-  public init(_ rewards: BraveRewards, tabId: UInt64, url: URL, faviconURL: URL?, pageHTML: String? = nil, delegate: RewardsUIDelegate, dataSource: RewardsDataSource) {
+  public init(_ rewards: BraveRewards, tabId: UInt64, url: URL, faviconURL: URL?, pageHTML: String? = nil, delegate: RewardsUIDelegate, dataSource: RewardsDataSource, initialPage: InitialPage = .default) {
     super.init()
     
     let state = RewardsState(ledger: rewards.ledger, ads: rewards.ads, tabId: tabId, url: url, faviconURL: faviconURL, delegate: delegate, dataSource: dataSource)
@@ -17,7 +22,11 @@ public class RewardsPanelController: PopoverNavigationController {
     if !rewards.ledger.isWalletCreated {
       viewControllers = [CreateWalletViewController(state: state)]
     } else {
-      viewControllers = [WalletViewController(state: state)]
+      var vcs: [UIViewController] = [WalletViewController(state: state)]
+      if initialPage == .settings {
+        vcs.append(SettingsViewController(state: state))
+      }
+      viewControllers = vcs
     }
   }
   

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -323,6 +323,7 @@ extension Strings {
     public static let walletCreationDate = NSLocalizedString("WalletCreationDate", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Wallet Creation Date", comment: "The date your wallet was created")
     public static let copyWalletSupportInfo = NSLocalizedString("CopyWalletSupportInfo", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Copy Support Info", comment: "Copy rewards internals info for support")
     public static let settingsLicenses = NSLocalizedString("SettingsLicenses", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Licenses", comment: "Row name for licenses.")
+    public static let openBraveRewardsSettings = NSLocalizedString("OpenBraveRewardsSettings", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Open Brave Rewards Settings", comment: "Button title for opening the Brave Rewards panel to settings")
 }
 
 // MARK:- Error pages.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1699,6 +1699,12 @@ extension BrowserViewController: SettingsDelegate {
             }
         })
     }
+    
+    func settingsOpenRewardsSettings(_ settingsViewController: SettingsViewController) {
+        settingsViewController.dismiss(animated: true, completion: {
+            self.showBraveRewardsPanel(initialPage: .settings)
+        })
+    }
 }
 
 extension BrowserViewController: PresentingModalViewControllerDelegate {

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -66,7 +66,7 @@ extension BrowserViewController {
         self.topToolbar.locationView.rewardsButton.forceShowBadge = !Preferences.Rewards.panelOpened.value
     }
 
-    func showBraveRewardsPanel() {
+    func showBraveRewardsPanel(initialPage: RewardsPanelController.InitialPage = .default) {
         Preferences.Rewards.panelOpened.value = true
         updateRewardsButtonState()
         
@@ -82,7 +82,8 @@ extension BrowserViewController {
             url: url,
             faviconURL: url,
             delegate: self,
-            dataSource: self
+            dataSource: self,
+            initialPage: initialPage
         )
         
         let popover = PopoverController(contentController: braveRewardsPanel, contentSizeBehavior: .preferredContentSize)

--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -33,6 +33,8 @@ class BraveRewardsSettingsViewController: TableViewController {
     
     let rewards: BraveRewards
     
+    var tappedShowRewardsSettings: (() -> Void)?
+    
     init(_ rewards: BraveRewards) {
         self.rewards = rewards
         super.init(style: .grouped)
@@ -69,6 +71,11 @@ class BraveRewardsSettingsViewController: TableViewController {
             }
             
             dataSource.sections += [
+                Section(rows: [
+                    Row(text: Strings.openBraveRewardsSettings, selection: { [unowned self] in
+                        self.tappedShowRewardsSettings?()
+                    }, cellClass: ButtonCell.self)
+                ]),
                 Section(rows: [
                     Row(text: Strings.walletCreationDate, detailText: walletCreatedDate, selection: {
                         let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -42,6 +42,7 @@ protocol SettingsDelegate: class {
     func settingsOpenURLInNewTab(_ url: URL)
     func settingsOpenURLs(_ urls: [URL])
     func settingsDidFinish(_ settingsViewController: SettingsViewController)
+    func settingsOpenRewardsSettings(_ settingsViewController: SettingsViewController)
 }
 
 class SettingsViewController: TableViewController {
@@ -205,6 +206,9 @@ class SettingsViewController: TableViewController {
                 section.rows += [
                     Row(text: Strings.braveRewardsTitle, selection: { [unowned self] in
                         let rewardsVC = BraveRewardsSettingsViewController(rewards)
+                        rewardsVC.tappedShowRewardsSettings = { [unowned self] in
+                            self.settingsDelegate?.settingsOpenRewardsSettings(self)
+                        }
                         self.navigationController?.pushViewController(rewardsVC, animated: true)
                         }, accessory: .disclosureIndicator),
                 ]


### PR DESCRIPTION
## Summary of Changes

This pull request fixes issue #1966 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- (Fresh install) Go to settings > Brave Rewards. Verify no open rewards button is there 
- Enable rewards
- Repeat step 1, but verify the open rewards settings button is there
- Tap said button, verify it opens the panel directly to settings

## Screenshots:

| Rewards Enabled | Fresh Install |
| --- | --- | 
| ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-29 at 11 27 26](https://user-images.githubusercontent.com/529104/73375934-9ae76f00-428a-11ea-8d81-a2eb96b75b54.png) | ![Simulator Screen Shot - iPhone 8 - 2020-01-29 at 11 27 11](https://user-images.githubusercontent.com/529104/73375947-9de25f80-428a-11ea-9897-c4a956f2033f.png) |

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).