### PR TITLE
Fix #3041: Crash when set as Default Browser and opening Link from other Application

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -663,18 +663,14 @@ extension TabTrayController: TabManagerDelegate {
         }
 
         tabDataSource.addTab(tab)
-        if navigationController?.visibleViewController === self {
-            self.collectionView?.performBatchUpdates({
-                self.collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
-            }, completion: { finished in
-                if finished {
-                    tabManager.selectTab(tab)
-                    // don't pop the tab tray view controller if it is not in the foreground
-                    if self.presentedViewController == nil {
-                        _ = self.navigationController?.popViewController(animated: true)
-                    }
+        
+        insertTabToCollection(tab, index: index) {
+            if let controller = self.navigationController?.visibleViewController, controller is TabTrayController {
+                // don't pop the tab tray view controller if it is not in the foreground
+                if self.presentedViewController == nil {
+                    _ = self.navigationController?.popViewController(animated: true)
                 }
-            })
+            }
         }
     }
 
@@ -711,6 +707,18 @@ extension TabTrayController: TabManagerDelegate {
                 make.bottom.equalTo(self.toolbar.snp.top)
             })
         }
+    }
+    
+    private func insertTabToCollection(_ tab: Tab, index: Int, completion: @escaping () -> Void ) {
+        collectionView?.performBatchUpdates({
+            self.collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
+        }, completion: { finished in
+            if finished {
+                self.tabManager.selectTab(tab)
+                
+                completion()
+            }
+        })
     }
 }
 


### PR DESCRIPTION
TabTray is not being dismissed when actual controller is not TabTray but Data is inserted to proper collectionView index.

This fixes the crash in TabTray CollectionView cause the right data will be reloaded in designated indexpath.

## Summary of Changes

This pull request fixes #3041

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Set Brave as default browser.
- Click the show all tabs button (leave it open.)
- Go to another app and open a link.
- Brave crashes.

## Screenshots:

![issue:3041](https://user-images.githubusercontent.com/6643505/99443591-09182380-28e9-11eb-8554-1ab12d8c2067.gif)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
