### PR TITLE
Fix #2839: Add option to disable WKWebView default safe-browsing

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -512,6 +512,8 @@ extension Strings {
     public static let HTTPSEverywhere = NSLocalizedString("HTTPSEverywhere", tableName: "BraveShared", bundle: Bundle.braveShared, value: "HTTPS Everywhere", comment: "")
     public static let HTTPSEverywhereDescription = NSLocalizedString("HTTPSEverywhereDescription", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Opens some sites using a secure HTTPS connection instead of plain HTTP.", comment: "")
     public static let blockPhishingAndMalware = NSLocalizedString("BlockPhishingAndMalware", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Block Phishing and Malware", comment: "")
+    public static let googleSafeBrowsing = NSLocalizedString("GoogleSafeBrowsing", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Block dangerous sites", comment: "")
+    public static let googleSafeBrowsingUsingWebKitDescription = NSLocalizedString("GoogleSafeBrowsingUsingWebKitDescription", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Sends obfuscated URLs of some pages you visit to the Google Safe Browsing service, when your security is at risk.", comment: "")
     public static let blockScripts = NSLocalizedString("BlockScripts", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Block Scripts", comment: "")
     public static let blockScriptsDescription = NSLocalizedString("BlockScriptsDescription", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Blocks Javascript (may break sites)", comment: "")
     public static let blockCookiesDescription = NSLocalizedString("BlockCookiesDescription", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Prevents websites from storing information about your previous visits", comment: "")

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -81,12 +81,14 @@ extension Preferences {
     }
     
     public final class Shields {
-        public static let allShields = [blockAdsAndTracking, httpsEverywhere, blockPhishingAndMalware, blockScripts, fingerprintingProtection, blockImages]
+        public static let allShields = [blockAdsAndTracking, httpsEverywhere, blockPhishingAndMalware, googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages]
         
         /// Shields will block ads and tracking if enabled
         public static let blockAdsAndTracking = Option<Bool>(key: "shields.block-ads-and-tracking", default: true)
         /// Websites will be upgraded to HTTPS if a loaded page attempts to use HTTP
         public static let httpsEverywhere = Option<Bool>(key: "shields.https-everywhere", default: true)
+        /// Enable Google Safe Browsing
+        public static let googleSafeBrowsing = Option<Bool>(key: "shields.google-safe-browsing", default: true)
         /// Shields will block websites related to potential phishing and malware
         public static let blockPhishingAndMalware = Option<Bool>(key: "shields.block-phishing-and-malware", default: true)
         /// Disables JavaScript execution in the browser

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3580,7 +3580,8 @@ extension BrowserViewController: PreferencesObserver {
              Preferences.Shields.fingerprintingProtection.key,
              Preferences.Shields.useRegionAdBlock.key:
             tabManager.allTabs.forEach { $0.webView?.reload() }
-        case Preferences.Privacy.blockAllCookies.key:
+        case Preferences.Privacy.blockAllCookies.key,
+             Preferences.Shields.googleSafeBrowsing.key:
             // All `block all cookies` toggle requires a hard reset of Webkit configuration.
             tabManager.reset()
             if !Preferences.Privacy.blockAllCookies.value {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -213,6 +213,9 @@ class Tab: NSObject {
             configuration!.userContentController = WKUserContentController()
             configuration!.preferences = WKPreferences()
             configuration!.preferences.javaScriptCanOpenWindowsAutomatically = false
+            if #available(iOS 14.0, *) {
+                configuration!.preferences.isFraudulentWebsiteWarningEnabled = Preferences.Shields.googleSafeBrowsing.value
+            }
             configuration!.allowsInlineMediaPlayback = true
             // Enables Zoom in website by ignoring their javascript based viewport Scale limits.
             configuration!.ignoresViewportScaleLimits = true

--- a/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -147,7 +147,7 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
     }()
     
     private lazy var otherSettingsSection: Section = {
-        Section(
+        var section = Section(
             header: .title(Strings.otherPrivacySettingsSection),
             rows: [
                 .boolRow(
@@ -161,6 +161,16 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
                 .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups)
             ]
         )
+        if #available(iOS 14.0, *) {
+            section.rows.append(
+                .boolRow(
+                    title: Strings.googleSafeBrowsing,
+                    detailText: Strings.googleSafeBrowsingUsingWebKitDescription,
+                    option: Preferences.Shields.googleSafeBrowsing
+                )
+            )
+        }
+        return section
     }()
     
     // MARK: - Actions


### PR DESCRIPTION
Starting in iOS 14, `isFraudulentWebsiteWarningEnabled` now extends to regions outside of China by default, so this toggle will enable & disable that setting

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2839 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit http://testsafebrowsing.appspot.com/
- Verify that by default on iOS 14 you see safe browsing interstitial pages when attempting to visit one of the phishing/malware sites
- Verify that after disabling the preference in Settings > Brave Shields & Privacy you can visit those malware/phishing sites

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
