### PR TITLE
No Bug: Revert "Fix #2644, Fix #2558: Tabs and edit bookmarks alert respect d…

### DIFF
--- a/Client/Extensions/UIAlertControllerExtensions.swift
+++ b/Client/Extensions/UIAlertControllerExtensions.swift
@@ -242,17 +242,9 @@ class UserTextInputAlert {
     private func textFieldConfig(text: String?, placeholder: String?, keyboardType: UIKeyboardType?, forcedInput: Bool)
         -> (UITextField) -> Void {
             return { textField in
-                if #available(iOS 13.0, *) {
-                    textField.attributedPlaceholder = NSAttributedString(
-                        string: placeholder ?? "",
-                        attributes: [.foregroundColor: UIColor.placeholderText])
-                } else {
-                    textField.placeholder = placeholder
-                }
-                
-                textField.keyboardAppearance = .default
-
+                textField.placeholder = placeholder
                 textField.isSecureTextEntry = false
+                textField.keyboardAppearance = .dark
                 textField.autocapitalizationType = keyboardType == .URL ? .none : .words
                 textField.autocorrectionType = keyboardType == .URL ? .no : .default
                 textField.returnKeyType = .done

--- a/Client/Frontend/Browser/TabsBar/TabBarCell.swift
+++ b/Client/Frontend/Browser/TabsBar/TabBarCell.swift
@@ -5,7 +5,7 @@
 import UIKit
 import BraveShared
 
-class TabBarCell: UICollectionViewCell, Themeable {
+class TabBarCell: UICollectionViewCell {
     
     lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -17,11 +17,9 @@ class TabBarCell: UICollectionViewCell, Themeable {
         let button = UIButton()
         button.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
         button.setImage(#imageLiteral(resourceName: "close_tab_bar").template, for: .normal)
-        button.tintColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? .white : .black
-        
+        button.tintColor = PrivateBrowsingManager.shared.isPrivateBrowsing ? UIColor.white : UIColor.black
         // Close button is a bit wider to increase tap area, this aligns the 'X' image closer to the right.
         button.imageEdgeInsets.left = 6
-        
         return button
     }()
     
@@ -117,7 +115,6 @@ class TabBarCell: UICollectionViewCell, Themeable {
     }
     
     fileprivate var titleUpdateScheduled = false
-    
     func updateTitleThrottled(for tab: Tab) {
         if titleUpdateScheduled {
             return
@@ -128,11 +125,5 @@ class TabBarCell: UICollectionViewCell, Themeable {
             strongSelf.titleUpdateScheduled = false
             strongSelf.titleLabel.text = tab.displayTitle
         }
-    }
-    
-    func applyTheme(_ theme: Theme) {        
-        backgroundColor = .clear
-        titleLabel.textColor = theme.colors.tints.header
-        closeButton.tintColor = theme.colors.tints.header
     }
 }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -14,11 +14,6 @@ protocol TabsBarViewControllerDelegate: class {
 }
 
 class TabsBarViewController: UIViewController {
-    
-    private struct ReuseIdentifier {
-        static let tabBarCell = "TabBarCell"
-    }
-    
     private let leftOverflowIndicator = CAGradientLayer()
     private let rightOverflowIndicator = CAGradientLayer()
     
@@ -49,7 +44,7 @@ class TabsBarViewController: UIViewController {
         view.dataSource = self
         view.allowsSelection = true
         view.decelerationRate = UIScrollView.DecelerationRate.normal
-        view.register(TabBarCell.self, forCellWithReuseIdentifier: ReuseIdentifier.tabBarCell)
+        view.register(TabBarCell.self, forCellWithReuseIdentifier: "TabCell")
         return view
     }()
     
@@ -57,10 +52,9 @@ class TabsBarViewController: UIViewController {
     
     fileprivate weak var tabManager: TabManager?
     fileprivate var tabList = WeakList<Tab>()
-        
+    
     init(tabManager: TabManager) {
         self.tabManager = tabManager
-        
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -110,31 +104,12 @@ class TabsBarViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         // Updating tabs here is especially handy when tabs are reordered from the tab tray.
         updateData()
-        
-        if #available(iOS 13.0, *) {
-            let oldTraitCollection = UITraitCollection.current
-            UITraitCollection.current = traitCollection
-            applyTheme(Theme.of(tabManager?.selectedTab))
-            UITraitCollection.current = oldTraitCollection
-        } else {
-            applyTheme(Theme.of(tabManager?.selectedTab))
-        }
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
         updateOverflowIndicatorsLayout()
-    }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if #available(iOS 13.0, *) {
-            if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
-                applyTheme(Theme.of(tabManager?.selectedTab))
-            }
-        }
     }
     
     deinit {
@@ -304,10 +279,8 @@ extension TabsBarViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReuseIdentifier.tabBarCell, for: indexPath) as? TabBarCell else {
-            return UICollectionViewCell()
-        }
-        
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TabCell", for: indexPath) as? TabBarCell
+            else { return UICollectionViewCell() }
         guard let tab = tabList[indexPath.row] else { return cell }
         
         cell.tabManager = tabManager
@@ -315,20 +288,17 @@ extension TabsBarViewController: UICollectionViewDataSource {
         cell.titleLabel.text = tab.displayTitle
         cell.currentIndex = indexPath.row
         cell.separatorLineRight.isHidden = (indexPath.row != tabList.count() - 1)
-        cell.applyTheme(Theme.of(tab))
-
+        
         cell.closeTabCallback = { [weak self] tab in
-            guard let self = self,
-                  let tabManager = self.tabManager,
-                  let previousIndex = self.tabList.index(of: tab) else { return }
+            guard let strongSelf = self, let tabManager = strongSelf.tabManager, let previousIndex = strongSelf.tabList.index(of: tab) else { return }
             
             tabManager.removeTab(tab)
-            self.updateData()
+            strongSelf.updateData()
             
             let previousOrNext = max(0, previousIndex - 1)
-            tabManager.selectTab(self.tabList[previousOrNext])
+            tabManager.selectTab(strongSelf.tabList[previousOrNext])
             
-            self.collectionView.selectItem(at: IndexPath(row: previousOrNext, section: 0), animated: true, scrollPosition: .centeredHorizontally)
+            strongSelf.collectionView.selectItem(at: IndexPath(row: previousOrNext, section: 0), animated: true, scrollPosition: .centeredHorizontally)
         }
         
         return cell
@@ -373,10 +343,6 @@ extension TabsBarViewController: TabManagerDelegate {
 }
 
 extension TabsBarViewController: Themeable {
-    var themeableChildren: [Themeable?]? {
-        collectionView.visibleCells.compactMap({ $0 as? TabBarCell })
-    }
-    
     func applyTheme(_ theme: Theme) {
         styleChildren(theme: theme)
         


### PR DESCRIPTION
…ark mode (#3029)"

This reverts commit f873a329432442caeb48e64738f0ef8536e9cb72.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
