### PR TITLE
Fix #3410: Possibly defer ledger initialize until Rewards interaction

### DIFF
--- a/Client/DeviceCheck/DeviceCheck.swift
+++ b/Client/DeviceCheck/DeviceCheck.swift
@@ -132,7 +132,7 @@ public class DeviceCheckClient {
   private static let privateKeyId = "com.brave.device.check.private.key"
   
   // The current build environment
-  private let environment: Environment
+  private let environment: BATEnvironment
   
   // A structure representing an error returned by the server
   public struct DeviceCheckError: Error, Codable {
@@ -143,7 +143,7 @@ public class DeviceCheckClient {
     let code: Int
   }
   
-  public init(environment: Environment) {
+  public init(environment: BATEnvironment) {
     self.environment = environment
   }
   

--- a/Client/Extensions/Rewards/BraveRewardsExtensions.swift
+++ b/Client/Extensions/Rewards/BraveRewardsExtensions.swift
@@ -28,7 +28,7 @@ extension BraveRewards {
             Preferences.Rewards.rewardsToggledOnce.value = true
             createWalletIfNeeded { [weak self] in
                 guard let self = self else { return }
-                self.ledger.isAutoContributeEnabled = newValue
+                self.ledger?.isAutoContributeEnabled = newValue
                 self.isAdsEnabled = newValue
                 self.didChangeValue(for: \.isEnabled)
             }
@@ -41,9 +41,12 @@ extension BraveRewards {
             return
         }
         isCreatingWallet = true
-        ledger.createWalletAndFetchDetails { [weak self] success in
-            self?.isCreatingWallet = false
-            completion?()
+        startLedgerService {
+            guard let ledger = self.ledger else { return }
+            ledger.createWalletAndFetchDetails { [weak self] success in
+                self?.isCreatingWallet = false
+                completion?()
+            }
         }
     }
     

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -82,15 +82,15 @@ extension BrowserViewController {
         popover.present(from: topToolbar.locationView.rewardsButton, on: self)
         popover.popoverDidDismiss = { [weak self] _ in
             guard let self = self else { return }
-            if let tabId = self.tabManager.selectedTab?.rewardsId, self.rewards.ledger.selectedTabId == 0 {
+            if let tabId = self.tabManager.selectedTab?.rewardsId, self.rewards.ledger?.selectedTabId == 0 {
                 // Show the tab currently visible
-                self.rewards.ledger.selectedTabId = tabId
+                self.rewards.ledger?.selectedTabId = tabId
             }
         }
         // Hide the current tab
-        rewards.ledger.selectedTabId = 0
+        rewards.ledger?.selectedTabId = 0
         // Fetch new promotions
-        rewards.ledger.fetchPromotions(nil)
+        rewards.ledger?.fetchPromotions(nil)
     }
     
     func showWalletTransferExpiryPanelIfNeeded() {
@@ -127,9 +127,10 @@ extension BrowserViewController {
     }
     
     func claimPendingPromotions() {
-        rewards.ledger.pendingPromotions.forEach { promo in
+        guard let ledger = rewards.ledger else { return }
+        ledger.pendingPromotions.forEach { promo in
             if promo.status == .active {
-                self.rewards.ledger.claimPromotion(promo) { success in
+                ledger.claimPromotion(promo) { success in
                     log.info("[BraveRewards] Auto-Claim Promotion - \(success) for \(promo.approximateValue)")
                 }
             }
@@ -137,13 +138,14 @@ extension BrowserViewController {
     }
     
     func authorizeUpholdWallet(from tab: Tab, queryItems items: [String: String]) {
-        rewards.ledger.authorizeExternalWallet(
+        guard let ledger = rewards.ledger else { return }
+        ledger.authorizeExternalWallet(
             ofType: .uphold,
             queryItems: items) { result, redirectURL in
                 switch result {
                 case .ledgerOk:
                     // Fetch the wallet
-                    self.rewards.ledger.fetchUpholdWallet { _ in
+                    ledger.fetchUpholdWallet { _ in
                         if let redirectURL = redirectURL {
                             // Requires verification
                             let request = URLRequest(url: redirectURL)
@@ -251,6 +253,46 @@ extension BrowserViewController {
             center.removePendingNotificationRequests(withIdentifiers: ids)
         }
     }
+    
+    func setupLedger() {
+        guard let ledger = rewards.ledger else { return }
+        // Update defaults
+        ledger.minimumVisitDuration = 8
+        ledger.minimumNumberOfVisits = 1
+        ledger.allowUnverifiedPublishers = false
+        ledger.allowVideoContributions = true
+        ledger.contributionAmount = Double.greatestFiniteMagnitude
+        
+        // Create ledger observer
+        let rewardsObserver = LedgerObserver(ledger: ledger)
+        ledger.add(rewardsObserver)
+        
+        rewardsObserver.walletInitalized = { [weak self] result in
+            guard let self = self, let client = self.deviceCheckClient else { return }
+            if result == .walletCreated {
+                ledger.setupDeviceCheckEnrollment(client) { }
+                self.updateRewardsButtonState()
+            }
+        }
+        rewardsObserver.promotionsAdded = { [weak self] promotions in
+            self?.claimPendingPromotions()
+        }
+        rewardsObserver.fetchedPanelPublisher = { [weak self] publisher, tabId in
+            guard let self = self, self.isViewLoaded, let tab = self.tabManager.selectedTab, tab.rewardsId == tabId else { return }
+            self.publisher = publisher
+        }
+        
+        promotionFetchTimer = Timer.scheduledTimer(
+            withTimeInterval: 1.hours,
+            repeats: true,
+            block: { [weak self, weak ledger] _ in
+                guard let self = self, let ledger = ledger else { return }
+                if self.rewards.isEnabled {
+                    ledger.fetchPromotions(nil)
+                }
+            }
+        )
+    }
 }
 
 extension Tab {
@@ -301,5 +343,9 @@ extension BrowserViewController: BraveRewardsDelegate {
     func logMessage(withFilename file: String, lineNumber: Int32, verbosity: Int32, message: String) {
         if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return }
         log.logln(verbosity.loggerLevel, fileName: file, lineNumber: Int(lineNumber), closure: { message })
+    }
+    
+    func ledgerServiceDidStart(_ ledger: BraveLedger) {
+        setupLedger()
     }
 }

--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -101,16 +101,18 @@ class BraveRewardsSettingsViewController: TableViewController {
             }
         }
         
-        rewards.ledger.rewardsInternalInfo { info in
-            if let info = info, !info.paymentId.isEmpty {
-                dataSource.sections += [
-                    Section(rows: [
-                        Row(text: Strings.RewardsInternals.title, selection: {
-                            let controller = RewardsInternalsViewController(ledger: self.rewards.ledger, legacyLedger: self.legacyWallet)
-                            self.navigationController?.pushViewController(controller, animated: true)
-                        }, accessory: .disclosureIndicator)
-                    ])
-                ]
+        if let ledger = rewards.ledger {
+            ledger.rewardsInternalInfo { info in
+                if let info = info, !info.paymentId.isEmpty {
+                    dataSource.sections += [
+                        Section(rows: [
+                            Row(text: Strings.RewardsInternals.title, selection: {
+                                let controller = RewardsInternalsViewController(ledger: ledger, legacyLedger: self.legacyWallet)
+                                self.navigationController?.pushViewController(controller, animated: true)
+                            }, accessory: .disclosureIndicator)
+                        ])
+                    ]
+                }
             }
         }
     }
@@ -119,7 +121,9 @@ class BraveRewardsSettingsViewController: TableViewController {
         super.viewDidLoad()
         
         title = Strings.braveRewardsTitle
-     
-        reloadSections()
+        
+        rewards.startLedgerService { [weak self] in
+            self?.reloadSections()
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,8 +1146,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.22.71/brave-core-ios-1.22.71.tgz",
-      "integrity": "sha512-xUYWz0++FXtDZNSOyWq0mLVm24RhNTcO2HcbNaICnDK4c4mA4i83Awd4C8cR4ChaME/lu9qwF5Ii/5IvUkwyaw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.23.70/brave-core-ios-1.23.70.tgz",
+      "integrity": "sha512-056SzMxVtrPy3+kxptD2GSPWekuJSeF+obePV1CXv1B3ghJnIVg9Pyjx3DB5Sy96sEoW3wdFAPJr0oVBpHf++w=="
     },
     "brorand": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^3.3.10",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.22.71/brave-core-ios-1.22.71.tgz"
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.23.70/brave-core-ios-1.23.70.tgz"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
This moves the assumption that ledger will be initialized immediately on launch, every launch, to possibly being deferred until user interaction.

This change moves to match desktop's logic around ledger only being initialized on launch if a user has already enabled Rewards (in our case we check for ads enabled since we control that preference). If they have not, then no outbound calls or ledger initialization happen until after the user opens either the Rewards panel or enters the Rewards settings screen

~To build this you must build local copies of Rewards pointing to this PR's branch https://github.com/brave/brave-core/pull/8347 (or find them in [`#build-downloads-bot`](https://bravesoftware.slack.com/archives/CMH8DU4TF/p1616609554087400))~

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3410
This pull request fixes #3523

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
