### PR TITLE
Fix#936/3300: Add Search Engine Changes/Fixes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -47,7 +47,13 @@ extension BrowserViewController {
         // thus in case of yahoo.com the title is 'Yahoo Search' and Shortname is 'Yahoo'
         // Instead we are checking referenceURL match to determine searchEngine is added or not
         
-        let searchEngineExists = profile.searchEngines.orderedEngines.contains(where: { $0.referenceURL == referenceObject.reference })
+        let searchEngineExists = profile.searchEngines.orderedEngines.contains(where: {
+            if let referenceURL =  $0.referenceURL {
+                return referenceObject.reference.contains(referenceURL)
+            }
+            
+            return false
+        })
 
         if searchEngineExists {
             self.customSearchEngineButton.action = .disabled

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -169,7 +169,7 @@ extension BrowserViewController {
                 try self.profile.searchEngines.addSearchEngine(engine)
                 
                 let toast = SimpleToast()
-                toast.showAlertWithText(Strings.thirdPartySearchEngineAdded, bottomContainer: self.webViewContainer)
+                toast.showAlertWithText(Strings.CustomSearchEngine.thirdPartySearchEngineAddedToastTitle, bottomContainer: self.webViewContainer)
                 
                 self.customSearchEngineButton.action = .disabled
             } catch {

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -19,7 +19,7 @@ enum SearchEngineError: Error {
     case failedToSave
     case invalidQuery
     case missingInformation
-    case insecureURL
+    case invalidURL
 }
 
 // BRAVE TODO: Move to newer Preferences class(#259)

--- a/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Client/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -28,22 +28,22 @@ class ThirdPartySearchAlerts: UIAlertController {
         let alertMessage = """
                             \n\(engine.displayName)
                             \(engine.searchTemplate)
-                            \n\(Strings.thirdPartySearchAddMessage)
+                            \n\(Strings.CustomSearchEngine.thirdPartySearchEngineAddAlertDescription)
                             """
         let alert = ThirdPartySearchAlerts(
-            title: Strings.thirdPartySearchAddTitle,
+            title: Strings.CustomSearchEngine.thirdPartySearchEngineAddAlertTitle,
             message: alertMessage,
             preferredStyle: .alert
         )
 
         let noOption = UIAlertAction(
-            title: Strings.thirdPartySearchCancelButton,
+            title: Strings.CancelString,
             style: .cancel,
             handler: completion
         )
 
         let okayOption = UIAlertAction(
-            title: Strings.thirdPartySearchOkayButton,
+            title: Strings.OKString,
             style: .default,
             handler: completion
         )
@@ -61,28 +61,28 @@ class ThirdPartySearchAlerts: UIAlertController {
      **/
 
     static func failedToAddThirdPartySearch() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.thirdPartySearchFailedTitle,
-                                 message: Strings.thirdPartySearchFailedMessage)
-    }
-    
-    static func incorrectCustomEngineForm() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.thirdPartySearchFailedTitle,
-                                      message: Strings.customEngineFormErrorMessage)
-    }
-    
-    static func duplicateCustomEngine() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.thirdPartySearchFailedTitle,
-                                 message: Strings.customEngineDuplicateErrorMessage)
+        return searchAlertWithOK(title: Strings.CustomSearchEngine.thirdPartySearchEngineAddErrorTitle,
+                                 message: Strings.CustomSearchEngine.thirdPartySearchEngineAddErrorDescription)
     }
     
     static func missingInfoToAddThirdPartySearch() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.thirdPartySearchFailedTitle,
-                                 message: Strings.customEngineFillAllFieldsErrorMessage)
+        return searchAlertWithOK(title: Strings.CustomSearchEngine.thirdPartySearchEngineAddErrorTitle,
+                                 message: Strings.CustomSearchEngine.thirdPartySearchEngineMissingInfoErrorDescription)
+    }
+    
+    static func incorrectCustomEngineForm() -> UIAlertController {
+        return searchAlertWithOK(title: Strings.CustomSearchEngine.thirdPartySearchEngineIncorrectFormErrorTitle,
+                                 message: Strings.CustomSearchEngine.thirdPartySearchEngineIncorrectFormErrorDescription)
+    }
+    
+    static func duplicateCustomEngine() -> UIAlertController {
+        return searchAlertWithOK(title: Strings.CustomSearchEngine.thirdPartySearchEngineAddErrorTitle,
+                                 message: Strings.CustomSearchEngine.thirdPartySearchEngineDuplicateErrorDescription)
     }
     
     static func insecureURLEntryThirdPartySearch() -> UIAlertController {
-        return searchAlertWithOK(title: Strings.thirdPartySearchFailedTitle,
-                                 message: Strings.customEngineFormErrorMessage)
+        return searchAlertWithOK(title: Strings.CustomSearchEngine.thirdPartySearchEngineAddErrorTitle,
+                                 message: Strings.CustomSearchEngine.thirdPartySearchEngineInsecureURLErrorDescription)
     }
     
     private static func searchAlertWithOK(title: String, message: String) -> UIAlertController {
@@ -93,7 +93,7 @@ class ThirdPartySearchAlerts: UIAlertController {
         )
         
         let okayOption = UIAlertAction(
-            title: Strings.thirdPartySearchOkayButton,
+            title: Strings.OKString,
             style: .default,
             handler: nil
         )

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -432,7 +432,7 @@ extension SearchCustomEngineViewController {
         }
     
         // Check Engine Exists
-        guard profile.searchEngines.orderedEngines.filter({ $0.shortName == name }).isEmpty else {
+        guard profile.searchEngines.orderedEngines.filter({ $0.shortName == name || $0.searchTemplate.contains(template)}).isEmpty else {
             completion(nil, SearchEngineError.duplicate)
             return
         }

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -504,30 +504,14 @@ extension SearchCustomEngineViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         changeAddButton(for: .disabled)
         
-        // This conditional clause is added in order to force use to use secure url scheme
+        // The withSecureUrlScheme is used in order to force user to use secure url scheme
         // Instead of checking paste-board with every character entry, the textView text is analyzed
-        // And according to what prefix the copied or entered text has we alter the result to start with https://
-        // Also block repeating https:// and http:// schemes
-        if !textView.text.hasPrefix("https://") {
-            var textEntered = textView.text ?? ""
-            
-            if textEntered.hasPrefix("http://") {
-                textEntered = String(textEntered.dropFirst(7))
-            }
-            
-            textView.text = "https://\(textEntered)"
-        } else {
-            let substringWithoutHttps = String(textView.text.dropFirst(8))
-            
-            if substringWithoutHttps.hasPrefix("https://") {
-                textView.text = substringWithoutHttps
-            } else if substringWithoutHttps.hasPrefix("http://") {
-                let substringWithoutHttp = String(substringWithoutHttps.dropFirst(7))
-                textView.text = "https://\(substringWithoutHttp)"
-            }
-        }
+        // and according to what prefix copied or entered, text is altered to start with https://
+        // this logic block repeating https:// and http:// schemes
+        let textEntered = textView.text.withSecureUrlScheme
         
-        urlText = textView.text
+        textView.text = textEntered
+        urlText = textEntered
 
         if searchEngineTimer != nil {
             searchEngineTimer?.invalidate()

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -51,6 +51,8 @@ class SearchCustomEngineViewController: UIViewController {
         didSet {
             if let host = host, oldValue != host {
                 fetchSearchEngineSupportForHost(host)
+            } else {
+                checkManualAddExists()
             }
         }
     }

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -125,7 +125,8 @@ class SearchSettingsTableViewController: UITableViewController {
         return SearchEnginePicker(type: type, showCancel: false).then {
             // Order alphabetically, so that picker is always consistently ordered.
             // Every engine is a valid choice for the default engine, even the current default engine.
-            $0.engines = searchPickerEngines
+            // In private mode only custom engines will not be shown
+            $0.engines = type == .privateMode ? searchPickerEngines.filter { !$0.isCustomEngine } : searchPickerEngines
             $0.delegate = self
             $0.selectedSearchEngineName = searchEngines.defaultEngine(forType: type).shortName
         }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -18,7 +18,7 @@ private func applicationBundle() -> Bundle {
 
 extension Strings {
     public static let OKString = NSLocalizedString("OKString", bundle: Bundle.shared, value: "OK", comment: "OK button")
-    public static let thirdPartySearchFailedTitle = NSLocalizedString("ThirdPartySearchFailedTitle", bundle: Bundle.shared, value: "Failed", comment: "A title explaining that we failed to add a search engine")
+    public static let CancelString = NSLocalizedString("CancelString", bundle: Bundle.shared, value: "Cancel", comment: "Cancel button")
 }
 
 // Settings.
@@ -126,15 +126,67 @@ extension Strings {
 
 // Third Party Search Engines
 extension Strings {
-    public static let thirdPartySearchEngineAdded = NSLocalizedString("ThirdPartySearchEngineAdded", bundle: Bundle.shared, value: "Added Search engine!", comment: "The success message that appears after a user sucessfully adds a new search engine")
-    public static let thirdPartySearchAddTitle = NSLocalizedString("ThirdPartySearchAddTitle", bundle: Bundle.shared, value: "Add Search Provider?", comment: "The title that asks the user to Add the search provider")
-    public static let thirdPartySearchAddMessage = NSLocalizedString("ThirdPartySearchAddMessage", bundle: Bundle.shared, value: "The new search engine will appear in the quick search bar.", comment: "The message that asks the user to Add the search provider explaining where the search engine will appear")
-    public static let thirdPartySearchCancelButton = NSLocalizedString("ThirdPartySearchCancelButton", bundle: Bundle.shared, value: "Cancel", comment: "The cancel button if you do not want to add a search engine.")
-    public static let thirdPartySearchOkayButton = NSLocalizedString("ThirdPartySearchOkayButton", bundle: Bundle.shared, value: "OK", comment: "The confirmation button")
-    public static let thirdPartySearchFailedMessage = NSLocalizedString("ThirdPartySearchFailedMessage", bundle: Bundle.shared, value: "The search provider could not be added.", comment: "A title explaining that we failed to add a search engine")
-    public static let customEngineFormErrorMessage = NSLocalizedString("CustomEngineFormErrorMessage", bundle: Bundle.shared, value: "Please fill all fields correctly.", comment: "A message explaining fault in custom search engine form.")
-    public static let customEngineDuplicateErrorMessage = NSLocalizedString("CustomEngineDuplicateErrorMessage", bundle: Bundle.shared, value: "A search engine with this title or URL has already been added.", comment: "A message explaining fault in custom search engine form.")
-    public static let customEngineFillAllFieldsErrorMessage = NSLocalizedString("CustomEngineFillAllFieldsErrorMessage", bundle: Bundle.shared, value: "Please fill all the form fields.", comment: "A message explaining that all form fields are to be filled.")
+    public struct CustomSearchEngine {
+        public static let thirdPartySearchEngineAddErrorTitle = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineAddErrorTitle",
+            bundle: Bundle.shared,
+            value: "Custom Search Engine Error",
+            comment: "A title explaining that there is error while adding a search engine")
+        
+        public static let thirdPartySearchEngineAddErrorDescription = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineAddErrorDescription",
+            bundle: Bundle.shared,
+            value: "The custom search engine could not be added. Please try again later.",
+            comment: "A descriotion explaining that there is error while adding a search engine")
+        
+        public static let thirdPartySearchEngineMissingInfoErrorDescription = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineMissingInfoErrorDescription",
+            bundle: Bundle.shared,
+            value: "Please fill both Title and URL fields.",
+            comment: "A descriotion explaining that the fields must filled while adding a search engine. ")
+        
+        public static let thirdPartySearchEngineIncorrectFormErrorTitle = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineIncorrectFormErrorTitle",
+            bundle: Bundle.shared,
+            value: "Search URL Query Error ",
+            comment: "A title explaining that there is a formatting error in URL field")
+        
+        public static let thirdPartySearchEngineIncorrectFormErrorDescription = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineIncorrectFormErrorDescription",
+            bundle: Bundle.shared,
+            value: "Write the search url and replace the query with %s. ",
+            comment: "A description explaining that there is a formatting error in URL field")
+        
+        public static let thirdPartySearchEngineDuplicateErrorDescription = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineDuplicateErrorDescription",
+            bundle: Bundle.shared,
+            value: "A search engine with this title or URL has already been added.",
+            comment: "A message explaining a replica search engine is already added")
+        
+        public static let thirdPartySearchEngineInsecureURLErrorDescription = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineInsecureURLErrorDescription",
+            bundle: Bundle.shared,
+            value: "The copied URL text should start with 'https://'",
+            comment: "A description explaining the copied url should be secure")
+        
+        public static let thirdPartySearchEngineAddedToastTitle = NSLocalizedString(
+            "custonmSearchEngine.thirdPartySearchEngineAddedToastTitle",
+            bundle: Bundle.shared,
+            value: "Added Search engine!",
+            comment: "The success message that appears after a user sucessfully adds a new search engine")
+        
+        public static let thirdPartySearchEngineAddAlertTitle = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineAddAlertTitle",
+            bundle: Bundle.shared,
+            value: "Add Search Provider?",
+            comment: "The title that asks the user to Add the search provider")
+
+        public static let thirdPartySearchEngineAddAlertDescription = NSLocalizedString(
+            "customSearchEngine.thirdPartySearchEngineAddAlertDescription",
+            bundle: Bundle.shared,
+            value: "The new search engine will appear in the quick search bar.",
+            comment: "The message that asks the user to Add the search provider explaining where the search engine will appear")
+    }
 }
 
 // Tabs Delete All Undo Toast

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -166,7 +166,7 @@ extension Strings {
         public static let thirdPartySearchEngineInsecureURLErrorDescription = NSLocalizedString(
             "customSearchEngine.thirdPartySearchEngineInsecureURLErrorDescription",
             bundle: Bundle.shared,
-            value: "The copied URL text should start with 'https://'",
+            value: "The copied text should be a valid secure URL which starts with 'https://'",
             comment: "A description explaining the copied url should be secure")
         
         public static let thirdPartySearchEngineAddedToastTitle = NSLocalizedString(

--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -77,4 +77,12 @@ class StringExtensionsTests: XCTestCase {
             XCTAssert(strip == nounicode)
         }
     }
+    
+    func testWithSecureUrlScheme() {
+        XCTAssertEqual("test".withSecureUrlScheme, "https://test")
+        XCTAssertEqual("http://test".withSecureUrlScheme, "https://test")
+        XCTAssertEqual("https://test".withSecureUrlScheme, "https://test")
+        XCTAssertEqual("https://https://test".withSecureUrlScheme, "https://test")
+        XCTAssertEqual("https://http://test".withSecureUrlScheme, "https://test")
+    }
 }

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -131,4 +131,27 @@ extension String {
     public var withNonBreakingSpace: String {
         self.replacingOccurrences(of: " ", with: "\u{00a0}")
     }
+    
+    public var withSecureUrlScheme: String {
+        var textEntered = self
+
+        if !textEntered.hasPrefix("https://") {
+            if textEntered.hasPrefix("http://") {
+                textEntered = String(textEntered.dropFirst(7))
+            }
+            
+            return "https://\(textEntered)"
+        } else {
+            let substringWithoutHttps = String(textEntered.dropFirst(8))
+            
+            if substringWithoutHttps.hasPrefix("https://") {
+                return substringWithoutHttps
+            } else if substringWithoutHttps.hasPrefix("http://") {
+                let substringWithoutHttp = String(substringWithoutHttps.dropFirst(7))
+                return "https://\(substringWithoutHttp)"
+            }
+        }
+        
+        return textEntered
+    }
 }


### PR DESCRIPTION
This PR has some fixes and changes related with Add Search Engine (Auto/Manual) which is merged with PR https://github.com/brave/brave-ios/pull/3231

- Limit open-search additions to https only - this is achieved by some changes inside textView protocol textViewDidChange
- Restrict open-search additions to regular mode
- Add variety to  error messages and localize the messages and titles with proper descriptive text
- Error fixes related with search engine duplicate addition

## Summary of Changes

This pull request references #936

This pull request references #3300

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Go to Settings - Search Engines - Add Custom Search Engine
- Try writing, deleting and copying variety of text

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
