### PR TITLE
Fix #3332 - Bookmarklet URLs not working properly with special characters

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
@@ -268,12 +268,12 @@ class AddEditBookmarkTableViewController: UITableViewController {
             
             switch saveLocation {
             case .rootLevel:
-                bookmark.updateWithNewLocation(customTitle: title, url: url.absoluteString, location: nil)
+                bookmark.updateWithNewLocation(customTitle: title, url: url, location: nil)
             case .favorites:
                 bookmark.delete()
                 Favorite.add(url: url, title: title)
             case .folder(let folder):
-                bookmark.updateWithNewLocation(customTitle: title, url: urlString, location: folder)
+                bookmark.updateWithNewLocation(customTitle: title, url: url, location: folder)
             }
             
         case .editFolder(let folder):
@@ -301,7 +301,7 @@ class AddEditBookmarkTableViewController: UITableViewController {
                 favorite.delete()
                 Bookmarkv2.add(url: url, title: title)
             case .favorites:
-                favorite.update(customTitle: title, url: url.absoluteString)
+                favorite.update(customTitle: title, url: url)
             case .folder(let folder):
                 favorite.delete()
                 Bookmarkv2.add(url: url, title: title, parentFolder: folder)

--- a/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
+++ b/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
@@ -233,12 +233,12 @@ extension Bookmarkv2 {
             .compactMap({ return !$0.isFolder ? Bookmarkv2($0) : nil })
     }
     
-    public func update(customTitle: String?, url: String?) {
+    public func update(customTitle: String?, url: URL?) {
         bookmarkNode.setTitle(customTitle ?? "")
-        bookmarkNode.url = URL(string: url ?? "")
+        bookmarkNode.url = url
     }
     
-    public func updateWithNewLocation(customTitle: String?, url: String?, location: Bookmarkv2?) {
+    public func updateWithNewLocation(customTitle: String?, url: URL?, location: Bookmarkv2?) {
         if let location = location?.bookmarkNode ?? Bookmarkv2.bookmarksAPI.mobileNode {
             if location.guid != bookmarkNode.parent?.guid {
                 bookmarkNode.move(toParent: location)
@@ -249,7 +249,7 @@ extension Bookmarkv2 {
             }
             
             if let url = url, !bookmarkNode.isFolder {
-                bookmarkNode.url = URL(string: url)
+                bookmarkNode.url = url
             } else if url != nil {
                 log.error("Error: Moving bookmark - Cannot convert a folder into a bookmark with url.")
             }
@@ -272,10 +272,10 @@ extension Bookmarkv2 {
                 node.move(toParent: parent, index: UInt(destinationIndexPath.row))
             }
             
-            //Notify the delegate that items did move..
-            //This is already done automatically in `Bookmarkv2Fetcher` listener.
-            //However, the Brave-Core delegate is being called before the move is actually complete OR too quickly
-            //So to fix it, we reload here AFTER the move is done so the UI can update accordingly.
+            // Notify the delegate that items did move..
+            // This is already done automatically in `Bookmarkv2Fetcher` listener.
+            // However, the Brave-Core delegate is being called before the move is actually complete OR too quickly
+            // So to fix it, we reload here AFTER the move is done so the UI can update accordingly.
             frc.delegate?.controllerDidReloadContents(frc)
         }
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes Bookmarklets to use the URL passed in via `.bookmarkletURL` or just plain `URL(string: str)` instead of attempting to part it as just a URL with the assumption it was already encoded properly.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3332

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Use one of examples in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
