### PR TITLE
Fix #2598: Add 14day retention DAU stat.

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -33,6 +33,8 @@ extension Preferences {
         // We need to translate that to use the new `firstPingParam` preference.
         static let firstPingParam: Option<Bool> =
             Option<Bool>(key: "dau.first-ping", default: Preferences.DAU.lastLaunchInfo.value == nil)
+        /// Date of installation, this preference is removed after 14 days of usage.
+        public static let installationDate = Option<Date?>(key: "dau.installation-date", default: nil)
     }
     public final class URP {
         static let nextCheckDate = Option<TimeInterval?>(key: "urp.next-check-date", default: nil)

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -41,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     var authenticator: AppAuthenticator?
     
     /// Object used to handle server pings
-    let dau = DAU()
+    private let dau = DAU()
 
     @discardableResult func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         //
@@ -257,6 +257,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         
         if isFirstLaunch {
             profile?.searchEngines.regionalSearchEngineSetup()
+            Preferences.DAU.installationDate.value = Date()
         }
         
         if let urp = UserReferralProgram.shared {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2598 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
I think we should coordinate it with the stats team.
For testing purposes I set retention days to 2 on dev builds

Install date test:
1. Clean install the build and launch it, see if `dtoi` param is present on the server

Null dtoi test:
1. Install previous build like 1.18.x, launch it
2. Upgrade to this new build, `dtoi` sent should be null at this point, verify at server side

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
