### PR TITLE
Fix 3551 - Playlist performance on bad network

### DIFF
--- a/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
+++ b/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
@@ -86,7 +86,7 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     
     func downloadHLSAsset(_ assetUrl: URL, for item: PlaylistInfo) {
         if Thread.current.isMainThread {
-            self.hlsDelegate.downloadAsset(self.hlsSession, assetUrl: assetUrl, for: item)
+            hlsDelegate.downloadAsset(self.hlsSession, assetUrl: assetUrl, for: item)
         } else {
             hlsQueue.addOperation {  [weak self] in
                 guard let self = self else { return }
@@ -97,7 +97,7 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     
     func downloadFileAsset(_ assetUrl: URL, for item: PlaylistInfo) {
         if Thread.current.isMainThread {
-            self.fileDelegate.downloadAsset(self.fileSession, assetUrl: assetUrl, for: item)
+            fileDelegate.downloadAsset(self.fileSession, assetUrl: assetUrl, for: item)
         } else {
             fileQueue.addOperation {  [weak self] in
                 guard let self = self else { return }

--- a/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
+++ b/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
@@ -30,10 +30,12 @@ struct MediaDownloadTask {
 public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     private let hlsSession: AVAssetDownloadURLSession
     private let fileSession: URLSession
-    private let hlsDelegate: PlaylistHLSDownloadManager
-    private let fileDelegate: PlaylistFileDownloadManager
-    private var didRestoreSession = false
+    private let hlsDelegate = PlaylistHLSDownloadManager()
+    private let fileDelegate = PlaylistFileDownloadManager()
+    private let hlsQueue = OperationQueue.main
+    private let fileQueue = OperationQueue.main
     
+    private var didRestoreSession = false
     weak var delegate: PlaylistDownloadManagerDelegate?
     
     public enum DownloadState: String {
@@ -43,18 +45,15 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     }
     
     init() {
-        hlsDelegate = PlaylistHLSDownloadManager()
-        fileDelegate = PlaylistFileDownloadManager()
-        
         let hlsConfiguration = URLSessionConfiguration.background(withIdentifier: "com.brave.playlist.hls.background.session")
         hlsSession = AVAssetDownloadURLSession(configuration: hlsConfiguration,
                                                assetDownloadDelegate: hlsDelegate,
-                                               delegateQueue: OperationQueue())
+                                               delegateQueue: hlsQueue)
         
         let fileConfiguration = URLSessionConfiguration.background(withIdentifier: "com.brave.playlist.file.background.session")
         fileSession = URLSession(configuration: fileConfiguration,
                                  delegate: fileDelegate,
-                                 delegateQueue: OperationQueue())
+                                 delegateQueue: fileQueue)
         
         hlsDelegate.delegate = self
         fileDelegate.delegate = self
@@ -86,20 +85,67 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     }
     
     func downloadHLSAsset(_ assetUrl: URL, for item: PlaylistInfo) {
-        hlsDelegate.downloadAsset(hlsSession, assetUrl: assetUrl, for: item)
+        if Thread.current.isMainThread {
+            self.hlsDelegate.downloadAsset(self.hlsSession, assetUrl: assetUrl, for: item)
+        } else {
+            hlsQueue.addOperation {  [weak self] in
+                guard let self = self else { return }
+                self.hlsDelegate.downloadAsset(self.hlsSession, assetUrl: assetUrl, for: item)
+            }
+        }
     }
     
     func downloadFileAsset(_ assetUrl: URL, for item: PlaylistInfo) {
-        fileDelegate.downloadAsset(fileSession, assetUrl: assetUrl, for: item)
+        if Thread.current.isMainThread {
+            self.fileDelegate.downloadAsset(self.fileSession, assetUrl: assetUrl, for: item)
+        } else {
+            fileQueue.addOperation {  [weak self] in
+                guard let self = self else { return }
+                self.fileDelegate.downloadAsset(self.fileSession, assetUrl: assetUrl, for: item)
+            }
+        }
     }
     
     func cancelDownload(item: PlaylistInfo) {
-        hlsDelegate.cancelDownload(item: item)
-        fileDelegate.cancelDownload(item: item)
+        if Thread.current.isMainThread {
+            hlsDelegate.cancelDownload(item: item)
+            fileDelegate.cancelDownload(item: item)
+        } else {
+            hlsQueue.addOperation { [weak self] in
+                self?.hlsDelegate.cancelDownload(item: item)
+            }
+            
+            fileQueue.addOperation { [weak self] in
+                self?.fileDelegate.cancelDownload(item: item)
+            }
+        }
     }
     
     func downloadTask(for pageSrc: String) -> MediaDownloadTask? {
-        hlsDelegate.downloadTask(for: pageSrc) ?? fileDelegate.downloadTask(for: pageSrc)
+        if Thread.current.isMainThread {
+            return hlsDelegate.downloadTask(for: pageSrc) ?? fileDelegate.downloadTask(for: pageSrc)
+        }
+        
+        let group = DispatchGroup()
+
+        group.enter()
+        var hlsTask: MediaDownloadTask?
+        hlsQueue.addOperation { [weak self] in
+            defer { group.leave() }
+            guard let self = self else { return }
+            hlsTask = self.hlsDelegate.downloadTask(for: pageSrc)
+        }
+
+        group.enter()
+        var fileTask: MediaDownloadTask?
+        fileQueue.addOperation { [weak self] in
+            defer { group.leave() }
+            guard let self = self else { return }
+            fileTask = self.fileDelegate.downloadTask(for: pageSrc)
+        }
+
+        group.wait()
+        return hlsTask ?? fileTask
     }
     
     // MARK: - PlaylistStreamDownloadManagerDelegate
@@ -151,7 +197,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
     func restoreSession(_ session: AVAssetDownloadURLSession, completion: @escaping () -> Void) {
         session.getAllTasks { [weak self] tasks in
             defer {
-                DispatchQueue.main.async {
+                ensureMainThread {
                     completion()
                 }
             }
@@ -193,7 +239,9 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
         activeDownloadTasks[task] = MediaDownloadTask(id: item.pageSrc, name: item.name, asset: asset)
         task.resume()
 
-        delegate?.onDownloadStateChanged(streamDownloader: self, id: item.pageSrc, state: .inProgress, displayName: asset.displayNames(for: asset.preferredMediaSelection), error: nil)
+        DispatchQueue.main.async {
+            self.delegate?.onDownloadStateChanged(streamDownloader: self, id: item.pageSrc, state: .inProgress, displayName: nil, error: nil)
+        }
     }
     
     func cancelDownload(item: PlaylistInfo) {
@@ -235,7 +283,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
         aggregateAssetDownloadTask.resume()
         
         DispatchQueue.main.async {
-            self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .inProgress, displayName: mediaSelection.asset?.displayNames(for: mediaSelection), error: nil)
+            self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .inProgress, displayName: nil, error: nil)
         }
     }
     
@@ -324,7 +372,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
     func restoreSession(_ session: URLSession, completion: @escaping () -> Void) {
         session.getAllTasks { [weak self] tasks in
             defer {
-                DispatchQueue.main.async {
+                ensureMainThread {
                     completion()
                 }
             }
@@ -333,13 +381,15 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
             
             for task in tasks {
                 guard let pageSrc = task.taskDescription else { break }
-                
-                if let item = PlaylistItem.getItem(pageSrc: pageSrc),
-                   let mediaSrc = item.mediaSrc,
-                   let assetUrl = URL(string: mediaSrc) {
-                    let info = PlaylistInfo(item: item)
-                    let asset = MediaDownloadTask(id: info.pageSrc, name: info.name, asset: AVURLAsset(url: assetUrl))
-                    self.activeDownloadTasks[task] = asset
+
+                ensureMainThread {
+                    if let item = PlaylistItem.getItem(pageSrc: pageSrc),
+                       let mediaSrc = item.mediaSrc,
+                       let assetUrl = URL(string: mediaSrc) {
+                        let info = PlaylistInfo(item: item)
+                        let asset = MediaDownloadTask(id: info.pageSrc, name: info.name, asset: AVURLAsset(url: assetUrl))
+                        self.activeDownloadTasks[task] = asset
+                    }
                 }
             }
         }
@@ -364,7 +414,9 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
         activeDownloadTasks[task] = MediaDownloadTask(id: item.pageSrc, name: item.name, asset: asset)
         task.resume()
         
-        delegate?.onDownloadStateChanged(streamDownloader: self, id: item.pageSrc, state: .inProgress, displayName: asset.displayNames(for: asset.preferredMediaSelection), error: nil)
+        DispatchQueue.main.async {
+            self.delegate?.onDownloadStateChanged(streamDownloader: self, id: item.pageSrc, state: .inProgress, displayName: nil, error: nil)
+        }
     }
     
     func cancelDownload(item: PlaylistInfo) {

--- a/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
+++ b/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
@@ -161,8 +161,7 @@ class PlaylistCell: UITableViewCell {
             return UIEdgeInsets(top: 0, left: self.titleLabel.frame.origin.x, bottom: 0, right: 0)
         }
         
-        set (newValue) {
-            // swiftlint:disable:this unused_setter_value
+        set (newValue) { // swiftlint:disable:this unused_setter_value
             super.separatorInset = UIEdgeInsets(top: 0, left: self.titleLabel.frame.origin.x, bottom: 0, right: 0)
         }
     }

--- a/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
+++ b/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
@@ -161,7 +161,7 @@ class PlaylistCell: UITableViewCell {
             return UIEdgeInsets(top: 0, left: self.titleLabel.frame.origin.x, bottom: 0, right: 0)
         }
         
-        set (newValue) { // swiftlint:disable:this unused_setter_value
+        set { // swiftlint:disable:this unused_setter_value
             super.separatorInset = UIEdgeInsets(top: 0, left: self.titleLabel.frame.origin.x, bottom: 0, right: 0)
         }
     }

--- a/Client/Frontend/Browser/Playlist/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistViewController.swift
@@ -536,6 +536,14 @@ extension ListController: UITableViewDataSource {
             return UITableViewCell()
         }
         
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard let cell = cell as? PlaylistCell else {
+            return
+        }
+        
         let item = PlaylistManager.shared.itemAtIndex(indexPath.row)
         
         cell.do {
@@ -551,7 +559,9 @@ extension ListController: UITableViewDataSource {
         let cacheState = PlaylistManager.shared.state(for: item.pageSrc)
         switch cacheState {
         case .inProgress:
-            cell.detailLabel.text = Strings.PlayList.savingForOfflineLabelTitle
+            getAssetDurationFormatted(item: item) {
+                cell.detailLabel.text = "\($0) - \(Strings.PlayList.savingForOfflineLabelTitle)"
+            }
         case .downloaded:
             if let itemSize = PlaylistManager.shared.sizeOfDownloadedItem(for: item.pageSrc) {
                 getAssetDurationFormatted(item: item) {
@@ -591,8 +601,6 @@ extension ListController: UITableViewDataSource {
                 PlaylistItem.updateItem(newItem)
             }
         }
-        
-        return cell
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix playlist performance on bad networks (Previously, if you download multiple items at the same time on a really bad network, the playlist UI locks up.. which means the main-thread locks up, and therefore even tabs, etc are blocked from loading and doing anything else).
- Fixed by moving everything to `willDisplayCell(forRow at:)` instead of `cellForRow(at:)` because `cellForRow(at:)` will re-configure the cell no matter what, even if it is already properly displaying and you just want to modify one thing.
- Fixed by moving callbacks to hlsQueue and fileQueue and dispatching to main only when UI needs updating.
- Fixed crash by making callbacks serial.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3551

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
