### PR TITLE
Ref #2934: Fix reset vpn button.

### DIFF
--- a/Client/Frontend/BraveVPN/BraveVPNSettingsViewController.swift
+++ b/Client/Frontend/BraveVPN/BraveVPNSettingsViewController.swift
@@ -128,7 +128,7 @@ class BraveVPNSettingsViewController: TableViewController {
                                cellClass: ButtonCell.self),
                            Row(text: Strings.VPN.settingsResetConfiguration,
                                selection: { [unowned self] in
-                                self.selectServerTapped()
+                                self.resetConfigurationTapped()
                                },
                                cellClass: ButtonCell.self, uuid: resetCellId)],
                     uuid: serverSectionId)


### PR DESCRIPTION
It pointed to 'change vpn server' by accident.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #2934 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
