### PR TITLE
Fix #2287 - NTP images not showing when the new assets are downloaded.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -623,8 +623,8 @@
 		5D5374A823846FFC00A2B587 /* annie-spratt.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5D53749923846FFC00A2B587 /* annie-spratt.jpg */; };
 		5D5374A923846FFC00A2B587 /* matt-palmer.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5D53749A23846FFC00A2B587 /* matt-palmer.jpg */; };
 		5D5374AA23846FFC00A2B587 /* andy-mai.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5D53749B23846FFC00A2B587 /* andy-mai.jpg */; };
-		5D5374BB238895B100A2B587 /* NewTabPageBackgroundDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5374BA238895B100A2B587 /* NewTabPageBackgroundDataSource.swift */; };
-		5D5E2361238C386B00AD6FBD /* NewTabPageTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5E2360238C386B00AD6FBD /* NewTabPageTableViewController.swift */; };
+		5D5374BB238895B100A2B587 /* NTPBackgroundDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5374BA238895B100A2B587 /* NTPBackgroundDataSource.swift */; };
+		5D5E2361238C386B00AD6FBD /* NTPTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5E2360238C386B00AD6FBD /* NTPTableViewController.swift */; };
 		5D6DDEF3214003A6001FF0AE /* DAU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DDEE6214003A6001FF0AE /* DAU.swift */; };
 		5D6DDEFE2141B6A1001FF0AE /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DDEF62141B6A0001FF0AE /* Preferences.swift */; };
 		5D6DDF0021428CF0001FF0AE /* DAUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DDEFF21428CF0001FF0AE /* DAUTests.swift */; };
@@ -2072,8 +2072,8 @@
 		5D53749923846FFC00A2B587 /* annie-spratt.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "annie-spratt.jpg"; sourceTree = "<group>"; };
 		5D53749A23846FFC00A2B587 /* matt-palmer.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "matt-palmer.jpg"; sourceTree = "<group>"; };
 		5D53749B23846FFC00A2B587 /* andy-mai.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "andy-mai.jpg"; sourceTree = "<group>"; };
-		5D5374BA238895B100A2B587 /* NewTabPageBackgroundDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageBackgroundDataSource.swift; sourceTree = "<group>"; };
-		5D5E2360238C386B00AD6FBD /* NewTabPageTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageTableViewController.swift; sourceTree = "<group>"; };
+		5D5374BA238895B100A2B587 /* NTPBackgroundDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPBackgroundDataSource.swift; sourceTree = "<group>"; };
+		5D5E2360238C386B00AD6FBD /* NTPTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPTableViewController.swift; sourceTree = "<group>"; };
 		5D6DDEE6214003A6001FF0AE /* DAU.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DAU.swift; sourceTree = "<group>"; };
 		5D6DDEF62141B6A0001FF0AE /* Preferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		5D6DDEFF21428CF0001FF0AE /* DAUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAUTests.swift; sourceTree = "<group>"; };
@@ -2822,7 +2822,7 @@
 				0AADC4CD20D2A6A200FDE368 /* favorites */,
 				0AADC4D620D2B03900FDE368 /* BraveShieldStatsView.swift */,
 				0AADC4C720D2A55A00FDE368 /* FavoritesViewController.swift */,
-				5D5374BA238895B100A2B587 /* NewTabPageBackgroundDataSource.swift */,
+				5D5374BA238895B100A2B587 /* NTPBackgroundDataSource.swift */,
 				5E6683A823D61CF7005B3A6C /* NTPDownloader.swift */,
 				5DB474F0237F4CC9007B7652 /* ntp-data.json */,
 				5DB474CE237F4BE9007B7652 /* NTP_Images */,
@@ -3426,7 +3426,7 @@
 				2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */,
 				2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */,
 				A1F66A7220DD71C400303328 /* SettingsViewController.swift */,
-				5D5E2360238C386B00AD6FBD /* NewTabPageTableViewController.swift */,
+				5D5E2360238C386B00AD6FBD /* NTPTableViewController.swift */,
 				A1CA29C320E1746A00CB9126 /* OptionSelectionViewController.swift */,
 				A16DC67E20E585D90069C8E1 /* PasscodeSettingsViewController.swift */,
 				0AEFB84822244135007AF600 /* AdblockDebugMenuTableViewController.swift */,
@@ -6078,7 +6078,7 @@
 				592F521E2217327C0078395E /* HttpCookieExtension.swift in Sources */,
 				4422D4D721BFFB7600BF1855 /* table.cc in Sources */,
 				0A4BEF62221B26610005551A /* LocalAdblockResourceProtocol.swift in Sources */,
-				5D5E2361238C386B00AD6FBD /* NewTabPageTableViewController.swift in Sources */,
+				5D5E2361238C386B00AD6FBD /* NTPTableViewController.swift in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				D0FCF7F51FE45842004A7995 /* UserScriptManager.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
@@ -6296,7 +6296,7 @@
 				4422D50121BFFB7600BF1855 /* repair.cc in Sources */,
 				E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */,
 				4422D55721BFFB7F00BF1855 /* unicode_groups.cc in Sources */,
-				5D5374BB238895B100A2B587 /* NewTabPageBackgroundDataSource.swift in Sources */,
+				5D5374BB238895B100A2B587 /* NTPBackgroundDataSource.swift in Sources */,
 				4422D55421BFFB7E00BF1855 /* re2_fuzzer.cc in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
 				C6B81B8C212D989200996084 /* ImageCacheOptions.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -58,7 +58,7 @@ class BrowserViewController: UIViewController {
     fileprivate var findInPageBar: FindInPageBar?
     
     // Single data source used for all favorites vcs
-    fileprivate let backgroundDataSource = NewTabPageBackgroundDataSource()
+    fileprivate let backgroundDataSource = NTPBackgroundDataSource()
     
     var loadQueue = Deferred<Void>()
 

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -143,7 +143,7 @@ class FavoritesViewController: UIViewController, Themeable {
             let noSponsor = background?.sponsor == nil
             
             // Image Sponsor
-            imageSponsorButton.setImage(background?.sponsor?.logo.imageLiteral, for: .normal)
+            imageSponsorButton.setImage(background?.sponsor?.logo.image, for: .normal)
             imageSponsorButton.isHidden = noSponsor
             
             // Image Credit
@@ -550,7 +550,7 @@ class FavoritesViewController: UIViewController, Themeable {
         self.background = backgroundDataSource?.newBackground()
         //
         
-        guard let image = background?.wallpaper.imageLiteral else {
+        guard let image = background?.wallpaper.image else {
             return
         }
         

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -50,7 +50,7 @@ class FavoritesViewController: UIViewController, Themeable {
         return view
     }()
     private let dataSource: FavoritesDataSource
-    private let backgroundDataSource: NewTabPageBackgroundDataSource?
+    private let backgroundDataSource: NTPBackgroundDataSource?
 
     private let braveShieldStatsView = BraveShieldStatsView(frame: CGRect.zero).then {
         $0.autoresizingMask = [.flexibleWidth]
@@ -138,7 +138,7 @@ class FavoritesViewController: UIViewController, Themeable {
     // MARK: - Init/lifecycle
     
     private var backgroundViewInfo: (imageView: UIImageView, portraitCenterConstraint: Constraint, landscapeCenterConstraint: Constraint)?
-    private var background: (wallpaper: NewTabPageBackgroundDataSource.Background, sponsor: NewTabPageBackgroundDataSource.Sponsor?)? {
+    private var background: (wallpaper: NTPBackgroundDataSource.Background, sponsor: NTPBackgroundDataSource.Sponsor?)? {
         didSet {
             let noSponsor = background?.sponsor == nil
             
@@ -173,7 +173,7 @@ class FavoritesViewController: UIViewController, Themeable {
     private var rewards: BraveRewards?
     
     init(profile: Profile, dataSource: FavoritesDataSource = FavoritesDataSource(), fromOverlay: Bool,
-         rewards: BraveRewards?, backgroundDataSource: NewTabPageBackgroundDataSource?) {
+         rewards: BraveRewards?, backgroundDataSource: NTPBackgroundDataSource?) {
         self.profile = profile
         self.dataSource = dataSource
         self.fromOverlay = fromOverlay

--- a/Client/Frontend/Browser/HomePanel/NTPBackgroundDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPBackgroundDataSource.swift
@@ -7,7 +7,7 @@ import Shared
 import BraveShared
 import BraveRewards
 
-class NewTabPageBackgroundDataSource {
+class NTPBackgroundDataSource {
     
     struct Background: Codable {
         let imageUrl: String
@@ -122,10 +122,10 @@ class NewTabPageBackgroundDataSource {
         if !Preferences.NewTabPage.backgroundImages.value { return nil }
         
         // Identifying the background array to use
-        let (backgroundSet, useSponsor) = { () -> ([NewTabPageBackgroundDataSource.Background], Bool) in
+        let (backgroundSet, useSponsor) = { () -> ([NTPBackgroundDataSource.Background], Bool) in
             // Determine what type of background to display
             let attemptSponsored = Preferences.NewTabPage.backgroundSponsoredImages.value
-                && backgroundRotationCounter == NewTabPageBackgroundDataSource.sponsorshipShowValue
+                && backgroundRotationCounter == NTPBackgroundDataSource.sponsorshipShowValue
                 && !PrivateBrowsingManager.shared.isPrivateBrowsing
             
             // Sponsor is lazy-loaded so only want to access it if needed.
@@ -162,12 +162,12 @@ class NewTabPageBackgroundDataSource {
             // This index is now added to 'past' tracking list to prevent duplicates
             self.lastBackgroundChoices.append(chosenIndex)
             // Trimming to fixed length to release older backgrounds
-            self.lastBackgroundChoices = self.lastBackgroundChoices.suffix(NewTabPageBackgroundDataSource.numberOfDuplicateAvoidance)
+            self.lastBackgroundChoices = self.lastBackgroundChoices.suffix(NTPBackgroundDataSource.numberOfDuplicateAvoidance)
             return chosenIndex
         }()
         
         // Force back to `0` if at end
-        backgroundRotationCounter %= NewTabPageBackgroundDataSource.sponsorshipShowRate
+        backgroundRotationCounter %= NTPBackgroundDataSource.sponsorshipShowRate
         // Increment regardless, this is a counter, not an index, so smallest should be `1`
         backgroundRotationCounter += 1
         
@@ -192,13 +192,13 @@ class NewTabPageBackgroundDataSource {
     }
 }
 
-extension NewTabPageBackgroundDataSource: NTPDownloaderDelegate {
-    func onNTPUpdated(ntpInfo: NewTabPageBackgroundDataSource.Sponsor?) {
+extension NTPBackgroundDataSource: NTPDownloaderDelegate {
+    func onNTPUpdated(ntpInfo: NTPBackgroundDataSource.Sponsor?) {
         sponsor = ntpInfo
     }
 }
 
-extension NewTabPageBackgroundDataSource: PreferencesObserver {
+extension NTPBackgroundDataSource: PreferencesObserver {
     func preferencesDidChange(for key: String) {
         let sponsoredPref = Preferences.NewTabPage.backgroundSponsoredImages
         if sponsoredPref.key == key {

--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -197,7 +197,8 @@ class NTPDownloader {
                 NewTabPageBackgroundDataSource.Background(
                     imageUrl: downloadsFolderURL.appendingPathComponent($0.imageUrl).path,
                     focalPoint: $0.focalPoint,
-                    credit: nil)
+                    credit: nil,
+                    packaged: false)
             }
             
             return NewTabPageBackgroundDataSource.Sponsor(wallpapers: wallpapers, logo: logo)

--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -196,9 +196,7 @@ class NTPDownloader {
             let wallpapers = itemInfo.wallpapers.map {
                 NewTabPageBackgroundDataSource.Background(
                     imageUrl: downloadsFolderURL.appendingPathComponent($0.imageUrl).path,
-                    focalPoint: $0.focalPoint,
-                    credit: nil,
-                    packaged: false)
+                    focalPoint: $0.focalPoint)
             }
             
             return NewTabPageBackgroundDataSource.Sponsor(wallpapers: wallpapers, logo: logo)

--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -10,7 +10,7 @@ import BraveRewards
 private let logger = Logger.browserLogger
 
 protocol NTPDownloaderDelegate: class {
-    func onNTPUpdated(ntpInfo: NewTabPageBackgroundDataSource.Sponsor?)
+    func onNTPUpdated(ntpInfo: NTPBackgroundDataSource.Sponsor?)
 }
 
 class NTPDownloader {
@@ -42,7 +42,7 @@ class NTPDownloader {
         self.removeObservers()
     }
     
-    private func getNTPInfo(_ completion: @escaping (NewTabPageBackgroundDataSource.Sponsor?) -> Void) {
+    private func getNTPInfo(_ completion: @escaping (NTPBackgroundDataSource.Sponsor?) -> Void) {
         //Load from cache because the time since the last fetch hasn't expired yet..
         if let nextDate = Preferences.NTP.ntpCheckDate.value,
             Date().timeIntervalSince1970 - nextDate < 0 {
@@ -171,7 +171,7 @@ class NTPDownloader {
         }
     }
     
-    private func loadNTPInfo() -> NewTabPageBackgroundDataSource.Sponsor? {
+    private func loadNTPInfo() -> NTPBackgroundDataSource.Sponsor? {
         do {
             let metadataFileURL = try self.ntpMetadataFileURL()
             if !FileManager.default.fileExists(atPath: metadataFileURL.path) {
@@ -185,21 +185,21 @@ class NTPDownloader {
             }
             
             let downloadsFolderURL = try self.ntpDownloadsURL()
-            let itemInfo = try JSONDecoder().decode(NewTabPageBackgroundDataSource.Sponsor.self, from: metadata)
+            let itemInfo = try JSONDecoder().decode(NTPBackgroundDataSource.Sponsor.self, from: metadata)
             
-            let logo = NewTabPageBackgroundDataSource.Sponsor.Logo(
+            let logo = NTPBackgroundDataSource.Sponsor.Logo(
                 imageUrl: downloadsFolderURL.appendingPathComponent(itemInfo.logo.imageUrl).path,
                 alt: itemInfo.logo.alt,
                 companyName: itemInfo.logo.companyName,
                 destinationUrl: itemInfo.logo.destinationUrl)
             
             let wallpapers = itemInfo.wallpapers.map {
-                NewTabPageBackgroundDataSource.Background(
+                NTPBackgroundDataSource.Background(
                     imageUrl: downloadsFolderURL.appendingPathComponent($0.imageUrl).path,
                     focalPoint: $0.focalPoint)
             }
             
-            return NewTabPageBackgroundDataSource.Sponsor(wallpapers: wallpapers, logo: logo)
+            return NTPBackgroundDataSource.Sponsor(wallpapers: wallpapers, logo: logo)
         } catch {
             logger.error(error)
         }
@@ -273,7 +273,7 @@ class NTPDownloader {
             }
             
             do {
-                let item = try JSONDecoder().decode(NewTabPageBackgroundDataSource.Sponsor.self, from: data)
+                let item = try JSONDecoder().decode(NTPBackgroundDataSource.Sponsor.self, from: data)
                 self.unpackMetadata(item: item) { url, error in
                     completion(url, cacheInfo, error)
                 }
@@ -341,7 +341,7 @@ class NTPDownloader {
     
     // Unpacks NTPItemInfo by downloading all of its assets to a temporary directory
     // and returning the URL to the directory
-    private func unpackMetadata(item: NewTabPageBackgroundDataSource.Sponsor, _ completion: @escaping (URL?, NTPError?) -> Void) {
+    private func unpackMetadata(item: NTPBackgroundDataSource.Sponsor, _ completion: @escaping (URL?, NTPError?) -> Void) {
         let tempDirectory = FileManager.default.temporaryDirectory
         let directory = tempDirectory.appendingPathComponent(NTPDownloader.ntpDownloadsFolder)
         

--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -148,13 +148,17 @@ class NTPDownloader {
             self.timer?.invalidate()
             self.timer = nil
             
-            if let nextDate = Preferences.NTP.ntpCheckDate.value {
+            //If the time hasn't passed yet, reschedule the timer with the relative time..
+            if let nextDate = Preferences.NTP.ntpCheckDate.value,
+                Date().timeIntervalSince1970 - nextDate < 0 {
+                
                 let relativeTime = abs(Date().timeIntervalSince1970 - nextDate)
                 self.timer = Timer.scheduledTimer(withTimeInterval: relativeTime, repeats: true) { [weak self] _ in
                     self?.notifyObservers()
                 }
             } else {
-                self.startNTPTimer()
+                //Else the time has already passed so download the new data, reschedule the timers and notify the observers
+                self.notifyObservers()
             }
         }
     }

--- a/Client/Frontend/Browser/HomePanel/NewTabPageBackgroundDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/NewTabPageBackgroundDataSource.swift
@@ -21,6 +21,13 @@ class NewTabPageBackgroundDataSource {
         /// Whether the background is a packaged resource or a remote one, impacts how it should be loaded
         let packaged: Bool?
         
+        init(imageUrl: String, focalPoint: FocalPoint?) {
+            self.imageUrl = imageUrl
+            self.focalPoint = focalPoint
+            self.credit = nil
+            self.packaged = nil
+        }
+        
         struct Credit: Codable {
             let name: String
             let url: String?
@@ -31,10 +38,9 @@ class NewTabPageBackgroundDataSource {
             let y: CGFloat?
         }
         
-        lazy var imageLiteral: UIImage? = {
+        lazy var image: UIImage? = {
             // Remote resources are downloaded files, so must be loaded differently
-            let image = packaged == true ? UIImage(named: imageUrl) : UIImage(contentsOfFile: imageUrl)
-            return image
+            packaged == true ? UIImage(named: imageUrl) : UIImage(contentsOfFile: imageUrl)
         }()
     }
     
@@ -48,8 +54,8 @@ class NewTabPageBackgroundDataSource {
             let companyName: String
             let destinationUrl: String
             
-            lazy var imageLiteral: UIImage? = {
-                return UIImage(contentsOfFile: imageUrl)
+            lazy var image: UIImage? = {
+                UIImage(contentsOfFile: imageUrl)
             }()
         }
     }

--- a/Client/Frontend/Browser/HomePanel/NewTabPageBackgroundDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/NewTabPageBackgroundDataSource.swift
@@ -18,6 +18,9 @@ class NewTabPageBackgroundDataSource {
         /// Only available for normal wallpapers, not for sponsored images
         let credit: Credit?
         
+        /// Whether the background is a packaged resource or a remote one, impacts how it should be loaded
+        let packaged: Bool?
+        
         struct Credit: Codable {
             let name: String
             let url: String?
@@ -29,7 +32,9 @@ class NewTabPageBackgroundDataSource {
         }
         
         lazy var imageLiteral: UIImage? = {
-            return UIImage(contentsOfFile: imageUrl)
+            // Remote resources are downloaded files, so must be loaded differently
+            let image = packaged == true ? UIImage(named: imageUrl) : UIImage(contentsOfFile: imageUrl)
+            return image
         }()
     }
     

--- a/Client/Frontend/Browser/HomePanel/NewTabPageBackgroundDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/NewTabPageBackgroundDataSource.swift
@@ -29,7 +29,7 @@ class NewTabPageBackgroundDataSource {
         }
         
         lazy var imageLiteral: UIImage? = {
-            return UIImage(named: imageUrl)
+            return UIImage(contentsOfFile: imageUrl)
         }()
     }
     
@@ -44,7 +44,7 @@ class NewTabPageBackgroundDataSource {
             let destinationUrl: String
             
             lazy var imageLiteral: UIImage? = {
-                return UIImage(named: imageUrl)
+                return UIImage(contentsOfFile: imageUrl)
             }()
         }
     }

--- a/Client/Frontend/Browser/HomePanel/ntp-data.json
+++ b/Client/Frontend/Browser/HomePanel/ntp-data.json
@@ -1,5 +1,6 @@
 [
   {
+    "packaged": true,
     "imageUrl": "anders-jilden.jpg",
     "focalPoint": {
       "x": 1200,
@@ -11,6 +12,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "andreas-gucklhorn.jpg",
     "focalPoint": {
       "x": 1160,
@@ -22,6 +24,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "andy-mai.jpg",
     "focalPoint": {
       "x": 988,
@@ -33,6 +36,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "annie-spratt.jpg",
     "focalPoint": {
       "x": 682,
@@ -44,6 +48,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "anton-repponen.jpg",
     "focalPoint": {
       "x": 2185,
@@ -55,6 +60,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "ben-karpinski.jpg",
     "focalPoint": {
       "x": 815,
@@ -66,6 +72,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "dc-cavalleri.jpg",
     "focalPoint": {
       "x": 480,
@@ -77,6 +84,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "joe-gardner.jpg",
     "focalPoint": {
       "x": 1277,
@@ -88,6 +96,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "louis-kim.jpg",
     "focalPoint": {
       "x": 300,
@@ -99,6 +108,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "matt-palmer.jpg",
     "focalPoint": {
       "x": 1205,
@@ -110,6 +120,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "oliwier gesla.jpg",
     "focalPoint": {
       "x": 780,
@@ -121,6 +132,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "Svalbard_Jerol_Soibam.jpeg",
     "focalPoint": {
       "x": 1280,
@@ -132,6 +144,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "will_christiansen_glacier_peak.jpg",
     "focalPoint": {
       "x": 1630,
@@ -143,6 +156,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "will_christiansen_ice.jpg",
     "focalPoint": {
       "x": 1330,
@@ -154,6 +168,7 @@
     }
   },
   {
+    "packaged": true,
     "imageUrl": "xavier-balderas-cejudo.jpg",
     "focalPoint": {
       "x": 1975,

--- a/Client/Frontend/Settings/NTPTableViewController.swift
+++ b/Client/Frontend/Settings/NTPTableViewController.swift
@@ -8,7 +8,7 @@ import BraveShared
 import Shared
 import BraveRewards
 
-class NewTabPageTableViewController: TableViewController {
+class NTPTableViewController: TableViewController {
     let sponsoredRow = Row.boolRow(title: Strings.newTabPageSettingsSponsoredImages, option: Preferences.NewTabPage.backgroundSponsoredImages)
     
     override func viewDidLoad() {

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -161,7 +161,7 @@ class SettingsViewController: TableViewController {
         
         display.rows.append(Row(text: Strings.newTabPageSettingsTitle,
             selection: { [unowned self] in
-                self.navigationController?.pushViewController(NewTabPageTableViewController(), animated: true)
+                self.navigationController?.pushViewController(NTPTableViewController(), animated: true)
             },
             accessory: .disclosureIndicator,
             cellClass: MultilineValue1Cell.self


### PR DESCRIPTION
## Summary of Changes

Not actually sure why `UIImage(named: "/var/UUID/ApplicationSupport/NTPDownloads/someImage.png")` loads "sometimes".. In the debugger, the image NEVER loads and we can never debug it.. It gives an error `"File contains no IDAT"` if we try to watch it as a variable expression.. but in app, it loads "sometimes".. If I change it to `contentsOfFile`, it loads 100% of the time in the debugger so we are doing this to make sure it also loads 100% of the time in app.

This pull request fixes issue #2288 (unconfirmed) #2287
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
