### PR TITLE
Fix #3453: Base relative feed/favicon URLs on the page response URL

### DIFF
--- a/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
+++ b/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
@@ -345,7 +345,9 @@ class FaviconFetcher {
     private func parseHTMLForFavicons(for url: URL, _ completion: @escaping (FaviconAttributes) -> Void) {
         let pageTask = session.dataTask(with: url) { [weak self] (data, response, error) in
             guard let self = self else { return }
-            guard let data = data, error == nil, let root = try? HTMLDocument(data: data) else {
+            guard let data = data, error == nil,
+                  let root = try? HTMLDocument(data: data),
+                  let url = response?.url else {
                 completion(self.monogramFavicon)
                 return
             }

--- a/Client/Frontend/Settings/Brave Today/BraveTodayAddSourceViewController.swift
+++ b/Client/Frontend/Settings/Brave Today/BraveTodayAddSourceViewController.swift
@@ -165,7 +165,9 @@ class BraveTodayAddSourceViewController: UITableViewController {
                 completion(.failure(.dataTaskError(error)))
                 return
             }
-            guard let data = data, let root = try? HTMLDocument(data: data) else {
+            guard let data = data,
+                  let root = try? HTMLDocument(data: data),
+                  let url = response?.url else {
                 completion(.failure(.invalidData))
                 return
             }


### PR DESCRIPTION
## Summary of Changes

Attempting to download page source of insecure/http pages (i.e. `github.com`, which `URIFixup` makes `http://github.com`) which are upgraded to secure/https from the server making a redirect do not use the response URL when forming relative `URL`'s

This also fixes the same problem in favicon fetching HTML scraping

This pull request fixes #3453 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Search for a RSS feed on a popular website that automatically redirects to https
- Verify that the results are secure for URLs that are relative

Example: Typing in `daringfireball.net` loads `http://daringfireball.net` which automatically redirects and responds as `https://daringfireball.net` and has the following feeds linked in its HTML:

```html
<link rel="alternate" type="application/json" href="/feeds/json">
<link rel="alternate" type="application/atom+xml" href="/feeds/main">
```

Which are relative, and now should still return as secure feeds:

![image](https://user-images.githubusercontent.com/529104/112342769-e469f900-8c98-11eb-841d-ab3e1766dead.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
