### PR TITLE
Fix #3365: Modernize NTP campaign invalidation logic.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		0A1E84452190A57F0042F782 /* SyncPairWordsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E843B2190A57F0042F782 /* SyncPairWordsViewController.swift */; };
 		0A1E84462190A57F0042F782 /* SyncAddDeviceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E843C2190A57F0042F782 /* SyncAddDeviceViewController.swift */; };
 		0A27ABA123D1B9C400194921 /* BrandedImageCalloutState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A27ABA023D1B9C400194921 /* BrandedImageCalloutState.swift */; };
+		0A2BFB3425F2754600719AA9 /* NTPDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2BFB3325F2754600719AA9 /* NTPDownloaderTests.swift */; };
 		0A2FF33F24A4B75100F88F43 /* vpncheckmark.json in Resources */ = {isa = PBXBuildFile; fileRef = 0A2FF33E24A4B75000F88F43 /* vpncheckmark.json */; };
 		0A39FE902486604D00290ABC /* GRDSubscriberCredential.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A39FE832486604100290ABC /* GRDSubscriberCredential.h */; };
 		0A39FE912486604D00290ABC /* GRDGatewayAPIResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A39FE842486604200290ABC /* GRDGatewayAPIResponse.h */; };
@@ -1382,6 +1383,7 @@
 		0A24F846233EB5B5004D2F3A /* Dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Dev.xcconfig; sourceTree = "<group>"; };
 		0A24F847233EB5B5004D2F3A /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		0A27ABA023D1B9C400194921 /* BrandedImageCalloutState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandedImageCalloutState.swift; sourceTree = "<group>"; };
+		0A2BFB3325F2754600719AA9 /* NTPDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPDownloaderTests.swift; sourceTree = "<group>"; };
 		0A2D5DF623571F02001ED889 /* ko-KR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ko-KR"; path = "ko-KR.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0A2FF33E24A4B75000F88F43 /* vpncheckmark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = vpncheckmark.json; sourceTree = "<group>"; };
 		0A38EA7F216532DB00142710 /* CRUDProtocolsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRUDProtocolsTests.swift; sourceTree = "<group>"; };
@@ -5244,6 +5246,7 @@
 				0A42F3BC25B5CFAE00BD370B /* DefaultBrowserIntroTests.swift */,
 				F9488F12258D6B9800A72C84 /* WKWebViewExtensionsTest.swift */,
 				F95ED17D25A95426001A432D /* UserScriptManagerTest.swift */,
+				0A2BFB3325F2754600719AA9 /* NTPDownloaderTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -7244,6 +7247,7 @@
 				D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */,
 				F939FBFE22A596B900D9CD3F /* U2FTests.swift in Sources */,
 				0A4BEFD6221E13830005551A /* ContentBlockerTests.swift in Sources */,
+				0A2BFB3425F2754600719AA9 /* NTPDownloaderTests.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
 				E696FE511C47F86E00EC007C /* AuthenticatorTests.swift in Sources */,
 				275965E224EEC4EA0051A827 /* FeedFillStrategyTests.swift in Sources */,

--- a/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
+++ b/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
@@ -275,7 +275,7 @@ class NTPDownloader {
             }
             
             let metadata = try Data(contentsOf: metadataFileURL)
-            if self.isCampaignEnded(data: metadata) {
+            if NTPDownloader.isCampaignEnded(data: metadata) {
                 try self.removeCampaign(type: type)
                 return nil
             }
@@ -392,7 +392,7 @@ class NTPDownloader {
                 return completion(nil, nil, .metadataError("Invalid \(type.resourceName) for NTP Download"))
             }
             
-            if self.isCampaignEnded(data: data) {
+            if NTPDownloader.isCampaignEnded(data: data) {
                 return completion(nil, nil, .campaignEnded)
             }
             
@@ -582,8 +582,14 @@ class NTPDownloader {
         return saveLocation.appendingPathComponent(type.resourceName)
     }
     
-    private func isCampaignEnded(data: Data) -> Bool {
-        return data.count <= 5 || String(data: data, encoding: .utf8) == "{\n}\n"
+    static func isCampaignEnded(data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+              let wallpapers = json["wallpapers"] as? [[String: Any]],
+              wallpapers.count > 0 else {
+            return true
+        }
+        
+        return false
     }
     
     private struct CacheResponse {

--- a/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
+++ b/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
@@ -275,7 +275,7 @@ class NTPDownloader {
             }
             
             let metadata = try Data(contentsOf: metadataFileURL)
-            if NTPDownloader.isCampaignEnded(data: metadata) {
+            if Self.isCampaignEnded(data: metadata) {
                 try self.removeCampaign(type: type)
                 return nil
             }
@@ -392,7 +392,7 @@ class NTPDownloader {
                 return completion(nil, nil, .metadataError("Invalid \(type.resourceName) for NTP Download"))
             }
             
-            if NTPDownloader.isCampaignEnded(data: data) {
+            if Self.isCampaignEnded(data: data) {
                 return completion(nil, nil, .campaignEnded)
             }
             

--- a/ClientTests/NTPDownloaderTests.swift
+++ b/ClientTests/NTPDownloaderTests.swift
@@ -1,0 +1,95 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import Client
+
+class NTPDownloaderTests: XCTestCase {
+
+    func testIsCampaignEnded() throws {
+        XCTAssert(NTPDownloader.isCampaignEnded(data: emptyJson.asData))
+        XCTAssert(NTPDownloader.isCampaignEnded(data: schemaKeyJson.asData))
+        XCTAssert(NTPDownloader.isCampaignEnded(data: noWallpapersJson.asData))
+        
+        XCTAssertFalse(NTPDownloader.isCampaignEnded(data: validJson.asData))
+    }
+
+    // MARK: - Json input
+    
+    private let emptyJson =
+        """
+        {
+        }
+        """
+    
+    // Regression test:
+    // Adding schemakey to empty json caused regression on campaign invalidation logic.
+    private let schemaKeyJson =
+        """
+        {
+            "schemaVersion": 1
+        }
+        """
+    
+    private let noWallpapersJson =
+        """
+        {
+            "schemaVersion": 1,
+            "logo": {
+                "imageUrl": "logo.png",
+                "alt": "Visit Brave.com",
+                "companyName": "Brave",
+                "destinationUrl": "https://brave.com"
+            },
+            "wallpapers": []
+        }
+        """
+    
+    // Taken from an old campaign, brand replaced with Brave.
+    private let validJson =
+        """
+        {
+            "schemaVersion": 1,
+            "logo": {
+                "imageUrl": "logo.png",
+                "alt": "Visit Brave.com",
+                "companyName": "Brave",
+                "destinationUrl": "https://brave.com"
+            },
+            "wallpapers": [
+                {
+                    "imageUrl": "background-1.jpg",
+                    "focalPoint": {
+                        "x": 1187,
+                        "y": 720
+                    },
+                    "creativeInstanceId": "749f67dd-f755-48b2-8699-6d214051de20"
+                },
+                {
+                    "imageUrl": "background-2.jpg",
+                    "focalPoint": {
+                        "x": 1436,
+                        "y": 720
+                    },
+                    "creativeInstanceId": "266b1ade-51fb-4311-9468-b0406faa0288"
+                },
+                {
+                    "imageUrl": "background-3.jpg",
+                    "focalPoint": {
+                        "x": 905,
+                        "y": 720
+                    },
+                    "creativeInstanceId": "07edaf61-0f9c-47a9-8c0b-26284f92596b"
+                }
+            ]
+        }
+        """
+}
+
+private extension String {
+    var asData: Data {
+        Data(self.utf8)
+    }
+}


### PR DESCRIPTION
Now we set the campaign as invalid if there is no wallpapers present
in the JSON we get from the server.

Previously we simply checked for an empty json or if the file was
smaller than 5 bytes.
This has caused regression when `schemaVersion` started to be added
to that JSON.

Current implementation should closer match what desktop does.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3365 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Make a sanity check on production, verify that NTP SI are showing up on prod build

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
