### PR TITLE
Fix#3433: Search Engine Favicons doesn't Respect theme 

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -326,8 +326,15 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         for engine in quickSearchEngines {
             let engineButton = UIButton()
             engineButton.setImage(engine.image, for: [])
-            engineButton.imageView?.contentMode = .scaleAspectFit
+            
+            if engine.isCustomEngine, let hostURL = fetchEngineHost(from: engine.searchTemplate) {
+                engineButton.imageView?.loadFavicon(for: hostURL, fallbackMonogramCharacter: engine.displayName.first)
+            } else {
+                engineButton.imageView?.contentMode = .scaleAspectFit
+            }
+
             engineButton.layer.backgroundColor = SearchViewControllerUX.engineButtonBackgroundColor
+            
             engineButton.addTarget(self, action: #selector(didSelectEngine), for: .touchUpInside)
             engineButton.accessibilityLabel = String(format: Strings.searchEngineFormatText, engine.shortName)
 
@@ -349,6 +356,21 @@ class SearchViewController: SiteTableViewController, LoaderListener {
             }
             leftEdge = engineButton.snp.right
         }
+    }
+    
+    private func fetchEngineHost(from searchTemplate: String) -> URL? {
+        var engineHost: URL?
+        
+        guard let siteURL = searchTemplate.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed),
+              let url = URL(string: siteURL) else {
+            return nil
+        }
+        
+        if let scheme = url.scheme, let host = url.host {
+            engineHost = URL(string: "\(scheme)://\(host)")
+        }
+
+        return engineHost
     }
 
     private func querySuggestClient() {


### PR DESCRIPTION
For Custom Search engines loaded in SearchEngineScrollView on Keyboard. Load Favicon with monogram is used for taking care the icons. So theme changes will be sucessful.

A method is added in order to fetch the url for favicon fetching.

## Summary of Changes

This pull request fixes #3433

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
