### PR TITLE
Fix #3296: Educational Notifications/modals should be displayed once per session

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -152,10 +152,6 @@ class BrowserViewController: UIViewController {
     /// in order to not to try to present another one over existing popover
     var benchmarkNotificationPresented = false
     
-    /// Boolean which is tracking If a benchmark notification is presented
-    /// in single application instance
-    var shieldStatChangesNotified = false
-    
     /// Number of Ads/Trackers used a limit to show benchmark notification
     let benchmarkNumberOfTrackers = 10
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -37,43 +37,38 @@ extension BrowserViewController {
         // Step 1: First Time Block Notification
         if !Preferences.ProductNotificationBenchmarks.firstTimeBlockingShown.value,
            contentBlockerStats.total > 0 {
-
-            notifyFirstTimeBlock(theme: Theme.of(selectedTab))
             
+            notifyFirstTimeBlock(theme: Theme.of(selectedTab))
             Preferences.ProductNotificationBenchmarks.firstTimeBlockingShown.value = true
+            
+            return
         }
         
         // Step 2: Load a video on a streaming site
-        if benchmarkNotificationPresented || shieldStatChangesNotified { return }
-
         if !Preferences.ProductNotificationBenchmarks.videoAdBlockShown.value,
            selectedTab.url?.isVideoSteamingSiteURL == true {
 
             notifyVideoAdsBlocked(theme: Theme.of(selectedTab))
             
-            shieldStatChangesNotified = true
+            return
         }
         
         // Step 3: Pre-determined # of Trackers and Ads Blocked
-        if benchmarkNotificationPresented || shieldStatChangesNotified { return }
-
         if !Preferences.ProductNotificationBenchmarks.privacyProtectionBlockShown.value,
            contentBlockerStats.total > benchmarkNumberOfTrackers {
             
             notifyPrivacyProtectBlock(theme: Theme.of(selectedTab))
             
-            shieldStatChangesNotified = true
+            return
         }
         
         // Step 4: Https Upgrade
-        if benchmarkNotificationPresented || shieldStatChangesNotified { return }
-
         if !Preferences.ProductNotificationBenchmarks.httpsUpgradeShown.value,
            contentBlockerStats.httpsCount > 0 {
 
             notifyHttpsUpgrade(theme: Theme.of(selectedTab))
             
-            shieldStatChangesNotified = true
+            return
         }
     }
     
@@ -116,31 +111,22 @@ extension BrowserViewController {
     }
     
     private func showBenchmarkNotificationPopover(controller: (UIViewController & PopoverContentComponent)) {
+        benchmarkNotificationPresented = true
+
         let popover = PopoverController(contentController: controller, contentSizeBehavior: .autoLayout)
         popover.addsConvenientDismissalMargins = false
-        popover.popoverDidDismiss = { [weak self] _ in
-            guard let self = self else { return }
-            
-            self.benchmarkNotificationPresented = false
-        }
-                    
         popover.present(from: self.topToolbar.locationView.shieldsButton, on: self)
-        benchmarkNotificationPresented = true
     }
     
     // MARK: Actions
     
     func showShieldsScreen() {
-        benchmarkNotificationPresented = false
-
         dismiss(animated: true) {
             self.presentBraveShieldsViewController()
         }
     }
     
     func dismissAndAddNoShowList(_ type: TrackingType) {
-        benchmarkNotificationPresented = false
-        
         dismiss(animated: true) {
             switch type {
                 case .videoAdBlock:


### PR DESCRIPTION
All special conditions about showing popvoer are removed.

One educational pop-over per app instance.

## Summary of Changes

This pull request fixes #3296

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

> launch 1.23 (21.2.10.18) from TF
> open amazon.com
> you'll notice that you'll get the Trackers & ads blocked on this page. notification/modal (red)
> dismiss the first notification and check if there is no other notification presented

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
