### PR TITLE
Fix #3294: Tooltip shows up sometimes when shields is not in view

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -27,7 +27,8 @@ extension BrowserViewController {
     
     private func presentEducationalProductNotifications() {
         guard let selectedTab = tabManager.selectedTab,
-              !benchmarkNotificationPresented else {
+              !benchmarkNotificationPresented,
+              !topToolbar.inOverlayMode else {
             return
         }
         


### PR DESCRIPTION

## Summary of Changes

This pull request fixes #3294

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
Install 1.23 build
Visit a page
Before the page loads tap on the URL bar, page loads and notification shows not showing when the overlay is on the screen

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
