### PR TITLE
Fix #2365: Making Shields Menu More VoiceOver Accessible

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -733,3 +733,10 @@ extension Strings {
     
 }
 
+// MARK: - Popover Views
+extension Strings {
+    public struct Popover {
+        public static let closeContextMenu = NSLocalizedString("PopoverDefaultClose", bundle: Bundle.braveShared, value: "Close Context Menu", comment: "Description for closing a popover menu that is displayed.")
+        public static let closeShieldsMenu = NSLocalizedString("PopoverShieldsMenuClose", bundle: Bundle.braveShared, value: "Close Shields Menu", comment: "Description for closing the `Brave Shields` popover menu that is displayed.")
+    }
+}

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -257,7 +257,7 @@ class TabLocationView: UIView {
 
     override var accessibilityElements: [Any]? {
         get {
-            return [lockImageView, urlTextField, readerModeButton, reloadButton].filter { !$0.isHidden }
+            return [lockImageView, urlTextField, readerModeButton, reloadButton, shieldsButton].filter { !$0.isHidden }
         }
         set {
             super.accessibilityElements = newValue

--- a/Client/Frontend/Popover/PopoverContentComponent.swift
+++ b/Client/Frontend/Popover/PopoverContentComponent.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+import Shared
 
 /// Defines behavior of a component which will be used with a `PopoverController`
 protocol PopoverContentComponent {
@@ -16,6 +17,9 @@ protocol PopoverContentComponent {
     /// Allows the component to decide whether or not the popover should dismiss based on some gestural action (tapping
     /// the background around the popover or dismissing via pan). Optional, true by defualt
     func popoverShouldDismiss(_ popoverController: PopoverController) -> Bool
+
+    /// Description for closing the popover view for accessibility users
+    var closeActionAccessibilityLabel: String { get }
 }
 
 extension PopoverContentComponent {
@@ -32,6 +36,10 @@ extension PopoverContentComponent {
     }
     
     func popoverDidDismiss(_ popoverController: PopoverController) {
+    }
+
+    var closeActionAccessibilityLabel: String {
+        return Strings.Popover.closeContextMenu
     }
 }
 

--- a/Client/Frontend/Popover/PopoverController.swift
+++ b/Client/Frontend/Popover/PopoverController.swift
@@ -117,7 +117,11 @@ class PopoverController: UIViewController {
         super.viewDidLoad()
         
         backgroundOverlayView.backgroundColor = UIColor(white: 0.0, alpha: 0.2)
-        backgroundOverlayView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tappedBackgroundOverlay(_:))))
+        let backgroundTap = UITapGestureRecognizer(target: self, action: #selector(tappedBackgroundOverlay(_:)))
+        backgroundOverlayView.isAccessibilityElement = true
+        backgroundOverlayView.accessibilityLabel = contentController.closeActionAccessibilityLabel
+        backgroundOverlayView.accessibilityElements = [backgroundTap]
+        backgroundOverlayView.addGestureRecognizer(backgroundTap)
         
         let pan = UIPanGestureRecognizer(target: self, action: #selector(pannedPopover(_:)))
         pan.delegate = self

--- a/Client/Frontend/Shields/ShieldsView.swift
+++ b/Client/Frontend/Shields/ShieldsView.swift
@@ -314,3 +314,10 @@ extension ShieldsViewController {
         }
     }
 }
+
+extension ShieldsViewController {
+
+    var closeActionAccessibilityLabel: String {
+        return Strings.Popover.closeShieldsMenu
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Attempting to make the `PopoverController` more VoiceOver accessible by adding accessibility action to `backgroundOverlay` view.

This pull request fixes #2365

This seems to work for fixing the Brave Shields, Settings Button but not the Rewards Button.
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
