### PR TITLE
Fix #3071: Load favicons on background thread, fix cell reusing.

### DIFF
--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -113,6 +113,32 @@ class SiteTableViewCell: TwoLineTableViewCell {
     }
 }
 
+class BookmarkTableViewCell: TwoLineTableViewCell {
+    /// Holds url domain for bookmarks or folder name for folders.
+    /// This property is used to see if the cell's image should be reused.
+    var domainOrFolderName: String?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+        guard let textLabel = textLabel, let detailTextLabel = detailTextLabel,
+              let imageView = imageView else { return }
+        
+        twoLineHelper.setUpViews(contentView,
+                                 textLabel: textLabel,
+                                 detailTextLabel: detailTextLabel,
+                                 imageView: imageView)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        twoLineHelper.layoutSubviews(accessoryWidth: self.contentView.frame.origin.x)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 class TwoLineHeaderFooterView: UITableViewHeaderFooterView {
     fileprivate let twoLineHelper = TwoLineCellHelper()
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3071 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Import large amount of bookmarks, can use file from here https://github.com/brave/brave-ios/issues/3070
Scroll through bookmarks, see if there is a lag

This also fixed a bug where sometimes folder had backgrounds colors or favicons were incorrect

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
