### PR TITLE
Fix #3113: Fetch adblock data every 6 hours.

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -478,6 +478,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         if let authInfo = KeychainWrapper.sharedAppContainerKeychain.authenticationInfo(), authInfo.isPasscodeRequiredImmediately {
             authenticator?.willEnterForeground()
         }
+        
+        AdblockResourceDownloader.shared.startLoading()
     }
     
     func applicationWillResignActive(_ application: UIApplication) {

--- a/Client/Frontend/Settings/AdblockDebugMenuTableViewController.swift
+++ b/Client/Frontend/Settings/AdblockDebugMenuTableViewController.swift
@@ -22,6 +22,7 @@ class AdblockDebugMenuTableViewController: TableViewController {
             if listNames.isEmpty { return }
             
             self.dataSource.sections = [self.actionsSection,
+                                        self.fetchSection,
                                         self.datesSection,
                                         self.bundledListsSection(names: listNames),
                                         self.downloadedListsSection(names: listNames)]
@@ -40,6 +41,19 @@ class AdblockDebugMenuTableViewController: TableViewController {
                 }
                 }, cellClass: ButtonCell.self)
         ]
+        
+        return section
+    }
+    
+    private var fetchSection: Section {
+        var section = Section(footer: "Last time we pinged the server for new data. If adblock list hasn't changed `Last Time Updated` section does not update.")
+        let dateFormatter = DateFormatter().then {
+            $0.dateStyle = .short
+            $0.timeStyle = .short
+        }
+
+        section.rows = [.init(text: "Last fetch time", detailText:
+                                dateFormatter.string(from: AdblockResourceDownloader.shared.lastFetchDate))]
         
         return section
     }

--- a/Client/WebFilters/AdblockResourceDownloader.swift
+++ b/Client/WebFilters/AdblockResourceDownloader.swift
@@ -34,9 +34,19 @@ class AdblockResourceDownloader {
         Preferences.Shields.useRegionAdBlock.observe(from: self)
     }
     
+    /// Initialized with year 1970 to force adblock fetch at first launch.
+    private(set) var lastFetchDate = Date(timeIntervalSince1970: 0)
+    
     func startLoading() {
-        AdblockResourceDownloader.shared.regionalAdblockResourcesSetup()
-        AdblockResourceDownloader.shared.generalAdblockResourcesSetup()
+        let now = Date()
+        let fetchInterval = AppConstants.buildChannel.isPublic ? 6.hours : 10.minutes
+        
+        if now.timeIntervalSince(lastFetchDate) >= fetchInterval {
+            lastFetchDate = now
+            
+            AdblockResourceDownloader.shared.regionalAdblockResourcesSetup()
+            AdblockResourceDownloader.shared.generalAdblockResourcesSetup()
+        }
     }
     
     func regionalAdblockResourcesSetup() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3113 

Security review https://github.com/brave/security/issues/269

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Launch the app
2. Open app settings -> `adblock debug`
3. Write down `last fetch time` value
4. On dev build wait 10+ minutes, on prod 6+ hours
5. Close the app or switch to another app, no need to remove it from memory
6. Open it again, open `adblock debug`
7. Verify that `last fetch` time value changed

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
