### PR TITLE
Fix #2402: Update copy for Auto-Contribute settings to match desktop

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -102,7 +102,7 @@ internal extension Strings {
     return NSLocalizedString("BraveRewardsNotificationTokenGrantTitle", bundle: .rewardsUI, value: "Token Grants", comment: "")
   }
   static let learnMoreBraveAdsBody = NSLocalizedString("BraveRewardsLearnMoreBraveAdsBody", bundle: .rewardsUI, value: "Get paid to view relevant ads that respect your privacy.", comment: "")
-  static let autoContributeToUnverifiedSites = NSLocalizedString("BraveRewardsAutoContributeToUnverifiedSites", bundle: .rewardsUI, value: "Allow contribution to non-verified sites", comment: "")
+  static let autoContributeToUnverifiedSites = NSLocalizedString("BraveRewardsAutoContributeToUnverifiedSites", bundle: .rewardsUI, value: "Show non-verified sites in list", comment: "")
   static let learnMoreWhyTitle = NSLocalizedString("BraveRewardsLearnMoreWhyTitle", bundle: .rewardsUI, value: "Why Brave Rewards?", comment: "")
   static let attention = NSLocalizedString("BraveRewardsAttention", bundle: .rewardsUI, value: "Attention", comment: "")
   static let exclude = NSLocalizedString("BraveRewardsExclude", bundle: .rewardsUI, value: "Exclude", comment: "")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2402 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Verify copy is changed

## Screenshots:
![Simulator Screen Shot - iPhone 11 Pro - 2020-03-17 at 12 39 04](https://user-images.githubusercontent.com/529104/76879203-4e60ee80-684c-11ea-8163-cc53376d2e9c.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
