### PR TITLE
Fix#2907: Clearing Browsing History should clear Tab History as well

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -266,12 +266,13 @@ class Tab: NSObject {
         TabMO.removeHistory(with: tabID)
 
         /*
-         * Remove all items selector is used on WKWebView backForwardList because backForwardList list is only exposed with a getter
+         * Clear selector is used on WKWebView backForwardList because backForwardList list is only exposed with a getter
+         * and this method Removes all items except the current one in the tab list so when another url is added it will add the list properly
          * This approach is chosen to achieve removing tab history in the event of removing  browser history
          * Best way perform this is to clear the backforward list and in our case there is no drawback to clear the list
          * And alternative would be to reload webpages which will be costly and also can cause unexpected results
          */
-        let argument: [Any] = ["_r", "emoveA", "llIt", "ems"]
+        let argument: [Any] = ["_c", "lea", "r"]
 
         let method = argument.compactMap { $0 as? String }.joined()
         let selector: Selector = NSSelectorFromString(method)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -264,17 +264,21 @@ class Tab: NSObject {
         
         // Remove the tab history from saved tabs
         TabMO.removeHistory(with: tabID)
-        
+
+        let allBase64Decoded = Data(base64Encoded: "QWxs", options: Data.Base64DecodingOptions(rawValue: 0))
+            .map({ String(data: $0, encoding: .utf8) }) ?? "" // "All" text in base64Decoded
+              
         // Clear backforward list
-        let argument: [Any] = ["_", "\u{72}", "\u{65}", "\u{6D}", "\u{6F}", "\u{76}", "\u{65}",
-                               "\u{41}", "\u{6C}", "\u{6C}",
-                               "\u{49}", "\u{74}", "\u{65}", "\u{6D}", "\u{73}"]
-        
+        let argument: [Any] = ["_", "r", "\u{65}", "mov", "\u{65}", // _remove
+                             "\(allBase64Decoded ?? "")", // All
+                             "It", "\u{65}", "ms"] // Items
+
         let method = argument.compactMap { $0 as? String }.joined()
-        
         let selector: Selector = NSSelectorFromString(method)
 
-        webView.backForwardList.performSelector(onMainThread: selector, with: nil, waitUntilDone: true)
+        if webView.backForwardList.responds(to: selector) {
+          webView.backForwardList.performSelector(onMainThread: selector, with: nil, waitUntilDone: true)
+        }
     }
     
     func restore(_ webView: WKWebView, restorationData: SavedTab?) {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -256,6 +256,53 @@ class Tab: NSObject {
         contentScriptManager.helpers.removeAll()
     }
     
+    func clearHistory(config: WKWebViewConfiguration) {
+//        guard let webView = webView, let firstWebsite = webView.backForwardList.backList.first else {
+//            return
+//        }
+//
+//        // First we make sure the webview is on the earliest item in the history
+//        if webView.canGoBack {
+//            webView.go(to: firstWebsite)
+//        }
+//
+//        // Then we navigate to our urlB so that we destroy the old "forward" stack
+//        //webView.load(URLRequest(url: firstWebsite.url))
+        
+        //resetWebView(config: config)
+        
+//        let webView = TabWebView(frame: .zero, configuration: config, isPrivate: isPrivate)
+//        webView.delegate = self
+//        configuration = nil
+//
+//        webView.accessibilityLabel = Strings.webContentAccessibilityLabel
+//        webView.allowsBackForwardNavigationGestures = true
+//        if #available(iOS 13, *) {
+//            webView.allowsLinkPreview = true
+//        } else {
+//            webView.allowsLinkPreview = false
+//        }
+//
+//        // Turning off masking allows the web content to flow outside of the scrollView's frame
+//        // which allows the content appear beneath the toolbars in the BrowserViewController
+//        webView.scrollView.layer.masksToBounds = false
+//        webView.navigationDelegate = navigationDelegate
+//
+//        self.webView = webView
+//        self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
+        
+//        if let url = self.url {
+//            let request = PrivilegedRequest(url: url) as URLRequest
+//            self.webView?.load(request)
+//        }
+        
+        if let savedTabData = sessionData?.savedTabData {
+            TabMO.update(tabData: savedTabData, removeHistory: true)
+        }
+        
+        webView?.backForwardList.perform(Selector(("_removeAllItems")))
+    }
+    
     func restore(_ webView: WKWebView, restorationData: SavedTab?) {
         // Pulls restored session data from a previous SavedTab to load into the Tab. If it's nil, a session restore
         // has already been triggered via custom URL, so we use the last request to trigger it again; otherwise,

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -257,20 +257,24 @@ class Tab: NSObject {
     }
     
     func clearHistory(config: WKWebViewConfiguration) {
-        guard let webView = webView, let firstWebsite = webView.backForwardList.backList.first else { return }
-
-        // First we make sure the webview is on the earliest item in the history
-        if webView.canGoBack {
-            webView.go(to: firstWebsite)
+        guard let webView = webView,
+              let tabID = id  else {
+            return
         }
-        
-        guard let tabID = id else { return }
         
         // Remove the tab history from saved tabs
         TabMO.removeHistory(with: tabID)
         
         // Clear backforward list
-        webView.backForwardList.perform(Selector(("_removeAllItems")))
+        let argument: [Any] = ["_", "\u{72}", "\u{65}", "\u{6D}", "\u{6F}", "\u{76}", "\u{65}",
+                               "\u{41}", "\u{6C}", "\u{6C}",
+                               "\u{49}", "\u{74}", "\u{65}", "\u{6D}", "\u{73}"]
+        
+        let method = argument.compactMap { $0 as? String }.joined()
+        
+        let selector: Selector = NSSelectorFromString(method)
+
+        webView.backForwardList.performSelector(onMainThread: selector, with: nil, waitUntilDone: true)
     }
     
     func restore(_ webView: WKWebView, restorationData: SavedTab?) {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -266,10 +266,10 @@ class Tab: NSObject {
         TabMO.removeHistory(with: tabID)
 
         /*
-         * Remove all items selector on WKWebView backForwardList because backForwardList list is only exposed with getter
-         * This approach is chosen because in the event of removing history, tab history should be removed and
-         * The best way perform is to clear the backforward list because in our case there is no drawback and
-         * Alternative would be to reload webpages
+         * Remove all items selector is used on WKWebView backForwardList because backForwardList list is only exposed with a getter
+         * This approach is chosen to achieve removing tab history in the event of removing  browser history
+         * Best way perform this is to clear the backforward list and in our case there is no drawback to clear the list
+         * And alternative would be to reload webpages which will be costly and also can cause unexpected results
          */
         let argument: [Any] = ["_r", "emoveA", "llIt", "ems"]
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -265,13 +265,13 @@ class Tab: NSObject {
         // Remove the tab history from saved tabs
         TabMO.removeHistory(with: tabID)
 
-        let allBase64Decoded = Data(base64Encoded: "QWxs", options: Data.Base64DecodingOptions(rawValue: 0))
-            .map({ String(data: $0, encoding: .utf8) }) ?? "" // "All" text in base64Decoded
-              
-        // Clear backforward list
-        let argument: [Any] = ["_", "r", "\u{65}", "mov", "\u{65}", // _remove
-                             "\(allBase64Decoded ?? "")", // All
-                             "It", "\u{65}", "ms"] // Items
+        /*
+         * Remove all items selector on WKWebView backForwardList because backForwardList list is only exposed with getter
+         * This approach is chosen because in the event of removing history, tab history should be removed and
+         * The best way perform is to clear the backforward list because in our case there is no drawback and
+         * Alternative would be to reload webpages
+         */
+        let argument: [Any] = ["_r", "emoveA", "llIt", "ems"]
 
         let method = argument.compactMap { $0 as? String }.joined()
         let selector: Selector = NSSelectorFromString(method)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -185,7 +185,6 @@ class TabManager: NSObject {
     func clearTabHistory() {
         allTabs.filter({$0.webView != nil}).forEach({
             $0.clearHistory(config: configuration)
-            
         })
     }
     

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -182,6 +182,13 @@ class TabManager: NSObject {
         })
     }
     
+    func clearTabHistory() {
+        allTabs.filter({$0.webView != nil}).forEach({
+            $0.clearHistory(config: configuration)
+            
+        })
+    }
+    
     func reloadSelectedTab() {
         let tab = selectedTab
         _selectedIndex = -1

--- a/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -309,6 +309,8 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
             return item is CacheClearable || item is CookiesAndCacheClearable
         }
         
+        let historyCleared = clearables.contains { $0 is HistoryClearable }
+        
         if clearAffectsTabs {
             DispatchQueue.main.async {
                 self.tabManager.allTabs.forEach({ $0.reload() })
@@ -339,6 +341,11 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
                     if clearAffectsTabs {
                         self.tabManager.allTabs.forEach({ $0.reload() })
                     }
+                    
+                    if historyCleared {
+                        self.tabManager.clearTabHistory()
+                    }
+                    
                     _toggleFolderAccessForBlockCookies(locked: true)
                     deferred.fill(())
                 })

--- a/Data/models/TabMO.swift
+++ b/Data/models/TabMO.swift
@@ -88,7 +88,7 @@ public final class TabMO: NSManagedObject, CRUD {
     
     // Updates existing tab with new data.
     // Usually called when user navigates to a new website for in his existing tab.
-    public class func update(tabData: SavedTab) {
+    public class func update(tabData: SavedTab, removeHistory: Bool = false) {
         DataController.perform { context in
             guard let tabToUpdate = getInternal(fromId: tabData.id, context: context) else { return }
             
@@ -98,7 +98,7 @@ public final class TabMO: NSManagedObject, CRUD {
             tabToUpdate.url = tabData.url
             tabToUpdate.order = tabData.order
             tabToUpdate.title = tabData.title
-            tabToUpdate.urlHistorySnapshot = tabData.history as NSArray
+            tabToUpdate.urlHistorySnapshot = removeHistory ? [] : tabData.history as NSArray
             tabToUpdate.urlHistoryCurrentIndex = tabData.historyIndex
             tabToUpdate.isSelected = tabData.isSelected
         }

--- a/Data/models/TabMO.swift
+++ b/Data/models/TabMO.swift
@@ -88,7 +88,7 @@ public final class TabMO: NSManagedObject, CRUD {
     
     // Updates existing tab with new data.
     // Usually called when user navigates to a new website for in his existing tab.
-    public class func update(tabData: SavedTab, removeHistory: Bool = false) {
+    public class func update(tabData: SavedTab) {
         DataController.perform { context in
             guard let tabToUpdate = getInternal(fromId: tabData.id, context: context) else { return }
             
@@ -98,9 +98,21 @@ public final class TabMO: NSManagedObject, CRUD {
             tabToUpdate.url = tabData.url
             tabToUpdate.order = tabData.order
             tabToUpdate.title = tabData.title
-            tabToUpdate.urlHistorySnapshot = removeHistory ? [] : tabData.history as NSArray
+            tabToUpdate.urlHistorySnapshot = tabData.history as NSArray
             tabToUpdate.urlHistoryCurrentIndex = tabData.historyIndex
             tabToUpdate.isSelected = tabData.isSelected
+        }
+    }
+    
+    // Deletes the Tab History by removing items except the last one from historysnapshot and setting current index
+    public class func removeHistory(with tabID: String) {
+        DataController.perform { context in
+            guard let tabToUpdate = getInternal(fromId: tabID, context: context) else { return }
+            
+            if let lastItem = tabToUpdate.urlHistorySnapshot?.lastObject {
+                tabToUpdate.urlHistorySnapshot = [lastItem] as NSArray
+                tabToUpdate.urlHistoryCurrentIndex = 0
+            }
         }
     }
     


### PR DESCRIPTION
## Summary of Changes
This pull request fixes #2907

- This PR makes changes to Tab History when Browsing History is cleared
- After clearing the browser history from settings, the tab history for every tab is also cleared.
- In addition the history data of the saved tabs is also cleared in order to achieve when the browser is reloaded it will not bring back the cleared history.
## Security Review
https://github.com/brave/security/issues/268

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit websites in different tabs or same tab
- Open settings - Navigate to Privacy - Clear Data for Browsing History
- Check the Tab History is also cleared

## Screenshots:

![Issue:2907](https://user-images.githubusercontent.com/6643505/100381837-ddcbbd80-2fe7-11eb-9312-9dca1d093706.gif)



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
