### PR TITLE
Fix #3477: Do not show Brave Today share activity if BT is disabled

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1792,7 +1792,8 @@ class BrowserViewController: UIViewController {
             }
             activities.append(requestDesktopSiteActivity)
             
-            if let metadata = tab?.pageMetadata, !metadata.feeds.isEmpty {
+            if Preferences.BraveToday.isEnabled.value, let metadata = tab?.pageMetadata,
+               !metadata.feeds.isEmpty {
                 let feeds: [RSSFeedLocation] = metadata.feeds.compactMap { feed in
                     if let url = URL(string: feed.href) {
                         return RSSFeedLocation(title: feed.title, url: url)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3477 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit site that has RSS feeds on their page (example: `theverge.com`)
- Verify that while Brave Today is disabled, the "Add Source to Brave Today" activity does not appear
- Verify the opposite while Brave Today is enabled

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
