### PR TITLE
Fix3412: Shields educational message shown when shields not visible

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -67,7 +67,8 @@ extension BrowserViewController {
     private func presentEducationalProductNotifications() {
         guard let selectedTab = tabManager.selectedTab,
               !benchmarkNotificationPresented,
-              !topToolbar.inOverlayMode else {
+              !topToolbar.inOverlayMode,
+              selectedTab.webView?.scrollView.isDragging == false else {
             return
         }
         

--- a/Client/Frontend/Shields/ShareTrackersController.swift
+++ b/Client/Frontend/Shields/ShareTrackersController.swift
@@ -51,7 +51,7 @@ enum TrackingType: Equatable {
 
 // MARK: - ShareTrackersController
 
-class ShareTrackersController: UIViewController, Themeable {
+class ShareTrackersController: UIViewController, Themeable, PopoverContentComponent {
     
     // MARK: Action
     
@@ -301,10 +301,4 @@ private class ShareTrackersView: UIView, Themeable {
         subtitleLabel.appearanceTextColor = .white
         actionButton.appearanceTextColor = .white
     }
-}
-
-// MARK: - PopoverContentComponent
-
-extension ShareTrackersController: PopoverContentComponent {
-    var isPanToDismissEnabled: Bool { return false }
 }


### PR DESCRIPTION
Adding Scrolling guard to pop-over presentation and re-enabling the gestures.

We decided to take different approach here we add a new condition to webview-scrollview to check If user is dragging and disable showing pop-overs If user started dragging.

This will help us to prevent having issue like seeing pop-over when toolbar(shields) are hidden and other issues that can cause dead-lock also help user not to get irritated while they are scrolling in the page for some information.

With the help of this we can also enable gestures again on our pop-overs.

## Summary of Changes

This pull request fixes #3412

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Scroll down Brave today
- Open an article and before the page loads scroll so shields and bottom toolbar is hidden, educational tooltip will not show  even when shields is not visible

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
