### PR TITLE
Fix #2961: Problems with Sharing a PDF File

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
@@ -177,7 +177,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     private func shareDownloadedFile(_ downloadedFile: DownloadedFile, indexPath: IndexPath) {
         let helper = ShareExtensionHelper(url: downloadedFile.path, tab: nil)
-        let controller = helper.createActivityViewController { completed, activityType in
+        let controller = helper.createActivityViewController { completed, activityType, _ in
             log.debug("Shared downloaded file: \(completed)")
         }
 

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -14,17 +14,6 @@ class ShareExtensionHelper: NSObject {
         case password
         case iBooks
         case `default`
-        
-        var description: String? {
-            switch self {
-            case .password:
-                return "All Password Activity Types pwsafe / 1Password"
-            case .iBooks:
-                return "PDF Sharing Activity Type"
-            case .default:
-                return "Other Types"
-            }
-        }
     }
     
     fileprivate weak var selectedTab: Tab?


### PR DESCRIPTION
WIP:

Fixed:
- Creating PDF from the WebPage and passing it to iBooks If activity is chosen
- Sharing Downloaded Files

Need to fix:

- Sharing PDF file with iBooks and Mail app. 

## Summary of Changes

This pull request fixes #2961

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Load Brave Browser with a PDF link and Press Share from Menu
- Choose iBook Apps for sharing or Mail

## Screenshots:
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
