### PR TITLE
Fix #3060: Toggling ads on/off no longer crashes

### DIFF
--- a/Client/Extensions/Rewards/BraveLedgerExtensions.swift
+++ b/Client/Extensions/Rewards/BraveLedgerExtensions.swift
@@ -52,10 +52,6 @@ extension BraveLedger {
             self.allowUnverifiedPublishers = false
             self.contributionAmount = Double.greatestFiniteMagnitude
             
-            if let ads = self.ads, BraveAds.isCurrentLocaleSupported() {
-                ads.isEnabled = true
-            }
-            
             let group = DispatchGroup()
             var success = true
             group.enter()

--- a/Client/Extensions/Rewards/BraveRewardsExtensions.swift
+++ b/Client/Extensions/Rewards/BraveRewardsExtensions.swift
@@ -20,7 +20,7 @@ extension BraveRewards {
     /// Whether or not rewards is enabled
     @objc public var isEnabled: Bool {
         get {
-            ledger.isWalletCreated && ledger.isEnabled && ads.isEnabled
+            ledger.isWalletCreated && ledger.isEnabled && isAdsEnabled
         }
         set {
             willChangeValue(for: \.isEnabled)
@@ -29,7 +29,7 @@ extension BraveRewards {
                 guard let self = self else { return }
                 self.ledger.isEnabled = newValue
                 self.ledger.isAutoContributeEnabled = newValue
-                self.ads.isEnabled = newValue
+                self.isAdsEnabled = newValue
                 self.didChangeValue(for: \.isEnabled)
             }
         }

--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
@@ -156,6 +156,10 @@ class BraveRewardsViewController: UIViewController, Themeable, PopoverContentCom
     
     private var isCreatingWallet: Bool = false
     @objc private func rewardsToggleValueChanged() {
+        rewardsView.rewardsToggle.isUserInteractionEnabled = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.rewardsView.rewardsToggle.isUserInteractionEnabled = true
+        }
         let isOn = rewardsView.rewardsToggle.isOn
         rewards.isEnabled = isOn
         rewardsView.subtitleLabel.text = isOn ? Strings.Rewards.enabledBody : Strings.Rewards.disabledBody

--- a/Client/Frontend/Browser/New Tab Page/Notifications/NewTabPageNotifications.swift
+++ b/Client/Frontend/Browser/New Tab Page/Notifications/NewTabPageNotifications.swift
@@ -30,7 +30,7 @@ class NewTabPageNotifications {
         
         let state = BrandedImageCalloutState.getState(
             rewardsEnabled: isRewardsEnabled,
-            adsEnabled: rewards.ads.isEnabled,
+            adsEnabled: rewards.isAdsEnabled,
             adsAvailableInRegion: BraveAds.isCurrentLocaleSupported(),
             isSponsoredImage: isShowingSponseredImage
         )

--- a/Client/Rewards/AdsMediaReporting.swift
+++ b/Client/Rewards/AdsMediaReporting.swift
@@ -24,7 +24,7 @@ class AdsMediaReporting: TabContentScript {
     }
     
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
-        if let isPlaying = message.body as? Bool, rewards.ledger.isEnabled && rewards.ads.isEnabled {
+        if let isPlaying = message.body as? Bool, rewards.ledger.isEnabled && rewards.isAdsEnabled {
             guard let tab = tab else { return }
             if isPlaying {
                 rewards.reportMediaStarted(tabId: tab.rewardsId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1327,8 +1327,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.76.tgz",
-      "integrity": "sha512-QMftj05YPZYSmWKxI0IBMUZ1aNyTsdeHxDpA9D5UnpvKocRykGtcAZ5436l9njYrngKhTlODM5c+l4VD3mI5FA=="
+      "version": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.77.tgz",
+      "integrity": "sha512-XH8AfHmrPBp5wmILUgWx9/Bq+ttw1EXuK8QNjfCQtvuYJVQ74hE3OOTWA48IxweWd7h9tX45sApUyfi8c6kqVw=="
     },
     "brave-crypto": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^3.3.10",
-    "brave-core-ios": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.76.tgz"
+    "brave-core-ios": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.77.tgz"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3060

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable and disable rewards over and over again as fast as possible
- Bonus points for running Network Link Conditioner to emulate a slow network (3G) while turning on/off

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
