### PR TITLE
Fix #3572: Opening PDF crashes in Brave release and Dev

### DIFF
--- a/Data/models/FaviconMO.swift
+++ b/Data/models/FaviconMO.swift
@@ -8,8 +8,8 @@ import Storage
 public final class FaviconMO: NSManagedObject, CRUD {
     
     @NSManaged public var url: String?
-    @NSManaged public var width: Int16
-    @NSManaged public var height: Int16
+    @NSManaged public var width: Int32
+    @NSManaged public var height: Int32
     @NSManaged public var type: Int16
     @NSManaged public var domain: Domain?
 
@@ -29,8 +29,8 @@ public final class FaviconMO: NSManagedObject, CRUD {
                                                           saveStrategy: strategy)
             }
             
-            let w = Int16(favicon.width ?? 0)
-            let h = Int16(favicon.height ?? 0)
+            let w = Int32(favicon.width ?? 0)
+            let h = Int32(favicon.height ?? 0)
             let t = Int16(favicon.type?.rawValue ?? 0)
             
             if w != item!.width && w > 0 {

--- a/Data/models/Model.xcdatamodeld/Model11.xcdatamodel/contents
+++ b/Data/models/Model.xcdatamodeld/Model11.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="19H114" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Bookmark" representedClassName=".Favorite" syncable="YES">
         <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="customTitle" optional="YES" attributeType="String"/>
@@ -61,10 +61,10 @@
         </fetchIndex>
     </entity>
     <entity name="Favicon" representedClassName=".FaviconMO" syncable="YES">
-        <attribute name="height" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="height" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="url" optional="YES" attributeType="String"/>
-        <attribute name="width" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="width" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="favicon" inverseEntity="Domain"/>
     </entity>
     <entity name="FeedSourceOverride" representedClassName=".FeedSourceOverride" syncable="YES">
@@ -125,7 +125,7 @@
         <element name="Bookmark" positionX="0" positionY="-450" width="155" height="285"/>
         <element name="Device" positionX="-252" positionY="-207" width="128" height="150"/>
         <element name="Domain" positionX="225" positionY="-321" width="128" height="240"/>
-        <element name="Favicon" positionX="439" positionY="-414" width="128" height="120"/>
+        <element name="Favicon" positionX="439" positionY="-414" width="128" height="104"/>
         <element name="FeedSourceOverride" positionX="-279" positionY="-297" width="128" height="28"/>
         <element name="History" positionX="493" positionY="-150" width="128" height="135"/>
         <element name="PlaylistItem" positionX="-279" positionY="-297" width="128" height="178"/>


### PR DESCRIPTION
The crash is not related with pdf, the example website has weird dimension for fav_icon and Int_16 is nit enough to store.

Changing Favicon dimensions to Int32 so it will not overflow and crash in some websites.

## Summary of Changes

This pull request fixes #3572

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open https://almanacbeer.com/s/QR-MENU-42421-2-1.pdf
- Observe pdf is opening successful

## Screenshots:

https://user-images.githubusercontent.com/6643505/116102075-5eb4e100-a67c-11eb-8314-a0d73b2a7a2c.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
