### PR TITLE
Ref #3204: Add additional info in rewards internals around legacy wallet

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1696,6 +1696,8 @@ extension Strings {
   public struct RewardsInternals {
     public static let title = NSLocalizedString("RewardsInternalsTitle", bundle: Bundle.braveShared, value: "Rewards Internals", comment: "'Rewards' as in 'Brave Rewards'")
     public static let walletInfoHeader = NSLocalizedString("RewardsInternalsWalletInfoHeader", bundle: Bundle.braveShared, value: "Wallet Info", comment: "")
+    public static let legacyWalletInfoHeader = NSLocalizedString("RewardsInternalsLegacyWalletInfoHeader", bundle: Bundle.braveShared, value: "Legacy Wallet Info", comment: "")
+    public static let legacyWalletHasTransferrableBalance = NSLocalizedString("RewardsInternalsLegacyWalletHasTransferrableBalance", bundle: Bundle.braveShared, value: "Has Transferrable Balance", comment: "")
     public static let keyInfoSeed = NSLocalizedString("RewardsInternalsKeyInfoSeed", bundle: Bundle.braveShared, value: "Key Info Seed", comment: "")
     public static let valid = NSLocalizedString("RewardsInternalsValid", bundle: Bundle.braveShared, value: "Valid", comment: "")
     public static let invalid = NSLocalizedString("RewardsInternalsInvalid", bundle: Bundle.braveShared, value: "Invalid", comment: "")

--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -77,7 +77,7 @@ class BraveRewardsSettingsViewController: TableViewController {
                 dataSource.sections += [
                     Section(rows: [
                         Row(text: Strings.RewardsInternals.title, selection: {
-                            let controller = RewardsInternalsViewController(ledger: self.rewards.ledger)
+                            let controller = RewardsInternalsViewController(ledger: self.rewards.ledger, legacyLedger: self.legacyWallet)
                             self.navigationController?.pushViewController(controller, animated: true)
                         }, accessory: .disclosureIndicator)
                     ])


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

- Adds legacy wallet info to the rewards internals screen.
- Adds ability to tap wallet payment ID buttons to copy

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Migrate with a legacy wallet
- View rewards internals and verify the info there


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
