### PR TITLE
Ref #2824: Remove early return in `configureAndConnectVPN`.

### DIFF
--- a/Client/Frontend/BraveVPN/BraveVPN.swift
+++ b/Client/Frontend/BraveVPN/BraveVPN.swift
@@ -362,11 +362,6 @@ class BraveVPN {
     /// in this case it tries to reconfigure the vpn before connecting to it.
     static func connectOrMigrateToNewNode(completion: @escaping ((VPNConfigStatus) -> Void)) {
         helper.configureAndConnectVPN { message, status in
-            if status != .success {
-                completion(.error(type: .loadConfigError))
-                return
-            }
-            
             switch status {
             case .success:
                 completion(.success)


### PR DESCRIPTION
This didn't allow user to migrate to new node. Now if the status
we get is `doesNeedMigration` proper code branch will be called.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #2824 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
