### PR TITLE
Fix #3104: Generate no-padded build numbers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-appcenter (1.10.0)
+    fastlane-plugin-appcenter (1.11.0)
     gh_inspector (1.1.3)
     google-api-client (0.38.0)
       addressable (~> 2.5, >= 2.5.1)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -157,9 +157,9 @@ platform :ios do
 
   desc "Updates the project's build number to be the next number acceptable by TestFlight. Takes the following arguments:"
   lane :set_build_number do |options|
-    dateFormat = "%y.%m.%d.%H"
+    dateFormat = "%y.%-m.%-d.%-H"
     # Allows minute override in case two betas within same hour are required
-    dateFormat += ".%M" if options[:minutes_in_build_number]
+    dateFormat += ".%-M" if options[:minutes_in_build_number]
     formattedBuildNumber = Time.now.getutc.strftime(dateFormat)
     sh("echo GENERATED_BUILD_ID=#{formattedBuildNumber} > #{LOCAL_PATH}/BuildId.xcconfig")
   end


### PR DESCRIPTION
Also updates fastlane plugins

Changes Ruby time format to use no-padded instead of 0-padded numbers (i.e. "1" instead of "01")

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3104

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
