### PR TITLE
Fix #2747: Update IAP disclaimer copy.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1274,7 +1274,7 @@ extension Strings {
         public static let vpnIAPBoilerPlate =
             NSLocalizedString("vpn.vpnIAPBoilerPlate",
                               bundle: .braveShared,
-                              value: "Price may vary by location. Subscriptions will be charged to your credit card through your iTunes account. Subscriptions are offered for either 1 month ($9.99) or 1-year ($99.99) periods, and will automatically renew unless canceled at least 24 hours before the end of the current period. You will not be able to cancel the subscription once activated. You can manage your subscriptions in Account Settings after purchase. Free trials may only be used once. Any unused portion of a free trial will be forfeited if you purchase a subscription",
+                              value: "Subscriptions will be charged via your iTunes account.\n\nAny unused portion of the free trial, if offered, is forfeited when you buy a subscription.\n\nYour subscription will renew automatically unless it is cancelled at least at least 24 hours before the end of the current period.\n\nYou can manage your subscriptions in Settings.\n\nBy using Brave, you agree to the Terms of Use and Privacy Policy.",
                               comment: "Disclaimer for user purchasing the VPN plan.")
     }
 }

--- a/Client/Frontend/BraveVPN/BuyVPNView.swift
+++ b/Client/Frontend/BraveVPN/BuyVPNView.swift
@@ -122,7 +122,6 @@ extension BuyVPNViewController {
             $0.font = UIFont.systemFont(ofSize: 13, weight: .semibold)
             $0.numberOfLines = 0
             $0.lineBreakMode = .byWordWrapping
-            $0.textAlignment = .center
             $0.appearanceTextColor = UIColor.white.withAlphaComponent(0.6)
         }
         


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2747 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Note, on this screen prices are not visible bc im testing in development mode.
<img width="373" alt="Zrzut ekranu 2020-08-5 o 15 33 31" src="https://user-images.githubusercontent.com/6950387/89419090-39b8c080-d731-11ea-92a3-38f1f9f64ea4.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
