### PR TITLE
Fix #2699: Adblock-rust race condition crash.

### DIFF
--- a/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
@@ -53,7 +53,7 @@ enum TPStatsResourceType: String {
 
 class TPStatsBlocklistChecker {
     static let shared = TPStatsBlocklistChecker()
-    private let adblockSerialQueue = DispatchQueue(label: "com.brave.adblock-dispatch-queue")
+    private let adblockSerialQueue = AdBlockStats.adblockSerialQueue
 
     func isBlocked(request: URLRequest, domain: Domain, resourceType: TPStatsResourceType? = nil) -> Deferred<BlocklistName?> {
         let deferred = Deferred<BlocklistName?>()

--- a/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -27,6 +27,8 @@ class AdBlockStats: LocalAdblockResourceProtocol {
         generalAdblockEngine = AdblockRustEngine()
     }
     
+    static let adblockSerialQueue = DispatchQueue(label: "com.brave.adblock-dispatch-queue")
+    
     func startLoading() {
         parseBundledGeneralBlocklist()
         loadDownloadedDatFiles()
@@ -41,7 +43,9 @@ class AdBlockStats: LocalAdblockResourceProtocol {
         
         do {
             let data = try Data(contentsOf: fileUrl)
-            generalAdblockEngine.set(data: data)
+            AdBlockStats.adblockSerialQueue.async {
+                self.generalAdblockEngine.set(data: data)
+            }
         } catch {
             log.error("Failed to parse bundled general blocklist: \(error)")
         }
@@ -136,15 +140,18 @@ class AdBlockStats: LocalAdblockResourceProtocol {
             return completion
         }
         
-        if engine.set(data: data) {
-            log.debug("Adblock file with id: \(id) deserialized successfully")
-            // Clearing the cache or checked urls.
-            // The new list can bring blocked resource that were previously set as not-blocked.
-            fifoCacheOfUrlsChecked = FifoDict()
-            completion.fill(())
-        } else {
-            log.error("Failed to deserialize adblock list with id: \(id)")
+        AdBlockStats.adblockSerialQueue.async {
+            if engine.set(data: data) {
+                log.debug("Adblock file with id: \(id) deserialized successfully")
+                // Clearing the cache or checked urls.
+                // The new list can bring blocked resource that were previously set as not-blocked.
+                self.fifoCacheOfUrlsChecked = FifoDict()
+                completion.fill(())
+            } else {
+                log.error("Failed to deserialize adblock list with id: \(id)")
+            }
         }
+        
         return completion
     }
     

--- a/Client/WebFilters/ShieldStats/Adblock/AdblockRustEngine.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdblockRustEngine.swift
@@ -3,15 +3,26 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import Shared
+import BraveShared
+
+private let log = Logger.browserLogger
 
 /// A wrapper around adblock_rust_lib header.
 class AdblockRustEngine {
     private let engine: OpaquePointer
     
+    var deserializationPending = false
+    
     init(rules: String = "") { engine = engine_create(rules) }
     deinit { engine_destroy(engine) }
     
     func shouldBlock(requestUrl: String, requestHost: String, sourceHost: String) -> Bool {
+        if deserializationPending {
+            log.info("Not checking for blocked resource when engine deserialization is pending")
+            return false
+        }
+        
         var explicitCancel = false
         var savedFromException = false
         let thirdPartyRequest = requestHost != sourceHost
@@ -25,6 +36,14 @@ class AdblockRustEngine {
     }
     
     @discardableResult func set(data: Data) -> Bool {
-        return engine_deserialize(engine, data.int8Array, data.count)
+        // Extra safety check to prevent race condition in case engine deserialization
+        // is called from another thread than `shouldBlock` invocation(#2699).
+        deserializationPending = true
+        
+        let status = engine_deserialize(engine, data.int8Array, data.count)
+        if !status { assertionFailure("Failed to deserialize engine") }
+        
+        deserializationPending = false
+        return status
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2699 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Verify that adblock stat counting works

Upgrade test:
1. Install 1.17
2. Open ad heavy website, keep that tab open
3. Upgrade to 1.18.1
4. The upgrade should not crash

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
