### PR TITLE
Fix #1397: Save regular tabs that are opened as popups

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -696,7 +696,7 @@ class BrowserViewController: UIViewController {
 
     fileprivate func showRestoreTabsAlert() {
         guard canRestoreTabs() else {
-            self.tabManager.addTabAndSelect()
+            self.tabManager.addTabAndSelect(isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
             return
         }
         let alert = UIAlertController.restoreTabsAlert(
@@ -705,7 +705,7 @@ class BrowserViewController: UIViewController {
             },
             noCallback: { _ in
                 TabMO.deleteAll()
-                self.tabManager.addTabAndSelect()
+                self.tabManager.addTabAndSelect(isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
             }
         )
         self.present(alert, animated: true, completion: nil)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -293,7 +293,7 @@ class TabManager: NSObject {
             tab.expireSnackbars()
         }
     }
-
+    
     func addPopupForParentTab(_ parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
         let popup = Tab(configuration: configuration, type: parentTab.type)
         configureTab(popup, request: nil, afterTab: parentTab, flushToDisk: true, zombie: false, isPopup: true)
@@ -308,25 +308,11 @@ class TabManager: NSObject {
         return popup
     }
     
-    @discardableResult func addTab(_ request: URLRequest! = nil, configuration: WKWebViewConfiguration! = nil, afterTab: Tab? = nil, isPrivate: Bool) -> Tab {
-        return self.addTab(request, configuration: configuration, afterTab: afterTab, flushToDisk: true, zombie: false, isPrivate: isPrivate)
-    }
-
-    @discardableResult func addTabAndSelect(_ request: URLRequest! = nil, configuration: WKWebViewConfiguration! = nil, afterTab: Tab? = nil, isPrivate: Bool) -> Tab {
+    @discardableResult
+    func addTabAndSelect(_ request: URLRequest! = nil, configuration: WKWebViewConfiguration! = nil, afterTab: Tab? = nil, isPrivate: Bool) -> Tab {
         let tab = addTab(request, configuration: configuration, afterTab: afterTab, isPrivate: isPrivate)
         selectTab(tab)
         return tab
-    }
-
-    @discardableResult func addTabAndSelect(_ request: URLRequest! = nil, configuration: WKWebViewConfiguration! = nil, afterTab: Tab? = nil) -> Tab {
-        let tab = addTab(request, configuration: configuration, afterTab: afterTab)
-        selectTab(tab)
-        return tab
-    }
-
-    // This method is duplicated to hide the flushToDisk option from consumers.
-    @discardableResult func addTab(_ request: URLRequest! = nil, configuration: WKWebViewConfiguration! = nil, afterTab: Tab? = nil) -> Tab {
-        return self.addTab(request, configuration: configuration, afterTab: afterTab, flushToDisk: true, zombie: false)
     }
 
     func addTabsForURLs(_ urls: [URL], zombie: Bool, isPrivate: Bool = false) {
@@ -347,8 +333,9 @@ class TabManager: NSObject {
         // Okay now notify that we bulk-loaded so we can adjust counts and animate changes.
         delegates.forEach { $0.get()?.tabManagerDidAddTabs(self) }
     }
-
-    fileprivate func addTab(_ request: URLRequest? = nil, configuration: WKWebViewConfiguration? = nil, afterTab: Tab? = nil, flushToDisk: Bool, zombie: Bool, id: String? = nil, isPrivate: Bool) -> Tab {
+    
+    @discardableResult
+    func addTab(_ request: URLRequest? = nil, configuration: WKWebViewConfiguration? = nil, afterTab: Tab? = nil, flushToDisk: Bool = true, zombie: Bool = false, id: String? = nil, isPrivate: Bool) -> Tab {
         assert(Thread.isMainThread)
 
         // Take the given configuration. Or if it was nil, take our default configuration for the current browsing mode.
@@ -357,27 +344,10 @@ class TabManager: NSObject {
         let type: TabType = isPrivate ? .private : .regular
         let tab = Tab(configuration: configuration, type: type)
         
-        if isPrivate {
-            // Creating random tab id for private mode, as we don't want to save to database.
-            tab.id = UUID().uuidString
-        } else {
-            tab.id = id ?? TabMO.create()
-        }
-        
-        configureTab(tab, request: request, afterTab: afterTab, flushToDisk: flushToDisk, zombie: zombie, isPrivate: isPrivate)
+        configureTab(tab, request: request, afterTab: afterTab, flushToDisk: flushToDisk, zombie: zombie, id: id)
         return tab
     }
 
-    fileprivate func addTab(_ request: URLRequest? = nil, configuration: WKWebViewConfiguration? = nil, afterTab: Tab? = nil, flushToDisk: Bool, zombie: Bool) -> Tab {
-        assert(Thread.isMainThread)
-
-        let tab = Tab(configuration: configuration ?? self.configuration)
-        tab.id = TabMO.create()
-        
-        configureTab(tab, request: request, afterTab: afterTab, flushToDisk: flushToDisk, zombie: zombie)
-        return tab
-    }
-    
     func moveTab(_ tab: Tab, toIndex visibleToIndex: Int) {
         assert(Thread.isMainThread)
         
@@ -408,9 +378,17 @@ class TabManager: NSObject {
         TabMO.saveTabOrder(tabIds: allTabIds)
     }
 
-    func configureTab(_ tab: Tab, request: URLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool, isPopup: Bool = false, isPrivate: Bool = false) {
+    func configureTab(_ tab: Tab, request: URLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool, id: String? = nil, isPopup: Bool = false) {
         assert(Thread.isMainThread)
-
+        
+        let isPrivate = tab.type == .private
+        if isPrivate {
+            // Creating random tab id for private mode, as we don't want to save to database.
+            tab.id = UUID().uuidString
+        } else {
+            tab.id = id ?? TabMO.create()
+        }
+        
         delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }
 
         if parent == nil || parent?.type != tab.type {

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -190,7 +190,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
                         (.webSiteData, true)
                         ])
                 }
-                self.tabManager.removeTab(self.tabManager.addTab())
+                self.tabManager.removeTab(self.tabManager.addTab(isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing))
             }
         })
     }

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -166,7 +166,7 @@ class TabManagerTests: XCTestCase {
         manager.addDelegate(delegate)
         
         delegate.expect([willAdd, didAdd])
-        manager.addTab()
+        manager.addTab(isPrivate: false)
         delegate.verify("Not all delegate methods were called")
     }
     
@@ -174,7 +174,7 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
         manager.selectTab(tab)
         manager.addDelegate(delegate)
         
@@ -212,7 +212,7 @@ class TabManagerTests: XCTestCase {
     
     func testDeletePrivateTabsOnExit() {
         // create one private and one normal tab
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
         manager.selectTab(tab)
         manager.selectTab(manager.addTab(isPrivate: true))
         
@@ -231,15 +231,15 @@ class TabManagerTests: XCTestCase {
         manager.selectTab(manager.addTab(isPrivate: true))
         manager.selectTab(manager.addTab(isPrivate: true))
         XCTAssertEqual(manager.tabs(withType: .private).count, 2, "Private tabs should not be deleted when another one is added")
-        manager.selectTab(manager.addTab())
+        manager.selectTab(manager.addTab(isPrivate: false))
         XCTAssertEqual(manager.tabs(withType: .private).count, 0, "But once we add a normal tab we've switched out of private mode. Private tabs should be deleted")
         XCTAssertEqual(manager.tabs(withType: .regular).count, 2, "The original normal tab and the new one should both still exist")
     }
     
     func testTogglePBMDelete() {
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
         manager.selectTab(tab)
-        manager.selectTab(manager.addTab())
+        manager.selectTab(manager.addTab(isPrivate: false))
         manager.selectTab(manager.addTab(isPrivate: true))
         
         manager.willSwitchTabMode(leavingPBM: false)
@@ -254,10 +254,10 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
         manager.selectTab(tab)
-        manager.addTab()
-        let deleteTab = manager.addTab()
+        manager.addTab(isPrivate: false)
+        let deleteTab = manager.addTab(isPrivate: false)
         manager.addDelegate(delegate)
         
         delegate.expect([willRemove, didRemove])
@@ -270,7 +270,7 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         
         func addTab(_ visit: Bool) -> Tab {
-            let tab = manager.addTab()
+            let tab = manager.addTab(isPrivate: false)
             if visit {
                 tab.lastExecutedTime = Date.now()
             }
@@ -309,7 +309,7 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
-        (0..<10).forEach {_ in manager.addTab() }
+        (0..<10).forEach {_ in manager.addTab(isPrivate: false) }
         manager.selectTab(manager.allTabs.last)
         let deleteTab = manager.allTabs.last
         let newSelectedTab = manager.allTabs[8]
@@ -332,8 +332,8 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         
         // create one private and one normal tab
-        let tab = manager.addTab()
-        let newTab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
+        let newTab = manager.addTab(isPrivate: false)
         manager.selectTab(tab)
         manager.selectTab(manager.addTab(isPrivate: true))
         manager.addDelegate(delegate)
@@ -370,7 +370,7 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         
         //create the tab before adding the mock delegate. So we don't have to check delegate calls we dont care about
-        (0..<10).forEach {_ in manager.addTab() }
+        (0..<10).forEach {_ in manager.addTab(isPrivate: false) }
         manager.selectTab(manager.allTabs.first)
         let deleteTab = manager.allTabs.first
         let newSelectedTab = manager.allTabs[1]
@@ -394,10 +394,10 @@ class TabManagerTests: XCTestCase {
         
         // We add 2 tabs. Then a private one before adding another normal tab and selecting it.
         // Make sure that when the last one is deleted we dont switch to the private tab
-        manager.addTab()
-        let newSelected = manager.addTab()
+        manager.addTab(isPrivate: false)
+        let newSelected = manager.addTab(isPrivate: false)
         manager.addTab(isPrivate: true)
-        let deleted = manager.addTab()
+        let deleted = manager.addTab(isPrivate: false)
         manager.selectTab(manager.allTabs.last)
         manager.addDelegate(delegate)
         
@@ -418,10 +418,10 @@ class TabManagerTests: XCTestCase {
         
         // We add 2 tabs. Then a private one before adding another normal tab and selecting the first.
         // Make sure that when the last one is deleted we dont switch to the private tab
-        let deleted = manager.addTab()
-        let newSelected = manager.addTab()
+        let deleted = manager.addTab(isPrivate: false)
+        let newSelected = manager.addTab(isPrivate: false)
         manager.addTab(isPrivate: true)
-        manager.addTab()
+        manager.addTab(isPrivate: false)
         manager.selectTab(manager.allTabs.first)
         manager.addDelegate(delegate)
         
@@ -439,7 +439,7 @@ class TabManagerTests: XCTestCase {
     func testRemoveOnlyTab() {
         let delegate = MockTabManagerDelegate()
         
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
         
         manager.addDelegate(delegate)
         delegate.expect([willRemove, didRemove, willAdd, didAdd, MethodSpy(functionName: "tabManager(_:didSelectedTabChange:previous:)")])
@@ -452,7 +452,7 @@ class TabManagerTests: XCTestCase {
     }
     
     func testRemoveAllTabs() {
-        (0..<10).forEach { _ in manager.addTab() }
+        (0..<10).forEach { _ in manager.addTab(isPrivate: false) }
         manager.removeAll()
         
         XCTAssertFalse(manager.allTabs.isEmpty, "Should create a new tab when all others are removed")
@@ -460,10 +460,10 @@ class TabManagerTests: XCTestCase {
     }
     
     func testMoveTabToEnd() {
-        let firstTab = manager.addTabAndSelect()
-        let secondTab = manager.addTab()
+        let firstTab = manager.addTabAndSelect(isPrivate: false)
+        let secondTab = manager.addTab(isPrivate: false)
         manager.addTab(isPrivate: true)
-        let thirdTab = manager.addTab()
+        let thirdTab = manager.addTab(isPrivate: false)
         
         manager.moveTab(firstTab, toIndex: manager.tabs(withType: .regular).count - 1)
         
@@ -474,10 +474,10 @@ class TabManagerTests: XCTestCase {
     }
     
     func testMoveTabToStart() {
-        let firstTab = manager.addTabAndSelect()
-        let secondTab = manager.addTab()
+        let firstTab = manager.addTabAndSelect(isPrivate: false)
+        let secondTab = manager.addTab(isPrivate: false)
         manager.addTab(isPrivate: true)
-        let thirdTab = manager.addTab()
+        let thirdTab = manager.addTab(isPrivate: false)
         
         manager.moveTab(thirdTab, toIndex: 0)
         
@@ -488,11 +488,11 @@ class TabManagerTests: XCTestCase {
     }
     
     func testMoveTabToMiddle() {
-        let firstTab = manager.addTab()
-        let secondTab = manager.addTab()
+        let firstTab = manager.addTab(isPrivate: false)
+        let secondTab = manager.addTab(isPrivate: false)
         manager.addTab(isPrivate: true)
-        let thirdTab = manager.addTabAndSelect()
-        let forthTab = manager.addTab()
+        let thirdTab = manager.addTabAndSelect(isPrivate: false)
+        let forthTab = manager.addTab(isPrivate: false)
         
         manager.moveTab(forthTab, toIndex: 1)
         
@@ -508,7 +508,7 @@ class TabManagerTests: XCTestCase {
         DataController.shared = InMemoryDataController()
         
         delegate.expect([willAdd, didAdd])
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
         wait(1)
         delegate.verify("Not all delegate methods were called")
         
@@ -540,7 +540,7 @@ class TabManagerTests: XCTestCase {
         delegate.expect([willAdd, didAdd, willAdd, didAdd])
         manager.addTab(isPrivate: true)
 
-        let tab = manager.addTab()
+        let tab = manager.addTab(isPrivate: false)
         wait(1)
         delegate.verify("Not all delegate methods were called")
         


### PR DESCRIPTION
Also refactors out a bunch of `addTab` methods in TabManager

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fixes #1397 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
