### PR TITLE
Fix #2922: Restore vpn settings cell.

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -190,14 +190,17 @@ class SettingsViewController: TableViewController {
             ]
         }
         
-        vpnRow = vpnSettingsRow()
-        
         section.rows.append(
             Row(text: Strings.BraveToday.braveToday, selection: {
                 let todaySettings = BraveTodaySettingsViewController(dataSource: self.feedDataSource)
                 self.navigationController?.pushViewController(todaySettings, animated: true)
             }, image: #imageLiteral(resourceName: "settings-brave-today").template, accessory: .disclosureIndicator)
         )
+         
+        vpnRow = vpnSettingsRow()
+        if let vpnRow = vpnRow {
+            section.rows.append(vpnRow)
+        }
         
         return section
     }()


### PR DESCRIPTION
Regression caused by #1923

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2922 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
