### PR TITLE
Fix #627 Add brave://search URL scheme

### DIFF
--- a/BraveShareTo/ShareToBraveViewController.swift
+++ b/BraveShareTo/ShareToBraveViewController.swift
@@ -56,14 +56,8 @@ class ShareToBraveViewController: SLComposeServiceViewController {
             }
             
             // Open url if it was found, in other case search for text with default search engine in browser
-            if let urlString = urlItem?.absoluteString {
-                if let braveUrl = urlString.addingPercentEncoding(withAllowedCharacters: .alphanumerics).flatMap(self.urlScheme) {
-                    self.handleUrl(braveUrl)
-                }
-            } else if let text = nonUrlText {
-                if let braveUrl = text.addingPercentEncoding(withAllowedCharacters: .alphanumerics).flatMap(self.searchScheme) {
-                    self.handleUrl(braveUrl)
-                }
+            if let braveUrl = urlItem?.absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics).flatMap(self.urlScheme) ?? nonUrlText?.addingPercentEncoding(withAllowedCharacters: .alphanumerics).flatMap(self.searchScheme) {
+                self.handleUrl(braveUrl)
             }
         }
         

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -60,6 +60,9 @@ enum NavigationPath: Equatable {
         } else if urlString.starts(with: "\(scheme)://open-text") {
             let text = components.valueForQuery("text")
             self = .text(text ?? "")
+        } else if urlString.starts(with: "\(scheme)://search") {
+            let text = components.valueForQuery("q")
+            self = .text(text ?? "")
         } else {
             return nil
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1725,7 +1725,7 @@ class BrowserViewController: UIViewController {
                 // This let's the user spam the Cmd+T button without lots of responder changes.
                 guard freshTab == self.tabManager.selectedTab else { return }
                 if let text = searchText {
-                    self.topToolbar.setLocation(text, search: true)
+                    self.topToolbar.submitLocation(text)
                 }
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1725,7 +1725,6 @@ class BrowserViewController: UIViewController {
                 // This let's the user spam the Cmd+T button without lots of responder changes.
                 guard freshTab == self.tabManager.selectedTab else { return }
                 if let text = searchText {
-//                    self.topToolbar.enterOverlayMode(text, pasted: true, search: true)
                     self.topToolbar.setLocation(text, search: true)
                 }
             }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1725,6 +1725,7 @@ class BrowserViewController: UIViewController {
                 // This let's the user spam the Cmd+T button without lots of responder changes.
                 guard freshTab == self.tabManager.selectedTab else { return }
                 if let text = searchText {
+//                    self.topToolbar.enterOverlayMode(text, pasted: true, search: true)
                     self.topToolbar.setLocation(text, search: true)
                 }
             }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -386,7 +386,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
         if search {
             locationTextField?.text = text
             // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
-            delegate?.topToolbar(self, didEnterText: text)
+            delegate?.topToolbar(self, didSubmitText: text)
         } else {
             locationTextField?.setTextWithoutSearching(text)
         }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -393,12 +393,10 @@ class TopToolbarView: UIView, ToolbarProtocol {
     }
     
     func submitLocation(_ location: String?) {
+        locationTextField?.text = location
         guard let text = location, !text.isEmpty else {
-            locationTextField?.text = location
             return
         }
-        
-        locationTextField?.text = text
         // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
         delegate?.topToolbar(self, didSubmitText: text)
     }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -386,10 +386,21 @@ class TopToolbarView: UIView, ToolbarProtocol {
         if search {
             locationTextField?.text = text
             // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
-            delegate?.topToolbar(self, didSubmitText: text)
+            delegate?.topToolbar(self, didEnterText: text)
         } else {
             locationTextField?.setTextWithoutSearching(text)
         }
+    }
+    
+    func submitLocation(_ location: String?) {
+        guard let text = location, !text.isEmpty else {
+            locationTextField?.text = location
+            return
+        }
+        
+        locationTextField?.text = text
+        // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
+        delegate?.topToolbar(self, didSubmitText: text)
     }
     
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/ClientTests/NavigationRouterTests.swift
+++ b/ClientTests/NavigationRouterTests.swift
@@ -42,6 +42,14 @@ class NavigationRouterTests: XCTestCase {
         XCTAssertEqual(badNav, NavigationPath.url(webURL: URL(string: "blah"), isPrivate: false))
     }
     
+    func testSearchScheme() {
+        let query = "Foo Bar".addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+        let appURL = "\(appScheme)://search?q="+query
+        let navItem = NavigationPath(url: URL(string: appURL)!)!
+        
+        XCTAssertEqual(navItem, NavigationPath.text("Foo Bar"))
+    }
+    
     func testDefaultNavigationPath() {
         let url = URL(string: "https://duckduckgo.com")!
         let appURL = URL(string: "\(self.appScheme)://open-url?url=\(url.absoluteString.escape()!)")!


### PR DESCRIPTION
## Summary of Changes

This pull request fixes part of #627.
It fix handling nonUrl text when sharing to Brave. Before, app opened blank tab. With this fix, app search for the text using default search engine in the browser.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Open safari, go to a wikipedia article
- Select a word or a sentence, tap 'share', and share it with Brave
- Verify that text you selected was used as a search query in Brave app

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
