### PR TITLE
Fix #2571: Always load CHP resources from cache.

### DIFF
--- a/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPDownloader.swift
@@ -118,6 +118,17 @@ class NTPDownloader {
             return completion(self.loadNTPResource(for: type))
         }
         
+        // For super referrer we want to load assets from cache first, then check if new resources
+        // are on the server.
+        // This is because as super referrer install we never want to show other images than the ones
+        // provided by the super referrer.
+        // In the future we might want to extend this preload from cache logic to other resource types.
+        //
+        // Note: this will call the same completion handler twice.
+        if case .superReferral = type {
+            completion(self.loadNTPResource(for: type))
+        }
+        
         // Download the NTP resource to a temporary directory
         self.downloadMetadata(type: type) { [weak self] url, cacheInfo, error in
             guard let self = self else { return }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2571 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Download using one of test CHP codes.
- Verify that the bg image at first launch is correct.
- Wait at least 3 minutes.
- Kill the app and reopen it
- Verify that proper CHP image is showing instead of regular bg image

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
