### PR TITLE
Fix #2333 - Fixes issue where rewards SummaryView is null.

### DIFF
--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -224,7 +224,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
       self.state.delegate?.loadNewTabWithURL(url)
     }
     
-    walletView.rewardsSummaryView?.disclaimerView?.labels.forEach {
+    rewardsSummaryView.disclaimerView?.labels.forEach {
       $0.onLinkedTapped = { [weak self] link in
         guard let self = self, let disclaimerLink = RewardsSummaryLink(rawValue: link.absoluteString) else { return }
         switch disclaimerLink {


### PR DESCRIPTION
Fixes issue where Wallet.rewardsSummaryView is nil and not set to self.summaryView before setup is called.. therefore accessing it is a NOP and event handlers aren't triggered.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2333
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
