### PR TITLE
Fix #2864: Update user agents.

### DIFF
--- a/Shared/UserAgentBuilder.swift
+++ b/Shared/UserAgentBuilder.swift
@@ -11,10 +11,6 @@ public struct UserAgentBuilder {
     private let safariBuildNumber = "604.1"
     private let webkitVersion = "605.1.15"
     
-    /// If we fail getting proper safari version, this version will be used instead.
-    /// It is for the 'Safari/13.0.5' part of UA.
-    private let fallbackSafariVersion = "13.0.5"
-    
     private let device: UIDevice
     private let os: OperatingSystemVersion
     
@@ -37,7 +33,7 @@ public struct UserAgentBuilder {
         return """
         Mozilla/5.0 (\(cpuInfo)) \
         AppleWebKit/\(webkitVersion) (KHTML, like Gecko) \
-        Version/\(versionNumber) \
+        Version/\(safariVersion) \
         Mobile/\(kernelVersion) \
         Safari/\(safariBuildNumber)
         """
@@ -47,6 +43,15 @@ public struct UserAgentBuilder {
     // These are not super precise because each iOS version can have slighly different desktop UA.
     // The only differences are with exact `Version/XX` and `MAC OS X 10_XX` numbers.
     private var desktopUA: String {
+        // Taken from Safari 14.0(ios 14 beta 7)
+        let iOS14DesktopUA =
+        """
+        Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
+        AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0 \
+        Safari/605.1.15
+        """
+        
         // Taken from Safari 13.4
         let iOS13DesktopUA =
         """
@@ -68,18 +73,13 @@ public struct UserAgentBuilder {
         switch os.majorVersion {
         case 12: return iOS12DesktopUA
         case 13: return iOS13DesktopUA
+        case 14: return iOS14DesktopUA
         // Fallback to iOS13 UA, next desktop UA will be added once iOS 14 is ready.
         default: return iOS13DesktopUA
         }
     }
     
     private var cpuInfo: String {
-        var osVersionString = "\(os.majorVersion)_\(os.minorVersion)"
-        
-        if os.patchVersion > 0 {
-            osVersionString.append("_\(os.patchVersion)")
-        }
-        
         var currentDevice = device.model
         // Only use first part of device name(so "iPod Touch" becomes "iPod")
         if let deviceNameFirstPart = currentDevice.split(separator: " ").first {
@@ -88,66 +88,28 @@ public struct UserAgentBuilder {
         
         let platform = device.userInterfaceIdiom == .pad ? "OS" : "iPhone OS"
         
-        return "\(currentDevice); CPU \(platform) \(osVersionString) like Mac OS X"
+        return "\(currentDevice); CPU \(platform) \(osVersion) like Mac OS X"
     }
     
-    // 'Version/13.0' part of UA. It seems to be based on Safaris build number.
-    private var versionNumber: String {
-        var versionWithDots = "\(os.majorVersion).\(os.minorVersion)"
-        if os.patchVersion > 0 {
-            versionWithDots += ".\(os.patchVersion)"
-        }
-        
-        return getSafariVersion(for: versionWithDots)
-    }
-    
-    private func getSafariVersion(for iOSVersion: String) -> String {
-        // Safari's versions don't follow iOS versions directly.
-        // For better coverage of versions, each iOS version has their Safari number set individually.
-        // Correct Safari numbers were taken from https://user-agents.net/browsers/safari
-        switch iOSVersion {
-        case "12.0", "12.0.1", "12.1", "12.1.1", "12.1.2", "12.1.3", "12.1.4":
-            return "12.0"
-        case "12.2":
-            return "12.1"
-        case "12.3", "12.3.1", "12.3.2":
-            return "12.1.1"
-        case "12.4", "12.4.1", "12.4.2", "12.4.3", "12.4.4", "12.4.5":
-            return "12.1.2"
-        case "13.0":
-            return "13.0"
-        case "13.1", "13.1.1", "13.1.2", "13.1.3":
-            return "13.0.1"
-        case "13.2", "13.2.1", "13.2.2", "13.2.3":
-            return "13.0.3"
-        case "13.3":
-            return "13.0.4"
-        case "13.3.1":
-            return "13.0.5"
-        case "13.4":
-            return "13.1"
-        default:
-            // We can't predict what exact safari versions for future iOS releases.
-            // As a fallback we aim to use as highest Safari version as possible for give iOS major version.
-            //
-            // For example if new iOS 13.5 release shows up `highestSafariVersion` will be used.
-            // This also works for iOS 12, as Apple still releases hotfixes there.
-            // iOS versions were taken from https://en.wikipedia.org/wiki/IOS_version_history
-            guard let majorVersion = iOSVersion.components(separatedBy: ".").first else {
-                assertionFailure("Could not extract major version from \(iOSVersion)")
-                return fallbackSafariVersion
-            }
-            
-            return highestSafariVersion(majorOSVersion: majorVersion)
+    /// 'Version/13.0' part of UA. It seems to be based on Safaris build number.
+    private var osVersion: String {
+        switch os.majorVersion {
+            case 12: return "12_4_1"
+            case 13: return "13_6_1"
+            case 14: return "14_0"
+            default: return "\(os.majorVersion)_0"
+                
         }
     }
     
-    private func highestSafariVersion(majorOSVersion: String) -> String {
-        switch majorOSVersion {
-        case "12": return "12.1.2"
-        case "13": return "13.1"
-        default:
-            return "\(majorOSVersion).0"
+    /// 'Version/13.0' part of UA. It seems to be based on Safaris build number.
+    private var safariVersion: String {
+        switch os.majorVersion {
+            case 12: return "12.1.2"
+            case 13: return "13.1.2"
+            case 14: return "14.0"
+            default: return "\(os.majorVersion).0"
+                
         }
     }
 }

--- a/SharedTests/UserAgentBuilderTests.swift
+++ b/SharedTests/UserAgentBuilderTests.swift
@@ -38,6 +38,14 @@ class UserAgentBuilderTests: XCTestCase {
         Safari/605.1.15
         """
         
+        let iOS14DesktopUA =
+        """
+        Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
+        AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0 \
+        Safari/605.1.15
+        """
+        
         let iOS12 = OperatingSystemVersion(majorVersion: 12, minorVersion: 0, patchVersion: 0)
         
         XCTAssertEqual(iOS12DesktopUA,
@@ -57,6 +65,16 @@ class UserAgentBuilderTests: XCTestCase {
         XCTAssertEqual(iOS13DesktopUA,
                        UserAgentBuilder(device: iPad, iOSVersion: iOS13).build(desktopMode: true),
                        "iOS 13 desktop User Agent on iPad doesn't match")
+        
+        let iOS14 = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0)
+        
+        XCTAssertEqual(iOS14DesktopUA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: iOS14).build(desktopMode: true),
+                       "iOS 13 desktop User Agent on iPhone doesn't match")
+        
+        XCTAssertEqual(iOS14DesktopUA,
+                       UserAgentBuilder(device: iPad, iOSVersion: iOS14).build(desktopMode: true),
+                       "iOS 13 desktop User Agent on iPad doesn't match")
     }
     
     func testSpecificMobileUA() {
@@ -65,56 +83,121 @@ class UserAgentBuilderTests: XCTestCase {
         //
         // For iPads please remember that desktop UA is used by default on 13+,
         // switch to mobile UA in safari before pasting the results here.
+        //
+        // At the moment each iOS version has one corresponding Safari UA attached
+        // so for example 13.1 and 13.3 have the same UA.
         
-        // MARK: iPhone 13.3.1
-        let ios13_3_1 = OperatingSystemVersion(majorVersion: 13, minorVersion: 3, patchVersion: 1)
-        let iPhone_safari_13_3_1_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/13.0.5 \
+        // MARK: - iOS 14
+        let iPhone_safari_14_UA = """
+        Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        XCTAssertEqual(iPhone_safari_13_3_1_UA,
+        let iPad_safari_14_UA = """
+        Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0 \
+        Mobile/15E148 \
+        Safari/604.1
+        """
+        
+        // MARK: 14.0
+        let ios14_0 = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0)
+        
+        XCTAssertEqual(iPhone_safari_14_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios14_0).build(desktopMode: false),
+                       "User agent for iOS 14.0 iPhone doesn't match.")
+        
+        XCTAssertEqual(iPad_safari_14_UA,
+                       UserAgentBuilder(device: iPad, iOSVersion: ios14_0).build(desktopMode: false),
+                       "User agent for iOS 14.0 iPad doesn't match.")
+        
+        // MARK: 14.1.1
+        let ios14_1_1 = OperatingSystemVersion(majorVersion: 14, minorVersion: 1, patchVersion: 1)
+        
+        XCTAssertEqual(iPhone_safari_14_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios14_1_1).build(desktopMode: false),
+                       "User agent for iOS 14.1.1 iPhone doesn't match.")
+        
+        XCTAssertEqual(iPad_safari_14_UA,
+                       UserAgentBuilder(device: iPad, iOSVersion: ios14_1_1).build(desktopMode: false),
+                       "User agent for iOS 14.1.1 iPad doesn't match.")
+        
+        
+        // MARK: - iOS 13
+        let iPhone_safari_13_UA = """
+        Mozilla/5.0 (iPhone; CPU iPhone OS 13_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/13.1.2 \
+        Mobile/15E148 \
+        Safari/604.1
+        """
+        
+        let iPad_safari_13_UA = """
+        Mozilla/5.0 (iPad; CPU OS 13_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/13.1.2 \
+        Mobile/15E148 \
+        Safari/604.1
+        """
+        
+        // MARK: 13.3.1
+        let ios13_3_1 = OperatingSystemVersion(majorVersion: 13, minorVersion: 3, patchVersion: 1)
+        
+        XCTAssertEqual(iPhone_safari_13_UA,
                        UserAgentBuilder(device: iPhone, iOSVersion: ios13_3_1).build(desktopMode: false),
                        "User agent for iOS 13.3.1 iPhone doesn't match.")
         
-        // MARK: iPad 13.3.1
-        let iPad_safari_13_3_1_UA = """
-        Mozilla/5.0 (iPad; CPU OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/13.0.5 \
-        Mobile/15E148 \
-        Safari/604.1
-        """
-        
-        XCTAssertEqual(iPad_safari_13_3_1_UA,
+        XCTAssertEqual(iPad_safari_13_UA,
                        UserAgentBuilder(device: iPad, iOSVersion: ios13_3_1).build(desktopMode: false),
                        "User agent for iOS 13.3.1 iPad doesn't match.")
         
-        // MARK: iPhone 12.4
-        let ios12_4 = OperatingSystemVersion(majorVersion: 12, minorVersion: 4, patchVersion: 0)
-        let iPhone_safari_12_4_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        // MARK: 13.7
+        let ios13_7 = OperatingSystemVersion(majorVersion: 13, minorVersion: 7, patchVersion: 0)
+        
+        XCTAssertEqual(iPhone_safari_13_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios13_7).build(desktopMode: false),
+                       "User agent for iOS 13.7 iPhone doesn't match.")
+        
+        XCTAssertEqual(iPad_safari_13_UA,
+                       UserAgentBuilder(device: iPad, iOSVersion: ios13_7).build(desktopMode: false),
+                       "User agent for iOS 13.7 iPad doesn't match.")
+        
+        // MARK: - iOS 12
+        let iPhone_safari_12_UA = """
+        Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
         Version/12.1.2 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        XCTAssertEqual(iPhone_safari_12_4_UA,
+        let iPad_safari_12_4_UA = """
+        Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/12.1.2 \
+        Mobile/15E148 \
+        Safari/604.1
+        """
+        
+        // MARK: 12.4
+        let ios12_4 = OperatingSystemVersion(majorVersion: 12, minorVersion: 4, patchVersion: 0)
+        
+        XCTAssertEqual(iPhone_safari_12_UA,
                        UserAgentBuilder(device: iPhone, iOSVersion: ios12_4).build(desktopMode: false),
                        "User agent for iOS 12.4 iPhone doesn't match.")
-        
-        // MARK: iPad 12.4
-        let iPad_safari_12_4_UA = """
-        Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/12.1.2 \
-        Mobile/15E148 \
-        Safari/604.1
-        """
         
         XCTAssertEqual(iPad_safari_12_4_UA,
                        UserAgentBuilder(device: iPad, iOSVersion: ios12_4).build(desktopMode: false),
                        "User agent for iOS 12.4 iPad doesn't match.")
+        
+        // MARK: 12.2.1
+        let ios12_2_1 = OperatingSystemVersion(majorVersion: 12, minorVersion: 2, patchVersion: 1)
+        
+        XCTAssertEqual(iPhone_safari_12_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios12_2_1).build(desktopMode: false),
+                       "User agent for iOS 12.2.1 iPhone doesn't match.")
+        
+        XCTAssertEqual(iPad_safari_12_4_UA,
+                       UserAgentBuilder(device: iPad, iOSVersion: ios12_2_1).build(desktopMode: false),
+                       "User agent for iOS 12.2.1 iPad doesn't match.")
     }
     
     func testFutureProofDesktopUA() {
@@ -126,92 +209,117 @@ class UserAgentBuilderTests: XCTestCase {
         Safari/605.1.15
         """
         
-        let iOS14 = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0)
+        let iOS15 = OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
         
         XCTAssertEqual(iOS13DesktopUA,
-                       UserAgentBuilder(device: iPhone, iOSVersion: iOS14).build(desktopMode: true),
+                       UserAgentBuilder(device: iPhone, iOSVersion: iOS15).build(desktopMode: true),
                        "iOS 14 fallback desktop User Agent on iPhone doesn't match")
         
         XCTAssertEqual(iOS13DesktopUA,
-                       UserAgentBuilder(device: iPad, iOSVersion: iOS14).build(desktopMode: true),
+                       UserAgentBuilder(device: iPad, iOSVersion: iOS15).build(desktopMode: true),
                        "iOS 14 fallback desktop User Agent on iPad doesn't match")
     }
     
     func testFutureProofMobileUA() {
-        // MARK: - iPhone iOS 14
-        let ios14 = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0)
-        let iPhone_safari_14_UA = """
+        // MARK: - iPhone iOS 15
+        let ios14 = OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+        let iPhone_safari_15_UA = """
+        Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/15.0 \
+        Mobile/15E148 \
+        Safari/604.1
+        """
+        
+        XCTAssertEqual(iPhone_safari_15_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios14).build(desktopMode: false),
+                       "User agent for iOS 15.0 iPhone doesn't match.")
+        
+        // MARK: - iPad iOS 15
+        let iPad_safari_15_UA = """
+        Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/15.0 \
+        Mobile/15E148 \
+        Safari/604.1
+        """
+        
+        XCTAssertEqual(iPad_safari_15_UA,
+                       UserAgentBuilder(device: iPad, iOSVersion: ios14).build(desktopMode: false),
+                       "User agent for iOS 15.0 iPad doesn't match.")
+        
+        // MARK: - iPhone iOS 14.8, non existent version(14.8)
+        let ios14_8 = OperatingSystemVersion(majorVersion: 14, minorVersion: 8, patchVersion: 0)
+        let iPhone_safari_14_8_UA = """
         Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
         Version/14.0 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        XCTAssertEqual(iPhone_safari_14_UA,
-                       UserAgentBuilder(device: iPhone, iOSVersion: ios14).build(desktopMode: false),
-                       "User agent for iOS 14.0 iPhone doesn't match.")
+        XCTAssertEqual(iPhone_safari_14_8_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios14_8).build(desktopMode: false),
+                       "User agent for non existent iOS 14.8 iPhone doesn't match.")
         
-        // MARK: - iPad iOS 14
-        let iPad_safari_14_UA = """
+        // MARK: - iPad iOS 14.8, non existent version(14.8)
+        let iPad_safari_14_8_UA = """
         Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
         Version/14.0 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        XCTAssertEqual(iPad_safari_14_UA,
-                       UserAgentBuilder(device: iPad, iOSVersion: ios14).build(desktopMode: false),
-                       "User agent for iOS 14.0 iPad doesn't match.")
+        XCTAssertEqual(iPad_safari_14_8_UA,
+                       UserAgentBuilder(device: iPad, iOSVersion: ios14_8).build(desktopMode: false),
+                       "User agent for non existent iOS 14.8 iPad doesn't match.")
         
-        // MARK: - iPhone iOS 13, non existent version(13.5.1)
-        let ios13_5_1 = OperatingSystemVersion(majorVersion: 13, minorVersion: 5, patchVersion: 1)
-        let iPhone_safari_13_5_1_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/13.1 \
+        // MARK: - iPhone iOS 13, non existent version(13.9.9)
+        let ios13_9_9 = OperatingSystemVersion(majorVersion: 13, minorVersion: 9, patchVersion: 0)
+        let iPhone_safari_13_9_9_UA = """
+        Mozilla/5.0 (iPhone; CPU iPhone OS 13_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/13.1.2 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        XCTAssertEqual(iPhone_safari_13_5_1_UA,
-                       UserAgentBuilder(device: iPhone, iOSVersion: ios13_5_1).build(desktopMode: false),
-                       "User agent for non existent iOS 13.5.1 iPhone doesn't match.")
+        XCTAssertEqual(iPhone_safari_13_9_9_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios13_9_9).build(desktopMode: false),
+                       "User agent for non existent iOS 13.9.9 iPhone doesn't match.")
         
-        // MARK: - iPad iOS 13, non existent version(13.5.1)
-        let iPad_safari_13_5_1_UA = """
-        Mozilla/5.0 (iPad; CPU OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/13.1 \
+        // MARK: - iPad iOS 13, non existent version(13.9.9)
+        let iPad_safari_13_9_9_UA = """
+        Mozilla/5.0 (iPad; CPU OS 13_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/13.1.2 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        XCTAssertEqual(iPad_safari_13_5_1_UA,
-                       UserAgentBuilder(device: iPad, iOSVersion: ios13_5_1).build(desktopMode: false),
-                       "User agent for non existent iOS 13.5.1 iPad doesn't match.")
+        XCTAssertEqual(iPad_safari_13_9_9_UA,
+                       UserAgentBuilder(device: iPad, iOSVersion: ios13_9_9).build(desktopMode: false),
+                       "User agent for non existent iOS 13.9.9 iPad doesn't match.")
         
-        // MARK: - iPhone iOS 12, non existent version(12.6)
-        let ios12_6 = OperatingSystemVersion(majorVersion: 12, minorVersion: 6, patchVersion: 0)
-        let iPhone_safari_12_6_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 12_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        // MARK: - iPhone iOS 12, non existent version(12.9)
+        let ios12_9 = OperatingSystemVersion(majorVersion: 12, minorVersion: 9, patchVersion: 0)
+        let iPhone_safari_12_9_UA = """
+        Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
         Version/12.1.2 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        XCTAssertEqual(iPhone_safari_12_6_UA,
-                       UserAgentBuilder(device: iPhone, iOSVersion: ios12_6).build(desktopMode: false),
-                       "User agent for non existent iOS 13.5.1 iPhone doesn't match.")
+        XCTAssertEqual(iPhone_safari_12_9_UA,
+                       UserAgentBuilder(device: iPhone, iOSVersion: ios12_9).build(desktopMode: false),
+                       "User agent for non existent iOS 12.9 iPhone doesn't match.")
         
-        // MARK: - iPad iOS 12, non existent version(12.6)
+        // MARK: - iPad iOS 12, non existent version(12.9)
         let iPad_safari_12_6_UA = """
-        Mozilla/5.0 (iPad; CPU OS 12_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
         Version/12.1.2 \
         Mobile/15E148 \
         Safari/604.1
         """
         
         XCTAssertEqual(iPad_safari_12_6_UA,
-                       UserAgentBuilder(device: iPad, iOSVersion: ios12_6).build(desktopMode: false),
-                       "User agent for non existent iOS 13.5.1 iPad doesn't match.")
+                       UserAgentBuilder(device: iPad, iOSVersion: ios12_9).build(desktopMode: false),
+                       "User agent for non existent iOS 12.9 iPad doesn't match.")
     }
     
     func testUADifferences() {
@@ -220,7 +328,7 @@ class UserAgentBuilderTests: XCTestCase {
         let ios13_1_1 = OperatingSystemVersion(majorVersion: 13, minorVersion: 1, patchVersion: 1)
         
         // Minor version difference
-        XCTAssertNotEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios12_1_1).build(desktopMode: false),
+        XCTAssertEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios12_1_1).build(desktopMode: false),
                           UserAgentBuilder(device: iPhone, iOSVersion: ios12_1_3).build(desktopMode: false))
         
         // Major version difference


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
I simplified the logic, now we use 1 user agent per iOS version, this should apply to older iOS versions 12 and 13,
for 14 we might choose to keep it more up to date

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2864 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
test plan in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
