### PR TITLE
Fix #2697: Use correct icon size during edge loop for scaled image data

### DIFF
--- a/ClientTests/TestFavicons.swift
+++ b/ClientTests/TestFavicons.swift
@@ -27,4 +27,53 @@ class TestFavicons: ProfileTest {
         }
         wait(for: [expectation], timeout: 5.0)
     }
+    
+    func testIconTransparentAroundEdges() {
+        let expectation = XCTestExpectation(description: "favicon.transparent.1")
+        var image: UIImage!
+        let size = CGSize(width: 48, height: 48)
+        UIGraphicsBeginImageContext(size)
+        let context = UIGraphicsGetCurrentContext()!
+        context.setFillColor(UIColor.black.cgColor)
+        context.addEllipse(in: CGRect(size: size).insetBy(dx: 5, dy: 5))
+        context.fillPath()
+        image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        FaviconFetcher.isIconBackgroundTransparentAroundEdges(image) { isTransparent in
+            dispatchPrecondition(condition: .onQueue(.main))
+            XCTAssert(isTransparent)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    func testIconNotTransparentAroundEdges() {
+        let expectation = XCTestExpectation(description: "favicon.transparent.2")
+        var image: UIImage!
+        let size = CGSize(width: 48, height: 48)
+        UIGraphicsBeginImageContext(size)
+        let context = UIGraphicsGetCurrentContext()!
+        context.setFillColor(UIColor.black.cgColor)
+        context.addRect(CGRect(size: size))
+        context.fillPath()
+        image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        FaviconFetcher.isIconBackgroundTransparentAroundEdges(image) { isTransparent in
+            dispatchPrecondition(condition: .onQueue(.main))
+            XCTAssertFalse(isTransparent)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    func testIconTransparencyDoesntCrashWithEmptyImage() {
+        let expectation = XCTestExpectation(description: "favicon.transparent.3")
+        let image = UIImage()
+        FaviconFetcher.isIconBackgroundTransparentAroundEdges(image) { isTransparent in
+            dispatchPrecondition(condition: .onQueue(.main))
+            XCTAssertFalse(isTransparent)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5.0)
+    }
 }


### PR DESCRIPTION
Also:
- Adds a check for if the icon passed is non-zero in both axis
- Dispatches completion blocks within the global thread on main queue because the function is now static and not private

## Summary of Changes

This pull request fixes #2697 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test plan
Hard to reproduce. Please do a general browsing test
Try to add each website you visit to bookmarks.
You only have to bring up the 'add bookmark' screen, no need to tap to add it.


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
