### PR TITLE
Fix #3169: Database race condition crash at startup.

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -99,10 +99,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         
         // Set the Firefox UA for browsing.
         setUserAgent()
+        
+        // An attempt to fix #2185.
+        // There's an unknown crash related to database creation, which happens when tabs are being restored.
+        // Our DataControllers uses a mix of static and lazy properties, there is a chance that some
+        // concurrency problems are occuring.
+        // This forces the database to initialize the most important lazy properties before doing any other
+        // database related code.
+        // Please note that this is called after bookmark and keychain restoration processes.
+        DataController.shared.lazyInitialization()
 
         // Start the keyboard helper to monitor and cache keyboard state.
         KeyboardHelper.defaultHelper.startObserving()
-
         DynamicFontHelper.defaultHelper.startObserving()
 
         MenuHelper.defaultHelper.setItems()
@@ -112,21 +120,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let logDate = Date()
         // Create a new sync log file on cold app launch. Note that this doesn't roll old logs.
         Logger.syncLogger.newLogWithDate(logDate)
-
         Logger.browserLogger.newLogWithDate(logDate)
 
         let profile = getProfile(application)
         let profilePrefix = profile.prefs.getBranchPrefix()
         Migration.launchMigrations(keyPrefix: profilePrefix)
         
-        // An attempt to fix #2185.
-        // There's an unknown crash related to database creation, which happens when tabs are being restored.
-        // Our DataControllers uses a mix of static and lazy properties, there is a chance that some
-        // concurrency problems are occuring.
-        // This forces the database to initialize most important lazy properties before doing any other
-        // database related code.
-        // Please note that this is called after bookmark and keychain restoration processes.
-        DataController.shared.lazyInitialization()
         setUpWebServer(profile)
         
         var imageStore: DiskImageStore?


### PR DESCRIPTION
`DataController` internals were initialized after first DB operations,
`Migration.launchMigrations` were called first, on a background thread
which can result in race conditions.

I simply moved the DB initialization before launching migration code.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3169 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
