### PR TITLE
Fix #3020: Update UserAgent to iOS 14.3 version.

### DIFF
--- a/Shared/UserAgentBuilder.swift
+++ b/Shared/UserAgentBuilder.swift
@@ -43,12 +43,12 @@ public struct UserAgentBuilder {
     // These are not super precise because each iOS version can have slighly different desktop UA.
     // The only differences are with exact `Version/XX` and `MAC OS X 10_XX` numbers.
     private var desktopUA: String {
-        // Taken from Safari 14.0(ios 14 beta 7)
+        // Taken from Safari 14.3
         let iOS14DesktopUA =
         """
         Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
         AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0 \
+        Version/14.0.2 \
         Safari/605.1.15
         """
         
@@ -96,7 +96,7 @@ public struct UserAgentBuilder {
         switch os.majorVersion {
             case 12: return "12_4_1"
             case 13: return "13_6_1"
-            case 14: return "14_0"
+            case 14: return "14_3"
             default: return "\(os.majorVersion)_0"
                 
         }
@@ -107,7 +107,7 @@ public struct UserAgentBuilder {
         switch os.majorVersion {
             case 12: return "12.1.2"
             case 13: return "13.1.2"
-            case 14: return "14.0"
+            case 14: return "14.0.2"
             default: return "\(os.majorVersion).0"
                 
         }

--- a/SharedTests/UserAgentBuilderTests.swift
+++ b/SharedTests/UserAgentBuilderTests.swift
@@ -42,7 +42,7 @@ class UserAgentBuilderTests: XCTestCase {
         """
         Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
         AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0 \
+        Version/14.0.2 \
         Safari/605.1.15
         """
         
@@ -66,7 +66,7 @@ class UserAgentBuilderTests: XCTestCase {
                        UserAgentBuilder(device: iPad, iOSVersion: iOS13).build(desktopMode: true),
                        "iOS 13 desktop User Agent on iPad doesn't match")
         
-        let iOS14 = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0)
+        let iOS14 = OperatingSystemVersion(majorVersion: 14, minorVersion: 3, patchVersion: 0)
         
         XCTAssertEqual(iOS14DesktopUA,
                        UserAgentBuilder(device: iPhone, iOSVersion: iOS14).build(desktopMode: true),
@@ -89,21 +89,21 @@ class UserAgentBuilderTests: XCTestCase {
         
         // MARK: - iOS 14
         let iPhone_safari_14_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0 \
+        Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0.2 \
         Mobile/15E148 \
         Safari/604.1
         """
         
         let iPad_safari_14_UA = """
-        Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0 \
+        Mozilla/5.0 (iPad; CPU OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0.2 \
         Mobile/15E148 \
         Safari/604.1
         """
         
-        // MARK: 14.0
-        let ios14_0 = OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0)
+        // MARK: 14.3
+        let ios14_0 = OperatingSystemVersion(majorVersion: 14, minorVersion: 3, patchVersion: 0)
         
         XCTAssertEqual(iPhone_safari_14_UA,
                        UserAgentBuilder(device: iPhone, iOSVersion: ios14_0).build(desktopMode: false),
@@ -249,8 +249,8 @@ class UserAgentBuilderTests: XCTestCase {
         // MARK: - iPhone iOS 14.8, non existent version(14.8)
         let ios14_8 = OperatingSystemVersion(majorVersion: 14, minorVersion: 8, patchVersion: 0)
         let iPhone_safari_14_8_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0 \
+        Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0.2 \
         Mobile/15E148 \
         Safari/604.1
         """
@@ -261,8 +261,8 @@ class UserAgentBuilderTests: XCTestCase {
         
         // MARK: - iPad iOS 14.8, non existent version(14.8)
         let iPad_safari_14_8_UA = """
-        Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0 \
+        Mozilla/5.0 (iPad; CPU OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.0.2 \
         Mobile/15E148 \
         Safari/604.1
         """


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3020 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Compare user agent to Safari.

Test note: when testing on iOS simulator i noticed that `Version/` part of UA can be `14.0.1.` sometimes instead of `.2`,
both numbers should be fine.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="858" alt="Zrzut ekranu 2021-01-5 o 21 40 38" src="https://user-images.githubusercontent.com/6950387/103759836-97b93f00-5014-11eb-8d16-574a754f429a.png">



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
