### PR TITLE
Fix #2463: Javascript URLs should only work for bookmarklets

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1176,9 +1176,9 @@ class BrowserViewController: UIViewController {
             
             //Another Fix for: https://github.com/brave/brave-ios/pull/2296
             //Disable any sort of privileged execution contexts
-            //IE: The user must explicitly type OR must explicitly tap a bookmark they have saved.
+            //IE: The user must explicitly tap a bookmark they have saved.
             //Block all other contexts such as redirects, downloads, embed, linked, etc..
-            if visitType == .typed || visitType == .bookmark {
+            if visitType == .bookmark {
                 if let webView = tab.webView, let code = url.bookmarkletCodeComponent {
                     webView.evaluateJavaScript(code, completionHandler: { _, error in
                         if let error = error {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2463 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Enter `javascript:alert(1)` - Verify no alert box is displayed.
2. Navigate to https://jumde.github.io/test/javascript_copy.html - Copy the text
3. Enter the URL in the address bar and verify no alert box is not displayed.
4. Modify one of your bookmark to set its value to `javascript:alert(1)`
5. Click the bookmark and verify that the alert box is displayed

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
