### PR TITLE
Fix #3155 - Remove RTL characters from filenames

### DIFF
--- a/BraveSharedTests/StringExtensionTests.swift
+++ b/BraveSharedTests/StringExtensionTests.swift
@@ -42,4 +42,12 @@ class StringExtensionTests: XCTestCase {
         let wordsWithPunctuation = "\"It's a wonderful life—isn't it…\""
         XCTAssertEqual(wordsWithPunctuation.words, ["It's", "a", "wonderful", "life", "isn't", "it"])
     }
+    
+    func testRemoveUnicodeFromFilename() {
+        let file = "foo-\u{200F}cod.jpg" // Unicode RTL-switch code, becomes "foo-gpj.doc"
+        let nounicode = "foo-cod.jpg"
+        XCTAssert(file != nounicode)
+        let strip = HTTPDownload.stripUnicode(fromFilename: file)
+        XCTAssert(strip == nounicode)
+    }
 }

--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -69,6 +69,12 @@ class HTTPDownload: Download {
     
     private var resumeData: Data?
     
+    // Used to avoid name spoofing using Unicode RTL char to change file extension
+    public static func stripUnicode(fromFilename string: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet.punctuationCharacters)
+        return string.components(separatedBy: allowed.inverted).joined()
+     }
+    
     init(preflightResponse: URLResponse, request: URLRequest) {
         self.preflightResponse = preflightResponse
         self.request = request
@@ -76,7 +82,7 @@ class HTTPDownload: Download {
         super.init()
         
         if let filename = preflightResponse.suggestedFilename {
-            self.filename = filename
+            self.filename = HTTPDownload.stripUnicode(fromFilename: filename)
         }
         
         if let mimeType = preflightResponse.mimeType {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3155 

Refer to: https://github.com/mozilla-mobile/firefox-ios/pull/6942/files

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
Specified here: https://github.com/brave/internal/issues/743


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
