### PR TITLE
Fix #2859: Replace 'https upgrades' with 'data saved' stat.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -449,7 +449,7 @@ extension Strings {
     public static let shieldsAdStats = NSLocalizedString("AdsrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Ads \nBlocked", comment: "Shields Ads Stat")
     public static let shieldsAdAndTrackerStats = NSLocalizedString("AdsAndTrackersrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Trackers & ads blocked", comment: "Shields Ads Stat")
     public static let shieldsTrackerStats = NSLocalizedString("TrackersrBlocked", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Trackers \nBlocked", comment: "Shields Trackers Stat")
-    public static let shieldsHttpsStats = NSLocalizedString("HTTPSrUpgrades", tableName: "BraveShared", bundle: Bundle.braveShared, value: "HTTPS \nUpgrades", comment: "Shields Https Stat")
+    public static let dataSavedStat = NSLocalizedString("DataSavedStat", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Est. Data \nSaved", comment: "Data Saved Shield Stat")
     public static let shieldsTimeStats = NSLocalizedString("EstTimerSaved", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Est. Time \nSaved", comment: "Shields Time Saved Stat")
     public static let shieldsTimeStatsHour = NSLocalizedString("ShieldsTimeStatsHour", tableName: "BraveShared", bundle: Bundle.braveShared, value: "h", comment: "Time Saved Hours")
     public static let shieldsTimeStatsMinutes = NSLocalizedString("ShieldsTimeStatsMinutes", tableName: "BraveShared", bundle: Bundle.braveShared, value: "min", comment: "Time Saved Minutes")

--- a/Client/Assets/Themes/ACE618A3-D6FC-45A4-94F2-1793C40AE927.json
+++ b/Client/Assets/Themes/ACE618A3-D6FC-45A4-94F2-1793C40AE927.json
@@ -27,7 +27,7 @@
         "stats": {
             "ads": "0xFB542B",
             "trackers": "0x742BC4",
-            "httpse": "0xA0A5EB",
+            "dataSaved": "0xA0A5EB",
             "timeSaved": "0xffffff"
         }
     },

--- a/Client/Assets/Themes/B900A41F-2C02-4664-9DE4-C170956339AC.json
+++ b/Client/Assets/Themes/B900A41F-2C02-4664-9DE4-C170956339AC.json
@@ -27,7 +27,7 @@
         "stats": {
             "ads": "0xFB542B",
             "trackers": "0x1bc760",
-            "httpse": "0xA0A5EB",
+            "dataSaved": "0xA0A5EB",
             "timeSaved": "0xffffff"
         }
     },

--- a/Client/Assets/Themes/C5CB0D9A-5467-432C-AB35-1A78C55CFB41.json
+++ b/Client/Assets/Themes/C5CB0D9A-5467-432C-AB35-1A78C55CFB41.json
@@ -27,7 +27,7 @@
         "stats": {
             "ads": "0xFB542B",
             "trackers": "0x1bc760",
-            "httpse": "0xA0A5EB",
+            "dataSaved": "0xA0A5EB",
             "timeSaved": "0xffffff"
         }
     },

--- a/Client/Frontend/Widgets/Themes/Theme.swift
+++ b/Client/Frontend/Widgets/Themes/Theme.swift
@@ -132,18 +132,18 @@ class Theme: Equatable, Decodable {
                 let container = try decoder.container(keyedBy: ThemeCodingKeys.ColorCodingKeys.StatCodingKeys.self)
                 let adsStr = try container.decode(String.self, forKey: .ads)
                 let trackersStr = try container.decode(String.self, forKey: .trackers)
-                let httpseStr = try container.decode(String.self, forKey: .httpse)
+                let dataSavedStr = try container.decode(String.self, forKey: .dataSaved)
                 let timeSavedStr = try container.decode(String.self, forKey: .timeSaved)
 
                 ads = UIColor(colorString: adsStr)
                 trackers = UIColor(colorString: trackersStr)
-                httpse = UIColor(colorString: httpseStr)
+                dataSaved = UIColor(colorString: dataSavedStr)
                 timeSaved = UIColor(colorString: timeSavedStr)
             }
 
             let ads: UIColor
             let trackers: UIColor
-            let httpse: UIColor
+            let dataSaved: UIColor
             let timeSaved: UIColor
         }
         
@@ -317,7 +317,7 @@ fileprivate enum ThemeCodingKeys: String, CodingKey {
         enum StatCodingKeys: String, CodingKey {
             case ads
             case trackers
-            case httpse
+            case dataSaved
             case timeSaved
         }
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2859 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Visit few websites with ads
- Verify that data saved stat is being updated

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="520" alt="Zrzut ekranu 2021-01-22 o 16 29 17" src="https://user-images.githubusercontent.com/6950387/105907957-e8c1bf00-6025-11eb-9395-e991a54b8de8.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
