### PR TITLE
Fix #2184: Making the Reload Button VoiceOver Accessible

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -163,6 +163,7 @@ class TabLocationView: UIView {
     
     lazy var reloadButton = ToolbarButton(top: true).then {
         $0.accessibilityIdentifier = "TabToolbar.stopReloadButton"
+        $0.isAccessibilityElement = true
         $0.accessibilityLabel = Strings.tabToolbarReloadButtonAccessibilityLabel
         $0.setImage(#imageLiteral(resourceName: "nav-refresh").template, for: .normal)
         $0.tintColor = UIColor.Photon.grey30
@@ -256,7 +257,7 @@ class TabLocationView: UIView {
 
     override var accessibilityElements: [Any]? {
         get {
-            return [lockImageView, urlTextField, readerModeButton].filter { !$0.isHidden }
+            return [lockImageView, urlTextField, readerModeButton, reloadButton].filter { !$0.isHidden }
         }
         set {
             super.accessibilityElements = newValue


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Resolving an issue where the reload button was not accessible when using VoiceOver controls.
This pull request fixes issue #2184 

**Aside**: Currently the Shields button and the Rewards Button are not VoiceOver accessible. Making the buttons themselves accessible are not an issue however the popover views as they exist today would trap VoiceOver users on the respective screens. The popovers are dismissed when tapping outside the popover modal or drag/swiping them away; both of these options are not available when VoiceOver is activated. An option would be to add a _Close_ or _X_ button on the views that VoiceOver users could use to close out the view. These issues should probably be addressed in another ticket. 
 

## Submitter Checklist:


- [X] *Unit Tests* are updated to cover new or changed functionality
- [X] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Enable VoiceOver and very the reload bottom in discoverable and usable on multiple web pages. 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
