### PR TITLE
Added toggle for last visited bookmarks folder.

### DIFF
--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -52,6 +52,8 @@ extension Preferences {
         static let alwaysRequestDesktopSite = Option<Bool>(key: "general.always-request-desktop-site", default: UIDevice.isIpad)
         /// Controls whether or not media auto-plays
         static let mediaAutoPlays = Option<Bool>(key: "general.media-auto-plays", default: false)
+        /// Controls whether or not to show the last visited bookmarks folder
+        static let showLastVisitedBookmarksFolder = Option<Bool>(key: "general.bookmarks-show-last-visited-bookmarks-folder", default: true)
         
         /// Whether or not to show the clipboard bar when the user has a URL in their pasteboard on launch
         ///

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -85,7 +85,9 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         setUpToolbar()
         updateEditBookmarksButtonStatus()
         
-        self.showLastVisitedFolder()
+        if Preferences.General.showLastVisitedBookmarksFolder.value {
+            self.showLastVisitedFolder()
+        }
     }
     
     private func updateEditBookmarksButtonStatus() {

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -238,7 +238,10 @@ class SettingsViewController: TableViewController {
                         self.navigationController?.pushViewController(SyncWelcomeViewController(), animated: true)
                     }
                     }, image: #imageLiteral(resourceName: "settings-sync").template, accessory: .disclosureIndicator,
-                       cellClass: MultilineValue1Cell.self)
+                       cellClass: MultilineValue1Cell.self),
+                Row(text: Strings.bookmarksLastVisitedFolderTitle, image: #imageLiteral(resourceName: "menu_folder_open").template, accessory: .switchToggle(value: Preferences.General.showLastVisitedBookmarksFolder.value, { newValue in
+                    Preferences.General.showLastVisitedBookmarksFolder.value = newValue
+                }), cellClass: MultilineValue1Cell.self)
             ]
         )
         

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -239,9 +239,7 @@ class SettingsViewController: TableViewController {
                     }
                     }, image: #imageLiteral(resourceName: "settings-sync").template, accessory: .disclosureIndicator,
                        cellClass: MultilineValue1Cell.self),
-                Row(text: Strings.bookmarksLastVisitedFolderTitle, image: #imageLiteral(resourceName: "menu_folder_open").template, accessory: .switchToggle(value: Preferences.General.showLastVisitedBookmarksFolder.value, { newValue in
-                    Preferences.General.showLastVisitedBookmarksFolder.value = newValue
-                }), cellClass: MultilineValue1Cell.self)
+                .boolRow(title: Strings.bookmarksLastVisitedFolderTitle, option: Preferences.General.showLastVisitedBookmarksFolder, image: #imageLiteral(resourceName: "menu_folder_open").template)
             ]
         )
         

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -28,6 +28,8 @@ extension Strings {
     public static let settingsSearchEditButton = NSLocalizedString("SettingsSearchEditButton", bundle: Bundle.shared, value: "Edit", comment: "Button displayed at the top of the search settings.")
     public static let useTouchID = NSLocalizedString("UseTouchID", bundle: Bundle.shared, value: "Use Touch ID", comment: "List section title for when to use Touch ID")
     public static let useFaceID = NSLocalizedString("UseFaceID", bundle: Bundle.shared, value: "Use Face ID", comment: "List section title for when to use Face ID")
+    
+    public static let bookmarksLastVisitedFolderTitle = NSLocalizedString("BookmarksLastVisitedFolderTitle", bundle: Bundle.shared, value: "Show Last Visited Bookmarks", comment: "General settings bookmarks last visited folder toggle title")
 }
 
 // Logins Helper.

--- a/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
+++ b/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
@@ -109,7 +109,8 @@ class Bookmarkv2: WebsitePresentable {
     // If no folder was visited, returns the mobile bookmarks folder
     // If the root folder was visited, returns nil
     public static func lastVisitedFolder() -> Bookmarkv2? {
-        guard let nodeId = Preferences.Chromium.lastBookmarksFolderNodeId.value else {
+        guard Preferences.General.showLastVisitedBookmarksFolder.value,
+              let nodeId = Preferences.Chromium.lastBookmarksFolderNodeId.value else {
             // Default folder is the mobile node..
             if let mobileNode = bookmarksAPI.mobileNode {
                 return Bookmarkv2(mobileNode)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Added a toggle to enable/disable showing the last visited bookmarks folder.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3371

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Verify option controls the behaviour of whether or not when opening the Bookmarks screen shows the last visited folder immediately 

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
