### PR TITLE
Fix #3162: Add legacy wallet transfer status UI

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1999,7 +1999,7 @@ extension Strings {
         public static let walletTransferTitle = NSLocalizedString(
             "rewards.walletTransferTitle",
             bundle: .braveShared,
-            value: "Wallet Transfer",
+            value: "Wallet Transfer Status",
             comment: "Title of the legacy wallet transfer screen"
         )
         public static let walletTransferFailureAlertTitle = NSLocalizedString(
@@ -2073,6 +2073,126 @@ extension Strings {
             "rewards.transferNoLongerAvailableWarningMessage",
             bundle: .braveShared,
             value: "Please use the wallet transfer by March 13, 2021. Wallet transfer will no longer be available after March 13.",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusShortformInvalid = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusShortformInvalid",
+            bundle: .braveShared,
+            value: "Invalid",
+            comment: "Invalid as in: stating that the status of the users transfer is invalid"
+        )
+        public static let legacyWalletTransferStatusButtonInvalidTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusButtonInvalidTitle",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer is invalid",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusInvalidTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusInvalidTitle",
+            bundle: .braveShared,
+            value: "Transfer Invalid",
+            comment: "Title shown above body of text explaining that their transfer is invalid"
+        )
+        public static let legacyWalletTransferStatusInvalidBody = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusInvalidBody",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer is invalid and cannot be completed",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusShortformPending = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusShortformPending",
+            bundle: .braveShared,
+            value: "Pending",
+            comment: "Pending as in: stating that the status of the users transfer is pending"
+        )
+        public static let legacyWalletTransferStatusButtonPendingTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusButtonPendingTitle",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer status is pending",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusPendingTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusPendingTitle",
+            bundle: .braveShared,
+            value: "Transfer Pending",
+            comment: "Title shown above body of text explaining that their transfer is pending"
+        )
+        public static let legacyWalletTransferStatusPendingBody = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusPendingBody",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer status is pending and should begin processing shortly.",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusShortformInProgress = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusShortformInProgress",
+            bundle: .braveShared,
+            value: "In Progress",
+            comment: "In Progress as in: stating that the status of the users transfer is in progress"
+        )
+        public static let legacyWalletTransferStatusButtonInProgressTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusButtonInProgressTitle",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer is in progress",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusInProgressTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusInProgressTitle",
+            bundle: .braveShared,
+            value: "Transfer In-Progress",
+            comment: "Title shown above body of text explaining that their transfer is in progress"
+        )
+        public static let legacyWalletTransferStatusInProgressBody = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusInProgressBody",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer is in-progress and may take several minutes to complete.",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusShortformDelayed = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusShortformDelayed",
+            bundle: .braveShared,
+            value: "Delayed",
+            comment: "Delayed as in: stating that the status of the users transfer is in delayed"
+        )
+        public static let legacyWalletTransferStatusButtonDelayedTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusButtonDelayedTitle",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer has been delayed…",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusDelayedTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusDelayedTitle",
+            bundle: .braveShared,
+            value: "Transfer Delayed",
+            comment: "Title shown above body of text explaining that their transfer is delayed"
+        )
+        public static let legacyWalletTransferStatusDelayedBody = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusDelayedBody",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer has been delayed and may take several minutes to resume.",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusShortformCompleted = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusShortformCompleted",
+            bundle: .braveShared,
+            value: "Completed!",
+            comment: "Completed as in: stating that the status of the users transfer is in completed"
+        )
+        public static let legacyWalletTransferStatusButtonCompletedTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusButtonCompletedTitle",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer has completed!",
+            comment: ""
+        )
+        public static let legacyWalletTransferStatusCompletedTitle = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusCompletedTitle",
+            bundle: .braveShared,
+            value: "Transfer Completed!",
+            comment: "Title shown above body of text explaining that their transfer is completed"
+        )
+        public static let legacyWalletTransferStatusCompletedBody = NSLocalizedString(
+            "rewards.legacyWalletTransferStatusCompletedBody",
+            bundle: .braveShared,
+            value: "Your legacy wallet transfer is done! Your existing balance may still take several minutes to appear on your desktop Brave Rewards wallet.",
             comment: ""
         )
     }

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -124,6 +124,10 @@ extension Preferences {
         public static let seenDataMigrationFailureError = Option<Bool>(key: "rewards.seen-data-migration-failure-error", default: false)
         public static let migratedLegacyWallet = Option<Bool>(key: "rewards.migrated-legacy-wallet", default: false)
         public static let dismissedLegacyWalletTransfer = Option<Bool>(key: "rewards.dismissed-legacy-wallet-transfer", default: false)
+        public static let transferDrainID = Option<String?>(key: "rewards.legacy-wallet-transfer-drain-id", default: nil)
+        public static let lastTransferStatus = Option<Int?>(key: "rewards.legacy-wallet-transfer-status", default: nil)
+        public static let lastTransferStatusDismissed = Option<Int?>(key: "rewards.legacy-wallet-transfer-last-dismissed-status", default: nil)
+        public static let transferCompletionAcknowledged = Option<Bool>(key: "rewards.legacy-wallet-transfer-completion-acknowledged", default: false)
         public static let transferUnavailableLastSeen = Option<TimeInterval?>(key: "rewards.transfer-unavailable-warning-last-seen-date", default: nil)
         
         public enum EnvironmentOverride: Int {
@@ -162,7 +166,7 @@ extension Preferences {
     /// An entry in the `Preferences`
     ///
     /// `ValueType` defines the type of value that will stored in the UserDefaults object
-    public class Option<ValueType: UserDefaultsEncodable & Equatable> {
+    public class Option<ValueType: UserDefaultsEncodable & Equatable>: ObservableObject {
         /// The list of observers for this option
         private let observers = WeakList<PreferencesObserver>()
         /// The UserDefaults container that you wish to save to
@@ -170,7 +174,7 @@ extension Preferences {
         /// The current value of this preference
         ///
         /// Upon setting this value, UserDefaults will be updated and any observers will be called
-        public var value: ValueType {
+        @Published public var value: ValueType {
             didSet {
                 if value == oldValue { return }
                 

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -129,6 +129,7 @@ extension Preferences {
         public static let lastTransferStatusDismissed = Option<Int?>(key: "rewards.legacy-wallet-transfer-last-dismissed-status", default: nil)
         public static let transferCompletionAcknowledged = Option<Bool>(key: "rewards.legacy-wallet-transfer-completion-acknowledged", default: false)
         public static let transferUnavailableLastSeen = Option<TimeInterval?>(key: "rewards.transfer-unavailable-warning-last-seen-date", default: nil)
+        public static let drainStatusOverride = Option<Int?>(key: "rewards.drain-status-override", default: nil)
         
         public enum EnvironmentOverride: Int {
             case none

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		27036F9B25684F9F004EF6B6 /* AdsNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27036F9625684F9F004EF6B6 /* AdsNotificationHandler.swift */; };
 		27036F9C25684F9F004EF6B6 /* AdContentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27036F9725684F9F004EF6B6 /* AdContentButton.swift */; };
 		2703BE8B24F4508E00CBE6CD /* CreatePDFActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2703BE8A24F4508E00CBE6CD /* CreatePDFActivity.swift */; };
+		270A0F392605267D0091D880 /* LegacyWalletTransferStatusButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270A0F382605267D0091D880 /* LegacyWalletTransferStatusButton.swift */; };
 		27187808216526090006036E /* AlertPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27187807216526090006036E /* AlertPopupView.swift */; };
 		2718780A216526240006036E /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27187809216526240006036E /* PopupView.swift */; };
 		2719DA00249AAC2A0080AB48 /* FeedContextMenuDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2719D9FF249AAC2A0080AB48 /* FeedContextMenuDelegate.swift */; };
@@ -1602,6 +1603,7 @@
 		27036F9625684F9F004EF6B6 /* AdsNotificationHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdsNotificationHandler.swift; sourceTree = "<group>"; };
 		27036F9725684F9F004EF6B6 /* AdContentButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdContentButton.swift; sourceTree = "<group>"; };
 		2703BE8A24F4508E00CBE6CD /* CreatePDFActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePDFActivity.swift; sourceTree = "<group>"; };
+		270A0F382605267D0091D880 /* LegacyWalletTransferStatusButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyWalletTransferStatusButton.swift; sourceTree = "<group>"; };
 		27187807216526090006036E /* AlertPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPopupView.swift; sourceTree = "<group>"; };
 		27187809216526240006036E /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		2719D9FF249AAC2A0080AB48 /* FeedContextMenuDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedContextMenuDelegate.swift; sourceTree = "<group>"; };
@@ -3704,6 +3706,7 @@
 			isa = PBXGroup;
 			children = (
 				27829E142548AD52007CF0B2 /* LegacyWalletTransferButton.swift */,
+				270A0F382605267D0091D880 /* LegacyWalletTransferStatusButton.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -7128,6 +7131,7 @@
 				4422D4C221BFFB7600BF1855 /* comparator.cc in Sources */,
 				0A1E84452190A57F0042F782 /* SyncPairWordsViewController.swift in Sources */,
 				2746D27524A2A9FE00E38852 /* RewardsInternalsContributionPublishersListController.swift in Sources */,
+				270A0F392605267D0091D880 /* LegacyWalletTransferStatusButton.swift in Sources */,
 				4422D4DF21BFFB7600BF1855 /* table_builder.cc in Sources */,
 				27448536245B608E001920B5 /* QRCodePopupView.swift in Sources */,
 				4422D50121BFFB7600BF1855 /* repair.cc in Sources */,

--- a/Client/Extensions/Rewards/BraveLedgerExtensions.swift
+++ b/Client/Extensions/Rewards/BraveLedgerExtensions.swift
@@ -54,6 +54,13 @@ extension BraveLedger {
             completion(nil)
             return
         }
+        if !AppConstants.buildChannel.isPublic,
+           let overrideValue = Preferences.Rewards.drainStatusOverride.value,
+           let status = DrainStatus(rawValue: overrideValue) {
+            Preferences.Rewards.lastTransferStatus.value = status.rawValue
+            completion(status)
+            return
+        }
         drainStatus(for: drainID) { result, status in
             if result != .ledgerOk {
                 if let lastStatus = Preferences.Rewards.lastTransferStatus.value {

--- a/Client/Extensions/Rewards/BraveLedgerExtensions.swift
+++ b/Client/Extensions/Rewards/BraveLedgerExtensions.swift
@@ -6,6 +6,7 @@
 import Foundation
 import BraveRewards
 import Shared
+import BraveShared
 
 private let log = Logger.rewardsLogger
 
@@ -45,6 +46,25 @@ extension BraveLedger {
         }()
         listActivityInfo(fromStart: 0, limit: 0, filter: filter) { list in
             completion(list)
+        }
+    }
+    
+    public func updateDrainStatus(_ completion: @escaping (DrainStatus?) -> Void) {
+        guard let drainID = Preferences.Rewards.transferDrainID.value else {
+            completion(nil)
+            return
+        }
+        drainStatus(for: drainID) { result, status in
+            if result != .ledgerOk {
+                if let lastStatus = Preferences.Rewards.lastTransferStatus.value {
+                    completion(DrainStatus(rawValue: lastStatus))
+                } else {
+                    completion(nil)
+                }
+                return
+            }
+            Preferences.Rewards.lastTransferStatus.value = status.rawValue
+            completion(status)
         }
     }
     

--- a/Client/Extensions/Rewards/BraveRewardsExtensions.swift
+++ b/Client/Extensions/Rewards/BraveRewardsExtensions.swift
@@ -57,8 +57,8 @@ private struct AssociatedKeys {
   static var isCreatingWallet: Int = 0
 }
 
-extension DrainStatus {
-    var displayString: String {
+extension DrainStatus: RepresentableOptionType {
+    public var displayString: String {
         switch self {
         case .invalid:
             return Strings.Rewards.legacyWalletTransferStatusShortformInvalid

--- a/Client/Extensions/Rewards/BraveRewardsExtensions.swift
+++ b/Client/Extensions/Rewards/BraveRewardsExtensions.swift
@@ -5,6 +5,7 @@
 import Foundation
 import BraveRewards
 import BraveShared
+import Shared
 
 extension BraveRewards {
     
@@ -55,4 +56,70 @@ extension BraveRewards {
 private struct AssociatedKeys {
   static var isCreatingWallet: Int = 0
 }
-  
+
+extension DrainStatus {
+    var displayString: String {
+        switch self {
+        case .invalid:
+            return Strings.Rewards.legacyWalletTransferStatusShortformInvalid
+        case .pending:
+            return Strings.Rewards.legacyWalletTransferStatusShortformPending
+        case .inProgress:
+            return Strings.Rewards.legacyWalletTransferStatusShortformInProgress
+        case .delayed:
+            return Strings.Rewards.legacyWalletTransferStatusShortformDelayed
+        case .complete:
+            return Strings.Rewards.legacyWalletTransferStatusShortformCompleted
+        @unknown default:
+            return ""
+        }
+    }
+    var statusButtonTitle: String {
+        switch self {
+        case .invalid:
+            return Strings.Rewards.legacyWalletTransferStatusButtonInvalidTitle
+        case .pending:
+            return Strings.Rewards.legacyWalletTransferStatusButtonPendingTitle
+        case .inProgress:
+            return Strings.Rewards.legacyWalletTransferStatusButtonInProgressTitle
+        case .delayed:
+            return Strings.Rewards.legacyWalletTransferStatusButtonDelayedTitle
+        case .complete:
+            return Strings.Rewards.legacyWalletTransferStatusButtonCompletedTitle
+        @unknown default:
+            return ""
+        }
+    }
+    var transferStatusTitle: String {
+        switch self {
+        case .invalid:
+            return Strings.Rewards.legacyWalletTransferStatusInvalidTitle
+        case .pending:
+            return Strings.Rewards.legacyWalletTransferStatusPendingTitle
+        case .inProgress:
+            return Strings.Rewards.legacyWalletTransferStatusInProgressTitle
+        case .delayed:
+            return Strings.Rewards.legacyWalletTransferStatusDelayedTitle
+        case .complete:
+            return Strings.Rewards.legacyWalletTransferStatusCompletedTitle
+        @unknown default:
+            return ""
+        }
+    }
+    var transferStatusBody: String {
+        switch self {
+        case .invalid:
+            return Strings.Rewards.legacyWalletTransferStatusInvalidBody
+        case .pending:
+            return Strings.Rewards.legacyWalletTransferStatusPendingBody
+        case .inProgress:
+            return Strings.Rewards.legacyWalletTransferStatusInProgressBody
+        case .delayed:
+            return Strings.Rewards.legacyWalletTransferStatusDelayedBody
+        case .complete:
+            return Strings.Rewards.legacyWalletTransferStatusCompletedBody
+        @unknown default:
+            return ""
+        }
+    }
+}

--- a/Client/Frontend/Brave Rewards/Common/LegacyWalletTransferStatusButton.swift
+++ b/Client/Frontend/Brave Rewards/Common/LegacyWalletTransferStatusButton.swift
@@ -1,0 +1,65 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import BraveUI
+
+class LegacyWalletTransferStatusButton: UIControl, Themeable {
+    
+    let dismissButton = Button(type: .system).then {
+        $0.setImage(UIImage(imageLiteralResourceName: "close-medium").template, for: .normal)
+        $0.tintColor = .white
+        $0.hitTestSlop = UIEdgeInsets(equalInset: -10)
+        $0.setContentHuggingPriority(.required, for: .horizontal)
+    }
+    
+    let titleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 18, weight: .medium)
+        $0.numberOfLines = 0
+        $0.appearanceTextColor = .white
+        $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        isAccessibilityElement = true
+        accessibilityTraits.insert(.button)
+        
+        layer.cornerRadius = 8
+        if #available(iOS 13, *) {
+            layer.cornerCurve = .continuous
+        }
+        
+        backgroundColor = UIColor(rgb: 0x339AF0)
+        
+        addSubview(titleLabel)
+        addSubview(dismissButton)
+        
+        accessibilityLabel = titleLabel.text
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.leading.bottom.equalToSuperview().inset(UIEdgeInsets(top: 14, left: 20, bottom: 14, right: 20))
+            $0.trailing.equalTo(dismissButton.snp.leading).offset(-14)
+        }
+        dismissButton.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview().inset(5)
+        }
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override var isHighlighted: Bool {
+        didSet {
+            UIView.animate(withDuration: 0.15) {
+                self.titleLabel.alpha = self.isHighlighted ? 0.4 : 1.0
+            }
+        }
+    }
+}

--- a/Client/Frontend/Brave Rewards/Common/LegacyWalletTransferStatusButton.swift
+++ b/Client/Frontend/Brave Rewards/Common/LegacyWalletTransferStatusButton.swift
@@ -30,9 +30,7 @@ class LegacyWalletTransferStatusButton: UIControl, Themeable {
         accessibilityTraits.insert(.button)
         
         layer.cornerRadius = 8
-        if #available(iOS 13, *) {
-            layer.cornerCurve = .continuous
-        }
+        layer.cornerCurve = .continuous
         
         backgroundColor = UIColor(rgb: 0x339AF0)
         

--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
@@ -32,6 +32,9 @@ extension BraveRewardsViewController {
         let publisherView = BraveRewardsPublisherView()
         let statusView = BraveRewardsStatusView()
         let legacyWalletTransferButton = LegacyWalletTransferButton()
+        let legacyWalletTransferStatusButton = LegacyWalletTransferStatusButton().then {
+            $0.isHidden = true
+        }
         
         override init(frame: CGRect) {
             super.init(frame: frame)
@@ -62,6 +65,7 @@ extension BraveRewardsViewController {
                     $0.spacing = 8
                     $0.addStackViewItems(
                         .view(legacyWalletTransferButton),
+                        .view(legacyWalletTransferStatusButton),
                         .view(statusView)
                     )
                 }),

--- a/Client/Frontend/Brave Rewards/Transfer/WalletTransferCompleteView.swift
+++ b/Client/Frontend/Brave Rewards/Transfer/WalletTransferCompleteView.swift
@@ -16,12 +16,13 @@ extension WalletTransferCompleteViewController {
             $0.layoutMargins = UIEdgeInsets(equalInset: 16)
             $0.isLayoutMarginsRelativeArrangement = true
         }
-        private let titleLabel = UILabel().then {
+        let titleLabel = UILabel().then {
             $0.text = Strings.Rewards.walletTransferCompleteTitle
             $0.numberOfLines = 0
             $0.font = .systemFont(ofSize: 17, weight: .semibold)
+            $0.appearanceTextColor = UIColor(rgb: 0x339AF0)
         }
-        private let bodyLabel = UILabel().then {
+        let bodyLabel = UILabel().then {
             $0.text = Strings.Rewards.walletTransferCompleteBody
             $0.numberOfLines = 0
             $0.font = .systemFont(ofSize: 17)

--- a/Client/Frontend/Brave Rewards/Transfer/WalletTransferCompleteViewController.swift
+++ b/Client/Frontend/Brave Rewards/Transfer/WalletTransferCompleteViewController.swift
@@ -5,8 +5,26 @@
 
 import UIKit
 import Shared
+import BraveRewards
+import BraveShared
 
 class WalletTransferCompleteViewController: UIViewController, Themeable {
+    
+    private let status: DrainStatus?
+    
+    init(status: DrainStatus?) {
+        self.status = status
+        super.init(nibName: nil, bundle: nil)
+        if status == .complete {
+            // Require user to acknowledge by tapping done
+            isModalInPresentation = true
+        }
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
     
     private var transferCompleteView: WalletTransferCompleteView {
         view as! WalletTransferCompleteView // swiftlint:disable:this force_cast
@@ -23,6 +41,11 @@ class WalletTransferCompleteViewController: UIViewController, Themeable {
         navigationItem.hidesBackButton = true
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(tappedDone))
         title = Strings.Rewards.walletTransferTitle
+        
+        if let status = status {
+            transferCompleteView.titleLabel.text = status.transferStatusTitle
+            transferCompleteView.bodyLabel.text = status.transferStatusBody
+        }
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -38,6 +61,7 @@ class WalletTransferCompleteViewController: UIViewController, Themeable {
     }
     
     @objc private func tappedDone() {
+        Preferences.Rewards.transferCompletionAcknowledged.value = true
         dismiss(animated: true)
     }
 }

--- a/Client/Frontend/Brave Rewards/Transfer/WalletTransferViewController.swift
+++ b/Client/Frontend/Brave Rewards/Transfer/WalletTransferViewController.swift
@@ -6,6 +6,7 @@
 import Foundation
 import BraveRewards
 import Shared
+import BraveShared
 
 class WalletTransferViewController: UIViewController, Themeable {
     
@@ -42,7 +43,7 @@ class WalletTransferViewController: UIViewController, Themeable {
         transferView.cameraView.scanCallback = { [weak self] paymentId in
             guard let self = self, !paymentId.isEmpty, !self.isTransferring else { return }
             self.isTransferring = true
-            self.legacyWallet.linkBraveWallet(paymentId: paymentId) { [weak self] result in
+            self.legacyWallet.linkBraveWallet(paymentId: paymentId) { [weak self] result, drainID in
                 guard let self = self else { return }
                 if result != .ledgerOk {
                     let alert = UIAlertController(title: Strings.Rewards.walletTransferFailureAlertTitle, message: "\(Strings.Rewards.walletTransferFailureAlertMessage) (\(result.rawValue))", preferredStyle: .alert)
@@ -52,8 +53,11 @@ class WalletTransferViewController: UIViewController, Themeable {
                     self.present(alert, animated: true)
                     return
                 }
-                let completedVC = WalletTransferCompleteViewController()
-                self.navigationController?.pushViewController(completedVC, animated: true)
+                Preferences.Rewards.transferDrainID.value = drainID
+                self.legacyWallet.updateDrainStatus { status in
+                    let completedVC = WalletTransferCompleteViewController(status: status)
+                    self.navigationController?.pushViewController(completedVC, animated: true)
+                }
             }
         }
         transferView.learnMoreButton.addTarget(self, action: #selector(tappedLearnMoreButton), for: .touchUpInside)

--- a/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
+++ b/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
@@ -42,6 +42,8 @@ class RewardsDebugSettingsViewController: TableViewController {
         let overrideForIndex = EnvironmentOverride.sortedCases[value]
         Preferences.Rewards.environmentOverride.value = overrideForIndex.rawValue
         self.rewards.reset()
+        Preferences.Rewards.transferDrainID.value = nil
+        Preferences.Rewards.transferCompletionAcknowledged.value = false
         self.showResetRewardsAlert()
     }
     
@@ -324,6 +326,8 @@ class RewardsDebugSettingsViewController: TableViewController {
     
     @objc private func tappedReset() {
         rewards.reset()
+        Preferences.Rewards.transferDrainID.value = nil
+        Preferences.Rewards.transferCompletionAcknowledged.value = false
         showResetRewardsAlert()
     }
     

--- a/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
+++ b/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
@@ -150,6 +150,44 @@ class RewardsDebugSettingsViewController: TableViewController {
         reloadSections()
     }
     
+    private var drainOverrideStatusRow: Row {
+        enum DrainStatusOverride: Int, CaseIterable, RepresentableOptionType {
+            case none = -1
+            case invalid
+            case pending
+            case inProgress
+            case delayed
+            case complete
+            
+            var status: DrainStatus? {
+                switch self {
+                case .none: return nil
+                case .invalid: return .invalid
+                case .pending: return .pending
+                case .inProgress: return .inProgress
+                case .delayed: return .delayed
+                case .complete: return .complete
+                }
+            }
+            var displayString: String {
+                status?.displayString ?? "None"
+            }
+        }
+        var selected: DrainStatusOverride = .none
+        if let override = Preferences.Rewards.drainStatusOverride.value,
+           let status = DrainStatusOverride(rawValue: override) {
+            selected = status
+        }
+        return Row(text: "Drain Status Override", detailText: selected.displayString, selection: { [unowned self] in
+            let options = OptionSelectionViewController(
+                options: DrainStatusOverride.allCases,
+                selectedOption: selected) { _, option in
+                Preferences.Rewards.drainStatusOverride.value = option.status?.rawValue
+            }
+            self.navigationController?.pushViewController(options, animated: true)
+        }, accessory: .disclosureIndicator)
+    }
+    
     private func reloadSections() {
         let isDefaultEnvironmentProd = AppConstants.buildChannel != .debug
         
@@ -189,7 +227,8 @@ class RewardsDebugSettingsViewController: TableViewController {
                     }, accessory: .disclosureIndicator),
                     Row(text: "Create Legacy Wallet", selection: { [unowned self] in
                         self.createLegacyLedger()
-                    }, cellClass: ButtonCell.self)
+                    }, cellClass: ButtonCell.self),
+                    drainOverrideStatusRow
                 ]
             ),
             Section(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,8 +1146,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.21.78/brave-core-ios-1.21.78.tgz",
-      "integrity": "sha512-rXjBVmLQ8fEPgPUQjGaT0LcBsvMbZcOx6vdTZq8sfp3gYhxlA50Vufh4S8rYdJmbbbrf5GWekGbGhgivuEsYbw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.22.71/brave-core-ios-1.22.71.tgz",
+      "integrity": "sha512-xUYWz0++FXtDZNSOyWq0mLVm24RhNTcO2HcbNaICnDK4c4mA4i83Awd4C8cR4ChaME/lu9qwF5Ii/5IvUkwyaw=="
     },
     "brorand": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^3.3.10",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.21.78/brave-core-ios-1.21.78.tgz"
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.22.71/brave-core-ios-1.22.71.tgz"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
~Blocked waiting for updated 1.22.x builds that include https://github.com/brave/brave-core/pull/8369~

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3162 
This pull request fixes #3479

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
