### PR TITLE
Fix #3326: WebAuthn APIs should not be available in third party iframes

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/U2F-low-level.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F-low-level.js
@@ -5,10 +5,12 @@
 try {
     var sameOrigin = (window.top.location.origin == window.location.origin)
     if (!sameOrigin) {
-        window.u2f = {}
+        window.u2f = undefined
+        return
     }
 } catch (e) {
-    window.u2f = {}
+    window.u2f = undefined
+    return
 }
 
 Object.defineProperty(window.u2f, 'receiveChannel', {
@@ -126,13 +128,3 @@ Object.defineProperty(window.u2f.receiveChannel.port2.onmessage, 'toString', {
         return defaultU2FString
     }
 })
-
-try {
-    var sameOrigin = (window.top.location.origin == window.location.origin)
-    if (!sameOrigin) {
-        window.u2f = undefined
-    }
-} catch (e) {
-    window.u2f = undefined
-}
-

--- a/Client/Frontend/UserContent/UserScripts/U2F.js
+++ b/Client/Frontend/UserContent/UserScripts/U2F.js
@@ -333,33 +333,27 @@ Object.defineProperty($<webauthn-internal>, 'undefineU2F', {
   }
 })
 
-Object.defineProperty(window, 'PublicKeyCredential', {
-  value: $<pkc>
-})
+var sameOrigin = (window.top.location.origin == window.location.origin)
+if (sameOrigin) {
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      value: $<pkc>
+    })
 
-Object.defineProperty(window, 'AuthenticatorAttestationResponse', {
-  value: $<attest>
-})
+    Object.defineProperty(window, 'AuthenticatorAttestationResponse', {
+      value: $<attest>
+    })
 
-Object.defineProperty(window, 'AuthenticatorAssertionResponse', {
-  value: $<assert>
-})
+    Object.defineProperty(window, 'AuthenticatorAssertionResponse', {
+      value: $<assert>
+    })
 
-try {
-    var sameOrigin = (window.top.location.origin == window.location.origin)
-    if (!sameOrigin) {
-        $<webauthn-internal>.undefineU2F();
-    }
-} catch (e) {
-    $<webauthn-internal>.undefineU2F();
+    // Hook $<webauthn> to navigator.credentials
+    Object.defineProperty(navigator, 'credentials', {
+      value: $<webauthn>
+    })
+
+    // Hook $<u2f> to window.u2f
+    Object.defineProperty(window, 'u2f', {
+       value: $<u2f>
+    })
 }
-
-// Hook $<webauthn> to navigator.credentials
-Object.defineProperty(navigator, 'credentials', {
-  value: $<webauthn>
-})
-
-// Hook $<u2f> to window.u2f
-Object.defineProperty(window, 'u2f', {
-   value: $<u2f>
-})


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
WebAuthn APIs should not be available in third party iframes.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3326 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Navigate to https://dustiest-limitation.000webhostapp.com/fido-iframe.html
2. Verify the WebAuthn test-plan listed here: https://github.com/brave/security/issues/267

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
