### PR TITLE
Fix #2955: Open external link by other navigation action types too.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -267,10 +267,14 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-        // Ignore JS navigated links, the intention is to match Safari and native WKWebView behaviour.
-        if navigationAction.navigationType == .linkActivated {
+        // Standard schemes are handled in previous if-case.
+        // This check handles custom app schemes to open external apps.
+        // Our own 'brave' scheme does not require the switch-app prompt.
+        if url.scheme?.contains("brave") == false {
             handleExternalURL(url) { didOpenURL in
-                if !didOpenURL {
+                // Do not show error message for JS navigated links or redirect
+                // as it's not the result of a user action.
+                if !didOpenURL, navigationAction.navigationType == .linkActivated {
                     let alert = UIAlertController(title: Strings.unableToOpenURLErrorTitle, message: Strings.unableToOpenURLError, preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
                     self.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
Previously we opened external links only when navigation action type
was `linkActivated`. This is not always the case, sometimes tapping
on a link has a different navigation type.

This is a followup to #551 ticket.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2955 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Try to open a zoom link and make it switch to the external Zoom app.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
