### PR TITLE
Fix #2818: Do not write rewards logs to disk

### DIFF
--- a/Shared/Logger.swift
+++ b/Shared/Logger.swift
@@ -19,7 +19,7 @@ public extension Logger {
     
     /// Logger used for things recorded on BraveRewards framework.
     static let rewardsLogger: RollingFileLogger = {
-        let logger = RollingFileLogger(filenameRoot: "rewards", logDirectoryPath: Logger.logFileDirectoryPath())
+        let logger = RollingFileLogger(filenameRoot: "rewards", logDirectoryPath: nil)
         logger.identifier = "BraveRewards"
         logger.newLogWithDate(Date(), configureDestination: { destination in
             // Same as debug log, Rewards framework handles function names in message


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2818

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

In simulator (or on a Jailbroken device) you can verify this by checking the logs directory in the applications container (looks like this, part of the directory is logged at the apps start: `~/Library/Developer/CoreSimulator/Devices/.../data/Containers/Data/Application/.../Library/Caches/Logs`) 

There should not be any new files with the prefix `rewards`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
