### PR TITLE
Fix #3116: Correctly show shields popover on error pages

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2229,8 +2229,11 @@ extension BrowserViewController: TopToolbarDelegate {
     }
     
     func topToolbarDidTapBraveShieldsButton(_ topToolbar: TopToolbarView) {
-        guard let selectedTab = tabManager.selectedTab else { return }
-        if selectedTab.url?.isLocalUtility == true {
+        guard let selectedTab = tabManager.selectedTab, var url = selectedTab.url else { return }
+        if url.isErrorPageURL, let originalURL = url.originalURLFromErrorURL {
+            url = originalURL
+        }
+        if url.isLocalUtility {
             return
         }
         let shields = ShieldsViewController(tab: selectedTab)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3116

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit `badssl.com`, verify on error pages that you can still open the shields panel and it shows the correct URL

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
