### PR TITLE
Fix #2730 - Added SetJS to Adblock script.

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -220,6 +220,7 @@ class UserScriptManager {
         let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<prunePaths>", with: "ABSPP\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<findOwner>", with: "ABSFO\(token)", options: .literal)
+        alteredSource = alteredSource.replacingOccurrences(of: "$<setJS>", with: "ABSSJ\(token)", options: .literal)
         
         return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
     }()

--- a/Client/Frontend/UserContent/UserScripts/YoutubeAdblock.js
+++ b/Client/Frontend/UserContent/UserScripts/YoutubeAdblock.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// PruneJS
 (function() {
     const $<prunePaths> = ['playerResponse.adPlacements', 'playerResponse.playerAds', 'adPlacements', 'playerAds'];
     const $<findOwner> = function(root, path) {
@@ -33,4 +34,120 @@
             return r;
         },
     });
+})();
+
+/// SetJS
+(function() {
+    const chain = '{{1}}';
+    let cValue = '{{2}}';
+    const thisScript = document.currentScript;
+    if ( cValue === 'undefined' ) {
+        cValue = undefined;
+    } else if ( cValue === 'false' ) {
+        cValue = false;
+    } else if ( cValue === 'true' ) {
+        cValue = true;
+    } else if ( cValue === 'null' ) {
+        cValue = null;
+    } else if ( cValue === 'noopFunc' ) {
+        cValue = function(){};
+    } else if ( cValue === 'trueFunc' ) {
+        cValue = function(){ return true; };
+    } else if ( cValue === 'falseFunc' ) {
+        cValue = function(){ return false; };
+    } else if ( /^\d+$/.test(cValue) ) {
+        cValue = parseFloat(cValue);
+        if ( isNaN(cValue) ) { return; }
+        if ( Math.abs(cValue) > 0x7FFF ) { return; }
+    } else if ( cValue === "''" ) {
+        cValue = '';
+    } else {
+        return;
+    }
+    let aborted = false;
+    const mustAbort = function(v) {
+        if ( aborted ) { return true; }
+        aborted =
+            (v !== undefined && v !== null) &&
+            (cValue !== undefined && cValue !== null) &&
+            (typeof v !== typeof cValue);
+        return aborted;
+    };
+    // https://github.com/uBlockOrigin/uBlock-issues/issues/156
+    //   Support multiple trappers for the same property.
+    const trapProp = function(owner, prop, handler) {
+        if ( handler.init(owner[prop]) === false ) { return; }
+        const odesc = Object.getOwnPropertyDescriptor(owner, prop);
+        let prevGetter, prevSetter;
+        if ( odesc instanceof Object ) {
+            if ( odesc.get instanceof Function ) {
+                prevGetter = odesc.get;
+            }
+            if ( odesc.set instanceof Function ) {
+                prevSetter = odesc.set;
+            }
+        }
+        Object.defineProperty(owner, prop, {
+            configurable: true,
+            get() {
+                if ( prevGetter !== undefined ) {
+                    prevGetter();
+                }
+                return handler.getter();
+            },
+            set(a) {
+                if ( prevSetter !== undefined ) {
+                    prevSetter(a);
+                }
+                handler.setter(a);
+            }
+        });
+    };
+    const trapChain = function(owner, chain) {
+        const pos = chain.indexOf('.');
+        if ( pos === -1 ) {
+            trapProp(owner, chain, {
+                v: undefined,
+                init: function(v) {
+                    if ( mustAbort(v) ) { return false; }
+                    this.v = v;
+                    return true;
+                },
+                getter: function() {
+                    return document.currentScript === thisScript
+                        ? this.v
+                        : cValue;
+                },
+                setter: function(a) {
+                    if ( mustAbort(a) === false ) { return; }
+                    cValue = a;
+                }
+            });
+            return;
+        }
+        const prop = chain.slice(0, pos);
+        const v = owner[prop];
+        chain = chain.slice(pos + 1);
+        if ( v instanceof Object || typeof v === 'object' && v !== null ) {
+            trapChain(v, chain);
+            return;
+        }
+        trapProp(owner, prop, {
+            v: undefined,
+            init: function(v) {
+                this.v = v;
+                return true;
+            },
+            getter: function() {
+                return this.v;
+            },
+            setter: function(a) {
+                this.v = a;
+                if ( a instanceof Object ) {
+                    trapChain(a, chain);
+                }
+            }
+        });
+    };
+    trapChain(window, chain);
 })();


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Adds `SetJS` script to YoutubeAdblock.js to block Pre-Roll ads.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2730

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
