### PR TITLE
Fix #2770: Set updated search engines when onboarding is skipped.

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -268,8 +268,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             Preferences.VPN.appLaunchCountForVPNPopup.value += 1
         }
         
-        if isFirstLaunch {
+        // Search engine setup must be checked outside of 'firstLaunch' loop because of #2770.
+        // There was a bug that when you skipped onboarding, default search engine preference
+        // was not set.
+        if Preferences.Search.defaultEngineName.value == nil {
             profile?.searchEngines.searchEngineSetup()
+        }
+        
+        if isFirstLaunch {
             Preferences.DAU.installationDate.value = Date()
             
             // VPN credentials are kept in keychain and persist between app reinstalls.


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2770 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
