### PR TITLE
Fix #3458: Bump Rewards to 1.21.78 which includes ad conversion fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,8 +1146,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.21.76/brave-core-ios-1.21.76.tgz",
-      "integrity": "sha512-YQWfNxMnkJEpdNe2clMiaChon8iBokhCOflwGZNSscjRDtsFtXOPo0XuLKt/AQsTGkXtrem5++VCPxqdVln9zQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.21.78/brave-core-ios-1.21.78.tgz",
+      "integrity": "sha512-rXjBVmLQ8fEPgPUQjGaT0LcBsvMbZcOx6vdTZq8sfp3gYhxlA50Vufh4S8rYdJmbbbrf5GWekGbGhgivuEsYbw=="
     },
     "brorand": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^3.3.10",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.21.76/brave-core-ios-1.21.76.tgz"
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.21.78/brave-core-ios-1.21.78.tgz"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3458 

brave-core change: https://github.com/brave/brave-core/pull/8352

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
