### PR TITLE
Fix #2635: Add delay before shutting down web server, use random port

### DIFF
--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -23,6 +23,10 @@ class WebServer {
 
     /// The private credentials for accessing resources on this Web server.
     let credentials: URLCredential
+    
+    // For development builds, random host is used in case of working with multiple instances of the app.
+    // For safety we keep static port number for public builds.
+    let port = AppConstants.buildChannel.isPublic ? 6571 : Int.random(in: 6572..<6600)
 
     /// A random, transient token used for authenticating requests.
     /// Other apps are able to make requests to our local Web server,
@@ -36,9 +40,9 @@ class WebServer {
     @discardableResult func start() throws -> Bool {
         if !server.isRunning {
             try server.start(options: [
-                GCDWebServerOption_Port: 6571,
+                GCDWebServerOption_Port: port,
                 GCDWebServerOption_BindToLocalhost: true,
-                GCDWebServerOption_AutomaticallySuspendInBackground: true,
+                GCDWebServerOption_AutomaticallySuspendInBackground: false, // done by the app in AppDelegate
                 GCDWebServerOption_AuthenticationMethod: GCDWebServerAuthenticationMethod_Basic,
                 GCDWebServerOption_AuthenticationAccounts: [sessionToken: ""]
             ])

--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -52,7 +52,9 @@ class ClientTests: XCTestCase {
 
     fileprivate func hostIsValid(_ host: String) -> Bool {
         let expectation = self.expectation(description: "Validate host for \(host)")
-        var request = URLRequest(url: URL(string: "http://\(host):6571/about/license")!)
+        let port = WebServer.sharedInstance.port
+        
+        var request = URLRequest(url: URL(string: "http://\(host):\(port)/about/license")!)
         var response: HTTPURLResponse?
         
         let username = WebServer.sharedInstance.credentials.user ?? ""


### PR DESCRIPTION
on development builds.

The webserver delay fix comes from upstream:
https://github.com/mozilla-mobile/firefox-ios/pull/4343

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2635 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
