### PR TITLE
Fix #3158: Fix test failure testRemoveUnicodeFromFilename

### DIFF
--- a/BraveSharedTests/StringExtensionTests.swift
+++ b/BraveSharedTests/StringExtensionTests.swift
@@ -42,12 +42,4 @@ class StringExtensionTests: XCTestCase {
         let wordsWithPunctuation = "\"It's a wonderful life—isn't it…\""
         XCTAssertEqual(wordsWithPunctuation.words, ["It's", "a", "wonderful", "life", "isn't", "it"])
     }
-    
-    func testRemoveUnicodeFromFilename() {
-        let file = "foo-\u{200F}cod.jpg" // Unicode RTL-switch code, becomes "foo-gpj.doc"
-        let nounicode = "foo-cod.jpg"
-        XCTAssert(file != nounicode)
-        let strip = HTTPDownload.stripUnicode(fromFilename: file)
-        XCTAssert(strip == nounicode)
-    }
 }

--- a/Client/Frontend/Browser/DownloadQueue.swift
+++ b/Client/Frontend/Browser/DownloadQueue.swift
@@ -71,8 +71,11 @@ class HTTPDownload: Download {
     
     // Used to avoid name spoofing using Unicode RTL char to change file extension
     public static func stripUnicode(fromFilename string: String) -> String {
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet.punctuationCharacters)
-        return string.components(separatedBy: allowed.inverted).joined()
+        let validFilenameSet = CharacterSet(charactersIn: ":/")
+                                .union(.newlines)
+                                .union(.controlCharacters)
+                                .union(.illegalCharacters)
+        return string.components(separatedBy: validFilenameSet).joined()
      }
     
     init(preflightResponse: URLResponse, request: URLRequest) {

--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import XCTest
+@testable import Client
 
 class StringExtensionsTests: XCTestCase {
 
@@ -58,5 +59,12 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("tEST".capitalizeFirstLetter, "TEST")
         XCTAssertEqual("test test".capitalizeFirstLetter, "Test test")
     }
-
+    
+    func testRemoveUnicodeFromFilename() {
+        let file = "foo-\u{200F}cod.jpg" // Unicode RTL-switch code, becomes "foo-gpj.doc"
+        let nounicode = "foo-cod.jpg"
+        XCTAssert(file != nounicode)
+        let strip = HTTPDownload.stripUnicode(fromFilename: file)
+        XCTAssert(strip == nounicode)
+    }
 }

--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -61,10 +61,20 @@ class StringExtensionsTests: XCTestCase {
     }
     
     func testRemoveUnicodeFromFilename() {
-        let file = "foo-\u{200F}cod.jpg" // Unicode RTL-switch code, becomes "foo-gpj.doc"
-        let nounicode = "foo-cod.jpg"
-        XCTAssert(file != nounicode)
-        let strip = HTTPDownload.stripUnicode(fromFilename: file)
-        XCTAssert(strip == nounicode)
+        let files = [
+            "foo-\u{200F}cod.jpg",
+            "regedt\u{202e}gpj.apk",
+        ]
+        
+        let nounicodes = [
+            "foo-cod.jpg",
+            "regedtgpj.apk"
+        ]
+        
+        for (file, nounicode) in zip(files, nounicodes) {
+            XCTAssert(file != nounicode)
+            let strip = HTTPDownload.stripUnicode(fromFilename: file)
+            XCTAssert(strip == nounicode)
+        }
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3158 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
CI should pass

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
