### PR TITLE
Fix #3051: Add support for language specific feeds for Brave Today

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -142,9 +142,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         }
         
         #if !NO_BRAVE_TODAY
-        if !Preferences.BraveToday.languageChecked.value {
+        if !Preferences.BraveToday.languageChecked.value,
+           let languageCode = Locale.preferredLanguages.first?.prefix(2) {
             Preferences.BraveToday.languageChecked.value = true
-            Preferences.BraveToday.isEnabled.value = Locale.preferredLanguages.first?.prefix(2) == "en"
+            Preferences.BraveToday.isEnabled.value = FeedDataSource.supportedLanguages.contains(String(languageCode))
         }
         #endif
 


### PR DESCRIPTION
For now we only support English and Japanese

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3051 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Ensure you are on Brave Today dev environment 
- Change language of phone to japanese
- Verify it loads the correct feed
- Delete app & reinstall, verify it enables Brave Today by default

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
