### PR TITLE
Fix #3334: Handle invalid VPN credentials, add 406 status code to it.

### DIFF
--- a/Client/Frontend/BraveVPN/GRDAPI/GRDGatewayAPI.m
+++ b/Client/Frontend/BraveVPN/GRDAPI/GRDGatewayAPI.m
@@ -227,11 +227,11 @@
             if (completion) completion(nil, NO, @"Internal server error authenticating with subscriber credential");
             return;
             
-        } else if (statusCode == 410) {
-            NSLog(@"Subscriber credential invalid");
-            if (completion) completion(nil, NO, @"Subscriber credential invalid");
-            return;
-            
+        } else if (statusCode == 410 || statusCode == 406) {
+            NSLog(@"Subscriber credential invalid: %@", subscriberCredential);
+                [GRDKeychain removeKeychanItemForAccount:kKeychainStr_SubscriberCredential];
+                if (completion) completion(nil, NO, @"Invalid Subscriber Credential. Please try again.");
+                   return;
         } else if (statusCode == 400) {
             NSLog(@"Subscriber credential missing");
             if (completion) completion(nil, NO, @"Subscriber credential missing");


### PR DESCRIPTION
Change requested by the Guardian team.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3334 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
This is hard to reproduce and test properly.
Please do a simple sanity check only, see if vpn can still be purchased and if 'reset vpn configuration' works

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
