### PR TITLE
Fixes #507: Show toast before auto filling credentials

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2326,6 +2326,10 @@ extension BrowserViewController: TabDelegate {
         alertStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
     }
 
+    func tab(_ tab: Tab, shouldShowToast toast: Toast) {
+        show(toast: toast)
+    }
+
     func tab(_ tab: Tab, didAddSnackbar bar: SnackBar) {
         showBar(bar, animated: true)
     }

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -210,15 +210,24 @@ class LoginsHelper: TabContentScript {
 
             let json = JSON(jsonObj)
             let src = "window.__firefox__.logins.inject(\(json.stringValue()!))"
+
+            guard !json["logins"].isEmpty else {
+                self.tab?.webView?.evaluateJavaScript(src, completionHandler: { (obj, err) -> Void in
+                })
+                return
+            }
+
             let toast = ButtonToast(labelText: Strings.autoPopulateCredentialsToastLabelText, buttonText: Strings.autoPopulateCredentialsToastButtonText, completion: { buttonPressed in
                 if buttonPressed {
                     self.tab?.webView?.evaluateJavaScript(src, completionHandler: { (obj, err) -> Void in
                     })
                 }
             })
+
             guard let tab = self.tab else {
                 return
             }
+
             tab.tabDelegate?.tab(tab, shouldShowToast: toast)
         }
     }

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -210,8 +210,16 @@ class LoginsHelper: TabContentScript {
 
             let json = JSON(jsonObj)
             let src = "window.__firefox__.logins.inject(\(json.stringValue()!))"
-            self.tab?.webView?.evaluateJavaScript(src, completionHandler: { (obj, err) -> Void in
+            let toast = ButtonToast(labelText: Strings.autoPopulateCredentialsToastLabelText, buttonText: Strings.autoPopulateCredentialsToastButtonText, completion: { buttonPressed in
+                if buttonPressed {
+                    self.tab?.webView?.evaluateJavaScript(src, completionHandler: { (obj, err) -> Void in
+                    })
+                }
             })
+            guard let tab = self.tab else {
+                return
+            }
+            tab.tabDelegate?.tab(tab, shouldShowToast: toast)
         }
     }
 }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -22,6 +22,7 @@ protocol TabContentScript {
 
 @objc
 protocol TabDelegate {
+    func tab(_ tab: Tab, shouldShowToast toast: Toast)
     func tab(_ tab: Tab, didAddSnackbar bar: SnackBar)
     func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar)
     func tab(_ tab: Tab, didSelectFindInPageForSelection selection: String)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -177,6 +177,12 @@ extension Strings {
     public static let contextMenuButtonToastNewTabOpenedButtonText = NSLocalizedString("ContextMenuButtonToastNewTabOpenedButtonText", bundle: Bundle.shared, value: "Switch", comment: "The button text in the Button Toast for switching to a fresh New Tab.")
 }
 
+// Autopopulate credentials toast
+extension Strings {
+    public static let autoPopulateCredentialsToastLabelText = NSLocalizedString("autoPopulateCredentialsToastLabelText", bundle: Bundle.shared, value: "Saved credentials found for this site", comment: "The label text in the toast for auto populating credentials.")
+    public static let autoPopulateCredentialsToastButtonText = NSLocalizedString("autoPopulateCredentialsToastButtonText", bundle: Bundle.shared, value: "Fill", comment: "The button text in the toast for filling login credentials.")
+}
+
 // Reader Mode.
 extension Strings {
     public static let readerModeAvailableVoiceOverAnnouncement = NSLocalizedString("ReaderModeAvailableVoiceOverAnnouncement", bundle: Bundle.shared, value: "Reader Mode available", comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #507 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
