### PR TITLE
Fix #2910: Don't do collection view insert on tab tray unless visible

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3515,7 +3515,6 @@ extension BrowserViewController: NewTabPageDelegate {
             self.present(editPopup, animated: true)
         }
     }
-
     
     func focusURLBar() {
         focusLocationField()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -663,17 +663,19 @@ extension TabTrayController: TabManagerDelegate {
         }
 
         tabDataSource.addTab(tab)
-        self.collectionView?.performBatchUpdates({
-            self.collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
-        }, completion: { finished in
-            if finished {
-                tabManager.selectTab(tab)
-                // don't pop the tab tray view controller if it is not in the foreground
-                if self.presentedViewController == nil {
-                    _ = self.navigationController?.popViewController(animated: true)
+        if navigationController?.visibleViewController === self {
+            self.collectionView?.performBatchUpdates({
+                self.collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
+            }, completion: { finished in
+                if finished {
+                    tabManager.selectTab(tab)
+                    // don't pop the tab tray view controller if it is not in the foreground
+                    if self.presentedViewController == nil {
+                        _ = self.navigationController?.popViewController(animated: true)
+                    }
                 }
-            }
-        })
+            })
+        }
     }
 
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab) {


### PR DESCRIPTION
A bit of a band-aid fix but it works.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2910 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Use context menu on + button to create a new private tab within regular mode, verify no crash
- Verify adding tabs in the tab tray work as usual
- Verify tabs added outside the tab tray still show in the tab tray correctly


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
