### PR TITLE
Fix#3389: Implement NTP Tutorial Page

### DIFF
--- a/BraveShared/BraveUX.swift
+++ b/BraveShared/BraveUX.swift
@@ -12,6 +12,7 @@ public struct BraveUX {
     public static let braveTermsOfUseURL = URL(string: "https://www.brave.com/terms_of_use")!
     public static let prefKeyOptInDialogWasSeen = "OptInDialogWasSeen"
     public static let prefKeyUserAllowsTelemetry = "userallowstelemetry"
+    public static let ntpTutorialPageURL = URL(string: "https://brave.com/ja/ntp-tutorial")
     
     public static let maxTabsInMemory = 9
     

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 		2FCAE33E1ABB5F1800877008 /* Storage-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FCAE33D1ABB5F1800877008 /* Storage-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2FD0E3AF2576C48A000C773B /* SchemePermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */; };
 		2FD0E3D62577F327000C773B /* SearchSuggestionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */; };
+		2FD1C61C2639AE9100E3C25F /* BrowserViewController+Onboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD1C61B2639AE9100E3C25F /* BrowserViewController+Onboarding.swift */; };
 		2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */; };
 		2FDF290825DEE265001E5C87 /* AddToPlaylistActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDF290725DEE265001E5C87 /* AddToPlaylistActivity.swift */; };
 		2FE5B42B2580216700BFDDB8 /* ShareTrackersController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE5B42A2580216700BFDDB8 /* ShareTrackersController.swift */; };
@@ -1968,6 +1969,7 @@
 		2FCAE33D1ABB5F1800877008 /* Storage-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Storage-Bridging-Header.h"; sourceTree = "<group>"; };
 		2FD0E3AE2576C48A000C773B /* SchemePermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemePermissionTests.swift; sourceTree = "<group>"; };
 		2FD0E3D52577F327000C773B /* SearchSuggestionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionCell.swift; sourceTree = "<group>"; };
+		2FD1C61B2639AE9100E3C25F /* BrowserViewController+Onboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+Onboarding.swift"; sourceTree = "<group>"; };
 		2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefsTests.swift; sourceTree = "<group>"; };
 		2FDF290725DEE265001E5C87 /* AddToPlaylistActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToPlaylistActivity.swift; sourceTree = "<group>"; };
 		2FE5B42A2580216700BFDDB8 /* ShareTrackersController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTrackersController.swift; sourceTree = "<group>"; };
@@ -4850,6 +4852,7 @@
 				2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */,
 				2FB9C2A02587E742009DA1FE /* BrowserViewController+ProductNotification.swift */,
 				2F45B409263AF1C20033A594 /* BrowserViewController+ToolbarDelegate.swift */,
+				2FD1C61B2639AE9100E3C25F /* BrowserViewController+Onboarding.swift */,
 				0A91598822B834CE00CCC119 /* BVC+Rewards.swift */,
 				2F55443025913BAA000E4689 /* OpenSearch */,
 			);
@@ -7225,6 +7228,7 @@
 				4422D4BB21BFFB7600BF1855 /* cache.cc in Sources */,
 				CA439A9025E80EE400FE9150 /* VideoPlayerTrackbar.swift in Sources */,
 				0A39FEA0248660EA00290ABC /* VPNConstants.m in Sources */,
+				2FD1C61C2639AE9100E3C25F /* BrowserViewController+Onboarding.swift in Sources */,
 				39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */,
 				4422D4B721BFFB7600BF1855 /* filter_policy.cc in Sources */,
 				27036EA325671817004EF6B6 /* FeedCardFooterButton.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -933,6 +933,11 @@ class BrowserViewController: UIViewController {
         screenshotHelper.takePendingScreenshots(tabManager.allTabs)
 
         super.viewDidAppear(animated)
+        
+        // NTP Education Load after onboarding screen
+        if showNTPEducation().isEnabled, let url = showNTPEducation().url {
+            tabManager.selectedTab?.loadRequest(PrivilegedRequest(url: url) as URLRequest)
+        }
 
         if shouldShowWhatsNewTab() {
             // Only display if the SUMO topic has been configured in the Info.plist (present and not empty)
@@ -1129,6 +1134,17 @@ class BrowserViewController: UIViewController {
         }
 
         return latestMajorAppVersion != AppInfo.majorAppVersion && DeviceInfo.hasConnectivity()
+    }
+    
+    /// New Tab Page Education screen should load after onboarding is finished and user is on locale JP
+    /// - Returns: A tuple which shows NTP Edication is enabled and URL to be loaed
+    fileprivate func showNTPEducation() -> (isEnabled: Bool, url: URL?) {
+        guard Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue,
+              let url = AppInfo.ntpTutorialPageURL else {
+            return (false, nil)
+        }
+
+        return (Locale.current.regionCode == "JP", url)
     }
 
     fileprivate func showQueuedAlertIfAvailable() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -117,7 +117,7 @@ extension BrowserViewController {
     /// New Tab Page Education screen should load after onboarding is finished and user is on locale JP
     /// - Returns: A tuple which shows NTP Edication is enabled and URL to be loaed
     fileprivate func showNTPEducation() -> (isEnabled: Bool, url: URL?) {
-        guard let url = AppInfo.ntpTutorialPageURL else {
+        guard let url = BraveUX.ntpTutorialPageURL else {
             return (false, nil)
         }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -1,0 +1,189 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveShared
+import BraveUI
+import Shared
+import BraveRewards
+
+// MARK: - Onboarding
+
+extension BrowserViewController {
+    
+    func presentOnboardingIntro(_ completion: @escaping () -> Void) {
+        if Preferences.DebugFlag.skipOnboardingIntro == true { return }
+        
+        // 1. Existing user.
+        // 2. User already completed onboarding.
+        if Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue {
+            // The user doesn't have ads in their region and they've completed rewards.
+            if !BraveAds.isCurrentLocaleSupported()
+                &&
+                Preferences.General.basicOnboardingProgress.value == OnboardingProgress.rewards.rawValue {
+                return
+            }
+        }
+        
+        // The user either skipped or didn't complete onboarding.
+        let isRewardsEnabled = rewards.isEnabled
+        let currentProgress = OnboardingProgress(rawValue: Preferences.General.basicOnboardingProgress.value) ?? .none
+        
+        // 1. Existing user.
+        // 2. The user skipped onboarding before.
+        // 3. 60 days have passed since they last saw onboarding.
+        if Preferences.General.basicOnboardingCompleted.value == OnboardingState.skipped.rawValue {
+
+            guard let daysUntilNextPrompt = Preferences.General.basicOnboardingNextOnboardingPrompt.value else {
+                return
+            }
+            
+            // 60 days has passed since the user last saw the onboarding.. it's time to show the onboarding again..
+            if daysUntilNextPrompt <= Date() && !isRewardsEnabled {
+                guard let onboarding = OnboardingNavigationController(
+                    profile: profile,
+                    onboardingType: .existingUserRewardsOff(currentProgress),
+                    rewards: rewards,
+                    theme: Theme.of(tabManager.selectedTab)
+                    ) else { return }
+                
+                onboarding.onboardingDelegate = self
+                present(onboarding, animated: true)
+                
+                Preferences.General.basicOnboardingNextOnboardingPrompt.value = Date(timeIntervalSinceNow: BrowserViewController.onboardingDaysInterval)
+            }
+            
+            return
+        }
+        
+        // 1. Rewards are on/off (existing user)
+        // 2. User hasn't seen the rewards part of the onboarding yet.
+        if (Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue)
+            &&
+            (Preferences.General.basicOnboardingProgress.value == OnboardingProgress.searchEngine.rawValue) {
+            
+            guard !isRewardsEnabled, let onboarding = OnboardingNavigationController(
+                profile: profile,
+                onboardingType: .existingUserRewardsOff(currentProgress),
+                rewards: rewards,
+                theme: Theme.of(tabManager.selectedTab)
+                ) else { return }
+            
+            onboarding.onboardingDelegate = self
+            present(onboarding, animated: true)
+            return
+        }
+        
+        // 1. Rewards are on/off (existing user)
+        // 2. User hasn't seen the rewards part of the onboarding yet because their version of the app is insanely OLD and somehow the progress value doesn't exist.
+        if (Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue)
+            &&
+            (Preferences.General.basicOnboardingProgress.value == OnboardingProgress.none.rawValue) {
+            
+            guard !isRewardsEnabled, let onboarding = OnboardingNavigationController(
+                profile: profile,
+                onboardingType: .existingUserRewardsOff(currentProgress),
+                rewards: rewards,
+                theme: Theme.of(tabManager.selectedTab)
+                ) else { return }
+            
+            onboarding.onboardingDelegate = self
+            present(onboarding, animated: true)
+            return
+        }
+        
+        // 1. User is brand new
+        // 2. User hasn't completed onboarding
+        // 3. We don't care how much progress they made. Onboarding is only complete when ALL of it is complete.
+        if Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue {
+            // The user has never completed the onboarding..
+            
+            guard let onboarding = OnboardingNavigationController(
+                profile: profile,
+                onboardingType: .newUser(currentProgress),
+                rewards: rewards,
+                theme: Theme.of(tabManager.selectedTab)
+                ) else { return }
+            
+            onboarding.onboardingDelegate = self
+            present(onboarding, animated: true)
+            completion()
+            
+            return
+        }
+    }
+    
+    /// New Tab Page Education screen should load after onboarding is finished and user is on locale JP
+    /// - Returns: A tuple which shows NTP Edication is enabled and URL to be loaed
+    fileprivate func showNTPEducation() -> (isEnabled: Bool, url: URL?) {
+        guard let url = AppInfo.ntpTutorialPageURL else {
+            return (false, nil)
+        }
+
+        return (Locale.current.regionCode == "JP", url)
+    }
+}
+
+// MARK: OnboardingControllerDelegate
+
+extension BrowserViewController: OnboardingControllerDelegate {
+    
+    func onboardingCompleted(_ onboardingController: OnboardingNavigationController) {
+        Preferences.General.basicOnboardingCompleted.value = OnboardingState.completed.rawValue
+        Preferences.General.basicOnboardingNextOnboardingPrompt.value = nil
+        
+        if BraveRewards.isAvailable {
+            switch onboardingController.onboardingType {
+            case .newUser:
+                Preferences.General.basicOnboardingProgress.value = OnboardingProgress.rewards.rawValue
+            default:
+                break
+            }
+        } else {
+            switch onboardingController.onboardingType {
+            case .newUser:
+                Preferences.General.basicOnboardingProgress.value = OnboardingProgress.searchEngine.rawValue
+            case .existingUserRewardsOff:
+                break
+            default:
+                break
+            }
+        }
+        
+        // Present private browsing prompt if necessary when onboarding has been completed
+        onboardingController.dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
+            
+            // NTP Education Load after onboarding screen
+            if self.shouldShowNTPEducation,
+               self.showNTPEducation().isEnabled,
+               let url = self.showNTPEducation().url {
+                self.tabManager.selectedTab?.loadRequest(PrivilegedRequest(url: url) as URLRequest)
+            }
+            
+            self.presentDuckDuckGoCalloutIfNeeded()
+        }
+    }
+    
+    func onboardingSkipped(_ onboardingController: OnboardingNavigationController) {
+        Preferences.General.basicOnboardingCompleted.value = OnboardingState.skipped.rawValue
+        Preferences.General.basicOnboardingNextOnboardingPrompt.value = Date(timeIntervalSinceNow: BrowserViewController.onboardingDaysInterval)
+        
+        // Present private browsing prompt if necessary when onboarding has been skipped
+        onboardingController.dismiss(animated: true) {
+            self.presentDuckDuckGoCalloutIfNeeded()
+        }
+    }
+    
+    func presentDuckDuckGoCalloutIfNeeded() {
+        if PrivateBrowsingManager.shared.isPrivateBrowsing && self.presentedViewController == nil {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                self.presentDuckDuckGoCallout()
+            }
+        }
+    }
+    
+    // 60 days until the next time the user sees the onboarding..
+    static let onboardingDaysInterval = TimeInterval(60.days)
+}

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -84,7 +84,4 @@ open class AppInfo {
     public static var isApplication: Bool {
         return Bundle.main.infoDictionaryString(forKey: "CFBundlePackageType") == "APPL"
     }
-    
-    /// Return URL used for New Tab Page Tutorial in JP locale
-    public static let ntpTutorialPageURL = URL(string: "https://brave.com/ja/ntp-tutorial")
 }

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -84,4 +84,7 @@ open class AppInfo {
     public static var isApplication: Bool {
         return Bundle.main.infoDictionaryString(forKey: "CFBundlePackageType") == "APPL"
     }
+    
+    /// Return URL used for New Tab Page Tutorial in JP locale
+    public static let ntpTutorialPageURL = URL(string: "https://brave.com/ja/ntp-tutorial")
 }


### PR DESCRIPTION
When the users location is set to Japan, auto load the URL after onboarding.
URL: https://brave.com/ja/ntp-tutorial

## Summary of Changes

This pull request fixes #3389

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Show Case:
- Fresh install and load browser in JP locale and check URL is loaded after onboarding

No Show Cases:
- Fresh install and load browser outside JP locale and check URL is not loaded after onboarding
- Check URL is not loaded, If not install fresh

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
