### PR TITLE
Fix #2344: Add default font color for `accessoryLabel` of TableViewCell.

### DIFF
--- a/BraveRewardsUI/Common/Tables/TableViewCell.swift
+++ b/BraveRewardsUI/Common/Tables/TableViewCell.swift
@@ -31,14 +31,13 @@ class TableViewCell: UITableViewCell, TableViewReusable {
     }
     
     switch style {
-    case .default:
+    case .default, .subtitle, .value2:
       accessoryLabel = nil
     case .value1:
       accessoryLabel = UILabel().then {
         $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+        $0.appearanceTextColor = Colors.grey100
       }
-    case .subtitle, .value2:
-      fallthrough
     @unknown default:
       fatalError("Currently not supported")
     }

--- a/BraveRewardsUI/Pending Contributions/PendingContributionDetailController.swift
+++ b/BraveRewardsUI/Pending Contributions/PendingContributionDetailController.swift
@@ -85,6 +85,7 @@ extension PendingContributionDetailController: UITableViewDataSource {
       cell.label.font = SettingsUX.bodyFont
       cell.accessoryLabel?.font = SettingsUX.bodyFont
       cell.manualSeparators = []
+      cell.selectionStyle = .none
       switch row {
       case .type:
         cell.label.text = Strings.pendingContributionType

--- a/BraveRewardsUI/Pending Contributions/PendingContributionListController.swift
+++ b/BraveRewardsUI/Pending Contributions/PendingContributionListController.swift
@@ -57,6 +57,11 @@ final class PendingContributionListController: UIViewController {
     
     title = Strings.pendingContributionsTitle.capitalized
     
+    navigationController?.toolbar.do {
+      $0.appearanceBarTintColor = nil
+      $0.appearanceBackgroundColor = nil
+    }
+    
     navigationItem.rightBarButtonItem = editButton
     toolbarItems = [
       .init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),

--- a/BraveRewardsUI/Settings/Ads/Details/AdsDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Ads/Details/AdsDetailsViewController.swift
@@ -126,7 +126,6 @@ extension AdsDetailsViewController: UITableViewDelegate, UITableViewDataSource {
     cell.label.font = SettingsUX.bodyFont
     cell.label.numberOfLines = 0
     cell.label.lineBreakMode = .byWordWrapping
-    cell.accessoryLabel?.appearanceTextColor = Colors.grey100
     cell.accessoryLabel?.font = SettingsUX.bodyFont
     cell.accessoryType = .none
     switch row {

--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -268,7 +268,6 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       cell.label.font = SettingsUX.bodyFont
       cell.label.appearanceTextColor = .black
       cell.label.numberOfLines = 0
-      cell.accessoryLabel?.appearanceTextColor = Colors.grey100
       cell.accessoryLabel?.font = SettingsUX.bodyFont
       cell.accessoryType = .none
       cell.selectionStyle = .none
@@ -293,7 +292,6 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       cell.label.font = SettingsUX.bodyFont
       cell.label.appearanceTextColor = .black
       cell.label.numberOfLines = 0
-      cell.accessoryLabel?.appearanceTextColor = Colors.grey100
       cell.accessoryLabel?.font = UIFont.monospacedDigitSystemFont(ofSize: 14.0, weight: .semibold)
       cell.accessoryType = .disclosureIndicator
       cell.selectionStyle = .default
@@ -313,7 +311,6 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       cell.label.font = SettingsUX.bodyFont
       cell.label.numberOfLines = 0
       cell.label.lineBreakMode = .byWordWrapping
-      cell.accessoryLabel?.appearanceTextColor = Colors.grey100
       cell.accessoryLabel?.font = SettingsUX.bodyFont
       cell.accessoryType = row.accessoryType
       switch row {

--- a/BraveRewardsUI/Settings/SettingsTableView.swift
+++ b/BraveRewardsUI/Settings/SettingsTableView.swift
@@ -16,6 +16,7 @@ class SettingsTableView: UIView {
     }
     tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: CGFloat.leastNormalMagnitude))
     tableView.separatorInset = .zero
+    tableView.appearanceSeparatorColor = nil
     
     addSubview(tableView)
     tableView.snp.makeConstraints {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes issue #2344 
<!-- If no ticket has been fixed, please file one now: https://github.com/brave/brave-ios/issues -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
