### PR TITLE
Error URL validation

### DIFF
--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -405,7 +405,7 @@ extension URL {
 
     public var originalURLFromErrorURL: URL? {
         let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
-        if let queryURL = components?.queryItems?.find({ $0.name == "url" })?.value {
+        if self.isErrorPageURL, let queryURL = components?.queryItems?.find({ $0.name == "url" })?.value {
             return URL(string: queryURL)
         }
         return nil

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -477,6 +477,27 @@ class NSURLExtensionsTests: XCTestCase {
         XCTAssertEqual("http://foo.com/bar/?ppp=123&rrr=aaa", urlE.absoluteString)
     }
     
+    func testLocalQueryParamHandling() {
+        let urlA = URL(string: "http://brave.com?url=https://foo.com")
+        let urlB = URL(string: "http://brave.com/?url=https://foo.com")
+        let urlC = URL(string: "http://brave.com?url=https://foo.com/meh")
+        let urlD = URL(string: "http://localhost/errors/foo.hmtl?url=https://foo.com")
+        let urlE = URL(string: "http://localhost/errors/foo.hmtl?url=https://foo.com/meh")
+        
+        for url in [urlA, urlB, urlC, urlD, urlE] {
+            if url == nil {
+                XCTAssertTrue(false, "Cannot parse URL")
+                return
+            }
+        }
+        
+        XCTAssertNotEqual(urlA?.originalURLFromErrorURL, urlA)
+        XCTAssertNotEqual(urlB?.originalURLFromErrorURL, urlB)
+        XCTAssertNotEqual(urlC?.originalURLFromErrorURL, urlC)
+        XCTAssertEqual(urlD?.originalURLFromErrorURL?.absoluteString, "https://foo.com")
+        XCTAssertEqual(urlE?.originalURLFromErrorURL?.absoluteString, "https://foo.com/meh")
+    }
+    
     func testAppendPathComponentsHelper() {
         var urlA = URL(string: "http://foo.com/bar/")!
         var urlB = URL(string: "http://bar.com/noo")!


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Added Error **URL validation** to prevent unintended URL opening.
- Since this is a security issue, the steps to reproduce it, is in the linked security ticket.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2913
Security Ticket: https://github.com/brave/security/issues/231

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
