### PR TITLE
Fix #3291: Intermittent crash when scrolling page while educational notification appearing

### DIFF
--- a/Client/Frontend/Shields/ShareTrackersController.swift
+++ b/Client/Frontend/Shields/ShareTrackersController.swift
@@ -51,7 +51,7 @@ enum TrackingType: Equatable {
 
 // MARK: - ShareTrackersController
 
-class ShareTrackersController: UIViewController, Themeable, PopoverContentComponent {
+class ShareTrackersController: UIViewController, Themeable {
     
     // MARK: Action
     
@@ -321,4 +321,10 @@ private class ShareTrackersView: UIView, ShareTrayViewDelegate, Themeable {
         subtitleLabel.appearanceTextColor = .white
         actionButton.appearanceTextColor = .white
     }
+}
+
+// MARK: - PopoverContentComponent
+
+extension ShareTrackersController: PopoverContentComponent {
+    var isPanToDismissEnabled: Bool { return false }
 }


### PR DESCRIPTION
Until we can find the real reason Disabling Pan Gesture for Share Educational Pop-Overs

## Summary of Changes

This pull request fixes #3291

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

> Skip all onboarding
> Ensure that you have https://www.theverge.com/2021/2/10/22277540/star-wars-severs-ties-the-mandalorian-gina-carano-cara-dune in your clipboard/copied
> Paste the above using Paste & Go
> Once the page starts loading, start swiping down before the Trackers & ads blocked on this page education modal appears 

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
