### PR TITLE
Fix #2921: Disallow invocation of message handlers from JS

### DIFF
--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -46,4 +46,31 @@ class BraveWebView: WKWebView {
         lastHitPoint = point
         return super.hitTest(point, with: event)
     }
+
+    private func generateJavascriptFunctionString(functionName: String, args: [Any]) -> String {
+        let argsJS = args
+          .map { "'\(String(describing: $0).escapeHTML())'" }
+          .joined(separator: ", ")
+        return "\(functionName)(\(argsJS))"
+    }
+
+    func evaluateSafeJavascript(functionName: String, args: [Any], completion: @escaping ((Any?, Error?) -> Void)) {
+        let javascript = generateJavascriptFunctionString(functionName: functionName, args: args)
+        evaluateJavaScript(javascript) { data, error  in
+            completion(data, error)
+        }
+    }
+}
+
+extension String {
+    /// Encode HTMLStrings
+    func escapeHTML() -> String {
+       return self
+        .replacingOccurrences(of: "&", with: "&amp;", options: .literal)
+        .replacingOccurrences(of: "\"", with: "&quot;", options: .literal)
+        .replacingOccurrences(of: "'", with: "&#39;", options: .literal)
+        .replacingOccurrences(of: "<", with: "&lt;", options: .literal)
+        .replacingOccurrences(of: ">", with: "&gt;", options: .literal)
+        .replacingOccurrences(of: "`", with: "&lsquo;", options: .literal)
+    }
 }

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -12,6 +12,9 @@ class UserScriptManager {
 
     // Scripts can use this to verify the app –not js on the page– is calling into them.
     public static let securityToken = UUID()
+    
+    // Ensures that the message handlers cannot be invoked by the page scripts
+    public static let messageHandlerToken = UUID()
 
     private weak var tab: Tab?
     
@@ -137,6 +140,8 @@ class UserScriptManager {
         
         var alteredSource = source
         let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        let messageHandlerToken = UserScriptManager.messageHandlerToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        
         alteredSource = alteredSource.replacingOccurrences(of: "$<webauthn>", with: "fido2\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<u2f>", with: "fido\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<pkc>", with: "pkp\(token)", options: .literal)
@@ -144,6 +149,7 @@ class UserScriptManager {
         alteredSource = alteredSource.replacingOccurrences(of: "$<attest>", with: "attest\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<u2fregister>", with: "u2fregister\(token)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<u2fsign>", with: "u2fsign\(token)", options: .literal)
+        alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "U2F\(messageHandlerToken)", options: .literal)
         
         return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
     }()
@@ -175,7 +181,10 @@ class UserScriptManager {
         }
         var alteredSource = source
         let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+        let handlerToken = UserScriptManager.messageHandlerToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)
+
         alteredSource = alteredSource.replacingOccurrences(of: "$<u2f>", with: "U\(token)", options: .literal)
+        alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "handler\(handlerToken)", options: .literal)
 
         return WKUserScript(source: alteredSource, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     }()

--- a/Client/Frontend/UserContent/UserScripts/U2F-low-level.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F-low-level.js
@@ -5,6 +5,10 @@
 // FIDO - Low Level API
 var $<u2f> = window.u2f
 
+// Default string for toString outputs
+var defaultU2FString = "function () { [native code] }";
+
+
 try {
     var sameOrigin = (window.top.location.origin == window.location.origin)
     if (!sameOrigin) {
@@ -121,8 +125,14 @@ Object.defineProperty($<u2f>, 'getPortSingleton_', {
 
 $<u2f>.receiveChannel.port2.onmessage = function (e) {
   const handle = $<u2f>.low_level_id++
-  webkit.messageHandlers.U2F.postMessage({ name: 'fido-low-level', handle: handle, data: JSON.stringify(e.data) })
+  webkit.messageHandlers.$<handler>.postMessage({ name: 'fido-low-level', handle: handle, data: JSON.stringify(e.data) })
 }
+
+Object.defineProperty($<u2f>.receiveChannel.port2.onmessage, 'toString', {
+    value: function () {
+        return defaultU2FString
+    }
+})
 
 try {
     var sameOrigin = (window.top.location.origin == window.location.origin)

--- a/Client/Frontend/UserContent/UserScripts/U2F.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F.js
@@ -7,6 +7,9 @@
 // FIDO2 - WebAuthn
 var $<webauthn> = {}
 
+// Default string for toString outputs
+var defaultU2FString = "function () { [native code] }";
+
 // We use the define property method to avoid the properties from being changed
 // by default configurable, enumerable and writable properties of the object
 // are false
@@ -206,10 +209,16 @@ Object.defineProperty($<webauthn>, 'create', {
         $<webauthn>.reject[handle] = reject
         $<webauthn>.resolve[handle] = resolve
         window.top.$<webauthn>.caller[handle] = window
-        webkit.messageHandlers.U2F.postMessage({ name: 'fido2-create', data: cleanedArgs, handle: handle })
+        webkit.messageHandlers.$<handler>.postMessage({ name: 'fido2-create', data: cleanedArgs, handle: handle })
       }
     )
   }
+})
+
+Object.defineProperty($<webauthn>.create, 'toString', {
+    value: function () {
+        return defaultU2FString
+    }
 })
 
 Object.defineProperty($<webauthn>, 'get', {
@@ -222,10 +231,16 @@ Object.defineProperty($<webauthn>, 'get', {
         $<webauthn>.reject[handle] = reject
         $<webauthn>.resolve[handle] = resolve
         window.top.$<webauthn>.caller[handle] = window
-        webkit.messageHandlers.U2F.postMessage({ name: 'fido2-get', data: cleanedArgs, handle: handle })
+        webkit.messageHandlers.$<handler>.postMessage({ name: 'fido2-get', data: cleanedArgs, handle: handle })
       }
     )
   }
+})
+
+Object.defineProperty($<webauthn>.get, 'toString', {
+    value: function () {
+        return defaultU2FString
+    }
 })
 
 Object.defineProperty($<u2f>, 'sign', {
@@ -235,10 +250,16 @@ Object.defineProperty($<u2f>, 'sign', {
         const handle = $<u2f>.id++
         $<u2f>.resolve[handle] = callback
         window.top.$<u2f>.caller[handle] = window
-        webkit.messageHandlers.U2F.postMessage({ name: 'fido-sign', appId: appId, challenge: challenge, keys: JSON.stringify(registeredKeys), handle: handle })
+        webkit.messageHandlers.$<handler>.postMessage({ name: 'fido-sign', appId: appId, challenge: challenge, keys: JSON.stringify(registeredKeys), handle: handle })
       }
     )
   }
+})
+
+Object.defineProperty($<u2f>.sign, 'toString', {
+    value: function () {
+        return defaultU2FString
+    }
 })
                       
 // From: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable
@@ -261,9 +282,15 @@ Object.defineProperty($<u2f>, 'register', {
         const handle = $<u2f>.id++
         $<u2f>.resolve[handle] = responseHandler
         window.top.$<u2f>.caller[handle] = window
-        webkit.messageHandlers.U2F.postMessage({ name: 'fido-register', appId: appId, requests: JSON.stringify(registerRequests), keys: JSON.stringify(registeredKeys), handle: handle })
+        webkit.messageHandlers.$<handler>.postMessage({ name: 'fido-register', appId: appId, requests: JSON.stringify(registerRequests), keys: JSON.stringify(registeredKeys), handle: handle })
       })
   }
+})
+
+Object.defineProperty($<u2f>.register, 'toString', {
+    value: function () {
+        return defaultU2FString
+    }
 })
 
 // FIDO2 APIs are not available in 3p iframes


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2921 
Security Review: https://github.com/brave/security/issues/238

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
Specified here: https://github.com/brave/security/issues/239

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
