### PR TITLE
Fix #3274: Handle too long data saved numbers.

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/Sections/StatsSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/StatsSectionProvider.swift
@@ -107,9 +107,16 @@ class BraveShieldStatsView: UIView, Themeable {
     }
     
     var dataSaved: String {
-        let estimatedDataSavedInBytes = (BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection) * bytesPerItem
+        var estimatedDataSavedInBytes = (BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection) * bytesPerItem
         
         if estimatedDataSavedInBytes <= 0 { return "0" }
+        let _1MB = 1000 * 1000
+        
+        // Byte formatted megabytes value can be too long to display nicely(#3274).
+        // As a workaround we cut fraction value from megabytes by rounding it down.
+        if estimatedDataSavedInBytes > _1MB {
+            estimatedDataSavedInBytes = (estimatedDataSavedInBytes / _1MB) * _1MB
+        }
         
         let formatter = ByteCountFormatter().then {
             $0.allowsNonnumericFormatting = false
@@ -118,20 +125,7 @@ class BraveShieldStatsView: UIView, Themeable {
             $0.allowedUnits = [.useKB, .useMB, .useGB, .useTB]
         }
         
-        // Byte formatted megabytes value can be too long to display nicely(#3274).
-        // As a workaround we trim the decimal value when megabytes or kilobytes are displayed.
-        // For gigabytes it takes a lot of time to make the stat 100GB+ to be a problem.
-        // In such case the stat font is being scaled down.
-        // In the future we might have to write our own byte formater to handle this.
-        let byteFormattedString = formatter.string(fromByteCount: Int64(estimatedDataSavedInBytes))
-        let _1MB = 1000 * 1000
-        if estimatedDataSavedInBytes / _1MB < 1000 {
-            if let withRemovedDecimal = try? byteFormattedString.regexReplacePattern("\\.[0-9]+", with: "") {
-                return withRemovedDecimal
-            }
-        }
-        
-        return byteFormattedString
+        return formatter.string(fromByteCount: Int64(estimatedDataSavedInBytes))
     }
     
     var timeSaved: String {


### PR DESCRIPTION
Byte formatted megabytes value can be too long to display nicely.
As a workaround we trim the decimal value when megabytes are displayed.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3274 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


<img width="388" alt="Zrzut ekranu 2021-02-9 o 12 33 54" src="https://user-images.githubusercontent.com/6950387/107357992-194c3300-6ad3-11eb-8b62-fb352d1a9da9.png">



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
