### PR TITLE
Fix #2649: Reader-Mode Toolbar Problem

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 		28E08C991AF44EF9009BA2FA /* SQLiteHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2551ABB531100877008 /* SQLiteHistory.swift */; };
 		28FDFF0C1C1F725800840F86 /* SeparatorTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FDFF0B1C1F725800840F86 /* SeparatorTableCell.swift */; };
 		2C49854E206173C800893DAE /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
+		2F098F8B255F2D730084FB37 /* BrowserViewController+ReaderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
 		2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */; };
 		2F44FB2D1A9D5D8500FD20CC /* FiraSans-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B7421A793CF20022C5E0 /* FiraSans-BoldItalic.ttf */; };
@@ -1895,6 +1896,7 @@
 		28CE83E81A1D206D00576538 /* Client-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Client-Bridging-Header.h"; sourceTree = "<group>"; };
 		28FDFF0B1C1F725800840F86 /* SeparatorTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeparatorTableCell.swift; sourceTree = "<group>"; };
 		2C49854D206173C800893DAE /* photon-colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "photon-colors.swift"; sourceTree = "<group>"; };
+		2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+ReaderMode.swift"; sourceTree = "<group>"; };
 		2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHashExtensions.swift; sourceTree = "<group>"; };
 		2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
@@ -4835,6 +4837,7 @@
 				C8F457A91F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift */,
 				D0C95EF5201A55A800E4E51C /* BrowserViewController+UIDropInteractionDelegate.swift */,
 				C8F457A71F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift */,
+				2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */,
 				0A91598822B834CE00CCC119 /* BVC+Rewards.swift */,
 			);
 			path = BrowserViewController;
@@ -6890,6 +6893,7 @@
 				4422D4E621BFFB7600BF1855 /* two_level_iterator.cc in Sources */,
 				27FCA8E72447BCFE00A8CA48 /* DuckDuckGoCalloutSectionProvider.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
+				2F098F8B255F2D730084FB37 /* BrowserViewController+ReaderMode.swift in Sources */,
 				4422D57421BFFB7F00BF1855 /* prog.cc in Sources */,
 				4422D42F21BFCF8900BF1855 /* HttpsEverywhereObjC.mm in Sources */,
 				4422D56B21BFFB7F00BF1855 /* prefilter_tree.cc in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -76,8 +76,8 @@ class BrowserViewController: UIViewController {
     fileprivate var customSearchBarButton: UIBarButtonItem?
 
     // popover rotation handling
-    fileprivate var displayedPopoverController: UIViewController?
-    fileprivate var updateDisplayedPopoverProperties: (() -> Void)?
+    var displayedPopoverController: UIViewController?
+    var updateDisplayedPopoverProperties: (() -> Void)?
 
     var openInHelper: OpenInHelper?
 
@@ -1098,8 +1098,9 @@ class BrowserViewController: UIViewController {
     
     private(set) weak var activeNewTabPageViewController: NewTabPageViewController?
     
-    fileprivate func hideActiveNewTabPageController() {
+    fileprivate func hideActiveNewTabPageController(_ isReaderModeURL: Bool = false) {
         guard let controller = activeNewTabPageViewController else { return }
+        
         UIView.animate(withDuration: 0.2, animations: {
             controller.view.alpha = 0.0
         }, completion: { finished in
@@ -1110,7 +1111,10 @@ class BrowserViewController: UIViewController {
             UIAccessibility.post(notification: .screenChanged, argument: nil)
             
             // Refresh the reading view toolbar since the article record may have changed
-            if let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode, readerMode.state == .active {
+            if let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode,
+               readerMode.state == .active,
+               isReaderModeURL
+            {
                 self.showReaderModeBar(animated: false)
             }
         })
@@ -1125,7 +1129,7 @@ class BrowserViewController: UIViewController {
             if url.isAboutHomeURL && !url.isErrorPageURL {
                 showNewTabPageController()
             } else if !url.isLocalUtility || url.isReaderModeURL || url.isErrorPageURL {
-                hideActiveNewTabPageController()
+                hideActiveNewTabPageController(url.isReaderModeURL)
             }
         }
     }
@@ -2851,24 +2855,6 @@ extension BrowserViewController: WKUIDelegate {
     }
 }
 
-extension BrowserViewController: ReaderModeDelegate {
-    func readerMode(_ readerMode: ReaderMode, didChangeReaderModeState state: ReaderModeState, forTab tab: Tab) {
-        // If this reader mode availability state change is for the tab that we currently show, then update
-        // the button. Otherwise do nothing and the button will be updated when the tab is made active.
-        if tabManager.selectedTab === tab {
-            topToolbar.updateReaderModeState(state)
-        }
-    }
-
-    func readerMode(_ readerMode: ReaderMode, didDisplayReaderizedContentForTab tab: Tab) {
-        self.showReaderModeBar(animated: true)
-        tab.showContent(true)
-    }
-
-    func readerMode(_ readerMode: ReaderMode, didParseReadabilityResult readabilityResult: ReadabilityResult, forTab tab: Tab) {
-    }
-}
-
 // MARK: - UIPopoverPresentationControllerDelegate
 
 extension BrowserViewController: UIPopoverPresentationControllerDelegate {
@@ -2883,172 +2869,6 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
     // not as a full-screen modal, which is the default on compact device classes.
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .none
-    }
-}
-
-// MARK: - ReaderModeStyleViewControllerDelegate
-
-extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
-    func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, didConfigureStyle style: ReaderModeStyle) {
-        // Persist the new style to the profile
-        let encodedStyle: [String: Any] = style.encodeAsDictionary()
-        profile.prefs.setObject(encodedStyle, forKey: ReaderModeProfileKeyStyle)
-        // Change the reader mode style on all tabs that have reader mode active
-        for tabIndex in 0..<tabManager.count {
-            if let tab = tabManager[tabIndex] {
-                if let readerMode = tab.getContentScript(name: "ReaderMode") as? ReaderMode {
-                    if readerMode.state == ReaderModeState.active {
-                        readerMode.style = style
-                    }
-                }
-            }
-        }
-    }
-}
-
-extension BrowserViewController {
-    func updateReaderModeBar() {
-        if let readerModeBar = readerModeBar {
-            let theme = Theme.of(tabManager.selectedTab)
-            readerModeBar.applyTheme(theme)
-        }
-    }
-
-    func showReaderModeBar(animated: Bool) {
-        if self.readerModeBar == nil {
-            let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
-            readerModeBar.delegate = self
-            view.insertSubview(readerModeBar, belowSubview: header)
-            self.readerModeBar = readerModeBar
-            
-            readerModeBar.snp.makeConstraints { make in
-                make.top.equalTo(self.header.snp.bottom)
-                make.height.equalTo(UIConstants.toolbarHeight)
-                make.leading.trailing.equalTo(self.view)
-            }
-        }
-
-        updateReaderModeBar()
-
-        self.updateViewConstraints()
-    }
-
-    func hideReaderModeBar(animated: Bool) {
-        if let readerModeBar = self.readerModeBar {
-            readerModeBar.removeFromSuperview()
-            self.readerModeBar = nil
-            self.updateViewConstraints()
-        }
-    }
-
-    /// There are two ways we can enable reader mode. In the simplest case we open a URL to our internal reader mode
-    /// and be done with it. In the more complicated case, reader mode was already open for this page and we simply
-    /// navigated away from it. So we look to the left and right in the BackForwardList to see if a readerized version
-    /// of the current page is there. And if so, we go there.
-
-    func enableReaderMode() {
-        guard let tab = tabManager.selectedTab, let webView = tab.webView else { return }
-
-        let backList = webView.backForwardList.backList
-        let forwardList = webView.backForwardList.forwardList
-
-        guard let currentURL = webView.backForwardList.currentItem?.url, let readerModeURL = currentURL.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) else { return }
-
-        if backList.count > 1 && backList.last?.url == readerModeURL {
-            webView.go(to: backList.last!)
-        } else if forwardList.count > 0 && forwardList.first?.url == readerModeURL {
-            webView.go(to: forwardList.first!)
-        } else {
-            // Store the readability result in the cache and load it. This will later move to the ReadabilityHelper.
-            webView.evaluateJavaScript("\(ReaderModeNamespace).readerize()", completionHandler: { (object, error) -> Void in
-                if let readabilityResult = ReadabilityResult(object: object as AnyObject?) {
-                    do {
-                        try self.readerModeCache.put(currentURL, readabilityResult)
-                    } catch _ {
-                    }
-                    
-                    webView.load(PrivilegedRequest(url: readerModeURL) as URLRequest)
-                }
-            })
-        }
-    }
-
-    /// Disabling reader mode can mean two things. In the simplest case we were opened from the reading list, which
-    /// means that there is nothing in the BackForwardList except the internal url for the reader mode page. In that
-    /// case we simply open a new page with the original url. In the more complicated page, the non-readerized version
-    /// of the page is either to the left or right in the BackForwardList. If that is the case, we navigate there.
-
-    func disableReaderMode() {
-        if let tab = tabManager.selectedTab,
-            let webView = tab.webView {
-            let backList = webView.backForwardList.backList
-            let forwardList = webView.backForwardList.forwardList
-
-            if let currentURL = webView.backForwardList.currentItem?.url {
-                if let originalURL = currentURL.decodeReaderModeURL {
-                    if backList.count > 1 && backList.last?.url == originalURL {
-                        webView.go(to: backList.last!)
-                    } else if forwardList.count > 0 && forwardList.first?.url == originalURL {
-                        webView.go(to: forwardList.first!)
-                    } else {
-                        webView.load(URLRequest(url: originalURL))
-                    }
-                }
-            }
-        }
-    }
-
-    @objc func dynamicFontChanged(_ notification: Notification) {
-        guard notification.name == .dynamicFontChanged else { return }
-
-        var readerModeStyle = DefaultReaderModeStyle
-        if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
-            if let style = ReaderModeStyle(dict: dict as [String: AnyObject]) {
-                readerModeStyle = style
-            }
-        }
-        readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
-        self.readerModeStyleViewController(ReaderModeStyleViewController(), didConfigureStyle: readerModeStyle)
-    }
-}
-
-extension BrowserViewController: ReaderModeBarViewDelegate {
-    func readerModeBar(_ readerModeBar: ReaderModeBarView, didSelectButton buttonType: ReaderModeBarButtonType) {
-        switch buttonType {
-        case .settings:
-            if let readerMode = tabManager.selectedTab?.getContentScript(name: "ReaderMode") as? ReaderMode, readerMode.state == ReaderModeState.active {
-                var readerModeStyle = DefaultReaderModeStyle
-                if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
-                    if let style = ReaderModeStyle(dict: dict as [String: AnyObject]) {
-                        readerModeStyle = style
-                    }
-                }
-
-                let readerModeStyleViewController = ReaderModeStyleViewController()
-                readerModeStyleViewController.delegate = self
-                readerModeStyleViewController.readerModeStyle = readerModeStyle
-                readerModeStyleViewController.modalPresentationStyle = .popover
-
-                let setupPopover = { [unowned self] in
-                    if let popoverPresentationController = readerModeStyleViewController.popoverPresentationController {
-                        popoverPresentationController.backgroundColor = UIColor.Photon.white100
-                        popoverPresentationController.delegate = self
-                        popoverPresentationController.sourceView = readerModeBar
-                        popoverPresentationController.sourceRect = CGRect(x: readerModeBar.frame.width/2, y: UIConstants.toolbarHeight, width: 1, height: 1)
-                        popoverPresentationController.permittedArrowDirections = .up
-                    }
-                }
-
-                setupPopover()
-
-                if readerModeStyleViewController.popoverPresentationController != nil {
-                    displayedPopoverController = readerModeStyleViewController
-                    updateDisplayedPopoverProperties = setupPopover
-                }
-
-                self.present(readerModeStyleViewController, animated: true, completion: nil)
-            }
-        }
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1113,8 +1113,7 @@ class BrowserViewController: UIViewController {
             // Refresh the reading view toolbar since the article record may have changed
             if let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode,
                readerMode.state == .active,
-               isReaderModeURL
-            {
+               isReaderModeURL {
                 self.showReaderModeBar(animated: false)
             }
         })

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -1,0 +1,207 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Shared
+import WebKit
+import Storage
+
+// MARK: - ReaderModeDelegate
+
+extension BrowserViewController: ReaderModeDelegate {
+    func readerMode(_ readerMode: ReaderMode, didChangeReaderModeState state: ReaderModeState, forTab tab: Tab) {
+        // If this reader mode availability state change is for the tab that we currently show, then update
+        // the button. Otherwise do nothing and the button will be updated when the tab is made active.
+        if tabManager.selectedTab === tab {
+            topToolbar.updateReaderModeState(state)
+        }
+    }
+
+    func readerMode(_ readerMode: ReaderMode, didDisplayReaderizedContentForTab tab: Tab) {
+        showReaderModeBar(animated: true)
+        tab.showContent(true)
+    }
+
+    func readerMode(_ readerMode: ReaderMode, didParseReadabilityResult readabilityResult: ReadabilityResult, forTab tab: Tab) { }
+}
+
+// MARK: - ReaderModeStyleViewControllerDelegate
+
+extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
+    func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController, didConfigureStyle style: ReaderModeStyle) {
+        // Persist the new style to the profile
+        let encodedStyle: [String: Any] = style.encodeAsDictionary()
+        profile.prefs.setObject(encodedStyle, forKey: ReaderModeProfileKeyStyle)
+        // Change the reader mode style on all tabs that have reader mode active
+        for tabIndex in 0..<tabManager.count {
+            if let tab = tabManager[tabIndex] {
+                if let readerMode = tab.getContentScript(name: "ReaderMode") as? ReaderMode {
+                    if readerMode.state == ReaderModeState.active {
+                        readerMode.style = style
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - ReaderModeBarViewDelegate
+
+extension BrowserViewController: ReaderModeBarViewDelegate {
+    
+    func readerModeBar(_ readerModeBar: ReaderModeBarView, didSelectButton buttonType: ReaderModeBarButtonType) {
+        switch buttonType {
+        case .settings:
+            if let readerMode = tabManager.selectedTab?.getContentScript(name: "ReaderMode") as? ReaderMode, readerMode.state == ReaderModeState.active {
+                var readerModeStyle = DefaultReaderModeStyle
+                if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
+                    if let style = ReaderModeStyle(dict: dict as [String: AnyObject]) {
+                        readerModeStyle = style
+                    }
+                }
+
+                let readerModeStyleViewController = ReaderModeStyleViewController()
+                readerModeStyleViewController.delegate = self
+                readerModeStyleViewController.readerModeStyle = readerModeStyle
+                readerModeStyleViewController.modalPresentationStyle = .popover
+
+                let setupPopover = { [unowned self] in
+                    if let popoverPresentationController = readerModeStyleViewController.popoverPresentationController {
+                        popoverPresentationController.backgroundColor = UIColor.Photon.white100
+                        popoverPresentationController.delegate = self
+                        popoverPresentationController.sourceView = readerModeBar
+                        popoverPresentationController.sourceRect = CGRect(x: readerModeBar.frame.width/2, y: UIConstants.toolbarHeight, width: 1, height: 1)
+                        popoverPresentationController.permittedArrowDirections = .up
+                    }
+                }
+
+                setupPopover()
+
+                if readerModeStyleViewController.popoverPresentationController != nil {
+                    displayedPopoverController = readerModeStyleViewController
+                    updateDisplayedPopoverProperties = setupPopover
+                }
+
+                present(readerModeStyleViewController, animated: true, completion: nil)
+            }
+        }
+    }
+}
+
+// MARK: - ReaderModeBarUpdate
+
+extension BrowserViewController {
+    
+    func updateReaderModeBar() {
+        if let readerModeBar = readerModeBar {
+            let theme = Theme.of(tabManager.selectedTab)
+            readerModeBar.applyTheme(theme)
+        }
+    }
+
+    func showReaderModeBar(animated: Bool) {
+        if self.readerModeBar == nil {
+            let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
+            readerModeBar.delegate = self
+            view.insertSubview(readerModeBar, belowSubview: header)
+            self.readerModeBar = readerModeBar
+            
+            readerModeBar.snp.makeConstraints { make in
+                make.top.equalTo(self.header.snp.bottom)
+                make.height.equalTo(UIConstants.toolbarHeight)
+                make.leading.trailing.equalTo(self.view)
+            }
+        }
+
+        updateReaderModeBar()
+
+        updateViewConstraints()
+    }
+
+    func hideReaderModeBar(animated: Bool) {
+        if let readerModeBar = self.readerModeBar {
+            readerModeBar.removeFromSuperview()
+            self.readerModeBar = nil
+            self.updateViewConstraints()
+        }
+    }
+
+    /// There are two ways we can enable reader mode. In the simplest case we open a URL to our internal reader mode
+    /// and be done with it. In the more complicated case, reader mode was already open for this page and we simply
+    /// navigated away from it. So we look to the left and right in the BackForwardList to see if a readerized version
+    /// of the current page is there. And if so, we go there.
+
+    func enableReaderMode() {
+        guard let tab = tabManager.selectedTab, let webView = tab.webView else { return }
+
+        let backList = webView.backForwardList.backList
+        let forwardList = webView.backForwardList.forwardList
+
+        guard let currentURL = webView.backForwardList.currentItem?.url, let readerModeURL = currentURL.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) else { return }
+
+        if backList.count > 1 && backList.last?.url == readerModeURL {
+            webView.go(to: backList.last!)
+        } else if forwardList.count > 0 && forwardList.first?.url == readerModeURL {
+            webView.go(to: forwardList.first!)
+        } else {
+            // Store the readability result in the cache and load it. This will later move to the ReadabilityHelper.
+            webView.evaluateJavaScript("\(ReaderModeNamespace).readerize()", completionHandler: { (object, error) -> Void in
+                if let readabilityResult = ReadabilityResult(object: object as AnyObject?) {
+                    try? self.readerModeCache.put(currentURL, readabilityResult)
+                    if let nav = webView.load(PrivilegedRequest(url: readerModeURL) as URLRequest) {
+                        self.ignoreNavigationInTab(tab, navigation: nav)
+                    }
+                }
+            })
+        }
+    }
+
+    /// Disabling reader mode can mean two things. In the simplest case we were opened from the reading list, which
+    /// means that there is nothing in the BackForwardList except the internal url for the reader mode page. In that
+    /// case we simply open a new page with the original url. In the more complicated page, the non-readerized version
+    /// of the page is either to the left or right in the BackForwardList. If that is the case, we navigate there.
+
+    func disableReaderMode() {
+        if let tab = tabManager.selectedTab,
+            let webView = tab.webView {
+            let backList = webView.backForwardList.backList
+            let forwardList = webView.backForwardList.forwardList
+
+            if let currentURL = webView.backForwardList.currentItem?.url {
+                if let originalURL = currentURL.decodeReaderModeURL {
+                    if backList.count > 1 && backList.last?.url == originalURL {
+                        webView.go(to: backList.last!)
+                    } else if forwardList.count > 0 && forwardList.first?.url == originalURL {
+                        webView.go(to: forwardList.first!)
+                    } else {
+                        if let nav = webView.load(URLRequest(url: originalURL)) {
+                            ignoreNavigationInTab(tab, navigation: nav)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @objc func dynamicFontChanged(_ notification: Notification) {
+        guard notification.name == .dynamicFontChanged else { return }
+
+        var readerModeStyle = DefaultReaderModeStyle
+        if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
+            if let style = ReaderModeStyle(dict: dict as [String: AnyObject]) {
+                readerModeStyle = style
+            }
+        }
+        readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
+        self.readerModeStyleViewController(ReaderModeStyleViewController(), didConfigureStyle: readerModeStyle)
+    }
+    
+    func ignoreNavigationInTab(_ tab: Tab, navigation: WKNavigation) {
+        self.ignoredNavigation.insert(navigation)
+    }
+    
+    func recordNavigationInTab(_ tab: Tab, navigation: WKNavigation, visitType: VisitType) {
+        self.typedNavigation[navigation] = visitType
+    }
+}


### PR DESCRIPTION
Fixed the Reader Mode Problem and Extracted Reader Mode Properties

## Summary of Changes

This pull request fixes #2649

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
The problem was when user changes to a new tab and in old tab after switching to reader mode back and forth, Reader Mode Toolbar never disappears.

- Load Brave Browser and Load a webpage that supports Reader Mode 
- Create a new Tab and load a Webpage
- Switch back to Old Tab
- Enable Disable Mode Reader and witness toolbar reader is disappearing

## Screenshots:

![Issue:2649](https://user-images.githubusercontent.com/6643505/99125479-1e800b80-25d2-11eb-866d-e19e3e25d539.gif)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
