### PR TITLE
No Bug: Remove swiftlint step from gh actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,9 +24,6 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install required software.
-        run: |
-          brew install swiftlint
       - name: Update node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Swiftlint is now preinstalled on macOS instances.
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#linters

Without this change I see following error in logs, it started to happen today
```
The formula built, but is not symlinked into /usr/local
Could not symlink bin/swiftlint
Target /usr/local/bin/swiftlint
already exists. You may want to remove it:
  rm '/usr/local/bin/swiftlint'
```

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
