### PR TITLE
Fix#2790: Unable to save Gif images on iOS 12

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3017,42 +3017,11 @@ extension BrowserViewController: WKUIDelegate {
                 
                 if let url = elements.image {
                     actions.append(UIAction(title: Strings.saveImageActionTitle, identifier: UIAction.Identifier("linkContextMenu.saveImage")) { _ in
-                        self.getData(url) { [weak self] data in
-                            guard let self = self,
-                                  let image = data.isGIF ? UIImage.imageFromGIFDataThreadSafe(data) : UIImage.imageFromDataThreadSafe(data) else { return }
-
-                            UIImageWriteToSavedPhotosAlbum(image, self, #selector(self.image(image:didFinishSavingwithError:contextInfo:)), nil)
-                        }
+                        self.writePhotoToAlbumAction(url)
                     })
 
                     actions.append(UIAction(title: Strings.copyImageActionTitle, identifier: UIAction.Identifier("linkContextMenu.copyImage")) { _ in
-                        // put the actual image on the clipboard
-                        // do this asynchronously just in case we're in a low bandwidth situation
-                        let pasteboard = UIPasteboard.general
-                        pasteboard.url = url as URL
-                        let changeCount = pasteboard.changeCount
-                        let application = UIApplication.shared
-                        var taskId: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier(rawValue: 0)
-                        taskId = application.beginBackgroundTask(expirationHandler: {
-                            application.endBackgroundTask(taskId)
-                        })
-
-                        URLSession(configuration: .default, delegate: nil, delegateQueue: .main).dataTask(with: url, completionHandler: { data, response, error in
-                            if let response = response as? HTTPURLResponse {
-                                if !(200..<300).contains(response.statusCode) {
-                                    return application.endBackgroundTask(taskId)
-                                }
-                            }
-                                                    
-                            // Only set the image onto the pasteboard if the pasteboard hasn't changed since
-                            // fetching the image; otherwise, in low-bandwidth situations,
-                            // we might be overwriting something that the user has subsequently added.
-                            if changeCount == pasteboard.changeCount, let imageData = data, error == nil {
-                                pasteboard.addImageWithData(imageData, forURL: url)
-                            }
-                            
-                            application.endBackgroundTask(taskId)
-                        }).resume()
+                        self.copyImageClipBoardAction(url)
                     })
 
                     actions.append(UIAction(title: Strings.copyImageActionTitle, identifier: UIAction.Identifier("linkContextMenu.copyImageLink")) { _ in
@@ -3192,45 +3161,12 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             actionSheetController.addAction(openInNewTabAction, accessibilityIdentifier: "linkContextMenu.openImageInNewTab")
 
             let saveImageAction = UIAlertAction(title: Strings.saveImageActionTitle, style: .default) { _ in
-                self.getData(url) { [weak self] data in
-                    guard let self = self, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
-                        return
-                    }
-                    
-                    UIImageWriteToSavedPhotosAlbum(image, self, #selector(self.image(image:didFinishSavingwithError:contextInfo:)), nil)
-                }
+                self.writePhotoToAlbumAction(url)
             }
             actionSheetController.addAction(saveImageAction, accessibilityIdentifier: "linkContextMenu.saveImage")
 
             let copyAction = UIAlertAction(title: Strings.copyImageActionTitle, style: .default) { _ in
-                // put the actual image on the clipboard
-                // do this asynchronously just in case we're in a low bandwidth situation
-                let pasteboard = UIPasteboard.general
-                pasteboard.url = url as URL
-                let changeCount = pasteboard.changeCount
-                let application = UIApplication.shared
-                var taskId: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier(rawValue: 0)
-                taskId = application.beginBackgroundTask(expirationHandler: {
-                    application.endBackgroundTask(taskId)
-                })
-                
-                URLSession(configuration: .default, delegate: nil, delegateQueue: .main).dataTask(with: url, completionHandler: { data, response, error in
-                    
-                    if let response = response as? HTTPURLResponse {
-                        if !(200..<300).contains(response.statusCode) {
-                            return application.endBackgroundTask(taskId)
-                        }
-                    }
-                    
-                    // Only set the image onto the pasteboard if the pasteboard hasn't changed since
-                    // fetching the image; otherwise, in low-bandwidth situations,
-                    // we might be overwriting something that the user has subsequently added.
-                    if changeCount == pasteboard.changeCount, let imageData = data, error == nil {
-                        pasteboard.addImageWithData(imageData, forURL: url)
-                    }
-                    
-                    application.endBackgroundTask(taskId)
-                }).resume()
+                self.copyImageClipBoardAction(url)
             }
             actionSheetController.addAction(copyAction, accessibilityIdentifier: "linkContextMenu.copyImage")
         }
@@ -3274,6 +3210,46 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     func contextMenuHelper(_ contextMenuHelper: ContextMenuHelper, didCancelGestureRecognizer: UIGestureRecognizer) {
         displayedPopoverController?.dismiss(animated: true) {
             self.displayedPopoverController = nil
+        }
+    }
+    
+    private func copyImageClipBoardAction(_ url: URL) {
+        // put the actual image on the clipboard
+        // do this asynchronously just in case we're in a low bandwidth situation
+        let pasteboard = UIPasteboard.general
+        pasteboard.url = url as URL
+        let changeCount = pasteboard.changeCount
+        let application = UIApplication.shared
+        var taskId: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier(rawValue: 0)
+        taskId = application.beginBackgroundTask(expirationHandler: {
+            application.endBackgroundTask(taskId)
+        })
+        
+        URLSession(configuration: .default, delegate: nil, delegateQueue: .main).dataTask(with: url, completionHandler: { data, response, error in
+            
+            if let response = response as? HTTPURLResponse {
+                if !(200..<300).contains(response.statusCode) {
+                    return application.endBackgroundTask(taskId)
+                }
+            }
+            
+            // Only set the image onto the pasteboard if the pasteboard hasn't changed since
+            // fetching the image; otherwise, in low-bandwidth situations,
+            // we might be overwriting something that the user has subsequently added.
+            if changeCount == pasteboard.changeCount, let imageData = data, error == nil {
+                pasteboard.addImageWithData(imageData, forURL: url)
+            }
+            
+            application.endBackgroundTask(taskId)
+        }).resume()
+    }
+    
+    private func writePhotoToAlbumAction(_ url: URL) {
+        self.getData(url) { [weak self] data in
+            guard let self = self,
+                  let image = data.isGIF ? UIImage.imageFromGIFDataThreadSafe(data) : UIImage.imageFromDataThreadSafe(data) else { return }
+
+            UIImageWriteToSavedPhotosAlbum(image, self, #selector(self.image(image:didFinishSavingwithError:contextInfo:)), nil)
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3015,17 +3015,17 @@ extension BrowserViewController: WKUIDelegate {
                 guard let contextHelper = currentTab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper,
                 let elements = contextHelper.elements else { return nil }
                 
-                if let url = elements.image {
+                if let imageURL = elements.image {
                     actions.append(UIAction(title: Strings.saveImageActionTitle, identifier: UIAction.Identifier("linkContextMenu.saveImage")) { _ in
-                        self.writePhotoToAlbumAction(url)
+                        self.writePhotoToAlbumAction(imageURL)
                     })
 
                     actions.append(UIAction(title: Strings.copyImageActionTitle, identifier: UIAction.Identifier("linkContextMenu.copyImage")) { _ in
-                        self.copyImageClipBoardAction(url)
+                        self.copyImageClipBoardAction(imageURL)
                     })
 
                     actions.append(UIAction(title: Strings.copyImageActionTitle, identifier: UIAction.Identifier("linkContextMenu.copyImageLink")) { _ in
-                        UIPasteboard.general.url = url as URL
+                        UIPasteboard.general.url = imageURL as URL
                     })
                 }
             }
@@ -3160,13 +3160,13 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             }
             actionSheetController.addAction(openInNewTabAction, accessibilityIdentifier: "linkContextMenu.openImageInNewTab")
 
-            let saveImageAction = UIAlertAction(title: Strings.saveImageActionTitle, style: .default) { _ in
-                self.writePhotoToAlbumAction(url)
+            let saveImageAction = UIAlertAction(title: Strings.saveImageActionTitle, style: .default) { [weak self] _ in
+                self?.writePhotoToAlbumAction(url)
             }
             actionSheetController.addAction(saveImageAction, accessibilityIdentifier: "linkContextMenu.saveImage")
 
-            let copyAction = UIAlertAction(title: Strings.copyImageActionTitle, style: .default) { _ in
-                self.copyImageClipBoardAction(url)
+            let copyAction = UIAlertAction(title: Strings.copyImageActionTitle, style: .default) { [weak self] _ in
+                self?.copyImageClipBoardAction(url)
             }
             actionSheetController.addAction(copyAction, accessibilityIdentifier: "linkContextMenu.copyImage")
         }


### PR DESCRIPTION
For linkContextMenu saveImage - copyImage action is not handled properly for gifs in contextMenuConfigurationForElement.

## Summary of Changes

This pull request fixes #2790

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Same as explained in the ticket
Save a gif image in context menu while using iOS 12

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
