### PR TITLE
Fix #2728: Show NTP SI notification only once.

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -375,6 +375,8 @@ class NewTabPageViewController: UIViewController, Themeable {
         
         switch notification {
         case .brandedImages(let state):
+            if Preferences.NewTabPage.atleastOneNTPNotificationWasShowed.value { return }
+            
             guard let notificationVC = NTPNotificationViewController(state: state, rewards: rewards) else { return }
             
             notificationVC.closeHandler = { [weak self] in


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2728 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
