### PR TITLE
Fix #3550 - Last Visited toggle not showing Desktop bookmarks folder in hierarchy

### DIFF
--- a/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
+++ b/Client/Frontend/Sync/BraveCore/Bookmarkv2.swift
@@ -137,7 +137,8 @@ class Bookmarkv2: WebsitePresentable {
     }
     
     public static func lastFolderPath() -> [Bookmarkv2] {
-        if let nodeId = Preferences.Chromium.lastBookmarksFolderNodeId.value,
+        if Preferences.General.showLastVisitedBookmarksFolder.value,
+           let nodeId = Preferences.Chromium.lastBookmarksFolderNodeId.value,
            var folderNode = Bookmarkv2.bookmarksAPI.getNodeById(nodeId),
            folderNode.isVisible {
             


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixed last visited folder bug where it stopped showing Desktop bookmarks folder in the hierarchy.
- Updated to iOS 13+ APIs for swipe to delete.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3550

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
