### PR TITLE
Fix #3070, #3072 - Fixes folders displaying incorrectly & saving the last visited folder on iOS 12.

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -142,11 +142,6 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     private func updateLastVisitedFolder(_ folder: Bookmarkv2?) {
         Preferences.Chromium.lastBookmarksFolderNodeId.value = folder?.objectID ?? -1
     }
-    
-    override func navigationShouldPopOnBackButton() -> Bool {
-        updateLastVisitedFolder(currentFolder?.parent)
-        return true
-    }
   
   override func reloadData() {
     
@@ -666,18 +661,5 @@ extension BookmarksViewController {
             guard let importExportButton = self.importExportButton else { return }
             vc.presentOptionsMenu(from: importExportButton, animated: true)
         }
-    }
-}
-
-private extension UIViewController {
-    @objc
-    func navigationShouldPopOnBackButton() -> Bool {
-        return true
-    }
-}
-
-extension UINavigationController: UINavigationBarDelegate {
-    public func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
-        return self.topViewController?.navigationShouldPopOnBackButton() ?? true
     }
 }

--- a/Client/Frontend/Sync/BraveCore/BookmarkFetchers.swift
+++ b/Client/Frontend/Sync/BraveCore/BookmarkFetchers.swift
@@ -143,7 +143,7 @@ class Bookmarkv2ExclusiveFetcher: NSObject, BookmarksV2FetchResultsController {
     
     private func getNestedFolders(_ node: BookmarkNode, guid: String?) -> [Bookmarkv2] {
         if let guid = guid {
-            return node.nestedChildFolders.filter({ $0.bookmarkNode.guid == guid }).map({ BraveBookmarkFolder($0) })
+            return node.nestedChildFolders.filter({ $0.bookmarkNode.guid != guid }).map({ BraveBookmarkFolder($0) })
         }
         return node.nestedChildFolders.map({ BraveBookmarkFolder($0) })
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Removed code that messed with iOS 12's navigation popping. There is already code in `viewWillAppear` that saves the currently viewed folder as the last visited one.
- Fixed excluded folder when fetching a list of folders for displaying when adding a bookmark or editing an existing bookmark/folder.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes: #3070, #3072

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
