### PR TITLE
Fix #3508: Include Sandboxed AtDocumentStart scripts when injecting JS

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -108,6 +108,7 @@ class UserScriptManager {
     private let packedUserScripts: [WKUserScript] = {
         [(WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: false, sandboxed: false),
          (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: false, sandboxed: false),
+         (WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: false, sandboxed: true),
          (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: false, sandboxed: true),
          (WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: true, sandboxed: false),
          (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: true, sandboxed: false)].compactMap { arg in


### PR DESCRIPTION
This was causing Rewards/Ads related JS to not be injected

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3508 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
