### PR TITLE
Fix #2119: Add preference around opening external apps

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -585,6 +585,7 @@ extension Strings {
 
 extension Strings {
     public static let blockPopups = NSLocalizedString("BlockPopups", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Block Popups", comment: "Setting to enable popup blocking")
+    public static let followUniversalLinks = NSLocalizedString("FollowUniversalLinks", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Allow universal links to open in external apps", comment: "Setting to follow universal links")
     public static let mediaAutoPlays = NSLocalizedString("MediaAutoPlays", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Enable background video autoplay", comment: "Setting to allow media to play automatically")
     public static let showTabsBar = NSLocalizedString("ShowTabsBar", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Show Tabs Bar", comment: "Setting to show/hide the tabs bar")
     public static let privateBrowsingOnly = NSLocalizedString("PrivateBrowsingOnly", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Private Browsing Only", comment: "Setting to keep app in private mode")

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -74,6 +74,9 @@ extension Preferences {
         /// Whether the default browser callout on new tab page was dismissed.
         static let defaultBrowserCalloutDismissed =
             Option<Bool>(key: "general.default-browser-callout-dismissed", default: false)
+        
+        /// Whether or not the app (in regular browsing mode) will follow universal links
+        static let followUniversalLinks = Option<Bool>(key: "general.follow-universal-links", default: true)
     }
     
     final class DefaultBrowserIntro {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -259,6 +259,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 self.tabManager.selectedTab?.alertShownCount = 0
                 self.tabManager.selectedTab?.blockAllAlerts = false
             }
+            
             decisionHandler(.allow)
             return
         }

--- a/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -164,7 +164,8 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
                         self.pboModeToggled(value: value)
                     }
                 ),
-                .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups)
+                .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups),
+                .boolRow(title: Strings.followUniversalLinks, option: Preferences.General.followUniversalLinks)
             ]
         )
         if #available(iOS 14.0, *) {


### PR DESCRIPTION
Also disables opening external apps while browsing in Private Mode

## Summary of Changes

This pull request fixes #2119 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Verify tapping universal links open apps by default in regular browsing mode
- Verify tapping universal links never open apps by default in private browsing mode
- Verify that switching the preference in _Brave Shields & Privacy_ page allows you to mimic private browsing mode behavior in regular mode

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
