### PR TITLE
Fix #3449: Restrict reporting promoted content events to regular tabs

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -518,7 +518,7 @@ class NewTabPageViewController: UIViewController, Themeable {
         case .itemAction(.opened(let inNewTab, let switchingToPrivateMode), let context):
             guard let url = context.item.content.url else { return }
             let item = context.item
-            if item.content.contentType == .partner,
+            if !switchingToPrivateMode, item.content.contentType == .partner,
                let creativeInstanceID = item.content.creativeInstanceID {
                 rewards.ads.reportPromotedContentAdEvent(
                     item.content.urlHash,


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3449 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan

- Verify click event is sent when opening a promoted content card link in the same tab, and in a new regular tab
- Verify click event is **not** sent when opening a promoted content card link in a new private tab

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
