### PR TITLE
Fix #3195, #3194 - Delete Other Devices + Bookmarks Fix

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -229,6 +229,11 @@ class SettingsViewController: TableViewController {
                 }, image: #imageLiteral(resourceName: "settings-search").template, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: Strings.sync, selection: { [unowned self] in
                     if BraveSyncAPI.shared.isInSyncGroup {
+                        if !DeviceInfo.hasConnectivity() {
+                            self.present(SyncAlerts.noConnection, animated: true)
+                            return
+                        }
+                        
                         self.navigationController?
                             .pushViewController(SyncSettingsTableViewController(style: .grouped), animated: true)
                     } else {

--- a/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
+++ b/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
@@ -298,7 +298,8 @@ extension Bookmarkv2 {
             guard let self = self else { return }
             
             if case .favIconChanged(let node) = state {
-                if node.guid == self.bookmarkNode.guid {
+                if node.isValid && self.bookmarkNode.isValid &&
+                    node.guid == self.bookmarkNode.guid {
                     observer()
                 }
             }

--- a/Client/Frontend/Sync/BraveCore/BraveSyncAPI+Utilities.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveSyncAPI+Utilities.swift
@@ -26,10 +26,9 @@ extension BraveSyncAPI {
         return false
     }
     
-    //See: BraveSyncDevice.remove() for more info.
-    /*func removeDeviceFromSyncGroup(deviceGuid: String) {
-        BraveSyncAPI.shared.removeDevice(deviceGuid)
-    }*/
+    func removeDeviceFromSyncGroup(deviceGuid: String) {
+        BraveSyncAPI.shared.deleteDevice(deviceGuid)
+    }
     
     func leaveSyncGroup() {
         // Remove all observers before leaving the sync chain

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -236,6 +236,11 @@ class SyncWelcomeViewController: SyncViewController {
     }
     
     private func pushSettings() {
+        if !DeviceInfo.hasConnectivity() {
+            present(SyncAlerts.noConnection, animated: true)
+            return
+        }
+        
         let syncSettingsVC = SyncSettingsTableViewController(style: .grouped)
         syncSettingsVC.disableBackButton = true
         navigationController?.pushViewController(syncSettingsVC, animated: true)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Adds support for deleting other devices from the sync chain.
- Potential fix for a crash when favIcon changes and when deleting a bookmark (extremely hard to reproduce bug)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3195, #3194

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
