### PR TITLE
Fix #2831: Add default browser callouts for iOS14 users.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -335,6 +335,9 @@ extension Strings {
     public static let setDefaultBrowserCalloutTitle =
         NSLocalizedString("setDefaultBrowserCalloutTitle", tableName: "BraveShared", bundle: .braveShared,
                           value: "Brave can now be set as your default browser in iOS. Tap here to open settings.", comment: "")
+    public static let defaultBrowserCalloutCloseAccesabilityLabel =
+        NSLocalizedString("defaultBrowserCalloutCloseAccesabilityLabel", tableName: "BraveShared",
+                          bundle: .braveShared, value: "Close default browser callout", comment: "")
 }
 
 // MARK:- Error pages.

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -330,6 +330,11 @@ extension Strings {
     public static let copyWalletSupportInfo = NSLocalizedString("CopyWalletSupportInfo", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Copy Support Info", comment: "Copy rewards internals info for support")
     public static let settingsLicenses = NSLocalizedString("SettingsLicenses", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Licenses", comment: "Row name for licenses.")
     public static let openBraveRewardsSettings = NSLocalizedString("OpenBraveRewardsSettings", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Open Brave Rewards Settings", comment: "Button title for opening the Brave Rewards panel to settings")
+    public static let setDefaultBrowserSettingsCell =
+        NSLocalizedString("setDefaultBrowserSettingsCell", tableName: "BraveShared", bundle: .braveShared, value: "Set as Default Browser", comment: "Settings item to set the Brave as a default browser on the iOS device.")
+    public static let setDefaultBrowserCalloutTitle =
+        NSLocalizedString("setDefaultBrowserCalloutTitle", tableName: "BraveShared", bundle: .braveShared,
+                          value: "Brave can now be set as your default browser in iOS. Tap here to open settings.", comment: "")
 }
 
 // MARK:- Error pages.

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		0A62A355238C6F3E008902E3 /* Bookmark+Restoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A62A354238C6F3E008902E3 /* Bookmark+Restoration.swift */; };
 		0A66550A23E9D9750047EF2A /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550923E9D9750047EF2A /* UserAgent.swift */; };
 		0A66550C23E9E04F0047EF2A /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550B23E9E04F0047EF2A /* UserAgentTests.swift */; };
+		0A6BEF6624FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6BEF6524FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift */; };
 		0A6F957624044F070098217F /* NTPLearnMoreContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */; };
 		0A764F31230EE5CA003A1D9B /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A764F30230EE5CA003A1D9B /* OnboardingState.swift */; };
 		0A771D35218C8FDC00336E0D /* Bookmark+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A771D34218C8FDC00336E0D /* Bookmark+Sync.swift */; };
@@ -172,6 +173,7 @@
 		0AF3B4F2213D8E3300695962 /* BookmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF3B4EA213D8E3200695962 /* BookmarkTests.swift */; };
 		0AF3B4F3213D8E3300695962 /* DeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF3B4EB213D8E3300695962 /* DeviceTests.swift */; };
 		0AF3B4F4213D8E3300695962 /* TabMOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF3B4EC213D8E3300695962 /* TabMOTests.swift */; };
+		0AF4C59424F8003A00E500DD /* DefaultBrowserCalloutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF4C59324F8003A00E500DD /* DefaultBrowserCalloutProvider.swift */; };
 		0AF52D06237B19CB00BFAB56 /* BytesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF52D05237B19CB00BFAB56 /* BytesTests.swift */; };
 		0AF684622191D6470079EC77 /* bookmark_util.js in Resources */ = {isa = PBXBuildFile; fileRef = 0AF6845A2191D6470079EC77 /* bookmark_util.js */; };
 		0AF6B1E824A0EDC1005417FC /* InstallVPNViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF6B1E624A0EDC1005417FC /* InstallVPNViewController.swift */; };
@@ -1452,6 +1454,7 @@
 		0A66550D23E9EA540047EF2A /* Brave_iPad.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Brave_iPad.xctestplan; sourceTree = "<group>"; };
 		0A67500A23571F21006A6D00 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Storage.strings; sourceTree = "<group>"; };
 		0A6AC4E824484FBC003D1ED7 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		0A6BEF6524FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabCenteredCollectionViewCell.swift; sourceTree = "<group>"; };
 		0A6E095E230E05BC00AB3F19 /* onboarding-shields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-shields.json"; sourceTree = "<group>"; };
 		0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPLearnMoreContentView.swift; sourceTree = "<group>"; };
 		0A75A3BD23571F2B00013540 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Storage.strings"; sourceTree = "<group>"; };
@@ -1531,6 +1534,7 @@
 		0AF3B4EA213D8E3200695962 /* BookmarkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkTests.swift; sourceTree = "<group>"; };
 		0AF3B4EB213D8E3300695962 /* DeviceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceTests.swift; sourceTree = "<group>"; };
 		0AF3B4EC213D8E3300695962 /* TabMOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabMOTests.swift; sourceTree = "<group>"; };
+		0AF4C59324F8003A00E500DD /* DefaultBrowserCalloutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserCalloutProvider.swift; sourceTree = "<group>"; };
 		0AF52D05237B19CB00BFAB56 /* BytesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesTests.swift; sourceTree = "<group>"; };
 		0AF6845A2191D6470079EC77 /* bookmark_util.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = bookmark_util.js; sourceTree = "<group>"; };
 		0AF6B1E624A0EDC1005417FC /* InstallVPNViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstallVPNViewController.swift; sourceTree = "<group>"; };
@@ -3610,6 +3614,7 @@
 				27201EFB24535C2F00C19DD1 /* NewTabPageFlowLayout.swift */,
 				27201EF824535A9500C19DD1 /* NewTabCollectionViewCell.swift */,
 				27EB601F244607DA00265C1B /* NewTabPageViewController.swift */,
+				0A6BEF6524FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift */,
 			);
 			path = "New Tab Page";
 			sourceTree = "<group>";
@@ -3617,6 +3622,7 @@
 		276A790E24476F8100AC9446 /* Sections */ = {
 			isa = PBXGroup;
 			children = (
+				0AF4C59324F8003A00E500DD /* DefaultBrowserCalloutProvider.swift */,
 				276A790F24476FD200AC9446 /* StatsSectionProvider.swift */,
 				27FCA8DF2447708300A8CA48 /* FavoritesSectionProvider.swift */,
 				27FCA8E2244770AB00A8CA48 /* FavoritesOverflowSectionProvider.swift */,
@@ -6769,6 +6775,7 @@
 				396CDB55203C5B870034A3A3 /* TabTrayController+KeyCommands.swift in Sources */,
 				74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */,
 				0A1DF468244858CA00541FE4 /* VPNProductInfo.swift in Sources */,
+				0AF4C59424F8003A00E500DD /* DefaultBrowserCalloutProvider.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
 				E689C7301E0C7617008BAADB /* NSAttributedStringExtensions.swift in Sources */,
@@ -6932,6 +6939,7 @@
 				D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */,
 				E4A961181AC041C40069AD6F /* ReadabilityService.swift in Sources */,
 				0A55E544243744DC0069F06A /* BraveVPN.swift in Sources */,
+				0A6BEF6624FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift in Sources */,
 				5E612A90234B7FCD007D12B5 /* OnboardingRewardsAgreementView.swift in Sources */,
 				4422D56A21BFFB7F00BF1855 /* simplify.cc in Sources */,
 				5EC594F1232C697200922111 /* OnboardingAdsCountdownView.swift in Sources */,

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -70,6 +70,9 @@ extension Preferences {
         static let basicOnboardingProgress = Option<Int>(key: "general.basic-onboarding-progress", default: OnboardingProgress.none.rawValue)
         /// Whether or not link preview upon long press action should be shown.
         static let enableLinkPreview = Option<Bool>(key: "general.night-mode", default: true)
+        
+        static let defaultBrowserCalloutDismissed =
+            Option<Bool>(key: "general.default-browser-callout-dismissed", default: false)
     }
     final class Search {
         /// Whether or not to show suggestions while the user types

--- a/Client/Frontend/Browser/New Tab Page/NewTabCenteredCollectionViewCell.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabCenteredCollectionViewCell.swift
@@ -1,0 +1,38 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveUI
+
+/// A new tab collection view cell where the view is horizontally centered and themeable.
+class NewTabCenteredCollectionViewCell<View: UIView & Themeable>: UICollectionViewCell, Themeable, CollectionViewReusable {
+    /// The content view
+    let view = View()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(view)
+        view.snp.remakeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.centerX.equalToSuperview()
+        }
+    }
+    
+    var themeableChildren: [Themeable?]? {
+        [view]
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        // swiftlint:disable:next force_cast
+        let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
+        attributes.size.height = systemLayoutSizeFitting(layoutAttributes.size, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel).height
+        return attributes
+    }
+}

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -123,6 +123,12 @@ class NewTabPageViewController: UIViewController, Themeable {
                 self?.delegate?.tappedDuckDuckGoCallout()
             }),
         ]
+        
+        // This is a one-off view, adding it to the NTP only if necessary.
+        if DefaultBrowserCalloutProvider.shouldShowCallout {
+            sections.insert(DefaultBrowserCalloutProvider(), at: 0)
+        }
+        
         collectionView.delegate = self
         collectionView.dataSource = self
         applyTheme(Theme.of(tab))

--- a/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
@@ -50,7 +50,7 @@ class DefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
             return .zero
         }
         
-        return UIEdgeInsets(top: 24, left: 16, bottom: 16, right: 16)
+        return UIEdgeInsets(top: 12, left: 16, bottom: -16, right: 16)
     }
     
     @objc func openSettings() {

--- a/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
@@ -1,0 +1,113 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveUI
+import Shared
+import BraveShared
+
+class DefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
+    var sectionDidChange: (() -> Void)?
+    
+    private typealias Cell = NewTabCenteredCollectionViewCell<DefaultBrowserCalloutView>
+    
+    static var shouldShowCallout: Bool {
+        !Preferences.General.defaultBrowserCalloutDismissed.value
+            && AppConstants.iOSVersionGreaterThanOrEqual(to: 14)
+    }
+    
+    func registerCells(to collectionView: UICollectionView) {
+        collectionView.register(Cell.self)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        Self.shouldShowCallout ? 1 : 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView,
+                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(for: indexPath) as Cell
+        cell.view.addTarget(self, action: #selector(openSettings), for: .touchUpInside)
+        cell.view.closeHaandler = { [weak self] in
+            Preferences.General.defaultBrowserCalloutDismissed.value = true
+            self?.sectionDidChange?()
+            
+        }
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        return fittingSizeForCollectionView(collectionView, section: indexPath.section)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        if !Self.shouldShowCallout {
+            return .zero
+        }
+        
+        return UIEdgeInsets(top: 24, left: 16, bottom: 16, right: 16)
+    }
+    
+    @objc func openSettings() {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        
+        Preferences.General.defaultBrowserCalloutDismissed.value = true
+        UIApplication.shared.open(settingsUrl)
+    }
+}
+
+private class DefaultBrowserCalloutView: SpringButton, Themeable {
+    
+    var closeHaandler: (() -> Void)?
+    
+    private let closeButton = UIButton().then {
+        $0.setImage(#imageLiteral(resourceName: "close_tab_bar").template, for: .normal)
+        $0.tintColor = .lightGray
+        $0.contentEdgeInsets = UIEdgeInsets(equalInset: 4)
+    }
+    
+    private let label = UILabel().then {
+        $0.text = Strings.setDefaultBrowserCalloutTitle
+        $0.appearanceTextColor = .black
+        $0.font = UIFont.systemFont(ofSize: 14.0, weight: .medium)
+        $0.numberOfLines = 0
+        $0.preferredMaxLayoutWidth = 280
+        $0.textAlignment = .center
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        clipsToBounds = true
+        layer.cornerRadius = 8
+        backgroundColor = #colorLiteral(red: 0.8588235294, green: 0.9568627451, blue: 0.862745098, alpha: 1)
+        
+        addSubview(label)
+        addSubview(closeButton)
+        
+        closeButton.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
+        
+        label.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview().inset(10)
+            $0.leading.equalToSuperview().offset(24)
+            $0.trailing.equalTo(closeButton).inset(20)
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(2)
+            $0.trailing.equalToSuperview().inset(8)
+        }
+    }
+    
+    @objc func closeTab() {
+        closeHaandler?()
+    }
+
+}

--- a/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
@@ -11,7 +11,7 @@ import BraveShared
 class DefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
     var sectionDidChange: (() -> Void)?
     
-    private typealias Cell = NewTabCenteredCollectionViewCell<DefaultBrowserCalloutView>
+    private typealias DefaultBrowserCalloutCell = NewTabCenteredCollectionViewCell<DefaultBrowserCalloutView>
     
     static var shouldShowCallout: Bool {
         !Preferences.General.defaultBrowserCalloutDismissed.value
@@ -19,7 +19,7 @@ class DefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
     }
     
     func registerCells(to collectionView: UICollectionView) {
-        collectionView.register(Cell.self)
+        collectionView.register(DefaultBrowserCalloutCell.self)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -28,7 +28,7 @@ class DefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
     
     func collectionView(_ collectionView: UICollectionView,
                         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(for: indexPath) as Cell
+        let cell = collectionView.dequeueReusableCell(for: indexPath) as DefaultBrowserCalloutCell
         cell.view.addTarget(self, action: #selector(openSettings), for: .touchUpInside)
         cell.view.closeHaandler = { [weak self] in
             Preferences.General.defaultBrowserCalloutDismissed.value = true
@@ -71,6 +71,7 @@ private class DefaultBrowserCalloutView: SpringButton, Themeable {
         $0.setImage(#imageLiteral(resourceName: "close_tab_bar").template, for: .normal)
         $0.tintColor = .lightGray
         $0.contentEdgeInsets = UIEdgeInsets(equalInset: 4)
+        $0.accessibilityLabel = Strings.defaultBrowserCalloutCloseAccesabilityLabel
     }
     
     private let label = UILabel().then {

--- a/Client/Frontend/Browser/New Tab Page/Sections/DuckDuckGoCalloutSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/DuckDuckGoCalloutSectionProvider.swift
@@ -53,27 +53,12 @@ private class DuckDuckGoCalloutButton: SpringButton, Themeable {
     }
 }
 
-private class DuckDuckGoCalloutCell: NewTabCollectionViewCell<DuckDuckGoCalloutButton> {
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        view.snp.remakeConstraints {
-            $0.top.bottom.equalToSuperview()
-            $0.centerX.equalToSuperview()
-        }
-    }
-    
-    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        // swiftlint:disable:next force_cast
-        let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
-        attributes.size.height = systemLayoutSizeFitting(layoutAttributes.size, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel).height
-        return attributes
-    }
-}
-
 class DuckDuckGoCalloutSectionProvider: NSObject, NTPObservableSectionProvider {
     var sectionDidChange: (() -> Void)?
     private let profile: Profile
     private let action: () -> Void
+    
+    private typealias Cell = NewTabCenteredCollectionViewCell<DuckDuckGoCalloutButton>
     
     init(profile: Profile, action: @escaping () -> Void) {
         self.profile = profile
@@ -103,11 +88,11 @@ class DuckDuckGoCalloutSectionProvider: NSObject, NTPObservableSectionProvider {
     }
     
     func registerCells(to collectionView: UICollectionView) {
-        collectionView.register(DuckDuckGoCalloutCell.self)
+        collectionView.register(Cell.self)
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(for: indexPath) as DuckDuckGoCalloutCell
+        let cell = collectionView.dequeueReusableCell(for: indexPath) as Cell
         cell.view.addTarget(self, action: #selector(tappedButton), for: .touchUpInside)
         return cell
     }

--- a/Client/Frontend/Browser/New Tab Page/Sections/DuckDuckGoCalloutSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/DuckDuckGoCalloutSectionProvider.swift
@@ -58,7 +58,7 @@ class DuckDuckGoCalloutSectionProvider: NSObject, NTPObservableSectionProvider {
     private let profile: Profile
     private let action: () -> Void
     
-    private typealias Cell = NewTabCenteredCollectionViewCell<DuckDuckGoCalloutButton>
+    private typealias DuckDuckGoCalloutCell = NewTabCenteredCollectionViewCell<DuckDuckGoCalloutButton>
     
     init(profile: Profile, action: @escaping () -> Void) {
         self.profile = profile
@@ -88,11 +88,11 @@ class DuckDuckGoCalloutSectionProvider: NSObject, NTPObservableSectionProvider {
     }
     
     func registerCells(to collectionView: UICollectionView) {
-        collectionView.register(Cell.self)
+        collectionView.register(DuckDuckGoCalloutCell.self)
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(for: indexPath) as Cell
+        let cell = collectionView.dequeueReusableCell(for: indexPath) as DuckDuckGoCalloutCell
         cell.view.addTarget(self, action: #selector(tappedButton), for: .touchUpInside)
         return cell
     }

--- a/Client/Frontend/Browser/New Tab Page/Sections/FavoritesOverflowSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/FavoritesOverflowSectionProvider.swift
@@ -43,26 +43,11 @@ class FavoritesOverflowButton: SpringButton, Themeable {
     }
 }
 
-class FavoritesOverflowCell: NewTabCollectionViewCell<FavoritesOverflowButton> {
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        view.snp.remakeConstraints {
-            $0.top.bottom.equalToSuperview()
-            $0.centerX.equalToSuperview()
-        }
-    }
-    
-    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        // swiftlint:disable:next force_cast
-        let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
-        attributes.size.height = systemLayoutSizeFitting(layoutAttributes.size, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel).height
-        return attributes
-    }
-}
-
 class FavoritesOverflowSectionProvider: NSObject, NTPObservableSectionProvider {
     let action: () -> Void
     var sectionDidChange: (() -> Void)?
+    
+    private typealias Cell = NewTabCenteredCollectionViewCell<FavoritesOverflowButton>
     
     private var frc: NSFetchedResultsController<Bookmark>
     
@@ -86,11 +71,11 @@ class FavoritesOverflowSectionProvider: NSObject, NTPObservableSectionProvider {
     }
     
     func registerCells(to collectionView: UICollectionView) {
-        collectionView.register(FavoritesOverflowCell.self)
+        collectionView.register(Cell.self)
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(for: indexPath) as FavoritesOverflowCell
+        let cell = collectionView.dequeueReusableCell(for: indexPath) as Cell
         cell.view.addTarget(self, action: #selector(tappedButton), for: .touchUpInside)
         return cell
     }

--- a/Client/Frontend/Browser/New Tab Page/Sections/FavoritesOverflowSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/FavoritesOverflowSectionProvider.swift
@@ -47,7 +47,7 @@ class FavoritesOverflowSectionProvider: NSObject, NTPObservableSectionProvider {
     let action: () -> Void
     var sectionDidChange: (() -> Void)?
     
-    private typealias Cell = NewTabCenteredCollectionViewCell<FavoritesOverflowButton>
+    private typealias FavoritesOverflowCell = NewTabCenteredCollectionViewCell<FavoritesOverflowButton>
     
     private var frc: NSFetchedResultsController<Bookmark>
     
@@ -71,11 +71,11 @@ class FavoritesOverflowSectionProvider: NSObject, NTPObservableSectionProvider {
     }
     
     func registerCells(to collectionView: UICollectionView) {
-        collectionView.register(Cell.self)
+        collectionView.register(FavoritesOverflowCell.self)
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(for: indexPath) as Cell
+        let cell = collectionView.dequeueReusableCell(for: indexPath) as FavoritesOverflowCell
         cell.view.addTarget(self, action: #selector(tappedButton), for: .touchUpInside)
         return cell
     }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -178,24 +178,34 @@ class SettingsViewController: TableViewController {
     }
     
     private lazy var generalSection: Section = {
-        var general = Section(
-            header: .title(Strings.settingsGeneralSectionTitle),
-            rows: [
-                Row(text: Strings.searchEngines, selection: {
-                    let viewController = SearchSettingsTableViewController()
-                    viewController.model = self.profile.searchEngines
-                    viewController.profile = self.profile
-                    self.navigationController?.pushViewController(viewController, animated: true)
-                }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
-                .boolRow(title: Strings.saveLogins, option: Preferences.General.saveLogins),
-                .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups)
-            ]
-        )
+        var rows = [
+            Row(text: Strings.searchEngines, selection: {
+                let viewController = SearchSettingsTableViewController()
+                viewController.model = self.profile.searchEngines
+                viewController.profile = self.profile
+                self.navigationController?.pushViewController(viewController, animated: true)
+            }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
+            .boolRow(title: Strings.saveLogins, option: Preferences.General.saveLogins),
+            .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups)]
         
         if #available(iOS 13.0, *), UIDevice.isIpad {
-            general.rows.append(.boolRow(title: Strings.alwaysRequestDesktopSite,
+            rows.append(.boolRow(title: Strings.alwaysRequestDesktopSite,
             option: Preferences.General.alwaysRequestDesktopSite))
         }
+        
+        if AppConstants.iOSVersionGreaterThanOrEqual(to: 14) {
+            rows.append(.init(text: Strings.setDefaultBrowserSettingsCell, selection: { [unowned self] in
+            guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+                return
+            }
+            UIApplication.shared.open(settingsUrl)
+            }, cellClass: MultilineButtonCell.self))
+        }
+        
+        var general = Section(
+            header: .title(Strings.settingsGeneralSectionTitle),
+            rows: rows
+        )
         
         return general
     }()

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -68,6 +68,10 @@ public struct AppConstants {
             return AppBuildChannel.debug
         #endif
     }()
+    
+    public static func iOSVersionGreaterThanOrEqual(to version: Int) -> Bool {
+        ProcessInfo().operatingSystemVersion.majorVersion >= version
+    }
 
     public static let scheme: String = {
         guard let identifier = Bundle.main.bundleIdentifier else {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2831 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="529" alt="Zrzut ekranu 2020-08-31 o 11 26 59" src="https://user-images.githubusercontent.com/6950387/91705708-a0d56380-eb7d-11ea-81a6-369fc5522ad4.png">

<img width="529" alt="Zrzut ekranu 2020-08-31 o 11 27 07" src="https://user-images.githubusercontent.com/6950387/91705806-c2cee600-eb7d-11ea-9a80-700821af02c7.png">

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
