### PR TITLE
Fix #2325: Re download NTP assets immediately once setting is re-enab…

### DIFF
--- a/Client/Frontend/Browser/HomePanel/NTPBackgroundDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPBackgroundDataSource.swift
@@ -204,6 +204,7 @@ extension NTPBackgroundDataSource: PreferencesObserver {
         if sponsoredPref.key == key {
             if sponsoredPref.value {
                 // Enabled? -> issue download
+                Preferences.NTP.ntpCheckDate.value = nil
                 downloader.delegate = self
 
             } else {


### PR DESCRIPTION
…led.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2325
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
str in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
