### PR TITLE
[Playlist] - Fix double tap to zoom and added swipe down to PlaylistToast.

### DIFF
--- a/Client/Frontend/Browser/Playlist/PlaylistToast.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistToast.swift
@@ -60,6 +60,11 @@ class PlaylistToast: Toast {
         self.snp.makeConstraints {
             $0.height.equalTo(ButtonToastUX.toastHeight)
         }
+        
+        toastView.addGestureRecognizer(UISwipeGestureRecognizer(target: self,
+                                                                action: #selector(onSwipeToDismiss(_:))).then {
+            $0.direction = [.down]
+        })
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -258,5 +263,10 @@ class PlaylistToast: Toast {
                 $0.edges.equalToSuperview()
             }
         }
+    }
+    
+    @objc
+    private func onSwipeToDismiss(_ gestureRecognizer: UISwipeGestureRecognizer) {
+        self.dismiss(false)
     }
 }

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/VideoPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/VideoPlayer.swift
@@ -156,6 +156,7 @@ public class VideoView: UIView, VideoTrackerBarDelegate {
         let overlayDoubleTappedGesture = UITapGestureRecognizer(target: self, action: #selector(onOverlayDoubleTapped(_:))).then {
             $0.numberOfTapsRequired = 2
             $0.numberOfTouchesRequired = 1
+            $0.delegate = self
         }
         
         addGestureRecognizer(overlayTappedGesture)
@@ -731,6 +732,19 @@ public class VideoView: UIView, VideoTrackerBarDelegate {
         // We do this because for m3u8 HLS streams,
         // tracks may not always be available and the particle effect will show even on videos..
         // It's best to assume this type of media is a video stream.
+        return true
+    }
+}
+
+extension VideoView: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        let location = touch.location(in: self)
+        let restrictedViews = [infoView, controlsView]
+        for view in restrictedViews {
+            if view.point(inside: self.convert(location, to: view), with: nil) {
+                return false
+            }
+        }
         return true
     }
 }


### PR DESCRIPTION
## Summary of Changes

- Fix double tap to zoom interfering with spam tapping rewind.
- Fix swipe down to dismiss playlist toast.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3574, fixes #3575 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
