### PR TITLE
Fix#2980: Adding new websites to determine streaming sites in JP

### DIFF
--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -427,7 +427,14 @@ extension URL {
             return false
         }
         
-        return ["youtube", "vimeo", "twitch"].contains(where: domain.contains)
+        var siteList = ["youtube", "vimeo", "twitch"]
+        
+        /// Additional sites for Japanese locale
+        if Locale.current.regionCode == "JP" {
+            siteList.append(contentsOf: ["nicovideo", "tiktok", "instagram"])
+        }
+        
+        return siteList.contains(where: domain.contains)
     }
 }
 


### PR DESCRIPTION
## Summary of Changes

Adding new websites for Japanese locale while determining video streaming sites for Video Block Educational Notification pop-over.

This pull request contains additional changes to #2980 over PR https://github.com/brave/brave-ios/pull/3151

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
