### PR TITLE
Ref #2778: Remove NSPhotoLibraryUsageDescription translations.

### DIFF
--- a/Client/de.lproj/InfoPlist.strings
+++ b/Client/de.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Damit können Sie Fotos speichern.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Damit können Sie Fotos speichern und hochladen.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Neuer privater Tab";
 
 /* (No Comment) */

--- a/Client/en.lproj/InfoPlist.strings
+++ b/Client/en.lproj/InfoPlist.strings
@@ -4,7 +4,6 @@
 
 NFCReaderUsageDescription = "The application needs access to NFC reading to communicate with your Yubikey.";
 NSLocationWhenInUseUsageDescription = "Websites you visit may request your location.";
-NSPhotoLibraryUsageDescription = "This lets you save and upload photos.";
 NSPhotoLibraryAddUsageDescription = "This lets you save photos.";
 NSCameraUsageDescription = "This lets you take and upload photos.";
 NSMicrophoneUsageDescription = "This lets you take and upload videos.";

--- a/Client/es.lproj/InfoPlist.strings
+++ b/Client/es.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Esto le permite guardar fotografías.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Esto le permite guardar y subir fotografías.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Nueva pestaña privada";
 
 /* (No Comment) */

--- a/Client/fr.lproj/InfoPlist.strings
+++ b/Client/fr.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Cette option vous permet d'enregistrer des photos.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Cette option vous permet d'enregistrer et d'importer des photos.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Nouvel onglet privé";
 
 /* (No Comment) */

--- a/Client/id-ID.lproj/InfoPlist.strings
+++ b/Client/id-ID.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Ini memungkinkan Anda menyimpan foto.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Ini memungkinkan Anda menyimpan dan mengunggah foto.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Tab Pribadi Baru";
 
 /* (No Comment) */

--- a/Client/it.lproj/InfoPlist.strings
+++ b/Client/it.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Questa impostazione ti permette di salvare le foto.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Questa impostazione ti permette di salvare e caricare le foto.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Nuova scheda privata";
 
 /* (No Comment) */

--- a/Client/ja.lproj/InfoPlist.strings
+++ b/Client/ja.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "写真を保存することができます。";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "写真を保存してアップロードすることができます。";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "新しいプライベートタブ";
 
 /* (No Comment) */

--- a/Client/ko-KR.lproj/InfoPlist.strings
+++ b/Client/ko-KR.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "이렇게 하면 사진을 저장할 수 있습니다.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "이렇게 하면 사진을 저장하고 업로드할 수 있습니다.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "새 비공개 탭";
 
 /* (No Comment) */

--- a/Client/ms.lproj/InfoPlist.strings
+++ b/Client/ms.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Ini membolehkan anda menyimpan foto.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Ini membolehkan anda menyimpan dan memuat naik foto.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Tab Peribadi Baharu";
 
 /* (No Comment) */

--- a/Client/nb.lproj/InfoPlist.strings
+++ b/Client/nb.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Dette lar deg lagre bilder.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Dette lar deg lagre og laste opp bilder.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Ny privat fane";
 
 /* (No Comment) */

--- a/Client/pl.lproj/InfoPlist.strings
+++ b/Client/pl.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Pozwala to na zapisywanie zdjęć.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Pozwala to na zapisywanie i przesyłanie zdjęć.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Nowa karta w trybie prywatnym";
 
 /* (No Comment) */

--- a/Client/pt-BR.lproj/InfoPlist.strings
+++ b/Client/pt-BR.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Isso permite que você salve fotos.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Isso permite que você salve e carregue fotos.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Nova aba privada";
 
 /* (No Comment) */

--- a/Client/ru.lproj/InfoPlist.strings
+++ b/Client/ru.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Вы сможете сохранять фото.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Вы сможете сохранять и загружать фото.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Новая приватная вкладка";
 
 /* (No Comment) */

--- a/Client/sv.lproj/InfoPlist.strings
+++ b/Client/sv.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Det här låter dig spara foton.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Det här låter dig spara och ladda upp foton.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Ny privat flik";
 
 /* (No Comment) */

--- a/Client/uk.lproj/InfoPlist.strings
+++ b/Client/uk.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "Це дозволить вам зберігати фото.";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "Це дозволить вам зберігати і надсилати фото.";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "Нова приватна вкладка";
 
 /* (No Comment) */

--- a/Client/zh-TW.lproj/InfoPlist.strings
+++ b/Client/zh-TW.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "這可讓您儲存相片。";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "這可讓您儲存並上傳相片。";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "新增隱私分頁";
 
 /* (No Comment) */

--- a/Client/zh.lproj/InfoPlist.strings
+++ b/Client/zh.lproj/InfoPlist.strings
@@ -22,9 +22,6 @@
 "NSPhotoLibraryAddUsageDescription" = "这可使您保存照片。";
 
 /* (No Comment) */
-"NSPhotoLibraryUsageDescription" = "这可使您拍照和上传照片。";
-
-/* (No Comment) */
 "ShortcutItemTitleNewPrivateTab" = "新私人标签页";
 
 /* (No Comment) */


### PR DESCRIPTION
This is required in order to upload the app to the AppStore.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2778 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
