### PR TITLE
Fix #3353: Do not show default browser callouts if settings were opened.

### DIFF
--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -71,7 +71,8 @@ extension Preferences {
         /// Whether or not link preview upon long press action should be shown.
         static let enableLinkPreview = Option<Bool>(key: "general.night-mode", default: true)
         
-        /// Whether the default browser callout on new tab page was dismissed.
+        /// Whether a default browser callout was dismissed.
+        /// It should apply to all kinds of callouts: banner on NTP, at-launch modal etc.
         static let defaultBrowserCalloutDismissed =
             Option<Bool>(key: "general.default-browser-callout-dismissed", default: false)
         

--- a/Client/Frontend/Browser/DefaultBrowserIntroCalloutViewController.swift
+++ b/Client/Frontend/Browser/DefaultBrowserIntroCalloutViewController.swift
@@ -65,6 +65,8 @@ class DefaultBrowserIntroCalloutViewController: UIViewController, Themeable {
             log.error("Failed to unwrap iOS settings URL")
             return
         }
+        
+        Preferences.General.defaultBrowserCalloutDismissed.value = true
         UIApplication.shared.open(settingsUrl)
         
         cancelAction()

--- a/Client/Frontend/Browser/DefaultBrowserIntroManager.swift
+++ b/Client/Frontend/Browser/DefaultBrowserIntroManager.swift
@@ -15,7 +15,9 @@ struct DefaultBrowserIntroManager {
     /// Returns true if the popup should be shown.
     @discardableResult
     static func prepareAndShowIfNeeded(isNewUser: Bool, launchDate: Date = Date()) -> Bool {
-        if IntroPrefs.completed.value { return false }
+        if IntroPrefs.completed.value || Preferences.General.defaultBrowserCalloutDismissed.value {
+            return false
+        }
         
         IntroPrefs.appLaunchCount.value += 1
         

--- a/ClientTests/DefaultBrowserIntroTests.swift
+++ b/ClientTests/DefaultBrowserIntroTests.swift
@@ -16,6 +16,7 @@ class DefaultBrowserIntroTests: XCTestCase {
         IntroPrefs.completed.reset()
         IntroPrefs.appLaunchCount.reset()
         IntroPrefs.nextShowDate.reset()
+        Preferences.General.defaultBrowserCalloutDismissed.reset()
     }
 
     func testPrepareAndShowIfNeeded() throws {
@@ -47,5 +48,21 @@ class DefaultBrowserIntroTests: XCTestCase {
         let superLateDate = Date(timeInterval: 10.days, since: now)
         XCTAssertFalse(DefaultBrowserIntroManager.prepareAndShowIfNeeded(isNewUser: true,
                                                                     launchDate: superLateDate))
+    }
+    
+    func testDoNotShowTwice() throws {
+        let now = Date()
+        // First launch
+        XCTAssertFalse(DefaultBrowserIntroManager.prepareAndShowIfNeeded(isNewUser: true, launchDate: now))
+        
+        // Simulate user tapping on settings, we always set this pref to true then.
+        Preferences.General.defaultBrowserCalloutDismissed.value = true
+        
+        // Second launch
+        XCTAssertFalse(DefaultBrowserIntroManager.prepareAndShowIfNeeded(isNewUser: true, launchDate: now))
+        
+        let laterDate = Date(timeInterval: 2.days, since: now)
+        XCTAssertFalse(DefaultBrowserIntroManager.prepareAndShowIfNeeded(isNewUser: true,
+                                                                    launchDate: laterDate))
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3353 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. NTP banner test
- Fresh install
- Tap on default browser banner at top of ntp
- Kill the app, launch second time
- Verify default browse callout was not presented

2. Callout test
- Fresh install
- Kill the app, launch second time
- Verify that callout is showing, tap on 'Open settings'
- Kill the app, wait 5+minutes(dev channel)
- Open app again
- Verify default browse callout was not presented, banner on ntp should be gone too

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
