### PR TITLE
Fix #2329: Ensure current Rewards notification is always in sync with UI

### DIFF
--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -17,7 +17,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
   private let networkMonitor = NWPathMonitor()
   let state: RewardsState
   let ledgerObserver: LedgerObserver
-  weak var currentNotification: RewardsNotification?
+  var currentNotification: RewardsNotification?
   private var recurringTipAmount: Double = 0.0
   private var publisher: PublisherInfo?
   
@@ -106,8 +106,9 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
     reloadUIState()
     setupPublisherView(publisherSummaryView)
     view.layoutIfNeeded()
-    startNotificationObserver()
     startNetworkObserver()
+    
+    NotificationCenter.default.addObserver(self, selector: #selector(notificationAdded(_:)), name: BraveLedger.NotificationAdded, object: nil)
   }
   
   override func viewWillAppear(_ animated: Bool) {
@@ -586,13 +587,6 @@ extension WalletViewController {
 }
 
 extension WalletViewController {
-  
-  func startNotificationObserver() {
-    // Stopping as a precaution
-    // Add observer
-    NotificationCenter.default.addObserver(self, selector: #selector(notificationAdded(_:)), name: BraveLedger.NotificationAdded, object: nil)
-    loadNextNotification()
-  }
   
   @objc private func notificationAdded(_ notification: Notification) {
     // TODO: Filter notification?


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2329 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
