### PR TITLE
Fix #2297 - Disable JSContext for any type that is privileged. User must explicitly initiate action.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1120,13 +1120,19 @@ class BrowserViewController: UIViewController {
                 return
             }
             
-            if let webView = tab.webView, let code = url.bookmarkletCodeComponent {
-                resetSpoofedUserAgentIfRequired(webView, newURL: url)
-                webView.evaluateJavaScript(code, completionHandler: { _, error in
-                    if let error = error {
-                        log.error(error)
-                    }
-                })
+            //Another Fix for: https://github.com/brave/brave-ios/pull/2296
+            //Disable any sort of privileged execution contexts
+            //IE: The user must explicitly type OR must explicitly tap a bookmark they have saved.
+            //Block all other contexts such as redirects, downloads, embed, linked, etc..
+            if visitType == .typed || visitType == .bookmark {
+                if let webView = tab.webView, let code = url.bookmarkletCodeComponent {
+                    resetSpoofedUserAgentIfRequired(webView, newURL: url)
+                    webView.evaluateJavaScript(code, completionHandler: { _, error in
+                        if let error = error {
+                            log.error(error)
+                        }
+                    })
+                }
             }
         } else {
             topToolbar.currentURL = url


### PR DESCRIPTION
Disable JSContext for any type that is privileged. User must explicitly initiate action.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2297
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
