### PR TITLE
Fix #2840: Add system notification to promote Default Browser setup.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -145,6 +145,16 @@ extension Strings {
                               tableName: "BraveShared", bundle: .braveShared,
                               value: "Not now",
                               comment: "Button text to close the default browser popup.")
+        public static let notificationTitle =
+            NSLocalizedString("defaultBrowserCallout.notificationTitle",
+                              tableName: "BraveShared", bundle: .braveShared,
+                              value: "Brave Web Browser",
+                              comment: "Notification title to promote setting Brave app as default browser")
+        public static let notificationBody =
+            NSLocalizedString("defaultBrowserCallout.notificationBody",
+                              tableName: "BraveShared", bundle: .braveShared,
+                              value: "Optimized for iOS 14. Make Brave your default browser today.",
+                              comment: "Notification body to promote setting Brave app as default browser")
     }
 }
 

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -88,6 +88,10 @@ extension Preferences {
         /// When to show next default browser popup.
         static let nextShowDate =
             Option<Date?>(key: "general.default-browser-intro-next-show-date", default: nil)
+        
+        /// Whether system notification showed or not
+        static let defaultBrowserNotificationScheduled =
+            Option<Bool>(key: "general.default-browser-notification-scheduled", default: false)
     }
     
     final class Search {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Note: this PR targets https://github.com/brave/brave-ios/pull/3178 instead of development,
Once 3178 is merged i will change base branch

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2840 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Launch the app.
- put app in background
- Wait 2 minutes on dev(2 hours on prod)
- Verify that app notification showed
- Tapping on this notification should take you to app's iOS settings

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
