### PR TITLE
Fix #2531: Estimated ads payout frame layout logic corrected

### DIFF
--- a/BraveRewardsUI/Settings/Ads/Details/AdsDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Ads/Details/AdsDetailsViewController.swift
@@ -143,7 +143,7 @@ extension AdsDetailsViewController: UITableViewDelegate, UITableViewDataSource {
       cell.accessoryView = BATUSDPairView().then {
         $0.batContainer.amountLabel.text = BATValue(estimatedEarnings).displayString
         $0.usdContainer.amountLabel.text = state.ledger.dollarStringForBATAmount(estimatedEarnings, includeCurrencyCode: false)
-        $0.bounds = CGRect(origin: .zero, size: $0.systemLayoutSizeFitting(UIView.layoutFittingExpandedSize))
+        $0.bounds = CGRect(origin: .zero, size: $0.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize))
       }
     case .nextPayment:
       cell.label.text = Strings.nextPaymentDate


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2531 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Go to Ads Details
- Verify that estimated payout appears

## Screenshots:

![image](https://user-images.githubusercontent.com/529104/81484041-82cfa600-9210-11ea-9b2d-504418c4c7ea.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
