### PR TITLE
Fix #2363: NTP views refinements.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -643,7 +643,7 @@ extension Strings {
             NSLocalizedString("ntp.getPaidToSeeThisImage",
                 tableName: "BraveShared",
                 bundle: .braveShared,
-                value: "Get paid to see this background image.",
+                value: "Earn tokens for viewing this image.",
                 comment: "")
         public static let supportWebCreatorsWithTokens =
             NSLocalizedString("ntp.supportWebCreatorsWithTokens",
@@ -661,7 +661,7 @@ extension Strings {
             NSLocalizedString("ntp.youArePaidToSeeThisImage",
                 tableName: "BraveShared",
                 bundle: .braveShared,
-                value: "You're getting paid to see this background image.",
+                value: "You're earning tokens for viewing this image.",
                 comment: "")
         public static let turnOnBraveAds =
             NSLocalizedString("ntp.turnOnBraveAds",
@@ -673,44 +673,38 @@ extension Strings {
             NSLocalizedString("ntp.turnOnBraveRewards",
                 tableName: "BraveShared",
                 bundle: .braveShared,
-                value: "Turn on Rewards",
+                value: "Turn on Brave Rewards",
                 comment: "")
         public static let getPaidForThisImageTurnRewards =
             NSLocalizedString("ntp.getPaidForThisImageTurnRewards",
                 tableName: "BraveShared",
                 bundle: .braveShared,
-                value: "Get paid to see this background image. Turn on Brave Rewards to claim your share.",
+                value: "Earn tokens for viewing this image. Turn on Brave Rewards to claim your share.",
                 comment: "")
         public static let getPaidForThisImageTurnAds =
             NSLocalizedString("ntp.getPaidForThisImageTurnAds",
                 tableName: "BraveShared",
                 bundle: .braveShared,
-                value: "Get paid to see this background image. Turn on Brave Ads to claim your share.",
+                value: "Earn tokens for viewing this image. Turn on Brave Ads to claim your share.",
                 comment: "")
         public static let turnRewardsTos =
             NSLocalizedString("ntp.turnRewardsTos",
                 tableName: "BraveShared",
                 bundle: .braveShared,
                 value: "By turning on Rewards, you agree to the %@.",
-                comment: "The placeholder says 'Terms of Service'. So full sentence goes like: 'By turnin Rewards, you agree to the Terms of Service'.")
-        public static let chooseToHideSponsoredImages =
-            NSLocalizedString("ntp.chooseToHideSponsoredImages",
-                tableName: "BraveShared",
-                bundle: .braveShared,
-                value: "You can also choose to %@.",
-                comment: "The placeholder says 'hide sponsored images'. So full sentence goes like: 'You can also choose to hide sponsored images.'")
+                comment: "The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'.")
         public static let hideSponsoredImages =
             NSLocalizedString("ntp.hideSponsoredImages",
                 tableName: "BraveShared",
                 bundle: .braveShared,
-                value: "hide sponsored images",
-                comment: "This sentence is not capitalized on purpose, it is a part of a bigger sentence which goes like this: 'You can also choose to hide sponsored images.'")
+                value: "Hide sponsored images",
+                comment: "")
         public static let learnMoreAboutBrandedImages =
             NSLocalizedString("ntp.learnMoreAboutBrandedImages",
                 tableName: "BraveShared",
                 bundle: .braveShared,
-                value: "%@ about sponsored images in Brave Rewards.",
-                comment: "The placeholder says 'Learn more'. So full sentence goes like: 'Learn more about sponsored images in Brave Rewards.'")
+                value: "For every sponsored image you view, you receive 70% of the revenue in tokens. With Brave Ads, you're always in control of the ads you see.",
+                comment: "")
         public static let goodJob =
             NSLocalizedString("ntp.goodJob",
                 tableName: "BraveShared",
@@ -729,6 +723,20 @@ extension Strings {
                 bundle: .braveShared,
                 value: "Claim my rewards",
                 comment: "")
+
+        public static let learnMoreAboutRewards =
+            NSLocalizedString("ntp.learnMoreAboutRewards",
+                    tableName: "BraveShared",
+                    bundle: .braveShared,
+                    value: "Learn more about Brave Rewards",
+                    comment: "")
+
+        public static let learnMoreAboutSI =
+            NSLocalizedString("ntp.learnMoreAboutSI",
+                    tableName: "BraveShared",
+                    bundle: .braveShared,
+                    value: "Learn more about sponsored images",
+                    comment: "")
     }
     
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		0A62A355238C6F3E008902E3 /* Bookmark+Restoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A62A354238C6F3E008902E3 /* Bookmark+Restoration.swift */; };
 		0A66550A23E9D9750047EF2A /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550923E9D9750047EF2A /* UserAgent.swift */; };
 		0A66550C23E9E04F0047EF2A /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550B23E9E04F0047EF2A /* UserAgentTests.swift */; };
+		0A6F957624044F070098217F /* NTPLearnMoreContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */; };
 		0A764F31230EE5CA003A1D9B /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A764F30230EE5CA003A1D9B /* OnboardingState.swift */; };
 		0A771D35218C8FDC00336E0D /* Bookmark+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A771D34218C8FDC00336E0D /* Bookmark+Sync.swift */; };
 		0A7B5D6722689C5D00AADF22 /* AddEditHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7B5D6622689C5D00AADF22 /* AddEditHeaderView.swift */; };
@@ -1323,6 +1324,7 @@
 		0A66550D23E9EA540047EF2A /* Brave_iPad.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Brave_iPad.xctestplan; sourceTree = "<group>"; };
 		0A67500A23571F21006A6D00 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A6E095E230E05BC00AB3F19 /* onboarding-shields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-shields.json"; sourceTree = "<group>"; };
+		0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPLearnMoreContentView.swift; sourceTree = "<group>"; };
 		0A75A3BD23571F2B00013540 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0A764F30230EE5CA003A1D9B /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
 		0A771D34218C8FDC00336E0D /* Bookmark+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmark+Sync.swift"; sourceTree = "<group>"; };
@@ -2809,6 +2811,7 @@
 			children = (
 				0AFC8F9D23D3762A00941895 /* NTPNotificationViewController.swift */,
 				0A5CBD3323D4677100362CC8 /* NTPLearnMoreViewController.swift */,
+				0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */,
 				0A16E2D623D4E1FB00B0BF94 /* ClaimRewardsNTPNotificationViewController.swift */,
 				0A27ABA023D1B9C400194921 /* BrandedImageCalloutState.swift */,
 				0A5CBD3723D4905D00362CC8 /* NTPNotificationView.swift */,
@@ -6133,6 +6136,7 @@
 				4422D4AF21BFFB7600BF1855 /* status.cc in Sources */,
 				4422D4EA21BFFB7600BF1855 /* db_impl.cc in Sources */,
 				0AAAAC972249174A009A8763 /* SyncAlerts.swift in Sources */,
+				0A6F957624044F070098217F /* NTPLearnMoreContentView.swift in Sources */,
 				4422D4F221BFFB7600BF1855 /* builder.cc in Sources */,
 				0A1E84432190A57F0042F782 /* SyncWelcomeViewController.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,

--- a/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/HomePanel/FavoritesViewController.swift
@@ -303,7 +303,7 @@ class FavoritesViewController: UIViewController, Themeable {
                       adsAvailableInRegion: adsAvailableInRegion,
                       isSponsoredImage: isSponsoredImage)
         
-        return .brandedImages(state: state)
+        return .brandedImages(state: .getPaidTurnRewardsOn)
     }
     
     private func showNTPNotification(for type: NTPNotificationType) {

--- a/Client/Frontend/NTP/NTPLearnMoreContentView.swift
+++ b/Client/Frontend/NTP/NTPLearnMoreContentView.swift
@@ -17,14 +17,15 @@ extension NTPLearnMoreViewController {
         let buttonType: NTPButtonType?
         let tosText: Bool
         let learnMoreButtonText: String
+        var headerBodySpacing: CGFloat?
     }
     
     class NTPLearnMoreContentView: UIStackView {
         
         weak var delegate: NTPLearnMoreViewDelegate?
         
-        let looseSpacing: CGFloat = 16
-        let tightSpacing: CGFloat = 8
+        private let looseSpacing: CGFloat = 16
+        private let tightSpacing: CGFloat = 8
         
         private lazy var titleStackView = UIStackView().then {
             $0.spacing = 10
@@ -54,6 +55,10 @@ extension NTPLearnMoreViewController {
         private func updateSpacing(amount: CGFloat) {
             spacing = amount
             contentStackView.spacing = amount
+            
+            if let customHeaderSpacing = config.headerBodySpacing {
+                contentStackView.setCustomSpacing(customHeaderSpacing, after: header)
+            }
         }
         
         let contentStackView = UIStackView().then { stackView in
@@ -76,9 +81,11 @@ extension NTPLearnMoreViewController {
             $0.setContentCompressionResistancePriority(.required, for: .vertical)
         }
         
+        private let tosString = Strings.termsOfService.withNonBreakingSpace
+        
         private lazy var tos = detailLinkLabel(with:
-            String(format: Strings.NTP.turnRewardsTos, Strings.termsOfService)).then {
-                $0.setURLInfo([Strings.termsOfService: "tos"])
+            String(format: Strings.NTP.turnRewardsTos, tosString)).then {
+                $0.setURLInfo([tosString: "tos"])
         }
         
         private lazy var primaryButton = RoundInterfaceButton(type: .system).then {
@@ -95,6 +102,7 @@ extension NTPLearnMoreViewController {
             }
             
             $0.setTitle(title, for: .normal)
+            $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
             $0.appearanceTextColor = .white
             $0.backgroundColor = BraveUX.blurple400
             $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
@@ -121,7 +129,7 @@ extension NTPLearnMoreViewController {
             stackView.axis = .vertical
             stackView.spacing = 8
             
-            [separator(), learnMoreButton, separator(), hideSponsoredImageButton]
+            [separator(), learnMoreButton, separator(), hideSponsoredImageButton, separator()]
                 .forEach(stackView.addArrangedSubview(_:))
         }
         

--- a/Client/Frontend/NTP/NTPLearnMoreContentView.swift
+++ b/Client/Frontend/NTP/NTPLearnMoreContentView.swift
@@ -1,0 +1,226 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Shared
+import BraveShared
+import BraveRewardsUI
+
+extension NTPLearnMoreViewController {
+    enum NTPButtonType {
+        case rewards, ads
+    }
+
+    struct NTPNotificationLearnMoreViewConfig {
+        let headerText: String
+        let buttonType: NTPButtonType?
+        let tosText: Bool
+        let learnMoreButtonText: String
+    }
+    
+    class NTPLearnMoreContentView: UIStackView {
+        
+        weak var delegate: NTPLearnMoreViewDelegate?
+        
+        let looseSpacing: CGFloat = 16
+        let tightSpacing: CGFloat = 8
+        
+        private lazy var titleStackView = UIStackView().then {
+            $0.spacing = 10
+            
+            let imageView = UIImageView(image: #imageLiteral(resourceName: "brave_rewards_button_enabled")).then { image in
+                image.snp.makeConstraints { make in
+                    make.size.equalTo(24)
+                }
+            }
+            
+            let title = UILabel().then {
+                $0.text = Strings.braveRewardsTitle
+                $0.appearanceTextColor = .black
+                $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+            }
+            
+            [imageView, title].forEach($0.addArrangedSubview(_:))
+        }
+        
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            
+            let smallHeight = UIScreen.main.bounds.height <= 375
+            updateSpacing(amount: smallHeight ? tightSpacing : looseSpacing)
+        }
+        
+        private func updateSpacing(amount: CGFloat) {
+            spacing = amount
+            contentStackView.spacing = amount
+        }
+        
+        let contentStackView = UIStackView().then { stackView in
+            stackView.axis = .vertical
+        }
+        
+        private lazy var header = UILabel().then {
+            $0.text = config.headerText
+            $0.appearanceTextColor = .black
+            
+            $0.font = UIFont.systemFont(ofSize: 14, weight: .medium)
+            
+            $0.numberOfLines = 0
+            $0.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+            $0.lineBreakMode = .byWordWrapping
+            $0.adjustsFontSizeToFitWidth = true
+        }
+        
+        private lazy var body = detailLinkLabel(with: Strings.NTP.learnMoreAboutBrandedImages).then {
+            $0.setContentCompressionResistancePriority(.required, for: .vertical)
+        }
+        
+        private lazy var tos = detailLinkLabel(with:
+            String(format: Strings.NTP.turnRewardsTos, Strings.termsOfService)).then {
+                $0.setURLInfo([Strings.termsOfService: "tos"])
+        }
+        
+        private lazy var primaryButton = RoundInterfaceButton(type: .system).then {
+            
+            var title = ""
+            
+            switch config.buttonType {
+            case .ads:
+                title = Strings.NTP.turnOnBraveAds
+            case .rewards:
+                title = Strings.NTP.turnOnBraveRewards
+            case .none:
+                assertionFailure("Unknown button type state")
+            }
+            
+            $0.setTitle(title, for: .normal)
+            $0.appearanceTextColor = .white
+            $0.backgroundColor = BraveUX.blurple400
+            $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+            $0.contentEdgeInsets = UIEdgeInsets(top: 12, left: 25, bottom: 12, right: 25)
+            $0.tintColor = .white
+            $0.addTarget(self, action: #selector(primaryButtonAction), for: .touchUpInside)
+            
+            if config.buttonType == .ads {
+                $0.setImage(#imageLiteral(resourceName: "turn_rewards_on_money_icon"), for: .normal)
+                $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -10, bottom: 0, right: 0)
+            }
+        }
+        
+        private lazy var buttonsStackView = UIStackView().then { stackView in
+            func separator() -> UIView {
+                UIView().then {
+                    $0.backgroundColor = UIColor(white: 0.8, alpha: 1.0)
+                    $0.snp.makeConstraints { v in
+                        v.height.equalTo(1)
+                    }
+                }
+            }
+            
+            stackView.axis = .vertical
+            stackView.spacing = 8
+            
+            [separator(), learnMoreButton, separator(), hideSponsoredImageButton]
+                .forEach(stackView.addArrangedSubview(_:))
+        }
+        
+        private let learnMoreButton = secondaryButton(title: nil).then {
+            $0.addTarget(self, action: #selector(learnMoreButtonAction), for: .touchDown)
+        }
+        
+        private let hideSponsoredImageButton = secondaryButton(title: Strings.NTP.hideSponsoredImages).then {
+          $0.addTarget(self, action: #selector(hideSponsoredImagesAction), for: .touchDown)
+        }
+        
+        private let config: NTPNotificationLearnMoreViewConfig
+        
+        init(config: NTPNotificationLearnMoreViewConfig) {
+            self.config = config
+            super.init(frame: .zero)
+            
+            var views: [UIView] = [titleStackView]
+            
+            axis = .vertical
+            translatesAutoresizingMaskIntoConstraints = false
+            
+            views.append(header)
+            
+            if config.buttonType != nil {
+                views.append(primaryButton)
+            }
+            
+            views.append(body)
+            
+            if config.tosText {
+                views.append(tos)
+                
+                tos.onLinkedTapped = { [weak self] url in
+                    self?.delegate?.tosTapped()
+                }
+            }
+            
+            let mainContentStackView = UIStackView().then {
+                $0.addArrangedSubview(UIView.spacer(.horizontal, amount: 32))
+                views.forEach(contentStackView.addArrangedSubview(_:))
+                
+                $0.addArrangedSubview(contentStackView)
+                $0.addArrangedSubview(UIView.spacer(.horizontal, amount: 32))
+            }
+            
+            addArrangedSubview(mainContentStackView)
+            addArrangedSubview(buttonsStackView)
+            
+            learnMoreButton.setTitle(config.learnMoreButtonText, for: .normal)
+        }
+        
+        @available(*, unavailable)
+        required init(coder: NSCoder) {
+            fatalError()
+        }
+        
+        // MARK: - Actions
+        
+        @objc func primaryButtonAction() {
+            guard let buttonType = config.buttonType else {
+                return
+            }
+            delegate?.buttonTapped(type: buttonType)
+        }
+        
+        @objc func learnMoreButtonAction() {
+            delegate?.learnMoreTapped()
+        }
+        
+        @objc func hideSponsoredImagesAction() {
+            delegate?.hideSponsoredImagesTapped()
+        }
+    }
+}
+
+// MARK: - View helpers
+
+private func detailLinkLabel(with text: String) -> LinkLabel {
+    LinkLabel().then {
+        $0.font = .systemFont(ofSize: 12.0)
+        $0.appearanceTextColor = UIColor(white: 0, alpha: 0.7)
+        $0.linkColor = BraveUX.braveOrange
+        $0.text = text
+        $0.textContainerInset = .zero
+        $0.textContainer.lineFragmentPadding = 0
+    }
+}
+
+private func secondaryButton(title: String?) -> UIButton {
+    UIButton().then {
+        if let title = title {
+            $0.setTitle(title, for: .normal)
+        }
+        $0.appearanceTextColor = .black
+        $0.contentHorizontalAlignment = .left
+        $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 32, bottom: 0, right: 32)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        $0.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        $0.titleLabel?.adjustsFontSizeToFitWidth = true
+    }
+}

--- a/Client/Frontend/NTP/NTPLearnMoreViewController.swift
+++ b/Client/Frontend/NTP/NTPLearnMoreViewController.swift
@@ -9,16 +9,25 @@ import BraveRewardsUI
 import BraveRewards
 import SafariServices
 
+protocol NTPLearnMoreViewDelegate: AnyObject {
+    func buttonTapped(type: NTPLearnMoreViewController.NTPButtonType)
+    func learnMoreTapped()
+    func hideSponsoredImagesTapped()
+    func tosTapped()
+}
+
 /// A view controller that is presented after user taps on 'Learn more' on one of `NTPNotificationViewController` views.
 class NTPLearnMoreViewController: BottomSheetViewController {
     
-    private let state: BrandedImageCalloutState
-    
     var linkHandler: ((URL) -> Void)?
     
-    private var rewards: BraveRewards?
+    private let state: BrandedImageCalloutState
+    private let rewards: BraveRewards
     
-    init(state: BrandedImageCalloutState, rewards: BraveRewards?) {
+    private let termsOfServiceUrl = "https://www.brave.com/terms_of_use"
+    private let learnMoreAboutBraveRewardsUrl = "https://brave.com/brave-rewards/"
+    
+    init(state: BrandedImageCalloutState, rewards: BraveRewards) {
         self.state = state
         self.rewards = rewards
         super.init()
@@ -27,123 +36,97 @@ class NTPLearnMoreViewController: BottomSheetViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        guard let mainView = createViewFromState() else {
+        guard let mainView = mainView else {
             assertionFailure()
             return
         }
-        contentView.addSubview(mainView)
         
+        mainView.delegate = self
+        
+        contentView.addSubview(mainView)
         mainView.snp.remakeConstraints {
             $0.top.equalToSuperview().inset(28)
-            $0.left.right.equalToSuperview().inset(16)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(28)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
         }
     }
     
-    func createViewFromState() -> NTPNotificationView? {
-        var config = NTPNotificationViewConfig(textColor: .black)
+    // MARK: - View setup
+    
+    private var mainView: NTPLearnMoreContentView? {
+        var config: NTPNotificationLearnMoreViewConfig?
         
         switch state {
         case .getPaidTurnRewardsOn:
-            config.headerText = Strings.NTP.getPaidForThisImageTurnRewards
-            
-            let tos = Strings.termsOfService
-            let tosPart = String(format: Strings.NTP.turnRewardsTos, tos)
-            
-            let hideImages = Strings.NTP.hideSponsoredImages
-            let hideImagesPart = String(format: Strings.NTP.chooseToHideSponsoredImages, hideImages)
-            
-            let fullBodyText = "\(tosPart) \(hideImagesPart)"
-            
-            config.bodyText =
-                (text: fullBodyText,
-                 urlInfo: [tos: "tos", hideImages: "hide-sponsored-images"],
-                 action: { [weak self] action in
-                    if action.absoluteString == "tos" {
-                        let urlString = "https://www.brave.com/terms_of_use"
-                        guard let url = URL(string: urlString) else { return }
-                        self?.showSFSafariViewController(url: url)
-                    } else if action.absoluteString == "hide-sponsored-images" {
-                        Preferences.NewTabPage.backgroundSponsoredImages.value = false
-                        self?.close()
-                    }
-                })
-            
-            config.primaryButtonConfig =
-                (text: Strings.NTP.turnOnBraveRewards,
-                 showCoinIcon: false,
-                 action: { [weak self] in
-                    guard let rewards = self?.rewards else { return }
-                    
-                    if rewards.ledger.isWalletCreated {
-                        rewards.ledger.isEnabled = true
-                    } else {
-                        rewards.ledger.createWalletAndFetchDetails { _ in }
-                    }
-                    
-                    self?.close()
-                })
-            
-            config.secondaryButtonConfig =
-                (text: Strings.learnMore,
-                 action: { [weak self] in
-                    guard let url = URL(string: "https://brave.com/brave-rewards/") else { return }
-                    self?.showSFSafariViewController(url: url)
-                })
+            config = NTPNotificationLearnMoreViewConfig(
+                headerText: Strings.NTP.getPaidForThisImageTurnRewards,
+                buttonType: .rewards,
+                tosText: true,
+                learnMoreButtonText: Strings.NTP.learnMoreAboutRewards)
         case .getPaidTurnAdsOn:
-            config.headerText = Strings.NTP.getPaidForThisImageTurnAds
-            
-            let hideImages = Strings.NTP.hideSponsoredImages
-            let hideImagesPart = String(format: Strings.NTP.chooseToHideSponsoredImages, hideImages)
-            
-            config.bodyText =
-                (text: hideImagesPart,
-                 urlInfo: [hideImages: "hide-sponsored-images"],
-                 action: { [weak self] action in
-                    if action.absoluteString == "hide-sponsored-images" {
-                        Preferences.NewTabPage.backgroundSponsoredImages.value = false
-                        self?.close()
-                    }
-                })
-            
-            config.primaryButtonConfig =
-                (text: Strings.NTP.turnOnBraveAds,
-                 showCoinIcon: true,
-                 action: { [weak self] in
-                    guard let rewards = self?.rewards else { return }
-                    
-                    rewards.ads.isEnabled = true
-                    self?.close()
-                })
+            config = NTPNotificationLearnMoreViewConfig(
+                headerText: Strings.NTP.getPaidForThisImageTurnAds,
+                buttonType: .ads,
+                tosText: false,
+                learnMoreButtonText: Strings.NTP.learnMoreAboutSI)
             
         case .gettingPaidAlready:
-            config.headerText = Strings.NTP.youArePaidToSeeThisImage
-            
-            let learnMore = Strings.learnMore
-            let learnMorePart = String(format: Strings.NTP.learnMoreAboutBrandedImages, learnMore)
-            
-            let hideImages = Strings.NTP.hideSponsoredImages
-            let hideImagesPart = String(format: Strings.NTP.chooseToHideSponsoredImages, hideImages)
-            
-            config.bodyText =
-                (text: "\(learnMorePart) \(hideImagesPart)",
-                    urlInfo: [learnMore: "sponsored-images", hideImages: "hide-sponsored-images"],
-                    action: { [weak self] action in
-                        if action.absoluteString == "sponsored-images" {
-                            guard let url = URL(string: "https://brave.com/brave-rewards/") else { return }
-                            self?.linkHandler?(url)
-                            self?.close()
-                        } else if action.absoluteString == "hide-sponsored-images" {
-                            Preferences.NewTabPage.backgroundSponsoredImages.value = false
-                            self?.close()
-                        }
-                })
+            config = NTPNotificationLearnMoreViewConfig(
+                headerText: Strings.NTP.youArePaidToSeeThisImage,
+                buttonType: nil,
+                tosText: false,
+                learnMoreButtonText: Strings.NTP.learnMoreAboutSI)
         case .dontShow, .youCanGetPaidTurnAdsOn:
             assertionFailure()
             return nil
         }
         
-        return NTPNotificationView(config: config)
+        guard let viewConfig = config else { return nil }
+        
+        return NTPLearnMoreContentView(config: viewConfig)
+    }
+}
+
+// MARK: - NTPLearnMoreDelegate
+extension NTPLearnMoreViewController: NTPLearnMoreViewDelegate {
+    func buttonTapped(type: NTPButtonType) {
+        switch type {
+        case .rewards:
+            if rewards.ledger.isWalletCreated {
+                rewards.ledger.isEnabled = true
+            } else {
+                rewards.ledger.createWalletAndFetchDetails { _ in }
+            }
+        case .ads:
+            rewards.ads.isEnabled = true
+        }
+        
+        self.close()
+    }
+    
+    func learnMoreTapped() {
+        guard let url = URL(string: learnMoreAboutBraveRewardsUrl) else { return }
+        
+        // When a view with 'Turn on Rewards/Ads' button is shown, tapping on 'learn more'
+        // opens the website modally and doesn't close the NTP view.
+        // This is so the user can go back and enable Rewards/Ads after reading the learn more url.
+        if state == .getPaidTurnAdsOn || state == .getPaidTurnRewardsOn {
+            self.showSFSafariViewController(url: url)
+        } else {
+            // Normal case, open link in current tab and close the modal.
+            linkHandler?(url)
+            self.close()
+        }
+    }
+    
+    func hideSponsoredImagesTapped() {
+        Preferences.NewTabPage.backgroundSponsoredImages.value = false
+        self.close()
+    }
+    
+    func tosTapped() {
+        guard let url = URL(string: termsOfServiceUrl) else { return }
+        self.showSFSafariViewController(url: url)
     }
     
     private func showSFSafariViewController(url: URL) {

--- a/Client/Frontend/NTP/NTPLearnMoreViewController.swift
+++ b/Client/Frontend/NTP/NTPLearnMoreViewController.swift
@@ -75,7 +75,8 @@ class NTPLearnMoreViewController: BottomSheetViewController {
                 headerText: Strings.NTP.youArePaidToSeeThisImage,
                 buttonType: nil,
                 tosText: false,
-                learnMoreButtonText: Strings.NTP.learnMoreAboutSI)
+                learnMoreButtonText: Strings.NTP.learnMoreAboutSI,
+                headerBodySpacing: 8)
         case .dontShow, .youCanGetPaidTurnAdsOn:
             assertionFailure()
             return nil

--- a/Client/Frontend/Widgets/BottomSheetViewController.swift
+++ b/Client/Frontend/Widgets/BottomSheetViewController.swift
@@ -99,7 +99,6 @@ class BottomSheetViewController: UIViewController {
         traitCollection.userInterfaceIdiom == .phone && UIApplication.shared.statusBarOrientation.isLandscape
     }
     
-    
     // MARK: - Lifecycle
 
     init() {
@@ -160,6 +159,13 @@ class BottomSheetViewController: UIViewController {
             if showAsPopup || isLandscapePhone {
                 $0.bottom.centerX.equalToSuperview()
                 $0.width.equalTo(maxHorizontalWidth)
+                
+                // If contents can't fit the screen height, we have to add top constraint
+                // in order to squeeze views in the `contentView`.
+                // At the moment it only happens on iPhone 5S in landscape mode.
+                //
+                // Otherwise no top constraint is set, it will take as much space as needed.
+                $0.top.greaterThanOrEqualToSuperview()
             } else {
                 $0.leading.trailing.bottom.equalToSuperview()
             }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2363 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Trigger each of the changed ntp states. Verify the copy changed and that the views look nice.
Verify that buttons are working correctly.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

|  First view | second view  |
|---|---|
| <img width="363" alt="" src="https://user-images.githubusercontent.com/6950387/75526216-a1940e00-5a11-11ea-9777-76af2d6ee9d6.png">  | <img width="361" alt="" src="https://user-images.githubusercontent.com/6950387/75526202-9d67f080-5a11-11ea-91b4-d030a00e7211.png"> |
| <img width="359" alt="" src="https://user-images.githubusercontent.com/6950387/75526348-eae45d80-5a11-11ea-91a9-c23990a7fe31.png"> | <img width="358" alt="" src="https://user-images.githubusercontent.com/6950387/75526341-e6b84000-5a11-11ea-9f3f-981fdaf116c8.png">  |
| <img width="356" alt="" src="https://user-images.githubusercontent.com/6950387/75526821-c3da5b80-5a12-11ea-921a-8cf51854dcce.png"> | <img width="360" alt="" src="https://user-images.githubusercontent.com/6950387/75526813-bfae3e00-5a12-11ea-9f9a-1f1fdc2f6945.png"> |

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
