### PR TITLE
Fix #2444: Remove no-store cache policy when classifying pages for Ads

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -279,15 +279,8 @@ extension BrowserViewController: WKNavigationDelegate {
         let response = navigationResponse.response
         let responseURL = response.url
         
-        if let tab = tabManager[webView] {
-            if let httpResponse = response as? HTTPURLResponse,
-                let cacheControl = httpResponse.allHeaderFields["Cache-Control"] as? String,
-                cacheControl.contains("no-store") {
-                tab.shouldClassifyLoadsForAds = false
-            }
-            if responseURL?.isSessionRestoreURL == true {
-                tab.shouldClassifyLoadsForAds = false
-            }
+        if let tab = tabManager[webView], responseURL?.isSessionRestoreURL == true {
+            tab.shouldClassifyLoadsForAds = false
         }
         
         var request: URLRequest?


### PR DESCRIPTION
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2444 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
