### PR TITLE
Fix #3002: Update Startpage search engine.

### DIFF
--- a/Client/Assets/SearchPlugins/startpage.xml
+++ b/Client/Assets/SearchPlugins/startpage.xml
@@ -3,16 +3,15 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <SearchPlugin xmlns="http://www.mozilla.org/2006/browser/search/">
-<ShortName>StartPage</ShortName>
+<ShortName>Startpage</ShortName>
 <Image width="88" height="88">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAACXBIWXMAAAY6AAAGOgENcKWeAAAFqklEQVR4nO3bP09bVxyH8Z9Rh5iFpMlUtZKtSq3KAi+Bpcxl64aXsmaIX4BfAENZmeAVkJnJI22H4qoibaUEpELUSEkJkDTdbnWsc+nh+tq+Nsbc8+X5SB5iILY5D+ee+6+SJIlNylrTama2ZGaLwWNuYi8ABWdmth882pvrdjSpz3XtoNeadt/MGv6xIPALx/R1zGzLPTbX7e11Xn3soP1s3DKzVQLABG27rsadtUcO2s/ILuTHjCJu0IYPe6QZe6Sg15r2jd80sC7GNLj1dmNz3Z4Wfa2Zot+41uyGvEPMmCLX2o5vr5ChM7RfYrTZ4cMtczuOS8OWIANnaGJGibgG277JvvoGTcwooaFRD5qhiRlltODbzJUbtF+EEzPKamGtad/nvbeenUJ/aG6HoUQEVrKH9K4E7dcmRxyaQyTccepaeOQju+RoETMiMuebvXQ5Q/trMw4ZTUSonl77Ec7QLUYSkbpstztD+7XzKaOJiD1wa+l0hm4wkohct2GChopuw5XvniTsDEJFfcbfAwgoWJrxN7MCChYJGkoIGlK6QXOqGyrmCt9TCMSAoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCHlo5g+zGzV7LNP8r/mnq9WB//8l5+P/ppfjPEzSj78a/bnSbEP9ObU7PXfg7/nj+f9v/b61OzNkJ8fZmpBu+BmfXDVTJh5oT782Ozhg2m9O/RTvVeOP+rjl2b/fOh9PvtHNHbQLrhHPrhwdgxnwbs+u2FyPu2zZc7qCTqcLdNQHwWzJZGizCo//5oks/fYxENDJUmShLGECg7bQQpBQwpBQwpBQwpBQwpBQwpBQwpBQ0pUV9uhnJ79/sLOz9/1fW97P3aGvu+D357b+cX7Qp/PvZb7/jwELe7i4n3u4HcDyolw76dfcn8hxyd/2fHJq9L/sgi6hE5evuqJJzvLneeEGkt0N4mgJyw7I55fvLODZ+G/e0MssklGMQTdxw/BptfNem72S4Wb5UHrOUzfnQg6jDOcDcMdETbXGqIMul+ge32ex91RmqDTSMM153Gwc+Sec18DBrnRoMPjk+mMSaS4SWMFnYYazqbpepSdJNymK0ETKmJX+Xa1mbADBRWV2ldfc5MsZHC1HaQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKS4oM8YUog4c0HvM5oQsU/QUELQkNINus2YQkR75vBg98jMOowoItdxLaeH7bYYTUSu2zBBQ8X/QR8e7L41s22GFpHa9g1fOVPYYjQRqct2L4P2O4cbjCgis+Hb7cpey9HiVDgicpZdWVwJ2q9DGowoItFI186pnqvtDg92n7KDiAhs+FavqCRJkvvW6/PL7pT4AiOLEnInURbz3tag66GXOIOIEur4NnP1DdqvTYgaZdKNObtuDg28Y4WoUSJDY7ZBa+is+vyyO7W4ygjjFrgzgYWOvhW+p9D/hyscp8YUudZWisZso94k6w+T1DijiClwjdXyDs0NUnjJkVWfX675szQsQzBJ7hxIKzydPYqxg07V55fv+7OLDY5bY0wdf/nn1rCdvmGuHXTIz9ruqMhi8JhjlBFw62J30i59tMedjXuY2X/Jct6OnArorQAAAABJRU5ErkJggg==</Image>
 <Url type="application/x-suggestions+json" method="GET" template="https://www.startpage.com/cgi-bin/csuggest">
     <Param name="limit" value="10" />
     <Param name="format" value="json" />
     <Param name="query" value="{searchTerms}"/>
 </Url>
-<Url type="text/html" method="GET" template="https://www.startpage.com/do/dsearch">
-    <Param name="cat" value="web" />
-    <Param name="pl" value="opensearch" />
-    <Param name="query" value="{searchTerms}" />
+<Url type="text/html" method="GET" template="https://www.startpage.com/do/search">
+    <Param name="q" value="{searchTerms}" />
+    <Param name="segment" value="startpage.brave" />
 </Url>
 </SearchPlugin>

--- a/ClientTests/SearchEnginesTests.swift
+++ b/ClientTests/SearchEnginesTests.swift
@@ -12,7 +12,7 @@ class SearchEnginesTests: XCTestCase {
     
     private let DefaultSearchEngineName = "Google"
     // BRAVE TODO: This list is not accurate because Brave uses many more engines
-    private let ExpectedEngineNames = ["Qwant", "Bing", "DuckDuckGo", "Google", "StartPage"]
+    private let ExpectedEngineNames = ["Qwant", "Bing", "DuckDuckGo", "Google", "Startpage"]
     
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3002 
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

New user path
- Fresh install 1.22 build
- Select startpage as default engine
- Search for `cats`
- Verify the url for the query is like `https://www.startpage.com/do/search?q=cats&segment=startpage.brave`

Existing user path
- Upgrade to 1.22 from lower app version
- Select Startpage as a default engine or make a search query and use Startpage from quick search engine panel
- Verify the url for the query is like `https://www.startpage.com/do/search?q=cats&segment=startpage.brave`

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
