### PR TITLE
Fix #3044: Search Suggestion  Text Color blinks when text is entered

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 		2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */; };
 		2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */; };
 		2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */; };
+		2F83C7422566C617008791BB /* SearchSuggestionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F83C7412566C617008791BB /* SearchSuggestionCell.swift */; };
 		2FCAE2251ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		2FCAE2311ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		2FCAE25D1ABB531100877008 /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE23F1ABB531100877008 /* Bookmarks.swift */; };
@@ -1637,6 +1638,7 @@
 		2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginePicker.swift; sourceTree = "<group>"; };
 		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
+		2F83C7412566C617008791BB /* SearchSuggestionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionCell.swift; sourceTree = "<group>"; };
 		2FCAE21A1ABB51F800877008 /* Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FCAE2241ABB51F800877008 /* StorageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StorageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FCAE22C1ABB51F800877008 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2805,6 +2807,7 @@
 				D34510871ACF415700EC27F0 /* SearchLoader.swift */,
 				D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */,
 				59A68CCB63E2A565CB03F832 /* SearchViewController.swift */,
+				2F83C7412566C617008791BB /* SearchSuggestionCell.swift */,
 				27F94A3921909A5900F4FADF /* SearchSuggestionsPromptView.swift */,
 				0A179E272519F97E0014D9E1 /* InitialSearchEngines.swift */,
 			);
@@ -6409,6 +6412,7 @@
 				0AD9F88122F049E5008B4D95 /* AdblockRustEngine.swift in Sources */,
 				0A39FE992486604D00290ABC /* GRDGatewayAPI.m in Sources */,
 				0A1DF48424487AA000541FE4 /* GRDGatewayAPIResponse.m in Sources */,
+				2F83C7422566C617008791BB /* SearchSuggestionCell.swift in Sources */,
 				4422D4B421BFFB7600BF1855 /* hash.cc in Sources */,
 				0A5CBD3823D4905D00362CC8 /* NTPNotificationView.swift in Sources */,
 				27D114D62358FCA400166534 /* SettingsRowViews.swift in Sources */,

--- a/Client/Frontend/Browser/Search/SearchSuggestionCell.swift
+++ b/Client/Frontend/Browser/Search/SearchSuggestionCell.swift
@@ -1,0 +1,226 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Shared
+
+// MARK: - SuggestionCellUX
+
+private struct SuggestionCellUX {
+    static let suggestionMargin: CGFloat = 8
+    static let suggestionInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+    static let suggestionBorderWidth: CGFloat = 1
+    static let suggestionCornerRadius: CGFloat = 4
+    static let suggestionCellVerticalPadding: CGFloat = 10
+    static let suggestionCellMaxRows = 2
+    
+    static let faviconSize: CGFloat = 29
+    static let leftItemEdgeInset = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
+    static let rightItemEdgeInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
+    
+    // The left bounds of the suggestions, aligned with where text would be displayed.
+    static let leftTextMargin: CGFloat = 61
+}
+
+// MARK: - SuggestionCelDelegate
+
+protocol SuggestionCellDelegate: class {
+    func suggestionCell(_ suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String)
+    func suggestionCell(_ suggestionCell: SuggestionCell, didLongPressSuggestion suggestion: String)
+}
+
+// MARK: - SuggestionCell
+
+/**
+ * Cell that wraps a list of search suggestion buttons.
+ */
+class SuggestionCell: UITableViewCell {
+    
+    // MARK: Properties
+    
+    weak var delegate: SuggestionCellDelegate?
+    
+    var suggestions: [String] = [] {
+        willSet {
+            for view in contentView.subviews {
+                view.removeFromSuperview()
+            }
+        }
+        
+        didSet {
+            var buttonList: [SuggestionButton] = []
+            
+            buttonList = suggestions.map { suggestion in
+                let button = SuggestionButton()
+                button.setTitle(suggestion, for: [])
+                button.titleLabel?.alpha = 1.0
+                
+                button.addTarget(self, action: #selector(didSelectSuggestion), for: .touchUpInside)
+                button.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressSuggestion)))
+
+                // If this is the first image, add the search icon.
+                if contentView.subviews.isEmpty {
+                    button.setImage(#imageLiteral(resourceName: "search"), for: [])
+                    
+                    if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+                        button.titleEdgeInsets = SuggestionCellUX.leftItemEdgeInset
+                    } else {
+                        button.titleEdgeInsets = SuggestionCellUX.rightItemEdgeInset
+                    }
+                }
+                
+                return button
+            }
+            
+            buttonList.forEach { contentView.addSubview($0) }
+
+            setNeedsLayout()
+        }
+    }
+
+    // MARK: Lifecycle
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        isAccessibilityElement = false
+        accessibilityLabel = nil
+        layoutMargins = .zero
+        separatorInset = .zero
+        selectionStyle = .none
+        
+        contentView.backgroundColor = .clear
+        backgroundColor = .clear
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Internal
+    
+    internal override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // The maximum width of the container, after which suggestions will wrap to the next line.
+        let maxWidth = contentView.frame.width
+
+        let imageSize = CGFloat(SuggestionCellUX.faviconSize)
+
+        // The height of the suggestions container (minus margins), used to determine the frame.
+        // We set it to imageSize.height as a minimum since we don't want the cell to be shorter than the icon
+        var height: CGFloat = imageSize
+
+        var currentLeft = SuggestionCellUX.leftTextMargin
+        var currentTop = SuggestionCellUX.suggestionCellVerticalPadding
+        var currentRow = 0
+        
+        let suggestionButtonList = contentView.subviews.compactMap({ $0 as? SuggestionButton })
+
+        for view in suggestionButtonList {
+            let button = view
+            var buttonSize = button.intrinsicContentSize
+
+            // Update our base frame height by the max size of either the image or the button so we never
+            // make the cell smaller than any of the two
+            if height == imageSize {
+                height = max(buttonSize.height, imageSize)
+            }
+
+            var width = currentLeft + buttonSize.width + SuggestionCellUX.suggestionMargin
+            if width > maxWidth {
+                // Only move to the next row if there's already a suggestion on this row.
+                // Otherwise, the suggestion is too big to fit and will be resized below.
+                if currentLeft > SuggestionCellUX.leftTextMargin {
+                    currentRow += 1
+                    if currentRow >= SuggestionCellUX.suggestionCellMaxRows {
+                        // Don't draw this button if it doesn't fit on the row.
+                        button.frame = .zero
+                        continue
+                    }
+
+                    currentLeft = SuggestionCellUX.leftTextMargin
+                    currentTop += buttonSize.height + SuggestionCellUX.suggestionMargin
+                    height += buttonSize.height + SuggestionCellUX.suggestionMargin
+                    width = currentLeft + buttonSize.width + SuggestionCellUX.suggestionMargin
+                }
+
+                // If the suggestion is too wide to fit on its own row, shrink it.
+                if width > maxWidth {
+                    buttonSize.width = maxWidth - currentLeft - SuggestionCellUX.suggestionMargin
+                }
+            }
+
+            button.frame = CGRect(x: currentLeft, y: currentTop, width: buttonSize.width, height: buttonSize.height)
+            button.titleLabel?.alpha = 1.0
+
+            currentLeft += buttonSize.width + SuggestionCellUX.suggestionMargin
+        }
+        
+        frame.size.height = height + 2 * SuggestionCellUX.suggestionCellVerticalPadding
+        contentView.frame = bounds
+        
+        let imageX = (SuggestionCellUX.leftTextMargin - imageSize) / 2
+        let imageY = (frame.size.height - imageSize) / 2
+        
+        if let cellImageView = imageView {
+            cellImageView.frame = CGRect(x: imageX, y: imageY, width: imageSize, height: imageSize)
+        }
+    }
+
+    // MARK: Actions
+    
+    @objc
+    func didSelectSuggestion(_ sender: UIButton) {
+        if let titleText = sender.titleLabel?.text {
+            delegate?.suggestionCell(self, didSelectSuggestion: titleText)
+        }
+    }
+
+    @objc
+    func didLongPressSuggestion(_ recognizer: UILongPressGestureRecognizer) {
+        if recognizer.state == .began {
+            if let button = recognizer.view as? UIButton, let titleText = button.titleLabel?.text {
+                delegate?.suggestionCell(self, didLongPressSuggestion: titleText)
+            }
+        }
+    }
+}
+
+// MARK: - SuggestionButton
+
+/**
+ * Rounded search suggestion button that highlights when selected.
+ */
+private class SuggestionButton: InsetButton {
+    
+    // MARK: Properties
+    
+    @objc
+    override var isHighlighted: Bool {
+        didSet {
+            alpha = isHighlighted ? 0.6 : 1.0
+        }
+    }
+    
+    // MARK: Lifecycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setTitleColor(UIConstants.highlightBlue, for: [])
+        titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
+        layer.borderWidth = SuggestionCellUX.suggestionBorderWidth
+        layer.cornerRadius = SuggestionCellUX.suggestionCornerRadius
+        layer.borderColor = UIConstants.highlightBlue.cgColor
+        contentEdgeInsets = SuggestionCellUX.suggestionInsets
+        
+        accessibilityHint = Strings.searchesForSuggestionButtonAccessibilityText
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -7,39 +7,7 @@ import Shared
 import Storage
 import BraveShared
 
-private enum SearchListSection: Int, CaseIterable {
-    case searchSuggestions
-    case findInPage
-    case bookmarksAndHistory
-}
-
-private struct SearchViewControllerUX {
-    static let searchEngineScrollViewBackgroundColor = UIColor.Photon.white100.withAlphaComponent(0.8).cgColor
-    static let searchEngineScrollViewBorderColor = UIColor.black.withAlphaComponent(0.2).cgColor
-
-    // TODO: This should use ToolbarHeight in BVC. Fix this when we create a shared theming file.
-    static let engineButtonHeight: Float = 44
-    static let engineButtonWidth = engineButtonHeight * 1.4
-    static let engineButtonBackgroundColor = UIColor.clear.cgColor
-
-    static let searchEngineTopBorderWidth = 0.5
-    static let searchImageHeight: Float = 44
-    static let searchImageWidth: Float = 24
-
-    static let suggestionBackgroundColor = UIColor.Photon.white100
-    static let suggestionBorderColor = UIConstants.highlightBlue
-    static let suggestionBorderWidth: CGFloat = 1
-    static let suggestionCornerRadius: CGFloat = 4
-    static let suggestionInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
-    static let suggestionMargin: CGFloat = 8
-    static let suggestionCellVerticalPadding: CGFloat = 10
-    static let suggestionCellMaxRows = 2
-
-    static let iconSize: CGFloat = 23
-    static let faviconSize: CGFloat = 29
-    static let iconBorderColor = UIColor(white: 0, alpha: 0.1)
-    static let iconBorderWidth: CGFloat = 0.5
-}
+// MARK: - SearchViewControllerUX
 
 protocol SearchViewControllerDelegate: class {
     func searchViewController(_ searchViewController: SearchViewController, didSelectURL url: URL)
@@ -50,16 +18,56 @@ protocol SearchViewControllerDelegate: class {
     func searchViewControllerAllowFindInPage() -> Bool
 }
 
-class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {
-    var searchDelegate: SearchViewControllerDelegate?
+// MARK: - SearchViewController
 
+class SearchViewController: SiteTableViewController, LoaderListener {
+    
+    // MARK: SearchViewControllerUX
+
+    private struct SearchViewControllerUX {
+        static let searchEngineScrollViewBorderColor = UIColor.black.withAlphaComponent(0.2).cgColor
+
+        // TODO: This should use ToolbarHeight in BVC. Fix this when we create a shared theming file.
+        static let engineButtonHeight: Float = 44
+        static let engineButtonWidth = engineButtonHeight * 1.4
+        static let engineButtonBackgroundColor = UIColor.clear.cgColor
+
+        static let searchEngineTopBorderWidth = 0.5
+        static let searchImageHeight: Float = 44
+        static let searchImageWidth: Float = 24
+        static let searchButtonMargin: CGFloat = 8
+
+        static let faviconSize: CGFloat = 29
+        static let iconBorderColor = UIColor(white: 0, alpha: 0.1)
+        static let iconBorderWidth: CGFloat = 0.5
+    }
+
+    // MARK: SearchListSection
+
+    private enum SearchListSection: Int, CaseIterable {
+        case searchSuggestions
+        case findInPage
+        case bookmarksAndHistory
+    }
+    
+    // MARK: Properties
+    
     private let tabType: TabType
     private var suggestClient: SearchSuggestClient?
 
     // Views for displaying the bottom scrollable search engine list. searchEngineScrollView is the
     // scrollable container; searchEngineScrollViewContent contains the actual set of search engine buttons.
-    private let searchEngineScrollView = ButtonScrollView()
-    private let searchEngineScrollViewContent = UIView()
+    private let searchEngineScrollView = ButtonScrollView().then {
+        $0.layer.shadowRadius = 0
+        $0.layer.shadowOpacity = 100
+        $0.layer.shadowOffset = CGSize(width: 0, height: -SearchViewControllerUX.searchEngineTopBorderWidth)
+        $0.layer.shadowColor = SearchViewControllerUX.searchEngineScrollViewBorderColor
+        $0.clipsToBounds = false
+        $0.decelerationRate = UIScrollView.DecelerationRate.fast
+    }
+    private let searchEngineScrollViewContent = UIView().then {
+        $0.layer.backgroundColor = UIColor.clear.cgColor
+    }
 
     private lazy var bookmarkedBadge: UIImage = {
         return #imageLiteral(resourceName: "bookmarked_passive")
@@ -71,6 +79,65 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     private var suggestionPrompt: SearchSuggestionPromptView?
     
     static var userAgent: String?
+    var searchDelegate: SearchViewControllerDelegate?
+    
+    var searchEngines: SearchEngines? {
+        didSet {
+            suggestClient?.cancelPendingRequest()
+
+            // Query and reload the table with new search suggestions.
+            querySuggestClient()
+
+            // Show the default search engine first.
+            if !tabType.isPrivate {
+                let userAgent = SearchViewController.userAgent ?? "FxSearch"
+                if let engines = searchEngines?.defaultEngine() {
+                    suggestClient = SearchSuggestClient(searchEngine: engines, userAgent: userAgent)
+                }
+            }
+
+            // Reload the footer list of search engines.
+            reloadSearchEngines()
+            
+            layoutSuggestionsOptInPrompt()
+        }
+    }
+
+    private var quickSearchEngines: [OpenSearchEngine] {
+        guard let engines = searchEngines else { return [] }
+        var quickEngines = engines.quickSearchEngines
+
+        // If we're not showing search suggestions, the default search engine won't be visible
+        // at the top of the table. Show it with the others in the bottom search bar.
+        if tabType.isPrivate || !engines.shouldShowSearchSuggestions {
+            quickEngines?.insert(engines.defaultEngine(), at: 0)
+        }
+        
+        guard let seachEngine = quickEngines else { return [] }
+        return seachEngine
+    }
+    
+    // If the user only has a single quick search engine, it is also their default one.
+    // In that case, we count it as if there are no quick suggestions to show
+    // Unless Default Search Engine is different than Quick Search Engine
+    private var hasQuickSearchEngines: Bool {
+        let isDefaultEngineQuickEngine = searchEngines?.defaultEngine().engineID == quickSearchEngines.first?.engineID
+        
+        if quickSearchEngines.count == 1 {
+            return !isDefaultEngineQuickEngine
+        }
+
+        return quickSearchEngines.count > 1
+    }
+    
+    var searchQuery: String = "" {
+        didSet {
+            // Reload the tableView to show the updated text in each engine.
+            reloadData()
+        }
+    }
+    
+    // MARK: Lifecycle
 
     init(forTabType tabType: TabType) {
         self.tabType = tabType
@@ -79,6 +146,10 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+      NotificationCenter.default.removeObserver(self, name: .dynamicFontChanged, object: nil)
     }
 
     override func viewDidLoad() {
@@ -91,12 +162,35 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         KeyboardHelper.defaultHelper.addDelegate(self)
 
         blur.snp.makeConstraints { make in
-            make.edges.equalTo(self.view)
+            make.edges.equalTo(view)
         }
 
         suggestionCell.delegate = self
 
         NotificationCenter.default.addObserver(self, selector: #selector(dynamicFontChanged), name: .dynamicFontChanged, object: nil)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reloadSearchEngines()
+        reloadData()
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        // The height of the suggestions row may change, so call reloadData() to recalculate cell heights.
+        coordinator.animate(alongsideTransition: { _ in
+            self.tableView.reloadData()
+        }, completion: nil)
+    }
+
+    private func animateSearchEnginesWithKeyboard(_ keyboardState: KeyboardState) {
+        layoutSearchEngineScrollView()
+
+        UIView.animate(withDuration: keyboardState.animationDuration, animations: {
+            UIView.setAnimationCurve(keyboardState.animationCurve)
+            self.view.layoutIfNeeded()
+        })
     }
 
     @objc func dynamicFontChanged(_ notification: Notification) {
@@ -104,101 +198,43 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
             reloadData()
         }
     }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        reloadSearchEngines()
-        reloadData()
-    }
     
+    // MARK: Internal
+
     private func setupSearchEngineScrollViewIfNeeded() {
         if !hasQuickSearchEngines { return }
 
-        searchEngineScrollView.layer.shadowRadius = 0
-        searchEngineScrollView.layer.shadowOpacity = 100
-        searchEngineScrollView.layer.shadowOffset = CGSize(width: 0, height: -SearchViewControllerUX.searchEngineTopBorderWidth)
-        searchEngineScrollView.layer.shadowColor = SearchViewControllerUX.searchEngineScrollViewBorderColor
-        searchEngineScrollView.clipsToBounds = false
-
-        searchEngineScrollView.decelerationRate = UIScrollView.DecelerationRate.fast
         view.addSubview(searchEngineScrollView)
-
-        searchEngineScrollViewContent.layer.backgroundColor = UIColor.clear.cgColor
         searchEngineScrollView.addSubview(searchEngineScrollViewContent)
 
         layoutTable()
         layoutSearchEngineScrollView()
 
         searchEngineScrollViewContent.snp.makeConstraints { make in
-            make.center.equalTo(self.searchEngineScrollView).priority(10)
+            make.center.equalTo(searchEngineScrollView).priority(10)
             // Left-align the engines on iphones, center on ipad
             if UIScreen.main.traitCollection.horizontalSizeClass == .compact {
-                make.left.equalTo(self.searchEngineScrollView).priority(1000)
+                make.left.equalTo(searchEngineScrollView).priority(1000)
             } else {
-                make.left.greaterThanOrEqualTo(self.searchEngineScrollView).priority(1000)
+                make.left.greaterThanOrEqualTo(searchEngineScrollView).priority(1000)
             }
-            make.bottom.right.top.equalTo(self.searchEngineScrollView)
+            make.bottom.right.top.equalTo(searchEngineScrollView)
         }
     }
 
     private func layoutSearchEngineScrollView() {
         if !hasQuickSearchEngines { return }
         
-        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.view) ?? 0
+        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(view) ?? 0
         searchEngineScrollView.snp.remakeConstraints { make in
-            make.left.right.equalTo(self.view)
-            make.bottom.equalTo(self.view).offset(-keyboardHeight)
+            make.left.right.equalTo(view)
+            make.bottom.equalTo(view).offset(-keyboardHeight)
             make.height.equalTo(SearchViewControllerUX.engineButtonHeight)
         }
     }
     
-    var searchEngines: SearchEngines! {
-        didSet {
-            suggestClient?.cancelPendingRequest()
-
-            // Query and reload the table with new search suggestions.
-            querySuggestClient()
-
-            // Show the default search engine first.
-            if !tabType.isPrivate {
-                let ua = SearchViewController.userAgent ?? "FxSearch"
-                suggestClient = SearchSuggestClient(searchEngine: searchEngines.defaultEngine(), userAgent: ua)
-            }
-
-            // Reload the footer list of search engines.
-            reloadSearchEngines()
-            
-            layoutSuggestionsOptInPrompt()
-        }
-    }
-
-    private var quickSearchEngines: [OpenSearchEngine] {
-        var engines = searchEngines.quickSearchEngines
-
-        // If we're not showing search suggestions, the default search engine won't be visible
-        // at the top of the table. Show it with the others in the bottom search bar.
-        if tabType.isPrivate || !searchEngines.shouldShowSearchSuggestions {
-            engines?.insert(searchEngines.defaultEngine(), at: 0)
-        }
-
-        return engines!
-    }
-    
-    // If the user only has a single quick search engine, it is also their default one.
-    // In that case, we count it as if there are no quick suggestions to show
-    // Unless Default Search Engine is different than Quick Search Engine
-    private var hasQuickSearchEngines: Bool {
-        let isDefaultEngineQuickEngine = searchEngines.defaultEngine().engineID == quickSearchEngines.first?.engineID
-        
-        if quickSearchEngines.count == 1 {
-            return !isDefaultEngineQuickEngine
-        }
-
-        return quickSearchEngines.count > 1
-    }
-    
     private func layoutSuggestionsOptInPrompt() {
-        if tabType.isPrivate || !searchEngines.shouldShowSearchSuggestionsOptIn {
+        if tabType.isPrivate || !(searchEngines?.shouldShowSearchSuggestionsOptIn ?? false) {
             // Make sure any pending layouts are drawn so they don't get coupled
             // with the "slide up" animation below.
             view.layoutIfNeeded()
@@ -223,8 +259,8 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         }
         
         let prompt = SearchSuggestionPromptView() { [unowned self] option in
-            self.searchEngines.shouldShowSearchSuggestions = option
-            self.searchEngines.shouldShowSearchSuggestionsOptIn = false
+            self.searchEngines?.shouldShowSearchSuggestions = option
+            self.searchEngines?.shouldShowSearchSuggestionsOptIn = false
             if option {
                 self.querySuggestClient()
             }
@@ -244,24 +280,17 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         
         layoutTable()
     }
-
-    var searchQuery: String = "" {
-        didSet {
-            // Reload the tableView to show the updated text in each engine.
-            reloadData()
-        }
-    }
-
-    override func reloadData() {
-        querySuggestClient()
-    }
-
+    
     private func layoutTable() {
         tableView.snp.remakeConstraints { make in
             make.top.equalTo(self.suggestionPrompt?.snp.bottom ?? self.view.snp.top)
             make.leading.trailing.equalTo(self.view)
             make.bottom.equalTo(hasQuickSearchEngines ? self.searchEngineScrollView.snp.top : self.view)
         }
+    }
+
+    override func reloadData() {
+        querySuggestClient()
     }
 
     private func reloadSearchEngines() {
@@ -285,9 +314,9 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         searchButton.snp.makeConstraints { make in
             make.size.equalTo(SearchViewControllerUX.faviconSize)
             //offset the left edge to align with search results
-            make.left.equalTo(leftEdge).offset(SearchViewControllerUX.suggestionMargin * 2)
-            make.top.equalTo(self.searchEngineScrollViewContent).offset(SearchViewControllerUX.suggestionMargin)
-            make.bottom.equalTo(self.searchEngineScrollViewContent).offset(-SearchViewControllerUX.suggestionMargin)
+            make.left.equalTo(leftEdge).offset(SearchViewControllerUX.searchButtonMargin * 2)
+            make.top.equalTo(self.searchEngineScrollViewContent).offset(SearchViewControllerUX.searchButtonMargin)
+            make.bottom.equalTo(self.searchEngineScrollViewContent).offset(-SearchViewControllerUX.searchButtonMargin)
         }
 
         //search engines
@@ -311,15 +340,65 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
                 make.left.equalTo(leftEdge)
                 make.top.equalTo(self.searchEngineScrollViewContent)
                 make.bottom.equalTo(self.searchEngineScrollViewContent)
-                if engine === self.searchEngines.quickSearchEngines.last {
+                if engine === self.searchEngines?.quickSearchEngines.last {
                     make.right.equalTo(self.searchEngineScrollViewContent)
                 }
             }
             leftEdge = engineButton.snp.right
         }
     }
+    
+    private func querySuggestClient() {
+        suggestClient?.cancelPendingRequest()
 
-    @objc func didSelectEngine(_ sender: UIButton) {
+        if searchQuery.isEmpty || !(searchEngines?.shouldShowSearchSuggestions ?? false) || searchQuery.looksLikeAURL() {
+            suggestionCell.suggestions = []
+            return
+        }
+
+        suggestClient?.query(searchQuery, callback: { [weak self] suggestions, error in
+            guard let self = self else { return }
+            
+            self.tableView.reloadData()
+
+            if let error = error {
+                let isSuggestClientError = error.domain == SearchSuggestClientErrorDomain
+
+                switch error.code {
+                case NSURLErrorCancelled where error.domain == NSURLErrorDomain:
+                    // Request was cancelled. Do nothing.
+                    break
+                case SearchSuggestClientErrorInvalidEngine where isSuggestClientError:
+                    // Engine does not support search suggestions. Do nothing.
+                    break
+                case SearchSuggestClientErrorInvalidResponse where isSuggestClientError:
+                    print("Error: Invalid search suggestion data")
+                default:
+                    print("Error: \(error.description)")
+                }
+            } else if let suggestionList = suggestions {
+                self.suggestionCell.suggestions = suggestionList
+            }
+
+            // If there are no suggestions, just use whatever the user typed.
+            if suggestions?.isEmpty ?? true {
+                self.suggestionCell.suggestions = [self.searchQuery]
+            }
+
+            // Reload the tableView to show the new list of search suggestions.
+            self.tableView.reloadData()
+        })
+    }
+    
+    func loader(dataLoaded data: [Site]) {
+        self.data = Array(data.prefix(5))
+        tableView.reloadData()
+    }
+
+    // MARK: Actions
+    
+    @objc
+    func didSelectEngine(_ sender: UIButton) {
         // The UIButtons are the same cardinality and order as the array of quick search engines.
         // Subtract 1 from index to account for magnifying glass accessory.
         guard let index = searchEngineScrollViewContent.subviews.firstIndex(of: sender) else {
@@ -337,83 +416,16 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         searchDelegate?.searchViewController(self, didSelectURL: url)
     }
 
-    @objc func didClickSearchButton() {
+    @objc
+    func didClickSearchButton() {
         self.searchDelegate?.presentSearchSettingsController()  
     }
 
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
-        animateSearchEnginesWithKeyboard(state)
-    }
-
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-    }
-
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        animateSearchEnginesWithKeyboard(state)
-    }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        // The height of the suggestions row may change, so call reloadData() to recalculate cell heights.
-        coordinator.animate(alongsideTransition: { _ in
-            self.tableView.reloadData()
-        }, completion: nil)
-    }
-
-    private func animateSearchEnginesWithKeyboard(_ keyboardState: KeyboardState) {
-        layoutSearchEngineScrollView()
-
-        UIView.animate(withDuration: keyboardState.animationDuration, animations: {
-            UIView.setAnimationCurve(keyboardState.animationCurve)
-            self.view.layoutIfNeeded()
-        })
-    }
-
-    private func querySuggestClient() {
-        suggestClient?.cancelPendingRequest()
-
-        if searchQuery.isEmpty || !searchEngines.shouldShowSearchSuggestions || searchQuery.looksLikeAURL() {
-            suggestionCell.suggestions = []
-            return
-        }
-
-        suggestClient?.query(searchQuery, callback: { suggestions, error in
-            if let error = error {
-                let isSuggestClientError = error.domain == SearchSuggestClientErrorDomain
-
-                switch error.code {
-                case NSURLErrorCancelled where error.domain == NSURLErrorDomain:
-                    // Request was cancelled. Do nothing.
-                    break
-                case SearchSuggestClientErrorInvalidEngine where isSuggestClientError:
-                    // Engine does not support search suggestions. Do nothing.
-                    break
-                case SearchSuggestClientErrorInvalidResponse where isSuggestClientError:
-                    print("Error: Invalid search suggestion data")
-                default:
-                    print("Error: \(error.description)")
-                }
-            } else {
-                self.suggestionCell.suggestions = suggestions!
-            }
-
-            // If there are no suggestions, just use whatever the user typed.
-            if suggestions?.isEmpty ?? true {
-                self.suggestionCell.suggestions = [self.searchQuery]
-            }
-
-            // Reload the tableView to show the new list of search suggestions.
-            self.tableView.reloadData()
-        })
-    }
-
-    func loader(dataLoaded data: [Site]) {
-        self.data = Array(data.prefix(5))
-        tableView.reloadData()
-    }
-
+    // MARK: UITableViewDelegate, UITableViewDataSource
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let section = SearchListSection(rawValue: indexPath.section)!
+        guard let section = SearchListSection(rawValue: indexPath.section) else { return }
+        
         if section == SearchListSection.bookmarksAndHistory {
             let site = data[indexPath.row]
             if let url = URL(string: site.url) {
@@ -467,11 +479,17 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        switch SearchListSection(rawValue: indexPath.section)! {
+        guard let section = SearchListSection(rawValue: indexPath.section) else {
+            return UITableViewCell()
+        }
+
+        switch section {
         case .searchSuggestions:
-            suggestionCell.imageView?.image = searchEngines.defaultEngine().image
+            suggestionCell.imageView?.image = searchEngines?.defaultEngine().image
             suggestionCell.imageView?.isAccessibilityElement = true
-            suggestionCell.imageView?.accessibilityLabel = String(format: Strings.searchSuggestionFromFormatText, searchEngines.defaultEngine().shortName)
+            if let defaultSearchEngine = searchEngines?.defaultEngine() {
+                suggestionCell.imageView?.accessibilityLabel = String(format: Strings.searchSuggestionFromFormatText, defaultSearchEngine.shortName)
+            }
             return suggestionCell
             
         case .findInPage:
@@ -500,9 +518,15 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch SearchListSection(rawValue: section)! {
+        guard let determinedSection = SearchListSection(rawValue: section) else {
+            return 0
+        }
+        
+        switch determinedSection {
         case .searchSuggestions:
-            return searchEngines.shouldShowSearchSuggestions && !searchQuery.looksLikeAURL() && !tabType.isPrivate ? 1 : 0
+            guard let shouldShowSuggestions =  searchEngines?.shouldShowSearchSuggestions else { return 0 }
+            
+            return shouldShowSuggestions && !searchQuery.looksLikeAURL() && !tabType.isPrivate ? 1 : 0
         case .bookmarksAndHistory:
             return data.count
         case .findInPage:
@@ -529,9 +553,27 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 }
 
+// MARK: KeyboardHelperDelegate
+
+extension SearchViewController: KeyboardHelperDelegate {
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
+        animateSearchEnginesWithKeyboard(state)
+    }
+
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
+    }
+
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
+        animateSearchEnginesWithKeyboard(state)
+    }
+}
+
+// MARK: KeyCommands
+
 extension SearchViewController {
     func handleKeyCommands(sender: UIKeyCommand) {
         let initialSection = SearchListSection.bookmarksAndHistory.rawValue
+        
         guard let current = tableView.indexPathForSelectedRow else {
             let count = tableView(tableView, numberOfRowsInSection: initialSection)
             if sender.input == UIKeyCommand.inputDownArrow, count > 0 {
@@ -544,7 +586,9 @@ extension SearchViewController {
 
         let nextSection: Int
         let nextItem: Int
+        
         guard let input = sender.input else { return }
+        
         switch input {
         case UIKeyCommand.inputUpArrow:
             // we're going down, we should check if we've reached the first item in this section.
@@ -580,23 +624,26 @@ extension SearchViewController {
         default:
             return
         }
-        guard nextItem >= 0 else {
-            return
-        }
+        
+        guard nextItem >= 0 else { return }
         let next = IndexPath(item: nextItem, section: nextSection)
+        
         self.tableView(tableView, didHighlightRowAt: next)
         tableView.selectRow(at: next, animated: false, scrollPosition: .middle)
     }
 }
 
+// MARK: SuggestionCellDelegate
+
 extension SearchViewController: SuggestionCellDelegate {
-    fileprivate func suggestionCell(_ suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String) {
+    func suggestionCell(_ suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String) {
         // Assume that only the default search engine can provide search suggestions.
-        let engine = searchEngines.defaultEngine()
+        let engine = searchEngines?.defaultEngine()
 
         var url = URIFixup.getURL(suggestion)
+        
         if url == nil {
-            url = engine.searchURLForQuery(suggestion)
+            url = engine?.searchURLForQuery(suggestion)
         }
 
         if let url = url {
@@ -604,10 +651,12 @@ extension SearchViewController: SuggestionCellDelegate {
         }
     }
 
-    fileprivate func suggestionCell(_ suggestionCell: SuggestionCell, didLongPressSuggestion suggestion: String) {
+    func suggestionCell(_ suggestionCell: SuggestionCell, didLongPressSuggestion suggestion: String) {
         searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
     }
 }
+
+// MARK: Private Extension - Class
 
 /**
  * Private extension containing string operations specific to this view controller
@@ -627,175 +676,5 @@ private extension String {
 private class ButtonScrollView: UIScrollView {
     fileprivate override func touchesShouldCancel(in view: UIView) -> Bool {
         return true
-    }
-}
-
-private protocol SuggestionCellDelegate: class {
-    func suggestionCell(_ suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String)
-    func suggestionCell(_ suggestionCell: SuggestionCell, didLongPressSuggestion suggestion: String)
-}
-
-/**
- * Cell that wraps a list of search suggestion buttons.
- */
-private class SuggestionCell: UITableViewCell {
-    weak var delegate: SuggestionCellDelegate?
-    let container = UIView()
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-
-        isAccessibilityElement = false
-        accessibilityLabel = nil
-        layoutMargins = .zero
-        separatorInset = .zero
-        selectionStyle = .none
-
-        container.backgroundColor = UIColor.clear
-        contentView.backgroundColor = UIColor.clear
-        backgroundColor = UIColor.clear
-        contentView.addSubview(container)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    var suggestions: [String] = [] {
-        didSet {
-            for view in container.subviews {
-                view.removeFromSuperview()
-            }
-
-            for suggestion in suggestions {
-                let button = SuggestionButton()
-                button.setTitle(suggestion, for: [])
-                button.addTarget(self, action: #selector(didSelectSuggestion), for: .touchUpInside)
-                button.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressSuggestion)))
-
-                // If this is the first image, add the search icon.
-                if container.subviews.isEmpty {
-                    button.setImage(#imageLiteral(resourceName: "search"), for: [])
-                    if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
-                        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
-                    } else {
-                        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
-                    }
-                }
-
-                container.addSubview(button)
-            }
-
-            setNeedsLayout()
-        }
-    }
-
-    @objc
-    func didSelectSuggestion(_ sender: UIButton) {
-        delegate?.suggestionCell(self, didSelectSuggestion: sender.titleLabel!.text!)
-    }
-
-    @objc
-    func didLongPressSuggestion(_ recognizer: UILongPressGestureRecognizer) {
-        if recognizer.state == .began {
-            if let button = recognizer.view as? UIButton {
-                delegate?.suggestionCell(self, didLongPressSuggestion: button.titleLabel!.text!)
-            }
-        }
-    }
-
-    fileprivate override func layoutSubviews() {
-        super.layoutSubviews()
-
-        // The left bounds of the suggestions, aligned with where text would be displayed.
-        let textLeft: CGFloat = 61
-
-        // The maximum width of the container, after which suggestions will wrap to the next line.
-        let maxWidth = contentView.frame.width
-
-        let imageSize = CGFloat(SearchViewControllerUX.faviconSize)
-
-        // The height of the suggestions container (minus margins), used to determine the frame.
-        // We set it to imageSize.height as a minimum since we don't want the cell to be shorter than the icon
-        var height: CGFloat = imageSize
-
-        var currentLeft = textLeft
-        var currentTop = SearchViewControllerUX.suggestionCellVerticalPadding
-        var currentRow = 0
-
-        for view in container.subviews.compactMap({ $0 as? UIButton }) {
-            let button = view
-            var buttonSize = button.intrinsicContentSize
-
-            // Update our base frame height by the max size of either the image or the button so we never
-            // make the cell smaller than any of the two
-            if height == imageSize {
-                height = max(buttonSize.height, imageSize)
-            }
-
-            var width = currentLeft + buttonSize.width + SearchViewControllerUX.suggestionMargin
-            if width > maxWidth {
-                // Only move to the next row if there's already a suggestion on this row.
-                // Otherwise, the suggestion is too big to fit and will be resized below.
-                if currentLeft > textLeft {
-                    currentRow += 1
-                    if currentRow >= SearchViewControllerUX.suggestionCellMaxRows {
-                        // Don't draw this button if it doesn't fit on the row.
-                        button.frame = .zero
-                        continue
-                    }
-
-                    currentLeft = textLeft
-                    currentTop += buttonSize.height + SearchViewControllerUX.suggestionMargin
-                    height += buttonSize.height + SearchViewControllerUX.suggestionMargin
-                    width = currentLeft + buttonSize.width + SearchViewControllerUX.suggestionMargin
-                }
-
-                // If the suggestion is too wide to fit on its own row, shrink it.
-                if width > maxWidth {
-                    buttonSize.width = maxWidth - currentLeft - SearchViewControllerUX.suggestionMargin
-                }
-            }
-
-            button.frame = CGRect(x: currentLeft, y: currentTop, width: buttonSize.width, height: buttonSize.height)
-            currentLeft += buttonSize.width + SearchViewControllerUX.suggestionMargin
-        }
-
-        frame.size.height = height + 2 * SearchViewControllerUX.suggestionCellVerticalPadding
-        contentView.frame = bounds
-        container.frame = bounds
-
-        let imageX = (textLeft - imageSize) / 2
-        let imageY = (frame.size.height - imageSize) / 2
-        imageView!.frame = CGRect(x: imageX, y: imageY, width: imageSize, height: imageSize)
-    }
-}
-
-/**
- * Rounded search suggestion button that highlights when selected.
- */
-private class SuggestionButton: InsetButton {
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-
-        setTitleColor(UIConstants.highlightBlue, for: [])
-        titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
-        layer.borderWidth = SearchViewControllerUX.suggestionBorderWidth
-        layer.cornerRadius = SearchViewControllerUX.suggestionCornerRadius
-        layer.borderColor = UIConstants.highlightBlue.cgColor
-        contentEdgeInsets = SearchViewControllerUX.suggestionInsets
-
-        accessibilityHint = Strings.searchesForSuggestionButtonAccessibilityText
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc
-    override var isHighlighted: Bool {
-        didSet {
-            alpha = isHighlighted ? 0.6 : 1.0
-        }
     }
 }

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -211,12 +211,13 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         layoutSearchEngineScrollView()
 
         searchEngineScrollViewContent.snp.makeConstraints { make in
-            make.center.equalTo(searchEngineScrollView).priority(10)
+            make.center.equalTo(searchEngineScrollView).priority(.low)
+            
             // Left-align the engines on iphones, center on ipad
             if UIScreen.main.traitCollection.horizontalSizeClass == .compact {
-                make.left.equalTo(searchEngineScrollView).priority(1000)
+                make.left.equalTo(searchEngineScrollView).priority(.required)
             } else {
-                make.left.greaterThanOrEqualTo(searchEngineScrollView).priority(1000)
+                make.left.greaterThanOrEqualTo(searchEngineScrollView).priority(.required)
             }
             make.bottom.right.top.equalTo(searchEngineScrollView)
         }
@@ -234,7 +235,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     }
     
     private func layoutSuggestionsOptInPrompt() {
-        if tabType.isPrivate || !(searchEngines?.shouldShowSearchSuggestionsOptIn ?? false) {
+        if tabType.isPrivate || searchEngines?.shouldShowSearchSuggestionsOptIn == true {
             // Make sure any pending layouts are drawn so they don't get coupled
             // with the "slide up" animation below.
             view.layoutIfNeeded()
@@ -351,7 +352,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     private func querySuggestClient() {
         suggestClient?.cancelPendingRequest()
 
-        if searchQuery.isEmpty || !(searchEngines?.shouldShowSearchSuggestions ?? false) || searchQuery.looksLikeAURL() {
+        if searchQuery.isEmpty || searchEngines?.shouldShowSearchSuggestionsOptIn == true || searchQuery.looksLikeAURL() {
             suggestionCell.suggestions = []
             return
         }


### PR DESCRIPTION
This PR fixes Search suggestion Text Color flickering. 

In addition SearchViewController and SearchSuggestionCell are refactored to easy access, better performance and organization.

## Summary of Changes

This pull request fixes #3044

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Load Brave Browser
- Go Settings - Search Engines - Enable Search Suggestions
- Create a new Tab and load a Webpage and press search bar
- Start typing something
- Observe Search Suggestion Boxes Text color is not flickering from blue to white

## Screenshots:

![ezgif-7-f5203d6961b3](https://user-images.githubusercontent.com/6643505/99704404-58379300-2a66-11eb-9da3-8affae67bea4.gif)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
