### PR TITLE
Fix #2919: Use orange toggle color in private mode in new shields UI

### DIFF
--- a/BraveShared/AppearanceAttributes.swift
+++ b/BraveShared/AppearanceAttributes.swift
@@ -39,6 +39,13 @@ public extension UITextField {
     }
 }
 
+public extension UISwitch {
+    @objc dynamic var appearanceOnTintColor: UIColor? {
+        get { return self.onTintColor }
+        set { self.onTintColor = newValue }
+    }
+}
+
 public extension UIView {
     @objc dynamic var appearanceOverrideUserInterfaceStyle: UIUserInterfaceStyle {
         get {

--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -21,7 +21,7 @@ extension Theme {
         UINavigationBar.appearance().tintColor = colors.accent
         UINavigationBar.appearance().appearanceBarTintColor = colors.header
         
-        UISwitch.appearance().onTintColor = colors.accent
+        UISwitch.appearance().appearanceOnTintColor = colors.accent
         
         // This is a subtle "abuse" of theme colors
         // In order to properly style things, `addressBar` has been utilized to offer contrast to `home`/`header`, as many of the themes utilize similar colors.

--- a/Client/Frontend/Shields/AdvancedShieldsView.swift
+++ b/Client/Frontend/Shields/AdvancedShieldsView.swift
@@ -96,7 +96,9 @@ extension AdvancedShieldsView {
             return l
         }()
         
-        let toggleSwitch = UISwitch()
+        let toggleSwitch = UISwitch().then {
+            $0.appearanceOnTintColor = BraveUX.braveOrange
+        }
         var valueToggled: ((Bool) -> Void)?
         
         init(title: String) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2919

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Verify that "on" toggle color is brave orange for all themes: regular, private, dark

## Screenshots:

![Simulator Screen Shot - iPhone 11 Pro - 2020-09-30 at 13 58 37](https://user-images.githubusercontent.com/529104/94722293-18d1ad80-0325-11eb-8e70-aa8001dfee3a.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
