### PR TITLE
Fix #2375: Crash when NTP resource is downloaded with network error.

### DIFF
--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -320,15 +320,18 @@ class NTPDownloader {
             guard let self = self else { return }
             
             if let error = error {
-                return completion(nil, nil, error)
+                completion(nil, nil, error)
+                return
             }
             
             guard let response = response as? HTTPURLResponse else {
-                return completion(nil, nil, "Response is not an HTTP Response")
+                completion(nil, nil, "Response is not an HTTP Response")
+                return
             }
             
             if response.statusCode != 304 && (response.statusCode < 200 || response.statusCode > 299) {
                 completion(nil, nil, "Invalid Response Status Code: \(response.statusCode)")
+                return
             }
             
             completion(data, self.parseETagResponseInfo(response), nil)
@@ -356,12 +359,14 @@ class NTPDownloader {
                 self.download(path: itemURL, etag: nil) { data, _, err in
                     if let err = err {
                         error = err
-                        return group.leave()
+                        group.leave()
+                        return
                     }
                     
                     guard let data = data else {
                         error = "No Data Available for NTP-Download: \(itemURL)"
-                        return group.leave()
+                        group.leave()
+                        return
                     }
                     
                     do {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Completion handler from `unpackMetadata` was sent twice in case of network error.
This caused the dispatchgroup to crash.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2375 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
