### PR TITLE
Fix #2041 - Session storage not clearing when toggling the PBO switch.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -411,6 +411,7 @@ extension Strings {
 
 extension Strings {
     public static let home = NSLocalizedString("Home", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Home", comment: "")
+    public static let clearingData = NSLocalizedString("ClearData", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Clearing Data", comment: "")
 }
 
 extension Strings {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -730,6 +730,7 @@
 		5E0FCD212342526700AC831E /* FullscreenHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 5EB57D0122FDC0CB00A07325 /* FullscreenHelper.js */; };
 		5E0FCD23234253DC00AC831E /* CertificatePinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FCD22234253DC00AC831E /* CertificatePinning.swift */; };
 		5E0FCD252342544C00AC831E /* URLSession+Requests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FCD242342544C00AC831E /* URLSession+Requests.swift */; };
+		5E1645A824ABA35B0003C3B2 /* SpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1645A724ABA35B0003C3B2 /* SpinnerView.swift */; };
 		5E3477E922D7771700B0D5F8 /* ResourceDownloader.js in Resources */ = {isa = PBXBuildFile; fileRef = 5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */; };
 		5E34781022D7A1D200B0D5F8 /* ResourceDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */; };
 		5E46C371234FACC600ACA8C1 /* root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5E46C36D234FACC600ACA8C1 /* root.cer */; };
@@ -2275,6 +2276,7 @@
 		5E0FCD22234253DC00AC831E /* CertificatePinning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatePinning.swift; sourceTree = "<group>"; };
 		5E0FCD242342544C00AC831E /* URLSession+Requests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Requests.swift"; sourceTree = "<group>"; };
 		5E11C3FF23314D970003C363 /* onboarding-ads.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-ads.json"; sourceTree = "<group>"; };
+		5E1645A724ABA35B0003C3B2 /* SpinnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerView.swift; sourceTree = "<group>"; };
 		5E1D8C66232BE43100BDE662 /* OnboardingAdsAvailableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAdsAvailableController.swift; sourceTree = "<group>"; };
 		5E1D8C68232BE47A00BDE662 /* OnboardingAdsAvailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAdsAvailableView.swift; sourceTree = "<group>"; };
 		5E1D8C6A232BF95200BDE662 /* OnboardingRewardsAgreementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRewardsAgreementViewController.swift; sourceTree = "<group>"; };
@@ -4690,6 +4692,7 @@
 				59A68B1F857A8638598A63A0 /* TwoLineCell.swift */,
 				D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */,
 				27D87C2D2152B50200FB55C6 /* GradientView.swift */,
+				5E1645A724ABA35B0003C3B2 /* SpinnerView.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -6885,6 +6888,7 @@
 				0A8C6993225BC7B100988715 /* ToolbarUrlActionsProtocol.swift in Sources */,
 				0AFC8F9523D1DF6500941895 /* TranslucentBottomSheet.swift in Sources */,
 				E68E7ADA1CAC207400FDCA76 /* ChangePasscodeViewController.swift in Sources */,
+				5E1645A824ABA35B0003C3B2 /* SpinnerView.swift in Sources */,
 				E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */,
 				4422D4BF21BFFB7600BF1855 /* logging.cc in Sources */,
 				A1AD4BD420BF4757007A6EA1 /* ImageCache.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3617,9 +3617,6 @@ extension BrowserViewController: PreferencesObserver {
             updateTabsBarVisibility()
             updateApplicationShortcuts()
             if isPrivate { //When PBO is turned ON, we remove all tabs and configurations.
-                tabManager.removeAll()
-                tabManager.resetConfiguration()
-                
                 // Clear ALL data when going from normal mode to private
                 // The other way around is handled in `removeTab`
                 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3616,26 +3616,6 @@ extension BrowserViewController: PreferencesObserver {
             setupTabs()
             updateTabsBarVisibility()
             updateApplicationShortcuts()
-            /*if isPrivate { //When PBO is turned ON, we remove all tabs and configurations.
-                // Clear ALL data when going from normal mode to private
-                // The other way around is handled in `removeTab`
-                
-                //If I don't dispatch after, the WKWebsiteDataStore has no time to sync its process.
-                //This is a bug in WebKit itself. If this isn't done, data is NOT cleared!
-                let group = DispatchGroup()
-                group.enter()
-                DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.1) {
-                    let clearables: [Clearable] = [CookiesAndCacheClearable()]
-                    ClearPrivateDataTableViewController.clearPrivateData(clearables).uponQueue(.main) { [weak self] in
-                        defer { group.leave() }
-                        guard let self = self else { return }
-                        self.tabManager.removeAll()
-                        self.tabManager.reset()
-                    }
-                }
-                
-                group.wait(timeout: .now() + 10.0)
-            }*/
         case Preferences.General.alwaysRequestDesktopSite.key:
             tabManager.reset()
             self.tabManager.reloadSelectedTab()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3616,7 +3616,7 @@ extension BrowserViewController: PreferencesObserver {
             setupTabs()
             updateTabsBarVisibility()
             updateApplicationShortcuts()
-            if isPrivate { //When PBO is turned ON, we remove all tabs and configurations.
+            /*if isPrivate { //When PBO is turned ON, we remove all tabs and configurations.
                 // Clear ALL data when going from normal mode to private
                 // The other way around is handled in `removeTab`
                 
@@ -3635,7 +3635,7 @@ extension BrowserViewController: PreferencesObserver {
                 }
                 
                 group.wait(timeout: .now() + 10.0)
-            }
+            }*/
         case Preferences.General.alwaysRequestDesktopSite.key:
             tabManager.reset()
             self.tabManager.reloadSelectedTab()

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -429,8 +429,15 @@ class SettingsViewController: TableViewController {
                                 let clearables: [Clearable] = [CookiesAndCacheClearable()]
                                 ClearPrivateDataTableViewController.clearPrivateData(clearables).uponQueue(.main) { [weak self] in
                                     guard let self = self else { return }
+                                    
+                                    //First remove all tabs so that only a blank tab exists.
                                     self.tabManager.removeAll()
+                                    
+                                    //Reset tab configurations and delete all webviews..
                                     self.tabManager.reset()
+                                    
+                                    //Restore all existing tabs by removing the blank tabs and recreating new ones..
+                                    self.tabManager.removeAll()
                                     
                                     spinner.dismiss()
                                     applyThemeBlock()

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -419,11 +419,9 @@ class SettingsViewController: TableViewController {
                         }))
 
                         alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: { _ in
-                            let oldItem = self.navigationItem.rightBarButtonItem
-                            self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: UIActivityIndicatorView(style: .white).then {
-                                $0.color = UX.braveOrange
-                                $0.startAnimating()
-                            })
+                            let spinner = SpinnerView().then {
+                                $0.present(on: self.view)
+                            }
                             
                             Preferences.Privacy.privateBrowsingOnly.value = value
                             
@@ -434,7 +432,7 @@ class SettingsViewController: TableViewController {
                                     self.tabManager.removeAll()
                                     self.tabManager.reset()
                                     
-                                    self.navigationItem.rightBarButtonItem = oldItem
+                                    spinner.dismiss()
                                     applyThemeBlock()
                                 }
                             }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -419,8 +419,25 @@ class SettingsViewController: TableViewController {
                         }))
 
                         alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: { _ in
+                            let oldItem = self.navigationItem.rightBarButtonItem
+                            self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: UIActivityIndicatorView(style: .white).then {
+                                $0.color = UX.braveOrange
+                                $0.startAnimating()
+                            })
+                            
                             Preferences.Privacy.privateBrowsingOnly.value = value
-                            applyThemeBlock()
+                            
+                            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.1) {
+                                let clearables: [Clearable] = [CookiesAndCacheClearable()]
+                                ClearPrivateDataTableViewController.clearPrivateData(clearables).uponQueue(.main) { [weak self] in
+                                    guard let self = self else { return }
+                                    self.tabManager.removeAll()
+                                    self.tabManager.reset()
+                                    
+                                    self.navigationItem.rightBarButtonItem = oldItem
+                                    applyThemeBlock()
+                                }
+                            }
                         }))
 
                         self.present(alert, animated: true, completion: nil)

--- a/Client/Frontend/Widgets/SpinnerView.swift
+++ b/Client/Frontend/Widgets/SpinnerView.swift
@@ -1,0 +1,104 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import Shared
+
+class SpinnerView: UIView {
+    
+    struct DefaultUX {
+        static let backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        static let spinnerBackgroundColor = UIColor.black.withAlphaComponent(0.60)
+        static let cornerRadius = 10.0
+        static let animationSpeed = 0.25
+        static let insets = 20.0
+    }
+    
+    private let container = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .center
+        $0.spacing = 6.0
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layoutMargins = UIEdgeInsets(equalInset: 15.0)
+    }
+    
+    private let backgroundView = UIView().then {
+        $0.layer.masksToBounds = true
+        $0.layer.cornerRadius = CGFloat(DefaultUX.cornerRadius)
+        $0.backgroundColor = DefaultUX.spinnerBackgroundColor
+    }
+    
+    private let activityView = UIActivityIndicatorView(style: .whiteLarge).then {
+        $0.color = .white
+        $0.startAnimating()
+    }
+    
+    private let textLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 16.0, weight: .medium)
+        $0.textColor = .white
+        $0.text = Strings.clearingData
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = DefaultUX.backgroundColor
+        
+        addSubview(backgroundView)
+        backgroundView.addSubview(container)
+        
+        backgroundView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.leading.greaterThanOrEqualTo(self.safeArea.leading).offset(DefaultUX.insets)
+            $0.trailing.lessThanOrEqualTo(self.safeArea.trailing).offset(-DefaultUX.insets)
+            $0.top.greaterThanOrEqualTo(self.safeArea.top).offset(DefaultUX.insets)
+            $0.bottom.lessThanOrEqualTo(self.safeArea.bottom).offset(-DefaultUX.insets)
+            $0.width.equalTo(backgroundView.snp.height)
+            $0.height.equalTo(backgroundView.snp.width)
+        }
+        
+        container.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        container.addArrangedSubview(activityView)
+        container.addArrangedSubview(textLabel)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public func present(on view: UIView) {
+        if self.superview != nil {
+            return
+        }
+        
+        self.alpha = 0.0
+        
+        view.window?.addSubview(self)
+        self.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        UIView.animate(withDuration: DefaultUX.animationSpeed) {
+            self.alpha = 1.0
+        }
+    }
+    
+    public func dismiss() {
+        if self.superview == nil {
+            return
+        }
+        
+        self.alpha = 1.0
+        UIView.animate(withDuration: DefaultUX.animationSpeed, animations: {
+            self.alpha = 0.0
+        }, completion: { _ in
+            self.removeFromSuperview()
+        })
+    }
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes session storage not being cleared due to a race-condition in WKWebsiteDataStore. 
- Also added a popup UI to block the user from toggling the switch back & forth until the data has actually been cleared.

This pull request fixes issue #2041
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
