### PR TITLE
Fix #2718: Remove sync v1.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1278,3 +1278,13 @@ extension Strings {
                               comment: "Disclaimer for user purchasing the VPN plan.")
     }
 }
+
+extension Strings {
+    public struct Sync {
+        public static let syncV1DeprecationText =
+            NSLocalizedString("sync.syncV1DeprecationText",
+                              bundle: .braveShared,
+                              value: "A new Brave Sync is coming and will affect your setup. Get ready for the upgrade.",
+                              comment: "Text that informs a user about Brave Sync service deprecation.")
+    }
+}

--- a/BraveShared/de.lproj/Localizable.strings
+++ b/BraveShared/de.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Sie surfen auf dieser Website ohne den Datenschutz von Brave. Funktioniert es nicht richtig mit Shields?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Brave Sync wird überarbeitet, was sich auf Ihre Konfiguration auswirken kann. Bereiten Sie sich auf das Upgrade vor.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Sollen Suchvorschläge aktiviert werden?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Bitte wählen Sie die Daten, die Sie mit uns teilen möchten.\n\nJe mehr Daten Sie direkt mit uns teilen, umso einfacher fällt es dem Support-Team, Ihr Problem zu lösen.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Support bereitgestellt mit der Hilfe des Guardian-Teams.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "VPN-Hostname";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problem";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Unzuverlässige Verbindung";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Kein Internet auch bei Verbindung";

--- a/BraveShared/es.lproj/Localizable.strings
+++ b/BraveShared/es.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Estás utilizando este sitio web sin la protección de privacidad de Brave. ¿Acaso no funciona bien con los escudos activados?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Pronto se realizará una nueva sincronización Brave que alterará tu configuración. Prepárate para la actualización.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "¿Activar las sugerencias de búsqueda?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Selecciona la información que quieres compartir con nosotros.\n\nCuanta más información compartas con nosotros en un primer momento, más fácil lo tendrá nuestro equipo de asistencia para ayudarte a resolver el problema.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Asistencia ofrecida con la ayuda del equipo de Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Nombre de host de VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problema";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Problema con la fiabilidad de la conexión";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "No hay Internet cuando me conecto";

--- a/BraveShared/fr.lproj/Localizable.strings
+++ b/BraveShared/fr.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Vous utilisez ce site sans les protections de confidentialité de Brave. Ne fonctionne-t-il pas correctement avec Shields activé ?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Une nouvelle synchronisation Brave sera bientôt effectuée, ce qui affectera votre configuration. Préparez-vous pour la mise à niveau.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Activer les suggestions de recherche ?";
 
@@ -205,6 +208,9 @@
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problème";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "La connexion n'est pas stable";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Aucun accès à Internet une fois connecté";

--- a/BraveShared/id-ID.lproj/Localizable.strings
+++ b/BraveShared/id-ID.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Anda menjelajahi situs ini tanpa perlindungan privasi Brave. Apakah situs tidak berfungsi benar dengan Perisai?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Brave Sync baru segera tiba dan akan mempengaruhi pengaturan Anda. Bersiaplah untuk peningkatan.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Aktifkan saran pencarian?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Silakan pilih informasi yang ingin Anda bagikan kepada kami.\n\nSemakin banyak informasi yang sejak awal Anda bagikan kepada kami, akan lebih mudah bagi staf pendukung kami untuk membantu Anda menyelesaikan masalah Anda.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Dukungan disediakan dengan bantuan dari tim Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Nama Host VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Masalah";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Masalah keandalan koneksi";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Tidak ada internet saat terkoneksi";

--- a/BraveShared/it.lproj/Localizable.strings
+++ b/BraveShared/it.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Stai navigando sul sito senza le protezioni alla privacy di Brave. Non funziona bene con Shields attivato?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "È in arrivo una nuova versione di Brave Sync che apporterà delle modifiche alla tua configurazione. Preparati all’upgrade.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Attivare i suggerimenti di ricerca?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Seleziona i dati che vuoi condividere con noi.\n\nPiù dati condividi con noi dall’inizio, più facile sarà per l’assistenza aiutarti a risolvere il tuo problema.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Assistenza in collaborazione con il team di Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Hostname VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problema";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Problema di affidabilità della connessione";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Nessun collegamento a internet durante la connessione";

--- a/BraveShared/ja.lproj/Localizable.strings
+++ b/BraveShared/ja.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "現在Braveのプライバシー保護機能オフの状態でブラウジングしています。Shieldをオンにした状態では不具合が発生しますか？";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Brave Syncがリニューアルされます。ご利用の環境にも影響がございますのでアップグレードに向けてご準備ください。";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "検索候補をオンにしますか？";
 
@@ -180,7 +183,7 @@
 "vpn.checkboxNoSellout" = "あなたの情報を第三者に共有・販売しません";
 
 /* Text for a checkbox to present the user benefits for using Brave VPN */
-"vpn.checkboxProtectConnections" = "Braveに限らず全てのアプリを保護します";
+"vpn.checkboxProtectConnections" = "Braveに限らず全てのアプリを保護";
 
 /* AppStore Receipt field for customer support contact form. */
 "vpn.contactFormAppStoreReceipt" = "AppStoreレシート";
@@ -205,6 +208,9 @@
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "イシュー";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "接続信頼性の問題";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "接続時にインターネットに接続できなかった";

--- a/BraveShared/ko-KR.lproj/Localizable.strings
+++ b/BraveShared/ko-KR.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Brave의 개인정보 보호 없이 이 사이트를 브라우징하고 계십니다. Shields 사용 시 제대로 작동하지 않나요?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "새로운 Brave Sync가 출시되어 설정에 적용될 예정입니다. 곧 업그레이드됩니다.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "추천 검색어를 사용하시겠습니까?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "공유해도 괜찮은 정보를 선택하세요.\n\n초기에 공유해주시는 정보가 많을수록 지원 담당 직원이 문제를 해결해드리기 쉬워집니다.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "지원은 Guardian 팀의 도움을 받아 제공됩니다.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "VPN 호스트 이름";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "문제";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "연결 안정성 문제";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "인터넷에 연결되지 않음";

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -587,7 +587,7 @@
 "NotEnoughWordsTitle" = "Perkataan Tidak Cukup";
 
 /* Bookmark title for Brave Support */
-"ntp.braveSupportFavoriteTitle" = "Sokongan Brave";
+"ntp.braveSupportFavoriteTitle" = "Sokongan Berani";
 
 /* No comment provided by engineer. */
 "ntp.claimRewards" = "Tuntut ganjaran saya";

--- a/BraveShared/ms.lproj/Localizable.strings
+++ b/BraveShared/ms.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Anda melayari laman web ini tanpa perlindungan privasi Brave. Adakah ia tidak berfungsi dengan betul dengan Pelindung atas?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Penyegerakan Brave baharu akan tiba dan akan mempengaruhi persediaan anda. Bersedia untuk naik taraf.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Hidupkan cadangan carian?";
 
@@ -162,7 +165,7 @@
 "vpn.buyButton" = "Beli";
 
 /* Title for screen to buy the VPN. */
-"vpn.buyVPNTitle" = "Brave Firewall + VPN";
+"vpn.buyVPNTitle" = "Tembok Api Berani + VPN";
 
 /* Text for a checkbox to present the user benefits for using Brave VPN */
 "vpn.checkboxBlockAds" = "Blok sambungan rangkaian yang tidak diingini";
@@ -183,7 +186,7 @@
 "vpn.checkboxProtectConnections" = "Lindungi semua aplikasi anda (bukan hanya Berani)";
 
 /* AppStore Receipt field for customer support contact form. */
-"vpn.contactFormAppStoreReceipt" = "Resit AppStore";
+"vpn.contactFormAppStoreReceipt" = "Resit App Store";
 
 /* App Version field for customer support contact form. */
 "vpn.contactFormAppVersion" = "Versi Aplikasi";
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Sila pilih maklumat yang anda selesa berkongsi dengan kami.\n\nSemakin banyak maklumat anda kongsi pada awalnya, semakin mudah kakitangan sokongan kami membantu menyelesaikan masalah anda.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Sokongan diberikan dengan bantuan pasukan Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Nama Hos VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Isu";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Masalah keutuhan sambungan";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Tidak ada internet apabila disambungkan";
@@ -354,7 +363,7 @@
 "vpn.vpnConfigPermissionDeniedErrorTitle" = "Kebenaran ditolak";
 
 /* Message for error when VPN could not be purchased. */
-"vpn.vpnErrorPurchaseFailedBody" = "Tidak dapat menyelesaikan pembelian. Sila cuba lagi atau periksa maklumat pembayaran anda di Apple dan cuba lagi.";
+"vpn.vpnErrorPurchaseFailedBody" = "Tidak dapat menghabiskan pembelian. Sila cuba lagi, atau periksa maklumat pembayaran anda di Apple dan cuba lagi.";
 
 /* Title for error when VPN could not be purchased. */
 "vpn.vpnErrorPurchaseFailedTitle" = "Ralat";

--- a/BraveShared/nb.lproj/Localizable.strings
+++ b/BraveShared/nb.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Du surfer på dette nettstedet uten Braves personvernsbeskyttelse. Fungerer det ikke med Skjold oppe?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "En ny versjon av Brave Sync er på vei, og dette vil påvirke oppsettet ditt. Gjør deg klar for oppgraderingen.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Slå på søkeforslag?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Velg informasjonen du vil dele med oss.\n\nJo mer informasjon du deler med oss i første omgang, jo lettere blir det for støttepersonellet å hjelpe deg med å løse problemet.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Støtte tilbys ved hjelp av Guardian-teamet.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "VPN-vertsnavn";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problem";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Problem med tilkoblingens stabilitet";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Ingen internett når du er tilkoblet";

--- a/BraveShared/pl.lproj/Localizable.strings
+++ b/BraveShared/pl.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Przeglądasz tę stronę bez użycia ochrony prywatności Brave. Czy nie działa ona właściwie przy włączonej ochronie?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Nadchodzi nowa synchronizacja Brave, która będzie miała wpływ na Twoją konfigurację. Przygotuj się na aktualizację.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Czy włączyć sugestie wyszukiwania?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Wybierz informacje, które chcesz nam udostępnić.\n\nIm więcej informacji wstępnie udostępnisz, tym łatwiej będzie naszemu działowi pomocy technicznej rozwiązać Twój problem.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Wsparcie jest zapewniane przy pomocy zespołu Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Nazwa hosta VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problem";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Problem z połączeniem";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Brak dostępu do Internetu po połączeniu";

--- a/BraveShared/pt-BR.lproj/Localizable.strings
+++ b/BraveShared/pt-BR.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Você está navegando neste site sem as proteções de privacidade do Brave. O site não funciona com as Proteções ativadas?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Uma nova versão do Sincronizar Brave chegará em breve e afetará sua configuração. Prepare-se para o upgrade.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Ativar as sugestões de pesquisa?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Selecione as informações que você aceita compartilhar conosco.\n\nQuanto mais informações você compartilhar conosco inicialmente, mais fácil será para nossa equipe de suporte ajudar você a resolver seu problema.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Suporte oferecido com a ajuda da equipe da Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Nome do host da VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problema";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Problema de confiabilidade da conexão";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Não tenho internet quando me conecto";

--- a/BraveShared/ru.lproj/Localizable.strings
+++ b/BraveShared/ru.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Вы выключили защиту конфиденциальности. Сайт неправильно отображается при включенных щитах?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Скоро станет доступна свежая версия функции «Синхронизация Brave». Это повлияет на ваши настройки. Подготовьтесь к обновлению.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Включить подсказки при поиске?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Укажите, какой информацией вы хотели бы с нами поделиться.\n\nЧем больше информации вы изначально нам предоставите, тем легче нашей службе поддержки будет помогать вам в решении возникающих проблем.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Поддержка обеспечивается при участии команды Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Имя хоста VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Проблема";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Ненадежное подключение";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Отсутствует соединение с Интернетом";

--- a/BraveShared/sv.lproj/Localizable.strings
+++ b/BraveShared/sv.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Du surfar på den här webbplatsen utan Braves sekretesskydd. Fungerar den inte korrekt med sköldar uppe?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "En ny Brave Sync är på väg och kommer att påverka dina inställningar. Gör dig redo för uppgraderingen.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Sätt på sökförslag?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Välj den information du är bekväm med att dela med oss.\n\nJu mer information du delar med dig till oss desto enklare blir det för vår supportpersonal att hjälpa dig med ditt problem.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Support tillhandahålls med hjälp av Guardian teamet.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "VPN-värdnamn";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Problem";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Problem med anslutningstillförlitlighet";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "Inget internet när jag är ansluten";

--- a/BraveShared/uk.lproj/Localizable.strings
+++ b/BraveShared/uk.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "Ви переглядаєте вебсайт з вимкненим засобом захисту конфіденційності від Brave. Вебсайт не працює належним чином, якщо щити увімкнено?";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "Скоро виходить нова синхронізація Brave, яка вплине на ваші налаштування. Підготуйтеся до оновлення.";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "Увімкнути пошукові підказки?";
 
@@ -197,11 +200,17 @@
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Вкажіть, якою інформацією ви хотіли би з нами поділитись.\n\nЧим більше інформації ви надасте нам спочатку, тим легше нашій службі підтримки буде допомагати вам у вирішенні різноманітних проблем.";
 
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "Підтримка надається за допомогою команди Guardian.";
+
 /* VPN Hostname field for customer support contact form. */
 "vpn.contactFormHostname" = "Ім’я хоста VPN";
 
 /* Specific issue field for customer support contact form. */
 "vpn.contactFormIssue" = "Проблема";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "Проблема з надійністю з’єднання";
 
 /* No internet problem for contact form issue field. */
 "vpn.contactFormIssueNoInternet" = "З’єднання з Інтернетом відсутнє";

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -550,6 +550,9 @@
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "顯示";
 
+/* Abbreviation for 'Month', use full word' Month' if this word can't be shortened in your language */
+"monthAbbreviation" = "月";
+
 /* Bookmark title / Device name */
 "Name" = "名稱";
 
@@ -582,6 +585,9 @@
 
 /* Sync Alert */
 "NotEnoughWordsTitle" = "沒有足够詞語";
+
+/* Bookmark title for Brave Support */
+"ntp.braveSupportFavoriteTitle" = "Brave 支援";
 
 /* No comment provided by engineer. */
 "ntp.claimRewards" = "領取我的獎勵";
@@ -1227,6 +1233,9 @@
 
 /* Word count title */
 "WordCount" = "字數：%i";
+
+/* Abbreviation for 'Year', use full word' Yeara' if this word can't be shortened in your language */
+"yearAbbreviation" = "年";
 
 /* Button title to confirm the deletion of a bookmarks folder */
 "YesDeleteButtonTitle" = "是的，刪除";

--- a/BraveShared/zh-TW.lproj/Localizable.strings
+++ b/BraveShared/zh-TW.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "您目前是在沒有 Brave 隱私防護的情況下瀏覽此網站。開啟 Shields 時無法正常瀏覽嗎？";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "最新 Brave Sync 即將推出，屆時您的設定將會受到影響。敬請準備升級。";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "開啟搜尋建議？";
 
@@ -157,6 +160,243 @@
 
 /* No comment provided by engineer. */
 "UserWalletGenericErrorTitle" = "抱歉，出現錯誤了。";
+
+/* Button text to buy Brave VPN */
+"vpn.buyButton" = "購買";
+
+/* Title for screen to buy the VPN. */
+"vpn.buyVPNTitle" = "Brave 防火牆 + VPN";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxBlockAds" = "封鎖不需要的網路連線";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxEncryption" = "使用 IKEv2 安全加密 VPN 通道";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxFast" = "最高可支援 100 Mbps 的速度";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxNoIPLog" = "讓您在線上保持匿名狀態";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxNoSellout" = "我們絕不會洩漏或販賣您的資訊";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxProtectConnections" = "保護您的所有應用程式 (不只是 Brave 而已)";
+
+/* AppStore Receipt field for customer support contact form. */
+"vpn.contactFormAppStoreReceipt" = "AppStore 收據";
+
+/* App Version field for customer support contact form. */
+"vpn.contactFormAppVersion" = "應用程式版本";
+
+/* Cellular Carrier field for customer support contact form. */
+"vpn.contactFormCarrier" = "行動通訊業者";
+
+/* Text to tell user to not modify support info below email's body. */
+"vpn.contactFormDoNotEditText" = "請勿編輯下方任何資訊";
+
+/* Footer for customer support contact form. */
+"vpn.contactFormFooter" = "請選取您願意提供的資訊。\n\n您主動提供的資訊越多，越有利於我們的支援人員協助您解決問題。";
+
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "支援服務由 Guardian 團隊協助提供。";
+
+/* VPN Hostname field for customer support contact form. */
+"vpn.contactFormHostname" = "VPN 主機名稱";
+
+/* Specific issue field for customer support contact form. */
+"vpn.contactFormIssue" = "問題";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "連線穩定性問題";
+
+/* No internet problem for contact form issue field. */
+"vpn.contactFormIssueNoInternet" = "沒有可用的網際網路連線";
+
+/* Other problem for contact form issue field. */
+"vpn.contactFormIssueOther" = "其他";
+
+/* Other connection problem for contact form issue field. */
+"vpn.contactFormIssueOtherConnectionError" = "無法連線至 VPN (其他錯誤)";
+
+/* Slow connection problem for contact form issue field. */
+"vpn.contactFormIssueSlowConnection" = "連線速度緩慢";
+
+/* Website problem for contact form issue field. */
+"vpn.contactFormIssueWebsiteProblems" = "網站無法運作";
+
+/* Network Type field for customer support contact form. */
+"vpn.contactFormNetworkType" = "網路類型";
+
+/* Button name to send contact form. */
+"vpn.contactFormSendButton" = "傳送";
+
+/* Subscription Type field for customer support contact form. */
+"vpn.contactFormSubscriptionType" = "訂閱類型";
+
+/* iOS Timezone field for customer support contact form. */
+"vpn.contactFormTimezone" = "iOS 時區";
+
+/* Title for contact form email. */
+"vpn.contactFormTitle" = "Brave 防火牆 + VPN 問題";
+
+/* Button text to enable Brave VPN */
+"vpn.enableButton" = "啟用";
+
+/* Message for an alert when the VPN can't get prices from the App Store */
+"vpn.errorCantGetPricesBody" = "無法連線至 App Store，請稍候再試。";
+
+/* Title for an alert when the VPN can't get prices from the App Store */
+"vpn.errorCantGetPricesTitle" = "App Store 錯誤";
+
+/* No comment provided by engineer. */
+"vpn.freeTrial" = "所有方案均包含 7 天免費試用期！";
+
+/* Disclaimer about free trial */
+"vpn.freeTrialDisclaimer" = "免費試用 7 天，7 天後將依方案價格計費。";
+
+/* Disclaimer about in app subscription */
+"vpn.iapDisclaimer" = "所有訂閱都會自動續約，但可在續約前取消。";
+
+/* Text explaining how the VPN works. */
+"vpn.installProfileBody" = "此設定檔可讓 VPN 自動連線，並隨時確保您裝置上所有應用程式的流量安全無虞。此 VPN 連線會經過加密，並採用 Brave 智慧型防火牆的路由規則，有效封鎖廣告和追蹤程式。";
+
+/* Text for 'install vpn profile' button */
+"vpn.installProfileButtonText" = "安裝 VPN 設定檔";
+
+/* No comment provided by engineer. */
+"vpn.installProfileTitle" = "Brave 現在要開始安裝 VPN 設定檔。";
+
+/* Popup that shows after user installs the vpn for the first time. */
+"vpn.installSuccessPopup" = "VPN 現已啟用";
+
+/* Title for screen to install the VPN. */
+"vpn.installTitle" = "安裝 VPN";
+
+/* Used in context: 'Monthly subscription, (it) renews monthly' */
+"vpn.monthlySubDetail" = "每月自動續約";
+
+/* No comment provided by engineer. */
+"vpn.monthlySubTitle" = "按月訂閱";
+
+/* Text to show user when their vpn plan has expired */
+"vpn.planExpired" = "已過期";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.popupCheckmark247Support" = "全天候支援";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.popupCheckmarkSecureConnections" = "確保所有連線安全無虞";
+
+/* It is used in context: 'Powered by BRAND_NAME' */
+"vpn.poweredBy" = "技術提供：";
+
+/* Message to show when vpn configuration reset fails. */
+"vpn.resetVPNErrorBody" = "無法重設 VPN 組態，請稍後再試。";
+
+/* Title for error message when vpn configuration reset fails. */
+"vpn.resetVPNErrorTitle" = "錯誤";
+
+/* No comment provided by engineer. */
+"vpn.restorePurchases" = "還原";
+
+/* No comment provided by engineer. */
+"vpn.settingHeaderBody" = "保護您的連線，並協助您的裝置徹底封鎖廣告和追蹤程式。";
+
+/* Button to contact tech support */
+"vpn.settingsContactSupport" = "與技術支援人員聯絡";
+
+/* Button for FAQ */
+"vpn.settingsFAQ" = "VPN 支援";
+
+/* Button to manage your VPN subscription */
+"vpn.settingsManageSubscription" = "管理訂閱";
+
+/* Button to reset VPN configuration */
+"vpn.settingsResetConfiguration" = "重設組態";
+
+/* Table cell title for vpn's server host */
+"vpn.settingsServerHost" = "主機";
+
+/* Table cell title for vpn's server location */
+"vpn.settingsServerLocation" = "位置";
+
+/* Header title for vpn settings server section. */
+"vpn.settingsServerSection" = "伺服器";
+
+/* Table cell title for cell that shows when the VPN subscription expires. */
+"vpn.settingsSubscriptionExpiration" = "到期日";
+
+/* Header title for vpn settings subscription section. */
+"vpn.settingsSubscriptionSection" = "訂閱";
+
+/* Table cell title for status of current VPN subscription. */
+"vpn.settingsSubscriptionStatus" = "狀態";
+
+/* Whether the VPN is enabled or not */
+"vpn.settingsVPNDisabled" = "已停用";
+
+/* Whether the VPN is enabled or not */
+"vpn.settingsVPNEnabled" = "已啟用";
+
+/* Whether the VPN plan has expired */
+"vpn.settingsVPNExpired" = "已過期";
+
+/* Notification title to tell user that the vpn is turned on even in background */
+"vpn.vpnBackgroundNotificationBody" = "即使在背景運作，Brave 也會繼續為您提供防護。";
+
+/* Notification title to tell user that the vpn is turned on even in background */
+"vpn.vpnBackgroundNotificationTitle" = "Brave 防火牆 + VPN 已開啟";
+
+/* Message for an alert when the VPN can't be configured. */
+"vpn.vpnConfigGenericErrorBody" = "初始化 VPN 時發生問題。請再試一次，或嘗試在 VPN 設定頁面中重設組態。";
+
+/* Title for an alert when the VPN can't be configured */
+"vpn.vpnConfigGenericErrorTitle" = "錯誤";
+
+/* Title for an alert when the user didn't allow to install VPN profile */
+"vpn.vpnConfigPermissionDeniedErrorBody" = "Brave 防火牆 + VPN 需要 VPN 設定檔，才能安裝到您的裝置上，發揮效用。";
+
+/* Title for an alert when the user didn't allow to install VPN profile */
+"vpn.vpnConfigPermissionDeniedErrorTitle" = "權限遭拒";
+
+/* Message for error when VPN could not be purchased. */
+"vpn.vpnErrorPurchaseFailedBody" = "無法完成購買。請再試一次，或檢查您的 Apple 付款詳細資訊後重試。";
+
+/* Title for error when VPN could not be purchased. */
+"vpn.vpnErrorPurchaseFailedTitle" = "錯誤";
+
+/* Disclaimer for user purchasing the VPN plan. */
+"vpn.vpnIAPBoilerPlate" = "各地價格可能不盡相同。我們會透過您在 iTunes 帳戶中提供的信用卡收取訂閱費用。您可以選擇 1 個月 ($9.99) 或 1 年 ($99.99) 訂閱方案，只要未在目前約期結束前 24 小時取消，系統就會自動為您續約。訂閱一旦生效即無法取消。您可以在購買後前往「帳戶設定」管理訂閱事宜。僅限免費試用一次。如果您在免費試用期結束前便選擇訂閱，未結束的效期即告失效。";
+
+/* Title Brave VPN menu item. */
+"vpn.vpnMenuItemTitle" = "Brave VPN";
+
+/* Message for alert to reset vpn configuration */
+"vpn.vpnResetAlertBody" = "此程序會重設您的 Brave 防火牆 + VPN 組態，並修正任何錯誤。這會需要一點時間，請稍候。";
+
+/* Title for alert to reset vpn configuration */
+"vpn.vpnResetAlertTitle" = "重設組態";
+
+/* Button name to reset vpn configuration */
+"vpn.vpnResetButton" = "重設";
+
+/* Name of monthly subscription in VPN Settings */
+"vpn.vpnSettingsMonthlySubName" = "按月訂閱";
+
+/* Name of annual subscription in VPN Settings */
+"vpn.vpnSettingsYearlySubName" = "按年訂閱";
+
+/* Used in context: 'yearly subscription, renew annually (to) save 16%'. The placeholder is for percent value */
+"vpn.yearlySubDetail" = "每年自動續約，立即省下 %@";
+
+/* It's like when there's few subscription plans, and one plan has the best value to price ratio, so this label says next to that plan: '(plan) - Best value' */
+"vpn.yearlySubDisclaimer" = "最超值";
+
+/* One year lenght vpn subcription */
+"vpn.yearlySubTitle" = "1 年";
 
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "Yes" = "是";

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -550,6 +550,9 @@
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "显示";
 
+/* Abbreviation for 'Month', use full word' Month' if this word can't be shortened in your language */
+"monthAbbreviation" = "月";
+
 /* Bookmark title / Device name */
 "Name" = "名称";
 
@@ -582,6 +585,9 @@
 
 /* Sync Alert */
 "NotEnoughWordsTitle" = "字数不足";
+
+/* Bookmark title for Brave Support */
+"ntp.braveSupportFavoriteTitle" = "Brave 支持";
 
 /* No comment provided by engineer. */
 "ntp.claimRewards" = "领取我的奖励";
@@ -1227,6 +1233,9 @@
 
 /* Word count title */
 "WordCount" = "字数：%i";
+
+/* Abbreviation for 'Year', use full word' Yeara' if this word can't be shortened in your language */
+"yearAbbreviation" = "年";
 
 /* Button title to confirm the deletion of a bookmarks folder */
 "YesDeleteButtonTitle" = "是的，确认删除";

--- a/BraveShared/zh.lproj/Localizable.strings
+++ b/BraveShared/zh.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 /* No comment provided by engineer. */
 "ShieldsDownDisclaimer" = "你正在没有 Brave 隐私保护的情况下浏览本网站。Shields 处于开启状态时无法正常工作吗？";
 
+/* Text that informs a user about Brave Sync service deprecation. */
+"sync.syncV1DeprecationText" = "即将推出新的 Brave Sync，它将影响您的设置。赶快做好升级的准备吧。";
+
 /* Prompt shown before enabling provider search queries */
 "Turn on search suggestions?" = "开启搜索建议功能？";
 
@@ -157,6 +160,243 @@
 
 /* No comment provided by engineer. */
 "UserWalletGenericErrorTitle" = "抱歉，出错了";
+
+/* Button text to buy Brave VPN */
+"vpn.buyButton" = "购买";
+
+/* Title for screen to buy the VPN. */
+"vpn.buyVPNTitle" = "Brave Firewall + VPN";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxBlockAds" = "阻止不需要的网络连接";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxEncryption" = "使用 IKEv2 安全加密的 VPN 隧道";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxFast" = "最高支持 100 Mbps 的速度";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxNoIPLog" = "让您匿名在线";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxNoSellout" = "我们绝不会分享或出售您的信息";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.checkboxProtectConnections" = "保护您所有的应用程序（不仅仅是 Brave）";
+
+/* AppStore Receipt field for customer support contact form. */
+"vpn.contactFormAppStoreReceipt" = "AppStore 收据";
+
+/* App Version field for customer support contact form. */
+"vpn.contactFormAppVersion" = "应用程序版本";
+
+/* Cellular Carrier field for customer support contact form. */
+"vpn.contactFormCarrier" = "蜂窝网络提供商";
+
+/* Text to tell user to not modify support info below email's body. */
+"vpn.contactFormDoNotEditText" = "请勿修改以下信息";
+
+/* Footer for customer support contact form. */
+"vpn.contactFormFooter" = "请选择您愿意与我们分享的信息。\n\n您最初与我们分享的信息越多，我们的支持人员就越容易帮助您解决问题。";
+
+/* Footer for customer support contact form. */
+"vpn.contactFormFooterSharedWithGuardian" = "在 Guardian 团队的帮助下提供的支持。";
+
+/* VPN Hostname field for customer support contact form. */
+"vpn.contactFormHostname" = "VPN 主机名";
+
+/* Specific issue field for customer support contact form. */
+"vpn.contactFormIssue" = "问题";
+
+/* Connection problems for contact form issue field. */
+"vpn.contactFormIssueConnectionReliability" = "连接可靠性问题";
+
+/* No internet problem for contact form issue field. */
+"vpn.contactFormIssueNoInternet" = "连接后没有互联网";
+
+/* Other problem for contact form issue field. */
+"vpn.contactFormIssueOther" = "其他";
+
+/* Other connection problem for contact form issue field. */
+"vpn.contactFormIssueOtherConnectionError" = "无法连接到 VPN（其他错误） ";
+
+/* Slow connection problem for contact form issue field. */
+"vpn.contactFormIssueSlowConnection" = "连接缓慢";
+
+/* Website problem for contact form issue field. */
+"vpn.contactFormIssueWebsiteProblems" = "网站无法正常运作";
+
+/* Network Type field for customer support contact form. */
+"vpn.contactFormNetworkType" = "网络类型";
+
+/* Button name to send contact form. */
+"vpn.contactFormSendButton" = "发送";
+
+/* Subscription Type field for customer support contact form. */
+"vpn.contactFormSubscriptionType" = "订阅类型";
+
+/* iOS Timezone field for customer support contact form. */
+"vpn.contactFormTimezone" = "iOS 时区";
+
+/* Title for contact form email. */
+"vpn.contactFormTitle" = "Brave Firewall + VPN 问题";
+
+/* Button text to enable Brave VPN */
+"vpn.enableButton" = "启用";
+
+/* Message for an alert when the VPN can't get prices from the App Store */
+"vpn.errorCantGetPricesBody" = "无法连接到 App Store，请在几分钟后重试。";
+
+/* Title for an alert when the VPN can't get prices from the App Store */
+"vpn.errorCantGetPricesTitle" = "App Store 错误";
+
+/* No comment provided by engineer. */
+"vpn.freeTrial" = "所有计划均包括 7 天免费试用！";
+
+/* Disclaimer about free trial */
+"vpn.freeTrialDisclaimer" = "免费试用 7 天。 7 天后，我们会向您收取计划费。";
+
+/* Disclaimer about in app subscription */
+"vpn.iapDisclaimer" = "所有订阅都会自动续订，但也可以在续订之前取消。";
+
+/* Text explaining how the VPN works. */
+"vpn.installProfileBody" = "通过此配置文件，VPN 可以始终在每个应用程序中自动连接并保护整个设备上的流量。此 VPN 连接将会被加密，并通过 Brave 的智能防火墙进行路由，以阻止广告和跟踪器。";
+
+/* Text for 'install vpn profile' button */
+"vpn.installProfileButtonText" = "安装 VPN 配置文件";
+
+/* No comment provided by engineer. */
+"vpn.installProfileTitle" = "Brave 现在会安装一个 VPN 配置文件。";
+
+/* Popup that shows after user installs the vpn for the first time. */
+"vpn.installSuccessPopup" = "VPN 已启用";
+
+/* Title for screen to install the VPN. */
+"vpn.installTitle" = "安装 VPN";
+
+/* Used in context: 'Monthly subscription, (it) renews monthly' */
+"vpn.monthlySubDetail" = "每月续约";
+
+/* No comment provided by engineer. */
+"vpn.monthlySubTitle" = "每月订阅";
+
+/* Text to show user when their vpn plan has expired */
+"vpn.planExpired" = "已到期";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.popupCheckmark247Support" = "24/7 支持";
+
+/* Text for a checkbox to present the user benefits for using Brave VPN */
+"vpn.popupCheckmarkSecureConnections" = "保护所有连接";
+
+/* It is used in context: 'Powered by BRAND_NAME' */
+"vpn.poweredBy" = "提供支持方：";
+
+/* Message to show when vpn configuration reset fails. */
+"vpn.resetVPNErrorBody" = "无法重置 VPN 配置，请稍后重试。";
+
+/* Title for error message when vpn configuration reset fails. */
+"vpn.resetVPNErrorTitle" = "错误";
+
+/* No comment provided by engineer. */
+"vpn.restorePurchases" = "恢复";
+
+/* No comment provided by engineer. */
+"vpn.settingHeaderBody" = "保护您的连接并在整个设备上屏蔽广告和跟踪器。";
+
+/* Button to contact tech support */
+"vpn.settingsContactSupport" = "联系技术支持部门";
+
+/* Button for FAQ */
+"vpn.settingsFAQ" = "VPN 支持";
+
+/* Button to manage your VPN subscription */
+"vpn.settingsManageSubscription" = "管理订阅";
+
+/* Button to reset VPN configuration */
+"vpn.settingsResetConfiguration" = "重置配置";
+
+/* Table cell title for vpn's server host */
+"vpn.settingsServerHost" = "主机";
+
+/* Table cell title for vpn's server location */
+"vpn.settingsServerLocation" = "位置";
+
+/* Header title for vpn settings server section. */
+"vpn.settingsServerSection" = "服务器";
+
+/* Table cell title for cell that shows when the VPN subscription expires. */
+"vpn.settingsSubscriptionExpiration" = "过期";
+
+/* Header title for vpn settings subscription section. */
+"vpn.settingsSubscriptionSection" = "订阅";
+
+/* Table cell title for status of current VPN subscription. */
+"vpn.settingsSubscriptionStatus" = "状态";
+
+/* Whether the VPN is enabled or not */
+"vpn.settingsVPNDisabled" = "禁用";
+
+/* Whether the VPN is enabled or not */
+"vpn.settingsVPNEnabled" = "启用";
+
+/* Whether the VPN plan has expired */
+"vpn.settingsVPNExpired" = "过期";
+
+/* Notification title to tell user that the vpn is turned on even in background */
+"vpn.vpnBackgroundNotificationBody" = "即使在后台， Brave 也会继续保护您。";
+
+/* Notification title to tell user that the vpn is turned on even in background */
+"vpn.vpnBackgroundNotificationTitle" = "Brave Firewall + VPN 已启用";
+
+/* Message for an alert when the VPN can't be configured. */
+"vpn.vpnConfigGenericErrorBody" = "初始化 VPN 时出现问题。请重试或尝试在 VPN 设置页面中重置配置。";
+
+/* Title for an alert when the VPN can't be configured */
+"vpn.vpnConfigGenericErrorTitle" = "错误";
+
+/* Title for an alert when the user didn't allow to install VPN profile */
+"vpn.vpnConfigPermissionDeniedErrorBody" = "需要在设备上安装 VPN 配置文件，Brave Firewall + VPN 才能正常工作。";
+
+/* Title for an alert when the user didn't allow to install VPN profile */
+"vpn.vpnConfigPermissionDeniedErrorTitle" = "授权被拒";
+
+/* Message for error when VPN could not be purchased. */
+"vpn.vpnErrorPurchaseFailedBody" = "无法完成购买。请重试，或在 Apple 网站查看您的付款详细信息，然后重试。";
+
+/* Title for error when VPN could not be purchased. */
+"vpn.vpnErrorPurchaseFailedTitle" = "错误";
+
+/* Disclaimer for user purchasing the VPN plan. */
+"vpn.vpnIAPBoilerPlate" = "价格可能会因位置而异。订阅将通过 iTunes 帐户从您的信用卡中扣除。订阅价格为 1 个月（$ 9.99）或  1 年（$ 99.99）。除非在当前期限结束前至少 24 小时取消，否则订阅将自动续订。激活后，您将无法取消订阅。购买后，您可以在“帐户设置”页面管理您的订阅。免费试用只能使用一次。在免费试用期间未使用的任何部分都会被没收。";
+
+/* Title Brave VPN menu item. */
+"vpn.vpnMenuItemTitle" = "Brave VPN";
+
+/* Message for alert to reset vpn configuration */
+"vpn.vpnResetAlertBody" = "这将重置您的 Brave Firewall + VPN 配置并修复所有错误。此过程可能需要一分钟。";
+
+/* Title for alert to reset vpn configuration */
+"vpn.vpnResetAlertTitle" = "重置配置";
+
+/* Button name to reset vpn configuration */
+"vpn.vpnResetButton" = "重置";
+
+/* Name of monthly subscription in VPN Settings */
+"vpn.vpnSettingsMonthlySubName" = "每月订阅";
+
+/* Name of annual subscription in VPN Settings */
+"vpn.vpnSettingsYearlySubName" = "每年订阅";
+
+/* Used in context: 'yearly subscription, renew annually (to) save 16%'. The placeholder is for percent value */
+"vpn.yearlySubDetail" = "每年续约，可节省 %@";
+
+/* It's like when there's few subscription plans, and one plan has the best value to price ratio, so this label says next to that plan: '(plan) - Best value' */
+"vpn.yearlySubDisclaimer" = "最超值";
+
+/* One year lenght vpn subcription */
+"vpn.yearlySubTitle" = "一年";
 
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "Yes" = "是";

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -121,9 +121,7 @@ class SettingsViewController: TableViewController {
         }
         list.append(generalSection)
         list.append(displaySection)
-        #if !NO_SYNC
-            list.append(otherSettingsSection)
-        #endif
+        list.append(otherSettingsSection)
         list.append(contentsOf: [privacySection,
                                  securitySection,
                                  shieldsSection,
@@ -280,28 +278,6 @@ class SettingsViewController: TableViewController {
                 ]
             }
         }
-        section.rows += [
-            Row(text: Strings.sync, selection: { [unowned self] in
-                if Sync.shared.isInSyncGroup {
-                    let syncSettingsVC = SyncSettingsTableViewController(style: .grouped)
-                    syncSettingsVC.dismissHandler = {
-                        self.navigationController?.popToRootViewController(animated: true)
-                    }
-                    
-                    self.navigationController?.pushViewController(syncSettingsVC, animated: true)
-                } else {
-                    let view = SyncWelcomeViewController()
-                    view.dismissHandler = {
-                        view.navigationController?.popToRootViewController(animated: true)
-                    }
-                    self.navigationController?.pushViewController(view, animated: true)
-                }
-                }, accessory: .disclosureIndicator,
-                   cellClass: MultilineValue1Cell.self),
-            
-            //Disabled until 1.13
-            //.boolRow(title: Strings.mediaAutoPlays, option: Preferences.General.mediaAutoPlays)
-        ]
         
         vpnRow = vpnSettingsRow()
         

--- a/Data/sync/Sync.swift
+++ b/Data/sync/Sync.swift
@@ -435,9 +435,7 @@ extension Sync {
                 //                                    }
         })
         
-        #if NO_SYNC
         leaveSyncGroup()
-        #endif
     }
     
     /// Makes call to sync to fetch new records, instead of just returning records, sync sends `get-existing-objects` message


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2718 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
No sync user
- Update from 1.19 to 1.19.1
- Nothing should happen, no alert, sync setting should be gone

Sync user
- Install 1.19 or earlier
- Enable sync chain, can add few bookmarks
- Update to 1.19.1
- Verify that alert message is showing
- Verify that no sync setting is shown, and syncing bookmarks from another device does not work

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
