### PR TITLE
Fix #3046: Add universal link support for the Brave VPN page.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		0A7B5D6722689C5D00AADF22 /* AddEditHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7B5D6622689C5D00AADF22 /* AddEditHeaderView.swift */; };
 		0A7B5D702269E72C00AADF22 /* BookmarkSaveLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7B5D6F2269E72C00AADF22 /* BookmarkSaveLocation.swift */; };
 		0A7B5D722269E7AD00AADF22 /* BookmarkEditMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7B5D712269E7AD00AADF22 /* BookmarkEditMode.swift */; };
+		0A8A6225257905E300B035F4 /* UniversalLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8A6224257905E300B035F4 /* UniversalLinkManager.swift */; };
+		0A8A623025790D0900B035F4 /* UniversalLinkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8A622F25790D0900B035F4 /* UniversalLinkManagerTests.swift */; };
 		0A8ABE19247435E30062DA81 /* BraveVPNCommonUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8ABE18247435E30062DA81 /* BraveVPNCommonUI.swift */; };
 		0A8C6993225BC7B100988715 /* ToolbarUrlActionsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8C6992225BC7B100988715 /* ToolbarUrlActionsProtocol.swift */; };
 		0A8C69AB225CFCAF00988715 /* AddEditBookmarkTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8C69AA225CFCAF00988715 /* AddEditBookmarkTableViewController.swift */; };
@@ -1356,6 +1358,8 @@
 		0A7B5D6F2269E72C00AADF22 /* BookmarkSaveLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSaveLocation.swift; sourceTree = "<group>"; };
 		0A7B5D712269E7AD00AADF22 /* BookmarkEditMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkEditMode.swift; sourceTree = "<group>"; };
 		0A86268423571F3300FD4C11 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Storage.strings; sourceTree = "<group>"; };
+		0A8A6224257905E300B035F4 /* UniversalLinkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkManager.swift; sourceTree = "<group>"; };
+		0A8A622F25790D0900B035F4 /* UniversalLinkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkManagerTests.swift; sourceTree = "<group>"; };
 		0A8ABE18247435E30062DA81 /* BraveVPNCommonUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveVPNCommonUI.swift; sourceTree = "<group>"; };
 		0A8C6992225BC7B100988715 /* ToolbarUrlActionsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarUrlActionsProtocol.swift; sourceTree = "<group>"; };
 		0A8C69AA225CFCAF00988715 /* AddEditBookmarkTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkTableViewController.swift; sourceTree = "<group>"; };
@@ -4399,6 +4403,7 @@
 				5E4845C122DE3DF800372022 /* WindowRenderHelperScript.swift */,
 				0A19365323508756002E2B81 /* LinkPreviewViewController.swift */,
 				0A66550923E9D9750047EF2A /* UserAgent.swift */,
+				0A8A6224257905E300B035F4 /* UniversalLinkManager.swift */,
 			);
 			indentWidth = 4;
 			path = Browser;
@@ -4732,6 +4737,7 @@
 				0A66550B23E9E04F0047EF2A /* UserAgentTests.swift */,
 				275965E124EEC4EA0051A827 /* FeedFillStrategyTests.swift */,
 				2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */,
+				0A8A622F25790D0900B035F4 /* UniversalLinkManagerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -6079,6 +6085,7 @@
 				0A4BEFD1221E115B0005551A /* NetworkSessionMock.swift in Sources */,
 				0A43293B21B1C8D10041625B /* FifoDict.swift in Sources */,
 				FA6B2AC21D41F02D00429414 /* Punycode.swift in Sources */,
+				0A8A6225257905E300B035F4 /* UniversalLinkManager.swift in Sources */,
 				D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */,
 				0A7B5D702269E72C00AADF22 /* BookmarkSaveLocation.swift in Sources */,
 				0B3E7D951B27A7CE00E2E84D /* AboutHomeHandler.swift in Sources */,
@@ -6461,6 +6468,7 @@
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				5E9288CA22DF864C007BE7A6 /* TabSessionTests.swift in Sources */,
 				0A4214E921A6EBCF006B8E39 /* SafeBrowsingTests.swift in Sources */,
+				0A8A623025790D0900B035F4 /* UniversalLinkManagerTests.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */,
 				0A4BEFDE221F03C80005551A /* NetworkManagerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -549,19 +549,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         }
     }
 
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity,
+                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
 
-        // If the `NSUserActivity` has a `webpageURL`, it is either a deep link or an old history item
-        // reached via a "Spotlight" search before we began indexing visited pages via CoreSpotlight.
         if let url = userActivity.webpageURL {
-            let query = url.getQuery()
-            
-            // Per Adjust documenation, https://docs.adjust.com/en/universal-links/#running-campaigns-through-universal-links,
-            // it is recommended that links contain the `deep_link` query parameter. This link will also
-            // be url encoded.
-            if let deepLink = query["deep_link"]?.removingPercentEncoding, let url = URL(string: deepLink) {
-                browserViewController.switchToTabForURLOrOpen(url, isPrivileged: true)
+            switch UniversalLinkManager.universalLinkType(for: url, checkPath: false) {
+            case .buyVPN:
+                browserViewController.presentCorrespondingVPNViewController()
                 return true
+            case .none:
+                break
             }
 
             browserViewController.switchToTabForURLOrOpen(url, isPrivileged: true)

--- a/Client/Entitlements/Beta.entitlements
+++ b/Client/Entitlements/Beta.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vpn.brave.com</string>
+	</array>
 	<key>com.apple.developer.networking.vpn.api</key>
 	<array>
 		<string>allow-vpn</string>

--- a/Client/Entitlements/Debug.entitlements
+++ b/Client/Entitlements/Debug.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vpn.brave.com</string>
+	</array>
 	<key>com.apple.developer.networking.vpn.api</key>
 	<array>
 		<string>allow-vpn</string>

--- a/Client/Entitlements/Dev.entitlements
+++ b/Client/Entitlements/Dev.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vpn.brave.com</string>
+	</array>
 	<key>com.apple.developer.networking.vpn.api</key>
 	<array>
 		<string>allow-vpn</string>

--- a/Client/Entitlements/Enterprise.entitlements
+++ b/Client/Entitlements/Enterprise.entitlements
@@ -4,14 +4,18 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vpn.brave.com</string>
+	</array>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>NDEF</string>
+		<string>TAG</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(MOZ_BUNDLE_ID).unique</string>
 	</array>
-        <key>com.apple.developer.nfc.readersession.formats</key>
-        <array>
-                <string>NDEF</string>
-                <string>TAG</string>
-        </array>
 </dict>
 </plist>

--- a/Client/Entitlements/Release (AppStore).entitlements
+++ b/Client/Entitlements/Release (AppStore).entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vpn.brave.com</string>
+	</array>
 	<key>com.apple.developer.networking.vpn.api</key>
 	<array>
 		<string>allow-vpn</string>
@@ -13,11 +17,11 @@
 		<string>NDEF</string>
 		<string>TAG</string>
 	</array>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(MOZ_BUNDLE_ID)</string>
 	</array>
-	<key>com.apple.developer.web-browser</key>
-	<true/>
 </dict>
 </plist>

--- a/Client/Entitlements/Release.entitlements
+++ b/Client/Entitlements/Release.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vpn.brave.com</string>
+	</array>
 	<key>com.apple.developer.networking.vpn.api</key>
 	<array>
 		<string>allow-vpn</string>

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1034,23 +1034,30 @@ class BrowserViewController: UIViewController {
         }
         
         popup.enableVPNTapped = { [weak self] in
-            guard let vc = BraveVPN.vpnState.enableVPNDestinationVC else { return }
-            let nav = DismissableNavigationViewController(rootViewController: vc)
-            nav.navigationBar.topItem?.leftBarButtonItem =
-                .init(barButtonSystemItem: .cancel, target: nav, action: #selector(nav.dismissViewController))
-            
-            let idiom = UIDevice.current.userInterfaceIdiom
-            if #available(iOS 13.0, *) {
-                nav.modalPresentationStyle = idiom == .phone ? .pageSheet : .formSheet
-            } else {
-                nav.modalPresentationStyle = idiom == .phone ? .fullScreen : .formSheet
-            }
-            self?.present(nav, animated: true)
+            self?.presentCorrespondingVPNViewController()
         }
         
         present(popup, animated: false)
         
         showedPopup.value = true
+    }
+    
+    /// Shows a vpn screen based on vpn state.
+    func presentCorrespondingVPNViewController() {
+        guard let vc = BraveVPN.vpnState.enableVPNDestinationVC else { return }
+        let nav = SettingsNavigationController(rootViewController: vc)
+        nav.navigationBar.topItem?.leftBarButtonItem =
+            .init(barButtonSystemItem: .cancel, target: nav, action: #selector(nav.done))
+        let idiom = UIDevice.current.userInterfaceIdiom
+        
+        UIDevice.current.forcePortraitIfIphone(for: UIApplication.shared)
+        
+        if #available(iOS 13.0, *) {
+            nav.modalPresentationStyle = idiom == .phone ? .pageSheet : .formSheet
+        } else {
+            nav.modalPresentationStyle = idiom == .phone ? .fullScreen : .formSheet
+        }
+        present(nav, animated: true)
     }
 
     // THe logic for shouldShowWhatsNewTab is as follows: If we do not have the LatestAppVersionProfileKey in

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -142,6 +142,17 @@ extension BrowserViewController: WKNavigationDelegate {
             decisionHandler(.cancel)
             return
         }
+        
+        // Universal links do not work if the request originates from the app, manual handling is required.
+        if let mainDocURL = navigationAction.request.mainDocumentURL,
+           let universalLink = UniversalLinkManager.universalLinkType(for: mainDocURL, checkPath: true) {
+            switch universalLink {
+            case .buyVPN:
+                presentCorrespondingVPNViewController()
+                decisionHandler(.cancel)
+                return
+            }
+        }
 
         // First special case are some schemes that are about Calling. We prompt the user to confirm this action. This
         // gives us the exact same behaviour as Safari.

--- a/Client/Frontend/Browser/UniversalLinkManager.swift
+++ b/Client/Frontend/Browser/UniversalLinkManager.swift
@@ -1,0 +1,48 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// A helper structure to deal with universal link handling.
+struct UniversalLinkManager {
+    enum LinkType: CaseIterable {
+        // https://vpn.brave.com/.well-known/apple-app-site-association
+        case buyVPN
+        
+        var associatedDomain: String {
+            switch self {
+            case .buyVPN: return "vpn.brave.com"
+            }
+        }
+        
+        var path: String {
+            switch self {
+            case .buyVPN: return "/dl/"
+            }
+        }
+    }
+    
+    /// Returns a universal link type for given URL. Returns nil if the URL is not a universal link
+    ///
+    /// - parameter url: URL to to check against.
+    /// - parameter checkPath: If false, only url host is checked, if true we check for both host and path matching.
+    /// This is because we have to handle universal link from 2 places. When a user opens it from another app, path checking is not needed
+    /// since this is handled by the `AppDelegate`. If the link is opened from the Brave app itself and it matches the associated domain
+    /// app delegate doesn't handle such case, it must be handled manually.
+    static func universalLinkType(for url: URL, checkPath: Bool) -> LinkType? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let host = components.host else { return nil }
+        
+        if checkPath {
+            for type in LinkType.allCases where type.associatedDomain == host {
+                if components.path.starts(with: type.path) { return type }
+            }
+        } else {
+            return LinkType.allCases.first(where: { $0.associatedDomain == host })
+        }
+        
+        return nil
+    }
+}

--- a/ClientTests/UniversalLinkManagerTests.swift
+++ b/ClientTests/UniversalLinkManagerTests.swift
@@ -1,0 +1,35 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import Client
+
+class UniversalLinkManagerTests: XCTestCase {
+    private typealias ULM = UniversalLinkManager
+
+    func testVpnUniversalLink() throws {
+        // Good cases
+        ["https://vpn.brave.com/dl/test": true,
+         "https://vpn.brave.com/dl/test2": false,
+         "http://vpn.brave.com/dl/test3": true,
+         "https://vpn.brave.com/dl/test/123": true,
+         "https://vpn.brave.com/path/does/not/matter": false]
+            .forEach {
+                XCTAssertEqual(ULM.LinkType.buyVPN,
+                               ULM.universalLinkType(for: URL(string: $0.key)!, checkPath: $0.value))
+            }
+        
+        // Bad cases
+        ["https://vpn.brave.com/bad/dl/test/123": true,
+         "https://brave.com/dl/test": true,
+         "https://example.com": false,
+         "https://example.com/dl/test": true,
+         "https://vpn.brave.com/dl": true,
+         "https://vpn.brave.com/dlonger/test": true]
+            .forEach {
+                XCTAssertNil(ULM.universalLinkType(for: URL(string: $0.key)!, checkPath: $0.value))
+            }
+    }
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3046 
Security review https://github.com/brave/security/issues/266

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
External app test:
- Install Brave app, open it
- Open safari, go to `https://gist.github.com/iccub/1c864bb424a65c0c5a1749f52c6f5a68`
- tap on the vpn link
- Verify that after tapping on the link it took you to the Brave app and opened a buy-vpn screen

^ this should also work for other apps link Notes, mail, messages etc

Open from Brave test:
- Install Brave app
- go to `https://gist.github.com/iccub/1c864bb424a65c0c5a1749f52c6f5a68`
- tap on the vpn link
- verify that buy-vpn screen showed up

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
