### PR TITLE
Fix#3059: Browser crashes when closing Tab from TabTray

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -79,7 +79,8 @@ enum NavigationPath: Equatable {
     
     private static func handleURL(url: URL?, isPrivate: Bool, with bvc: BrowserViewController) {
         if let newURL = url {
-            bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
+            bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false, isExternal: true)
+            bvc.popToBVC()
         } else {
             bvc.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: isPrivate)
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1618,8 +1618,11 @@ class BrowserViewController: UIViewController {
         self.tabTrayController = tabTrayController
     }
 
-    func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false, isPrivileged: Bool) {
-        popToBVC()
+    func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false, isPrivileged: Bool, isExternal: Bool = false) {
+        if !isExternal {
+            popToBVC()
+        }
+        
         if let tab = tabManager.getTabForURL(url) {
             tabManager.selectTab(tab)
         } else {
@@ -1663,11 +1666,12 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    fileprivate func popToBVC() {
+    func popToBVC() {
         guard let currentViewController = navigationController?.topViewController else {
-                return
+            return
         }
         currentViewController.dismiss(animated: true, completion: nil)
+        
         if currentViewController != self {
             _ = self.navigationController?.popViewController(animated: true)
         } else if topToolbar.inOverlayMode {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -665,11 +665,9 @@ extension TabTrayController: TabManagerDelegate {
         tabDataSource.addTab(tab)
         
         insertTabToCollection(tab, index: index) {
-            if let controller = self.navigationController?.visibleViewController, controller is TabTrayController {
-                // don't pop the tab tray view controller if it is not in the foreground
-                if self.presentedViewController == nil {
-                    _ = self.navigationController?.popViewController(animated: true)
-                }
+            // don't pop the tab tray view controller if it is not in the foreground
+            if self.presentedViewController == nil {
+                _ = self.navigationController?.popViewController(animated: true)
             }
         }
     }
@@ -710,15 +708,17 @@ extension TabTrayController: TabManagerDelegate {
     }
     
     private func insertTabToCollection(_ tab: Tab, index: Int, completion: @escaping () -> Void ) {
-        collectionView?.performBatchUpdates({
-            self.collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
-        }, completion: { finished in
-            if finished {
-                self.tabManager.selectTab(tab)
-                
-                completion()
-            }
-        })
+        if let controller = self.navigationController?.visibleViewController, controller is TabTrayController {
+            collectionView?.performBatchUpdates({
+                self.collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
+            }, completion: { finished in
+                if finished {
+                    self.tabManager.selectTab(tab)
+                    
+                    completion()
+                }
+            })
+        }
     }
 }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -677,7 +677,8 @@ extension TabTrayController: TabManagerDelegate {
         // through the Close All Tabs feature (which will close tabs that are not in our current privacy mode)
         // check this before removing the item from the collection
         let removedIndex = tabDataSource.removeTab(tab)
-        if removedIndex > -1, let collectionView = self.collectionView {
+        
+        if removedIndex > -1, let collectionView = collectionView, collectionView.numberOfItems(inSection: 0) > 0 {
             collectionView.performBatchUpdates({
                 collectionView.deleteItems(at: [IndexPath(item: removedIndex, section: 0)])
             }, completion: { finished in


### PR DESCRIPTION

## Summary of Changes

This pull request fixes #3059

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Long press on NTP/search button in a normal tab
- Open private tab
- Search anything in private tab
- Open tab tray and close the tab, browser crashes

## Screenshots:

![Issue:3059](https://user-images.githubusercontent.com/6643505/99996695-1a9a7900-2d8a-11eb-881f-11f8efac3d4c.gif)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
