### PR TITLE
No Bug: Create xcframeworks instead of FAT frameworks for BraveCore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ node_modules
 scripts/
 BuildId.xcconfig
 
+BraveCore/BraveRewards.xcframework
+BraveCore/MaterialComponents.xcframework
+
 Client/Configuration/Local/
 
 adblock-regions.txt

--- a/BraveCore/Updating the BraveRewards framework.md
+++ b/BraveCore/Updating the BraveRewards framework.md
@@ -84,8 +84,7 @@ When you have changes that need to be fixed in the BraveRewards.framework (such 
     ```shell
     npm run lint
     ```
-1. Copy a FAT framework to `brave-ios` by running `build_in_core.sh --skip-update ~/path/to/brave-browser`.
-    - _Note:_ You must include `--skip-update` or your local changes will be removed
+1. Copy xcframeworks to `brave-ios/node_modules/brave-core-ios` by running `build_in_core.sh ~/path/to/brave-browser`.
     - If your PR is likely to take some time and your branch is on the brave-core remote you can edit `package.json` in brave-browser to point brave-core to your branch. This means any `npm run init` will set brave-core to your branch and not master.
 1. When things are working correctly, open a PR in brave-core and add all recommended reviewers.
     - Add auto-closing words to your PR description that references your original issue created in step 1 (i.e. `resolves https://github.com/brave/brave-ios/issues/9000`)

--- a/BraveCore/build_in_core.sh
+++ b/BraveCore/build_in_core.sh
@@ -12,7 +12,6 @@ build_device=0
 release_flag="Release"
 brave_browser_dir="${@: -1}"
 
-base_path=""
 sim_dir="out/ios_Release"
 device_dir="out/ios_Release_arm64"
 
@@ -20,7 +19,6 @@ function usage() {
   echo "Usage: ./build_in_core.sh [--clean] [--debug] {\$home/brave/brave-browser}"
   echo " --clean:           Cleans build directories before building"
   echo " --debug:           Builds a debug instead of release framework. (Should not be pushed with the repo)"
-  echo " --skip-update:     Skips cloning and rebasing"
   echo " --build-simulator: Build only for simulator"
   echo " --build-device:    Build only for device"
   exit 1
@@ -53,6 +51,12 @@ case $i in
 esac
 done
 
+# If neither argument is supplied, build both
+if [ "$build_simulator" = 0 ] && [ "$build_device" = 0 ]; then
+  build_simulator=1
+  build_device=1
+fi
+
 if [ ! -d "$brave_browser_dir/src/brave" ]; then
   echo "Did not pass in a directory pointing to brave-browser which has already been init"
   echo "(by running \`npm run init\` at its root)"
@@ -69,15 +73,9 @@ cd src
 
 git fetch --tags --quiet
 
-# [ -d brave/vendor/brave-rewards-ios ] && rm -r brave/vendor/brave-rewards-ios
-# rsync -a --delete "$current_dir/../" brave/vendor/brave-rewards-ios
-
-# TODO: Check if there are any changes made to any of the dependent vendors via git. If no files are changed,
-#       we can just skip building altogether
-
 if [ "$clean" = 1 ]; then
   # If this script has already been run, we'll clean out the build folders
-  [[ -d $sim_dir ]] && gn clean  $sim_dir
+  [[ -d $sim_dir ]] && gn clean $sim_dir
   [[ -d $device_dir ]] && gn clean $device_dir
 else
   # Force it to reassemble the products if they've been built already
@@ -86,48 +84,33 @@ else
   [[ -d $device_dir/BraveRewards.framework ]] && rm -rf $device_dir/BraveRewards.framework
 fi
 
-if { [ "$build_simulator" = 1 ] && [ "$build_device" = 1 ]; } || { [ "$build_simulator" = 0 ] && [ "$build_device" = 0 ]; } ; then
+bc_framework_args=""
+mc_framework_args=""
+
+if [ "$build_simulator" = 1 ]; then
   npm run build -- $release_flag --target_os=ios
+  bc_framework_args="-framework $sim_dir/BraveRewards.framework -debug-symbols $(pwd)/$sim_dir/BraveRewards.dSYM" 
+  mc_framework_args="-framework $sim_dir/MaterialComponents.framework"
+fi
+
+if [ "$build_device" = 1 ]; then
   npm run build -- $release_flag --target_os=ios --target_arch=arm64
-elif [ "$build_simulator" = 1 ]; then
-  npm run build -- $release_flag --target_os=ios
-elif [ "$build_device" = 1 ]; then
-  npm run build -- $release_flag --target_os=ios --target_arch=arm64
+  bc_framework_args="$bc_framework_args -framework $device_dir/BraveRewards.framework -debug-symbols $(pwd)/$device_dir/BraveRewards.dSYM" 
+  mc_framework_args="$mc_framework_args -framework $device_dir/MaterialComponents.framework"
 fi
 
-# Copy the framework structure (from iphoneos build) to the universal folder
-if { [ "$build_simulator" = 1 ] && [ "$build_device" = 1 ]; } || { [ "$build_simulator" = 0 ] && [ "$build_device" = 0 ]; } || { [ "$build_simulator" = 0 ] && [ "$build_device" = 1 ]; } ; then
-  base_path="$device_dir"
-elif [ "$build_simulator" = 1 ]; then
-  base_path="$sim_dir"
-fi
+[ -d "$framework_drop_point/BraveRewards.xcframework" ] && rm -rf "$framework_drop_point/BraveRewards.xcframework"
+xcodebuild -create-xcframework $bc_framework_args -output "$framework_drop_point/BraveRewards.xcframework"
+echo "Created XCFramework: $framework_drop_point/BraveRewards.xcframework"
 
-rsync -a --delete "$base_path/BraveRewards.framework" "$framework_drop_point/"
-rsync -a --delete "$base_path/MaterialComponents.framework" "$framework_drop_point/"
-
-if [ -d "$base_path/BraveRewards.dSYM" ]; then
-  # Copy the dSYM if available
-  pushd $base_path > /dev/null
-  # zip up the dSYM since its too big to upload
-  zip -FSr "BraveRewards.dSYM.zip" "BraveRewards.dSYM"
-  popd > /dev/null
-  rsync -a --delete "$base_path/BraveRewards.dSYM.zip" "$framework_drop_point/"
-fi
-
-# Create universal binary file using lipo and place the combined executable in the copied framework directory
-if { [ "$build_simulator" = 1 ] && [ "$build_device" = 1 ]; } || { [ "$build_simulator" = 0 ] && [ "$build_device" = 0 ]; } ; then
-  lipo -create -output "$framework_drop_point/BraveRewards.framework/BraveRewards" "$sim_dir/BraveRewards.framework/BraveRewards" "$device_dir/BraveRewards.framework/BraveRewards"
-  lipo -create -output "$framework_drop_point/MaterialComponents.framework/MaterialComponents" "$sim_dir/MaterialComponents.framework/MaterialComponents" "$device_dir/MaterialComponents.framework/MaterialComponents"
-fi
-
-echo "Created FAT framework: $framework_drop_point/BraveRewards.framework"
+[ -d "$framework_drop_point/MaterialComponents.xcframework" ] && rm -rf "$framework_drop_point/MaterialComponents.xcframework"
+xcodebuild -create-xcframework $mc_framework_args -output "$framework_drop_point/MaterialComponents.xcframework"
+echo "Created XCFramework: $framework_drop_point/MaterialComponents.xcframework"
 
 echo "Moving Frameworks to node_modules"
 mkdir -p "$node_modules_path"
-rsync -a --delete "$framework_drop_point/BraveRewards.framework" "$node_modules_path/"
-rsync -a --delete "$framework_drop_point/MaterialComponents.framework" "$node_modules_path/"
-rsync -a --delete "$framework_drop_point/BraveRewards.dSYM.zip" "$node_modules_path/"
-rsync -a --delete "$framework_drop_point/copy_rewards_dsym.sh" "$node_modules_path/"
+rsync -a --delete "$framework_drop_point/BraveRewards.xcframework" "$node_modules_path/"
+rsync -a --delete "$framework_drop_point/MaterialComponents.xcframework" "$node_modules_path/"
 echo "Moved Frameworks to node_modules"
 
 cd brave
@@ -138,16 +121,13 @@ brave_core_tag=`git describe --tags --abbrev=0`
 popd > /dev/null
 
 echo "Completed building BraveRewards from \`brave-core/$brave_core_build_hash\`"
-cat > "$framework_drop_point/BraveRewards.resolved" << EOL
+cat > "$framework_drop_point/Local.resolved" << EOL
+REMINDER: Your local brave-core-ios dependency has been overwritten in node_modules. Re-run bootstrap.sh when you are done testing.  
+
 build: $release_flag
 brave-browser: $brave_browser_branch ($brave_browser_build_hash)
 brave-core: $brave_core_branch ($brave_core_build_hash)
   latest tag: $brave_core_tag
-EOL
 
-# Check if any of the includes had changed.
-if `git diff --quiet "$node_modules_path/BraveRewards.framework/Headers/"`; then
-  echo "  → No updates to library includes were made"
-else
-  echo "  → Changes found in library includes"
-fi
+DO NOT COMMIT THIS FILE
+EOL

--- a/BraveCore/copy_rewards_dsym.sh
+++ b/BraveCore/copy_rewards_dsym.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-#
-# Copies the BraveRewards symbols file into the archive
-#
-
-REWARDS_DSYM_FILE="$SRCROOT/node_modules/brave-core-ios/BraveRewards.dSYM.zip"
-[ -f $REWARDS_DSYM_FILE ] && unzip -oq "$REWARDS_DSYM_FILE" -d "$BUILT_PRODUCTS_DIR"

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -369,6 +369,10 @@
 		27B16C5924E1D72600E0CF2C /* NewTabPageFeedOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B16C5824E1D72600E0CF2C /* NewTabPageFeedOverlayView.swift */; };
 		27B3DDD024AE83710006A7ED /* FeedSourceOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B3DDCF24AE83710006A7ED /* FeedSourceOverride.swift */; };
 		27B3DDD524AF98EA0006A7ED /* FeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B3DDD424AF98EA0006A7ED /* FeedItem.swift */; };
+		27B68DE425C48F36002D0826 /* BraveRewards.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD725C48EE9002D0826 /* BraveRewards.xcframework */; };
+		27B68DE525C48F36002D0826 /* BraveRewards.xcframework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD725C48EE9002D0826 /* BraveRewards.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		27B68DF025C48F39002D0826 /* MaterialComponents.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; };
+		27B68DF125C48F39002D0826 /* MaterialComponents.xcframework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		27C405E3242559AE00347246 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
 		27C405E924255A2B00347246 /* BraveShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DE7688420B3456C00FF5533 /* BraveShared.framework */; };
 		27C461DE211B76500088A441 /* ShieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C461DD211B76500088A441 /* ShieldsView.swift */; };
@@ -1317,6 +1321,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				27756A8425ACFFEB00C129AF /* pop.framework in Copy Frameworks */,
+				27B68DF125C48F39002D0826 /* MaterialComponents.xcframework in Copy Frameworks */,
 				5D1DC52920AC9AFB00905E5A /* Data.framework in Copy Frameworks */,
 				E60138661C89EB7D00DF9756 /* Storage.framework in Copy Frameworks */,
 				5DE7689A20B3456E00FF5533 /* BraveShared.framework in Copy Frameworks */,
@@ -1327,6 +1332,7 @@
 				278C468E23F1E6270083347F /* BraveUI.framework in Copy Frameworks */,
 				278655A325C227C8009FFE80 /* AdblockRust.xcframework in Copy Frameworks */,
 				E60138651C89EB7600DF9756 /* Shared.framework in Copy Frameworks */,
+				27B68DE525C48F36002D0826 /* BraveRewards.xcframework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1525,7 +1531,6 @@
 		0AC0D3C1233E889D0091EFA5 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0AC775FF242A282C00139377 /* BuyVPNViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyVPNViewController.swift; sourceTree = "<group>"; };
 		0AC77601242A6AE000139377 /* BuyVPNView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyVPNView.swift; sourceTree = "<group>"; };
-		0AC8E23A22A6C56D0064F3FA /* libYubiKit.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libYubiKit.a; path = ThirdParty/YubiKit/libYubiKit.a; sourceTree = "<group>"; };
 		0ACB38EA23571F5600DDC245 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0ACB3BF723571ED1000AC688 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Storage.strings; sourceTree = "<group>"; };
 		0AD48EEE24AF6E6200938B3B /* FeedSourceOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSourceOverrideTests.swift; sourceTree = "<group>"; };
@@ -1841,6 +1846,8 @@
 		27B16C5824E1D72600E0CF2C /* NewTabPageFeedOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageFeedOverlayView.swift; sourceTree = "<group>"; };
 		27B3DDCF24AE83710006A7ED /* FeedSourceOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSourceOverride.swift; sourceTree = "<group>"; };
 		27B3DDD424AF98EA0006A7ED /* FeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItem.swift; sourceTree = "<group>"; };
+		27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MaterialComponents.xcframework; path = "node_modules/brave-core-ios/MaterialComponents.xcframework"; sourceTree = "<group>"; };
+		27B68DD725C48EE9002D0826 /* BraveRewards.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraveRewards.xcframework; path = "node_modules/brave-core-ios/BraveRewards.xcframework"; sourceTree = "<group>"; };
 		27C461DD211B76500088A441 /* ShieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsView.swift; sourceTree = "<group>"; };
 		27C626CA25BA198700418F40 /* WalletTransferExpiredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransferExpiredViewController.swift; sourceTree = "<group>"; };
 		27C647762550AE16006D72FC /* WalletTransferCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransferCompleteViewController.swift; sourceTree = "<group>"; };
@@ -1867,7 +1874,6 @@
 		27F47A3125AFCECE004922E4 /* AdblockRust.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = AdblockRust.xcframework; sourceTree = "<group>"; };
 		27F56F7D24E447020018F2F9 /* DateTools.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = DateTools.bundle; sourceTree = "<group>"; };
 		27F94A3921909A5900F4FADF /* SearchSuggestionsPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsPromptView.swift; sourceTree = "<group>"; };
-		27FA2D4F234CC9FB004D5D2D /* BraveRewards.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BraveRewards.framework; path = "node_modules/brave-core-ios/BraveRewards.framework"; sourceTree = "<group>"; };
 		27FCA8DF2447708300A8CA48 /* FavoritesSectionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesSectionProvider.swift; sourceTree = "<group>"; };
 		27FCA8E2244770AB00A8CA48 /* FavoritesOverflowSectionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesOverflowSectionProvider.swift; sourceTree = "<group>"; };
 		27FCA8E62447BCFE00A8CA48 /* DuckDuckGoCalloutSectionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckDuckGoCalloutSectionProvider.swift; sourceTree = "<group>"; };
@@ -2586,7 +2592,6 @@
 		E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = BasePasscodeViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RollingFileLoggerTests.swift; sourceTree = "<group>"; };
 		E6231C001B90A44F005ABB0D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
-		E6231C021B90A466005ABB0D /* libstdc++.6.0.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libstdc++.6.0.9.tbd"; path = "usr/lib/libstdc++.6.0.9.tbd"; sourceTree = SDKROOT; };
 		E6231C041B90A472005ABB0D /* libxml2.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.2.tbd; path = usr/lib/libxml2.2.tbd; sourceTree = SDKROOT; };
 		E62AC15F1E956AFC00843532 /* Dev.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Dev.entitlements; sourceTree = "<group>"; };
 		E633E2D91C21EAF8001FFF6C /* LoginDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoginDetailViewController.swift; path = ../Settings/LoginDetailViewController.swift; sourceTree = "<group>"; };
@@ -2781,10 +2786,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				27B68DF025C48F39002D0826 /* MaterialComponents.xcframework in Frameworks */,
 				2748626925AD30A500BC40AA /* sqlcipher.xcframework in Frameworks */,
 				27756C8A25AD153700C129AF /* Static.framework in Frameworks */,
 				5EE5918123A290E000E8E8DE /* CoreNFC.framework in Frameworks */,
 				278C468D23F1E6270083347F /* BraveUI.framework in Frameworks */,
+				27B68DE425C48F36002D0826 /* BraveRewards.xcframework in Frameworks */,
 				5E8CD8E123D5E3DA00548FC0 /* libarchive.2.tbd in Frameworks */,
 				27756A8325ACFFEB00C129AF /* pop.framework in Frameworks */,
 				E6231C051B90A472005ABB0D /* libxml2.2.tbd in Frameworks */,
@@ -4660,15 +4667,14 @@
 		7B604FC11C496005006EEEC3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				27B68DD725C48EE9002D0826 /* BraveRewards.xcframework */,
+				27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */,
 				0A1DF485244A2ECB00541FE4 /* NetworkExtension.framework */,
 				0A6AC4E824484FBC003D1ED7 /* StoreKit.framework */,
 				5E8CD8E023D5E3D100548FC0 /* libarchive.2.tbd */,
 				27AC169623834510004BE19C /* UserNotifications.framework */,
-				27FA2D4F234CC9FB004D5D2D /* BraveRewards.framework */,
 				F926647A234D4EF400359492 /* CoreNFC.framework */,
-				0AC8E23A22A6C56D0064F3FA /* libYubiKit.a */,
 				E6231C041B90A472005ABB0D /* libxml2.2.tbd */,
-				E6231C021B90A466005ABB0D /* libstdc++.6.0.9.tbd */,
 				E6231C001B90A44F005ABB0D /* libz.tbd */,
 			);
 			name = Frameworks;
@@ -5875,7 +5881,6 @@
 			buildConfigurationList = F84B21DD1A090F8100AAB793 /* Build configuration list for PBXNativeTarget "Client" */;
 			buildPhases = (
 				F979BE0F25BCC098009B6ACF /* Build packaged javascript files */,
-				7B604F8F1C494AAA006EEEC3 /* Copy Carthage Dependencies */,
 				2779B7052159297D0044A102 /* Run SwiftLint */,
 				F84B21BA1A090F8100AAB793 /* Sources */,
 				0A43293F21B1CB810041625B /* Headers */,
@@ -5883,7 +5888,6 @@
 				28CE83DE1A1D1E7C00576538 /* Frameworks */,
 				F84B22531A0920C600AAB793 /* Embed App Extensions */,
 				E6B09CD31C74EEDB00C63FA1 /* Copy Frameworks */,
-				2757538624D9F27100DF54EC /* Copy BraveRewards dSYM */,
 			);
 			buildRules = (
 			);
@@ -6415,25 +6419,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2757538624D9F27100DF54EC /* Copy BraveRewards dSYM */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Copy BraveRewards dSYM";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "sh \"$SRCROOT/node_modules/brave-core-ios/copy_rewards_dsym.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		2779B7052159297D0044A102 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -6451,22 +6436,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh \"$SRCROOT/swiftlint.sh\"\n\n";
-		};
-		7B604F8F1C494AAA006EEEC3 /* Copy Carthage Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/node_modules/brave-core-ios/BraveRewards.framework",
-				"$(SRCROOT)/node_modules/brave-core-ios/MaterialComponents.framework",
-			);
-			name = "Copy Carthage Dependencies";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "rm -rf ${TMPDIR}/TemporaryItems/*carthage*\n/usr/local/bin/carthage copy-frameworks\n";
 		};
 		F979BE0F25BCC098009B6ACF /* Build packaged javascript files */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Building the code
 
 1. Install the latest [Xcode developer tools](https://developer.apple.com/xcode/downloads/) from Apple. (Xcode 11 and up required).
 1. Make sure `npm` is installed, `node` version 12 is recommended
-1. Install SwiftLint & Carthage (Carthage is only used for copy-frameworks build phase):
+1. Install SwiftLint:
     ```shell
     brew update
     brew install swiftlint
-    brew install carthage
     ```
 1. Clone the repository:
     ```shell


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

- Replaces FAT frameworks in the project with XCFrameworks
- Removes dSYM copy since dSYMS will be bundles inside the XCFrameworks
- Updates `build_in_core` script to make XCFrameworks instead of FAT frameworks
- Removes last usage of Carthage

Will combine this with 1.19 release PR at some point as this will not compile until the underlying package.json also uses xcframeworks

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
