### PR TITLE
Fix #3099 - Chromium using a lot of space on users devices.

### DIFF
--- a/Client/Frontend/Sync/BraveCore/BraveCoreImportExportUtility.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveCoreImportExportUtility.swift
@@ -208,9 +208,9 @@ private enum ParsingError: String, Error {
 // MARK: - Private
 
 extension Bookmark {
-    fileprivate func toChromiumExportedBookmark() -> BraveExportedBookmark {
+    fileprivate func toChromiumExportedBookmark() -> BookmarkNode {
         // Tail recursion to map children..
-        return BraveExportedBookmark(
+        return BookmarkNode(
             title: self.isFolder ? self.customTitle ?? "(No Title)" : self.title ?? "(No Title)",
             id: Int64(self.order),
             guid: UUID().uuidString.lowercased(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1327,8 +1327,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.77.tgz",
-      "integrity": "sha512-XH8AfHmrPBp5wmILUgWx9/Bq+ttw1EXuK8QNjfCQtvuYJVQ74hE3OOTWA48IxweWd7h9tX45sApUyfi8c6kqVw=="
+      "version": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.78.tgz",
+      "integrity": "sha512-XdPQMOAXCncVauJs2gzkaq/KFhqV3ScGCwFCAtjFlmM/bqHpcMH/GnVqhsjWILm37J08P0sJa3NTngz04n/a9g=="
     },
     "brave-crypto": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^3.3.10",
-    "brave-core-ios": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.77.tgz"
+    "brave-core-ios": "https://github.com/brave/brave-ios/releases/download/v1.22-pre-release/brave-core-ios-1.16.78.tgz"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
## Summary of Changes
- Renamed `BraveExportedBookmark` to `BookmarkNode` so that it works with the 1.16.x uplift.
- Dependent on https://github.com/brave/brave-core/pull/7355 which is Dependent on: https://github.com/brave/brave-core/pull/7349

- Fixes Browser-Metrics issue where a new file is created every time and is 4.2MB in size.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3099

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Launch the Appstore 1.21 or Testflight 1.21 application, kill it. Launch again, kill it. Repeat enough times and observe that the size of that version increases ~4.2MB each time.
2. Repeat the same steps for this version and verify that the size does NOT increase. Alternatively, use Xcode to view the `Application Support` directory to see that there are no new files being created.
3. Install Appstore version, repeatedly launch and kill after loading. Verify large size. Install new version as an UPGRADE and verify that the size decreased.

1. Verify Import/Export bookmarks still works.
2. Small sanity check for migration from old CoreData bookmarks.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
