### PR TITLE
Fix #3496: Pop-over messages should not be shown on NTP

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -50,7 +50,7 @@ extension BrowserViewController {
         }
         
         var value: Int {
-            AppConstants.buildChannel.isPublic ? self.rawValue : self.rawValue / 10
+            AppConstants.buildChannel.isPublic ? self.rawValue : self.rawValue / 100
         }
     }
     
@@ -74,7 +74,8 @@ extension BrowserViewController {
         guard let selectedTab = tabManager.selectedTab,
               !benchmarkNotificationPresented,
               !topToolbar.inOverlayMode,
-              selectedTab.webView?.scrollView.isDragging == false else {
+              selectedTab.webView?.scrollView.isDragging == false,
+              tabManager.selectedTab?.url?.isAboutHomeURL == false else {
             return
         }
         


### PR DESCRIPTION
Changing the debug values divide by 100 and adding condition for NTP is on the screen

## Summary of Changes

This pull request fixes #3496

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- While testing Benchmark Tiers in Debug Scheme observe Tier values will be presented divided by 100 for easy testing
- Check Pop-over messages are being shown when NTP is on active display

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
