### PR TITLE
Fix #3530 - Detecting file sizes for HLS streams!

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1101,7 +1101,7 @@ extension Strings {
         public static let addToPlayListAlertTitle =
             NSLocalizedString("playList.addToPlayListAlertTitle",
                               bundle: .braveShared,
-                              value: "Add to Playlist",
+                              value: "Add to Brave Playlist",
                               comment: "Alert Title for adding videos to playlist")
         
         public static let addToPlayListAlertDescription =
@@ -1155,7 +1155,7 @@ extension Strings {
         public static let toastAddToPlaylistTitle =
             NSLocalizedString("playList.toastAddToPlaylistTitle",
                               bundle: .braveShared,
-                              value: "Add to Playlist",
+                              value: "Add to Brave Playlist",
                               comment: "The title for the toast that shows up on a page containing a playlist item")
         
         public static let toastAddedToPlaylistTitle =
@@ -1203,13 +1203,13 @@ extension Strings {
         public static let playlistToastShowSettingsOptionTitle =
             NSLocalizedString("playlist.playlistToastShowSettingsOptionTitle",
                               bundle: .braveShared,
-                              value: "Show \"Add to Playlist\"",
+                              value: "Show \"Add to Brave Playlist\"",
                               comment: "Title for the Playlist Settings Option for Enable/Disable Add Toast")
         
         public static let playlistToastShowSettingsOptionFooterText =
             NSLocalizedString("playlist.playlistToastShowSettingsOptionFooterText",
                               bundle: .braveShared,
-                              value: "This option will ask you to 'Add to Playlist' on some media websites. You can still add media (video/audio) by long-pressing media, or from the \"Share With…\" menu button.",
+                              value: "This option will ask you to 'Add to Brave Playlist' on some media websites. You can still add media (video/audio) by long-pressing media, or from the \"Share With…\" menu button.",
                               comment: "Footer Text for the Playlist Settings Option for Enable/Disable Add Toast")
         
         public static let playlistAutoPlaySettingsOptionTitle =


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes HLS stream sizes by iterating through all the files in a `.movpkg`.
- Although `.movpkg` seems like a file, it is NOT.. It's a folder that contains all the media fragments of the stream.. and iOS does NOT give the correct folder size! So to get the size, we enumerate all files in the folder. This seems to be correct as it reports the exact same size as "Settings.app"! So now we have proper file sizes showing.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3530, fixes #3555

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
