### PR TITLE
Fix #3306: Same tooltip is shown multiple times when browser is restarted

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -49,7 +49,8 @@ extension BrowserViewController {
            selectedTab.url?.isVideoSteamingSiteURL == true {
 
             notifyVideoAdsBlocked(theme: Theme.of(selectedTab))
-            
+            Preferences.ProductNotificationBenchmarks.videoAdBlockShown.value = true
+
             return
         }
         
@@ -58,7 +59,8 @@ extension BrowserViewController {
            contentBlockerStats.total > benchmarkNumberOfTrackers {
             
             notifyPrivacyProtectBlock(theme: Theme.of(selectedTab))
-            
+            Preferences.ProductNotificationBenchmarks.privacyProtectionBlockShown.value = true
+
             return
         }
         
@@ -67,7 +69,8 @@ extension BrowserViewController {
            contentBlockerStats.httpsCount > 0 {
 
             notifyHttpsUpgrade(theme: Theme.of(selectedTab))
-            
+            Preferences.ProductNotificationBenchmarks.httpsUpgradeShown.value = true
+
             return
         }
     }
@@ -92,21 +95,19 @@ extension BrowserViewController {
     private func notifyVideoAdsBlocked(theme: Theme) {
         let shareTrackersViewController = ShareTrackersController(theme: theme, trackingType: .videoAdBlock)
         
-        dismissAndAddNoShowList(.videoAdBlock)
+        dismiss(animated: true)
         showBenchmarkNotificationPopover(controller: shareTrackersViewController)
     }
     
     private func notifyPrivacyProtectBlock(theme: Theme) {
         let shareTrackersViewController = ShareTrackersController(theme: theme, trackingType: .trackerAdCountBlock(count: benchmarkNumberOfTrackers))
-        dismissAndAddNoShowList(.trackerAdCountBlock(count: benchmarkNumberOfTrackers))
-        
+        dismiss(animated: true)
         showBenchmarkNotificationPopover(controller: shareTrackersViewController)
     }
     
     private func notifyHttpsUpgrade(theme: Theme) {
         let shareTrackersViewController = ShareTrackersController(theme: theme, trackingType: .encryptedConnectionWarning)
-        
-        dismissAndAddNoShowList(.encryptedConnectionWarning)
+        dismiss(animated: true)
         showBenchmarkNotificationPopover(controller: shareTrackersViewController)
     }
     
@@ -123,21 +124,6 @@ extension BrowserViewController {
     func showShieldsScreen() {
         dismiss(animated: true) {
             self.presentBraveShieldsViewController()
-        }
-    }
-    
-    func dismissAndAddNoShowList(_ type: TrackingType) {
-        dismiss(animated: true) {
-            switch type {
-                case .videoAdBlock:
-                    Preferences.ProductNotificationBenchmarks.videoAdBlockShown.value = true
-                case .trackerAdCountBlock:
-                    Preferences.ProductNotificationBenchmarks.privacyProtectionBlockShown.value = true
-                case .encryptedConnectionWarning:
-                    Preferences.ProductNotificationBenchmarks.httpsUpgradeShown.value = true
-                default:
-                    break
-            }
         }
     }
 }


### PR DESCRIPTION
Removing the Switch case while dismissing, cause it causes problems on iOS12

## Summary of Changes

This pull request fixes #3306

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Install 1.23(21.2.12.9)
Trigger 10+ ads blocked tooltip
Quit and relaunch browser, same tooltip is shown after page loads
Quite and relaunch and visit a different site that has 10+ items blocked, check same tooltip is shown or not

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
