### PR TITLE
[WIP] Fix#936: Add Support for OpenSearch - Auto/ Manual

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -42,6 +42,8 @@ extension Strings {
                                              bundle: .braveShared, value: "Learn More", comment: "")
     public static let termsOfService = NSLocalizedString("TermsOfService", tableName: "BraveShared",
                                                   bundle: .braveShared, value: "Terms of Service", comment: "")
+    public static let title = NSLocalizedString("Title", tableName: "BraveShared",
+                                                  bundle: .braveShared, value: "Title", comment: "")
     public static let monthAbbreviation =
         NSLocalizedString("monthAbbreviation", tableName: "BraveShared",
                           bundle: .braveShared, value: "mo.", comment: "Abbreviation for 'Month', use full word' Month' if this word can't be shortened in your language")
@@ -250,6 +252,31 @@ extension Strings {
                           bundle: .braveShared,
                           value: "Add Custom Search Engine",
                           comment: "Add Custom Search Engine Table Cell Row Title")
+}
+
+// MARK: - SearchCustomEngineViewController
+
+extension Strings {
+    public struct CustomSearchEngine {
+        public static let customEngineNavigationTitle = NSLocalizedString(
+            "customSearchEngine.navigationTitle",
+            bundle: .braveShared,
+            value: "Add Search Engine",
+            comment: "Navigation Bar title")
+        
+        public static let customEngineAddDesription = NSLocalizedString(
+            "customSearchEngine.addEngineDescription",
+            bundle: Bundle.braveShared,
+            value: "Write the search url and replace the query with %s.\nFor example: https://youtube.com/search?q=%s \n(If the site supports OpenSearch an option to add automatically will be provided while editing this field.)",
+            comment: "Label explaining how to add search engine.")
+        
+        public static let customEngineAutoAddTitle = NSLocalizedString(
+            "customSearchEngine.autoAddTitle",
+            bundle: Bundle.braveShared,
+            value: "Auto Add",
+            comment: "Button title for Auto Add in header")
+
+    }
 }
 
 // MARK:-  SettingsContentViewController.swift

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -245,6 +245,11 @@ extension Strings {
 extension Strings {
     public static let searchSettingNavTitle = NSLocalizedString("SearchSettingNavTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Search", comment: "Navigation title for search settings.")
     public static let searchSettingSuggestionCellTitle = NSLocalizedString("SearchSettingSuggestionCellTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Show Search Suggestions", comment: "Label for show search suggestions setting.")
+    public static let searchSettingAddCustomEngineCellTitle =
+        NSLocalizedString("searchSettingAddCustomEngineCellTitle",
+                          bundle: .braveShared,
+                          value: "Add Custom Search Engine",
+                          comment: "Add Custom Search Engine Table Cell Row Title")
 }
 
 // MARK:-  SettingsContentViewController.swift

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -467,6 +467,7 @@ extension Strings {
     
     public static let currentlyUsedSearchEngines = NSLocalizedString("CurrentlyUsedSearchEngines", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Currently used search engines", comment: "Currently usedd search engines section name.")
     public static let quickSearchEngines = NSLocalizedString("QuickSearchEngines", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Quick-Search Engines", comment: "Title for quick-search engines settings section.")
+    public static let customSearchEngines = NSLocalizedString("QuickSearchEngines", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Custom-Search Engines", comment: "Title for quick-search engines settings section.")
     public static let standardTabSearch = NSLocalizedString("StandardTabSearch", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Standard Tab", comment: "Open search section of settings")
     public static let privateTabSearch = NSLocalizedString("PrivateTabSearch", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Private Tab", comment: "Default engine for private search.")
     public static let searchEngines = NSLocalizedString("SearchEngines", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Search Engines", comment: "Search engines section of settings")

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		2FD0E3AF2576C48A000C773B /* SchemePermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */; };
 		2FD0E3D62577F327000C773B /* SearchSuggestionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */; };
 		2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */; };
+		2FE63DB8258BCC29004B219D /* BrowserViewController+OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
 		392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */; };
@@ -1681,6 +1682,7 @@
 		2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemePermissionTests.swift; sourceTree = "<group>"; };
 		2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionCell.swift; sourceTree = "<group>"; };
 		2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefsTests.swift; sourceTree = "<group>"; };
+		2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+OpenSearch.swift"; sourceTree = "<group>"; };
 		2FEBABAE1AB3659000DB5728 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipboardBarDisplayHandler.swift; sourceTree = "<group>"; };
 		39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandlerTests.swift; sourceTree = "<group>"; };
@@ -4193,6 +4195,7 @@
 				C8F457A71F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift */,
 				2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */,
 				0A91598822B834CE00CCC119 /* BVC+Rewards.swift */,
+				2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */,
 			);
 			path = BrowserViewController;
 			sourceTree = "<group>";
@@ -6165,6 +6168,7 @@
 				27AC7CFA24C77EBC00441317 /* FeedActionAlertView.swift in Sources */,
 				27E0652824CB6AE300134946 /* BraveTodayErrorView.swift in Sources */,
 				E650755C1E37F747006961AC /* Swizzling.m in Sources */,
+				2FE63DB8258BCC29004B219D /* BrowserViewController+OpenSearch.swift in Sources */,
 				2719DA09249D37490080AB48 /* SponsorCardView.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -411,7 +411,7 @@
 		2F44FCC51A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */; };
 		2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */; };
 		2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */; };
-		2F55443225913BD5000E4689 /* OpenSearchEngineAddButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F55443125913BD5000E4689 /* OpenSearchEngineAddButton.swift */; };
+		2F55443225913BD5000E4689 /* OpenSearchEngineButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F55443125913BD5000E4689 /* OpenSearchEngineButton.swift */; };
 		2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */; };
 		2FCAE2251ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		2FCAE2311ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
@@ -1663,7 +1663,7 @@
 		2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableSectionHeaderFooterView.swift; sourceTree = "<group>"; };
 		2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginePicker.swift; sourceTree = "<group>"; };
-		2F55443125913BD5000E4689 /* OpenSearchEngineAddButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSearchEngineAddButton.swift; sourceTree = "<group>"; };
+		2F55443125913BD5000E4689 /* OpenSearchEngineButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSearchEngineButton.swift; sourceTree = "<group>"; };
 		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
 		2FCAE21A1ABB51F800877008 /* Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FCAE2241ABB51F800877008 /* StorageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StorageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3439,7 +3439,7 @@
 			isa = PBXGroup;
 			children = (
 				2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */,
-				2F55443125913BD5000E4689 /* OpenSearchEngineAddButton.swift */,
+				2F55443125913BD5000E4689 /* OpenSearchEngineButton.swift */,
 			);
 			path = OpenSearch;
 			sourceTree = "<group>";
@@ -6220,7 +6220,7 @@
 				A16DC67F20E585D90069C8E1 /* PasscodeSettingsViewController.swift in Sources */,
 				4422D56221BFFB7F00BF1855 /* dfa.cc in Sources */,
 				A1AD4BE120C082EF007A6EA1 /* UIGestureRecognizerExtensions.swift in Sources */,
-				2F55443225913BD5000E4689 /* OpenSearchEngineAddButton.swift in Sources */,
+				2F55443225913BD5000E4689 /* OpenSearchEngineButton.swift in Sources */,
 				5E1DF2FD253E138500F84C39 /* Bookmarkv2.swift in Sources */,
 				27829E412548B8A0007CF0B2 /* BraveRewardsSupportedCountView.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 		2FD0E3D62577F327000C773B /* SearchSuggestionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */; };
 		2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */; };
 		2FE63DB8258BCC29004B219D /* BrowserViewController+OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */; };
+		2FEA1613259CDFE800E00E4D /* SearchCustomEngineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEA1612259CDFE800E00E4D /* SearchCustomEngineViewController.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
 		392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */; };
@@ -1685,6 +1686,7 @@
 		2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionCell.swift; sourceTree = "<group>"; };
 		2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefsTests.swift; sourceTree = "<group>"; };
 		2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+OpenSearch.swift"; sourceTree = "<group>"; };
+		2FEA1612259CDFE800E00E4D /* SearchCustomEngineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCustomEngineViewController.swift; sourceTree = "<group>"; };
 		2FEBABAE1AB3659000DB5728 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipboardBarDisplayHandler.swift; sourceTree = "<group>"; };
 		39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandlerTests.swift; sourceTree = "<group>"; };
@@ -3419,6 +3421,7 @@
 				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
 				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
 				2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */,
+				2FEA1612259CDFE800E00E4D /* SearchCustomEngineViewController.swift */,
 				74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */,
 				2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */,
 				2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */,
@@ -6155,6 +6158,7 @@
 				0A0D3D5221A565C300BEE65B /* SafeBrowsingHandler.swift in Sources */,
 				0AFC8F9E23D3762B00941895 /* NTPNotificationViewController.swift in Sources */,
 				27829E152548AD52007CF0B2 /* LegacyWalletTransferButton.swift in Sources */,
+				2FEA1613259CDFE800E00E4D /* SearchCustomEngineViewController.swift in Sources */,
 				D0C95E36200FDC5500E4E51C /* MetadataParserHelper.swift in Sources */,
 				4422D55B21BFFB7F00BF1855 /* onepass.cc in Sources */,
 				0A3C78A1230597DA0022F6D8 /* OnboardingShieldsViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */; };
 		2FE63DB8258BCC29004B219D /* BrowserViewController+OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */; };
 		2FEA1613259CDFE800E00E4D /* SearchCustomEngineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEA1612259CDFE800E00E4D /* SearchCustomEngineViewController.swift */; };
+		2FF0EDB325BA19E9004B18E2 /* SearchQuickEnginesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF0EDB225BA19E9004B18E2 /* SearchQuickEnginesViewController.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
 		392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */; };
@@ -1688,6 +1689,7 @@
 		2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+OpenSearch.swift"; sourceTree = "<group>"; };
 		2FEA1612259CDFE800E00E4D /* SearchCustomEngineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCustomEngineViewController.swift; sourceTree = "<group>"; };
 		2FEBABAE1AB3659000DB5728 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
+		2FF0EDB225BA19E9004B18E2 /* SearchQuickEnginesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQuickEnginesViewController.swift; sourceTree = "<group>"; };
 		31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipboardBarDisplayHandler.swift; sourceTree = "<group>"; };
 		39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandlerTests.swift; sourceTree = "<group>"; };
 		392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NewTabAccessors.swift; path = Accessors/NewTabAccessors.swift; sourceTree = "<group>"; };
@@ -3421,6 +3423,7 @@
 				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
 				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
 				2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */,
+				2FF0EDB225BA19E9004B18E2 /* SearchQuickEnginesViewController.swift */,
 				2FEA1612259CDFE800E00E4D /* SearchCustomEngineViewController.swift */,
 				74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */,
 				2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */,
@@ -6228,6 +6231,7 @@
 				5E1DF2FD253E138500F84C39 /* Bookmarkv2.swift in Sources */,
 				27829E412548B8A0007CF0B2 /* BraveRewardsSupportedCountView.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
+				2FF0EDB325BA19E9004B18E2 /* SearchQuickEnginesViewController.swift in Sources */,
 				0A5CBD3423D4677100362CC8 /* NTPLearnMoreViewController.swift in Sources */,
 				F35B8D2F1D638408008E3D61 /* SessionRestoreHandler.swift in Sources */,
 				27201EF924535A9500C19DD1 /* NewTabCollectionViewCell.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -411,6 +411,7 @@
 		2F44FCC51A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */; };
 		2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */; };
 		2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */; };
+		2F55443225913BD5000E4689 /* OpenSearchEngineAddButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F55443125913BD5000E4689 /* OpenSearchEngineAddButton.swift */; };
 		2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */; };
 		2FCAE2251ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		2FCAE2311ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
@@ -1662,6 +1663,7 @@
 		2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableSectionHeaderFooterView.swift; sourceTree = "<group>"; };
 		2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginePicker.swift; sourceTree = "<group>"; };
+		2F55443125913BD5000E4689 /* OpenSearchEngineAddButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSearchEngineAddButton.swift; sourceTree = "<group>"; };
 		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
 		2FCAE21A1ABB51F800877008 /* Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FCAE2241ABB51F800877008 /* StorageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StorageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3433,6 +3435,15 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		2F55443025913BAA000E4689 /* OpenSearch */ = {
+			isa = PBXGroup;
+			children = (
+				2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */,
+				2F55443125913BD5000E4689 /* OpenSearchEngineAddButton.swift */,
+			);
+			path = OpenSearch;
+			sourceTree = "<group>";
+		};
 		2FCAE21B1ABB51F800877008 /* Storage */ = {
 			isa = PBXGroup;
 			children = (
@@ -4195,7 +4206,7 @@
 				C8F457A71F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift */,
 				2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */,
 				0A91598822B834CE00CCC119 /* BVC+Rewards.swift */,
-				2FE63DB7258BCC29004B219D /* BrowserViewController+OpenSearch.swift */,
+				2F55443025913BAA000E4689 /* OpenSearch */,
 			);
 			path = BrowserViewController;
 			sourceTree = "<group>";
@@ -6209,6 +6220,7 @@
 				A16DC67F20E585D90069C8E1 /* PasscodeSettingsViewController.swift in Sources */,
 				4422D56221BFFB7F00BF1855 /* dfa.cc in Sources */,
 				A1AD4BE120C082EF007A6EA1 /* UIGestureRecognizerExtensions.swift in Sources */,
+				2F55443225913BD5000E4689 /* OpenSearchEngineAddButton.swift in Sources */,
 				5E1DF2FD253E138500F84C39 /* Bookmarkv2.swift in Sources */,
 				27829E412548B8A0007CF0B2 /* BraveRewardsSupportedCountView.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -67,9 +67,8 @@ class BrowserViewController: UIViewController {
     // Custom Search Engine
     var openSearchEngine: OpenSearchReference?
 
-    lazy var customSearchEngineButton: UIButton = {
-        let searchButton = UIButton()
-        searchButton.setImage(#imageLiteral(resourceName: "AddSearch").template, for: [])
+    lazy var customSearchEngineButton: OpenSearchEngineButton = {
+        let searchButton = OpenSearchEngineButton(hidesWhenDisabled: false)
         searchButton.addTarget(self, action: #selector(addCustomSearchEngineForFocusedElement), for: .touchUpInside)
         searchButton.accessibilityIdentifier = "BrowserViewController.customSearchEngineButton"
         return searchButton

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -64,7 +64,9 @@ class BrowserViewController: UIViewController {
 
     lazy var mailtoLinkHandler: MailtoLinkHandler = MailtoLinkHandler()
 
-    // Custom Search Engine Buttons
+    // Custom Search Engine
+    var openSearchEngine: OpenSearchReference?
+
     lazy var customSearchEngineButton: UIButton = {
         let searchButton = UIButton()
         searchButton.setImage(#imageLiteral(resourceName: "AddSearch").template, for: [])

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2587,9 +2587,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func presentSearchSettingsController() {
-        let settingsNavigationController = SearchSettingsTableViewController()
-        settingsNavigationController.model = self.profile.searchEngines
-        settingsNavigationController.profile = self.profile
+        let settingsNavigationController = SearchSettingsTableViewController(model: profile.searchEngines)
         let navController = ModalSettingsNavigationController(rootViewController: settingsNavigationController)
 
         self.present(navController, animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -53,7 +53,7 @@ class BrowserViewController: UIViewController {
     fileprivate var screenshotHelper: ScreenshotHelper!
     fileprivate var homePanelIsInline = false
     fileprivate var searchLoader: SearchLoader?
-    fileprivate let alertStackView = UIStackView() // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
+    let alertStackView = UIStackView() // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
     fileprivate var findInPageBar: FindInPageBar?
     
     // Single data source used for all favorites vcs
@@ -64,15 +64,15 @@ class BrowserViewController: UIViewController {
 
     lazy var mailtoLinkHandler: MailtoLinkHandler = MailtoLinkHandler()
 
-    lazy fileprivate var customSearchEngineButton: UIButton = {
+    // Custom Search Engine Buttons
+    lazy var customSearchEngineButton: UIButton = {
         let searchButton = UIButton()
         searchButton.setImage(#imageLiteral(resourceName: "AddSearch").template, for: [])
         searchButton.addTarget(self, action: #selector(addCustomSearchEngineForFocusedElement), for: .touchUpInside)
         searchButton.accessibilityIdentifier = "BrowserViewController.customSearchEngineButton"
         return searchButton
     }()
-
-    fileprivate var customSearchBarButton: UIBarButtonItem?
+    var customSearchBarButton: UIBarButtonItem?
 
     // popover rotation handling
     var displayedPopoverController: UIViewController?
@@ -105,7 +105,7 @@ class BrowserViewController: UIViewController {
 
     var scrollController = TabScrollingController()
 
-    fileprivate var keyboardState: KeyboardState?
+    var keyboardState: KeyboardState?
 
     var pendingToast: Toast? // A toast that might be waiting for BVC to appear before displaying
     var downloadToast: DownloadToast? // A toast that is showing the combined download progress
@@ -3207,172 +3207,6 @@ extension BrowserViewController: ContextMenuHelperDelegate {
     func contextMenuHelper(_ contextMenuHelper: ContextMenuHelper, didCancelGestureRecognizer: UIGestureRecognizer) {
         displayedPopoverController?.dismiss(animated: true) {
             self.displayedPopoverController = nil
-        }
-    }
-}
-
-/**
- A third party search engine Browser extension
-**/
-extension BrowserViewController {
-
-    func addCustomSearchButtonToWebView(_ webView: WKWebView) {
-        // For now we're going to just not add the custom search button to the web view
-        // TODO: #586 Re-enable custom search engines button or remove entirely
-        return
-        
-        /*
-        //check if the search engine has already been added.
-        let domain = webView.url?.domainURL.host
-        let matches = self.profile.searchEngines.orderedEngines.filter {$0.shortName == domain}
-        if !matches.isEmpty {
-            self.customSearchEngineButton.tintColor = UIColor.Photon.grey50
-            self.customSearchEngineButton.isUserInteractionEnabled = false
-        } else {
-            self.customSearchEngineButton.tintColor = UIConstants.systemBlueColor
-            self.customSearchEngineButton.isUserInteractionEnabled = true
-        }
-
-        /*
-         This is how we access hidden views in the WKContentView
-         Using the public headers we can find the keyboard accessoryView which is not usually available.
-         Specific values here are from the WKContentView headers.
-         https://github.com/JaviSoto/iOS9-Runtime-Headers/blob/master/Frameworks/WebKit.framework/WKContentView.h
-        */
-        guard let webContentView = UIView.findSubViewWithFirstResponder(webView) else {
-            /*
-             In some cases the URL bar can trigger the keyboard notification. In that case the webview isnt the first responder
-             and a search button should not be added.
-             */
-            return
-        }
-
-        guard let input = webContentView.perform(#selector(getter: UIResponder.inputAccessoryView)),
-            let inputView = input.takeUnretainedValue() as? UIInputView,
-            let nextButton = inputView.value(forKey: "_nextItem") as? UIBarButtonItem,
-            let nextButtonView = nextButton.value(forKey: "view") as? UIView else {
-                //failed to find the inputView instead lets use the inputAssistant
-                addCustomSearchButtonToInputAssistant(webContentView)
-                return
-            }
-            inputView.addSubview(self.customSearchEngineButton)
-            self.customSearchEngineButton.snp.remakeConstraints { make in
-                make.leading.equalTo(nextButtonView.snp.trailing).offset(20)
-                make.width.equalTo(inputView.snp.height)
-                make.top.equalTo(nextButtonView.snp.top)
-                make.height.equalTo(inputView.snp.height)
-            }
-        */
-    }
-
-    /**
-     This adds the customSearchButton to the inputAssistant
-     for cases where the inputAccessoryView could not be found for example
-     on the iPad where it does not exist. However this only works on iOS9
-     **/
-    func addCustomSearchButtonToInputAssistant(_ webContentView: UIView) {
-        guard customSearchBarButton == nil else {
-            return //The searchButton is already on the keyboard
-        }
-        let inputAssistant = webContentView.inputAssistantItem
-        let item = UIBarButtonItem(customView: customSearchEngineButton)
-        customSearchBarButton = item
-        _ = Try(withTry: {
-            inputAssistant.trailingBarButtonGroups.last?.barButtonItems.append(item)
-        }) { exception in
-            log.error("Failed adding custom search button to input assistant: \(String(describing: exception))")
-        }
-    }
-
-    @objc func addCustomSearchEngineForFocusedElement() {
-        guard let webView = tabManager.selectedTab?.webView else {
-            return
-        }
-        webView.evaluateJavaScript("__firefox__.searchQueryForField()") { (result, _) in
-            guard let searchQuery = result as? String, let favicon = self.tabManager.selectedTab!.displayFavicon else {
-                //Javascript responded with an incorrectly formatted message. Show an error.
-                let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
-                self.present(alert, animated: true, completion: nil)
-                return
-            }
-            self.addSearchEngine(searchQuery, favicon: favicon)
-            self.customSearchEngineButton.tintColor = UIColor.Photon.grey50
-            self.customSearchEngineButton.isUserInteractionEnabled = false
-        }
-    }
-
-    func addSearchEngine(_ searchQuery: String, favicon: Favicon) {
-        guard searchQuery != "",
-            let iconURL = URL(string: favicon.url),
-            let url = URL(string: searchQuery.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed)!),
-            let shortName = url.domainURL.host else {
-                let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
-                self.present(alert, animated: true, completion: nil)
-                return
-        }
-
-        let alert = ThirdPartySearchAlerts.addThirdPartySearchEngine { alert in
-            self.customSearchEngineButton.tintColor = UIColor.Photon.grey50
-            self.customSearchEngineButton.isUserInteractionEnabled = false
-            
-            WebImageCacheManager.shared.load(from: iconURL) { (image, _, _, _, _) in
-                guard let image = image else {
-                    let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
-                    self.present(alert, animated: true, completion: nil)
-                    return
-                }
-
-                self.profile.searchEngines.addSearchEngine(OpenSearchEngine(engineID: nil, shortName: shortName, image: image, searchTemplate: searchQuery, suggestTemplate: nil, isCustomEngine: true))
-                let Toast = SimpleToast()
-                Toast.showAlertWithText(Strings.thirdPartySearchEngineAdded, bottomContainer: self.webViewContainer)
-            }
-        }
-
-        self.present(alert, animated: true, completion: {})
-    }
-}
-
-extension BrowserViewController: KeyboardHelperDelegate {
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
-        keyboardState = state
-        updateViewConstraints()
-
-        UIView.animate(withDuration: state.animationDuration) {
-            UIView.setAnimationCurve(state.animationCurve)
-            self.alertStackView.layoutIfNeeded()
-        }
-
-        guard let webView = tabManager.selectedTab?.webView else {
-            return
-        }
-        webView.evaluateJavaScript("__firefox__.searchQueryForField()") { (result, _) in
-            guard let _ = result as? String else {
-                return
-            }
-            self.addCustomSearchButtonToWebView(webView)
-        }
-    }
-
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-
-    }
-
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        keyboardState = nil
-        updateViewConstraints()
-        //If the searchEngineButton exists remove it form the keyboard
-        if let buttonGroup = customSearchBarButton?.buttonGroup {
-            buttonGroup.barButtonItems = buttonGroup.barButtonItems.filter { $0 != customSearchBarButton }
-            customSearchBarButton = nil
-        }
-
-        if self.customSearchEngineButton.superview != nil {
-            self.customSearchEngineButton.removeFromSuperview()
-        }
-
-        UIView.animate(withDuration: state.animationDuration) {
-            UIView.setAnimationCurve(state.animationCurve)
-            self.alertStackView.layoutIfNeeded()
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2587,7 +2587,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func presentSearchSettingsController() {
-        let settingsNavigationController = SearchSettingsTableViewController(model: profile.searchEngines)
+        let settingsNavigationController = SearchSettingsTableViewController(profile: profile)
         let navController = ModalSettingsNavigationController(rootViewController: settingsNavigationController)
 
         self.present(navController, animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+OpenSearch.swift
@@ -1,0 +1,176 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Shared
+import Storage
+import UIKit
+import WebKit
+import XCGLogger
+
+private let log = Logger.browserLogger
+
+/**
+ A third party search engine Browser extension
+**/
+extension BrowserViewController {
+
+    func addCustomSearchButtonToWebView(_ webView: WKWebView) {
+        // For now we're going to just not add the custom search button to the web view
+        // TODO: #586 Re-enable custom search engines button or remove entirely
+        return
+        
+        /*
+        //check if the search engine has already been added.
+        let domain = webView.url?.domainURL.host
+        let matches = self.profile.searchEngines.orderedEngines.filter {$0.shortName == domain}
+        if !matches.isEmpty {
+            self.customSearchEngineButton.tintColor = UIColor.Photon.grey50
+            self.customSearchEngineButton.isUserInteractionEnabled = false
+        } else {
+            self.customSearchEngineButton.tintColor = UIConstants.systemBlueColor
+            self.customSearchEngineButton.isUserInteractionEnabled = true
+        }
+
+        /*
+         This is how we access hidden views in the WKContentView
+         Using the public headers we can find the keyboard accessoryView which is not usually available.
+         Specific values here are from the WKContentView headers.
+         https://github.com/JaviSoto/iOS9-Runtime-Headers/blob/master/Frameworks/WebKit.framework/WKContentView.h
+        */
+        guard let webContentView = UIView.findSubViewWithFirstResponder(webView) else {
+            /*
+             In some cases the URL bar can trigger the keyboard notification. In that case the webview isnt the first responder
+             and a search button should not be added.
+             */
+            return
+        }
+
+        guard let input = webContentView.perform(#selector(getter: UIResponder.inputAccessoryView)),
+            let inputView = input.takeUnretainedValue() as? UIInputView,
+            let nextButton = inputView.value(forKey: "_nextItem") as? UIBarButtonItem,
+            let nextButtonView = nextButton.value(forKey: "view") as? UIView else {
+                //failed to find the inputView instead lets use the inputAssistant
+                addCustomSearchButtonToInputAssistant(webContentView)
+                return
+            }
+            inputView.addSubview(self.customSearchEngineButton)
+            self.customSearchEngineButton.snp.remakeConstraints { make in
+                make.leading.equalTo(nextButtonView.snp.trailing).offset(20)
+                make.width.equalTo(inputView.snp.height)
+                make.top.equalTo(nextButtonView.snp.top)
+                make.height.equalTo(inputView.snp.height)
+            }
+        */
+    }
+
+    /**
+     This adds the customSearchButton to the inputAssistant
+     for cases where the inputAccessoryView could not be found for example
+     on the iPad where it does not exist. However this only works on iOS9
+     **/
+    func addCustomSearchButtonToInputAssistant(_ webContentView: UIView) {
+        guard customSearchBarButton == nil else {
+            return //The searchButton is already on the keyboard
+        }
+        let inputAssistant = webContentView.inputAssistantItem
+        let item = UIBarButtonItem(customView: customSearchEngineButton)
+        customSearchBarButton = item
+        _ = Try(withTry: {
+            inputAssistant.trailingBarButtonGroups.last?.barButtonItems.append(item)
+        }) { exception in
+            log.error("Failed adding custom search button to input assistant: \(String(describing: exception))")
+        }
+    }
+
+    @objc func addCustomSearchEngineForFocusedElement() {
+        guard let webView = tabManager.selectedTab?.webView else {
+            return
+        }
+        webView.evaluateJavaScript("__firefox__.searchQueryForField()") { (result, _) in
+            guard let searchQuery = result as? String, let favicon = self.tabManager.selectedTab!.displayFavicon else {
+                //Javascript responded with an incorrectly formatted message. Show an error.
+                let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
+                self.present(alert, animated: true, completion: nil)
+                return
+            }
+            self.addSearchEngine(searchQuery, favicon: favicon)
+            self.customSearchEngineButton.tintColor = UIColor.Photon.grey50
+            self.customSearchEngineButton.isUserInteractionEnabled = false
+        }
+    }
+
+    func addSearchEngine(_ searchQuery: String, favicon: Favicon) {
+        guard searchQuery != "",
+            let iconURL = URL(string: favicon.url),
+            let url = URL(string: searchQuery.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed)!),
+            let shortName = url.domainURL.host else {
+                let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
+                self.present(alert, animated: true, completion: nil)
+                return
+        }
+
+        let alert = ThirdPartySearchAlerts.addThirdPartySearchEngine { alert in
+            self.customSearchEngineButton.tintColor = UIColor.Photon.grey50
+            self.customSearchEngineButton.isUserInteractionEnabled = false
+            
+            WebImageCacheManager.shared.load(from: iconURL, completion: { (image, _, _, _, _) in
+                guard let image = image else {
+                    let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
+                    self.present(alert, animated: true, completion: nil)
+                    return
+                }
+                
+                self.profile.searchEngines.addSearchEngine(OpenSearchEngine(engineID: nil, shortName: shortName, image: image, searchTemplate: searchQuery, suggestTemplate: nil, isCustomEngine: true))
+                let Toast = SimpleToast()
+                Toast.showAlertWithText(Strings.thirdPartySearchEngineAdded, bottomContainer: self.webViewContainer)
+            })
+        }
+
+        self.present(alert, animated: true, completion: {})
+    }
+}
+
+// MARK: KeyboardHelperDelegate
+
+extension BrowserViewController: KeyboardHelperDelegate {
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
+        keyboardState = state
+        updateViewConstraints()
+
+        UIView.animate(withDuration: state.animationDuration) {
+            UIView.setAnimationCurve(state.animationCurve)
+            self.alertStackView.layoutIfNeeded()
+        }
+
+        guard let webView = tabManager.selectedTab?.webView else {
+            return
+        }
+        webView.evaluateJavaScript("__firefox__.searchQueryForField()") { (result, _) in
+            guard let _ = result as? String else {
+                return
+            }
+            self.addCustomSearchButtonToWebView(webView)
+        }
+    }
+
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
+        keyboardState = nil
+        updateViewConstraints()
+        //If the searchEngineButton exists remove it form the keyboard
+        if let buttonGroup = customSearchBarButton?.buttonGroup {
+            buttonGroup.barButtonItems = buttonGroup.barButtonItems.filter { $0 != customSearchBarButton }
+            customSearchBarButton = nil
+        }
+
+        if self.customSearchEngineButton.superview != nil {
+            self.customSearchEngineButton.removeFromSuperview()
+        }
+
+        UIView.animate(withDuration: state.animationDuration) {
+            UIView.setAnimationCurve(state.animationCurve)
+            self.alertStackView.layoutIfNeeded()
+        }
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -148,8 +148,8 @@ extension BrowserViewController {
             }
             
             NetworkManager().downloadResource(with: url).uponQueue(.main) { [weak self] response in
-                guard let openSearchEngine =
-                        OpenSearchParser(pluginMode: true).parse(response.data, referenceURL: referenceURL, image: searchEngineIcon) else {
+                guard let openSearchEngine = OpenSearchParser(pluginMode: true).parse(
+                        response.data, referenceURL: referenceURL, image: searchEngineIcon, isCustomEngine: true) else {
                     return
                 }
                 

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -62,13 +62,10 @@ extension BrowserViewController {
         
         let matches = self.profile.searchEngines.orderedEngines.filter {$0.referenceURL == referenceObject.reference}
         
-        // TODO: Change the button !!!!!!!!!!!!!!! Enable Disable
         if !matches.isEmpty {
-            customSearchEngineButton.tintColor = .gray
-            customSearchEngineButton.isUserInteractionEnabled = false
+            self.customSearchEngineButton.state = .disabled
         } else {
-            customSearchEngineButton.tintColor = .blue
-            customSearchEngineButton.isUserInteractionEnabled = true
+            self.customSearchEngineButton.state = .enabled
         }
         
         /*
@@ -133,13 +130,15 @@ extension BrowserViewController {
     }
 
     func downloadOpenSearchXML(_ url: URL, referenceURL: String, title: String, iconURL: URL) {
-        
-        // TODO: Change the button !!!!!!!!!!!!!!! Loading
-        
+        customSearchEngineButton.state = .loading
+
         WebImageCacheManager.shared.load(from: iconURL, completion: { (image, _, _, _, _) in
             guard let image = image else {
                 let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
-                self.present(alert, animated: true, completion: nil)
+                self.present(alert, animated: true) {
+                    self.customSearchEngineButton.state = .enabled
+                }
+                
                 return
             }
             
@@ -162,12 +161,11 @@ extension BrowserViewController {
                 let toast = SimpleToast()
                 toast.showAlertWithText(Strings.thirdPartySearchEngineAdded, bottomContainer: self.webViewContainer)
                 
-                // TODO: Change the button !!!!!!!!!!!!!!! Enabled
-
+                self.customSearchEngineButton.state = .disabled
             } catch {
                 let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
                 self.present(alert, animated: true) {
-                    // TODO: Change the button !!!!!!!!!!!!!!! Disabled
+                    self.customSearchEngineButton.state = .enabled
                 }
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -143,7 +143,7 @@ extension BrowserViewController {
                 return
             }
             
-            NetworkManager().downloadResource(with: url).upon() { [weak self] response in
+            NetworkManager().downloadResource(with: url).uponQueue(.main) { [weak self] response in
                 guard let openSearchEngine =
                         OpenSearchParser(pluginMode: true).parse(response.data, referenceURL: referenceURL, image: image) else {
                     return

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -139,18 +139,15 @@ extension BrowserViewController {
         customSearchEngineButton.state = .loading
 
         WebImageCacheManager.shared.load(from: iconURL, completion: { (image, _, _, _, _) in
-            guard let image = image else {
-                let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
-                self.present(alert, animated: true) {
-                    self.customSearchEngineButton.state = .enabled
-                }
-                
-                return
+            var searchEngineIcon = #imageLiteral(resourceName: "defaultFavicon")
+
+            if let favIcon = image {
+                searchEngineIcon = favIcon
             }
             
             NetworkManager().downloadResource(with: url).uponQueue(.main) { [weak self] response in
                 guard let openSearchEngine =
-                        OpenSearchParser(pluginMode: true).parse(response.data, referenceURL: referenceURL, image: image) else {
+                        OpenSearchParser(pluginMode: true).parse(response.data, referenceURL: referenceURL, image: searchEngineIcon) else {
                     return
                 }
                 

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -138,9 +138,11 @@ extension BrowserViewController {
     func downloadOpenSearchXML(_ url: URL, referenceURL: String, title: String, iconURL: URL) {
         customSearchEngineButton.state = .loading
 
+        // Try to fetch Engine Icon using cache manager
         WebImageCacheManager.shared.load(from: iconURL, completion: { (image, _, _, _, _) in
             var searchEngineIcon = #imageLiteral(resourceName: "defaultFavicon")
 
+            // In case fetch fails use default icon and do not block addition of this engine
             if let favIcon = image {
                 searchEngineIcon = favIcon
             }

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -82,10 +82,16 @@ extension BrowserViewController {
             return
         }
         
+        let argumentNextItem: [Any] = ["_n", "extI", "tem"]
+        let argumentView: [Any] = ["v", "ie", "w"]
+        
+        let valueKeyNextItem = argumentNextItem.compactMap { $0 as? String }.joined()
+        let valueKeyView = argumentView.compactMap { $0 as? String }.joined()
+
         guard let input = webContentView.perform(#selector(getter: UIResponder.inputAccessoryView)),
               let inputView = input.takeUnretainedValue() as? UIInputView,
-              let nextButton = inputView.value(forKey: "_nextItem") as? UIBarButtonItem,
-              let nextButtonView = nextButton.value(forKey: "view") as? UIView else {
+              let nextButton = inputView.value(forKey: valueKeyNextItem) as? UIBarButtonItem,
+              let nextButtonView = nextButton.value(forKey: valueKeyView) as? UIView else {
             return
         }
         

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineAddButton.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineAddButton.swift
@@ -1,0 +1,104 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import SnapKit
+import BraveShared
+
+// MARK: - OpenSearchEngineAddButton
+
+class OpenSearchEngineAddButton: UIView {
+
+    // MARK: State
+    
+    enum State {
+        case loading
+        case enabled
+        case disabled
+    }
+
+    // MARK: Properties
+    
+    var state: State {
+        didSet {
+            switch state {
+            case .disabled:
+                searchButton.isHidden = hidesWhenDisabled ? true : false
+                loadingIndicator.stopAnimating()
+                searchButton.tintColor = UIColor.Photon.grey50
+                searchButton.isUserInteractionEnabled = false
+            case .enabled:
+                searchButton.isHidden = false
+                loadingIndicator.stopAnimating()
+                searchButton.tintColor = .systemBlue
+                searchButton.isUserInteractionEnabled = true
+            case .loading:
+                loadingIndicator.isHidden = false
+                loadingIndicator.startAnimating()
+                searchButton.isHidden = true
+            }
+        }
+    }
+    
+    private let searchButton = UIButton().then {
+        $0.setImage(#imageLiteral(resourceName: "AddSearch").template, for: [])
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 14)
+        $0.setTitleColor(BraveUX.braveOrange, for: .normal)
+    }
+    
+    private let loadingIndicator = UIActivityIndicatorView(style: .white).then {
+        $0.hidesWhenStopped = true
+        $0.color = UIColor.Photon.grey50
+    }
+    
+    private var hidesWhenDisabled: Bool = false
+    
+    // MARK: Lifecycle
+    
+    override init(frame: CGRect) {
+        self.state = .disabled
+        super.init(frame: frame)
+    }
+
+    convenience init(title: String? = nil, hidesWhenDisabled: Bool = false) {
+        self.init(frame: CGRect(x: 0, y: 0, width: 44.0, height: 44.0))
+        
+
+        self.hidesWhenDisabled = hidesWhenDisabled
+        
+        setTheme(with: title)
+        doLayout()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    //MARK: Internal
+    
+    private func setTheme(with title: String?) {
+        if let title = title {
+            searchButton.setImage(nil, for: .normal)
+            searchButton.setTitle(title, for: .normal)
+        }
+    }
+    
+    private func doLayout() {
+        addSubview(searchButton)
+        addSubview(loadingIndicator)
+        
+        searchButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        loadingIndicator.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+
+    func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {
+        searchButton.addTarget(target, action: action, for: controlEvents)
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
@@ -28,11 +28,13 @@ class OpenSearchEngineButton: UIView {
                 searchButton.isHidden = hidesWhenDisabled ? true : false
                 loadingIndicator.stopAnimating()
                 searchButton.tintColor = UIColor.Photon.grey50
+                searchButton.setTitleColor(UIColor.Photon.grey50, for: .normal)
                 searchButton.isUserInteractionEnabled = false
             case .enabled:
                 searchButton.isHidden = false
                 loadingIndicator.stopAnimating()
                 searchButton.tintColor = .systemBlue
+                searchButton.setTitleColor(BraveUX.braveOrange, for: .normal)
                 searchButton.isUserInteractionEnabled = true
             case .loading:
                 loadingIndicator.isHidden = false
@@ -45,7 +47,6 @@ class OpenSearchEngineButton: UIView {
     private let searchButton = UIButton().then {
         $0.setImage(#imageLiteral(resourceName: "AddSearch").template, for: [])
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 14)
-        $0.setTitleColor(BraveUX.braveOrange, for: .normal)
     }
     
     private let loadingIndicator = UIActivityIndicatorView(style: .white).then {

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
@@ -7,9 +7,9 @@ import UIKit
 import SnapKit
 import BraveShared
 
-// MARK: - OpenSearchEngineAddButton
+// MARK: - OpenSearchEngineButton
 
-class OpenSearchEngineAddButton: UIView {
+class OpenSearchEngineButton: UIView {
 
     // MARK: State
     
@@ -62,10 +62,9 @@ class OpenSearchEngineAddButton: UIView {
         super.init(frame: frame)
     }
 
-    convenience init(title: String? = nil, hidesWhenDisabled: Bool = false) {
+    convenience init(title: String? = nil, hidesWhenDisabled: Bool) {
         self.init(frame: CGRect(x: 0, y: 0, width: 44.0, height: 44.0))
         
-
         self.hidesWhenDisabled = hidesWhenDisabled
         
         setTheme(with: title)
@@ -102,3 +101,4 @@ class OpenSearchEngineAddButton: UIView {
         searchButton.addTarget(target, action: action, for: controlEvents)
     }
 }
+

--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -171,10 +171,7 @@ extension FavoritesViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
         updateKeyboardInset(state)
     }
-    
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-    }
-    
+
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         updateKeyboardInset(state)
     }

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -51,8 +51,8 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
 
     fileprivate lazy var searchQueryComponentKey: String? = self.getQueryArgFromTemplate()
 
-    init(engineID: String?, shortName: String, referenceURL: String? = nil, image: UIImage, searchTemplate: String,
-         suggestTemplate: String?, isCustomEngine: Bool) {
+    init(engineID: String? = nil, shortName: String, referenceURL: String? = nil, image: UIImage, searchTemplate: String,
+         suggestTemplate: String? = nil, isCustomEngine: Bool) {
         self.shortName = shortName
         self.referenceURL = referenceURL
         self.image = image

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -21,7 +21,8 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
     static let defaultSearchClientName = "brave"
     
     let shortName: String
-    
+    let referenceURL: String?
+
     // Backwards compatibility workaround, see #3056.
     // We use `shortName` to store persist what engines are set as default, order etc.
     // This means there's no easy way to change display text for the search engine without
@@ -50,9 +51,10 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
 
     fileprivate lazy var searchQueryComponentKey: String? = self.getQueryArgFromTemplate()
 
-    init(engineID: String?, shortName: String, image: UIImage, searchTemplate: String,
+    init(engineID: String?, shortName: String, referenceURL: String? = nil, image: UIImage, searchTemplate: String,
          suggestTemplate: String?, isCustomEngine: Bool) {
         self.shortName = shortName
+        self.referenceURL = referenceURL
         self.image = image
         self.searchTemplate = searchTemplate
         self.suggestTemplate = suggestTemplate
@@ -74,6 +76,7 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
 
         self.searchTemplate = searchTemplate
         self.shortName = shortName
+        self.referenceURL = aDecoder.decodeObject(of: NSString.self, forKey: "href") as String?
         self.isCustomEngine = isCustomEngine
         self.image = image
         self.engineID = aDecoder.decodeObject(of: NSString.self, forKey: "engineID") as String?
@@ -86,6 +89,7 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
         aCoder.encode(isCustomEngine, forKey: "isCustomEngine")
         aCoder.encode(image, forKey: "image")
         aCoder.encode(engineID, forKey: "engineID")
+        aCoder.encode(referenceURL, forKey: "href")
     }
 
     static var supportsSecureCoding: Bool {
@@ -239,7 +243,7 @@ class OpenSearchParser {
         self.pluginMode = pluginMode
     }
 
-    func parse(_ file: String, engineID: String) -> OpenSearchEngine? {
+    func parse(_ file: String, engineID: String, refenceURL: String? = nil, image: UIImage? = nil) -> OpenSearchEngine? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: file)) else {
             print("Invalid search file")
             return nil
@@ -346,9 +350,12 @@ class OpenSearchParser {
                 }
             }
         }
-
+        
         let uiImage: UIImage
-        if let imageElement = largestImageElement,
+        
+        if let image = image {
+            uiImage = image
+        } else if let imageElement = largestImageElement,
            let imageURL = URL(string: imageElement.stringValue),
            let imageData = try? Data(contentsOf: imageURL),
            let image = UIImage.imageFromDataThreadSafe(imageData) {
@@ -358,6 +365,6 @@ class OpenSearchParser {
             return nil
         }
 
-        return OpenSearchEngine(engineID: engineID, shortName: shortName, image: uiImage, searchTemplate: searchTemplate, suggestTemplate: suggestTemplate, isCustomEngine: false)
+        return OpenSearchEngine(engineID: engineID, shortName: shortName, referenceURL: refenceURL, image: uiImage, searchTemplate: searchTemplate, suggestTemplate: suggestTemplate, isCustomEngine: false)
     }
 }

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -242,13 +242,17 @@ class OpenSearchParser {
     init(pluginMode: Bool) {
         self.pluginMode = pluginMode
     }
-
-    func parse(_ file: String, engineID: String, refenceURL: String? = nil, image: UIImage? = nil) -> OpenSearchEngine? {
+    
+    func parse(_ file: String, engineID: String, referenceURL: String = "") -> OpenSearchEngine? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: file)) else {
             print("Invalid search file")
             return nil
         }
 
+        return parse(data, engineID: engineID, referenceURL: referenceURL)
+    }
+
+    func parse(_ data: Data, engineID: String = "", referenceURL: String? = nil, image: UIImage? = nil) -> OpenSearchEngine? {
         guard let indexer = try? XMLDocument(data: data),
             let docIndexer = indexer.root else {
                 print("Invalid XML document")
@@ -365,6 +369,6 @@ class OpenSearchParser {
             return nil
         }
 
-        return OpenSearchEngine(engineID: engineID, shortName: shortName, referenceURL: refenceURL, image: uiImage, searchTemplate: searchTemplate, suggestTemplate: suggestTemplate, isCustomEngine: false)
+        return OpenSearchEngine(engineID: engineID, shortName: shortName, referenceURL: referenceURL, image: uiImage, searchTemplate: searchTemplate, suggestTemplate: suggestTemplate, isCustomEngine: false)
     }
 }

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -252,7 +252,7 @@ class OpenSearchParser {
         return parse(data, engineID: engineID, referenceURL: referenceURL)
     }
 
-    func parse(_ data: Data, engineID: String = "", referenceURL: String? = nil, image: UIImage? = nil) -> OpenSearchEngine? {
+    func parse(_ data: Data, engineID: String = "", referenceURL: String? = nil, image: UIImage? = nil, isCustomEngine: Bool = false) -> OpenSearchEngine? {
         guard let indexer = try? XMLDocument(data: data),
             let docIndexer = indexer.root else {
                 print("Invalid XML document")
@@ -369,6 +369,6 @@ class OpenSearchParser {
             return nil
         }
 
-        return OpenSearchEngine(engineID: engineID, shortName: shortName, referenceURL: referenceURL, image: uiImage, searchTemplate: searchTemplate, suggestTemplate: suggestTemplate, isCustomEngine: false)
+        return OpenSearchEngine(engineID: engineID, shortName: shortName, referenceURL: referenceURL, image: uiImage, searchTemplate: searchTemplate, suggestTemplate: suggestTemplate, isCustomEngine: isCustomEngine)
     }
 }

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -12,6 +12,13 @@ private let log = Logger.browserLogger
 
 private let customSearchEnginesFileName = "customEngines.plist"
 
+// MARK: - SearchEngineError
+
+enum SearchEngineError: Error {
+    case duplicate
+    case failedToSave
+}
+
 // BRAVE TODO: Move to newer Preferences class(#259)
 enum DefaultEngineType: String {
     case standard = "search.default.name"
@@ -24,7 +31,7 @@ enum DefaultEngineType: String {
         }
     }
 }
-
+    
 /**
  * Manage a set of Open Search engines.
  *
@@ -174,22 +181,36 @@ class SearchEngines {
         disabledEngineNames[engine.shortName] = true
     }
 
-    func deleteCustomEngine(_ engine: OpenSearchEngine) {
+    func deleteCustomEngine(_ engine: OpenSearchEngine) throws {
         // We can't delete a preinstalled engine or an engine that is currently the default.
         if !engine.isCustomEngine || isEngineDefault(engine) {
             return
         }
 
         customEngines.remove(at: customEngines.firstIndex(of: engine)!)
-        saveCustomEngines()
+        do {
+            try saveCustomEngines()
+        } catch {
+            throw SearchEngineError.failedToSave
+        }
+
         orderedEngines = getOrderedEngines()
     }
 
     /// Adds an engine to the front of the search engines list.
-    func addSearchEngine(_ engine: OpenSearchEngine) {
+    func addSearchEngine(_ engine: OpenSearchEngine) throws {
+        guard orderedEngines.contains(where: { $0.searchTemplate != engine.searchTemplate}) else {
+            throw SearchEngineError.duplicate
+        }
+        
         customEngines.append(engine)
         orderedEngines.insert(engine, at: 1)
-        saveCustomEngines()
+        
+        do {
+            try saveCustomEngines()
+        } catch {
+            throw SearchEngineError.failedToSave
+        }
     }
 
     func queryForSearchURL(_ url: URL?) -> String? {
@@ -223,7 +244,7 @@ class SearchEngines {
         }
     }()
 
-    fileprivate func saveCustomEngines() {
+    fileprivate func saveCustomEngines() throws {
         do {
             let data = try NSKeyedArchiver.archivedData(withRootObject: customEngines, requiringSecureCoding: true)
             try data.write(to: URL(fileURLWithPath: customEngineFilePath()))

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -18,6 +18,7 @@ enum SearchEngineError: Error {
     case duplicate
     case failedToSave
     case invalidQuery
+    case missingInformation
 }
 
 // BRAVE TODO: Move to newer Preferences class(#259)

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -17,6 +17,7 @@ private let customSearchEnginesFileName = "customEngines.plist"
 enum SearchEngineError: Error {
     case duplicate
     case failedToSave
+    case invalidQuery
 }
 
 // BRAVE TODO: Move to newer Preferences class(#259)

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -552,9 +552,6 @@ extension SearchViewController: KeyboardHelperDelegate {
         animateSearchEnginesWithKeyboard(state)
     }
 
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-    }
-
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         animateSearchEnginesWithKeyboard(state)
     }

--- a/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -17,15 +17,22 @@ class ThirdPartySearchAlerts: UIAlertController {
     /**
      Builds the Alert view that asks if the users wants to add a third party search engine.
 
-     - parameter okayCallback: Okay option handler.
+     - parameter engine: To add engine details to alert
+
+     - parameter completion: Okay option handler.
 
      - returns: UIAlertController for asking the user to add a search engine
      **/
 
-    static func addThirdPartySearchEngine(_ okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
+    static func addThirdPartySearchEngine(_ engine: OpenSearchEngine, completion: @escaping (UIAlertAction) -> Void) -> UIAlertController {
+        let alertMessage = """
+                            \n\(engine.displayName)
+                            \(engine.searchTemplate)
+                            \n\(Strings.thirdPartySearchAddMessage)
+                            """
         let alert = ThirdPartySearchAlerts(
             title: Strings.thirdPartySearchAddTitle,
-            message: Strings.thirdPartySearchAddMessage,
+            message: alertMessage,
             preferredStyle: .alert
         )
 
@@ -38,7 +45,7 @@ class ThirdPartySearchAlerts: UIAlertController {
         let okayOption = UIAlertAction(
             title: Strings.thirdPartySearchOkayButton,
             style: .default,
-            handler: okayCallback
+            handler: completion
         )
 
         alert.addAction(okayOption)

--- a/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -75,6 +75,11 @@ class ThirdPartySearchAlerts: UIAlertController {
                                  message: Strings.customEngineDuplicateErrorMessage)
     }
     
+    static func missingInfoToAddThirdPartySearch() -> UIAlertController {
+        return searchAlertWithOK(title: Strings.thirdPartySearchFailedTitle,
+                                 message: Strings.customEngineFillAllFieldsErrorMessage)
+    }
+    
     private static func searchAlertWithOK(title: String, message: String) -> UIAlertController {
         let alert = ThirdPartySearchAlerts(
             title: title,

--- a/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -39,7 +39,7 @@ class ThirdPartySearchAlerts: UIAlertController {
         let noOption = UIAlertAction(
             title: Strings.thirdPartySearchCancelButton,
             style: .cancel,
-            handler: nil
+            handler: completion
         )
 
         let okayOption = UIAlertAction(

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -327,9 +327,6 @@ extension LoginListViewController: KeyboardHelperDelegate {
         tableView.contentInset.bottom = coveredHeight
     }
 
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-    }
-
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         tableView.contentInset.bottom = 0
     }

--- a/Client/Frontend/Popup/PopupView.swift
+++ b/Client/Frontend/Popup/PopupView.swift
@@ -583,9 +583,6 @@ extension PopupView: KeyboardHelperDelegate {
         _dialogFrameWithKeyboardHeight(height: keyboardHeight)
     }
     
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-    }
-    
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         keyboardState = nil
         if !automaticallyMovesWithKeyboard {

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -265,9 +265,6 @@ extension LoginDetailViewController: KeyboardHelperDelegate {
         tableView.contentInset.bottom = coveredHeight
     }
 
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-    }
-
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         tableView.contentInset.bottom = 0
     }

--- a/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
+++ b/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
@@ -354,8 +354,6 @@ extension RewardsDebugSettingsViewController: KeyboardHelperDelegate {
     public func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
-    public func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-    }
 }
 
 extension RewardsDebugSettingsViewController: UITextFieldDelegate {

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -420,25 +420,30 @@ extension SearchCustomEngineViewController {
         }
     
         // Check Engine Exists
-        guard !profile.searchEngines.orderedEngines.filter({ $0.shortName == name }).isEmpty else {
+        guard profile.searchEngines.orderedEngines.filter({ $0.shortName == name }).isEmpty else {
             completion(nil, SearchEngineError.duplicate)
             return
         }
-        
-        let fetcher = FaviconFetcher(siteURL: url, kind: .favicon, domain: nil)
-        
+
+        var engineImage = #imageLiteral(resourceName: "defaultFavicon")
+
+        guard let hostUrl = host else {
+            let engine = OpenSearchEngine(shortName: name, image: engineImage, searchTemplate: template, isCustomEngine: true)
+
+            completion(engine, nil)
+            return
+        }
+
+        let fetcher = FaviconFetcher(siteURL: hostUrl, kind: .favicon, domain: nil)
+
         fetcher.load { siteUrl, attributes in
             guard siteUrl == url else { return }
-            
-            let engineImage = attributes.image ?? #imageLiteral(resourceName: "defaultFavicon")
-            
-            let engine = OpenSearchEngine(
-                engineID: nil,
-                shortName: name,
-                image: engineImage,
-                searchTemplate: template,
-                suggestTemplate: nil,
-                isCustomEngine: true)
+
+            if let image = attributes.image {
+                engineImage = image
+            }
+
+            let engine = OpenSearchEngine(shortName: name, image: engineImage, searchTemplate: template, isCustomEngine: true)
 
             completion(engine, nil)
         }

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -16,36 +16,55 @@ private let log = Logger.browserLogger
 
 // MARK: - SearchCustomEngineViewController
 
-class SearchCustomEngineViewController: UITableViewController {
+class SearchCustomEngineViewController: UIViewController {
+    
+    // MARK: SaveButtonType
+    
+    private enum SaveButtonType {
+        case enabled
+        case loading
+    }
+    
+    // MARK: Section
+    
+    private enum Section: Int, CaseIterable {
+        case url
+        case title
+    }
+    
+    // MARK: Constants
+    
+    struct Constants {
+        static let textInputRowIdentifier = "textInputRowIdentifier"
+        static let urlInputRowIdentifier = "urlInputRowIdentifier"
+        static let titleInputRowIdentifier = "titleInputRowIdentifier"
+        static let searchEngineHeaderIdentifier = "searchEngineHeaderIdentifier"
+    }
     
     // MARK: Properties
     
     private var profile: Profile
     
-    private var showAutoAddSearchButton = false {
-        didSet {
-            manageURLHeaderView()
-        }
-    }
+    private var showAutoAddSearchButton = false
     
-    private var urlText = ""
+    private var urlText: String?
     
     private var titleText: String?
     
-    private var urlHeader: CustomSearchEngineURLHeader!
+    private var urlHeader: SearchEngineTableViewHeader?
     
-    private lazy var spinnerView: UIActivityIndicatorView = {
-        let spinner = UIActivityIndicatorView(style: .gray)
-        spinner.hidesWhenStopped = true
-        return spinner
-    }()
+    private lazy var spinnerView = UIActivityIndicatorView(style: .gray).then {
+        $0.hidesWhenStopped = true
+    }
+    
+    private var tableView = UITableView(frame: .zero, style: .grouped)
     
     // MARK: Lifecycle
     
     init(profile: Profile) {
         self.profile = profile
         
-        super.init(style: .grouped)
+        super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
@@ -55,84 +74,44 @@ class SearchCustomEngineViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //profile = (UIApplication.shared.delegate as! AppDelegate).profile!
-        
-        tableView.register(TextInputCell.self, forCellReuseIdentifier: TextInputCell.identifier)
-        
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(cancel))
-        
         title = "Add Search Engine"
         
-        setSaveButton()
-    }
-    
-    // MARK: UITableViewDelegate / UITableViewDataSource
-    
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
-    }
-    
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
-    }
-    
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TextInputCell.identifier) as? TextInputCell
-        switch indexPath.section {
-            case 0:
-                cell?.type = .textView(self)
-                cell?.textview?.autocapitalizationType = .none
-                cell?.textview?.autocorrectionType = .no
-                cell?.textview?.keyboardType = .URL
-            case 1:
-                cell?.type = .textField(self)
-            default:
-                break
-        }
-        return cell ?? UITableViewCell()
-    }
-    
-    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        switch section {
-            case 0:
-                return "Write the search url and replace the query with %s.\nFor example: https://youtube.com/search?q=%s \n(If the site supports OpenSearch an option to add automatically will be provided while editing this field.)"
-            default:
-                return nil
-        }
-    }
-    
-    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = CustomSearchEngineURLHeader(frame: CGRect(x: 0, y: 0, width: 1, height: 44.0))
-        
-        switch section {
-            case 0:
-                header.titleLabel.text = Strings.URL
-                header.addEngineButton.state = showAutoAddSearchButton ? .enabled : .disabled
-                urlHeader = header
-            default:
-                header.addEngineButton.isHidden = true
-                header.titleLabel.text = "Title"
-
-        }
-        
-        return header
+        setup()
+        doLayout()
+        setSaveButton(for: .enabled)
     }
     
     // MARK: Internal
     
-    fileprivate func setSaveButton() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(self.addCustomSearchEngine))
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "customEngineSaveButton"
+    private func setup() {
+        tableView.do {
+            $0.register(URLInputTableViewCell.self, forCellReuseIdentifier: Constants.urlInputRowIdentifier)
+            $0.register(TitleInputTableViewCell.self, forCellReuseIdentifier: Constants.titleInputRowIdentifier)
+            $0.register(SearchEngineTableViewHeader.self, forHeaderFooterViewReuseIdentifier: Constants.searchEngineHeaderIdentifier)
+            $0.dataSource = self
+            $0.delegate = self
+        }
+        
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(cancel))
     }
     
-    fileprivate func showNavBarLoader() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinnerView)
-        spinnerView.startAnimating()
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "customEngineActivityIndicator"
+    private func doLayout() {
+        view.addSubview(tableView)
+        
+        tableView.snp.makeConstraints { make in
+            make.edges.equalTo(self.view)
+        }
     }
     
-    private func manageURLHeaderView(loading: Bool = false) {
-        //urlHeader.addEngineButton.state = loading ? .loading : showAutoAddSearchButton ? .enabled : .disabled
+    private func setSaveButton(for type: SaveButtonType) {
+        switch type {
+            case .enabled:
+                navigationItem.rightBarButtonItem = UIBarButtonItem(
+                    barButtonSystemItem: .save, target: self, action: #selector(self.addCustomSearchEngine))
+            case .loading:
+                navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinnerView)
+                spinnerView.startAnimating()
+        }
     }
     
     private func handleError(error: Error) {
@@ -163,20 +142,91 @@ class SearchCustomEngineViewController: UITableViewController {
         // TODO: Add Logic
     }
     
-    @objc fileprivate func cancel() {
+    @objc func cancel() {
         navigationController?.popViewController(animated: true)
     }
 }
 
+// MARK: - UITableViewDelegate UITableViewDataSource
+
+extension SearchCustomEngineViewController: UITableViewDelegate, UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return Section.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.section {
+            case Section.url.rawValue:
+                guard let cell =
+                        tableView.dequeueReusableCell(withIdentifier: Constants.urlInputRowIdentifier) as? URLInputTableViewCell else {
+                    return UITableViewCell()
+                }
+                
+                cell.delegate = self
+                return cell
+            default:
+                guard let cell =
+                        tableView.dequeueReusableCell(withIdentifier: Constants.titleInputRowIdentifier) as? TitleInputTableViewCell else {
+                    return UITableViewCell()
+                }
+                
+                cell.delegate = self
+                return cell
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        guard section == Section.url.rawValue else { return nil }
+        
+        return "Write the search url and replace the query with %s.\nFor example: https://youtube.com/search?q=%s \n(If the site supports OpenSearch an option to add automatically will be provided while editing this field.)"
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(
+                withIdentifier: Constants.searchEngineHeaderIdentifier) as? SearchEngineTableViewHeader else {
+            return nil
+        }
+
+        switch section {
+            case Section.url.rawValue:
+                headerView.titleLabel.text = Strings.URL
+                headerView.addEngineButton.state = showAutoAddSearchButton ? .enabled : .disabled
+                urlHeader = headerView
+            default:
+                headerView.titleLabel.text = "Title"
+                headerView.addEngineButton.isHidden = true
+        }
+        
+        return headerView
+    }
+}
+
+// MARK: - UITextViewDelegate
+
 extension SearchCustomEngineViewController: UITextViewDelegate {
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        guard text.rangeOfCharacter(from: .newlines) == nil else {
+            textView.resignFirstResponder()
+            return false
+        }
+
+        return textView.text.count + (text.count - range.length) <= 150
+    }
+    
     func textViewDidChange(_ textView: UITextView) {
-        // Identify host if possible.
         if let text = textView.text?.trimmingCharacters(in: .whitespacesAndNewlines),
-            let url = URL(string: text.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!),
-            url.host != nil,
-            url.isWebPage() {
+           let encodedText = text.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed),
+           let url = URL(string: encodedText),
+           url.host != nil,
+           url.isWebPage() {
             
-           // Identify the host
+            // TODO: Identify the host
         }
         
         urlText = textView.text
@@ -185,45 +235,59 @@ extension SearchCustomEngineViewController: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         urlText = textView.text
     }
-
-    func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
-        let accessoryView = AddSearchEngineAccessoryView(frame: CGRect(width: 0, height: 44.0))
-        textView.inputAccessoryView = accessoryView
-        
-        return true
-    }
 }
 
+// MARK: - UITextFieldDelegate
+
 extension SearchCustomEngineViewController: UITextFieldDelegate {
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return false }
+        
+        let currentString: NSString = text as NSString
+        let newString: NSString = currentString.replacingCharacters(in: range, with: string) as NSString
+        
+        return newString.length <= 50
+    }
+    
     func textFieldDidEndEditing(_ textField: UITextField) {
-        //hold the text for future.
         titleText = textField.text
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.endEditing(true)
+        
         return true
     }
 }
 
-fileprivate class CustomSearchEngineURLHeader: UIView {
+// MARK: - SearchEngineTableViewHeader
 
-    var titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = UIColor.Photon.grey50
-        return label
-    }()
+fileprivate class SearchEngineTableViewHeader: UITableViewHeaderFooterView {
+    
+    // MARK: Design
+    
+    struct Design {
+        static let headerHeight: CGFloat = 44
+        static let headerInset: CGFloat = 20
+    }
+    
+    // MARK: Properties
+    
+    var titleLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 14)
+        $0.textColor = UIColor.Photon.grey50
+    }
 
-    lazy var addEngineButton: OpenSearchEngineButton = {
-        let searchButton = OpenSearchEngineButton(title: "Auto Add", hidesWhenDisabled: false)
-        searchButton.addTarget(self, action: #selector(addEngine), for: .touchUpInside)
-        searchButton.accessibilityIdentifier = "BrowserViewController.customSearchEngineButton"
-        return searchButton
-    }()
+    lazy var addEngineButton = OpenSearchEngineButton(title: "Auto Add", hidesWhenDisabled: false).then {
+        $0.addTarget(self, action: #selector(addEngine), for: .touchUpInside)
+    }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    // MARK: Lifecycle
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        
         addSubview(titleLabel)
         addSubview(addEngineButton)
         
@@ -234,117 +298,129 @@ fileprivate class CustomSearchEngineURLHeader: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: Internal
+    
     func setConstraints() {
         titleLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(20)
+            make.leading.equalToSuperview().offset(Design.headerInset)
             make.top.equalToSuperview()
             make.bottom.equalToSuperview()
-            make.height.equalTo(44.0)
+            make.height.equalTo(Design.headerHeight)
         }
+        
         addEngineButton.snp.makeConstraints { make in
-            make.trailing.equalTo(self.snp.trailing).inset(20)
+            make.trailing.equalTo(snp.trailing).inset(Design.headerInset)
             make.centerY.equalToSuperview()
-            make.height.equalTo(self.snp.height)
+            make.height.equalTo(snp.height)
         }
     }
+    
+    // MARK: Actions
 
     @objc private func addEngine() {
         // TODO: Add Engine URL
     }
 }
 
-fileprivate class AddSearchEngineAccessoryView: UIView {
-    private let contentView = UIView()
+// MARK: URLInputTableViewCell
+
+fileprivate class URLInputTableViewCell: UITableViewCell {
+
+    // MARK: Design
     
-    lazy var doneButton: UIButton = {
-        let doneButton = UIButton()
-        doneButton.setTitle("Done", for: .normal)
-        doneButton.addTarget(self, action: #selector(done), for: .touchUpInside)
-        doneButton.setTitleColor(UIConstants.systemBlueColor, for: .normal)
-        doneButton.accessibilityIdentifier = "AddCustomSearchTableViewController.doneButton"
-        return doneButton
-    }()
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        contentView.backgroundColor = UIColor.white
-        addSubview(contentView)
-        contentView.addSubview(doneButton)
-        setConstraints()
+    struct Design {
+        static let cellHeight: CGFloat = 88
+        static let cellInset: CGFloat = 16
     }
-
+    
+    // MARK: Properties
+    
+    var textview = UITextView(frame: .zero)
+    
+    weak var delegate: UITextViewDelegate? {
+        didSet {
+            textview.delegate = delegate
+        }
+    }
+    // MARK: Lifecycle
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setup()
+    }
+    
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    func setConstraints() {
-        contentView.snp.makeConstraints { make in
-            make.leading.trailing.top.bottom.equalToSuperview()
+    
+    // MARK: Internal
+    
+    private func setup() {
+        textview = UITextView(frame: CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)).then {
+            $0.backgroundColor = .clear
+            $0.backgroundColor = .clear
+            $0.font = UIFont.systemFont(ofSize: Design.cellInset)
+            $0.autocapitalizationType = .none
+            $0.autocorrectionType = .no
+            $0.spellCheckingType = .no
+            $0.keyboardType = .URL
         }
-
-        doneButton.snp.makeConstraints { make in
-            make.trailing.equalTo(self.contentView.snp.trailing).inset(20)
-            make.centerY.equalToSuperview()
-        }
-    }
-
-    @objc private func done() {
-        //TODO: Done
+        
+        contentView.addSubview(textview)
+        
+        textview.snp.makeConstraints({ make in
+            make.leading.trailing.equalToSuperview().inset(Design.cellInset)
+            make.bottom.top.equalToSuperview()
+            make.height.equalTo(Design.cellHeight)
+        })
     }
 }
 
-class TextInputCell: UITableViewCell {
+// MARK: TitleInputTableViewCell
+
+fileprivate class TitleInputTableViewCell: UITableViewCell {
+
+    // MARK: Design
     
-    fileprivate static let URLCellHeight = 88.0
-    fileprivate static let TitleCellHeight = 44.0
-    
-    enum CellType {
-        case textField(UITextFieldDelegate?)
-        case textView(UITextViewDelegate?)
+    struct Design {
+        static let cellHeight: CGFloat = 44
+        static let cellInset: CGFloat = 16
     }
     
-    static let identifier: String = "TextInputCell"
+    // MARK: Properties
     
-    var textfield: UITextField?
-    var textview: UITextView?
-
-    var type = CellType.textView(nil) {
+    var textfield: UITextField = UITextField(frame: .zero)
+    
+    weak var delegate: UITextFieldDelegate? {
         didSet {
-            setup()
+            textfield.delegate = delegate
         }
     }
 
+    // MARK: Lifecycle
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setup()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Internal
+    
     private func setup() {
+        textfield = UITextField(frame: CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height))
+                
+        contentView.addSubview(textfield)
         
-        //contentView.backgroundColor = .white
-        
-        switch type {
-        case .textField(let delegate):
-            textview?.removeFromSuperview()
-            textview = nil
-            textfield = UITextField(frame: CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height))
-            textfield?.delegate = delegate
-            contentView.addSubview(textfield!)
-            
-            textfield?.snp.makeConstraints({ make in
-                make.leading.trailing.equalToSuperview().inset(16)
-                make.bottom.top.equalToSuperview()
-                make.height.equalTo(TextInputCell.TitleCellHeight)
-            })
-        case .textView(let delegate):
-            textfield?.removeFromSuperview()
-            textfield = nil
-            textview = UITextView(frame: CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height))
-            textview?.backgroundColor = .clear
-            textview?.font = UIFont.systemFont(ofSize: 16)
-            textview?.delegate = delegate
-            self.contentView.addSubview(textview!)
-            
-            textview?.snp.makeConstraints({ make in
-                make.leading.trailing.equalToSuperview().inset(16)
-                make.bottom.top.equalToSuperview()
-                make.height.equalTo(TextInputCell.URLCellHeight)
-            })
-        }
+        textfield.snp.makeConstraints({ make in
+            make.leading.trailing.equalToSuperview().inset(Design.cellInset)
+            make.bottom.top.equalToSuperview()
+            make.height.equalTo(Design.cellHeight)
+        })
     }
 }

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -346,7 +346,9 @@ extension SearchCustomEngineViewController {
                 return
             }
             
-            self?.loadSearchEngineMetaData(from: data, url: host)
+            ensureMainThread {
+                self?.loadSearchEngineMetaData(from: data, url: host)
+            }
         }
         
         dataTask?.resume()
@@ -359,12 +361,16 @@ extension SearchCustomEngineViewController {
             return
         }
         
-        openSearchEngine = searchEngineDetails
+        faviconImage = #imageLiteral(resourceName: "defaultFavicon")
         
-        let fetcher = FaviconFetcher(siteURL: url, kind: .favicon, domain: nil)
+        let fetcher = FaviconFetcher(siteURL: url, kind: .largeIcon)
         fetcher.load { [weak self] _, attributes in
-            self?.faviconImage = attributes.image ?? #imageLiteral(resourceName: "defaultFavicon")
+            guard let self = self else { return }
+            
+            self.faviconImage = attributes.image ?? #imageLiteral(resourceName: "defaultFavicon")
         }
+        
+        openSearchEngine = searchEngineDetails
     }
     
     func fetchOpenSearchReference(document: HTMLDocument) -> OpenSearchReference? {

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -75,6 +75,8 @@ class SearchCustomEngineViewController: UIViewController {
         }
     }
     
+    private var fetcher: FaviconFetcher?
+    
     fileprivate var faviconImage: UIImage?
     
     private lazy var spinnerView = UIActivityIndicatorView(style: .gray).then {
@@ -360,17 +362,15 @@ extension SearchCustomEngineViewController {
             openSearchEngine = nil
             return
         }
+                
+        fetcher = FaviconFetcher(siteURL: url, kind: .favicon)
         
-        faviconImage = #imageLiteral(resourceName: "defaultFavicon")
-        
-        let fetcher = FaviconFetcher(siteURL: url, kind: .largeIcon)
-        fetcher.load { [weak self] _, attributes in
+        fetcher?.load { [weak self] _, attributes in
             guard let self = self else { return }
             
             self.faviconImage = attributes.image ?? #imageLiteral(resourceName: "defaultFavicon")
+            self.openSearchEngine = searchEngineDetails
         }
-        
-        openSearchEngine = searchEngineDetails
     }
     
     func fetchOpenSearchReference(document: HTMLDocument) -> OpenSearchReference? {
@@ -403,6 +403,7 @@ extension SearchCustomEngineViewController {
                 self.handleError(error: error)
             } else if let engine = engine {
                 try? self.profile.searchEngines.addSearchEngine(engine)
+                
             }
             
             self.setSaveButton(for: .enabled)
@@ -434,11 +435,9 @@ extension SearchCustomEngineViewController {
             return
         }
 
-        let fetcher = FaviconFetcher(siteURL: hostUrl, kind: .favicon, domain: nil)
+        fetcher = FaviconFetcher(siteURL: hostUrl, kind: .favicon)
 
-        fetcher.load { siteUrl, attributes in
-            guard siteUrl == url else { return }
-
+        fetcher?.load { siteUrl, attributes in
             if let image = attributes.image {
                 engineImage = image
             }

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -295,7 +295,7 @@ extension SearchCustomEngineViewController {
         NetworkManager().downloadResource(with: url).uponQueue(.main) { [weak self] response in
             guard let self = self else { return }
             
-            if let openSearchEngine = OpenSearchParser(pluginMode: true).parse(response.data, referenceURL: referenceURL, image: iconImage) {
+            if let openSearchEngine = OpenSearchParser(pluginMode: true).parse(response.data, referenceURL: referenceURL, image: iconImage, isCustomEngine: true) {
                 self.addSearchEngine(openSearchEngine)
             } else {
                 let alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -1,0 +1,350 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Static
+import Shared
+import WebKit
+import SnapKit
+import Fuzi
+import Storage
+import Data
+
+private let log = Logger.browserLogger
+
+// MARK: - SearchCustomEngineViewController
+
+class SearchCustomEngineViewController: UITableViewController {
+    
+    // MARK: Properties
+    
+    private var profile: Profile
+    
+    private var showAutoAddSearchButton = false {
+        didSet {
+            manageURLHeaderView()
+        }
+    }
+    
+    private var urlText = ""
+    
+    private var titleText: String?
+    
+    private var urlHeader: CustomSearchEngineURLHeader!
+    
+    private lazy var spinnerView: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .gray)
+        spinner.hidesWhenStopped = true
+        return spinner
+    }()
+    
+    // MARK: Lifecycle
+    
+    init(profile: Profile) {
+        self.profile = profile
+        
+        super.init(style: .grouped)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        //profile = (UIApplication.shared.delegate as! AppDelegate).profile!
+        
+        tableView.register(TextInputCell.self, forCellReuseIdentifier: TextInputCell.identifier)
+        
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(cancel))
+        
+        title = "Add Search Engine"
+        
+        setSaveButton()
+    }
+    
+    // MARK: UITableViewDelegate / UITableViewDataSource
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: TextInputCell.identifier) as? TextInputCell
+        switch indexPath.section {
+            case 0:
+                cell?.type = .textView(self)
+                cell?.textview?.autocapitalizationType = .none
+                cell?.textview?.autocorrectionType = .no
+                cell?.textview?.keyboardType = .URL
+            case 1:
+                cell?.type = .textField(self)
+            default:
+                break
+        }
+        return cell ?? UITableViewCell()
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        switch section {
+            case 0:
+                return "Write the search url and replace the query with %s.\nFor example: https://youtube.com/search?q=%s \n(If the site supports OpenSearch an option to add automatically will be provided while editing this field.)"
+            default:
+                return nil
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let header = CustomSearchEngineURLHeader(frame: CGRect(x: 0, y: 0, width: 1, height: 44.0))
+        
+        switch section {
+            case 0:
+                header.titleLabel.text = Strings.URL
+                header.addEngineButton.state = showAutoAddSearchButton ? .enabled : .disabled
+                urlHeader = header
+            default:
+                header.addEngineButton.isHidden = true
+                header.titleLabel.text = "Title"
+
+        }
+        
+        return header
+    }
+    
+    // MARK: Internal
+    
+    fileprivate func setSaveButton() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(self.addCustomSearchEngine))
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "customEngineSaveButton"
+    }
+    
+    fileprivate func showNavBarLoader() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinnerView)
+        spinnerView.startAnimating()
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "customEngineActivityIndicator"
+    }
+    
+    private func manageURLHeaderView(loading: Bool = false) {
+        //urlHeader.addEngineButton.state = loading ? .loading : showAutoAddSearchButton ? .enabled : .disabled
+    }
+    
+    private func handleError(error: Error) {
+        let alert: UIAlertController
+        
+        if let searchError = error as? SearchEngineError {
+            switch searchError {
+                case .duplicate:
+                    alert = ThirdPartySearchAlerts.duplicateCustomEngine()
+                case .invalidQuery:
+                    alert = ThirdPartySearchAlerts.incorrectCustomEngineForm()
+                case .failedToSave:
+                    alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
+            }
+        } else {
+            alert = ThirdPartySearchAlerts.failedToAddThirdPartySearch()
+        }
+        
+        log.error(error)
+        present(alert, animated: true, completion: nil)
+    }
+
+    // MARK: Actions
+    
+    @objc func addCustomSearchEngine(_ nav: UINavigationController?) {
+        view.endEditing(true)
+        
+        // TODO: Add Logic
+    }
+    
+    @objc fileprivate func cancel() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+extension SearchCustomEngineViewController: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        // Identify host if possible.
+        if let text = textView.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+            let url = URL(string: text.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!),
+            url.host != nil,
+            url.isWebPage() {
+            
+           // Identify the host
+        }
+        
+        urlText = textView.text
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        urlText = textView.text
+    }
+
+    func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+        let accessoryView = AddSearchEngineAccessoryView(frame: CGRect(width: 0, height: 44.0))
+        textView.inputAccessoryView = accessoryView
+        
+        return true
+    }
+}
+
+extension SearchCustomEngineViewController: UITextFieldDelegate {
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        //hold the text for future.
+        titleText = textField.text
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
+        return true
+    }
+}
+
+fileprivate class CustomSearchEngineURLHeader: UIView {
+
+    var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor.Photon.grey50
+        return label
+    }()
+
+    lazy var addEngineButton: OpenSearchEngineButton = {
+        let searchButton = OpenSearchEngineButton(title: "Auto Add", hidesWhenDisabled: false)
+        searchButton.addTarget(self, action: #selector(addEngine), for: .touchUpInside)
+        searchButton.accessibilityIdentifier = "BrowserViewController.customSearchEngineButton"
+        return searchButton
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(titleLabel)
+        addSubview(addEngineButton)
+        
+        setConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setConstraints() {
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(20)
+            make.top.equalToSuperview()
+            make.bottom.equalToSuperview()
+            make.height.equalTo(44.0)
+        }
+        addEngineButton.snp.makeConstraints { make in
+            make.trailing.equalTo(self.snp.trailing).inset(20)
+            make.centerY.equalToSuperview()
+            make.height.equalTo(self.snp.height)
+        }
+    }
+
+    @objc private func addEngine() {
+        // TODO: Add Engine URL
+    }
+}
+
+fileprivate class AddSearchEngineAccessoryView: UIView {
+    private let contentView = UIView()
+    
+    lazy var doneButton: UIButton = {
+        let doneButton = UIButton()
+        doneButton.setTitle("Done", for: .normal)
+        doneButton.addTarget(self, action: #selector(done), for: .touchUpInside)
+        doneButton.setTitleColor(UIConstants.systemBlueColor, for: .normal)
+        doneButton.accessibilityIdentifier = "AddCustomSearchTableViewController.doneButton"
+        return doneButton
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.backgroundColor = UIColor.white
+        addSubview(contentView)
+        contentView.addSubview(doneButton)
+        setConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setConstraints() {
+        contentView.snp.makeConstraints { make in
+            make.leading.trailing.top.bottom.equalToSuperview()
+        }
+
+        doneButton.snp.makeConstraints { make in
+            make.trailing.equalTo(self.contentView.snp.trailing).inset(20)
+            make.centerY.equalToSuperview()
+        }
+    }
+
+    @objc private func done() {
+        //TODO: Done
+    }
+}
+
+class TextInputCell: UITableViewCell {
+    
+    fileprivate static let URLCellHeight = 88.0
+    fileprivate static let TitleCellHeight = 44.0
+    
+    enum CellType {
+        case textField(UITextFieldDelegate?)
+        case textView(UITextViewDelegate?)
+    }
+    
+    static let identifier: String = "TextInputCell"
+    
+    var textfield: UITextField?
+    var textview: UITextView?
+
+    var type = CellType.textView(nil) {
+        didSet {
+            setup()
+        }
+    }
+
+    private func setup() {
+        
+        //contentView.backgroundColor = .white
+        
+        switch type {
+        case .textField(let delegate):
+            textview?.removeFromSuperview()
+            textview = nil
+            textfield = UITextField(frame: CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height))
+            textfield?.delegate = delegate
+            contentView.addSubview(textfield!)
+            
+            textfield?.snp.makeConstraints({ make in
+                make.leading.trailing.equalToSuperview().inset(16)
+                make.bottom.top.equalToSuperview()
+                make.height.equalTo(TextInputCell.TitleCellHeight)
+            })
+        case .textView(let delegate):
+            textfield?.removeFromSuperview()
+            textfield = nil
+            textview = UITextView(frame: CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height))
+            textview?.backgroundColor = .clear
+            textview?.font = UIFont.systemFont(ofSize: 16)
+            textview?.delegate = delegate
+            self.contentView.addSubview(textview!)
+            
+            textview?.snp.makeConstraints({ make in
+                make.leading.trailing.equalToSuperview().inset(16)
+                make.bottom.top.equalToSuperview()
+                make.height.equalTo(TextInputCell.URLCellHeight)
+            })
+        }
+    }
+}

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -39,6 +39,8 @@ class SearchCustomEngineViewController: UIViewController {
         static let urlInputRowIdentifier = "urlInputRowIdentifier"
         static let titleInputRowIdentifier = "titleInputRowIdentifier"
         static let searchEngineHeaderIdentifier = "searchEngineHeaderIdentifier"
+        static let urlEntryMaxCharacterCount  = 150
+        static let titleEntryMaxCharacterCount = 50
     }
     
     // MARK: Properties
@@ -96,7 +98,7 @@ class SearchCustomEngineViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        title = "Add Search Engine"
+        title = Strings.CustomSearchEngine.customEngineNavigationTitle
         
         setup()
         doLayout()
@@ -114,7 +116,7 @@ class SearchCustomEngineViewController: UIViewController {
             $0.delegate = self
         }
         
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(cancel))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.cancelButtonTitle, style: .plain, target: self, action: #selector(cancel))
     }
     
     private func doLayout() {
@@ -216,7 +218,7 @@ extension SearchCustomEngineViewController: UITableViewDelegate, UITableViewData
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard section == Section.url.rawValue else { return nil }
         
-        return "Write the search url and replace the query with %s.\nFor example: https://youtube.com/search?q=%s \n(If the site supports OpenSearch an option to add automatically will be provided while editing this field.)"
+        return Strings.CustomSearchEngine.customEngineAddDesription
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -235,7 +237,7 @@ extension SearchCustomEngineViewController: UITableViewDelegate, UITableViewData
                 headerView.addEngineButton.state = showAutoAddSearchButton ? .enabled : .disabled
                 urlHeader = headerView
             default:
-                headerView.titleLabel.text = "Title"
+                headerView.titleLabel.text = Strings.title
                 headerView.addEngineButton.isHidden = true
         }
         
@@ -276,7 +278,6 @@ extension SearchCustomEngineViewController {
         urlHeader?.addEngineButton.state = .loading
         view.endEditing(true)
         
-
         NetworkManager().downloadResource(with: url).uponQueue(.main) { [weak self] response in
             guard let self = self else { return }
             
@@ -379,7 +380,6 @@ extension SearchCustomEngineViewController {
     }
 }
 
-
 // MARK: Manual Add Engine
 
 extension SearchCustomEngineViewController {
@@ -442,11 +442,11 @@ extension SearchCustomEngineViewController {
         let searchTermPlaceholder = "%s"
         let searchTemplatePlaceholder = "{searchTerms}"
         
-        guard query.contains(searchTermPlaceholder) else {
-            return nil
+        if query.contains(searchTermPlaceholder) {
+            return query.replacingOccurrences(of: searchTermPlaceholder, with: searchTemplatePlaceholder)
         }
         
-        return query.replacingOccurrences(of: searchTermPlaceholder, with: searchTemplatePlaceholder)
+        return nil
     }
 }
 
@@ -460,7 +460,7 @@ extension SearchCustomEngineViewController: UITextViewDelegate {
             return false
         }
 
-        return textView.text.count + (text.count - range.length) <= 150
+        return textView.text.count + (text.count - range.length) <= Constants.urlEntryMaxCharacterCount
     }
     
     func textViewDidChange(_ textView: UITextView) {
@@ -492,7 +492,7 @@ extension SearchCustomEngineViewController: UITextFieldDelegate {
         let currentString: NSString = text as NSString
         let newString: NSString = currentString.replacingCharacters(in: range, with: string) as NSString
         
-        return newString.length <= 50
+        return newString.length <= Constants.titleEntryMaxCharacterCount
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
@@ -524,7 +524,7 @@ fileprivate class SearchEngineTableViewHeader: UITableViewHeaderFooterView {
         $0.textColor = UIColor.Photon.grey50
     }
 
-    lazy var addEngineButton = OpenSearchEngineButton(title: "Auto Add", hidesWhenDisabled: false).then {
+    lazy var addEngineButton = OpenSearchEngineButton(title: Strings.CustomSearchEngine.customEngineAutoAddTitle, hidesWhenDisabled: false).then {
         $0.addTarget(self, action: #selector(addEngineAuto), for: .touchUpInside)
     }
 

--- a/Client/Frontend/Settings/SearchQuickEnginesViewController.swift
+++ b/Client/Frontend/Settings/SearchQuickEnginesViewController.swift
@@ -1,0 +1,159 @@
+// Copyright 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Shared
+
+private let log = Logger.browserLogger
+
+// MARK: - SearchQuickEnginesViewController
+
+class SearchQuickEnginesViewController: UITableViewController {
+    
+    // MARK: Design
+    
+    struct Design {
+        static let iconSize = CGSize(
+            width: OpenSearchEngine.preferredIconSize,
+            height: OpenSearchEngine.preferredIconSize)
+        
+        static let headerHeight: CGFloat = 44
+    }
+    
+    // MARK: Constants
+    
+    struct Constants {
+        static let sectionHeaderIdentifier = "sectionHeaderIdentifier"
+        static let quickSearchEngineRowIdentifier = "quickSearchEngineRowIdentifier"
+    }
+    
+    private var searchEngines: SearchEngines
+    private let profile: Profile
+    
+    // MARK: Lifecycle
+    
+    init(profile: Profile) {
+        self.profile = profile
+        self.searchEngines = profile.searchEngines
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.title = Strings.quickSearchEngines
+
+        tableView.do {
+            $0.isEditing = true
+            $0.register(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: Constants.sectionHeaderIdentifier)
+            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickSearchEngineRowIdentifier)
+        }
+
+        let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: Design.headerHeight))
+        tableView.tableFooterView = footer
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        tableView.reloadData()
+    }
+    
+    // MARK: TableViewDataSource - TableViewDelegate
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return searchEngines.orderedEngines.count - 1
+    }
+    
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let headerView =
+                tableView.dequeueReusableHeaderFooterView(withIdentifier: Constants.sectionHeaderIdentifier) as? SettingsTableSectionHeaderFooterView else {
+            return UITableViewHeaderFooterView()
+        }
+                
+        headerView.titleLabel.text = Strings.quickSearchEngines
+        return headerView
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        var engine: OpenSearchEngine?
+
+        // The default engine is not a quick search engine.
+        let index = indexPath.item + 1
+        engine = searchEngines.orderedEngines[index]
+        
+        let toggle = UISwitch().then {
+            $0.tag = index
+            $0.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
+            if let searchEngine = engine {
+                $0.isOn = searchEngines.isEngineEnabled(searchEngine)
+            }
+        }
+        
+        let searchEngineCell = tableView.dequeueReusableCell(withIdentifier: Constants.quickSearchEngineRowIdentifier, for: indexPath).then {
+            $0.showsReorderControl = true
+            $0.editingAccessoryView = toggle
+            $0.selectionStyle = .none
+            $0.separatorInset = .zero
+            $0.textLabel?.text = engine?.displayName
+            $0.textLabel?.adjustsFontSizeToFitWidth = true
+            $0.textLabel?.minimumScaleFactor = 0.5
+            $0.imageView?.image = engine?.image.createScaled(Design.iconSize)
+            $0.imageView?.layer.cornerRadius = 4
+            $0.imageView?.layer.masksToBounds = true
+        }
+
+        return searchEngineCell
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return Design.headerHeight
+    }
+
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+
+    override func tableView(_ tableView: UITableView, moveRowAt indexPath: IndexPath, to newIndexPath: IndexPath) {
+        // The first engine (default engine) is not shown in the list, so the indices are off-by-1.
+        let index = indexPath.item + 1
+        let newIndex = newIndexPath.item + 1
+        let engine = searchEngines.orderedEngines.remove(at: index)
+        
+        searchEngines.orderedEngines.insert(engine, at: newIndex)
+        tableView.reloadData()
+    }
+    
+    override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        return .none
+    }
+
+    override func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+}
+
+// MARK: - Actions
+
+extension SearchQuickEnginesViewController {
+    
+    @objc func didToggleEngine(_ toggle: UISwitch) {
+        let engine = searchEngines.orderedEngines[toggle.tag]
+        
+        if toggle.isOn {
+            searchEngines.enableEngine(engine)
+        } else {
+            searchEngines.disableEngine(engine)
+        }
+    }
+}

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -5,6 +5,8 @@
 import UIKit
 import Shared
 
+private let log = Logger.browserLogger
+
 protocol SearchEnginePickerDelegate: class {
     func searchEnginePicker(_ searchEnginePicker: SearchEnginePicker?,
                             didSelectSearchEngine engine: OpenSearchEngine?, forType: DefaultEngineType?)
@@ -251,8 +253,13 @@ class SearchSettingsTableViewController: UITableViewController {
         if editingStyle == .delete {
             let index = indexPath.item + 1
             let engine = model.orderedEngines[index]
-            model.deleteCustomEngine(engine)
-            tableView.deleteRows(at: [indexPath], with: .right)
+            
+            do {
+                try model.deleteCustomEngine(engine)
+                tableView.deleteRows(at: [indexPath], with: .right)
+            } catch {
+                log.error("Search Engine Error while deleting")
+            }
         }
     }
 }

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -32,9 +32,11 @@ class SearchSettingsTableViewController: UITableViewController {
     
     struct Constants {
         static let sectionHeaderIdentifier = "sectionHeaderIdentifier"
-        static let customEngineRowIdentifier = "customEngineRowIdentifier"
+        static let addCustomEngineRowIdentifier = "addCustomEngineRowIdentifier"
         static let searchEngineRowIdentifier = "searchEngineRowIdentifier"
-        static let quickEngineRowIdentifier = "quickEngineRowIdentifier"
+        static let quickSearchEngineRowIdentifier = "quickSearchEngineRowIdentifier"
+        
+        static let quickRemoveEngineRowIdentifier = "quickRemoveEngineRowIdentifier"
     }
     
     // MARK: Section
@@ -49,6 +51,7 @@ class SearchSettingsTableViewController: UITableViewController {
     enum CurrentEngineType: Int, CaseIterable {
         case standard
         case `private`
+        case quick
         case suggestions
     }
     
@@ -92,9 +95,11 @@ class SearchSettingsTableViewController: UITableViewController {
             $0.allowsSelectionDuringEditing = true
 
             $0.register(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: Constants.sectionHeaderIdentifier)
-            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.customEngineRowIdentifier)
+            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.addCustomEngineRowIdentifier)
             $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.searchEngineRowIdentifier)
-            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickEngineRowIdentifier)
+            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickSearchEngineRowIdentifier)
+            
+            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickRemoveEngineRowIdentifier)
         }
 
         // Insert Done button if being presented outside of the Settings Nav stack
@@ -127,6 +132,11 @@ class SearchSettingsTableViewController: UITableViewController {
                 case CurrentEngineType.private.rawValue:
                     engine = model.defaultEngine(forType: .privateMode)
                     cell = configureSearchEngineCell(type: .privateMode, engineName: engine?.displayName)
+                case CurrentEngineType.quick.rawValue:
+                    cell = tableView.dequeueReusableCell(withIdentifier: Constants.quickSearchEngineRowIdentifier, for: indexPath).then {
+                        $0.textLabel?.text = Strings.quickSearchEngines
+                        $0.editingAccessoryType = .disclosureIndicator
+                    }
                 case CurrentEngineType.suggestions.rawValue:
                     let toggle = UISwitch().then {
                         $0.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
@@ -148,7 +158,7 @@ class SearchSettingsTableViewController: UITableViewController {
             
             // Add custom engine
             if index == model.orderedEngines.count {
-                cell = tableView.dequeueReusableCell(withIdentifier: Constants.customEngineRowIdentifier, for: indexPath).then {
+                cell = tableView.dequeueReusableCell(withIdentifier: Constants.addCustomEngineRowIdentifier, for: indexPath).then {
                     $0.textLabel?.text = Strings.searchSettingAddCustomEngineCellTitle
                     $0.editingAccessoryType = .disclosureIndicator
                 }
@@ -164,7 +174,7 @@ class SearchSettingsTableViewController: UITableViewController {
                     }
                 }
                 
-                cell = tableView.dequeueReusableCell(withIdentifier: Constants.quickEngineRowIdentifier, for: indexPath).then {
+                cell = tableView.dequeueReusableCell(withIdentifier: Constants.quickRemoveEngineRowIdentifier, for: indexPath).then {
                     $0.showsReorderControl = true
                     $0.editingAccessoryView = toggle
                     $0.textLabel?.text = engine?.displayName
@@ -244,6 +254,9 @@ class SearchSettingsTableViewController: UITableViewController {
             }
             
             navigationController?.pushViewController(searchEnginePicker, animated: true)
+        } else if indexPath.section == Section.current.rawValue && indexPath.item == CurrentEngineType.quick.rawValue {
+            let quickSearchEnginesViewController = SearchQuickEnginesViewController(profile: profile)
+            navigationController?.pushViewController(quickSearchEnginesViewController, animated: true)
         } else if indexPath.section == Section.quickSearch.rawValue && indexPath.item == model.orderedEngines.count - 1 {
             let customEngineViewController = SearchCustomEngineViewController(profile: profile)
             navigationController?.pushViewController(customEngineViewController, animated: true)

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -70,7 +70,7 @@ class SearchSettingsTableViewController: UITableViewController {
     
     // MARK: Lifecycle
     
-    init(profile: Profile, theme: Theme) {
+    init(profile: Profile) {
         self.profile = profile
         self.model = profile.searchEngines
         super.init(nibName: nil, bundle: nil)

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -53,6 +53,7 @@ class SearchSettingsTableViewController: UITableViewController {
     }
     
     private var model: SearchEngines
+    private let profile: Profile
     private var showDeletion = false
     
     private var searchPickerEngines: [OpenSearchEngine] {
@@ -69,9 +70,9 @@ class SearchSettingsTableViewController: UITableViewController {
     
     // MARK: Lifecycle
     
-    init(model: SearchEngines) {
-        self.model = model
-        
+    init(profile: Profile, theme: Theme) {
+        self.profile = profile
+        self.model = profile.searchEngines
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -244,7 +245,8 @@ class SearchSettingsTableViewController: UITableViewController {
             
             navigationController?.pushViewController(searchEnginePicker, animated: true)
         } else if indexPath.section == Section.quickSearch.rawValue && indexPath.item == model.orderedEngines.count - 1 {
-            // TODO: Add Custom Search Controller
+            let customEngineViewController = SearchCustomEngineViewController(profile: profile)
+            navigationController?.pushViewController(customEngineViewController, animated: true)
         }
         
         return nil

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -7,105 +7,187 @@ import Shared
 
 private let log = Logger.browserLogger
 
+// MARK: - SearchEnginePickerDelegate
+
 protocol SearchEnginePickerDelegate: class {
     func searchEnginePicker(_ searchEnginePicker: SearchEnginePicker?,
                             didSelectSearchEngine engine: OpenSearchEngine?, forType: DefaultEngineType?)
 }
 
+// MARK: - SearchSettingsTableViewController
+
 class SearchSettingsTableViewController: UITableViewController {
-    fileprivate let SectionDefault = 0
-    fileprivate let ItemDefaultEngine = 0
-    fileprivate let ItemDefaultPrivateEngine = 1
-    fileprivate let ItemDefaultSuggestions = 2
-    fileprivate let NumberOfItemsInSectionDefault = 3
-    fileprivate let SectionOrder = 1
-    fileprivate let NumberOfSections = 2
-    fileprivate let IconSize = CGSize(width: OpenSearchEngine.preferredIconSize, height: OpenSearchEngine.preferredIconSize)
-    fileprivate let SectionHeaderIdentifier = "SectionHeaderIdentifier"
     
-    fileprivate var showDeletion = false
+    // MARK: Design
     
-    var profile: Profile?
-    var tabManager: TabManager?
-
-    var model: SearchEngines!
-
+    struct Design {
+        static let iconSize = CGSize(
+            width: OpenSearchEngine.preferredIconSize,
+            height: OpenSearchEngine.preferredIconSize)
+        
+        static let headerHeight: CGFloat = 44
+    }
+    
+    // MARK: Constants
+    
+    struct Constants {
+        static let sectionHeaderIdentifier = "sectionHeaderIdentifier"
+        static let customEngineRowIdentifier = "customEngineRowIdentifier"
+        static let searchEngineRowIdentifier = "searchEngineRowIdentifier"
+        static let quickEngineRowIdentifier = "quickEngineRowIdentifier"
+    }
+    
+    // MARK: Section
+    
+    enum Section: Int, CaseIterable {
+        case current
+        case quickSearch
+    }
+    
+    // MARK: CurrentEngineType
+    
+    enum CurrentEngineType: Int, CaseIterable {
+        case standard
+        case `private`
+        case suggestions
+    }
+    
+    private var model: SearchEngines
+    private var showDeletion = false
+    
+    private var searchPickerEngines: [OpenSearchEngine] {
+        let orderedEngines = model.orderedEngines.sorted { $0.shortName < $1.shortName }
+        
+        guard let priorityEngine = InitialSearchEngines().priorityEngine?.rawValue else {
+            return orderedEngines
+        }
+        
+        return orderedEngines.sorted { engine, _ in
+            engine.engineID == priorityEngine
+        }
+    }
+    
+    // MARK: Lifecycle
+    
+    init(model: SearchEngines) {
+        self.model = model
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
         navigationItem.title = Strings.searchSettingNavTitle
 
-        // To allow re-ordering the list of search engines at all times.
-        tableView.isEditing = true
-        // So that we push the default search engine controller on selection.
-        tableView.allowsSelectionDuringEditing = true
+        tableView.do {
+            // To allow re-ordering the list of search engines at all times.
+            $0.isEditing = true
+            // So that we push the default search engine controller on selection.
+            $0.allowsSelectionDuringEditing = true
 
-        tableView.register(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderIdentifier)
-
-        // Insert Done button if being presented outside of the Settings Nav stack
-        if !(self.navigationController is SettingsNavigationController) {
-            self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.settingsSearchDoneButton, style: .done, target: self, action: #selector(self.dismissAnimated))
+            $0.register(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: Constants.sectionHeaderIdentifier)
+            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.customEngineRowIdentifier)
+            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.searchEngineRowIdentifier)
+            $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickEngineRowIdentifier)
         }
 
-        let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: 44))
+        // Insert Done button if being presented outside of the Settings Nav stack
+        if !(navigationController is SettingsNavigationController) {
+            navigationItem.leftBarButtonItem =
+                UIBarButtonItem(title: Strings.settingsSearchDoneButton, style: .done, target: self, action: #selector(dismissAnimated))
+        }
+
+        let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: Design.headerHeight))
         tableView.tableFooterView = footer
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        tableView.reloadData()
+    }
+    
+    // MARK: TableViewDataSource - TableViewDelegate
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        var cell: UITableViewCell!
-        var engine: OpenSearchEngine!
+        var cell: UITableViewCell?
+        var engine: OpenSearchEngine?
 
-        if indexPath.section == SectionDefault {
+        if indexPath.section == Section.current.rawValue {
             switch indexPath.item {
-            case ItemDefaultEngine:
-                engine = model.defaultEngine(forType: .standard)
-                cell = configureSearchEngineCell(type: .standard, engineName: engine.displayName)
-            case ItemDefaultPrivateEngine:
-                engine = model.defaultEngine(forType: .privateMode)
-                cell = configureSearchEngineCell(type: .privateMode, engineName: engine.displayName)
-            case ItemDefaultSuggestions:
-                cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-                cell.textLabel?.text = Strings.searchSettingSuggestionCellTitle
-                let toggle = UISwitch()
-                toggle.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
-                toggle.isOn = model.shouldShowSearchSuggestions
-                cell.editingAccessoryView = toggle
-                cell.selectionStyle = .none
-            default:
-                // Should not happen.
-                break
+                case CurrentEngineType.standard.rawValue:
+                    engine = model.defaultEngine(forType: .standard)
+                    cell = configureSearchEngineCell(type: .standard, engineName: engine?.displayName)
+                case CurrentEngineType.private.rawValue:
+                    engine = model.defaultEngine(forType: .privateMode)
+                    cell = configureSearchEngineCell(type: .privateMode, engineName: engine?.displayName)
+                case CurrentEngineType.suggestions.rawValue:
+                    let toggle = UISwitch().then {
+                        $0.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
+                        $0.isOn = model.shouldShowSearchSuggestions
+                    }
+                    
+                    cell = tableView.dequeueReusableCell(withIdentifier: Constants.searchEngineRowIdentifier, for: indexPath).then {
+                        $0.textLabel?.text = Strings.searchSettingSuggestionCellTitle
+                        $0.editingAccessoryView = toggle
+                        $0.selectionStyle = .none
+                    }
+                default:
+                    // Should not happen.
+                    break
             }
         } else {
             // The default engine is not a quick search engine.
             let index = indexPath.item + 1
-            engine = model.orderedEngines[index]
             
-            cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-            cell.showsReorderControl = true
-            
-            let toggle = UISwitch()
-            // This is an easy way to get from the toggle control to the corresponding index.
-            toggle.tag = index
-            toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
-            toggle.isOn = model.isEngineEnabled(engine)
-            
-            cell.editingAccessoryView = toggle
-            cell.textLabel?.text = engine.displayName
-            cell.textLabel?.adjustsFontSizeToFitWidth = true
-            cell.textLabel?.minimumScaleFactor = 0.5
-            cell.imageView?.image = engine.image.createScaled(IconSize)
-            cell.imageView?.layer.cornerRadius = 4
-            cell.imageView?.layer.masksToBounds = true
-            cell.selectionStyle = .none
+            // Add custom engine
+            if index == model.orderedEngines.count {
+                cell = tableView.dequeueReusableCell(withIdentifier: Constants.customEngineRowIdentifier, for: indexPath).then {
+                    $0.textLabel?.text = Strings.searchSettingAddCustomEngineCellTitle
+                    $0.editingAccessoryType = .disclosureIndicator
+                }
+            } else {
+                engine = model.orderedEngines[index]
+                
+                let toggle = UISwitch().then {
+                    // This is an easy way to get from the toggle control to the corresponding index.
+                    $0.tag = index
+                    $0.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
+                    if let searchEngine = engine {
+                        $0.isOn = model.isEngineEnabled(searchEngine)
+                    }
+                }
+                
+                cell = tableView.dequeueReusableCell(withIdentifier: Constants.quickEngineRowIdentifier, for: indexPath).then {
+                    $0.showsReorderControl = true
+                    $0.editingAccessoryView = toggle
+                    $0.textLabel?.text = engine?.displayName
+                    $0.textLabel?.adjustsFontSizeToFitWidth = true
+                    $0.textLabel?.minimumScaleFactor = 0.5
+                    $0.imageView?.image = engine?.image.createScaled(Design.iconSize)
+                    $0.imageView?.layer.cornerRadius = 4
+                    $0.imageView?.layer.masksToBounds = true
+                    $0.selectionStyle = .none
+                }
+            }
         }
 
+        guard let searchEngineCell = cell else { return UITableViewCell() }
+        
         // So that the seperator line goes all the way to the left edge.
-        cell.separatorInset = .zero
+        searchEngineCell.separatorInset = .zero
 
-        return cell
+        return searchEngineCell
     }
     
-    private func configureSearchEngineCell(type: DefaultEngineType, engineName: String) -> UITableViewCell {
+    private func configureSearchEngineCell(type: DefaultEngineType, engineName: String?) -> UITableViewCell {
+        guard let searchEngineName = engineName else { return UITableViewCell() }
+
         var text: String
         
         switch type {
@@ -115,64 +197,62 @@ class SearchSettingsTableViewController: UITableViewController {
             text = Strings.privateTabSearch
         }
         
-        let cell = UITableViewCell(style: UITableViewCell.CellStyle.value1, reuseIdentifier: nil)
-        cell.editingAccessoryType = UITableViewCell.AccessoryType.disclosureIndicator
-        cell.accessibilityLabel = text
-        cell.textLabel?.text = text
-        cell.accessibilityValue = engineName
-        cell.detailTextLabel?.text = engineName
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: Constants.searchEngineRowIdentifier).then {
+            $0.editingAccessoryType = .disclosureIndicator
+            $0.accessibilityLabel = text
+            $0.textLabel?.text = text
+            $0.accessibilityValue = searchEngineName
+            $0.detailTextLabel?.text = searchEngineName
+        }
         
         return cell
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return NumberOfSections
+        return Section.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == SectionDefault {
-            return NumberOfItemsInSectionDefault
+        if section == Section.current.rawValue {
+            return CurrentEngineType.allCases.count
         } else {
             // The first engine -- the default engine -- is not shown in the quick search engine list.
             // But the option to add Custom Engine is.
-            return model.orderedEngines.count - 1
+            return model.orderedEngines.count
         }
-    }
-    
-    private var searchPickerEngines: [OpenSearchEngine] {
-        let orderedEngines = model.orderedEngines.sorted { $0.shortName < $1.shortName }
-        
-        guard let priorityEngine = InitialSearchEngines().priorityEngine?.rawValue else {
-            return orderedEngines
-        }
-        
-        return orderedEngines.sorted { e, _ in e.engineID == priorityEngine }
     }
 
     override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        if indexPath.section == SectionDefault && indexPath.item == ItemDefaultEngine {
-            let searchEnginePicker = SearchEnginePicker(type: .standard)
-            // Order alphabetically, so that picker is always consistently ordered.
-            // Every engine is a valid choice for the default engine, even the current default engine.
-            searchEnginePicker.engines = searchPickerEngines
-            searchEnginePicker.delegate = self
-            searchEnginePicker.selectedSearchEngineName = model.defaultEngine(forType: .standard).shortName
+        if indexPath.section == Section.current.rawValue && indexPath.item == CurrentEngineType.standard.rawValue {
+            let searchEnginePicker = SearchEnginePicker(type: .standard).then {
+                // Order alphabetically, so that picker is always consistently ordered.
+                // Every engine is a valid choice for the default engine, even the current default engine.
+                $0.engines = searchPickerEngines
+                $0.delegate = self
+                $0.selectedSearchEngineName = model.defaultEngine(forType: .standard).shortName
+            }
+            
             navigationController?.pushViewController(searchEnginePicker, animated: true)
-        } else if indexPath.section == SectionDefault && indexPath.item == ItemDefaultPrivateEngine {
-            let searchEnginePicker = SearchEnginePicker(type: .privateMode)
-            // Order alphabetically, so that picker is always consistently ordered.
-            // Every engine is a valid choice for the default engine, even the current default engine.
-            searchEnginePicker.engines = searchPickerEngines
-            searchEnginePicker.delegate = self
-            searchEnginePicker.selectedSearchEngineName = model.defaultEngine(forType: .privateMode).shortName
+        } else if indexPath.section == Section.current.rawValue && indexPath.item == CurrentEngineType.private.rawValue {
+            let searchEnginePicker = SearchEnginePicker(type: .privateMode).then {
+                // Order alphabetically, so that picker is always consistently ordered.
+                // Every engine is a valid choice for the default engine, even the current default engine.
+                $0.engines = searchPickerEngines
+                $0.delegate = self
+                $0.selectedSearchEngineName = model.defaultEngine(forType: .privateMode).shortName
+            }
+            
             navigationController?.pushViewController(searchEnginePicker, animated: true)
+        } else if indexPath.section == Section.quickSearch.rawValue && indexPath.item == model.orderedEngines.count - 1 {
+            // TODO: Add Custom Search Controller
         }
+        
         return nil
     }
 
     // Don't show delete button on the left.
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        if indexPath.section == SectionDefault || indexPath.item + 1 == model.orderedEngines.count {
+        if indexPath.section == Section.current.rawValue || indexPath.item + 1 == model.orderedEngines.count {
             return UITableViewCell.EditingStyle.none
         }
 
@@ -196,14 +276,14 @@ class SearchSettingsTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 44
+        return Design.headerHeight
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         // swiftlint:disable:next force_cast
-        let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderIdentifier) as! SettingsTableSectionHeaderFooterView
+        let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: Constants.sectionHeaderIdentifier) as! SettingsTableSectionHeaderFooterView
         
-        let sectionTitle = section == SectionDefault ?
+        let sectionTitle = section == Section.current.rawValue ?
             Strings.currentlyUsedSearchEngines : Strings.quickSearchEngines
         
         headerView.titleLabel.text = sectionTitle
@@ -211,7 +291,7 @@ class SearchSettingsTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        if indexPath.section == SectionDefault || indexPath.item + 1 == model.orderedEngines.count {
+        if indexPath.section == Section.current.rawValue || indexPath.item + 1 == model.orderedEngines.count {
             return false
         } else {
             return true
@@ -230,7 +310,8 @@ class SearchSettingsTableViewController: UITableViewController {
     // Snap to first or last row of the list of engines.
     override func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         // You can't drag or drop on the default engine.
-        if sourceIndexPath.section == SectionDefault || proposedDestinationIndexPath.section == SectionDefault {
+        if sourceIndexPath.section == Section.current.rawValue ||
+            proposedDestinationIndexPath.section == Section.current.rawValue {
             return sourceIndexPath
         }
 
@@ -264,8 +345,10 @@ class SearchSettingsTableViewController: UITableViewController {
     }
 }
 
-// MARK: - Selectors
+// MARK: - Actions
+
 extension SearchSettingsTableViewController {
+    
     @objc func didToggleEngine(_ toggle: UISwitch) {
         let engine = model.orderedEngines[toggle.tag] // The tag is 1-based.
         if toggle.isOn {
@@ -281,16 +364,15 @@ extension SearchSettingsTableViewController {
         model.shouldShowSearchSuggestionsOptIn = false
     }
 
-    func cancel() {
-        _ = navigationController?.popViewController(animated: true)
-    }
-
     @objc func dismissAnimated() {
         self.dismiss(animated: true, completion: nil)
     }
 }
 
+// MARK: SearchEnginePickerDelegate
+
 extension SearchSettingsTableViewController: SearchEnginePickerDelegate {
+    
     func searchEnginePicker(_ searchEnginePicker: SearchEnginePicker?,
                             didSelectSearchEngine searchEngine: OpenSearchEngine?, forType: DefaultEngineType?) {
         if let engine = searchEngine, let type = forType {

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -217,7 +217,7 @@ class SettingsViewController: TableViewController {
             header: .title(Strings.settingsGeneralSectionTitle),
             rows: [
                 Row(text: Strings.searchEngines, selection: { [unowned self] in
-                    let viewController = SearchSettingsTableViewController(model: self.profile.searchEngines)
+                    let viewController = SearchSettingsTableViewController(profile: self.profile)
                     self.navigationController?.pushViewController(viewController, animated: true)
                 }, image: #imageLiteral(resourceName: "settings-search").template, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: Strings.sync, selection: { [unowned self] in

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -217,9 +217,7 @@ class SettingsViewController: TableViewController {
             header: .title(Strings.settingsGeneralSectionTitle),
             rows: [
                 Row(text: Strings.searchEngines, selection: { [unowned self] in
-                    let viewController = SearchSettingsTableViewController()
-                    viewController.model = self.profile.searchEngines
-                    viewController.profile = self.profile
+                    let viewController = SearchSettingsTableViewController(model: self.profile.searchEngines)
                     self.navigationController?.pushViewController(viewController, animated: true)
                 }, image: #imageLiteral(resourceName: "settings-search").template, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: Strings.sync, selection: { [unowned self] in

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -134,6 +134,7 @@ extension Strings {
     public static let thirdPartySearchFailedMessage = NSLocalizedString("ThirdPartySearchFailedMessage", bundle: Bundle.shared, value: "The search provider could not be added.", comment: "A title explaining that we failed to add a search engine")
     public static let customEngineFormErrorMessage = NSLocalizedString("CustomEngineFormErrorMessage", bundle: Bundle.shared, value: "Please fill all fields correctly.", comment: "A message explaining fault in custom search engine form.")
     public static let customEngineDuplicateErrorMessage = NSLocalizedString("CustomEngineDuplicateErrorMessage", bundle: Bundle.shared, value: "A search engine with this title or URL has already been added.", comment: "A message explaining fault in custom search engine form.")
+    public static let customEngineFillAllFieldsErrorMessage = NSLocalizedString("CustomEngineFillAllFieldsErrorMessage", bundle: Bundle.shared, value: "Please fill all the form fields.", comment: "A message explaining that all form fields are to be filled.")
 }
 
 // Tabs Delete All Undo Toast

--- a/Client/Networking/NetworkManager.swift
+++ b/Client/Networking/NetworkManager.swift
@@ -28,7 +28,8 @@ class NetworkManager {
     
     /// - parameter checkLastServerSideModification: If true, the `CachedNetworkResource` will contain a timestamp
     /// when the file was last time modified on the server.
-    func downloadResource(with url: URL, resourceType: NetworkResourceType,
+    func downloadResource(with url: URL,
+                          resourceType: NetworkResourceType = .regular,
                           retryTimeout: TimeInterval? = 60,
                           checkLastServerSideModification: Bool = false) -> Deferred<CachedNetworkResource> {
         let completion = Deferred<CachedNetworkResource>()

--- a/ClientTests/SearchEnginesTests.swift
+++ b/ClientTests/SearchEnginesTests.swift
@@ -54,10 +54,11 @@ class SearchEnginesTests: XCTestCase {
         let testEngine = OpenSearchEngine(engineID: "ATester", shortName: "ATester", image: UIImage(), searchTemplate: "http://firefox.com/find?q={searchTerm}", suggestTemplate: nil, isCustomEngine: true)
         let profile = MockProfile()
         let engines = SearchEngines(files: profile.files)
-        engines.addSearchEngine(testEngine)
+        try! engines.addSearchEngine(testEngine)
+
         XCTAssertEqual(engines.orderedEngines[1].engineID, testEngine.engineID)
 
-        engines.deleteCustomEngine(testEngine)
+        try! engines.deleteCustomEngine(testEngine)
         let deleted = engines.orderedEngines.filter {$0 == testEngine}
         XCTAssertEqual(deleted, [])
     }

--- a/Shared/KeyboardHelper.swift
+++ b/Shared/KeyboardHelper.swift
@@ -42,7 +42,6 @@ public struct KeyboardState {
 
 public protocol KeyboardHelperDelegate: class {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState)
-    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState)
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState)
 }
 
@@ -66,7 +65,6 @@ open class KeyboardHelper: NSObject {
      */
     open func startObserving() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidShow), name: UIResponder.keyboardDidShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
@@ -93,15 +91,6 @@ open class KeyboardHelper: NSObject {
             currentState = KeyboardState(userInfo)
             for weakDelegate in delegates {
                 weakDelegate.delegate?.keyboardHelper(self, keyboardWillShowWithState: currentState!)
-            }
-        }
-    }
-
-    @objc func keyboardDidShow(_ notification: Notification) {
-        if let userInfo = notification.userInfo {
-            currentState = KeyboardState(userInfo)
-            for weakDelegate in delegates {
-                weakDelegate.delegate?.keyboardHelper(self, keyboardDidShowWithState: currentState!)
             }
         }
     }


### PR DESCRIPTION
This PR is implementing adding Search Engine that has [OpenSearch-Compliance](https://developer.mozilla.org/en-US/docs/Web/OpenSearch).

This is done by 

- Evaluating Open Search engine script and finding out If the website supports Open Search.
- Parse the response and retrieve the title and reference URL
- Create the URL to download the XML + also retrieve the Fav Icon
- And create Search Engine object with the data and add it to search engine list

It also includes the UX elements like add button addition on the toolbar and dialogs for approval and error handling situations

WIP: Open Search Manual Addition / Tests

## Summary of Changes

This pull request fixes #936

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Go to a website that coplies to OpenSearch Compliance - Search Engines [Ecosia](https://www.ecosia.org/?c=en)
- Press Search Textfield and observe Add Button on toolbar
- Press the add button and accept adding the search engine
- Observe Engine is added in settings or while populating suggestions

## Screenshots:

![ezgif-6-92ad65bbb277](https://user-images.githubusercontent.com/6643505/102923233-66aa0d80-445d-11eb-9bd0-b24917318fee.gif)

![IMG936](https://user-images.githubusercontent.com/6643505/102924670-07013180-4460-11eb-91ba-5008ec8bda58.png)



## Reviewer Checklist:
- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
