### PR TITLE
Fix#3413: Adding GH as Search Engine doesn't show favicon

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -135,13 +135,27 @@ extension BrowserViewController {
            let iconURL = URL(string: faviconURLString) {
             
             // Try to fetch Engine Icon using cache manager
-            WebImageCacheManager.shared.load(from: iconURL, completion: { [weak self] (image, _, _, _, _) in
-                // In case fetch fails use default icon and do not block addition of this engine
-                if let favIcon = image {
-                    searchEngineIcon = favIcon
+            WebImageCacheManager.shared.load(from: iconURL, completion: { [weak self] (image, _, error, _, _) in
+                if error != nil {
+                    URLSession.shared.dataTask(with: iconURL, completionHandler: { [weak self] data, response, error in
+                        guard let data = data else { return }
+                        
+                        if let downloadedImage = UIImage(data: data) {
+                            searchEngineIcon = downloadedImage
+                            WebImageCacheManager.shared.cacheImage(image: downloadedImage, data: data, url: iconURL)
+                        }
+                        
+                        self?.createSearchEngine(url, reference: reference, icon: searchEngineIcon)
+                    }).resume()
+                } else {
+                    // In case fetch fails use default icon and do not block addition of this engine
+                    if let favIcon = image {
+                        searchEngineIcon = favIcon
+                    }
+                    
+                    self?.createSearchEngine(url, reference: reference, icon: searchEngineIcon)
                 }
-                
-                self?.createSearchEngine(url, reference: reference, icon: searchEngineIcon)
+                 
             })
         } else {
             createSearchEngine(url, reference: reference, icon: searchEngineIcon)

--- a/Client/Frontend/Browser/ImageCache/WebImageCache.swift
+++ b/Client/Frontend/Browser/ImageCache/WebImageCache.swift
@@ -65,6 +65,11 @@ final class WebImageCache: ImageCacheProtocol {
         return imageOperation
     }
     
+    func cacheImage(image: UIImage, data: Data, url: URL) {
+        let key = self.webImageManager.cacheKey(for: url)
+        webImageManager.imageCache.store(image, imageData: data, forKey: key, cacheType: .all)
+    }
+    
     func isCached(_ url: URL) -> Bool {
         return webImageManager.cacheKey(for: url) != nil
     }


### PR DESCRIPTION
Adding Data task for image downloads fail because of SDWebImage handling .ico format

WebImageCacheManager having some problems with some image formats and throwing "Downloaded image decode failed" error.
When we are adding custom Search Engine we added data task in order to fetch image data manually and cache it after in case WebImageManager will have problem while fetching the image.

## Summary of Changes

This pull request fixes #3413

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit https://github.com
- Click on Search bar
- Add GH as a search engine
- Open settings -> Search - Github is listed as a custom search engine and it will have a favIcon

## Screenshots:

![Simulator Screen Shot - iPhone 12 - 2021-03-17 at 17 00](https://user-images.githubusercontent.com/6643505/111538111-a9b90b80-8742-11eb-974e-8ab83e0c0385.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
