### PR TITLE
Fix 2952: Show about:blank for empty window.open

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1276,6 +1276,11 @@ class BrowserViewController: UIViewController {
         case .URL:
             guard let tab = tabManager[webView] else { break }
             
+            // Special case for "about:blank" popups, if the webView.url is nil, keep the tab url as "about:blank"
+            if tab.url?.absoluteString == "about:blank" && webView.url == nil {
+                break
+            }
+            
             // To prevent spoofing, only change the URL immediately if the new URL is on
             // the same origin as the current URL. Otherwise, do nothing and wait for
             // didCommitNavigation to confirm the page load.
@@ -2549,6 +2554,8 @@ extension BrowserViewController: WKUIDelegate {
         // IMPORTANT!!: WebKit will perform the `URLRequest` automatically!! Attempting to do
         // the request here manually leads to incorrect results!!
         let newTab = tabManager.addPopupForParentTab(parentTab, configuration: configuration)
+        
+        newTab.url = URL(string: "about:blank")
 
         return newTab.webView
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
- This pull request fixes #2952 
- From firefox-commit: https://github.com/mozilla-mobile/firefox-ios/commit/c8e1817305d1de5b5cfe8e97abcf56483cfb099c

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

Specified here: https://github.com/brave/security/issues/244

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
