### PR TITLE
Ref #2954: Set required default wallet prefs

### DIFF
--- a/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
+++ b/BraveRewardsUI/Extensions/BraveLedgerExtensions.swift
@@ -148,6 +148,11 @@ extension BraveLedger {
         return
       }
       
+      self.minimumVisitDuration = 8
+      self.minimumNumberOfVisits = 1
+      self.allowVideoContributions = true
+      self.allowUnverifiedPublishers = true
+      
       let group = DispatchGroup()
       var success = true
       group.enter()


### PR DESCRIPTION
Sets defaults based on when the user creates a wallet. Previous wallets are migrated by shared lib

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2954 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
