### PR TITLE
Fix #2602: Don't trim quotes from NTP resource etags.

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
+++ b/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
@@ -340,7 +340,6 @@ class NTPDownloader {
     private func setETag(_ etag: String, type: ResourceType) {
         do {
             let etagFileURL = try self.ntpETagFileURL(type: type)
-            let etag = etag.replacingOccurrences(of: "\"", with: "")
             try etag.write(to: etagFileURL, atomically: true, encoding: .utf8)
         } catch {
             logger.error(error)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2602 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
Just need to verify that NTP SI or SR assets are downloaded correctly.
1. Download the browser using SR code
2. Wait 4 minutes
3. Close the app, launch again
4. Verify sponsored image is still showing correctly

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
