### PR TITLE
Fix #3250: Text is not visible when editing a favourite/bookmark in dark mode 

### DIFF
--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -87,6 +87,11 @@ extension Theme {
             // See #1548.
             // Using tint color of iOS 13 UISwitch to match better with our light theme
             UISwitch.appearance().tintColor = #colorLiteral(red: 0.8392156863, green: 0.8392156863, blue: 0.8431372549, alpha: 1)
+            
+            // See #3250.
+            // Default Text attributes have to be changed in order to textfield text visible
+            UITextField.appearance(whenContainedInInstancesOf: [UIAlertController.self]).defaultTextAttributes =
+                                        [.foregroundColor: UIColor.black]
         }
     }
 }

--- a/Client/Extensions/UIAlertControllerExtensions.swift
+++ b/Client/Extensions/UIAlertControllerExtensions.swift
@@ -242,7 +242,16 @@ class UserTextInputAlert {
     private func textFieldConfig(text: String?, placeholder: String?, keyboardType: UIKeyboardType?, forcedInput: Bool)
         -> (UITextField) -> Void {
             return { textField in
-                textField.placeholder = placeholder
+                if #available(iOS 13.0, *) {
+                    textField.attributedPlaceholder = NSAttributedString(
+                        string: placeholder ?? "",
+                        attributes: [.foregroundColor: UIColor.placeholderText])
+                } else {
+                    textField.placeholder = placeholder
+                }
+                
+                textField.keyboardAppearance = .default
+
                 textField.isSecureTextEntry = false
                 textField.keyboardAppearance = .dark
                 textField.autocapitalizationType = keyboardType == .URL ? .none : .words


### PR DESCRIPTION
DefaultTextAttributes change for fixing iOS 12 Alert textfield textcolor. 
This change is probably the only working way to alter text attributes for textfield inside AlertViewController < iOS13 when browser is in Private Mode. 

## Summary of Changes

This pull request fixes #3250 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Launch 1.23 (21.1.28.17)
- Switch over to Private mode
- Edit a bookmark/favourite under NTP


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
