### PR TITLE
Reschedule timers once campaign is dead.

### DIFF
--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -59,19 +59,17 @@ class NTPDownloader {
         self.downloadMetadata { [weak self] url, cacheInfo, error in
             guard let self = self else { return }
             
+            //Start the timer no matter what..
+            self.startNTPTimer()
+            
             if case .campaignEnded = error {
                 do {
                     try self.removeCampaign()
                 } catch {
                     logger.error(error)
                 }
-                
-                self.startNTPTimer()
                 return completion(nil)
             }
-            
-            //Start the timer no matter what..
-            self.startNTPTimer()
             
             if let error = error?.underlyingError() {
                 logger.error(error)
@@ -243,9 +241,6 @@ class NTPDownloader {
     }
     
     func removeCampaign() throws {
-        Preferences.NTP.ntpCheckDate.value = nil
-        self.removeObservers()
-        
         try self.removeETag()
         let downloadsFolderURL = try self.ntpDownloadsURL()
         if FileManager.default.fileExists(atPath: downloadsFolderURL.path) {

--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -66,6 +66,7 @@ class NTPDownloader {
                     logger.error(error)
                 }
                 
+                self.startNTPTimer()
                 return completion(nil)
             }
             


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Reschedule the timer when the campaign is ended anyway.

This pull request fixes issue #<number>
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
