### PR TITLE
Fix #3215:  Removing Selected Tab Assertion

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -246,21 +246,7 @@ class TabManager: NSObject {
         }
         
         guard tab === selectedTab else {
-            var errorLog = "Expected tab is not selected.\n"
-            
-            if let currentTabData = tab?.pageMetadata {
-                errorLog += "Current tab metadata: \(currentTabData)\n"
-            } else {
-                errorLog += "Current tab metadata doesnt exist\n"
-            }
-            
-            if let selectedTabData = selectedTab?.pageMetadata {
-                errorLog += "Selected tab metadata: \(selectedTabData)"
-            } else {
-                errorLog += "Selected tab metadata doesnt exist\n"
-            }
-            
-            log.error(errorLog)
+            log.error("Expected tab (\(String(describing: tab?.url))) is not selected. Selected index: \(selectedIndex)")
             return
         }
     

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -245,6 +245,25 @@ class TabManager: NSObject {
             restoreTab(t)
         }
         
+        guard tab === selectedTab else {
+            var errorLog = "Expected tab is not selected.\n"
+            
+            if let currentTabData = tab?.pageMetadata {
+                errorLog += "Current tab metadata: \(currentTabData)\n"
+            } else {
+                errorLog += "Current tab metadata doesnt exist\n"
+            }
+            
+            if let selectedTabData = selectedTab?.pageMetadata {
+                errorLog += "Selected tab metadata: \(selectedTabData)"
+            } else {
+                errorLog += "Selected tab metadata doesnt exist\n"
+            }
+            
+            log.error(errorLog)
+            return
+        }
+    
         UIImpactFeedbackGenerator(style: .light).bzzt()
         selectedTab?.createWebview()
         selectedTab?.lastExecutedTime = Date.now()

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -244,8 +244,6 @@ class TabManager: NSObject {
             selectedTab?.createWebview()
             restoreTab(t)
         }
-
-        assert(tab === selectedTab, "Expected tab is selected")
         
         UIImpactFeedbackGenerator(style: .light).bzzt()
         selectedTab?.createWebview()


### PR DESCRIPTION
## Summary of Changes

Actually this assertion should be hit in Release build but wanted to test how Stack Trace will change when we are not checking actual tab is nit pointing to the same memory location with selected tab.

This pull request fixes #3215

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:

Sanity check:

- Create new tabs with different URLs and check selecting different tabs work (normal/private)
- Put application in background while some tabs are open and click an external link from a different application - Brave Browser should be default browser
- Open Tab Tray while some tabs open, put the application in background without closing the TabTray and click an external link from a different application while Brave Browser is default Browser



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
