### PR TITLE
Fix #3077 - Fixed reordering bug in bookmarks.

### DIFF
--- a/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
+++ b/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
@@ -258,7 +258,9 @@ extension Bookmarkv2 {
     
     public class func reorderBookmarks(frc: BookmarksV2FetchResultsController?, sourceIndexPath: IndexPath,
                                        destinationIndexPath: IndexPath) {
-        if let node = frc?.object(at: sourceIndexPath)?.bookmarkNode,
+        guard let frc = frc else { return }
+        
+        if let node = frc.object(at: sourceIndexPath)?.bookmarkNode,
            let parent = node.parent ?? bookmarksAPI.mobileNode {
             
             //Moving to the very last index.. same as appending..
@@ -267,6 +269,12 @@ extension Bookmarkv2 {
             } else {
                 node.move(toParent: parent, index: UInt(destinationIndexPath.row))
             }
+            
+            //Notify the delegate that items did move..
+            //This is already done automatically in `Bookmarkv2Fetcher` listener.
+            //However, the Brave-Core delegate is being called before the move is actually complete OR too quickly
+            //So to fix it, we reload here AFTER the move is done so the UI can update accordingly.
+            frc.delegate?.controllerDidReloadContents(frc)
         }
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Reload the table after moving bookmarks manually. This fixes a bug where the UI isn't updated because the bookmarks were cached.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3077

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
