### PR TITLE
fix #2370 - set background to black

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -57,7 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         self.application = application
         self.launchOptions = launchOptions
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        self.window!.backgroundColor = UIColor.Photon.white100
+        self.window!.backgroundColor = .black
         
         SceneObserver.setupApplication(window: self.window!)
 

--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -96,7 +96,5 @@ extension Theme {
         
         // This solves bunch of small theming problems like disclosure indicators color, cell highlight color..
         UIView.appearance(whenContainedInInstancesOf: [RewardsPanelController.self]).appearanceOverrideUserInterfaceStyle = .light
-        
-        (UIApplication.shared.delegate as? AppDelegate)?.window?.backgroundColor = colors.home
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2370 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

Have more than 4 favorites so the "show more" button is shown.

*Dark Mode* (should be no changes)
- click "Show More"
- Verify the app background (farthest back view, see screenshots in ticket / below) is _black_

*Light Mode* (this has changed from app store version)
- click "Show More"
- Verify the app background (farthest back view, see screenshots in ticket / below) is _black_


## Screenshots:

This is what should be seen on the light theme now (notice how the far back view is now black).
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
<img width="584" alt="Screen Shot 2020-02-24 at 10 31 01 PM" src="https://user-images.githubusercontent.com/318119/75221023-a5940780-5755-11ea-9b9b-ac74a24d69ea.png">
