### PR TITLE
Fix #2424: Disabling Synthetic clicks on WebPages

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -670,6 +670,7 @@
 		5E0FCD212342526700AC831E /* FullscreenHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 5EB57D0122FDC0CB00A07325 /* FullscreenHelper.js */; };
 		5E0FCD23234253DC00AC831E /* CertificatePinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FCD22234253DC00AC831E /* CertificatePinning.swift */; };
 		5E0FCD252342544C00AC831E /* URLSession+Requests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FCD242342544C00AC831E /* URLSession+Requests.swift */; };
+		5E2137EF24479D28005FC9DE /* DataURIParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2137EE24479D28005FC9DE /* DataURIParser.swift */; };
 		5E3477E922D7771700B0D5F8 /* ResourceDownloader.js in Resources */ = {isa = PBXBuildFile; fileRef = 5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */; };
 		5E34781022D7A1D200B0D5F8 /* ResourceDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */; };
 		5E46C371234FACC600ACA8C1 /* root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5E46C36D234FACC600ACA8C1 /* root.cer */; };
@@ -2140,6 +2141,7 @@
 		5E1D8C6A232BF95200BDE662 /* OnboardingRewardsAgreementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRewardsAgreementViewController.swift; sourceTree = "<group>"; };
 		5E1D8C6C232BF9C200BDE662 /* OnboardingRewardsAgreementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRewardsAgreementView.swift; sourceTree = "<group>"; };
 		5E1D8C6E232C0BDB00BDE662 /* onboarding-rewards.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-rewards.json"; sourceTree = "<group>"; };
+		5E2137EE24479D28005FC9DE /* DataURIParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURIParser.swift; sourceTree = "<group>"; };
 		5E3477E822D7771700B0D5F8 /* ResourceDownloader.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ResourceDownloader.js; sourceTree = "<group>"; };
 		5E34780F22D7A1D200B0D5F8 /* ResourceDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManager.swift; sourceTree = "<group>"; };
 		5E46C36D234FACC600ACA8C1 /* root.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = root.cer; sourceTree = "<group>"; };
@@ -4458,6 +4460,7 @@
 				5E4845C122DE3DF800372022 /* WindowRenderHelperScript.swift */,
 				0A19365323508756002E2B81 /* LinkPreviewViewController.swift */,
 				0A66550923E9D9750047EF2A /* UserAgent.swift */,
+				5E2137EE24479D28005FC9DE /* DataURIParser.swift */,
 			);
 			indentWidth = 4;
 			path = Browser;
@@ -6202,6 +6205,7 @@
 				4422D56321BFFB7F00BF1855 /* compile.cc in Sources */,
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				27C461DE211B76500088A441 /* ShieldsView.swift in Sources */,
+				5E2137EF24479D28005FC9DE /* DataURIParser.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
 				4422D4DA21BFFB7600BF1855 /* iterator.cc in Sources */,
 				4422D4AF21BFFB7600BF1855 /* status.cc in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -261,15 +261,7 @@ extension BrowserViewController: WKNavigationDelegate {
             
             // Prevents synthetically activated links such as: CVE-2017-7089
             //Follow desktop
-            /*
-            User explicitly entering/pasting “data:…” into the address bar
-            Opening all plain text data files
-            Opening “data:image/*” in top-level window, unless it’s “data:image/svg+xml”
-            Opening “data:application/pdf” and “data:application/json”
-            Downloading a data: URL, e.g. ‘save-link-as’ of “data:…”
- 
-            https://blog.mozilla.org/security/2017/11/27/blocking-top-level-navigations-data-urls-firefox-59/
-            */
+            //https://blog.mozilla.org/security/2017/11/27/blocking-top-level-navigations-data-urls-firefox-59
             
             if url.scheme == "data" {
                 do {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -258,6 +258,30 @@ extension BrowserViewController: WKNavigationDelegate {
                 self.tabManager.selectedTab?.alertShownCount = 0
                 self.tabManager.selectedTab?.blockAllAlerts = false
             }
+            
+            // Prevents synthetically activated links such as: CVE-2017-7089
+            if ["data", "blob", "file"].contains(url.scheme) {
+                if let clickType = navigationAction.value(forKey: "syntheticClickType") as? Int {
+                    if clickType == 0 {
+                        decisionHandler(.cancel)
+                        return
+                    }
+                }
+                
+                //Fallback.. Asks the user whether or not the url should be opened.. but only for `data`
+                if navigationAction.navigationType == .linkActivated && url.scheme == "data" {
+                    handleExternalURL(url) { didOpenURL in
+                        if !didOpenURL {
+                            let alert = UIAlertController(title: Strings.unableToOpenURLErrorTitle, message: Strings.unableToOpenURLError, preferredStyle: .alert)
+                            alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+                            self.present(alert, animated: true, completion: nil)
+                        }
+                    }
+                    decisionHandler(.cancel)
+                    return
+                }
+            }
+            
             decisionHandler(.allow)
             return
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -260,33 +260,10 @@ extension BrowserViewController: WKNavigationDelegate {
             }
             
             // Prevents synthetically activated links such as: CVE-2017-7089
-            if ["data", "blob", "file"].contains(url.scheme) {
-                if let clickType = navigationAction.value(forKey: "syntheticClickType") as? Int {
-                    //A click is synthetic if its value is 0 (aka WKSyntheticClickTypeNoTap).
-                    /*switch (syntheticClickType) {
-                    case WebKit::WebMouseEvent::OneFingerTap:
-                        return WKSyntheticClickTypeOneFingerTap;
-                    case WebKit::WebMouseEvent::TwoFingerTap:
-                        return WKSyntheticClickTypeTwoFingerTap;
-                    }*/
-                    if clickType == 0 {
-                        decisionHandler(.cancel)
-                        return
-                    }
-                }
-                
-                //Fallback.. Asks the user whether or not the url should be opened.. but only for `data`
-                if navigationAction.navigationType == .linkActivated && url.scheme == "data" {
-                    handleExternalURL(url) { didOpenURL in
-                        if !didOpenURL {
-                            let alert = UIAlertController(title: Strings.unableToOpenURLErrorTitle, message: Strings.unableToOpenURLError, preferredStyle: .alert)
-                            alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
-                            self.present(alert, animated: true, completion: nil)
-                        }
-                    }
-                    decisionHandler(.cancel)
-                    return
-                }
+            //Follow desktop
+            if url.scheme == "data" {
+                decisionHandler(.cancel)
+                return
             }
             
             decisionHandler(.allow)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -262,6 +262,13 @@ extension BrowserViewController: WKNavigationDelegate {
             // Prevents synthetically activated links such as: CVE-2017-7089
             if ["data", "blob", "file"].contains(url.scheme) {
                 if let clickType = navigationAction.value(forKey: "syntheticClickType") as? Int {
+                    //A click is synthetic if its value is 0 (aka WKSyntheticClickTypeNoTap).
+                    /*switch (syntheticClickType) {
+                    case WebKit::WebMouseEvent::OneFingerTap:
+                        return WKSyntheticClickTypeOneFingerTap;
+                    case WebKit::WebMouseEvent::TwoFingerTap:
+                        return WKSyntheticClickTypeTwoFingerTap;
+                    }*/
                     if clickType == 0 {
                         decisionHandler(.cancel)
                         return

--- a/Client/Frontend/Browser/DataURIParser.swift
+++ b/Client/Frontend/Browser/DataURIParser.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+class DataURIParser {
+    let mediaType: String
+    let headers: [String]
+    let data: Data
+    
+    init(uri: String) throws {
+        if uri == "data:," {
+            mediaType = "text/plain"
+            headers = ["charset=US-ASCII"]
+            data = Data()
+            return
+        }
+        
+        if !uri.lowercased().hasPrefix("data:") {
+            throw "Invalid Data-URI"
+        }
+        
+        guard let infoSegment = uri.firstIndex(of: ",") else {
+            throw "Invalid Data-URI"
+        }
+        
+        let startSegment = uri.index(uri.startIndex, offsetBy: "data:".count)
+        self.headers = uri[startSegment..<infoSegment].split(separator: ";").map({ String($0) })
+        mediaType = headers.first ?? "text/plain"
+        
+        let dataSegment = uri.index(infoSegment, offsetBy: 1)
+        //data = try! Data(contentsOf: URL(string: uri)!)
+        data = Data(base64Encoded: String(uri[dataSegment..<uri.endIndex])) ?? Data()
+    }
+}


### PR DESCRIPTION
## Security Review
https://github.com/brave/security/issues/104

## Test Plan
1. Go to reddit or any site with a login
2. Tap the URL bar and type `https://loving-newton-6b489c.netlify.com/`
3. Hit Enter and make sure you do NOT get a pop!
4. If you see a link on the page and you tap on it, it should ask you are you sure you want to open it.
5. If you manually type any data URIs into the URL bar, it should give a prompt to ask whether you want to open it or not.

## Summary of Changes
- Detect synthetic click types and automatically block them. 
- If this cannot be done, ask the user if they wish to proceed.
- If the url can't be opened, then it will just show an error.

## Other Browser:
- Safari: Attempts to open the URL but gives an error `Safari cannot open this URL` then proceeds to show the 2 popups.
- Chrome: Automatically begins downloading the `document`
- Firefox: Same behaviour as current Brave-iOS.. It shows the two popups but does NOT show the document cookies or any other sensitive information because `parent-tab://` is not a valid URL. If it were, we'd be in trouble. In both cases (brave and firefox), it's a minor UXSS attack.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2422 && #2424

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
