### PR TITLE
Fix #2536, Fix #2527: Update Brave Rewards lib to include ads payout fix

### DIFF
--- a/BraveRewards/BraveRewards.framework/Headers/BATBraveLedger.h
+++ b/BraveRewards/BraveRewards.framework/Headers/BATBraveLedger.h
@@ -215,7 +215,8 @@ NS_SWIFT_NAME(BraveLedger)
 
 - (void)fetchPromotions:(nullable void (^)(NSArray<BATPromotion *> *grants))completion;
 
-- (void)claimPromotion:(NSString *)deviceCheckPublicKey
+- (void)claimPromotion:(NSString *)promotionId
+             publicKey:(NSString *)deviceCheckPublicKey
             completion:(void (^)(BATResult result, NSString * _Nonnull nonce))completion;
 
 - (void)attestPromotion:(NSString *)promotionId

--- a/BraveRewards/BraveRewards.framework/Headers/ledger.mojom.objc.h
+++ b/BraveRewards/BraveRewards.framework/Headers/ledger.mojom.objc.h
@@ -74,7 +74,7 @@ typedef NS_ENUM(NSInteger, BATResult) {
   BATResultAcTableEmpty = 14,
   BATResultNotEnoughFunds = 15,
   BATResultTipError = 16,
-  BATResultCorruptedWallet = 17,
+  BATResultCorruptedData = 17,
   BATResultGrantAlreadyClaimed = 18,
   BATResultContributionAmountTooLow = 19,
   BATResultVerifiedPublisher = 20,
@@ -90,6 +90,7 @@ typedef NS_ENUM(NSInteger, BATResult) {
   BATResultRetryShort = 30,
   BATResultRetryLong = 31,
   BATResultContinue = 32,
+  BATResultInProgress = 33,
 } NS_SWIFT_NAME(Result);
 
 
@@ -180,6 +181,7 @@ typedef NS_ENUM(NSInteger, BATPromotionStatus) {
   BATPromotionStatusAttested = 1,
   BATPromotionStatusFinished = 4,
   BATPromotionStatusOver = 5,
+  BATPromotionStatusCorrupted = 6,
 } NS_SWIFT_NAME(PromotionStatus);
 
 
@@ -211,6 +213,7 @@ typedef NS_ENUM(NSInteger, BATCredsBatchStatus) {
   BATCredsBatchStatusClaimed = 2,
   BATCredsBatchStatusSigned = 3,
   BATCredsBatchStatusFinished = 4,
+  BATCredsBatchStatusCorrupted = 5,
 } NS_SWIFT_NAME(CredsBatchStatus);
 
 

--- a/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
+++ b/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
@@ -233,7 +233,7 @@ extension BraveLedger {
           completion(false)
           return
         }
-        self.claimPromotion(attestation.publicKeyHash) { result, nonce in
+        self.claimPromotion(promotion.id, publicKey: attestation.publicKeyHash) { result, nonce in
           if result != .ledgerOk {
             completion(false)
             return

--- a/BraveRewardsUI/README.md
+++ b/BraveRewardsUI/README.md
@@ -6,5 +6,5 @@ The latest BraveRewards.framework was built on:
 
 ```
 brave-browser/fa8c9a4f483e847b931496e4275db6c0aa38c0ae
-brave-core/bfd2c3f3230cb3232915ea6b9cc2e510b04bfd75
+brave-core/75c765d0e7b5703d3d10429f94d0ee293794ff7b
 ```


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #2536 
This pull request fixes #2527 

Related PRs from brave-core:

https://github.com/brave/brave-core/pull/5495
https://github.com/brave/brave-core/pull/5485

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
