### PR TITLE
Fix #3223: Flash scrollbars on search engine onboarding screen.

### DIFF
--- a/Client/Frontend/Browser/Onboarding/OnboardingSearchEnginesView.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingSearchEnginesView.swift
@@ -152,7 +152,9 @@ extension OnboardingSearchEnginesViewController {
                 self.braveLogoBounceEffect()
                 
                 UIView.animate(withDuration: 0.5, animations: self.showTitle) { _ in
-                    UIView.animate(withDuration: 0.5, animations: self.showRemainingViews)
+                    UIView.animate(withDuration: 0.5, animations: self.showRemainingViews) { _ in
+                        self.searchEnginesTable.flashScrollIndicators()
+                    }
                 }
             }
         }


### PR DESCRIPTION
On smaller devices, the search engines list is not fully visible,
making the scrollbar to flash will help users to notice that
the search engines list is scrollable.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3223 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Fresh launch the app.
- Wait for onboarding animation to finish
- Verify that scroll bar next to search engines flashed for a second or two


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
