### PR TITLE
Fix#3414: Add Search engine still shows up even if the site is manually added

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -45,14 +45,17 @@ extension BrowserViewController {
         
         // Open Search guidlines requires Title to be same as Short Name but it is not enforced,
         // thus in case of yahoo.com the title is 'Yahoo Search' and Shortname is 'Yahoo'
-        // Instead we are checking referenceURL match to determine searchEngine is added or not
+        // We are checking referenceURL match to determine searchEngine is added or not
+        //In addition we are also checking if there is another engine with same name
         
         let searchEngineExists = profile.searchEngines.orderedEngines.contains(where: {
+            let nameExists = $0.shortName.lowercased() == referenceObject.title?.lowercased() ?? ""
+            
             if let referenceURL =  $0.referenceURL {
-                return referenceObject.reference.contains(referenceURL)
+                return referenceObject.reference.contains(referenceURL) || nameExists
             }
             
-            return false
+            return nameExists
         })
 
         if searchEngineExists {

--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -334,7 +334,15 @@ extension SearchCustomEngineViewController {
             return
         }
         
-        let searchEngineExists = profile.searchEngines.orderedEngines.contains(where: {$0.referenceURL == openSearchEngine.reference})
+        let searchEngineExists = profile.searchEngines.orderedEngines.contains(where: {
+            let nameExists = $0.shortName.lowercased() == openSearchEngine.title?.lowercased() ?? ""
+            
+            if let referenceURL =  $0.referenceURL {
+                return openSearchEngine.reference.contains(referenceURL) || nameExists
+            }
+            
+            return nameExists
+        })
         
         if searchEngineExists {
             changeAddButton(for: .disabled)


### PR DESCRIPTION
The shortname is added as an extra criteria to determine if the search engine is added

## Summary of Changes

This pull request fixes #3414

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Add https://github.com/search?q=%s manually to search engine
- Ensure its listed under custom search engine list
- Visit https://github.com and tap on search box
- Add search engine using the Add search engine button
- Not Able to add duplicate entries for the same search engine

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
