### PR TITLE
Fix #2611: Update URLs for fetching adblock data

### DIFF
--- a/Client/WebFilters/AdblockResourceDownloader.swift
+++ b/Client/WebFilters/AdblockResourceDownloader.swift
@@ -23,7 +23,7 @@ class AdblockResourceDownloader {
     
     static let folderName = "abp-data"
     
-    static let endpoint = "https://adblock-data.s3.brave.com/iOS13"
+    static let endpoint = "https://adblock-data.s3.brave.com/ios"
     
     init(networkManager: NetworkManager = NetworkManager(), locale: String? = Locale.current.languageCode) {
         if locale == nil {
@@ -73,7 +73,8 @@ class AdblockResourceDownloader {
             let fileExtension = fileType.rawValue
             let etagExtension = fileExtension + ".etag"
             
-            guard let resourceName = type.resourceName(for: fileType), var url = type.endpoint else {
+            guard let resourceName = type.resourceName(for: fileType),
+                var url = URL(string: AdblockResourceDownloader.endpoint) else {
                 return Deferred<AdBlockNetworkResource>()
             }
             

--- a/Client/WebFilters/AdblockResourcesMappings.swift
+++ b/Client/WebFilters/AdblockResourcesMappings.swift
@@ -7,8 +7,7 @@ import Foundation
 struct AdblockResourcesMappings {
     static func generalAdblockName(for fileType: FileType) -> String? {
         switch fileType {
-        case .dat: return "combined-included-rs"
-        case .json: return "combined-included"
+        case .dat, .json: return "latest"
         default: return nil
         }
     }

--- a/Client/WebFilters/AdblockerType.swift
+++ b/Client/WebFilters/AdblockerType.swift
@@ -45,19 +45,12 @@ enum AdblockerType {
         switch self {
         case .general: return AdblockResourcesMappings.generalAdblockName(for: fileType)
         case .httpse: return AdblockResourcesMappings.generalHttpseName
-        case .regional(let locale): return ResourceLocale(rawValue: locale)?.resourceName(for: fileType)
+        case .regional(let locale):
+            guard let regionalName = ResourceLocale(rawValue: locale)?.resourceName(for: fileType) else {
+                return nil
+            }
+            return "\(regionalName)-latest"
         }
-    }
-    
-    /// A name under which given resource is stored on server.
-    var endpoint: URL? {
-        guard var url = URL(string: AdblockResourceDownloader.endpoint) else { return nil }
-        
-        if case .regional = self {
-            url.appendPathComponent("regional")
-        }
-        
-        return url
     }
     
     var blockListName: BlocklistName? {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2611

Blocked: Waiting on updated lambda's/devops to complete

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test adblock downloads to `abp-data` folder correctly
- Test adblock stats increase
- Test regional adblock

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
