### PR TITLE
Fix:3415: Selecting a custom search engine as default removes it from custom search engine list

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -71,7 +71,7 @@ class SearchSettingsTableViewController: UITableViewController {
     }
     
     private var customSearchEngines: [OpenSearchEngine] {
-        searchEngines.quickSearchEngines.filter { $0.isCustomEngine }
+        searchEngines.orderedEngines.filter { $0.isCustomEngine }
     }
     
     // MARK: Lifecycle
@@ -279,8 +279,7 @@ class SearchSettingsTableViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            let index = indexPath.row
-            let engine = customSearchEngines[index]
+            guard let engine = customSearchEngines[safe: indexPath.row] else { return }
             
             do {
                 try searchEngines.deleteCustomEngine(engine)
@@ -289,6 +288,15 @@ class SearchSettingsTableViewController: UITableViewController {
                 log.error("Search Engine Error while deleting")
             }
         }
+    }
+    
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        if let engine = customSearchEngines[safe: indexPath.row],
+           engine == searchEngines.defaultEngine(forType: .standard) {
+            return false
+        }
+        
+        return true
     }
 }
 


### PR DESCRIPTION
Adding back the custom search engine to the list if it is selected as default and disabling deletion for that row

## Summary of Changes

This pull request fixes #3415

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Add GH as a custom search engine
- Set GH as default SE and see it is not removed from the list
- Try to delete the engine while set as default and see option is not enable


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
