### PR TITLE
Fix #2644/#2558: Dark Mode Related Changes

### DIFF
--- a/Client/Extensions/UIAlertControllerExtensions.swift
+++ b/Client/Extensions/UIAlertControllerExtensions.swift
@@ -242,9 +242,17 @@ class UserTextInputAlert {
     private func textFieldConfig(text: String?, placeholder: String?, keyboardType: UIKeyboardType?, forcedInput: Bool)
         -> (UITextField) -> Void {
             return { textField in
-                textField.placeholder = placeholder
+                if #available(iOS 13.0, *) {
+                    textField.attributedPlaceholder = NSAttributedString(
+                        string: placeholder ?? "",
+                        attributes: [.foregroundColor: UIColor.placeholderText])
+                } else {
+                    textField.placeholder = placeholder
+                }
+                
+                textField.keyboardAppearance = .default
+
                 textField.isSecureTextEntry = false
-                textField.keyboardAppearance = .dark
                 textField.autocapitalizationType = keyboardType == .URL ? .none : .words
                 textField.autocorrectionType = keyboardType == .URL ? .no : .default
                 textField.returnKeyType = .done

--- a/Client/Frontend/Browser/TabsBar/TabBarCell.swift
+++ b/Client/Frontend/Browser/TabsBar/TabBarCell.swift
@@ -5,7 +5,7 @@
 import UIKit
 import BraveShared
 
-class TabBarCell: UICollectionViewCell {
+class TabBarCell: UICollectionViewCell, Themeable {
     
     lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -111,12 +111,6 @@ class TabBarCell: UICollectionViewCell {
         }
     }
     
-    func setTheme(with activeTheme: Theme) {
-        backgroundColor = .clear
-        titleLabel.textColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? .white : activeTheme.colors.tints.header
-        closeButton.tintColor = activeTheme.colors.tints.header
-    }
-    
     @objc func closeTab() {
         guard let tab = tab else { return }
         closeTabCallback?(tab)
@@ -134,5 +128,13 @@ class TabBarCell: UICollectionViewCell {
             strongSelf.titleUpdateScheduled = false
             strongSelf.titleLabel.text = tab.displayTitle
         }
+    }
+    
+    func applyTheme(_ theme: Theme) {
+        styleChildren(theme: theme)
+        
+        backgroundColor = .clear
+        titleLabel.textColor = theme.colors.tints.header
+        closeButton.tintColor = theme.colors.tints.header
     }
 }

--- a/Client/Frontend/Browser/TabsBar/TabBarCell.swift
+++ b/Client/Frontend/Browser/TabsBar/TabBarCell.swift
@@ -130,9 +130,7 @@ class TabBarCell: UICollectionViewCell, Themeable {
         }
     }
     
-    func applyTheme(_ theme: Theme) {
-        styleChildren(theme: theme)
-        
+    func applyTheme(_ theme: Theme) {        
         backgroundColor = .clear
         titleLabel.textColor = theme.colors.tints.header
         closeButton.tintColor = theme.colors.tints.header

--- a/Client/Frontend/Browser/TabsBar/TabBarCell.swift
+++ b/Client/Frontend/Browser/TabsBar/TabBarCell.swift
@@ -17,9 +17,11 @@ class TabBarCell: UICollectionViewCell {
         let button = UIButton()
         button.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
         button.setImage(#imageLiteral(resourceName: "close_tab_bar").template, for: .normal)
-        button.tintColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UIColor.white : UIColor.black
+        button.tintColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? .white : .black
+        
         // Close button is a bit wider to increase tap area, this aligns the 'X' image closer to the right.
         button.imageEdgeInsets.left = 6
+        
         return button
     }()
     
@@ -109,12 +111,19 @@ class TabBarCell: UICollectionViewCell {
         }
     }
     
+    func setTheme(with activeTheme: Theme) {
+        backgroundColor = .clear
+        titleLabel.textColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? .white : activeTheme.colors.tints.header
+        closeButton.tintColor = activeTheme.colors.tints.header
+    }
+    
     @objc func closeTab() {
         guard let tab = tab else { return }
         closeTabCallback?(tab)
     }
     
     fileprivate var titleUpdateScheduled = false
+    
     func updateTitleThrottled(for tab: Tab) {
         if titleUpdateScheduled {
             return

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -57,12 +57,9 @@ class TabsBarViewController: UIViewController {
     
     fileprivate weak var tabManager: TabManager?
     fileprivate var tabList = WeakList<Tab>()
-    
-    private var activeTheme: Theme
-    
+        
     init(tabManager: TabManager) {
         self.tabManager = tabManager
-        activeTheme = Theme.of(tabManager.selectedTab)
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -381,8 +378,6 @@ extension TabsBarViewController: Themeable {
     }
     
     func applyTheme(_ theme: Theme) {
-        activeTheme = theme
-        
         styleChildren(theme: theme)
         
         view.backgroundColor = theme.colors.header

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -374,7 +374,7 @@ extension TabsBarViewController: TabManagerDelegate {
 
 extension TabsBarViewController: Themeable {
     var themeableChildren: [Themeable?]? {
-        return  collectionView.visibleCells.compactMap({ $0 as? TabBarCell })
+        collectionView.visibleCells.compactMap({ $0 as? TabBarCell })
     }
     
     func applyTheme(_ theme: Theme) {

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -311,7 +311,7 @@ extension TabsBarViewController: UICollectionViewDataSource {
         cell.titleLabel.text = tab.displayTitle
         cell.currentIndex = indexPath.row
         cell.separatorLineRight.isHidden = (indexPath.row != tabList.count() - 1)
-        cell.setTheme(with: activeTheme)
+        cell.applyTheme(activeTheme)
 
         cell.closeTabCallback = { [weak self] tab in
             guard let strongSelf = self, let tabManager = strongSelf.tabManager, let previousIndex = strongSelf.tabList.index(of: tab) else { return }
@@ -367,6 +367,10 @@ extension TabsBarViewController: TabManagerDelegate {
 }
 
 extension TabsBarViewController: Themeable {
+    var themeableChildren: [Themeable?]? {
+        return  collectionView.visibleCells.compactMap({ $0 as? TabBarCell })
+    }
+    
     func applyTheme(_ theme: Theme) {
         activeTheme = theme
         


### PR DESCRIPTION
Some Dark mode related fixed are added to

- Edit Bookmark Textfield
- TabBar 

## Summary of Changes

This pull request fixes #2644
This pull request fixes #2558

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Load Brave Browser while using DarkMode and long press a favourite
- Click Edit BookMark and check colors in textfields are ok
- Delete values inside textfield and check placeholder text colors

- Load Brave Browser while using DarkMode or Light Mode and check Tabbar color
- Go settings change device appearance to the mode that is not being used 
- Go back to the browser and check TabBar color

## Screenshots:

![2644](https://user-images.githubusercontent.com/6643505/98846849-87725280-241d-11eb-9842-32c4d55e9617.png)

![2588](https://user-images.githubusercontent.com/6643505/98847087-cc968480-241d-11eb-9603-cf3225c1e0e6.gif)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
