### PR TITLE
Fix #2337: TabContentScript memory leak.

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -263,6 +263,8 @@ class Tab: NSObject {
     }
     
     func deleteWebView() {
+        contentScriptManager.uninstall(from: self)
+        
         if let webView = webView {
             webView.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
             tabDelegate?.tab?(self, willDeleteWebView: webView)
@@ -540,6 +542,14 @@ extension Tab: TabWebViewDelegate {
 
 private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
     fileprivate var helpers = [String: TabContentScript]()
+    
+    func uninstall(from tab: Tab) {
+        helpers.forEach {
+            if let name = $0.value.scriptMessageHandlerName() {
+                tab.webView?.configuration.userContentController.removeScriptMessageHandler(forName: name)
+            }
+        }
+    }
 
     @objc func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         for helper in helpers.values {

--- a/Client/WebAuthN/U2FExtensions.swift
+++ b/Client/WebAuthN/U2FExtensions.swift
@@ -231,8 +231,8 @@ class U2FExtensions: NSObject {
         
         super.init()
         
-        let handleCancelButton: () -> PopupViewDismissType = {
-            self.sendJSError()
+        let handleCancelButton: () -> PopupViewDismissType = { [weak self] in
+            self?.sendJSError()
             return .flyDown
         }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2337 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
For devs only:
you can add `deinit` in `TabContentScriptManager` and `U2F extensions` to verify it gets deallocated properly

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
