### PR TITLE
No Bug: Skip job if `CI/skip` label is found on a PR

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI/skip')) }}
     name: Run tests
     runs-on: macOS-latest
     env:


### PR DESCRIPTION
Testing `CI/skip` usage

Action without `CI/skip`: https://github.com/brave/brave-ios/actions/runs/136181549
Action with `CI/skip`: https://github.com/brave/brave-ios/actions/runs/136183419