### PR TITLE
Fix #2660: Don't reload search view controller multiple times on query.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -367,7 +367,6 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
         if searchQuery.isEmpty || !searchEngines.shouldShowSearchSuggestions || searchQuery.looksLikeAURL() {
             suggestionCell.suggestions = []
-            tableView.reloadData()
             return
         }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

`searchViewController.reloadData()` was called multiple times on user input, which resulted in race conditions once we refactored favicon fetch logic.
I removed 1 call to reload data to call it only once per typed character.
Now we call reload data in `func loader(dataLoaded data: [Site]) {` function

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2660

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
