### PR TITLE
Fix #2973: Add more keyboard shortcuts

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1771,7 +1771,11 @@ class BrowserViewController: UIViewController {
     }
     
     func openAddBookmark() {
-        guard let selectedTab = tabManager.selectedTab, let selectedUrl = selectedTab.url else { return }
+        guard let selectedTab = tabManager.selectedTab,
+              let selectedUrl = selectedTab.url,
+              !(selectedUrl.isLocal || selectedUrl.isReaderModeURL) else {
+            return
+        }
         
         let bookmarkUrl = selectedUrl.decodeReaderModeURL ?? selectedUrl
         

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1759,6 +1759,26 @@ class BrowserViewController: UIViewController {
         duckDuckGoPopup = popup
         popup.showWithType(showType: .flyUp)
     }
+    
+    func showBookmarkController() {
+        let bookmarkViewController = BookmarksViewController(
+            folder: nil,
+            isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        
+        bookmarkViewController.toolbarUrlActionsDelegate = self
+        
+        let navigationController = SettingsNavigationController(rootViewController: bookmarkViewController)
+        navigationController.modalPresentationStyle = .formSheet
+        
+        let doneBarbutton = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: navigationController,
+            action: #selector(SettingsNavigationController.done))
+        
+        navigationController.navigationBar.topItem?.rightBarButtonItem = doneBarbutton
+        
+        present(navigationController, animated: true)
+    }
 }
 
 extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
@@ -2055,17 +2075,7 @@ extension BrowserViewController: TopToolbarDelegate {
     // TODO: This logic should be fully abstracted away and share logic from current MenuViewController
     // See: https://github.com/brave/brave-ios/issues/1452
     func topToolbarDidTapBookmarkButton(_ topToolbar: TopToolbarView) {
-        let vc = BookmarksViewController(folder: nil,
-                                         isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        vc.toolbarUrlActionsDelegate = self
-        
-        let nav = SettingsNavigationController(rootViewController: vc)
-        nav.modalPresentationStyle = .formSheet
-        
-        let button = UIBarButtonItem(barButtonSystemItem: .done, target: nav, action: #selector(SettingsNavigationController.done))
-        nav.navigationBar.topItem?.rightBarButtonItem = button
-        
-        present(nav, animated: true)
+        showBookmarkController()
     }
     
     func topToolbarDidTapBraveRewardsButton(_ topToolbar: TopToolbarView) {
@@ -3428,6 +3438,12 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
 
     func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateTotalResults totalResults: Int) {
         findInPageBar?.totalResults = totalResults
+    }
+    
+    func findTextInPage(_ direction: TextSearchDirection) {
+        guard let seachText = findInPageBar?.text else { return }
+                
+        find(seachText, function: direction.rawValue)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1783,17 +1783,24 @@ class BrowserViewController: UIViewController {
         
         let addBookMarkController = AddEditBookmarkTableViewController(mode: mode)
         
-        presentSettingsNavigation(with: addBookMarkController)
+        presentSettingsNavigation(with: addBookMarkController, cancelEnabled: true)
     }
     
-    private func presentSettingsNavigation(with controller: UIViewController) {
+    private func presentSettingsNavigation(with controller: UIViewController, cancelEnabled: Bool = false) {
         let navigationController = SettingsNavigationController(rootViewController: controller)
         navigationController.modalPresentationStyle = .formSheet
+        
+        let cancelBarbutton = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: navigationController,
+            action: #selector(SettingsNavigationController.done))
         
         let doneBarbutton = UIBarButtonItem(
             barButtonSystemItem: .done,
             target: navigationController,
             action: #selector(SettingsNavigationController.done))
+        
+        navigationController.navigationBar.topItem?.leftBarButtonItem = cancelEnabled ? cancelBarbutton : nil
         
         navigationController.navigationBar.topItem?.rightBarButtonItem = doneBarbutton
         

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1760,14 +1760,30 @@ class BrowserViewController: UIViewController {
         popup.showWithType(showType: .flyUp)
     }
     
-    func showBookmarkController() {
+    private func showBookmarkController() {
         let bookmarkViewController = BookmarksViewController(
             folder: nil,
             isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
         
         bookmarkViewController.toolbarUrlActionsDelegate = self
         
-        let navigationController = SettingsNavigationController(rootViewController: bookmarkViewController)
+        presentSettingsNavigation(with: bookmarkViewController)
+    }
+    
+    func openAddBookmark() {
+        guard let selectedTab = tabManager.selectedTab, let selectedUrl = selectedTab.url else { return }
+        
+        let bookmarkUrl = selectedUrl.decodeReaderModeURL ?? selectedUrl
+        
+        let mode = BookmarkEditMode.addBookmark(title: selectedTab.displayTitle, url: bookmarkUrl.absoluteString)
+        
+        let addBookMarkController = AddEditBookmarkTableViewController(mode: mode)
+        
+        presentSettingsNavigation(with: addBookMarkController)
+    }
+    
+    private func presentSettingsNavigation(with controller: UIViewController) {
+        let navigationController = SettingsNavigationController(rootViewController: controller)
         navigationController.modalPresentationStyle = .formSheet
         
         let doneBarbutton = UIBarButtonItem(

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -6,6 +6,11 @@ import Shared
 
 // Naming functions: use the suffix 'KeyCommand' for an additional level of namespacing (bug 1415830)
 extension BrowserViewController {
+    
+    enum TextSearchDirection: String {
+        case next = "findNext"
+        case previous = "findPrevious"
+    }
 
     @objc private func reloadTabKeyCommand() {
         if let tab = tabManager.selectedTab, favoritesController == nil {
@@ -84,6 +89,18 @@ extension BrowserViewController {
     @objc private func showTabTrayKeyCommand() {
         showTabTray()
     }
+    
+    @objc private func showBookmarkCommand() {
+        showBookmarkController()
+    }
+    
+    @objc private func findNextCommand() {
+        findTextInPage(.next)
+    }
+    
+    @objc private func findPreviousCommand() {
+        findTextInPage(.previous)
+    }
 
     @objc private func moveURLCompletionKeyCommand(sender: UIKeyCommand) {
         guard let searchController = self.searchController else {
@@ -94,16 +111,18 @@ extension BrowserViewController {
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        let searchLocationCommands = [
+        let searchLocation = [
             UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
         ]
+        
         let overidesTextEditing = [
             UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
             UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
             UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: .command, action: #selector(goBackKeyCommand)),
             UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: .command, action: #selector(goForwardKeyCommand)),
         ]
+        
         let tabNavigation = [
             UIKeyCommand(input: "r", modifierFlags: .command, action: #selector(reloadTabKeyCommand), discoverabilityTitle: Strings.reloadPageTitle),
             UIKeyCommand(input: "[", modifierFlags: .command, action: #selector(goBackKeyCommand), discoverabilityTitle: Strings.backTitle),
@@ -124,14 +143,26 @@ extension BrowserViewController {
             UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(showTabTrayKeyCommand)), // Safari on macOS
             UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(showTabTrayKeyCommand), discoverabilityTitle: Strings.showTabTrayFromTabKeyCodeTitle)
         ]
+        
+        let bookmarkEditing = [
+            UIKeyCommand(input: "g", modifierFlags: [.command], action: #selector(showBookmarkCommand))
+        ]
+        
+        let findText = [
+            UIKeyCommand(input: "d", modifierFlags: [.command], action: #selector(findNextCommand)),
+            UIKeyCommand(input: "d", modifierFlags: [.command, .shift], action: #selector(findPreviousCommand))
+        ]
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false
 
+        var keycommandList = tabNavigation + bookmarkEditing + findText
+        
         if topToolbar.inOverlayMode {
-            return tabNavigation + searchLocationCommands
+            keycommandList.append(contentsOf: searchLocation)
         } else if !isEditingText {
-            return tabNavigation + overidesTextEditing
+            keycommandList.append(contentsOf: overidesTextEditing)
         }
-        return tabNavigation
+        
+        return keycommandList
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -90,8 +90,8 @@ extension BrowserViewController {
         showTabTray()
     }
     
-    @objc private func showBookmarkCommand() {
-        showBookmarkController()
+    @objc private func addBookmarkCommand() {
+        openAddBookmark()
     }
     
     @objc private func findNextCommand() {
@@ -145,7 +145,7 @@ extension BrowserViewController {
         ]
         
         let bookmarkEditing = [
-            UIKeyCommand(input: "g", modifierFlags: [.command], action: #selector(showBookmarkCommand))
+            UIKeyCommand(input: "g", modifierFlags: [.command], action: #selector(addBookmarkCommand))
         ]
         
         let findText = [

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -149,8 +149,8 @@ extension BrowserViewController {
         ]
         
         let findText = [
-            UIKeyCommand(input: "d", modifierFlags: [.command], action: #selector(findNextCommand)),
-            UIKeyCommand(input: "d", modifierFlags: [.command, .shift], action: #selector(findPreviousCommand))
+            UIKeyCommand(input: "d", modifierFlags: [.command, .shift], action: #selector(findNextCommand)),
+            UIKeyCommand(input: "d", modifierFlags: [.command], action: #selector(findPreviousCommand))
         ]
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -145,12 +145,12 @@ extension BrowserViewController {
         ]
         
         let bookmarkEditing = [
-            UIKeyCommand(input: "g", modifierFlags: [.command], action: #selector(addBookmarkCommand))
+            UIKeyCommand(input: "d", modifierFlags: [.command], action: #selector(addBookmarkCommand))
         ]
         
         let findText = [
-            UIKeyCommand(input: "d", modifierFlags: [.command, .shift], action: #selector(findNextCommand)),
-            UIKeyCommand(input: "d", modifierFlags: [.command], action: #selector(findPreviousCommand))
+            UIKeyCommand(input: "g", modifierFlags: [.command], action: #selector(findNextCommand)),
+            UIKeyCommand(input: "g", modifierFlags: [.command, .shift], action: #selector(findPreviousCommand))
         ]
 
         let isEditingText = tabManager.selectedTab?.isEditing ?? false


### PR DESCRIPTION
New Keyboard shortcuts are added

AddBookmark : CMD + D
Toggle next when finding text: CMD +SHIFT + G
Toggle previous when finding text: CMD + G

## Summary of Changes

This pull request fixes https://github.com/brave/brave-ios/issues/2973

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Load Brave Browser and press CMD + D
- Verify Add Bookmark screen is presented

- Load Brave Browser and press F to present Search Keyword
- Write a keyword and traverse inside the page using up / down button on toolbar
- Try the same behaviour this time using CMD + G for next and CMD +SHIFT + G for previous keyword


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
