### PR TITLE
Fix #2982: Update shields icon state immediately on shield change

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1993,6 +1993,9 @@ extension BrowserViewController: TopToolbarDelegate {
         }
         let shields = ShieldsViewController(tab: selectedTab)
         shields.shieldsSettingsChanged = { [unowned self] _ in
+            // Update the shields status immediately
+            self.topToolbar.refreshShieldsStatus()
+            
             // Reload this tab. This will also trigger an update of the brave icon in `TabLocationView` if
             // the setting changed is the global `.AllOff` shield
             self.tabManager.selectedTab?.reload()


### PR DESCRIPTION
This should prevent the delay of updating said icon state until a page finishes reloading

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2982 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan

- Ensure you're on a slower connection (maybe via Network Link Conditioner)
- Toggle shields off
- Verify: Shield icon changes to grey after 0.3s delay before the page finishes loading
- Turn shields on and verify the opposite

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
