### PR TITLE
Fix #2671: Fix crash when opening fav in PBM from NTP/Fav overlay

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		27201F022458879700C19DD1 /* NewTabPageBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27201F012458879700C19DD1 /* NewTabPageBackgroundView.swift */; };
 		27201F0424589B9800C19DD1 /* NewTabPageNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27201F0324589B9800C19DD1 /* NewTabPageNotifications.swift */; };
 		27253973236CE6B100D06EF1 /* GrantClaimedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271DEC81234CC7EF009DAC37 /* GrantClaimedViewController.swift */; };
+		2727369B24A65F650096DCB9 /* UIActionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2727369A24A65F650096DCB9 /* UIActionExtensions.swift */; };
 		272FCAA0225CF8F00091E645 /* OnePasswordExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 272FCA98225CF8F00091E645 /* OnePasswordExtension.framework */; };
 		27325A5724097DB900790DC6 /* LedgerInitializationFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27325A5624097DB900790DC6 /* LedgerInitializationFailedView.swift */; };
 		27325A622410586D00790DC6 /* SKUPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27325A612410586D00790DC6 /* SKUPurchaseViewController.swift */; };
@@ -1595,6 +1596,7 @@
 		27201EFD24539B5500C19DD1 /* NewTabPageBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageBackground.swift; sourceTree = "<group>"; };
 		27201F012458879700C19DD1 /* NewTabPageBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageBackgroundView.swift; sourceTree = "<group>"; };
 		27201F0324589B9800C19DD1 /* NewTabPageNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageNotifications.swift; sourceTree = "<group>"; };
+		2727369A24A65F650096DCB9 /* UIActionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActionExtensions.swift; sourceTree = "<group>"; };
 		272FCA98225CF8F00091E645 /* OnePasswordExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OnePasswordExtension.framework; path = Carthage/Build/iOS/OnePasswordExtension.framework; sourceTree = "<group>"; };
 		27325A5624097DB900790DC6 /* LedgerInitializationFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LedgerInitializationFailedView.swift; sourceTree = "<group>"; };
 		27325A612410586D00790DC6 /* SKUPurchaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKUPurchaseViewController.swift; sourceTree = "<group>"; };
@@ -3680,6 +3682,7 @@
 				595E0EE021CAEF5B00813D49 /* FileManagerExtension.swift */,
 				592F521D2217327B0078395E /* HttpCookieExtension.swift */,
 				5D8AE6AE230C76B60096C845 /* AppearanceExtensions.swift */,
+				2727369A24A65F650096DCB9 /* UIActionExtensions.swift */,
 			);
 			indentWidth = 4;
 			path = Extensions;
@@ -6762,6 +6765,7 @@
 				5E612A8E234B7FC8007D12B5 /* OnboardingAdsAvailableView.swift in Sources */,
 				27D114D62358FCA400166534 /* SettingsRowViews.swift in Sources */,
 				4422D56621BFFB7F00BF1855 /* tostring.cc in Sources */,
+				2727369B24A65F650096DCB9 /* UIActionExtensions.swift in Sources */,
 				4422D54821BFFB7E00BF1855 /* pcre.cc in Sources */,
 				C8F457AA1F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift in Sources */,
 				E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */,

--- a/Client/Extensions/UIActionExtensions.swift
+++ b/Client/Extensions/UIActionExtensions.swift
@@ -1,0 +1,25 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+
+@available(iOS 13.0, *)
+extension UIAction {
+    /// An action handler to use for a UIAction when you need to wait until the context menu finished the
+    /// dismissal animation.
+    ///
+    /// This ensures that the user can:
+    ///   1. See a change that happens based on their selection
+    ///   2. Ensure that if the view which has shown the context menu were to be removed from the view
+    ///      heirarchy as a result of the action, that the context menu does not crash on dismissal.
+    static func deferredActionHandler(_ handler: @escaping UIActionHandler) -> UIActionHandler {
+        return { action in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                handler(action)
+            }
+        }
+    }
+}

--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -258,29 +258,21 @@ extension FavoritesViewController: UICollectionViewDataSource, UICollectionViewD
     func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
         guard let bookmark = frc.fetchedObjects?[indexPath.item] else { return nil }
         return UIContextMenuConfiguration(identifier: indexPath as NSCopying, previewProvider: nil) { _ -> UIMenu? in
-            let openInNewTab = UIAction(title: Strings.openNewTabButtonTitle, image: nil, identifier: nil, discoverabilityTitle: nil) { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: false))
-                }
-            }
-            let edit = UIAction(title: Strings.editBookmark, image: nil, identifier: nil, discoverabilityTitle: nil) { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.action(bookmark, .edited)
-                }
-            }
-            let delete = UIAction(title: Strings.removeFavorite, image: nil, identifier: nil, discoverabilityTitle: nil, attributes: .destructive) { _ in
-                // Wait until the menu dismisses before deleting it so user can
-                // see the interaction
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    bookmark.delete()
-                }
-            }
+            let openInNewTab = UIAction(title: Strings.openNewTabButtonTitle, handler: UIAction.deferredActionHandler { _ in
+                self.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: false))
+            })
+            let edit = UIAction(title: Strings.editBookmark, handler: UIAction.deferredActionHandler { _ in
+                self.action(bookmark, .edited)
+            })
+            let delete = UIAction(title: Strings.removeFavorite, attributes: .destructive, handler: UIAction.deferredActionHandler { _ in
+                bookmark.delete()
+            })
             
             var urlChildren: [UIAction] = [openInNewTab]
             if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                let openInNewPrivateTab = UIAction(title: Strings.openNewPrivateTabButtonTitle, image: nil, identifier: nil, discoverabilityTitle: nil) { _ in
+                let openInNewPrivateTab = UIAction(title: Strings.openNewPrivateTabButtonTitle, handler: UIAction.deferredActionHandler { _ in
                     self.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
-                }
+                })
                 urlChildren.append(openInNewPrivateTab)
             }
             

--- a/Client/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
@@ -167,27 +167,21 @@ class FavoritesSectionProvider: NSObject, NTPObservableSectionProvider {
     func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
         guard let favourite = frc.fetchedObjects?[indexPath.item] else { return nil }
         return UIContextMenuConfiguration(identifier: indexPath as NSCopying, previewProvider: nil) { _ -> UIMenu? in
-            let openInNewTab = UIAction(title: Strings.openNewTabButtonTitle, image: nil, identifier: nil, discoverabilityTitle: nil) { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.action(favourite, .opened(inNewTab: true, switchingToPrivateMode: false))
-                }
-            }
-            let edit = UIAction(title: Strings.editBookmark, image: nil, identifier: nil, discoverabilityTitle: nil) { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.action(favourite, .edited)
-                }
-            }
-            let delete = UIAction(title: Strings.removeFavorite, image: nil, identifier: nil, discoverabilityTitle: nil, attributes: .destructive) { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    favourite.delete()
-                }
-            }
+            let openInNewTab = UIAction(title: Strings.openNewTabButtonTitle, handler: UIAction.deferredActionHandler { _ in
+                self.action(favourite, .opened(inNewTab: true, switchingToPrivateMode: false))
+            })
+            let edit = UIAction(title: Strings.editBookmark, handler: UIAction.deferredActionHandler { _ in
+                self.action(favourite, .edited)
+            })
+            let delete = UIAction(title: Strings.removeFavorite, attributes: .destructive, handler: UIAction.deferredActionHandler { _ in
+                favourite.delete()
+            })
             
             var urlChildren: [UIAction] = [openInNewTab]
             if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                let openInNewPrivateTab = UIAction(title: Strings.openNewPrivateTabButtonTitle, image: nil, identifier: nil, discoverabilityTitle: nil) { _ in
+                let openInNewPrivateTab = UIAction(title: Strings.openNewPrivateTabButtonTitle, handler: UIAction.deferredActionHandler { _ in
                     self.action(favourite, .opened(inNewTab: true, switchingToPrivateMode: true))
-                }
+                })
                 urlChildren.append(openInNewPrivateTab)
             }
             


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2671

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
