### PR TITLE
Fix #2285: Fix NTP SI foreground timer

### DIFF
--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -19,9 +19,10 @@ class NTPDownloader {
     private static let ntpDownloadsFolder = "NTPDownloads"
     private static let baseURL = { () -> String in
         switch BraveLedger.environment {
-        case .production: return "https://brave-ntp-crx-input.s3-us-west-2.amazonaws.com/"
-        case .development: return "https://brave-ntp-crx-input-dev.s3-us-west-2.amazonaws.com/"
-        default: return "https://brave-ntp-crx-input.s3-us-west-2.amazonaws.com/"
+        case .production: return "https://mobile-data.s3.brave.com/"
+        case .staging, .development: return "https://brave-ntp-crx-input-dev.s3-us-west-2.amazonaws.com/"
+        @unknown default:
+            return "https://mobile-data.s3.brave.com/"
         }
     }()
     

--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Shared
 import BraveShared
+import BraveRewards
 
 private let logger = Logger.browserLogger
 
@@ -16,7 +17,13 @@ class NTPDownloader {
     private static let etagFile = "crc.etag"
     private static let metadataFile = "photo.json"
     private static let ntpDownloadsFolder = "NTPDownloads"
-    private static let baseURL = "https://brave-ntp-crx-input-dev.s3-us-west-2.amazonaws.com/"
+    private static let baseURL = { () -> String in
+        switch BraveLedger.environment {
+        case .production: return "https://brave-ntp-crx-input.s3-us-west-2.amazonaws.com/"
+        case .development: return "https://brave-ntp-crx-input-dev.s3-us-west-2.amazonaws.com/"
+        default: return "https://brave-ntp-crx-input.s3-us-west-2.amazonaws.com/"
+        }
+    }()
     
     private var timer: Timer?
     private var backgroundObserver: NSObjectProtocol?

--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -148,13 +148,17 @@ class NTPDownloader {
             self.timer?.invalidate()
             self.timer = nil
             
-            if let nextDate = Preferences.NTP.ntpCheckDate.value {
+            //If the time hasn't passed yet, reschedule the timer with the relative time..
+            if let nextDate = Preferences.NTP.ntpCheckDate.value,
+                Date().timeIntervalSince1970 - nextDate < 0 {
+                
                 let relativeTime = abs(Date().timeIntervalSince1970 - nextDate)
                 self.timer = Timer.scheduledTimer(withTimeInterval: relativeTime, repeats: true) { [weak self] _ in
                     self?.notifyObservers()
                 }
             } else {
-                self.startNTPTimer()
+                //Else the time has already passed so download the new data, reschedule the timers and notify the observers
+                self.notifyObservers()
             }
         }
     }


### PR DESCRIPTION
Fixes the NTP timer calculation being off when you come back from the background after a longer period of time than the 5hours + max variance.

## Summary of Changes

This pull request fixes issue #2285 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
