### PR TITLE
Fix 3558 - Fixing live streams not showing up in ShareMenu's AddToPlaylist

### DIFF
--- a/Client/Frontend/Browser/Playlist/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistViewController.swift
@@ -437,7 +437,7 @@ extension ListController: UITableViewDataSource {
     }
     
     private func getAssetDuration(item: PlaylistInfo, _ completion: @escaping (TimeInterval, AVAsset?) -> Void) {
-        let tolerance: Float = 0.00001
+        let tolerance: Double = 0.00001
         let distance = abs(item.duration.distance(to: 0.0))
         
         // If the database duration is 0.0
@@ -450,7 +450,7 @@ extension ListController: UITableViewDataSource {
                     completion(track.timeRange.duration.seconds, asset)
                 } else if let track = asset.tracks(withMediaType: .audio).first {
                     completion(track.timeRange.duration.seconds, asset)
-                } else if abs(asset.duration.seconds.distance(to: 0.0)) < Double(tolerance) {
+                } else if abs(asset.duration.seconds.distance(to: 0.0)) < tolerance {
                     
                     // We can't get the duration synchronously so we need to let the AVAsset load the media item
                     // and hopefully we get a valid duration from that.
@@ -464,13 +464,13 @@ extension ListController: UITableViewDataSource {
                             duration = asset.duration.seconds
                         }
                         
-                        if abs(asset.duration.seconds.distance(to: 0.0)) > Double(tolerance) {
+                        if abs(asset.duration.seconds.distance(to: 0.0)) > tolerance {
                             let newItem = PlaylistInfo(name: item.name,
                                                        src: item.src,
                                                        pageSrc: item.pageSrc,
                                                        pageTitle: item.pageTitle,
                                                        mimeType: item.mimeType,
-                                                       duration: Float(duration),
+                                                       duration: duration,
                                                        detected: item.detected,
                                                        dateAdded: item.dateAdded)
                             
@@ -573,19 +573,19 @@ extension ListController: UITableViewDataSource {
         loadThumbnail(item: item, cell: cell) { newTrackDuration in
             guard let newTrackDuration = newTrackDuration else { return }
             
-            let tolerance: Float = 0.00001
+            let tolerance: Double = 0.00001
             let existingDistance = abs(item.duration.distance(to: 0.0))
             let newDistance = abs(newTrackDuration.distance(to: 0.0))
             
             // If the database duration is 0.0
             // and the new duration != 0.0
-            if existingDistance < tolerance && Float(newDistance) > tolerance {
+            if existingDistance < tolerance && newDistance > tolerance {
                 let newItem = PlaylistInfo(name: item.name,
                                            src: item.src,
                                            pageSrc: item.pageSrc,
                                            pageTitle: item.pageTitle,
                                            mimeType: item.mimeType,
-                                           duration: Float(newTrackDuration),
+                                           duration: newTrackDuration,
                                            detected: item.detected,
                                            dateAdded: item.dateAdded)
                 PlaylistItem.updateItem(newItem)

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -20,6 +20,25 @@ if (!window.__firefox__.includeOnce) {
 // MARK: - Media Detection
 
 window.__firefox__.includeOnce("$<Playlist>", function() {
+    function is_nan(value) {
+        return typeof value === "number" && value !== value;
+    }
+    
+    function is_infinite(value) {
+        return typeof value === "number" && (maxNumber === Infinity || value === -Infinity);
+    }
+    
+    function clamp_duration(value) {
+        if (is_nan(value)) {
+            return 0.0;
+        }
+        
+        if (is_infinite(value)) {
+            return Number.MAX_VALUE;
+        }
+        return value;
+    }
+    
     function $<sendMessage>(message) {
         if (window.webkit.messageHandlers.$<handler>) {
             window.webkit.messageHandlers.$<handler>.postMessage(message);
@@ -41,7 +60,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                     "pageSrc": window.location.href,
                     "pageTitle": document.title,
                     "mimeType": type,
-                    "duration": target.duration !== target.duration ? 0.0 : target.duration,
+                    "duration": clamp_duration(target.duration),
                     "detected": false,
                 });
             }
@@ -56,7 +75,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                                 "pageSrc": window.location.href,
                                 "pageTitle": document.title,
                                 "mimeType": type,
-                                "duration": target.duration !== target.duration ? 0.0 : target.duration,
+                                "duration": clamp_duration(target.duration),
                                 "detected": false,
                             });
                         }
@@ -69,7 +88,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                                 "pageSrc": window.location.href,
                                 "pageTitle": document.title,
                                 "mimeType": type,
-                                "duration": target.duration !== target.duration ? 0.0 : target.duration,
+                                "duration": clamp_duration(target.duration),
                                 "detected": false,
                             });
                         }
@@ -214,7 +233,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                     "pageSrc": window.location.href,
                     "pageTitle": document.title,
                     "mimeType": mimeType,
-                    "duration": node.duration !== node.duration ? 0.0 : node.duration,
+                    "duration": clamp_duration(node.duration),
                     "detected": true
                 });
             } else {
@@ -229,7 +248,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                                 "pageSrc": window.location.href,
                                 "pageTitle": document.title,
                                 "mimeType": mimeType,
-                                "duration": target.duration !== target.duration ? 0.0 : target.duration,
+                                "duration": clamp_duration(target.duration),
                     "detected": true
                             });
                         }
@@ -242,7 +261,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                                 "pageSrc": window.location.href,
                                 "pageTitle": document.title,
                                 "mimeType": mimeType,
-                                "duration": target.duration !== target.duration ? 0.0 : target.duration,
+                                "duration": clamp_duration(target.duration),
                     "detected": true
                             });
                         }

--- a/Data/models/Model.xcdatamodeld/Model11.xcdatamodel/contents
+++ b/Data/models/Model.xcdatamodeld/Model11.xcdatamodel/contents
@@ -90,7 +90,7 @@
     <entity name="PlaylistItem" representedClassName=".PlaylistItem" syncable="YES">
         <attribute name="cachedData" optional="YES" attributeType="Binary"/>
         <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="duration" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="mediaSrc" attributeType="String"/>
         <attribute name="mimeType" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
@@ -128,8 +128,8 @@
         <element name="Favicon" positionX="439" positionY="-414" width="128" height="120"/>
         <element name="FeedSourceOverride" positionX="-279" positionY="-297" width="128" height="28"/>
         <element name="History" positionX="493" positionY="-150" width="128" height="135"/>
+        <element name="PlaylistItem" positionX="-279" positionY="-297" width="128" height="178"/>
         <element name="RSSFeedSource" positionX="-270" positionY="-288" width="128" height="73"/>
         <element name="TabMO" positionX="-488" positionY="-229" width="128" height="210"/>
-        <element name="PlaylistItem" positionX="-279" positionY="-297" width="128" height="178"/>
     </elements>
 </model>

--- a/Data/models/PlaylistInfo.swift
+++ b/Data/models/PlaylistInfo.swift
@@ -15,7 +15,7 @@ public struct PlaylistInfo: Codable {
     public let pageSrc: String
     public let pageTitle: String
     public let mimeType: String
-    public let duration: Float
+    public let duration: TimeInterval
     public let detected: Bool
     public let dateAdded: Date
     
@@ -30,7 +30,7 @@ public struct PlaylistInfo: Codable {
         self.detected = false
     }
     
-    public init(name: String, src: String, pageSrc: String, pageTitle: String, mimeType: String, duration: Float, detected: Bool, dateAdded: Date) {
+    public init(name: String, src: String, pageSrc: String, pageTitle: String, mimeType: String, duration: TimeInterval, detected: Bool, dateAdded: Date) {
         self.name = name
         self.src = src
         self.pageSrc = pageSrc
@@ -48,7 +48,7 @@ public struct PlaylistInfo: Codable {
         self.pageSrc = try container.decode(String.self, forKey: .pageSrc)
         self.pageTitle = try container.decode(String.self, forKey: .pageTitle)
         self.mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""
-        self.duration = try container.decodeIfPresent(Float.self, forKey: .duration) ?? 0.0
+        self.duration = try container.decodeIfPresent(TimeInterval.self, forKey: .duration) ?? 0.0
         self.detected = try container.decodeIfPresent(Bool.self, forKey: .detected) ?? false
         self.dateAdded = Date()
     }

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -13,7 +13,7 @@ private let log = Logger.browserLogger
 final public class PlaylistItem: NSManagedObject, CRUD {
     @NSManaged public var cachedData: Data?
     @NSManaged public var dateAdded: Date?
-    @NSManaged public var duration: Float
+    @NSManaged public var duration: TimeInterval
     @NSManaged public var mediaSrc: String?
     @NSManaged public var mimeType: String?
     @NSManaged public var name: String?


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix the json passed to `JSONSerialization.isValidJSONObject(message.body)` so that it parses infinite numbers properly. This happens when a stream is live and the duration is `+inf`. If parsed, it returns false, as it parses as a float instead of a double. The solution is to cap/clamp `+inf` from JS to max native float/double.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3558

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
