### PR TITLE
Fix #2908: Selecting a single SE doesn't show up in quick search engine list

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1131,28 +1131,29 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate func showSearchController() {
-        if searchController != nil {
-            return
-        }
+        if searchController != nil { return }
 
         let tabType = TabType.of(tabManager.selectedTab)
         searchController = SearchViewController(forTabType: tabType)
-        searchController!.searchEngines = profile.searchEngines
-        searchController!.searchDelegate = self
-        searchController!.profile = self.profile
+        
+        guard let searchController = searchController else { return }
+
+        searchController.searchEngines = profile.searchEngines
+        searchController.searchDelegate = self
+        searchController.profile = self.profile
 
         searchLoader = SearchLoader(profile: profile, topToolbar: topToolbar)
-        searchLoader?.addListener(searchController!)
+        searchLoader?.addListener(searchController)
 
-        addChild(searchController!)
-        view.addSubview(searchController!.view)
-        searchController!.view.snp.makeConstraints { make in
+        addChild(searchController)
+        view.addSubview(searchController.view)
+        searchController.view.snp.makeConstraints { make in
             make.top.equalTo(self.topToolbar.snp.bottom)
             make.left.right.bottom.equalTo(self.view)
             return
         }
         
-        searchController!.didMove(toParent: self)
+        searchController.didMove(toParent: self)
     }
     
     func updateTabsBarVisibility() {

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -185,8 +185,15 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
     
     // If the user only has a single quick search engine, it is also their default one.
-    // In that case, we count it as if there are no quick suggestions to show.
+    // In that case, we count it as if there are no quick suggestions to show
+    // Unless Default Search Engine is different than Quick Search Engine
     private var hasQuickSearchEngines: Bool {
+        let isDefaultEngineQuickEngine = searchEngines.defaultEngine().engineID == quickSearchEngines.first?.engineID
+        
+        if quickSearchEngines.count == 1 {
+            return !isDefaultEngineQuickEngine
+        }
+
         return quickSearchEngines.count > 1
     }
     


### PR DESCRIPTION
Adding Quick Engine Search Bar If the only selected quick engine is not the default engine

## Summary of Changes

This pull request fixes #2908

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Load Brave Browser and Press Settings - Search Engines from Menu
- Choose a standard search engine and enable only one search engine
- Start Typing in URL bar and check quick search engine toolbar is shown

## Screenshots:

![Issue 2908](https://user-images.githubusercontent.com/6643505/99113326-0e116600-25bd-11eb-9892-49bfb444acf0.PNG)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
