### PR TITLE
Fix #3416, ref #3377: Attempt pre1.12 migration before Database init.

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -70,6 +70,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         
         // Must happen before passcode check, otherwise may unnecessarily reset keychain
         Migration.moveDatabaseToApplicationDirectory()
+        // We have to wait until pre1.12 migration is done until we proceed with database
+        // initialization. This is because Database container may change. See bugs #3416, #3377.
+        DataController.shared.initialize()
         
         // Passcode checking, must happen on immediate launch
         if !DataController.shared.storeExists() {

--- a/ClientTests/FingerprintingProtectionTests.swift
+++ b/ClientTests/FingerprintingProtectionTests.swift
@@ -13,6 +13,7 @@ class FingerprintProtectionTest: XCTestCase {
     
     override func setUp() {
         DataController.shared = DataController()
+        DataController.shared.initialize()
     }
     
     func testFingerprintProtection() {

--- a/ClientTests/SafeBrowsingTests.swift
+++ b/ClientTests/SafeBrowsingTests.swift
@@ -16,6 +16,7 @@ class SafeBrowsingTests: XCTestCase {
         
         Preferences.Shields.blockPhishingAndMalware.reset()
         DataController.shared = DataController()
+        DataController.shared.initialize()
     }
 
     override func tearDown() {

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -505,6 +505,7 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
         DataController.shared = InMemoryDataController()
+        DataController.shared.initialize()
         
         delegate.expect([willAdd, didAdd])
         let tab = manager.addTab(isPrivate: false)
@@ -521,6 +522,7 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
         DataController.shared = InMemoryDataController()
+        DataController.shared.initialize()
         
         delegate.expect([willAdd, didAdd])
         manager.addTab(isPrivate: true)
@@ -535,6 +537,7 @@ class TabManagerTests: XCTestCase {
         let delegate = MockTabManagerDelegate()
         manager.addDelegate(delegate)
         DataController.shared = InMemoryDataController()
+        DataController.shared.initialize()
         
         delegate.expect([willAdd, didAdd, willAdd, didAdd])
         manager.addTab(isPrivate: true)

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -46,7 +46,8 @@ public class DataController {
         return queue
     }()
     
-    init() {
+    /// IMPORTANT: This must be called after pre 1.12 migration logic has been called.
+    public func initialize() {
         configureContainer(container, store: storeURL)
         createOldDocumentStoreIfNeeded()
     }

--- a/DataTests/CoreDataTestCase.swift
+++ b/DataTests/CoreDataTestCase.swift
@@ -16,6 +16,7 @@ class CoreDataTestCase: XCTestCase {
                                                object: nil)
         
         DataController.shared = InMemoryDataController()
+        DataController.shared.initialize()
     }
     
     override func tearDown() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3416, references #3377 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
