### PR TITLE
Fix #3460: Reload sections instead of removing specific row

### DIFF
--- a/Client/Frontend/Settings/Brave Today/BraveTodaySettingsViewController.swift
+++ b/Client/Frontend/Settings/Brave Today/BraveTodaySettingsViewController.swift
@@ -92,7 +92,7 @@ class BraveTodaySettingsViewController: TableViewController {
                         editActions: [.init(title: Strings.BraveToday.deleteUserSourceTitle, style: .destructive, selection: { [unowned self] indexPath in
                             guard let location = feedDataSource.rssFeedLocations[safe: indexPath.row] else { return }
                             self.feedDataSource.removeRSSFeed(with: location.url)
-                            dataSource.sections[1].rows.remove(at: indexPath.row)
+                            self.reloadSections()
                         })]
                     )
                 } + [


### PR DESCRIPTION
Bug in Static causes the toggle state of shifted cells to be incorrect

## Summary of Changes

This pull request fixes #3460 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
