### PR TITLE
Fix #3556- Remove HTTPS Upgrade Educational Pop-Over

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -960,12 +960,6 @@ extension Strings {
                               value: "%ld+ trackers & ads blocked on this page.",
                               comment: "Title for Shield Education Tracker Ad Count Block when block count raises over the defined limit. The parameter substituted for \"%ld\" is the limit of the trackers and ads blocked on the page when education pop over is presented. E.g.: 10+ trackers & ads blocked on the page")
         
-        public static let encryptedConnectionWarningTitle =
-            NSLocalizedString("shieldEducation.encryptedConnectionWarningTitle",
-                              bundle: .braveShared,
-                              value: "Your connection is now encrypted.",
-                              comment: "Title for Shield Education Encrypted Connection Warning")
-        
         public static let trackerCountShareSubtitle =
             NSLocalizedString("shieldEducation.trackerCountShareSubtitle",
                               bundle: .braveShared,
@@ -989,12 +983,6 @@ extension Strings {
                               bundle: .braveShared,
                               value: "Brave Shields protects your online privacy on every site.",
                               comment: "Subtitle for Shield Education Tracker Ad Count Block")
-        
-        public static let encryptedConnectionWarningSubtitle =
-            NSLocalizedString("shieldEducation.encryptedConnectionWarningSubtitle",
-                              bundle: .braveShared,
-                              value: "If available, Brave upgrades you to a secure connection automatically.",
-                              comment: "Subtitle for Shield Education Encrypted Connection Warning")
         
         public static let educationInspectTitle =
             NSLocalizedString("shieldEducation.inspectTitle",

--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -85,7 +85,6 @@ extension Preferences {
     public final class ProductNotificationBenchmarks {
         public static let firstTimeBlockingShown = Option<Bool>(key: "product-benchmark.firstTimeBlocking", default: false)
         public static let privacyProtectionBlockShown = Option<Bool>(key: "product-benchmark.privacyProtectionBlockShown", default: false)
-        public static let httpsUpgradeShown = Option<Bool>(key: "product-benchmark.httpsUpgradeShown", default: false)
         public static let videoAdBlockShown = Option<Bool>(key: "product-benchmark.videoAdBlockShown", default: false)
         public static let trackerTierCount = Option<Int>(key: "product-benchmark.trackerTierCount", default: 0)
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -111,17 +111,7 @@ extension BrowserViewController {
             return
         }
         
-        // Step 4: Https Upgrade
-        if !Preferences.ProductNotificationBenchmarks.httpsUpgradeShown.value,
-           contentBlockerStats.httpsCount > 0 {
-
-            notifyHttpsUpgrade(theme: Theme.of(selectedTab))
-            Preferences.ProductNotificationBenchmarks.httpsUpgradeShown.value = true
-
-            return
-        }
-        
-        // Step 5: Share Brave Benchmark Tiers
+        // Step 4: Share Brave Benchmark Tiers
         // Benchmark Tier Pop-Over only exist in JP locale
         if Locale.current.regionCode == "JP" {
             let numOfTrackerAds = BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection
@@ -162,12 +152,6 @@ extension BrowserViewController {
     
     private func notifyPrivacyProtectBlock(theme: Theme) {
         let shareTrackersViewController = ShareTrackersController(theme: theme, trackingType: .trackerAdCountBlock(count: benchmarkNumberOfTrackers))
-        dismiss(animated: true)
-        showBenchmarkNotificationPopover(controller: shareTrackersViewController)
-    }
-    
-    private func notifyHttpsUpgrade(theme: Theme) {
-        let shareTrackersViewController = ShareTrackersController(theme: theme, trackingType: .encryptedConnectionWarning)
         dismiss(animated: true)
         showBenchmarkNotificationPopover(controller: shareTrackersViewController)
     }

--- a/Client/Frontend/Shields/ShareTrackersController.swift
+++ b/Client/Frontend/Shields/ShareTrackersController.swift
@@ -16,7 +16,6 @@ enum TrackingType: Equatable {
     case trackerAdWarning
     case videoAdBlock
     case trackerAdCountBlock(count: Int)
-    case encryptedConnectionWarning
     
     var title: String {
         switch self {
@@ -28,8 +27,6 @@ enum TrackingType: Equatable {
                 return Strings.ShieldEducation.videoAdBlockTitle
             case .trackerAdCountBlock(let count):
                 return String(format: Strings.ShieldEducation.trackerAdCountBlockTitle, count)
-            case .encryptedConnectionWarning:
-                return Strings.ShieldEducation.encryptedConnectionWarningTitle
         }
     }
     
@@ -43,8 +40,6 @@ enum TrackingType: Equatable {
                 return Strings.ShieldEducation.videoAdBlockSubtitle
             case .trackerAdCountBlock:
                 return Strings.ShieldEducation.trackerAdCountBlockSubtitle
-            case .encryptedConnectionWarning:
-                return Strings.ShieldEducation.encryptedConnectionWarningSubtitle
         }
     }
 }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3556

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Clean install 1.25 build
- Visit a page to trigger ad block tooltip
- Visit radio.garden which is a http page, witness connection encrypted tooltip not getting triggered

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
