### PR TITLE
Fix#3436: Add Search Engine missing on toolbar for iPad

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 		2C49854E206173C800893DAE /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		2F098F8B255F2D730084FB37 /* BrowserViewController+ReaderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
+		2F198EE82603FDD900945AB3 /* AddSearchEngineActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F198EE72603FDD900945AB3 /* AddSearchEngineActivity.swift */; };
 		2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */; };
 		2F44FB2D1A9D5D8500FD20CC /* FiraSans-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B7421A793CF20022C5E0 /* FiraSans-BoldItalic.ttf */; };
 		2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */; };
@@ -1913,6 +1914,7 @@
 		2C49854D206173C800893DAE /* photon-colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "photon-colors.swift"; sourceTree = "<group>"; };
 		2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+ReaderMode.swift"; sourceTree = "<group>"; };
 		2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
+		2F198EE72603FDD900945AB3 /* AddSearchEngineActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSearchEngineActivity.swift; sourceTree = "<group>"; };
 		2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHashExtensions.swift; sourceTree = "<group>"; };
 		2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
 		2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableSectionHeaderFooterView.swift; sourceTree = "<group>"; };
@@ -4888,6 +4890,7 @@
 				D3972BF21C22412B00035B87 /* TitleActivityItemProvider.swift */,
 				2703BE8A24F4508E00CBE6CD /* CreatePDFActivity.swift */,
 				2760056525D1FFF500D47A75 /* AddFeedToBraveTodayActivity.swift */,
+				2F198EE72603FDD900945AB3 /* AddSearchEngineActivity.swift */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -7134,7 +7137,6 @@
 				A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */,
 				4422D4EB21BFFB7600BF1855 /* filename.cc in Sources */,
 				2726636924944BFA0056CFE1 /* BraveTodayOptInView.swift in Sources */,
-				2FE5B4542582BEF500BFDDB8 /* ShareTrayView.swift in Sources */,
 				2755EABD255323C60033C43F /* PublisherInfoExtensions.swift in Sources */,
 				2746D28324A4FB7400E38852 /* RewardsInternalsSharable.swift in Sources */,
 				44331DDA22552313007E3E93 /* LocationContainerView.swift in Sources */,
@@ -7236,6 +7238,7 @@
 				27B68E9425C8911D002D0826 /* BraveTodayAddSourceViewController.swift in Sources */,
 				D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */,
 				4422D54621BFFB7E00BF1855 /* rune.cc in Sources */,
+				2F198EE82603FDD900945AB3 /* AddSearchEngineActivity.swift in Sources */,
 				EB11A1052044A90E0018F749 /* TrackingProtectionPageStats.swift in Sources */,
 				0A93F1802264C2D200A3571B /* FolderDetailsView.swift in Sources */,
 				0A0A07CE247518B100591DFB /* BraveVPNContactFormViewController.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1895,16 +1895,13 @@ class BrowserViewController: UIViewController {
             }
         }
         
-        if let webView = tabManager.selectedTab?.webView {
-            let sadsad = evaluateWebsiteSupportOpenSearchEngine(webView)
-            print("Sdasda \(sadsad)")
-            if sadsad {
-                let addSearchEngineActivity = AddSearchEngineActivity() { [weak self] in
-                    self?.addCustomSearchEngineForFocusedElement()
-                }
-                
-                activities.append(addSearchEngineActivity)
+        if let webView = tabManager.selectedTab?.webView,
+           evaluateWebsiteSupportOpenSearchEngine(webView) {
+            let addSearchEngineActivity = AddSearchEngineActivity() { [weak self] in
+                self?.addCustomSearchEngineForFocusedElement()
             }
+                
+            activities.append(addSearchEngineActivity)
         }
 
         let controller = helper.createActivityViewController(items: activities) { [weak self] completed, _, documentUrl  in

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1895,6 +1895,18 @@ class BrowserViewController: UIViewController {
             }
         }
         
+        if let webView = tabManager.selectedTab?.webView {
+            let sadsad = evaluateWebsiteSupportOpenSearchEngine(webView)
+            print("Sdasda \(sadsad)")
+            if sadsad {
+                let addSearchEngineActivity = AddSearchEngineActivity() { [weak self] in
+                    self?.addCustomSearchEngineForFocusedElement()
+                }
+                
+                activities.append(addSearchEngineActivity)
+            }
+        }
+
         let controller = helper.createActivityViewController(items: activities) { [weak self] completed, _, documentUrl  in
             guard let self = self else { return }
             

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -75,26 +75,32 @@ extension BrowserViewController {
             return
         }
         
-        let argumentNextItem: [Any] = ["_n", "extI", "tem"]
-        let argumentView: [Any] = ["v", "ie", "w"]
-        
-        let valueKeyNextItem = argumentNextItem.compactMap { $0 as? String }.joined()
-        let valueKeyView = argumentView.compactMap { $0 as? String }.joined()
+        if UIDevice.isIpad {
+            webContentView.inputAssistantItem.trailingBarButtonGroups +=
+                [UIBarButtonItemGroup(barButtonItems: [UIBarButtonItem(customView: customSearchEngineButton)], representativeItem: nil)]
 
-        guard let input = webContentView.perform(#selector(getter: UIResponder.inputAccessoryView)),
-              let inputView = input.takeUnretainedValue() as? UIInputView,
-              let nextButton = inputView.value(forKey: valueKeyNextItem) as? UIBarButtonItem,
-              let nextButtonView = nextButton.value(forKey: valueKeyView) as? UIView else {
-            return
-        }
-        
-        inputView.addSubview(customSearchEngineButton)
-        
-        customSearchEngineButton.snp.remakeConstraints { make in
-            make.leading.equalTo(nextButtonView.snp.trailing).offset(20)
-            make.width.equalTo(inputView.snp.height)
-            make.top.equalTo(nextButtonView.snp.top)
-            make.height.equalTo(inputView.snp.height)
+        } else {
+            let argumentNextItem: [Any] = ["_n", "extI", "tem"]
+            let argumentView: [Any] = ["v", "ie", "w"]
+            
+            let valueKeyNextItem = argumentNextItem.compactMap { $0 as? String }.joined()
+            let valueKeyView = argumentView.compactMap { $0 as? String }.joined()
+
+            guard let input = webContentView.perform(#selector(getter: UIResponder.inputAccessoryView)),
+                  let inputView = input.takeUnretainedValue() as? UIInputView,
+                  let nextButton = inputView.value(forKey: valueKeyNextItem) as? UIBarButtonItem,
+                  let nextButtonView = nextButton.value(forKey: valueKeyView) as? UIView else {
+                return
+            }
+            
+            inputView.addSubview(customSearchEngineButton)
+            
+            customSearchEngineButton.snp.remakeConstraints { make in
+                make.leading.equalTo(nextButtonView.snp.trailing).offset(20)
+                make.width.equalTo(inputView.snp.height)
+                make.top.equalTo(nextButtonView.snp.top)
+                make.height.equalTo(inputView.snp.height)
+            }
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -29,17 +29,23 @@ extension BrowserViewController {
     
     /// Adding Toolbar button over the keyboard for adding Open Search Engine
     /// - Parameter webView: webview triggered open seach engine
-    func evaluateWebsiteSupportOpenSearchEngine(_ webView: WKWebView) {
+    @discardableResult
+    func evaluateWebsiteSupportOpenSearchEngine(_ webView: WKWebView) -> Bool {
         if let tab = tabManager[webView],
            let openSearchMetaData = tab.pageMetadata?.search,
            let url = webView.url,
            url.isSecureWebPage() {
-            updateAddOpenSearchEngine(
+            return updateAddOpenSearchEngine(
                 webView, referenceObject: OpenSearchReference(reference: openSearchMetaData.href, title: openSearchMetaData.title))
         }
+        
+        return false
     }
     
-    private func updateAddOpenSearchEngine(_ webView: WKWebView, referenceObject: OpenSearchReference) {
+    @discardableResult
+    private func updateAddOpenSearchEngine(_ webView: WKWebView, referenceObject: OpenSearchReference) -> Bool {
+        var supportsAutoAdd = true
+            
         // Add Reference Object as Open Search Engine
         openSearchEngine = referenceObject
         
@@ -57,8 +63,10 @@ extension BrowserViewController {
 
         if searchEngineExists {
             self.customSearchEngineButton.action = .disabled
+            supportsAutoAdd = false
         } else {
             self.customSearchEngineButton.action = .enabled
+            supportsAutoAdd = true
         }
         
         /*
@@ -72,7 +80,7 @@ extension BrowserViewController {
              In some cases the URL bar can trigger the keyboard notification. In that case the webview isnt the first responder
              and a search button should not be added.
              */
-            return
+            return supportsAutoAdd
         }
         
         if UIDevice.isIpad {
@@ -90,7 +98,7 @@ extension BrowserViewController {
                   let inputView = input.takeUnretainedValue() as? UIInputView,
                   let nextButton = inputView.value(forKey: valueKeyNextItem) as? UIBarButtonItem,
                   let nextButtonView = nextButton.value(forKey: valueKeyView) as? UIView else {
-                return
+                return supportsAutoAdd
             }
             
             inputView.addSubview(customSearchEngineButton)
@@ -102,6 +110,8 @@ extension BrowserViewController {
                 make.height.equalTo(inputView.snp.height)
             }
         }
+        
+        return supportsAutoAdd
     }
 
     @objc func addCustomSearchEngineForFocusedElement() {

--- a/Client/Frontend/Share/AddSearchEngineActivity.swift
+++ b/Client/Frontend/Share/AddSearchEngineActivity.swift
@@ -1,0 +1,32 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+
+class AddSearchEngineActivity: UIActivity {
+    fileprivate let callback: () -> Void
+
+    init(callback: @escaping () -> Void) {
+        self.callback = callback
+    }
+
+    override var activityTitle: String? {
+        return Strings.CustomSearchEngine.customEngineNavigationTitle
+    }
+
+    override var activityImage: UIImage? {
+        return #imageLiteral(resourceName: "AddSearch").template
+    }
+
+    override func perform() {
+        callback()
+        activityDidFinish(true)
+    }
+
+    override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+        return true
+    }
+}


### PR DESCRIPTION
On iPad WKWebView -> webContentView doesnt respond UIResponder.inputAccessoryView so we had to take a total different approach.

Instead we add extra trailingBarButtonGroups(the add search engine button as bar buton) into webContentView.inputAssistantItem.

In addition to make it full fail proof, an Add Search Engine is added is added as an Activity.
              
## Summary of Changes

This pull request fixes #3436

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Install 1.24 on iPad Pro with iOS 12.4.1
- Visit Wikipedia or Github and click on search box
- Check the dd SE button on the toolbar

## Screenshots:

![11111](https://user-images.githubusercontent.com/6643505/111710179-887a1d00-881f-11eb-9830-ef83dcb6eed9.png)

![1111](https://user-images.githubusercontent.com/6643505/111710183-8b750d80-881f-11eb-8284-1bc36fcce74f.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
