### PR TITLE
Fix #2390 Settings Button UI Improvement

### DIFF
--- a/BraveRewardsUI/Wallet/WalletHeaderView.swift
+++ b/BraveRewardsUI/Wallet/WalletHeaderView.swift
@@ -83,7 +83,7 @@ class WalletHeaderView: UIView {
     $0.isHidden = true
   }
   
-  let settingsButton = Button(type: .system).then {
+  let settingsButton = ActionButton(type: .system).then {
     $0.appearanceTextColor = UIColor(white: 1.0, alpha: 0.75)
     $0.setTitle(Strings.settings, for: .normal)
     $0.setImage(UIImage(frameworkResourceNamed: "bat-small").alwaysOriginal, for: .normal)


### PR DESCRIPTION
convert setting button from a regular button into an action button so it has a border outline and looks clickable. You can see the discussion here: #2390 

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Simply converted the regular settings button into an action button so users know it is clickable. 
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2390 <number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Run application
2. Click the bat Icon
3. Notice the settings button now has an outline and is clearly clickable. 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
There are some screenshots provided within the issue but here is some more to help: 

Before: 
<img width="448" alt="Screen Shot 2020-03-30 at 5 49 24 PM" src="https://user-images.githubusercontent.com/16070192/77969271-f942c500-72ae-11ea-9042-2c9d19746a1b.png">


After:
<img width="421" alt="Screen Shot 2020-03-30 at 5 45 30 PM" src="https://user-images.githubusercontent.com/16070192/77969310-09f33b00-72af-11ea-979f-89a55422b465.png">


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
