### PR TITLE
Fix #3301: Fill passwords correctly via share menu password app extensions

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -82,7 +82,7 @@ class ShareExtensionHelper: NSObject {
                     UIPasteboard.general.urls = [url]
                 }
                 
-                if self.shareActivityType(activityType.map { $0.rawValue }) != .password {
+                if self.shareActivityType(activityType.map { $0.rawValue }) == .password {
                     if let logins = returnedItems {
                         self.fillPasswords(logins as [AnyObject])
                     }


### PR DESCRIPTION
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3301 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
