### PR TITLE
Fix #2749: Replace switch with spinner when VPN tries to reconnect.

### DIFF
--- a/Client/Frontend/BraveVPN/BraveVPN.swift
+++ b/Client/Frontend/BraveVPN/BraveVPN.swift
@@ -56,7 +56,7 @@ class BraveVPN {
     private static var firstTimeUserConfigPending = false
     
     /// Lock to prevent user from spamming connect/disconnect button.
-    private static var reconnectPending = false
+    static var reconnectPending = false
     
     /// Status of creating vpn credentials on Guardian's servers.
     enum VPNUserCreationStatus {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2749 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
When you reconnect to the vpn, a spinner should show instead of toggle

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
