### PR TITLE
Fix #3172: Autocomplete label covers clear button in url bar.

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -214,7 +214,10 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
         let enteredTextSize = self.attributedText?.boundingRect(with: self.frame.size, options: NSStringDrawingOptions.usesLineFragmentOrigin, context: nil)
         frame.origin.x = (enteredTextSize?.width.rounded() ?? 0)
-        frame.size.width = self.frame.size.width - frame.origin.x
+        // The autocomplete label overlaps whole uitextfield covering the clear button.
+        // The label's frame must be slightly shorter to make the clear button visible.
+        let clearButtonOffset: CGFloat = 30
+        frame.size.width = self.frame.size.width - frame.origin.x - clearButtonOffset
         frame.size.height = self.frame.size.height - 1
         label.frame = frame
         return label


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

The url autocomplete code is not great in general, it uses a mix of uitextfield and uilabel to display urls, and the uilabel gets recreated on each key input. This is an easy solution for now

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3172 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


![IMG_BD28589A9099-1](https://user-images.githubusercontent.com/6950387/103662264-04c6c900-4f70-11eb-8666-d4b654e09989.jpeg)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
