### PR TITLE
Fix #2650: Save favicons in in-memory db in private mode.

### DIFF
--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -46,7 +46,7 @@ class FaviconHandler {
             guard let tab = tab else { return }
             
             tab.favicons.append(favicon)
-            FaviconMO.add(favicon, forSiteUrl: currentURL, isPrivateBrowsing: tab.isPrivate)
+            FaviconMO.add(favicon, forSiteUrl: currentURL, persistent: !tab.isPrivate)
         }
 
         let onCompletedSiteFavicon: ImageCacheCompletion = { image, data, _, _, url in

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -46,10 +46,7 @@ class FaviconHandler {
             guard let tab = tab else { return }
             
             tab.favicons.append(favicon)
-            if !tab.isPrivate {
-                FaviconMO.add(favicon, forSiteUrl: currentURL)
-                
-            }
+            FaviconMO.add(favicon, forSiteUrl: currentURL, isPrivateBrowsing: tab.isPrivate)
         }
 
         let onCompletedSiteFavicon: ImageCacheCompletion = { image, data, _, _, url in

--- a/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
+++ b/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
@@ -217,8 +217,9 @@ class FaviconFetcher {
             if let image = image {
                 favicon.width = Int(image.size.width)
                 favicon.height = Int(image.size.height)
-                if addingToDatabase && !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                    FaviconMO.add(favicon, forSiteUrl: self.url)
+                if addingToDatabase {
+                    FaviconMO.add(favicon, forSiteUrl: self.url,
+                                  isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
                 }
                 
                 completion(image)
@@ -237,8 +238,22 @@ class FaviconFetcher {
     }
     
     private func fetchIcon(_ completion: @escaping (URL, FaviconAttributes) -> Void) {
+        // Fetch icon logic:
+        // 1. Check if current domain has a favicon.
+        var correctFavicon = domain.favicon
+        
+        // 2. Private mode uses their own in-memory only favicons.
+        // If no in-memory favicon is found we look if there's any persisted one(from normal browsing mode)
+        // and use that one until in-memory favicon is saved.
+        if correctFavicon == nil,
+            PrivateBrowsingManager.shared.isPrivateBrowsing,
+            let urlString = domain.url,
+            let url = URL(string: urlString) {
+            correctFavicon = Domain.getPersistedDomain(for: url)?.favicon
+        }
+        
         // Attempt to find favicon cached for the given Domain
-        if let favicon = domain.favicon, let urlString = favicon.url, let url = URL(string: urlString) {
+        if let favicon = correctFavicon, let urlString = favicon.url, let url = URL(string: urlString) {
             // Verify that the favicon we have on file is what we want to pull
             // If not, we will just default to monogram to avoid blurry images
             if faviconOnFileMatchesFetchKind(favicon) {

--- a/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
+++ b/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
@@ -219,7 +219,7 @@ class FaviconFetcher {
                 favicon.height = Int(image.size.height)
                 if addingToDatabase {
                     FaviconMO.add(favicon, forSiteUrl: self.url,
-                                  isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
+                                  persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
                 }
                 
                 completion(image)
@@ -240,20 +240,18 @@ class FaviconFetcher {
     private func fetchIcon(_ completion: @escaping (URL, FaviconAttributes) -> Void) {
         // Fetch icon logic:
         // 1. Check if current domain has a favicon.
-        var correctFavicon = domain.favicon
+        var domainFavicon = domain.favicon
         
         // 2. Private mode uses their own in-memory only favicons.
         // If no in-memory favicon is found we look if there's any persisted one(from normal browsing mode)
         // and use that one until in-memory favicon is saved.
-        if correctFavicon == nil,
-            PrivateBrowsingManager.shared.isPrivateBrowsing,
-            let urlString = domain.url,
-            let url = URL(string: urlString) {
-            correctFavicon = Domain.getPersistedDomain(for: url)?.favicon
+        if domainFavicon == nil,
+            PrivateBrowsingManager.shared.isPrivateBrowsing {
+            domainFavicon = Domain.getPersistedDomain(for: url)?.favicon
         }
         
         // Attempt to find favicon cached for the given Domain
-        if let favicon = correctFavicon, let urlString = favicon.url, let url = URL(string: urlString) {
+        if let favicon = domainFavicon, let urlString = favicon.url, let url = URL(string: urlString) {
             // Verify that the favicon we have on file is what we want to pull
             // If not, we will just default to monogram to avoid blurry images
             if faviconOnFileMatchesFetchKind(favicon) {

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -59,6 +59,12 @@ public final class Domain: NSManagedObject, CRUD {
         return getOrCreateInternal(url, context: context, saveStrategy: saveStrategy)
     }
     
+    /// Returns saved Domain for url or nil if it doesn't exist.
+    /// Always called on main thread context.
+    public class func getPersistedDomain(for url: URL) -> Domain? {
+        Domain.first(where: NSPredicate(format: "url == %@", url.domainURL.absoluteString))
+    }
+    
     // MARK: Shields
 
     public class func setBraveShield(forUrl url: URL, shield: BraveShield,

--- a/Data/models/FaviconMO.swift
+++ b/Data/models/FaviconMO.swift
@@ -15,15 +15,15 @@ public final class FaviconMO: NSManagedObject, CRUD {
 
     // MARK: - Public interface
     
-    public class func add(_ favicon: Favicon, forSiteUrl siteUrl: URL, isPrivateBrowsing: Bool) {
-        DataController.perform(context: .new(inMemory: isPrivateBrowsing)) { context in
+    public class func add(_ favicon: Favicon, forSiteUrl siteUrl: URL, persistent: Bool) {
+        DataController.perform(context: .new(inMemory: !persistent)) { context in
             var item = FaviconMO.get(forFaviconUrl: favicon.url, context: context)
             if item == nil {
                 item = FaviconMO(entity: FaviconMO.entity(context), insertInto: context)
                 item!.url = favicon.url
             }
             if item?.domain == nil {
-                let strategy: Domain.SaveStrategy = isPrivateBrowsing ? .inMemory : .delayedPersistentStore
+                let strategy: Domain.SaveStrategy = persistent ?.delayedPersistentStore : .inMemory
                 
                 item!.domain = Domain.getOrCreateInternal(siteUrl, context: context,
                                                           saveStrategy: strategy)

--- a/Data/models/FaviconMO.swift
+++ b/Data/models/FaviconMO.swift
@@ -15,16 +15,18 @@ public final class FaviconMO: NSManagedObject, CRUD {
 
     // MARK: - Public interface
     
-    public class func add(_ favicon: Favicon, forSiteUrl siteUrl: URL) {
-        DataController.perform { context in
+    public class func add(_ favicon: Favicon, forSiteUrl siteUrl: URL, isPrivateBrowsing: Bool) {
+        DataController.perform(context: .new(inMemory: isPrivateBrowsing)) { context in
             var item = FaviconMO.get(forFaviconUrl: favicon.url, context: context)
             if item == nil {
                 item = FaviconMO(entity: FaviconMO.entity(context), insertInto: context)
                 item!.url = favicon.url
             }
             if item?.domain == nil {
+                let strategy: Domain.SaveStrategy = isPrivateBrowsing ? .inMemory : .delayedPersistentStore
+                
                 item!.domain = Domain.getOrCreateInternal(siteUrl, context: context,
-                                                          saveStrategy: .delayedPersistentStore)
+                                                          saveStrategy: strategy)
             }
             
             let w = Int16(favicon.width ?? 0)

--- a/DataTests/FaviconMOTests.swift
+++ b/DataTests/FaviconMOTests.swift
@@ -45,7 +45,7 @@ class FaviconMOTests: CoreDataTestCase {
         let favicon = Favicon(url: exampleUrl.absoluteString)
         
         backgroundSaveAndWaitForExpectation {
-            FaviconMO.add(favicon, forSiteUrl: exampleUrl, isPrivateBrowsing: false)
+            FaviconMO.add(favicon, forSiteUrl: exampleUrl, persistent: true)
         }
         
         return try! DataController.viewContext.fetch(fetchRequest).first

--- a/DataTests/FaviconMOTests.swift
+++ b/DataTests/FaviconMOTests.swift
@@ -45,7 +45,7 @@ class FaviconMOTests: CoreDataTestCase {
         let favicon = Favicon(url: exampleUrl.absoluteString)
         
         backgroundSaveAndWaitForExpectation {
-            FaviconMO.add(favicon, forSiteUrl: exampleUrl)
+            FaviconMO.add(favicon, forSiteUrl: exampleUrl, isPrivateBrowsing: false)
         }
         
         return try! DataController.viewContext.fetch(fetchRequest).first


### PR DESCRIPTION
Use fallback persisted favicon in no in-memory favicon exists.

Sec review https://github.com/brave/security/issues/181

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2650 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
