### PR TITLE
No Bug: Fixing share description text typo

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -988,7 +988,7 @@ extension Strings {
             "socialSharing.shareDescriptionTitle",
             bundle: Bundle.shared,
             value: "Every day I save data by browsing the web with Brave.",
-            comment: "Text usedn for social sharing together with Brave Shield values")
+            comment: "Text used for social sharing together with Brave Shield values")
     }
 }
 

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -987,8 +987,8 @@ extension Strings {
         public static let shareDescriptionTitle = NSLocalizedString(
             "socialSharing.shareDescriptionTitle",
             bundle: Bundle.shared,
-            value: "Everyday I save data by browsing the web with Brave.",
-            comment: "Text used shile sharing Brave Shield values")
+            value: "Every day I save data by browsing the web with Brave.",
+            comment: "Text usedn for social sharing together with Brave Shield values")
     }
 }
 


### PR DESCRIPTION
Fixing share description text typo for "Every day" 

## Summary of Changes

This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
