### PR TITLE
Fix #2961: Problems with Sharing a PDF File / Additional Share Issues

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 		2FCAE2841ABB533A00877008 /* MockFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2791ABB533A00877008 /* MockFiles.swift */; };
 		2FCAE33E1ABB5F1800877008 /* Storage-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FCAE33D1ABB5F1800877008 /* Storage-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2FD0E3D62577F327000C773B /* SearchSuggestionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */; };
+		2FD0E3AF2576C48A000C773B /* SchemePermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */; };
 		2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
@@ -1655,6 +1656,7 @@
 		2FCAE2791ABB533A00877008 /* MockFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFiles.swift; sourceTree = "<group>"; };
 		2FCAE33D1ABB5F1800877008 /* Storage-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Storage-Bridging-Header.h"; sourceTree = "<group>"; };
 		2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionCell.swift; sourceTree = "<group>"; };
+		2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemePermissionTests.swift; sourceTree = "<group>"; };
 		2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefsTests.swift; sourceTree = "<group>"; };
 		2FEBABAE1AB3659000DB5728 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipboardBarDisplayHandler.swift; sourceTree = "<group>"; };
@@ -4729,6 +4731,7 @@
 				E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */,
 				0A66550B23E9E04F0047EF2A /* UserAgentTests.swift */,
 				275965E124EEC4EA0051A827 /* FeedFillStrategyTests.swift */,
+				2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -6454,6 +6457,7 @@
 				0AE16F8D251BEF8C00A688ED /* InitialSearchEnginesTests.swift in Sources */,
 				0ADCD45F2319799F0078CC67 /* RollingFileLoggerTests.swift in Sources */,
 				2795274A21A890EB00921AA1 /* FingerprintingProtectionTests.swift in Sources */,
+				2FD0E3AF2576C48A000C773B /* SchemePermissionTests.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				5E9288CA22DF864C007BE7A6 /* TabSessionTests.swift in Sources */,
 				0A4214E921A6EBCF006B8E39 /* SafeBrowsingTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2778,7 +2778,7 @@ extension BrowserViewController: WKUIDelegate {
         return newTab.webView
     }
 
-    fileprivate func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {
+    func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {
         // Treat `window.open("")` the same as `window.open("about:blank")`.
         if request.url?.absoluteString.isEmpty ?? false {
             return true

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2753,7 +2753,7 @@ extension BrowserViewController: TabManagerDelegate {
 }
 
 /// List of schemes that are allowed to be opened in new tabs.
-private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "about"]
+private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "about", "whatsapp"]
 
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1744,15 +1744,14 @@ class BrowserViewController: UIViewController {
             #endif
         }
         
-        let controller = helper.createActivityViewController(items: activities) { [unowned self] completed, _ in
-            // After dismissing, check to see if there were any prompts we queued up
-            self.showQueuedAlertIfAvailable()
-
-            // Usually the popover delegate would handle nil'ing out the references we have to it
-            // on the BVC when displaying as a popover but the delegate method doesn't seem to be
-            // invoked on iOS 10. See Bug 1297768 for additional details.
-            self.displayedPopoverController = nil
-            self.updateDisplayedPopoverProperties = nil
+        let controller = helper.createActivityViewController(items: activities) { [weak self] completed, _, documentUrl  in
+            guard let self = self else { return }
+            
+            if let url = documentUrl {
+                self.openPDFInIBooks(url)
+            }
+            
+            self.cleanUpCreateActivity()
         }
 
         if let popoverPresentationController = controller.popoverPresentationController {
@@ -1763,6 +1762,25 @@ class BrowserViewController: UIViewController {
         }
 
         present(controller, animated: true, completion: nil)
+    }
+    
+    private func cleanUpCreateActivity() {
+        // After dismissing, check to see if there were any prompts we queued up
+        showQueuedAlertIfAvailable()
+
+        // Usually the popover delegate would handle nil'ing out the references we have to it
+        // on the BVC when displaying as a popover but the delegate method doesn't seem to be
+        // invoked on iOS 10. See Bug 1297768 for additional details.
+        displayedPopoverController = nil
+        updateDisplayedPopoverProperties = nil
+    }
+    
+    private func openPDFInIBooks(_ url: URL) {
+        let iBooksURL = "itms-books://\(url.absoluteString)"
+
+        guard let url = URL(string: iBooksURL) else { return }
+        
+        UIApplication.shared.open(url, options: [:])
     }
 
     func updateFindInPageVisibility(visible: Bool, tab: Tab? = nil) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -331,6 +331,8 @@ extension BrowserViewController: WKNavigationDelegate {
             } else {
                 tab.temporaryDocument = nil
             }
+            
+            tab.mimeType = response.mimeType
         }
 
         // If none of our helpers are responsible for handling this response,

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/DownloadsViewController.swift
@@ -177,7 +177,7 @@ class DownloadsPanel: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     private func shareDownloadedFile(_ downloadedFile: DownloadedFile, indexPath: IndexPath) {
         let helper = ShareExtensionHelper(url: downloadedFile.path, tab: nil)
-        let controller = helper.createActivityViewController { completed, activityType in
+        let controller = helper.createActivityViewController { completed, activityType, _ in
             log.debug("Shared downloaded file: \(completed)")
         }
 

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -14,17 +14,6 @@ class ShareExtensionHelper: NSObject {
         case password
         case iBooks
         case `default`
-        
-        var description: String? {
-            switch self {
-            case .password:
-                return "All Password Activity Types pwsafe / 1Password"
-            case .iBooks:
-                return "PDF Sharing Activity Type"
-            case .default:
-                return "Other Types"
-            }
-        }
     }
     
     fileprivate weak var selectedTab: Tab?

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -23,7 +23,7 @@ class ShareExtensionHelper: NSObject {
     fileprivate var onePasswordExtensionItem: NSExtensionItem!
     fileprivate let browserFillIdentifier = "org.appextension.fill-browser-action"
 
-    fileprivate func isFile(url: URL) -> Bool { url.scheme == "file" }
+//    fileprivate func isFile(url: URL) -> Bool { url.scheme == "file" }
 
     init(url: URL, tab: Tab?) {
         self.selectedURL = tab?.canonicalURL?.displayURL ?? url
@@ -69,7 +69,9 @@ class ShareExtensionHelper: NSObject {
         activityViewController.completionWithItemsHandler = { [weak self] activityType, completed, returnedItems, activityError in
             guard let self = self else { return }
             
-            if self.shareActivityType(activityType.map { $0.rawValue }) != .iBooks { //!self.isOpenInIBooksActivityType(activityType.map { $0.rawValue }) {
+            print("Share type \(self.shareActivityType(activityType.map { $0.rawValue }))")
+            
+            if self.shareActivityType(activityType.map { $0.rawValue }) != .iBooks {
                 if !completed {
                     completionHandler(completed, activityType, nil)
                     return
@@ -80,7 +82,7 @@ class ShareExtensionHelper: NSObject {
                     UIPasteboard.general.urls = [url]
                 }
                 
-                if self.shareActivityType(activityType.map { $0.rawValue }) != .password { //self.isPasswordManagerActivityType(activityType.map { $0.rawValue }) {
+                if self.shareActivityType(activityType.map { $0.rawValue }) != .password {
                     if let logins = returnedItems {
                         self.fillPasswords(logins as [AnyObject])
                     }
@@ -162,7 +164,7 @@ extension ShareExtensionHelper: UIActivityItemSource {
             case .password:
                 return browserFillIdentifier
             case .openByCopy:
-                return isFile(url: selectedURL) ? kUTTypeFileURL as String : kUTTypeURL as String
+                return selectedURL.isFileScheme ? kUTTypeFileURL as String : kUTTypeURL as String
             default:
                 // Return the URL for the selected tab. If we are in reader view then decode
                 // it so that we copy the original and not the internal localhost one.

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -62,6 +62,9 @@
 		<string>org-appextension-feature-password-management</string>
 		<string>googlegmail</string>
 		<string>inbox-gmail</string>
+        <string>whatsapp</string>
+        <string>http</string>
+        <string>https</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/ClientTests/SchemePermissionTests.swift
+++ b/ClientTests/SchemePermissionTests.swift
@@ -1,0 +1,112 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import XCTest
+import Storage
+
+@testable import Client
+
+// MARK: SchemePermissionTests
+
+class SchemePermissionTests: XCTestCase {
+    
+    enum SchemeTestType: String {
+        case http
+        case https
+        case about
+        case javascript
+        case whatsapp
+        
+        var description: String {
+            switch self {
+            case .http:
+                return "Http URL Scheme in new tab"
+            case .https:
+                return "Https URL Scheme in new tab"
+            case .about:
+                return "About URL Scheme in new tab"
+            case .javascript:
+                return "Javascript URL Scheme in new tab"
+            case .whatsapp:
+                return "WhatsApp URL Scheme in new tab"
+            }
+        }
+        
+        var url: String {
+            switch self {
+            case .http:
+                return "http://test.com/"
+            case .https:
+                return "https://test.com/"
+            case .about:
+                return "about:Test"
+            case .javascript:
+                return "javascript:alert(Test)"
+            case .whatsapp:
+                return "whatsapp://send?text=Test"
+            }
+        }
+    }
+
+    // MARK: Lifecycle
+    
+    override func setUp() {
+        profile = BrowserProfile(localName: "mockProfile")
+
+        imageStore = try! DiskImageStore(files: MockFiles(), namespace: "MockTabManagerScreenshots", quality: 1)
+        tabManager = TabManager(prefs: profile.prefs, imageStore: imageStore)
+        
+        subject = BrowserViewController(
+            profile: profile,
+            tabManager: tabManager,
+            crashedLastSession: false)
+    }
+    
+    override func tearDown() {
+        subject = nil
+        profile = nil
+        
+        imageStore.clearExcluding(Set())
+        imageStore = nil
+        tabManager = nil
+
+        super.tearDown()
+    }
+
+    // MARK: Internal
+    
+    func testShouldRequestOpenPopup() {
+        let urlRequestHttp = urlRequestForScheme(.http)
+        let urlRequestHttps = urlRequestForScheme(.https)
+        let urlRequestJavascript = urlRequestForScheme(.javascript)
+        let urlRequestAbout = urlRequestForScheme(.about)
+        let urlRequestWhatsApp = urlRequestForScheme(.whatsapp)
+        
+        // Test Http URL Scheme
+        XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestHttp.request), urlRequestHttp.comment)
+        
+        // Test Https URL Scheme
+        XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestHttps.request), urlRequestHttps.comment)
+        
+        // Test Javascript URL Scheme
+        XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestJavascript.request), urlRequestJavascript.comment)
+
+        // Test About URL Scheme
+        XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestAbout.request), urlRequestAbout.comment)
+
+        // Test Whatapp URL Scheme
+        XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestWhatsApp.request), urlRequestWhatsApp.comment)
+    }
+    
+    private func urlRequestForScheme(_ type: SchemeTestType) -> (request: URLRequest, comment: String) {
+        (request: URLRequest(url: URL(string: type.url)!), comment: type.description)
+    }
+    
+    private var subject: BrowserViewController!
+    private var profile: Profile!
+    private var tabManager: TabManager!
+    private var imageStore: DiskImageStore!
+}

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -452,6 +452,7 @@ extension URL {
 }
 
 // Helpers to deal with Peek and Pop
+
 extension URL {
     public var eligibleForPeekAndPop: Bool {
         let ignoredSchemes = ["about"]
@@ -499,6 +500,8 @@ extension URL {
     }
 }
 
+// Helper To deal with Bookmark URLs
+
 extension URL {
     public var isBookmarklet: Bool {
         return self.absoluteString.isBookmarklet
@@ -506,6 +509,14 @@ extension URL {
     
     public var bookmarkletCodeComponent: String? {
         return self.absoluteString.bookmarkletCodeComponent
+    }
+}
+
+// Helper To deal with File URLs
+
+extension URL {
+    public var isFileScheme: Bool {
+        return self.scheme == "file"
     }
 }
 


### PR DESCRIPTION
Fixed:

Sharing PDF file with iBooks and Mail app.
Sharing Function inside a website with whatsapp will work properly
Creating PDF from the WebPage and passing it to iBooks If activity is chosen
Sharing Downloaded Files

## Summary of Changes

This pull request fixes #2961 / Adding "whatsapp" "http" " https" as Query Schemes

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Load Brave Browser with a PDF link and Press Share from Menu
- Choose iBook Apps for sharing or Mail

- Load a website that has whatsapp share
- Press share and observe the pop up for permission

## Screenshots:

![ezgif-6-20b0e9d7d636](https://user-images.githubusercontent.com/6643505/100021027-cc4ba100-2dae-11eb-8f51-32fbeb4fbf05.gif)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
