### PR TITLE
[No-Bug] - Allow audio only media tracks to show particle emitter.

### DIFF
--- a/Client/Frontend/Browser/Playlist/VideoPlayer/VideoPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/VideoPlayer.swift
@@ -487,10 +487,7 @@ public class VideoView: UIView, VideoTrackerBarDelegate {
         } else {
             // If the overlay is showing, hide the particle view.. else show it..
             except.append(particleView)
-            
-            if !showOverlay {
-                display.append(particleView)
-            }
+            display.append(particleView)
         }
         
         UIView.animate(withDuration: 1.0, delay: 0.0, usingSpringWithDamping: 1.0, initialSpringVelocity: 1.0, options: [.curveEaseInOut, .allowUserInteraction], animations: {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
 - Allow audio only media tracks to show particle emitter even when the overlay is showing. Otherwise it would only show a black screen which is undesirable (especially on iPad).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
