### PR TITLE
Fix #3127: Only count blocked URLs once per page in shield stats

### DIFF
--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
@@ -18,6 +18,7 @@ extension ContentBlockerHelper: TabContentScript {
 
     func clearPageStats() {
         stats = TPPageStats()
+        blockedRequests.removeAll()
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
@@ -57,6 +58,11 @@ extension ContentBlockerHelper: TabContentScript {
                         return
                     }
                 }
+                if self.blockedRequests.contains(url) {
+                    return
+                }
+                
+                self.blockedRequests.insert(url)
                 self.stats = self.stats.create(byAddingListItem: listItem)
                 
                 // Increase global stats (here due to BlocklistName being in Client and BraveGlobalShieldStats being

--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -73,6 +73,8 @@ class ContentBlockerHelper {
     }
     
     var statsDidChange: ((TPPageStats) -> Void)?
+    
+    var blockedRequests: Set<URL> = []
 
     static private var blockImagesRule: WKContentRuleList?
     static var heavyInitHasRunOnce = false


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3127

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

<img width="925" alt="image" src="https://user-images.githubusercontent.com/529104/101519406-245ad980-3951-11eb-9e15-6ee84b60a455.png">

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
