### PR TITLE
No Bug: Fix potential crash around unpadding private CDN images for BT

### DIFF
--- a/BraveShared/Private CDN/PrivateCDN.swift
+++ b/BraveShared/Private CDN/PrivateCDN.swift
@@ -29,8 +29,8 @@ public class PrivateCDN {
         let length = data.withUnsafeBytes {
             return UInt32(bigEndian: $0.load(as: UInt32.self)).hostEndian
         }
-        guard data.count > length else {
-            // Payload shorter than expected length
+        guard data.count >= length + 4, length != 0 else {
+            // Payload shorter than expected length, incorrect or malformed
             return nil
         }
         return length

--- a/BraveSharedTests/PrivateCDNTests.swift
+++ b/BraveSharedTests/PrivateCDNTests.swift
@@ -25,6 +25,29 @@ class PrivateCDNTests: BraveSharedTests {
         XCTAssertNil(PrivateCDN.unpadded(data: data))
     }
     
+    func testZeroLength() throws {
+        let length = UInt32(0)
+        let raw = "ABCDEFG"
+        let lengthData = withUnsafePointer(to: length) {
+            Data(bytes: $0, count: 4)
+        }
+        let rawData = try XCTUnwrap(raw.data(using: .ascii))
+        let data = lengthData + rawData
+        XCTAssertNil(PrivateCDN.unpadded(data: data))
+    }
+    
+    func testNoPadding() throws {
+        let raw = "ABCDEFG"
+        let rawData = try XCTUnwrap(raw.data(using: .ascii))
+        let length = UInt32(rawData.count).bigEndian
+        let lengthData = withUnsafePointer(to: length) {
+            Data(bytes: $0, count: 4)
+        }
+        let data = lengthData + rawData
+        let unpadded = try XCTUnwrap(PrivateCDN.unpadded(data: data))
+        XCTAssertEqual(rawData, unpadded)
+    }
+    
     func testValidData() throws {
         let raw = "ABCDEFG"
         let rawData = try XCTUnwrap(raw.data(using: .ascii))


### PR DESCRIPTION
## Summary of Changes

Basing this around some crash reports in Xcode:

```
0   libswiftFoundation.dylib      	0x000000019e68ca8c Data._Representation.subscript.getter + 984 (Data.swift:1801)
1   libswiftFoundation.dylib      	0x000000019e68f924 Data.subdata(in:) + 124 (Data.swift:2598)
2   libswiftFoundation.dylib      	0x000000019e68f924 Data.subdata(in:) + 124 (Data.swift:2598)
3   BraveShared                   	0x00000001011626d0 static PrivateCDN.unpadded(data:) + 44 (PrivateCDN.swift:55)
```

So adding some hardening code around the subscripting

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

There is no way to reproduce this unless you happened to find a corrupted/malformed Private CDN image in Brave Today previously.

- Verify images appear on Brave Today

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
