### PR TITLE
Fix #3424: Add popover details for Brave Today card long press on iOS 12

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -542,13 +542,20 @@ class NewTabPageViewController: UIViewController, Themeable {
                 )
                 alert.present(on: self)
             }
-        case .itemAction(.longPressed(let context), _):
+        case .itemAction(.longPressed(let longPressInfo), let context):
             let alertController = UIAlertController(
-                title: context.title,
-                message: context.message,
+                title: longPressInfo.title,
+                message: longPressInfo.message,
                 preferredStyle: .actionSheet
             )
-            for action in context.actions {
+            if let cell = collectionView.cellForItem(at: context.indexPath)?.subviews.first?.subviews.first {
+                alertController.popoverPresentationController?.sourceView = cell
+                alertController.popoverPresentationController?.sourceRect = cell.bounds
+            } else {
+                alertController.popoverPresentationController?.sourceView = view
+                alertController.popoverPresentationController?.sourceRect = view.bounds
+            }
+            for action in longPressInfo.actions {
                 alertController.addAction(action)
             }
             present(alertController, animated: true)


### PR DESCRIPTION
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3424 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
