### PR TITLE
Fix #2300: Add Brave Rewards panel icon to open rewards settings button

### DIFF
--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -74,7 +74,7 @@ class BraveRewardsSettingsViewController: TableViewController {
                 Section(rows: [
                     Row(text: Strings.openBraveRewardsSettings, selection: { [unowned self] in
                         self.tappedShowRewardsSettings?()
-                    }, cellClass: ButtonCell.self)
+                    }, image: RewardsPanelController.batLogoImage, cellClass: ButtonCell.self)
                 ]),
                 Section(rows: [
                     Row(text: Strings.walletCreationDate, detailText: walletCreatedDate, selection: {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2300

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2020-02-03 at 12 50 58](https://user-images.githubusercontent.com/529104/73677547-7e7d7500-4684-11ea-97e8-92d35ab94527.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
