### PR TITLE
Fix:3420: Animation Problems while Adding Custom Search Engine

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -167,6 +167,7 @@ extension BrowserViewController {
             
             do {
                 try self.profile.searchEngines.addSearchEngine(engine)
+                self.view.endEditing(true)
                 
                 let toast = SimpleToast()
                 toast.showAlertWithText(Strings.CustomSearchEngine.thirdPartySearchEngineAddedToastTitle, bottomContainer: self.webViewContainer)

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
@@ -25,16 +25,19 @@ class OpenSearchEngineButton: Button {
             switch action {
             case .disabled:
                 isLoading = false
+                setImage(#imageLiteral(resourceName: "AddSearch").template, for: .normal)
                 appearanceTintColor = UIColor.Photon.grey50
                 appearanceTextColor = UIColor.Photon.grey50
                 isUserInteractionEnabled = false
             case .enabled:
                 isLoading = false
+                setImage(#imageLiteral(resourceName: "AddSearch").template, for: .normal)
                 appearanceTintColor = BraveUX.braveOrange
                 appearanceTextColor = BraveUX.braveOrange
                 isUserInteractionEnabled = true
             case .loading:
                 isLoading = true
+                setImage(nil, for: .normal)
             }
         }
     }


### PR DESCRIPTION
Adding fixes for loading button and visibility of the toast

## Summary of Changes

This pull request fixes #3420

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Add GH as a custom search engine
- See loading animation is happening the magnifying button hidden
- Keyboard is dismissed when engine is added sucessfully

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
