### PR TITLE
Fix #3445: Add debug flags to disable onboarding UI in debug mode.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -95,7 +95,7 @@
 		0A66550A23E9D9750047EF2A /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550923E9D9750047EF2A /* UserAgent.swift */; };
 		0A66550C23E9E04F0047EF2A /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550B23E9E04F0047EF2A /* UserAgentTests.swift */; };
 		0A6BEF6624FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6BEF6524FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift */; };
-		0A6E20492608D7E200575798 /* LaunchArgs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6E20482608D7E200575798 /* LaunchArgs.swift */; };
+		0A6E20492608D7E200575798 /* DebugFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6E20482608D7E200575798 /* DebugFlag.swift */; };
 		0A6F957624044F070098217F /* NTPLearnMoreContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */; };
 		0A764F31230EE5CA003A1D9B /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A764F30230EE5CA003A1D9B /* OnboardingState.swift */; };
 		0A7B5D6722689C5D00AADF22 /* AddEditHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7B5D6622689C5D00AADF22 /* AddEditHeaderView.swift */; };
@@ -1476,7 +1476,7 @@
 		0A6AC4E824484FBC003D1ED7 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		0A6BEF6524FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabCenteredCollectionViewCell.swift; sourceTree = "<group>"; };
 		0A6E095E230E05BC00AB3F19 /* onboarding-shields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-shields.json"; sourceTree = "<group>"; };
-		0A6E20482608D7E200575798 /* LaunchArgs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgs.swift; sourceTree = "<group>"; };
+		0A6E20482608D7E200575798 /* DebugFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFlag.swift; sourceTree = "<group>"; };
 		0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPLearnMoreContentView.swift; sourceTree = "<group>"; };
 		0A75A3BD23571F2B00013540 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0A764F30230EE5CA003A1D9B /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
@@ -5346,7 +5346,7 @@
 				A13AC72420EC12360040D4BB /* Migration.swift */,
 				0A5E04F823FEADA800E5A3E9 /* LaunchScreen.storyboard */,
 				0A5E04FA23FEB53700E5A3E9 /* LaunchScreen.xcassets */,
-				0A6E20482608D7E200575798 /* LaunchArgs.swift */,
+				0A6E20482608D7E200575798 /* DebugFlag.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -6860,7 +6860,7 @@
 				4422D4E621BFFB7600BF1855 /* two_level_iterator.cc in Sources */,
 				27FCA8E72447BCFE00A8CA48 /* DuckDuckGoCalloutSectionProvider.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
-				0A6E20492608D7E200575798 /* LaunchArgs.swift in Sources */,
+				0A6E20492608D7E200575798 /* DebugFlag.swift in Sources */,
 				2F098F8B255F2D730084FB37 /* BrowserViewController+ReaderMode.swift in Sources */,
 				4422D57421BFFB7F00BF1855 /* prog.cc in Sources */,
 				4422D42F21BFCF8900BF1855 /* HttpsEverywhereObjC.mm in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		0A66550A23E9D9750047EF2A /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550923E9D9750047EF2A /* UserAgent.swift */; };
 		0A66550C23E9E04F0047EF2A /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66550B23E9E04F0047EF2A /* UserAgentTests.swift */; };
 		0A6BEF6624FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6BEF6524FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift */; };
+		0A6E20492608D7E200575798 /* LaunchArgs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6E20482608D7E200575798 /* LaunchArgs.swift */; };
 		0A6F957624044F070098217F /* NTPLearnMoreContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */; };
 		0A764F31230EE5CA003A1D9B /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A764F30230EE5CA003A1D9B /* OnboardingState.swift */; };
 		0A7B5D6722689C5D00AADF22 /* AddEditHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7B5D6622689C5D00AADF22 /* AddEditHeaderView.swift */; };
@@ -1475,6 +1476,7 @@
 		0A6AC4E824484FBC003D1ED7 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		0A6BEF6524FCF23C0057A166 /* NewTabCenteredCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabCenteredCollectionViewCell.swift; sourceTree = "<group>"; };
 		0A6E095E230E05BC00AB3F19 /* onboarding-shields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-shields.json"; sourceTree = "<group>"; };
+		0A6E20482608D7E200575798 /* LaunchArgs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgs.swift; sourceTree = "<group>"; };
 		0A6F957524044F070098217F /* NTPLearnMoreContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPLearnMoreContentView.swift; sourceTree = "<group>"; };
 		0A75A3BD23571F2B00013540 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Storage.strings"; sourceTree = "<group>"; };
 		0A764F30230EE5CA003A1D9B /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
@@ -5344,6 +5346,7 @@
 				A13AC72420EC12360040D4BB /* Migration.swift */,
 				0A5E04F823FEADA800E5A3E9 /* LaunchScreen.storyboard */,
 				0A5E04FA23FEB53700E5A3E9 /* LaunchScreen.xcassets */,
+				0A6E20482608D7E200575798 /* LaunchArgs.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -6857,6 +6860,7 @@
 				4422D4E621BFFB7600BF1855 /* two_level_iterator.cc in Sources */,
 				27FCA8E72447BCFE00A8CA48 /* DuckDuckGoCalloutSectionProvider.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
+				0A6E20492608D7E200575798 /* LaunchArgs.swift in Sources */,
 				2F098F8B255F2D730084FB37 /* BrowserViewController+ReaderMode.swift in Sources */,
 				4422D57421BFFB7F00BF1855 /* prog.cc in Sources */,
 				4422D42F21BFCF8900BF1855 /* HttpsEverywhereObjC.mm in Sources */,

--- a/Client.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -175,6 +175,18 @@
             argument = "-com.apple.CoreData.SQLDebug 1"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-BRSkipOnboarding YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-BRSkipEduPopups YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-BRSkipAppLaunchPopups YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/Client/Application/DebugFlag.swift
+++ b/Client/Application/DebugFlag.swift
@@ -8,8 +8,9 @@ import Shared
 import BraveShared
 
 extension Preferences {
-    /// Launch arguments can be set in scheme editor in XCode.
-    struct LaunchArgs {
+    /// Launch arguments can be set in scheme editor in Xcode.
+    /// Note: these flags may be used for values in Debug scheme only, otherwise it returns nill when trying to access any of them.
+    struct DebugFlag {
         private static let prefs = UserDefaults.standard
         
         static let skipOnboardingIntro = boolOrNil(for: "BRSkipOnboarding")
@@ -18,7 +19,7 @@ extension Preferences {
         static let skipNTPCallouts = boolOrNil(for: "BRSkipAppLaunchPopups")
         
         private static func boolOrNil(for key: String) -> Bool? {
-            if prefs.object(forKey: key) == nil {
+            if AppConstants.buildChannel != .debug || prefs.object(forKey: key) == nil {
                 return nil
             }
             

--- a/Client/Application/LaunchArgs.swift
+++ b/Client/Application/LaunchArgs.swift
@@ -1,0 +1,28 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import BraveShared
+
+extension Preferences {
+    /// Launch arguments can be set in scheme editor in XCode.
+    struct LaunchArgs {
+        private static let prefs = UserDefaults.standard
+        
+        static let skipOnboardingIntro = boolOrNil(for: "BRSkipOnboarding")
+        static let skipEduPopups = boolOrNil(for: "BRSkipEduPopups")
+        /// Skips default browser, Brave VPN, DDG callouts.
+        static let skipNTPCallouts = boolOrNil(for: "BRSkipAppLaunchPopups")
+        
+        private static func boolOrNil(for key: String) -> Bool? {
+            if prefs.object(forKey: key) == nil {
+                return nil
+            }
+            
+            return prefs.bool(forKey: key)
+        }
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -981,6 +981,8 @@ class BrowserViewController: UIViewController {
     }
     
     func presentOnboardingIntro() {
+        if Preferences.LaunchArgs.skipOnboardingIntro == true { return }
+        
         // 1. Existing user.
         // 2. User already completed onboarding.
         if Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue {
@@ -1079,6 +1081,8 @@ class BrowserViewController: UIViewController {
     }
     
     private func presentVPNCallout() {
+        if Preferences.LaunchArgs.skipNTPCallouts == true { return }
+        
         let onboardingNotCompleted =
             Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue
         let notEnoughAppLaunches = Preferences.VPN.appLaunchCountForVPNPopup.value < BraveVPN.appLaunchesToShowVPNPopup
@@ -1129,6 +1133,8 @@ class BrowserViewController: UIViewController {
     var shouldShowIntroScreen = false
 
     private func presentDefaultBrowserIntroScreen() {
+        if Preferences.LaunchArgs.skipNTPCallouts == true { return }
+        
         if !shouldShowIntroScreen {
             return
         }
@@ -2052,6 +2058,8 @@ class BrowserViewController: UIViewController {
     
     private var duckDuckGoPopup: AlertPopupView?
     func presentDuckDuckGoCallout(force: Bool = false) {
+        if Preferences.LaunchArgs.skipNTPCallouts == true { return }
+        
         // Don't show when onboarding is showing
         if let presentedViewController = self.presentedViewController, presentedViewController.isKind(of: OnboardingNavigationController.self) {
             return

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -981,7 +981,7 @@ class BrowserViewController: UIViewController {
     }
     
     func presentOnboardingIntro() {
-        if Preferences.LaunchArgs.skipOnboardingIntro == true { return }
+        if Preferences.DebugFlag.skipOnboardingIntro == true { return }
         
         // 1. Existing user.
         // 2. User already completed onboarding.
@@ -1081,7 +1081,7 @@ class BrowserViewController: UIViewController {
     }
     
     private func presentVPNCallout() {
-        if Preferences.LaunchArgs.skipNTPCallouts == true { return }
+        if Preferences.DebugFlag.skipNTPCallouts == true { return }
         
         let onboardingNotCompleted =
             Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue
@@ -1133,7 +1133,7 @@ class BrowserViewController: UIViewController {
     var shouldShowIntroScreen = false
 
     private func presentDefaultBrowserIntroScreen() {
-        if Preferences.LaunchArgs.skipNTPCallouts == true { return }
+        if Preferences.DebugFlag.skipNTPCallouts == true { return }
         
         if !shouldShowIntroScreen {
             return
@@ -2058,7 +2058,7 @@ class BrowserViewController: UIViewController {
     
     private var duckDuckGoPopup: AlertPopupView?
     func presentDuckDuckGoCallout(force: Bool = false) {
-        if Preferences.LaunchArgs.skipNTPCallouts == true { return }
+        if Preferences.DebugFlag.skipNTPCallouts == true { return }
         
         // Don't show when onboarding is showing
         if let presentedViewController = self.presentedViewController, presentedViewController.isKind(of: OnboardingNavigationController.self) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -69,7 +69,7 @@ extension BrowserViewController {
     }
     
     private func presentEducationalProductNotifications() {
-        if Preferences.LaunchArgs.skipEduPopups == true { return }
+        if Preferences.DebugFlag.skipEduPopups == true { return }
         
         guard let selectedTab = tabManager.selectedTab,
               !benchmarkNotificationPresented,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -69,6 +69,8 @@ extension BrowserViewController {
     }
     
     private func presentEducationalProductNotifications() {
+        if Preferences.LaunchArgs.skipEduPopups == true { return }
+        
         guard let selectedTab = tabManager.selectedTab,
               !benchmarkNotificationPresented,
               !topToolbar.inOverlayMode,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3445 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that app onboarding and educational popups still show up in production builds.
No need to check for all popups, if at least one showed up, all should be good.

This is mostly cleanup for our local development builds, only basic tests are required here.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
