### PR TITLE
Fix #2518: Crash when favorites are inserted to NTP.

### DIFF
--- a/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
+++ b/Client/Frontend/Browser/HomePanel/favorites/FavoritesDataSource.swift
@@ -126,17 +126,9 @@ extension FavoritesDataSource: NSFetchedResultsControllerDelegate {
     }
     
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
-
+        
         switch type {
-        case .insert:
-            // Do not insert to collection view if full row is already taken,
-            // otherwise it crashes with inconsistency exception.
-            if let indexPath = newIndexPath, indexPath.row < columnsPerRow {
-                collectionView?.insertItems(at: [indexPath])
-            }
-            
-            favoriteUpdatedHandler?()
-        case .delete:
+        case .insert, .delete:
             // Not all favorites must be visible at the time, so we can't just call `deleteItems` here.
             // Example:
             // There's 10 favorites total, 4 are visible on iPhone.


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This will require a bigger rework at some point, or just dropping FRC for this collection view, see https://stackoverflow.com/questions/20554137/nsfetchedresultscontollerdelegate-for-collectionview

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2518 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
