### PR TITLE
No Bug: Hide Default Browser UI from beta channel.

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/DefaultBrowserCalloutProvider.swift
@@ -16,6 +16,7 @@ class DefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
     static var shouldShowCallout: Bool {
         !Preferences.General.defaultBrowserCalloutDismissed.value
             && AppConstants.iOSVersionGreaterThanOrEqual(to: 14)
+            && AppConstants.buildChannel == .release
     }
     
     func registerCells(to collectionView: UICollectionView) {

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -193,7 +193,7 @@ class SettingsViewController: TableViewController {
             option: Preferences.General.alwaysRequestDesktopSite))
         }
         
-        if AppConstants.iOSVersionGreaterThanOrEqual(to: 14) {
+        if AppConstants.iOSVersionGreaterThanOrEqual(to: 14) && AppConstants.buildChannel == .release {
             rows.append(.init(text: Strings.setDefaultBrowserSettingsCell, selection: { [unowned self] in
             guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
                 return


### PR DESCRIPTION
Default browser for Brave Beta is not supported at the moment.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
