### PR TITLE
Fix #2505 - Lock Icon shows incorrectly on bad networks & multiple tabs.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1305,7 +1305,9 @@ class BrowserViewController: UIViewController {
                 tab.secureContentState = .insecure
             }
             
-            topToolbar.secureContentState = tab.secureContentState
+            if tabManager.selectedTab === tab {
+                topToolbar.secureContentState = tab.secureContentState
+            }
         case .serverTrust:
             guard let tab = tabManager[webView] else {
                 break
@@ -1336,7 +1338,9 @@ class BrowserViewController: UIViewController {
                     }
                 }
                 
-                topToolbar.secureContentState = tab.secureContentState
+                if tabManager.selectedTab === tab {
+                    topToolbar.secureContentState = tab.secureContentState
+                }
                 break
             }
             
@@ -1409,7 +1413,9 @@ class BrowserViewController: UIViewController {
         updateRewardsButtonState()
         
         topToolbar.currentURL = tab.url?.displayURL
-        topToolbar.secureContentState = tab.secureContentState
+        if tabManager.selectedTab === tab {
+            topToolbar.secureContentState = tab.secureContentState
+        }
         
         let isPage = tab.url?.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isPage)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1313,11 +1313,11 @@ class BrowserViewController: UIViewController {
                 break
             }
 
-            tab.secureContentState = .insecure
+            tab.secureContentState = .unknown
             
             guard let serverTrust = tab.webView?.serverTrust else {
-                if let url = tab.webView?.url {
-                    if url.isAboutHomeURL || url.isAboutURL {
+                if let url = tab.webView?.url ?? tab.url {
+                    if url.isAboutHomeURL || url.isAboutURL || url.scheme == "about" {
                         tab.secureContentState = .localHost
                         if tabManager.selectedTab === tab {
                             topToolbar.secureContentState = .localHost
@@ -1342,6 +1342,12 @@ class BrowserViewController: UIViewController {
                         }
                         break
                     }
+                    
+                    //All our checks failed, we show the page as insecure
+                    tab.secureContentState = .insecure
+                } else {
+                    //When there is no URL, it's likely a new tab.
+                    tab.secureContentState = .localHost
                 }
                 
                 if tabManager.selectedTab === tab {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1319,21 +1319,27 @@ class BrowserViewController: UIViewController {
                 if let url = tab.webView?.url {
                     if url.isAboutHomeURL || url.isAboutURL {
                         tab.secureContentState = .localHost
-                        topToolbar.secureContentState = .localHost
+                        if tabManager.selectedTab === tab {
+                            topToolbar.secureContentState = .localHost
+                        }
                         break
                     }
                     
                     if url.isErrorPageURL {
                         if ErrorPageHelper.certificateError(for: url) != 0 {
                             tab.secureContentState = .insecure
-                            topToolbar.secureContentState = .insecure
+                            if tabManager.selectedTab === tab {
+                                topToolbar.secureContentState = .insecure
+                            }
                             break
                         }
                     }
                     
                     if url.isReaderModeURL || url.isLocal {
                         tab.secureContentState = .unknown
-                        topToolbar.secureContentState = .unknown
+                        if tabManager.selectedTab === tab {
+                            topToolbar.secureContentState = .unknown
+                        }
                         break
                     }
                 }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -54,7 +54,7 @@ class Tab: NSObject {
         return type.isPrivate
     }
 
-    var secureContentState: TabSecureContentState = .insecure
+    var secureContentState: TabSecureContentState = .unknown
 
     // PageMetadata is derived from the page content itself, and as such lags behind the
     // rest of the tab.

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -55,7 +55,7 @@ class TabLocationView: UIView {
         }
     }
 
-    var secureContentState: TabSecureContentState = .insecure {
+    var secureContentState: TabSecureContentState = .unknown {
         didSet {
             updateLockImageView()
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

- Fixed so that icon doesn't flash when opening a new tab by setting the default to `unknown`.
- Fixed switching between tabs showing the wrong icon on a slow network due to each tab modifying the lock icon for its secure state.
- Tested it by using the `Network Link Conditioner` to purposely slow down the network to `Very Bad Network`, then doing:

1. Load Wikipedia in Tab1 (let it load fully so the secure icon shows)
2. Load BadSSL in Tab2 and click on expired (do not let it load fully after clicking on expired certificate)
3. Before BadSSL finishes loading, switch to Wikipedia tab.
4. Verify url-bar icon is still secure for wikipedia.
5. Once BadSSL finishes loading, switch to that tab.
6. Verify insecure url-bar icon is showing.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2505

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
