### PR TITLE
Fix #3193: Fix PIN visibility in dark mode

### DIFF
--- a/Client/Frontend/Popup/AlertPopupView.swift
+++ b/Client/Frontend/Popup/AlertPopupView.swift
@@ -60,8 +60,8 @@ class AlertPopupView: PopupView {
         if let inputType = inputType {
             textField = UITextField(frame: CGRect.zero).then {
                 $0.keyboardType = inputType
-                $0.textColor = .black
-                $0.placeholder = inputPlaceholder ?? ""
+                $0.appearanceTextColor = .black
+                $0.attributedPlaceholder = NSAttributedString(string: inputPlaceholder ?? "", attributes: [NSAttributedString.Key.foregroundColor: BraveUX.greyH])
                 $0.autocorrectionType = .no
                 $0.autocapitalizationType = .none
                 $0.layer.cornerRadius = 4


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3193 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Switch to dark mode
2. Navigate to https://demo.yubico.com/u2f
3. Use a NFC key with PIN
4. Verify that placeholder text and secure text is visible


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

**Placeholder Text:**
<img width="359" alt="Screen Shot 2021-01-13 at 12 24 36 PM" src="https://user-images.githubusercontent.com/1903815/104506524-5b4c8c80-559a-11eb-9fe2-c2b2d2348f7b.png">

**Secure Text**
<img width="357" alt="Screen Shot 2021-01-13 at 12 24 27 PM" src="https://user-images.githubusercontent.com/1903815/104506508-5687d880-559a-11eb-93c5-272cb781ab52.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
