### PR TITLE
Fix #2642: Adblock debug menu revamp.

### DIFF
--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -153,5 +153,12 @@ extension Preferences {
         static let vpnSettingHeaderWasDismissed =
             Option<Bool>(key: "vpn.vpn-header-dismissed", default: false)
     }
+    
+    final class Debug {
+        /// When general blocklists were last time updated on the device.
+        static let lastGeneralAdblockUpdate = Option<Date?>(key: "last-general-adblock-update", default: nil)
+        /// When regional blocklists were last time updated on the device.
+        static let lastRegionalAdblockUpdate = Option<Date?>(key: "last-regional-adblock-update", default: nil)
+    }
 }
 

--- a/Client/Networking/CachedNetworkResource.swift
+++ b/Client/Networking/CachedNetworkResource.swift
@@ -7,5 +7,7 @@ import Foundation
 struct CachedNetworkResource {
     let data: Data
     let etag: String?
+    /// When the resource was last time modified on the server.
+    let lastModifiedTimestamp: TimeInterval?
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2642 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Check out the new adblock menu, it should show file modified date, rule count and an etag.
Check it for other than US locale too, to see if regional lists are showing up.

You can ask someone from devops to check what file-modified and etag values are on the server if you want to compare them with what you see on client side.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="529" alt="Zrzut ekranu 2020-08-4 o 12 23 43" src="https://user-images.githubusercontent.com/6950387/89283906-3b5d8800-d64e-11ea-8670-d675ad7fb918.png">
<img width="529" alt="Zrzut ekranu 2020-08-4 o 12 23 41" src="https://user-images.githubusercontent.com/6950387/89283918-3e587880-d64e-11ea-9429-5da478ef829c.png">



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
