### PR TITLE
Fix #3079: Add 1.22 translations.

### DIFF
--- a/BraveShared/de.lproj/BraveShared.strings
+++ b/BraveShared/de.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Sie haben %@ durch das Surfen mit Brave verdient.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Sammeln Sie Token, um dieses Bild anzuzeigen. Aktivieren Sie Brave Ads und unterstützen Sie die Ersteller.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Sammeln Sie Token, um dieses Bild anzuzeigen. Aktivieren Sie Brave Rewards und unterstützen Sie die Ersteller.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Verdienen Sie Token für das Ansehen dieses Bildes.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Gut gemacht!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Gesponserte Bilder ausblenden";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Wenn Sie ein gesponsertes Bild anzeigen, erhalten Sie Token, mit denen Sie Ersteller unterstützen können. Mit Brave Ads haben Sie immer die Kontrolle über die Anzeigen, die Sie sehen.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Mehr über Brave Rewards erfahren";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Mehr anzeigen";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Verdienen Sie Token und belohnen Sie die Ersteller für großartige Inhalte, während Sie surfen.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Brave-Ads einschalten";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Brave Rewards einschalten";
+"ntp.sponsoredImageDescription" = "Durch die Anzeige von diesem gesponserten Bild unterstützen Sie Content-Ersteller und Publisher.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Mit der Aktivierung von Rewards erklären Sie sich einverstanden mit den %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Sie verdienen Token für das Ansehen dieses Bildes.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Alle (%i) öffnen";

--- a/BraveShared/de.lproj/Localizable.strings
+++ b/BraveShared/de.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Über Brave Shields";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Einmalige Überprüfung der Zwischenablage zulassen";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Mit der Aktivierung von Rewards erklären Sie sich einverstanden mit den";
+"OBRewardsAgreementDetail" = "Indem Sie auf „Unterstützen“ tippen, akzeptieren Sie die";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Allgemeinen Geschäftsbedingungen";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards unterstützt Content-Ersteller";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Wollen Sie Content-Ersteller unterstützen, indem Sie sich beim Browsen private und anonymisierte Anzeigen anzeigen lassen?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Verdienen Sie Token und belohnen Sie die Ersteller für großartige Inhalte, während Sie surfen.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Sammeln Sie Punkte und belohnen Sie die Ersteller für großartige Inhalte, während Sie surfen";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Unterstützen Sie Ihre Lieblings-Websites und -Ersteller basierend auf Ihrer Aufmerksamkeit.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Zeige mir";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Einschalten";
+"OBTurnOnButton" = "Unterstützen";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Weiter";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Wiederhergestellte Favoriten";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Aktiveren Sie diese Funktion, um Content-Ersteller zu unterstützen.";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Indem du Brave Rewards beim surfen benutzt, unterstützt du Webseiten-Betreiber ganz nebenbei.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Sie unterstützen Content-Ersteller.";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Danke, dass Sie Webseiten-Betreiber unterstützen indem Sie Brave Rewards beim surfen benützen!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Transfer der alten Wallet";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Einmaliger ausgehenden Transfer für bestehende Tokens";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Brave-Rewards-Auszahlungen sind auf diesem Gerät vorübergehend nicht verfügbar. Transferieren Sie Ihr bestehendes Wallet-Guthaben in eine Desktop-Wallet, um Ihre Tokens zu behalten.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Unterstützen Sie Content-Ersteller und Publisher automatisch, indem Sie Brave Private Ads aktivieren. Dabei handelt es sich um Anzeigen, die Ihre Privatsphäre respektieren und Content-Ersteller respektieren.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Brave Rewards aktivieren";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Sie unterstützen Content-Ersteller wie diesen.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Die Anzahl der Content-Ersteller, die Sie diesen Monat unterstützen.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Dieser Ersteller wurde nicht verifiziert und kann deshalb nicht unterstützt werden.";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Guthabentransfer eingeleitet";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave konnte keine Verbindung herstellen, es ist ein Fehler aufgetreten oder wir haben etwas falsch gemacht.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Erneut versuchen";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Ihr Guthaben an Brave-Rewards-Token kann einmalig in eine bestehende Brave-Rewards-Desktop-Wallet transferiert werden.\n\n1. Öffnen Sie den Brave Browser auf Ihrem Desktop-PC\n2. Gehen Sie zu brave://rewards\n3. Klicken Sie auf „QR-Code“\n4. Scannen Sie den QR-Code mit Ihrem Mobilgerät";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Einmaligen Transfercode scannen";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Wallet-Transfer";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Anzahl";
@@ -408,7 +459,7 @@
 "today.allSources" = "Alle Quellen";
 
 /* The name of the feature */
-"today.braveToday" = "Brave Heute";
+"today.braveToday" = "Brave Today";
 
 /* No comment provided by engineer. */
 "today.contentAvailableButtonTitle" = "Neue Inhalte verfügbar";
@@ -420,7 +471,7 @@
 "today.disableAll" = "Alle deaktivieren";
 
 /* '%@' will turn into the name of a publisher (verbatim), for example: Brave Blog */
-"today.disabledAlertBody" = "Brave Heute wird keine Inhalte von %@ mehr anzeigen.";
+"today.disabledAlertBody" = "Brave Today wird keine Inhalte von %@ mehr anzeigen.";
 
 /* No comment provided by engineer. */
 "today.disabledAlertTitle" = "Deaktiviert";
@@ -441,19 +492,19 @@
 "today.enablePublisherContent" = "Inhalte von %@ aktivieren";
 
 /* No comment provided by engineer. */
-"today.errorGeneralBody" = "Es gibt Probleme mit Brave Heute. Bitte versuchen Sie es erneut.";
+"today.errorGeneralBody" = "Es gibt Probleme mit Brave Today. Bitte versuchen Sie es erneut.";
 
 /* No comment provided by engineer. */
 "today.errorGeneralTitle" = "Hoppla …";
 
 /* No comment provided by engineer. */
-"today.introCardBody" = "Brave Heute gleicht Ihre Interessen mit Ihrem Gerät ab, damit Ihre personenbezogenen Daten niemals den Browser verlassen. Inhalte werden den ganzen Tag lang aktualisiert.";
+"today.introCardBody" = "Brave Today gleicht Ihre Interessen mit Ihrem Gerät ab, damit Ihre personenbezogenen Daten niemals den Browser verlassen. Inhalte werden den ganzen Tag lang aktualisiert.";
 
 /* No comment provided by engineer. */
 "today.introCardTitle" = "Nur für Sie: Die Top-Meldungen von heute in einem völlig privaten Feed.";
 
 /* No comment provided by engineer. */
-"today.isEnabledToggleLabel" = "Brave Heute anzeigen";
+"today.isEnabledToggleLabel" = "Brave Today anzeigen";
 
 /* No comment provided by engineer. */
 "today.learnMoreTitle" = "Mehr über Ihre Daten erfahren";

--- a/BraveShared/es.lproj/BraveShared.strings
+++ b/BraveShared/es.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Has ganado %@ por navegar con Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Gana tokens por ver esta imagen. Activa Brave Ads y empieza a apoyar a los creadores.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Gana tokens por ver esta imagen. Activa Brave Rewards y empieza a apoyar a los creadores.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Gana tokens por ver esta imagen.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "¡Sigue así!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Ocultar las imágenes de patrocinadores";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Cuando ves una imagen de un patrocinador, ganas tokens con los que puedes apoyar a los creadores. Con Brave Ads, siempre podrás controlar los anuncios que ves.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Más información sobre Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Mostrar más";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Gana tokens y recompensa a los creadores por su fantástico contenido mientras navegas.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Activar Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Activar Brave Rewards";
+"ntp.sponsoredImageDescription" = "Estás apoyando a los creadores y editores de contenido al ver esta imagen patrocinada.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Al activar Brave Rewards, aceptas los %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Estás ganando tokens por ver esta imagen.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Abrir todo (%i)";

--- a/BraveShared/es.lproj/Localizable.strings
+++ b/BraveShared/es.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Acerca de los escudos de Brave";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Permitir la comprobación única en el portapapeles";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Al activar Brave Rewards, acepta las";
+"OBRewardsAgreementDetail" = "Al tocar Empezar, aceptas el";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Condiciones de uso";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards apoya a los creadores";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "¿Empezar a apoyar a los creadores con anuncios privados y anónimos mientras navegas?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Gana tokens y recompensa a los creadores por su fantástico contenido mientras navegas.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Gana puntos y recompensa a los creadores por su fantástico contenido mientras navegas.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Apoye a sus sitios web y creadores favoritos en función de la atención que les presta.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Mostrar";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Activar";
+"OBTurnOnButton" = "Empezar";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Continuar";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Favoritos restaurados";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Activar para ayudar a apoyar a los creadores de contenido";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Si usas Brave Rewards, ayudas a apoyar a los creadores de contenido mientras navegas.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Estás ayudando a apoyar a los creadores de contenido";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "¡Gracias por ayudar a apoyar a los creadores de contenido mientras navegas!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Transferencia de cartera heredada";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Tokens existentes de transferencia saliente única";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Los pagos de Brave Rewards no están disponibles temporalmente en este dispositivo. Transfiere los fondos de tu cartera existente a una cartera de escritorio para conservar tus tokens.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Apoya a los creadores y editores de contenido de forma automática al activar Brave Private Ads. Brave Private Ads son anuncios que respetan la privacidad y que retribuyen a los creadores de contenido.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Activar Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Estás ayudando a apoyar a los creadores de contenido como este.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Número de creadores de contenido a los que ayudas a apoyar este mes.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Este creador no ha realizado la verificación y no se incluirá en el apoyo para creadores.";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Se ha iniciado la transferencia de saldo";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave no pudo conectarse: algo no funciona o nos equivocamos de alguna manera.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Volver a intentar";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Tu saldo de tokens de Brave Rewards puede transferirse, por única vez, a una cartera de escritorio de Brave Rewards existente.\n\n1. Abre el navegador de Brave en tu escritorio.\n2. Navega a brave://rewards.\n3. Haz clic en \"Código QR\".\n4. Escanea el código QR con tu dispositivo.";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Escanear código de transferencia de uso único";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Transferencia de cartera";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Importe";

--- a/BraveShared/fr.lproj/BraveShared.strings
+++ b/BraveShared/fr.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Vous avez gagné %@ en naviguant avec Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Gagnez des jetons en visionnant cette image. Activez Brave Ads pour soutenir les créateurs de contenu.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Gagnez des jetons en visionnant cette image. Activez Brave Rewards pour soutenir les créateurs de contenu.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Gagnez des jetons en visionnant cette image.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Bravo !";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Masquer les images sponsorisées";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Lorsque vous visionnez une image sponsorisée, vous gagnez des jetons qui peuvent être utilisés pour soutenir les créateurs de contenu. Avec Brave Ads, vous avez toujours le contrôle des publicités que vous voyez.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "En savoir plus sur Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Afficher plus";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Gagnez des jetons et récompensez les créateurs de contenu de qualité tout en naviguant.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Activer Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Activer Brave Rewards";
+"ntp.sponsoredImageDescription" = "En visualisant cette image sponsorisée, vous soutenez les créateurs de contenu et les diffuseurs.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "En activant Rewards, vous acceptez les %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Vous gagnez des jetons en visionnant cette image.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Tout ouvrir (%i)";

--- a/BraveShared/fr.lproj/Localizable.strings
+++ b/BraveShared/fr.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "À propos de Brave Shields";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Autoriser la vérification du presse-papier une seule fois";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "En activant Rewards, vous acceptez les";
+"OBRewardsAgreementDetail" = "En appuyant sur Démarrer, vous acceptez les";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Conditions d'utilisation";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards soutient les créateurs";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Commencer à soutenir les créateurs en visualisant des publicités privées et anonymes pendant la navigation ?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Gagnez des jetons et récompensez les créateurs de contenu de qualité tout en naviguant.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Gagnez des points et récompensez les créateurs de contenu de qualité tout en naviguant.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Soutenez vos sites Web et vos créateurs préférés grâce à l'attention que vous leur portez.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Afficher";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Activer";
+"OBTurnOnButton" = "Démarrer";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Continuer";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Favoris restaurés";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Activez cette fonctionnalité pour soutenir les créateurs de contenu";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Activez Brave Rewards pour soutenir les créateurs de contenu lorsque vous naviguez sur Internet.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Vous soutenez les créateurs de contenu";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Merci de soutenir les créateurs de contenu lorsque vous naviguez sur Internet !";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Transférer un ancien portefeuille";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Transfert unique des jetons existants";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Les paiements Brave Rewards sont temporairement indisponibles sur cet appareil. Transférez les fonds de votre portefeuille vers un portefeuille sur ordinateur pour conserver vos jetons.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Soutenez les créateurs de contenu et les diffuseurs automatiquement en activant les publicités privées Brave. Ces publicités respectent votre vie privée tout en récompensant les créateurs de contenu.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Activer Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Vous soutenez les créateurs de contenu comme celui-ci.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Nombre de créateurs de contenu que vous avez soutenu ce mois-ci.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Ce créateur n'est pas vérifié et ne fera pas partie des créateurs soutenus";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Le transfert du solde a démarré";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave n'a pas pu se connecter, une erreur est survenue, ou nous nous sommes trompés quelque part.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Réessayer";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Votre solde de jetons Brave Rewards peut être transféré vers un portefeuille Brave Rewards sur ordinateur, une seule fois seulement.\n\n1. Ouvrez le navigateur Brave sur votre ordinateur\n2. Accédez à brave://rewards\n3. Cliquez sur « Code QR »\n4. Scannez le code QR avec votre appareil";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Scanner le code de transfert unique";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Transférer un portefeuille";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Montant";

--- a/BraveShared/id-ID.lproj/BraveShared.strings
+++ b/BraveShared/id-ID.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Anda memperoleh %@ dengan menjelajahi dengan Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Dapatkan token dengan melihat gambar ini. Putar Brave Ads untuk mulai mendukung pembuat konten.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Dapatkan token dengan melihat gambar ini. Putar Brave Rewards untuk mulai mendukung pembuat konten.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Dapatkan token dengan melihat gambar ini.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Berhasil!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Sembunyikan gambar bersponsor";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Saat Anda melihat gambar bersponsor, Anda mendapat token yang dapat digunakan untuk mendukung pembuat konten. Dengan Brave Ads, Anda selalu pegang kendali atas iklan yang Anda lihat.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Pelajari lebih lanjut tentang Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Tampilkan Lainnya";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Dapatkan token dan beri reward pada pembuat konten atas konten hebat selagi Anda menjelajahi.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Putar Iklan Brave";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Aktifkan Brave Rewards";
+"ntp.sponsoredImageDescription" = "Anda mendukung konten kreator dan penerbit dengan melihat gambar bersponsor ini.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Dengan mengaktifkan Rewards, berarti Anda setuju dengan %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Anda mendapatkan token karena melihat gambar ini.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Buka Semua (%i)";

--- a/BraveShared/id-ID.lproj/Localizable.strings
+++ b/BraveShared/id-ID.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Tentang Perisai Brave";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Izinkan pemeriksaan clipboard satu kali";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Dengan mengaktifkan Brave Rewards, berarti Anda setuju dengan";
+"OBRewardsAgreementDetail" = "Dengan mengetuk Mulai, Anda menyetujui";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Persyaratan Layanan";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards mendukung para kreator";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Mulailah mendukung kreator dengan iklan privat dan anonim selagi Anda meramban?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Dapatkan token dan beri reward pada pembuat konten atas konten hebat selagi Anda menjelajahi";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Dapatkan poin dan beri reward pada pembuat konten atas konten hebat selagi Anda menjelajahi";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Dukung situs web dan pembuat konten favorit Anda berdasarkan atensi Anda.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Tampilkan Kepada Saya";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Aktifkan";
+"OBTurnOnButton" = "Mulai";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Lanjutkan";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Pilihan Favorit Dikembalikan";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Aktifkan untuk membantu mendukung para kreator konten";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Menggunakan Brave Rewards akan membantu mendukung kreator konten sembari Anda meramban.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Anda membantu mendukung para kreator konten";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Terima kasih karena telah membantu mendukung kreator konten sembari Anda meramban!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Transfer Dompet Lama";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Token transfer sekali yang sudah ada";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Pembayaran Brave Rewards sedang tidak tersedia di perangkat ini. Transfer dana dompet Anda yang ada ke dompet desktop untuk tetap menyimpan token Anda.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Dukung para kreator dan penerbit konten secara otomatis dengan mengaktifkan Brave Private Ads. Brave Private Ads adalah iklan yang menjaga privasi dan yang memberi imbalan kepada kreator konten. ";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Aktifkan Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Anda membantu mendukung para kreator konten seperti yang satu ini.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Jumlah kreator konten yang Anda bantu dukung bulan ini.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Kreator ini belum diverifikasi dan tidak akan disertakan dalam dukungan kreator.";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Transfer saldo telah dimulai";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave tidak mendapatkan koneksi, ada yang salah atau rusak.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Coba Lagi";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Saldo token Brave Rewards Anda dapat ditransfer to dompet desktop Brave Rewards yang ada, satu demi satu.\n\n1. Buka Peramban Brave pada desktop Anda\n2. Navigasi ke brave://rewards\n3. Klik \"Kode QR\"'\n4. Pindai Kode QR dengan perangkat Anda";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Pindai Kode Sekali Transfer";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Transfer Dompet";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Jumlah";

--- a/BraveShared/it.lproj/BraveShared.strings
+++ b/BraveShared/it.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Usando Brave hai guadagnato %@.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Ottieni dei token per la visualizzazione di questa immagine. Attiva Brave Ads e sostieni gli autori.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Ottieni dei token per la visualizzazione di questa immagine. Attiva Brave Rewards e sostieni gli autori.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Ottieni dei token per la visualizzazione di questa immagine.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Continua così!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Nascondi le immagini sponsorizzate";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Quando vedi un’immagine sponsorizzata, guadagni dei token con cui puoi sostenere chi crea i contenuti. Con Brave Ads, hai sempre il controllo sugli annunci che vedi.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Scopri di più su Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Mosta altro";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Ottieni dei token e mentre navighi potrai premiare gli autori per i contenuti che hanno creato.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Attiva Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Attiva Brave Rewards";
+"ntp.sponsoredImageDescription" = "Visualizzando l’immagine sponsorizzata sostieni chi crea e pubblica contenuti.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Attivando Rewards, accetti %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Con la visualizzazione di questa immagine stai guadagnando dei token.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Apri tutti (%i)";

--- a/BraveShared/it.lproj/Localizable.strings
+++ b/BraveShared/it.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Informazioni su Brave Shields";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Autorizzo la verifica una tantum degli appunti";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Attivando Rewards, accetti";
+"OBRewardsAgreementDetail" = "Selezionando Inizia, accetti";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Termini di servizio";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards sostiene chi crea contenuti";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Vuoi iniziare a sostenere chi crea contenuti, tramite annunci privati e anonimi durante la navigazione?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Ottieni dei token e mentre navighi potrai premiare gli autori per i contenuti che hanno creato.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Ottieni dei punti e mentre navighi potrai premiare gli autori per i contenuti che hanno creato.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Supporta i tuoi siti web e creatori preferiti in base alla tua attenzione.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Mostra";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Attiva";
+"OBTurnOnButton" = "Inizia";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Continua";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Preferiti ripristinati";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Attiva la funzione, per aiutarci a sostenere chi crea contenuti";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Con Brave Rewards mentre navighi sostieni le persone che creano i contenuti.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Ci stai aiutando a sostenere chi crea contenuti";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Grazie per il tuo aiuto: mentre navighi sostieni le persone che creano i contenuti!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Trasferimento del portafoglio esistente";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Trasferimento una tantum di token esistenti";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "I pagamenti di Brave Rewards al momento non sono disponibili su questo dispositivo. Per tenere i tuoi token, trasferisci a un portafoglio desktop gli importi presenti sul tuo portafoglio attuale.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Sostieni automaticamente chi crea e chi pubblica contenuti attivando Brave Private Ads. Sono annunci che finanziano chi crea contenuti, nel pieno rispetto della privacy.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Attiva Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Stai sostenendo chi crea contenuti. Ecco un esempio.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Numero di creatori di contenuti che stai aiutando questo mese.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Questo creatore di contenuti non è verificato e non sarà incluso tra quelli che verranno supportati";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Il trasferimento del saldo è iniziato";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave non riesce a connettersi, c’è qualche problema tecnico o qualche errore";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Riprova";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "I token che hai su Brave Rewards possono essere trasferiti a un portafoglio desktop Brave Rewards già esistente. L’operazione può essere effettuata una sola volta.\n\n1. Apri il browser di Brave da desktop\n2. Vai su brave://rewards\n3. Clicca su “Codice QR”\n4. Scansiona il codice QR con il tuo dispositivo";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Codice di scansione una tantum";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Trasferimento del portafoglio";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Importo";

--- a/BraveShared/ja.lproj/BraveShared.strings
+++ b/BraveShared/ja.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Braveをブラウジングで%@ BATポイント獲得しました";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "この背景画像を表示することで報酬を受け取ることができます。早速Brave Adsをオンにして報酬を受け取りましょう！";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "この背景画像を表示することで報酬を受け取ることができます。早速Brave Adsをオンにして報酬を受け取りましょう！";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "この背景画像を表示することで報酬を受け取ることができます。";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "おめでとうございます！";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "スポンサードイメージを非表示にする";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "スポンサーイメージを表示するたびに、広告費用の70％を報酬として受け取ることができます。Brave Adsでは表示する広告をコントロールすることができます。";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Brave Rewardsについて詳しく知る";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "もっと見る";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "ブラウジング中にBATポイントを獲得し、同時にコンテンツクリエイターに還元することができます";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Brave Adsを有効にする";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Brave Rewardsを有効にする";
+"ntp.sponsoredImageDescription" = "スポンサード画像を表示することで、間接的にコンテンツ制作者やパブリッシャーを支援することできます。";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Rewardsを有効にすると、以下に同意したものとみなされます: %@";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "この背景画像を表示することで報酬を受け取ることができます。";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "すべて開く (%i)";

--- a/BraveShared/ja.lproj/Localizable.strings
+++ b/BraveShared/ja.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Brave Shieldについて";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "一回限りのクリップボードチェックを許可する";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Rewardsを有効にすることで以下に同意したものと見なされます: ";
+"OBRewardsAgreementDetail" = "「開始する」をタップすると以下に同意したものと見なされます: ";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "利用規約";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewardsでクリエイターを支援する";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "ブラウジング中にプライバシーを重視した匿名広告を表示して、クリエイターの支援しませんか？";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "ブラウジング中にBATポイントを獲得し、同時にコンテンツクリエイターに還元することができます";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "ブラウジング中にBATポイントを獲得し、同時にコンテンツクリエイターに還元することができます";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "ウェブサーフィン中に自動的にサイトを支援したり、好きなタイミングでチップを送ることが可能です。";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "表示する";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "有効にする";
+"OBTurnOnButton" = "開始する";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "続ける";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "復元されたお気に入り";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "有効にしてことで、コンテンツクリエイターを支援することができます。";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Brave Rewardsを使うと、ブラウジングすることででクリエイターを支援";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "あなたはコンテンツクリエイターを支援中です";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "ブラウジングによるクリエイターの支援をありがとうございます！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "レガシーウォレットからの移行";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "既存のトークンの一度限りの移管";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Brave Rewardsの支払いは現在ご利用いただけません。既存のウォレットの資金はデスクトップ版Braveウォレットに移行することで、トークンを保持することができます。";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Braveのプライバシー重視型の広告を有効にすることで、コンテンツクリエイターやパブリッシャーを自動的にサポートすることができます。Brave Ads広告はプライバシーを尊重しつつコンテンツクリエイターに還元することを目指した新しい広告の仕組みです。";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Brave Rewardsを有効にする";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "あなたはコンテンツクリエイターを支援中です";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "今月支援中のコンテンツクリエイター数";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "このクリエイターは認証が完了していないため、支援対象になりません";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "残高の移行が開始されました";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Braveが接続に失敗した、または何らかの不具合が発生しています。";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "やり直す";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Brave Rewardsの残高は、一度限りデスクトップ版のBraveのウォレットに移行することができます。\n\n1.   デスクトップでBraveブラウザを開く\n2.  brave://rewards に移動\n3. 「QRコード」をクリック\n4.  QRコードを端末でスキャン";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "一度限りの転送用のQRコードをスキャンする";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "ウォレット移行";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "総額";

--- a/BraveShared/ko-KR.lproj/BraveShared.strings
+++ b/BraveShared/ko-KR.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Brave로 브라우징하여 %@를 얻었습니다.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "이 이미지를 보고 토큰을 획득하세요. Brave Ads를 켜고 제작자를 후원해주세요.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "이 이미지를 보고 토큰을 획득하세요. Brave Rewards를 켜고 제작자를 후원해주세요.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "이 이미지를 보고 토큰을 획득하세요.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "축하합니다!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "스폰서 이미지 숨기기";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "스폰서 이미지를 볼 때 토큰을 얻어 제작자를 후원하는 데 사용할 수 있습니다. 언제든지 Brave Ads를 사용하여 표시되는 광고를 마음대로 관리할 수 있습니다.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Brave Rewards 자세히 알아보기";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "더보기";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "브라우징하면서 토큰을 얻어 좋은 콘텐츠를 만들어준 제작자에게 보답하세요.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Brave Ads 켜기";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Brave Rewards 켜기";
+"ntp.sponsoredImageDescription" = "이 스폰서 이미지를 봄으로써 콘텐츠 제작자와 게시자를 지원하고 계십니다.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Rewards를 켜면 %@에 동의하는 것으로 간주됩니다.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "이 이미지를 보고 토큰을 획득하고 계십니다.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "모두 열기(%i)";

--- a/BraveShared/ko-KR.lproj/Localizable.strings
+++ b/BraveShared/ko-KR.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Brave Shields 정보";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "일회성 클립보드 확인 허용";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Rewards를 켜면 다음에 동의하는 것으로 간주됩니다.";
+"OBRewardsAgreementDetail" = "시작을 탭하면 다음에 동의하는 것으로 간주됩니다.";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "서비스 약관";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards, 제작자를 지원하는 방법";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "브라우징할 때 비공개 익명 광고를 보는 방법으로 제작자를 지원해보시겠어요?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "브라우징하면서 토큰을 얻어 좋은 콘텐츠를 만들어준 제작자에게 보답하세요.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "브라우징하면서 포인트를 얻어 좋은 콘텐츠를 만들어준 제작자에게 보답하세요.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "관심도를 기반으로 좋아하는 웹사이트와 제작자를 후원하세요.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "표시";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "켜기";
+"OBTurnOnButton" = "시작";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "계속";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "복원된 즐겨찾기";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "콘텐츠 제작자를 지원하려면 켜세요.";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Brave Rewards를 사용하면 브라우징하면서 콘텐츠 제작자를 지원할 수 있습니다.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "콘텐츠 제작자를 지원하고 계십니다.";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "브라우징하면서 콘텐츠 제작자를 지원해 주셔서 감사합니다!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "레거시 월렛 이전";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "기존 토큰 일회성 이전";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Brave Rewards 결제를 일시적으로 이 기기에서 이용할 수 없습니다. 기존 월렛 잔액을 데스크톱 월렛으로 이전하여 토큰을 안전하게 보호하세요.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Brave Private Ads를 활성화하면 자동으로 콘텐츠 제작자와 게시자를 지원하게 됩니다. Brave Private Ads는 개인정보를 존중하는 광고로 콘텐츠 제작자에게 보상을 줍니다.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Brave Rewards 활성화";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "이 제작자와 같은 콘텐츠 제작자를 지원하고 계십니다.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "이번 달 여러 콘텐츠 제작자를 지원하고 계십니다.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "확인되지 않은 제작자이기 때문에 제작자 지원에 포함되지 않습니다.";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "잔액 이전이 시작되었습니다.";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave가 연결할 수 없습니다. 문제가 생겼거나 오류가 발생한 것 같습니다.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "다시 시도";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Brave Rewards 토큰 잔액을 기존 Brave Rewards 데스크톱 월렛으로 단 한 번 이전할 수 있습니다.\n\n1. 데스크톱에서 Brave 브라우저를 엽니다.\n2. brave://rewards 페이지로 이동합니다.\n3. “QR Code”를 클릭합니다.\n4. 기기로 QR 코드를 스캔합니다.";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "일회성 이전 코드 스캔";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "월렛 이전";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "금액";

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Anda mendapat %@ dengan menyemak lalu dengan Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Dapatkan token untuk melihat imej ini. Hidupkan Brave Ads dan mula menyokong pencipta.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Dapatkan token untuk melihat imej ini. Hidupkan Brave Rewards dan mula menyokong pencipta.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Dapatkan token untuk melihat imej ini.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Begitu caranya!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Sembunyikan imej tajaan";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Apabila anda melihat imej yang ditaja, anda mendapat token yang boleh digunakan untuk menyokong pencipta. Dengan Brave Ads, anda sentiasa mengawal iklan yang anda lihat.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Ketahui lebih lanjut tentang Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Tunjukkan Lagi";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Dapatkan token dan beri ganjaran kepada pencipta untuk kandungan hebat sambil anda menyemak lalu.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Hidupkan Iklan Brave";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Hidupkan Brave Rewards";
+"ntp.sponsoredImageDescription" = "Anda menyokong pencipta dan penerbit kandungan dengan melihat imej yang ditaja ini.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Dengan menghidupkan Ganjaran, anda bersetuju dengan %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Anda akan mendapat token untuk melihat imej ini.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Buka Semua (%i)";

--- a/BraveShared/ms.lproj/Localizable.strings
+++ b/BraveShared/ms.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Mengenai Pelindung Brave";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Benarkan semakan papan klip satu kali";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Dengan menghidupkan Ganjaran, anda bersetuju dengan";
+"OBRewardsAgreementDetail" = "Dengan mengetik Mula, anda bersetuju dengan";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Syarat Perkhidmatan";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards menyokong pencipta";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Mula menyokong pencipta dengan iklan peribadi dan tanpa nama sambil anda menyemak lalu?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Dapatkan token dan beri ganjaran kepada pencipta untuk kandungan hebat sambil anda menyemak lalu.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Dapatkan mata dan beri ganjaran kepada pencipta untuk kandungan hebat sambil anda menyemak lalu.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Sokong laman web dan pencipta kegemaran anda berdasarkan perhatian anda.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Tunjukkan Saya";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Hidupkan";
+"OBTurnOnButton" = "Mula";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Teruskan";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Kegemaran yang Dipulihkan";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Hidupkan untuk membantu menyokong pencipta kandungan";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Menggunakan Brave Rewards membantu menyokong pencipta kandungan sambil anda menyemak lalu.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Anda membantu menyokong pencipta kandungan";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Terima kasih kerana membantu menyokong pencipta kandungan sambil anda menyemak lalu!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Pemindahan Dompet Legasi";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Pindah keluar sekali sahaja token sedia ada";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Pembayaran Brave Rewards tidak tersedia buat sementara waktu pada peranti ini. Pindahkan dana dompet sedia ada anda ke dompet desktop untuk menyimpan token anda.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Sokong pencipta dan penerbit kandungan secara automatik dengan mendayakan Brave Private Ads. Brave Private Ads adalah iklan yang menghormati privasi yang memberikan kembali kepada pencipta kandungan.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Dayakan Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Anda membantu menyokong pencipta kandungan seperti yang ini.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Bilangan pencipta kandungan yang anda bantu sokong bulan ini.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Pencipta ini belum mengesahkan dan tidak akan dimasukakn dalam sokongan pencipta";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Pemindahan baki telah dimulakan";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave tidak dapat menyambung, sesuatu rosak, atau kami yang silap.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Cuba Lagi";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Baki token Brave Rewards anda boleh dipindahkan ke dompet desktop Brave Rewards sedia ada, sekali.\n\n1. Buka Pelayar Brave pada desktop anda\n2. Navigasi ke brave://rewards\n3. Klik “Kod QR”\n4. Imbas Kod QR menggunakan peranti anda";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Imbas Kod Pemindahan Sekali Sahaja";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Pemindahan Dompet";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Jumlah";

--- a/BraveShared/nb.lproj/BraveShared.strings
+++ b/BraveShared/nb.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Du tjente %@ ved å surfe med Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Tjen tokener ved å vise dette bildet. Slå på Brave-annonser og begynn å støtte skaperne.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Tjen tokener for å vise dette bildet. Slå på Brave Rewards og begynn å støtte skaperne.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Tjen opp tokens for å se dette bildet.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Bra jobba!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Skjul sponsede bilder";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Når du viser et sponset bilde, tjener du tokener som kan brukes til å støtte skaperne. Med Brave-annonser har du alltid kontroll over annonsene du ser.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Lær mer om Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Vis mer";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Tjen tokener og belønn skaperne for supert innhold mens du surfer.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Slå på Brave-annonser";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Slå på Brave Rewards";
+"ntp.sponsoredImageDescription" = "Du støtter innholdsskapere og utgivere ved å se dette sponsede bildet.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Ved å slå på Rewards, godtar du %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Du tjener tokens for å se dette bildet.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Åpne alle (%i)";

--- a/BraveShared/nb.lproj/Localizable.strings
+++ b/BraveShared/nb.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Om Brave-skjold";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Tillat engangskontroll av utklippstavle";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Ved å slå på Rewards, godtar du";
+"OBRewardsAgreementDetail" = "Ved å trykke på Start godtar du";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Vilkår for bruk";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards støtter innholdsskapere";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Begynn å støtte skapere med private og anonymiserte annonser mens du er på nettet?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Tjen tokener og belønn skaperne for supert innhold mens du surfer.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Tjen poeng og belønn skaperne for supert innhold mens du surfer.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Støtt dine favorittnettsteder og -skapere basert på din oppmerksomhet.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Vis meg";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Slå på";
+"OBTurnOnButton" = "Start";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Fortsett";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Gjenopprettede favoritter";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Skru på for å støtte innholdsskapere";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Ved å bruke Brave Rewards støtter du innholdsskapere mens du er på nettet.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Du bidrar til å støtte innholdsskapere";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Takk for at du støtter innholdsskapere mens du er på nettet!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Overføring fra Legacy-lommebok";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Engangsoverføring ut for eksisterende tokener";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Brave Rewards-utbetalinger er midlertidig utilgjengelige på denne enheten. Overfør midler fra din eksisterende lommebok til en stasjonær lommebok for å beholde tokener.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Støtt innholdsskapere og utgivere automatisk ved å aktivere Brave Private Ads. Brave Private Ads er annonser som respekterer personvern og som gir tilbake til innholdsskapere.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Aktiver Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Du støtter innholdsskapere som denne.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Antall innholdsskapere du støtter denne måneden.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Denne skaperen har ikke blitt verifisert og vil ikke bli inkludert i skaperstøtten";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Saldooverføring startet";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave fikk ikke tilgang, noe gikk i stykker, eller vi dummet oss ut.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Prøv igjen";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Brave Rewards-saldoen din kan overføres til en eksisterende stasjonær Brave Rewards-lommebok, én gang.\n\n1. Åpne Brave Browser på skrivebordet\n2. Gå til brave://rewards\n3. Klikk på “QR-kode”\n4. Skann QR-kode med enheten din";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Skann engangskode for overføring";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Overføring fra lommebok";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Mengde";

--- a/BraveShared/pl.lproj/BraveShared.strings
+++ b/BraveShared/pl.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Udało Ci się zarobić %@, przeglądając z Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Zarabiaj tokeny, wyświetlając ten obraz. Włącz Brave Ads i zacznij wspierać twórców.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Zarabiaj tokeny, wyświetlając ten obraz. Włącz Brave Rewards i zacznij wspierać twórców.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Zarabiaj tokeny, wyświetlając ten obraz.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Świetnie!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Ukryj sponsorowane obrazy";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Za wyświetlenie sponsorowanego obrazu otrzymasz tokeny, które można wykorzystać do wspierania twórców. Dzięki Brave Ads będziesz mieć zawsze kontrolę nad reklamami, które oglądasz.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Dowiedz się więcej o Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Pokaż więcej";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Zarabiaj tokeny i, przeglądając, nagradzaj twórców za tworzenie świetnych treści.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Włącz Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Włącz Brave Rewards";
+"ntp.sponsoredImageDescription" = "Wspierasz twórców i wydawców treści, wyświetlając ten sponsorowany obraz.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Włączając nagrody, akceptujesz %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Zarabiasz tokeny, wyświetlając ten obraz.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Otwórz wszystko (%i)";

--- a/BraveShared/pl.lproj/Localizable.strings
+++ b/BraveShared/pl.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Brave Shields – informacje";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Pozwól na jednorazowe sprawdzenie schowka";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Włączając Nagrody, akceptujesz";
+"OBRewardsAgreementDetail" = "Naciskając przycisk Start, wyrażasz zgodę na";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Warunki świadczenia usług";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Nagrody Brave Rewards wspierają twórców";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Chcesz zacząć wspierać twórców przy pomocy prywatnych i anonimizowanych reklam wyświetlanych podczas przeglądania treści?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Zarabiaj tokeny i, przeglądając, nagradzaj twórców za tworzenie świetnych treści.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Zarabiaj punkty i, przeglądając, nagradzaj twórców za tworzenie świetnych treści.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Wykorzystaj swoją uwagę, aby wspierać swoje ulubione strony internetowe i twórców.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Pokaż mi";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Włącz";
+"OBTurnOnButton" = "Rozpocznij";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Kontynuuj";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Przywrócone ulubione";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Włącz, aby wspierać twórców treści";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Korzystanie z nagród Brave Rewards w trakcie przeglądania wspiera twórców treści.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Pomagasz twórcom treści";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Dziękujemy za wsparcie twórców treści udzielane w trakcie przeglądania!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Transfer ze starszego portfela";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Jednorazowy transfer istniejących tokenów";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Wypłaty nagród Brave Rewards są tymczasowo niedostępne na tym urządzeniu. Przenieś istniejące fundusze z portfela do portfela komputerowego, aby zachować tokeny.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Wspieraj twórców i wydawców treści automatycznie, włączając reklamy prywatne Brave. Reklamy prywatne Brave Private Ads to reklamy respektujące prywatność, które zapewniają wsparcie twórcom treści.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Włącz nagrody Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Pomagasz twórcom, takim jak ten.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Liczba twórców treści, których wspierasz w tym miesiącu.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Ten twórca nie został zweryfikowany i nie zostanie uwzględniony w funkcji wsparcia twórców.";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Zainicjowano transfer salda";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Przeglądarka Brave nie mogła nawiązać połączenia, coś nie działa lub doszło do jakiejś usterki.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Spróbuj ponownie";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Twoje saldo tokenów Brave Rewards można przenieść jednorazowo do istniejącego portfela komputerowego Brave Rewards.\n\n1. Otwórz przeglądarkę Brave Browser na komputerze\n2. Przejdź do strony brave://rewards\n3. Kliknij opcję „Kod QR”\n4. Zeskanuj kod QR przy użyciu urządzenia";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Zeskanuj jednorazowy kod transferowy";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Transfer portfela";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Kwota";

--- a/BraveShared/pt-BR.lproj/BraveShared.strings
+++ b/BraveShared/pt-BR.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Você ganhou %@ navegando com o Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Receba tokens para visualizar esta imagem. Ative o Brave Ads e comece a apoiar criadores.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Receba tokens para visualizar esta imagem. Ative o Brave Rewards e comece a apoiar criadores.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Receba tokens para visualizar esta imagem.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Muito bem!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Ocultar imagens patrocinadas";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "Ao visualizar uma imagem patrocinada, você ganha tokens que podem ser usados para apoiar criadores. Com o Brave Ads, você controla os anúncios que visualiza.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Saiba mais sobre o Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Mostrar mais";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Ganhe tokens enquanto navega e doe-os a criadores pelo conteúdo de qualidade que eles produzem.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Ativar o Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Ativar Brave Rewards";
+"ntp.sponsoredImageDescription" = "Ao visualizar esta imagem patrocinada, você está apoiando criadores de conteúdo e editores.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Ao ativar o Rewards, você concorda com os %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Você está recebendo tokens para visualizar esta imagem.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Abrir tudo (%i)";

--- a/BraveShared/pt-BR.lproj/Localizable.strings
+++ b/BraveShared/pt-BR.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Sobre as Proteções do Brave";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Permitir verificação única da área de transferência";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Ao ativar o Rewards, você concorda com os";
+"OBRewardsAgreementDetail" = "Ao tocar em \"Iniciar\", você concorda com os";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Termos de Serviço";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "O Brave Rewards apoia criadores de conteúdo";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Começar a apoiar criadores de conteúdo com a exibição de anúncios privados e anonimizados enquanto você navega?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Ganhe tokens enquanto navega e doe-os a criadores pelo conteúdo de qualidade que eles produzem.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Ganhe pontos enquanto navega e doe-os a criadores pelo conteúdo de qualidade que eles produzem.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Apoie seus sites e criadores favoritos com base na sua atenção.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Mostrar";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Ativar";
+"OBTurnOnButton" = "Iniciar";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Continuar";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Favoritos em destaque restaurados";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Ative para apoiar criadores de conteúdo";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Ao usar o Brave Rewards, você apoia os criadores do conteúdo que você acessa.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Você está apoiando criadores de conteúdo";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Obrigado por apoiar os criadores do conteúdo que você acessa!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Transferência de carteira legada";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Transferência única de tokens existentes";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Os pagamentos do Brave Rewards estão temporariamente indisponíveis neste dispositivo. Para manter seus tokens, transfira os fundos da sua carteira atual para uma carteira para computador.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Ative o Brave Private Ads para apoiar criadores de conteúdo e editores com a exibição de anúncios que respeitam sua privacidade.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Ativar o Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Você está apoiando criadores de conteúdo como este.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Número de criadores de conteúdo que você está apoiando neste mês.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Este criador de conteúdo não foi verificado e não será incluído no apoio a criadores";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "A transferência de saldo foi iniciada";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "O Brave não conseguiu se conectar, houve algum problema ou cometemos algum engano.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Tentar novamente";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Seu saldo de tokens do Brave Rewards pode ser transferido uma vez para uma carteira para computador existente do Brave Rewards.\n\n1. Abra o navegador Brave no seu computador\n2. Navegue até brave://rewards\n3. Clique em \"Código QR\"\n4. Leia o código QR com seu dispositivo";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Ler código de transferência única";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Transferência de carteira";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Valor";

--- a/BraveShared/ru.lproj/BraveShared.strings
+++ b/BraveShared/ru.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Вы заработали %@, пользуясь Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Посмотрите это изображение и заработайте баллы. Включите Brave Ads и начните поддерживать авторов контента.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Посмотрите это изображение и заработайте баллы. Включите Brave Rewards и начните поддерживать авторов контента.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Посмотрите это изображение и заработайте токены.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Так держать!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Не показывать спонсорские изображения";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "За каждый просмотр спонсорского изображения вы получаете баллы, которые можете потратить на поддержку авторов. Brave Ads позволяет с легкостью выбирать, какая реклама может появляться в браузере.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Подробнее о Brave Rewards…";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Показать еще";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Зарабатывайте баллы и вознаграждайте авторов контента, пользуясь браузером.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Включить Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Включить Brave Rewards";
+"ntp.sponsoredImageDescription" = "Просматривая это спонсорское изображение, вы поддерживаете издателей и создателей контента.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Включая Brave Rewards, вы принимаете";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "За просмотр этого изображения вы заработаете токены.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Открыть все (%i)";

--- a/BraveShared/ru.lproj/Localizable.strings
+++ b/BraveShared/ru.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "О щитах Brave";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Разрешить однократную проверку буфера обмена";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Включая Rewards, вы принимаете";
+"OBRewardsAgreementDetail" = "Нажимая «Начать», вы принимаете";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Условия использования";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards поддерживает создателей контента";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Хотите поддерживать создателей контента, просматривая в Интернете объявления, которые не будут нарушать конфиденциальность ваших данных?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Зарабатывайте баллы и вознаграждайте авторов контента, пользуясь браузером.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Зарабатывайте баллы и вознаграждайте авторов контента, пользуясь браузером.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Поддерживайте свои любимые сайты и создателей, уделяя им внимание.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Показать";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Включить";
+"OBTurnOnButton" = "Начать";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Далее";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Восстановленное избранное";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Включите, если хотите поддерживать создателей контента";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Используя Brave Rewards, вы помогаете поддерживать создателей контента.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Вы помогаете поддерживать создателей контента";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Просматривая сайты, вы помогаете поддерживать создателей контента. Спасибо!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Перенос устаревшего кошелька";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Однократный перенос имеющихся баллов";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Баллы Brave Rewards временно недоступны на этом устройстве. Чтобы не потерять их, перенесите средства из мобильного кошелька в кошелек на компьютере.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Включив Brave Private Ads, вы будете автоматически поддерживать издателей и создателей контента. Brave Private Ads — это реклама, которая не нарушает конфиденциальность ваших данных.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Включить Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Вы помогаете поддерживать создателей контента, таких как этот издатель.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Количество создателей контента, которых вы поддерживаете в этом месяце.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Этот создатель контента не прошел проверку, поэтому поддержка для него недоступна.";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Баланс перенесен";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Не удалось подключиться к Brave, или произошла другая ошибка.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Попробуйте снова";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Вы можете один раз перенести баллы Brave Rewards в кошелек Brave Rewards на компьютере.\n\n1. Откройте браузер Brave на компьютере.\n2. Перейдите по адресу brave://rewards.\n3. Нажмите «QR-код».\n4. Отсканируйте QR-код с помощью своего устройства.";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Отсканируйте код однократного переноса";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Перенос кошелька";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Сумма";

--- a/BraveShared/sv.lproj/BraveShared.strings
+++ b/BraveShared/sv.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Du tjänade %@ genom att surfa med Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Tjäna tokens för att se den här bilden. Aktivera Brave-annonser och börja stödja skapare.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Tjäna tokens för att se den här bilden. Aktivera Brave Rewards och börja stödja skapare.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Tjäna mynt för att se den här bilden.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Bra jobbat!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Dölj sponsrade bilder";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "När du ser en sponsrad bild tjänar du tokens som kan användas för att stödja skapare. Med Brave-annonser har du alltid kontroll över de annonser du ser.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Lär dig mer om Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Visa mer";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Tjäna tokens och belöna skapare för bra innehåll medan du surfar.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Slå på Brave annonser";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Aktivera Brave Rewards";
+"ntp.sponsoredImageDescription" = "Du stödjer innehållsskapare och utgivare genom att titta på den här sponsrade bilden.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Genom att aktivera Rewards godkänner du %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Du tjänar mynt för att se den här bilden.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Öppna alla (%i)";

--- a/BraveShared/sv.lproj/Localizable.strings
+++ b/BraveShared/sv.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Om Brave sköldar";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Tillåt kontroll av urklipp en gång";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Genom att aktivera Rewards godkänner du";
+"OBRewardsAgreementDetail" = "Genom att trycka på Starta godkänner du";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Tjänstevillkor";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards stödjer kreatörer";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Börja stödja kreatörer med privata och anonymiserade annonser medan du surfar?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Tjäna tokens och belöna skapare för bra innehåll medan du surfar.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Tjäna poäng och belöna skapare för bra innehåll medan du surfar.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Stötta webbplatser och skapare baserat på hur mycket tid du ger dem.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Visa";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Aktivera";
+"OBTurnOnButton" = "Starta";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Fortsätt";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Återställda favoriter";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Aktivera för att stödja innehållsskapare";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Använd Brave Rewards och stöd innehållsskapare när du surfar.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Du hjälper till att stödja innehållsskapare";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Tack för att du stödjer innehållsskapare när du surfar!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Äldre plånboksöverföring";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Engångsöverföring av befintliga token";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Brave Rewards-utbetalningar är tillfälligt otillgängliga på den här enheten. Överför dina befintliga plånboksmedel till en skrivbordsplånbok för att behålla dina tokens.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Stöd innehållsskapare och utgivare automatiskt genom att aktivera Brave Private Ads. Brave Private Ads är annonser som respekterar din sekretess och ger tillbaka till innehållsskapare.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Aktivera Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Du hjälper stödja innehållsskapare som den här.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Antal innehållsskapare som du hjälper till med att stödja den här månaden.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Den här kreatören har inte verifierat och kommer inte att ingå i kreatörsstödet";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Saldoöverföring har påbörjats";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave kunde inte ansluta. Ett fel inträffade.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Försök igen";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Ditt Brave Rewards-tokensaldo kan överföras till en befintlig Brave Rewards-skrivbordsplånbok en gång.\n\n1. Öppna Brave Browser på en dator\n2. Navigera till brave://rewards\n3. Klicka på \"QR-kod\"\n4. Skanna QR-koden med din enhet";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Skanna engångskod för överföring";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Plånboksöverföring";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Belopp";

--- a/BraveShared/uk.lproj/BraveShared.strings
+++ b/BraveShared/uk.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "Ви заробили %@ під час використання Brave.";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "Заробляйте токени за перегляд цього зображення. Увімкніть Brave Ads і почніть підтримувати авторів.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "Заробляйте токени за перегляд цього зображення. Увімкніть Brave Rewards і почніть підтримувати авторів.";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "Заробляйте токени за перегляд цього зображення.";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "Так тримати!";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "Приховати рекламні зображення";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "За перегляд рекламного зображення ви отримаєте токени, за допомогою яких можна підтримати авторів. Brave Ads дає змогу керувати рекламою, яку ви переглядатимете.";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "Докладніше про Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "Показати інші";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "Заробляйте токени під час перегляду вебсайтів і винагороджуйте авторів за чудовий уміст.";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "Увімкнути Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "Увімкнути Brave Rewards";
+"ntp.sponsoredImageDescription" = "Ви підтримуєте авторів умісту та видавців, переглядаючи це рекламне зображення.";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "Увімкнувши Rewards, ви приймаєте умови документа %@.";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "Ви заробляєте токени за перегляд цього зображення.";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "Відкрити всі (%i)";

--- a/BraveShared/uk.lproj/Localizable.strings
+++ b/BraveShared/uk.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "Про щити Brave";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "Дозволити одноразову перевірку буфера обміну";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "Увімкнувши Rewards, ви приймаєте";
+"OBRewardsAgreementDetail" = "Торкнувшись пункту «Почати», ви погоджуєтеся";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "Умови обслуговування";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Підтримка авторів у Brave Rewards";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "Увімкнути перегляд приватної та персоналізованої реклами під час користування Інтернетом, щоб підтримати авторів?";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "Заробляйте токени під час перегляду вебсайтів і винагороджуйте авторів за чудовий уміст.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "Заробляйте бали під час перегляду вебсайтів і винагороджуйте авторів за чудовий уміст.";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "Підтримуйте улюблені веб-сайти та авторів, приділяючи їм увагу.";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "Показати";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "Ввімкнути";
+"OBTurnOnButton" = "Почати";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "Продовжити";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "Відновлений список вибраного";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Увімкніть підтримку авторів умісту";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Brave Rewards дає змогу підтримувати авторів умісту, переглядаючи сторінки в Інтернеті.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Ви підтримуєте авторів умісту";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Дякуємо, що підтримуєте авторів умісту, переглядаючи сторінки в Інтернеті!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "Переказ коштів із застарілого гаманця";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "Одноразовий переказ наявних токенів";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "Виплати у Brave Rewards тимчасово недоступні на цьому пристрої. Перекажіть кошти з наявного гаманця на гаманець на настільному комп’ютері, щоб зберегти свої токени.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Увімкніть Brave Private Ads, щоб автоматично підтримувати авторів умісту та видавців. Brave Private Ads — це конфіденційний засіб перегляду реклами з можливістю підтримки авторів умісту.";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "Увімкнути Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Ви підтримуєте авторів умісту подібних до цього.";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "Кількість авторів умісту, яких ви підтримали цього місяця.";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "Цей автор не підтвердив особу і його не буде додано до програми підтримки авторів";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "Переказ коштів розпочато";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Не вдалося встановити підключення в Brave або сталася помилка.";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "Спробуйте ще раз";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "Токени з Brave Rewards можна один раз перевести в наявний гаманець Brave Rewards на настільному комп’ютері.\n\n1. Відкрийте браузер Brave на настільному комп’ютері.\n2. Перейдіть за адресою «brave://rewards».\n3. Натисніть на пункт «QR-код».\n4. Відскануйте QR-код за допомогою пристрою.";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "Сканування одноразового коду переказу";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "Переказ коштів із гаманця";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Сума";

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "您使用 Brave 瀏覽期間，一共賺取了 %@。";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "查看此圖片即可賺取代幣。立即啟用 Brave Ads，開始支持創作者。";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "查看此圖片即可賺取代幣。立即啟用 Brave Rewards，開始支持創作者。";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "查看此圖片即可賺取代幣。";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "做得很好！";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "隱藏贊助圖片";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "查看贊助圖片即可賺取代幣，支持創作者。啟用 Brave Ads 後，畫面顯示什麼廣告全由您掌控。";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "深入了解 Brave Rewards";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "顯示更多";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "一邊瀏覽，一邊賺取代幣，獎勵優質的內容創作者。";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "啟用 Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "啟用 Brave Rewards";
+"ntp.sponsoredImageDescription" = "查看這張贊助圖片，等同於支持內容創作者和發佈者。";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "開啟「獎勵」即表示您同意%@。";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "查看此圖片立即賺取代幣。";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "開啟全部 (%i)";

--- a/BraveShared/zh-TW.lproj/Localizable.strings
+++ b/BraveShared/zh-TW.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "關於 Brave Shields";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "允許查看一次剪貼簿";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "啟用「獎勵」代表您同意";
+"OBRewardsAgreementDetail" = "點選「開始」即代表您同意";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "服務條款";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards 全力支持創作者";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "想開始在瀏覽時透過私人匿名廣告支持創作者嗎？";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "一邊瀏覽，一邊賺取代幣，獎勵優質的內容創作者。";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "一邊瀏覽，一邊賺取點數，獎勵優質的內容創作者。";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "根據您的關注度來支持您喜歡的站點和創作者。";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "讓我看看";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "開啟";
+"OBTurnOnButton" = "開始";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "繼續";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "恢復的最愛";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "開啟以立即支持內容創作者";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "使用 Brave Rewards 就能在瀏覽期間支持內容創作者。";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "您正在支持內容創作者";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "感謝您在瀏覽期間不忘支持內容創作者！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "舊版錢包轉帳";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "一次轉出現有代幣";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "這部裝置暫時無法轉出 Brave Rewards，請將現有錢包金額轉至桌面版錢包，以便保存。";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "啟用 Brave Private Ads，即可自動支持內容創作者和發佈者。Brave Private Ads 是回饋內容創作者並兼顧隱私的廣告。";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "啟用 Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "您正在支持這樣的內容創作者。";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "本月您支持的內容創作者人數。";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "這位創作者尚未通過驗證，不會納入您支持的創作者名單";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "已轉出金額";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave 發生故障或錯誤，無法連線。";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "再試一次";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "您可將 Brave Rewards 代幣餘額一次轉至現有 Brave Rewards 桌面版錢包。\n\n1. 在桌上型電腦上開啟 Brave 瀏覽器\n2. 瀏覽至 brave://rewards\n3. 按一下「QR 碼」\n4. 以裝置掃描 QR 碼";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "掃描一次性轉帳碼";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "錢包轉帳";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "金額";

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -646,23 +646,11 @@
 /* Placeholder example: 'You earned 42 BAT by browsing with Brave.' */
 "ntp.earningsReport" = "您通过用 Brave 进行浏览赚取了 %@。";
 
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnAds" = "通过查看此图片赚取代币。启用“Brave Ads”开始支持创作者。";
-
-/* No comment provided by engineer. */
-"ntp.getPaidForThisImageTurnRewards" = "通过查看此图像赚取代币。启用“Brave Rewards”开始支持创作者。";
-
-/* No comment provided by engineer. */
-"ntp.getPaidToSeeThisImage" = "通过查看该图片赚取代币。";
-
 /* The context is to praise the user that they did a good job, to keep it up. It is used in full sentence like: 'Way to go! You earned 40 BAT last month.' */
 "ntp.goodJob" = "太棒了！";
 
 /* No comment provided by engineer. */
 "ntp.hideSponsoredImages" = "隐藏赞助图片";
-
-/* No comment provided by engineer. */
-"ntp.learnMoreAboutBrandedImages" = "查看赞助的图片时，您会赚到可用来支持创作者的代币。借助“Brave Ads”，您始终可以控制看到的广告。";
 
 /* No comment provided by engineer. */
 "ntp.learnMoreAboutRewards" = "了解更多有关 Brave Rewards 的内容";
@@ -692,19 +680,10 @@
 "ntp.showMoreFavorites" = "显示更多";
 
 /* No comment provided by engineer. */
-"ntp.supportWebCreatorsWithTokens" = "一边浏览，一边赚取代币并奖励创作者，以获得精彩内容。";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveAds" = "开启 Brave Ads";
-
-/* No comment provided by engineer. */
-"ntp.turnOnBraveRewards" = "开启 Brave Rewards";
+"ntp.sponsoredImageDescription" = "您即将通过查看此赞助图片来支持内容创建者和发布者。";
 
 /* The placeholder says 'Terms of Service'. So full sentence goes like: 'By turning Rewards, you agree to the Terms of Service'. */
 "ntp.turnRewardsTos" = "开启 Rewards 即表示您同意 %@。";
-
-/* No comment provided by engineer. */
-"ntp.youArePaidToSeeThisImage" = "您正在通过查看该图片赚取代币。";
 
 /* Context menu item for opening all folder bookmarks */
 "OpenAllBookmarks" = "打开所有（%i）";

--- a/BraveShared/zh.lproj/Localizable.strings
+++ b/BraveShared/zh.lproj/Localizable.strings
@@ -1,5 +1,4 @@
-/* The body of the screen explaining Brave Shields
-   The title of the screen explaining Brave Shields */
+/* The title of the screen explaining Brave Shields */
 "AboutBraveShields" = "关于 Brave Shields";
 
 /* No comment provided by engineer. */
@@ -90,22 +89,19 @@
 "OBPrivacyConsentYesButton" = "允许一次性剪贴板检查";
 
 /* Detail text for rewards agreement onboarding screen */
-"OBRewardsAgreementDetail" = "启用“Rewards”即表示您同意";
+"OBRewardsAgreementDetail" = "轻击“开始”即表示您同意";
 
 /* Detail text for rewards agreement onboarding screen */
 "OBRewardsAgreementDetailLink" = "服务条款";
 
 /* Title for rewards agreement onboarding screen */
-"OBRewardsAgreementTitle" = "Brave Rewards";
+"OBRewardsAgreementTitle" = "Brave Rewards 支持创建者";
+
+/* Detail text for rewards onboarding screen */
+"OBRewardsDetail" = "要在浏览时开始为创作者提供私人和匿名广告支持吗？";
 
 /* Detail text for rewards onboarding screen */
 "OBRewardsDetailInAdRegion" = "一边浏览，一边赚取代币并奖励创作者，以获得精彩内容。";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailInAdRegionJapan" = "一边浏览，一边赚取代币并奖励创作者，以获得精彩内容。";
-
-/* Detail text for rewards onboarding screen */
-"OBRewardsDetailOutsideAdRegion" = "根据您的关注度来支持您最喜欢的网站和创建者。";
 
 /* Title for rewards onboarding screen */
 "OBRewardsTitle" = "Brave Rewards";
@@ -129,7 +125,7 @@
 "OBShowMeButton" = "给我看看";
 
 /* Button to show Brave Rewards. */
-"OBTurnOnButton" = "打开";
+"OBTurnOnButton" = "开始";
 
 /* Continue button to navigate to next onboarding screen. */
 "OnboardingContinueButton" = "继续";
@@ -160,6 +156,61 @@
 
 /* Name of folder where restored favorites are retrieved */
 "RestoredFavoritesFolderName" = "恢复的收藏夹";
+
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "开启以帮助支持内容创建者";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "在浏览时使用 Brave Rewards 功能帮助支持内容创建者。";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "您即将帮助支持内容创建者";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "感谢您在浏览过程中帮助支持内容创建者！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransfer" = "旧版钱包转账";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferSubtitle" = "一次性转出现有代币";
+
+/* No comment provided by engineer. */
+"rewards.settingsFooterMessage" = "暂时无法在此设备上使用 Brave Rewards。将您钱包里现有的资金转账到台式机钱包中可保留代币。";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "通过启用 Brave Private Ads 自动支持内容创建者和发布者。Brave Private Ads 是尊重隐私的、回馈内容创作者的广告。";
+
+/* No comment provided by engineer. */
+"rewards.settingsToggleTitle" = "开启 Brave Rewards";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "您即将帮助支持象这一位这样的内容创建者。";
+
+/* Displayed next to a number representing the total number of publishers supported */
+"rewards.totalSupportedCount" = "您本月要帮助支持的内容创建者的数量。";
+
+/* Displayed under unverified publishers */
+"rewards.unverifiedPublisher" = "该创建者尚未验证，因此不会受创建者支持";
+
+/* Title shown above the confirmation message after completing a wallet transfer successfully */
+"rewards.walletTransferCompleteTitle" = "余额转账已启动";
+
+/* Message on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertMessage" = "Brave 无法连接、出了故障或我们不知怎么出了错。";
+
+/* Title on the alert presented if wallet transfer fails */
+"rewards.walletTransferFailureAlertTitle" = "请重试";
+
+/* A confirmation message shown to the user after completing a wallet transfer successfully
+   Describes the steps for using wallet transfer */
+"rewards.walletTransferStepsBody" = "您的 Brave Rewards 代币余额可以一次转到现有的 Brave Rewards 桌面钱包中。\n\n1. 在桌面上打开 Brave 浏览器 \n2. 导航至 brave://rewards\n3. 点击“QR 码”\n4. 使用设备扫描 QR 码";
+
+/* Title above the steps to use wallet transfer */
+"rewards.walletTransferStepsTitle" = "扫描一次性转账码";
+
+/* Title of the legacy wallet transfer screen */
+"rewards.walletTransferTitle" = "钱包转账";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "金额";


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3079 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Set language to non-english one
2. Open new Rewards panel, verify text is translated
3. Scroll down to see the Brave Today intro card, verify it's translated

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
