### PR TITLE
Fix 2420: Implement canMakePayment and add data validations for details

### DIFF
--- a/Client/Extensions/PaymentRequestExtension.swift
+++ b/Client/Extensions/PaymentRequestExtension.swift
@@ -21,10 +21,11 @@ class PaymentRequestExtension: NSObject {
     fileprivate var token: String
     
     fileprivate enum PaymentRequestErrors: String {
-        case NotSupportedError = "NotSupportedError"
-        case AbortError = "AbortError"
-        case TypeError = "TypeError"
-        case RangeError = "RangeError"
+        case notSupportedError = "NotSupportedError"
+        case abortError = "AbortError"
+        case typeError = "TypeError"
+        case rangeError = "RangeError"
+        case unknownError = "UnknownError"
     }
     
     private let paymentRequested: PaymentRequestHandler
@@ -63,23 +64,24 @@ extension PaymentRequestExtension: TabContentScript {
             let messageData = try JSONSerialization.data(withJSONObject: body, options: [])
             let body = try JSONDecoder().decode(PaymentRequest.self, from: messageData)
             if body.name != "payment-request-show" {
+                sendPaymentRequestError(errorName: PaymentRequestErrors.unknownError.rawValue, errorMessage: Strings.clientErrorMessage)
                 return
             }
             
             guard body.methodData.contains(where: {$0.supportedMethods.lowercased() == "bat"}) else {
-                sendPaymentRequestError(errorName: PaymentRequestErrors.NotSupportedError.rawValue, errorMessage: Strings.unsupportedInstrumentMessage)
+                sendPaymentRequestError(errorName: PaymentRequestErrors.notSupportedError.rawValue, errorMessage: Strings.unsupportedInstrumentMessage)
                 return
             }
             
             // All currencies should match
             guard body.details.displayItems.map({$0.amount.currency}).allSatisfy({ $0 == body.details.total.amount.currency }) else {
-                sendPaymentRequestError(errorName: PaymentRequestErrors.TypeError.rawValue, errorMessage: Strings.invalidDetailsMessage)
+                sendPaymentRequestError(errorName: PaymentRequestErrors.typeError.rawValue, errorMessage: Strings.invalidDetailsMessage)
                 return
             }
             
             // Sum of individual items does not match the total
             guard Double(body.details.total.amount.value) == body.details.displayItems.map({(Double($0.amount.value) ?? 0 )}).reduce(0, +) else {
-                sendPaymentRequestError(errorName: PaymentRequestErrors.RangeError.rawValue, errorMessage: Strings.unsupportedInstrumentMessage)
+                sendPaymentRequestError(errorName: PaymentRequestErrors.rangeError.rawValue, errorMessage: Strings.invalidDetailsMessage)
                 return
             }
 
@@ -87,7 +89,7 @@ extension PaymentRequestExtension: TabContentScript {
                 switch response {
                 case .cancelled:
                     ensureMainThread {
-                        self.sendPaymentRequestError(errorName: PaymentRequestErrors.AbortError.rawValue, errorMessage: Strings.userCancelledMessage)
+                        self.sendPaymentRequestError(errorName: PaymentRequestErrors.abortError.rawValue, errorMessage: Strings.userCancelledMessage)
                     }
                 case .completed(let response):
                     ensureMainThread {
@@ -101,7 +103,7 @@ extension PaymentRequestExtension: TabContentScript {
                 }
             }
         } catch {
-            sendPaymentRequestError(errorName: PaymentRequestErrors.TypeError.rawValue, errorMessage: Strings.invalidDetailsMessage)
+            sendPaymentRequestError(errorName: PaymentRequestErrors.typeError.rawValue, errorMessage: Strings.invalidDetailsMessage)
             return
         }
             
@@ -113,4 +115,5 @@ extension Strings {
     public static let unsupportedInstrumentMessage = NSLocalizedString("unsupportedInstrumentMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Unsupported payment instruments", comment: "Error message if list of Payment Instruments doesn't include BAT")
     public static let userCancelledMessage = NSLocalizedString("userCancelledMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "User cancelled", comment: "Error message if the payment workflow is canceled by the user")
     public static let invalidDetailsMessage = NSLocalizedString("invalidDetailsMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Invalid details in payment request", comment: "Error message if details don't have the right type or values")
+    public static let clientErrorMessage = NSLocalizedString("clientErrorMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Client error", comment: "Client is in an invalid state which caused the error")
 }

--- a/Client/Extensions/PaymentRequestExtension.swift
+++ b/Client/Extensions/PaymentRequestExtension.swift
@@ -78,7 +78,7 @@ extension PaymentRequestExtension: TabContentScript {
             }
             
             // Sum of individual items does not match the total
-            guard Int(body.details.total.amount.value) == body.details.displayItems.map({(Int($0.amount.value) ?? 0 )}).reduce(0, +) else {
+            guard Double(body.details.total.amount.value) == body.details.displayItems.map({(Double($0.amount.value) ?? 0 )}).reduce(0, +) else {
                 sendPaymentRequestError(errorName: PaymentRequestErrors.RangeError.rawValue, errorMessage: Strings.unsupportedInstrumentMessage)
                 return
             }

--- a/Client/Extensions/PaymentRequestExtension.swift
+++ b/Client/Extensions/PaymentRequestExtension.swift
@@ -80,7 +80,7 @@ extension PaymentRequestExtension: TabContentScript {
             }
             
             // Sum of individual items does not match the total
-            guard Double(body.details.total.amount.value) == body.details.displayItems.map({(Double($0.amount.value) ?? 0 )}).reduce(0, +) else {
+            guard Double(body.details.total.amount.value) == body.details.displayItems.compactMap({(Double($0.amount.value) )}).reduce(0, +) else {
                 sendPaymentRequestError(errorName: PaymentRequestErrors.rangeError.rawValue, errorMessage: Strings.invalidDetailsMessage)
                 return
             }

--- a/Client/Frontend/UserContent/UserScripts/PaymentRequest.js
+++ b/Client/Frontend/UserContent/UserScripts/PaymentRequest.js
@@ -1,3 +1,6 @@
+const $<paymentreq>_CREATED = "created";
+const $<paymentreq>_INTERACTIVE = "interactive";
+
 Object.defineProperty(window, '$<paymentreqcallback>', {
   value: {}
 });
@@ -17,13 +20,31 @@ class $<paymentreq> {
   constructor (methodData, details) {
       this.methodData = JSON.stringify(methodData)
       this.details = JSON.stringify(details)
+      this.state = $<paymentreq>_CREATED
   }
 
   canMakePayment() {
-    return true;
+    const methodData = JSON.parse(this.methodData)
+    const details = JSON.parse(this.details)
+    const state = this.state
+    return new Promise(
+      function (resolve, reject) {
+        if (state != $<paymentreq>_CREATED) {
+          reject(new DOMException("canMakePayment error", "InvalidStateError"))
+          return
+        }
+        if (!methodData.some(e => e.supportedMethods === 'bat')) {
+          resolve(false)
+          return
+        }
+        resolve(true)
+        return
+      }
+    )
   }
 
   show() {
+    this.state = $<paymentreq>_INTERACTIVE
     const methodData = this.methodData
     const details = this.details
     return new Promise(

--- a/Client/Frontend/UserContent/UserScripts/PaymentRequest.js
+++ b/Client/Frontend/UserContent/UserScripts/PaymentRequest.js
@@ -1,3 +1,4 @@
+const $<paymentreq>_CLOSED = "closed";
 const $<paymentreq>_CREATED = "created";
 const $<paymentreq>_INTERACTIVE = "interactive";
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2420 

Implements `canMakePayment` for payment request and adds validations on the client for payment details. 

canMakeRequest will:

1. Reject if the state of the payment request is incorrect. It should only be called in the CREATED state. https://www.w3.org/TR/payment-request/#canmakepayment-method
2. Resolve to false if the method Data does not have `bat` as the `supportedMethod`.

Client side will invoke reject if:

1.  If payment request is malformed
2. Currencies in the details don't match
3. Total does not match the sum of the display items.

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1. Navigate to `https://jumde.github.io/webpayments/brave/pr_reject.html` to verify Success is displayed.
2. Navigate to `https://jumde.github.io/webpayments/brave/pr_no_instrument.html` to verify Success is displayed.
3. Navigate to `https://jumde.github.io/webpayments/brave/pr_invalid_currency.html` to verify Success is displayed.
4. Navigate to `https://jumde.github.io/webpayments/brave/pr_invalid_sum.html` to verify Success is displayed.
5. Navigate to `https://test-sku-store.bravesoftware.com/sku/demo_one_click` and `https://test-sku-store.bravesoftware.com/sku/demo_cart` to verify the payment request completes

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
