### PR TITLE
Fix #2297 - Disable Bookmarklet URLRequests

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -126,12 +126,8 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
         
-        if url.isBookmarklet && navigationAction.isAllowed {
+        if url.isBookmarklet {
             decisionHandler(.cancel)
-            
-            if let code = url.bookmarkletCodeComponent {
-                webView.evaluateJavaScript(code)
-            }
             return
         }
 


### PR DESCRIPTION
Disable Bookmarklets execution via PrivilegedRequest and NavigationAction entirely. Doesn't matter if it's privileged or allowed or not, just disable it from the URL bar.

This ticket is the exact same as the one discovered by Firefox and the fix is the exact same. See slack channel: https://bravesoftware.slack.com/archives/G2KN13Z8C/p1580533016008700?thread_ts=1580526417.004800&cid=G2KN13Z8C

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2297
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
