### PR TITLE
Fix #3528 - Playlist toast being stuck

### DIFF
--- a/Client/Frontend/Browser/Playlist/PlaylistToast.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistToast.swift
@@ -211,14 +211,19 @@ class PlaylistToast: Toast {
         if animated {
             super.dismiss(buttonPressed)
         } else {
-            guard !dismissed else { return }
-            dismissed = true
+            if displayState == .pendingDismiss || displayState == .dismissed {
+                return
+            }
+            
+            displayState = .pendingDismiss
             superview?.removeGestureRecognizer(gestureRecognizer)
+            layer.removeAllAnimations()
             
             UIView.animate(withDuration: 0.1, animations: {
                 self.animationConstraint?.update(offset: SimpleToastUX.toastHeight)
                 self.layoutIfNeeded()
             }) { finished in
+                self.displayState = .dismissed
                 self.removeFromSuperview()
                 if !buttonPressed {
                     self.completionHandler?(false)


### PR DESCRIPTION
- Fixes playlist toast being stuck due to animations conflicting with each other.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes https://github.com/brave/brave-ios/issues/3528

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
