### PR TITLE
Fix issue 3501; YouTube is misspelled in preloaded Favorites

### DIFF
--- a/Client/Frontend/Browser/Favorites/PreloadedFavorites.swift
+++ b/Client/Frontend/Browser/Favorites/PreloadedFavorites.swift
@@ -15,7 +15,7 @@ struct PreloadedFavorites {
             var list = [FavoriteSite]()
             
             if let url = URL(string: "https://m.youtube.com") {
-                list.append(FavoriteSite(url: url, title: "Youtube"))
+                list.append(FavoriteSite(url: url, title: "YouTube"))
             }
             
             if let url = URL(string: "https://www.amazon.com/") {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3501

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test plan in issue :-)

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [X] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [X] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
