### PR TITLE
Fix #3067: Switch Brave Today to prod URLs

### DIFF
--- a/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
+++ b/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
@@ -94,7 +94,7 @@ class FeedDataSource {
             components.scheme = "https"
             // TODO: At the moment these files are only available on the dev servers, eventually we will
             // change `brave.software` to `bravesoftware.com` or `brave.com` based on staging/prod
-            components.host = "\(name).bravesoftware.com"
+            components.host = "\(name).brave.com"
             components.path = "/\(path)"
             return components.url!
         }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3067

Blocked until prod server is ready for BT

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
