### PR TITLE
Fix #2235: Adjusting Padding in DDG Logo and Font

### DIFF
--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -25,6 +25,7 @@ class FavoritesViewController: UIViewController, Themeable {
         static let statsHeight: CGFloat = 110.0
         static let statsBottomMargin: CGFloat = 5
         static let searchEngineCalloutPadding: CGFloat = 120.0
+        static let ddgButtonPadding: CGFloat = 12
     }
     
     weak var delegate: FavoritesDelegate?
@@ -109,7 +110,7 @@ class FavoritesViewController: UIViewController, Themeable {
     private let ddgLabel = UILabel().then {
         $0.numberOfLines = 0
         $0.textColor = BraveUX.greyD
-        $0.font = UIFont.systemFont(ofSize: 14, weight: UIFont.Weight.regular)
+        $0.font = UIFont.systemFont(ofSize: 13, weight: UIFont.Weight.bold)
         $0.text = Strings.DDGPromotion
     }
     
@@ -457,13 +458,14 @@ class FavoritesViewController: UIViewController, Themeable {
     // MARK: - Constraints setup
     fileprivate func makeConstraints() {
         ddgLogo.snp.makeConstraints { make in
-            make.top.left.bottom.equalTo(0)
+            make.top.left.greaterThanOrEqualTo(UI.ddgButtonPadding)
+            make.centerY.equalToSuperview()
             make.size.equalTo(38)
         }
         
         ddgLabel.snp.makeConstraints { make in
-            make.top.bottom.equalTo(0)
-            make.right.equalToSuperview().offset(-5)
+            make.top.bottom.greaterThanOrEqualTo(UI.ddgButtonPadding)
+            make.right.equalToSuperview().offset(-UI.ddgButtonPadding)
             make.left.equalTo(self.ddgLogo.snp.right).offset(5)
             make.width.equalTo(180)
             make.centerY.equalTo(self.ddgLogo)


### PR DESCRIPTION
## Summary of Changes

Adjusting the text and padding in DDG Button.
- Change font from `14 Regular` -> `13 Bold`
- Change padding from `0` -> `12 Points`
This pull request fixes issue #2235 

## Submitter Checklist:

- [X] *Unit Tests* are updated to cover new or changed functionality
- [X] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:

**BEFORE**
![DDG-Learn_Before](https://user-images.githubusercontent.com/43318682/74208702-a6f00b00-4c52-11ea-8bc6-7b0abf4ef3da.png)





**AFTER:**
![DDG-Learn_Updates_13boldfont+12padding_nostack](https://user-images.githubusercontent.com/43318682/74210942-bd4e9480-4c5b-11ea-811b-8d85f3b63e0a.png)



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
