### PR TITLE
Fix #3012: Do not translate 'Brave VPN' string.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -908,12 +908,6 @@ extension Strings {
                               value: "Brave Firewall + VPN",
                               comment: "Title for screen to buy the VPN.")
         
-        public static let vpnMenuItemTitle =
-            NSLocalizedString("vpn.vpnMenuItemTitle",
-                              bundle: .braveShared,
-                              value: "Brave VPN",
-                              comment: "Title Brave VPN menu item.")
-        
         public static let poweredBy =
             NSLocalizedString("vpn.poweredBy",
                               bundle: .braveShared,

--- a/Client/Frontend/BraveVPN/EnableVPNSettingHeader.swift
+++ b/Client/Frontend/BraveVPN/EnableVPNSettingHeader.swift
@@ -19,7 +19,8 @@ class EnableVPNSettingHeader: UIView {
     }
     
     private let titleLabel = UILabel().then {
-        $0.text = Strings.VPN.vpnMenuItemTitle
+        // This string should not be translated
+        $0.text = "Brave VPN"
         $0.appearanceTextColor = .white
         $0.font = UIFont.systemFont(ofSize: 19, weight: .semibold)
     }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -103,7 +103,8 @@ class MenuViewController: UITableViewController {
         
         var title: String {
             switch self {
-            case .vpn: return Strings.VPN.vpnMenuItemTitle
+            // This string should not be translated.
+            case .vpn: return "Brave VPN"
             case .bookmarks: return Strings.bookmarksMenuItem
             case .history: return Strings.historyMenuItem
             case .settings: return Strings.settingsMenuItem


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Not sure if hardcoding is better vs indicating in NSLocalized string comment that this is a DNT(do not translate)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3012 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
