### PR TITLE
Fix #3570 - Fixes Add to Playlist Share Menu allowing you to add duplicate items

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1774,9 +1774,7 @@ class BrowserViewController: UIViewController {
             guard let item = self.openInPlaylistActivityItem?.item else { return }
             
             // Update playlist with new items..
-            self.openInPlaylist(item: item) { [weak self]  in
-                guard let self = self else { return }
-                
+            self.openInPlaylist(item: item) {
                 log.debug("Playlist Item Opened")
                 UIImpactFeedbackGenerator(style: .medium).bzzt()
                 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -112,6 +112,7 @@ class BrowserViewController: UIViewController {
     var downloadToast: DownloadToast? // A toast that is showing the combined download progress
     var playlistToast: PlaylistToast? // A toast displayed when a playlist item is updated or added
     var addToPlayListActivityItem: (enabled: Bool, item: PlaylistInfo?)? // A boolean to determine If AddToListActivity should be added
+    var openInPlaylistActivityItem: (enabled: Bool, item: PlaylistInfo?)? // A boolean to determine if OpenInPlaylistActivity should be shown
 
     // Tracking navigation items to record history types.
     // TODO: weak references?
@@ -1769,6 +1770,19 @@ class BrowserViewController: UIViewController {
             }
         }
         
+        let openInPlayListActivity = OpenInPlaylistActivity() { [unowned self] in
+            guard let item = self.openInPlaylistActivityItem?.item else { return }
+            
+            // Update playlist with new items..
+            self.openInPlaylist(item: item) { [weak self]  in
+                guard let self = self else { return }
+                
+                log.debug("Playlist Item Opened")
+                UIImpactFeedbackGenerator(style: .medium).bzzt()
+                
+            }
+        }
+        
         var activities: [UIActivity] = [findInPageActivity]
         
         // These actions don't apply if we're sharing a temporary document
@@ -1881,6 +1895,10 @@ class BrowserViewController: UIViewController {
 
         if let playListActivityItem = addToPlayListActivityItem, playListActivityItem.enabled {
             activities.append(addToPlayListActivity)
+        }
+        
+        if let playListActivityItem = openInPlaylistActivityItem, playListActivityItem.enabled {
+            activities.append(openInPlayListActivity)
         }
         
         let controller = helper.createActivityViewController(items: activities) { [weak self] completed, _, documentUrl  in

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -86,13 +86,25 @@ extension BrowserViewController: PlaylistHelperDelegate {
         }
     }
     
+    func openInPlayListActivity(info: PlaylistInfo?) {
+        if info == nil {
+            openInPlaylistActivityItem = nil
+        } else {
+            openInPlaylistActivityItem = (enabled: true, item: info)
+        }
+    }
+    
     func addToPlaylist(item: PlaylistInfo, completion: ((_ didAddItem: Bool) -> Void)?) {
         if PlaylistManager.shared.isDiskSpaceEncumbered() {
             let style: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
             let alert = UIAlertController(
                 title: Strings.PlayList.playlistDiskSpaceWarningTitle, message: Strings.PlayList.playlistDiskSpaceWarningMessage, preferredStyle: style)
             
-            alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: { _ in
+            alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: { [weak self] _ in
+                guard let self = self else { return }
+                self.openInPlaylistActivityItem = (enabled: true, item: item)
+                self.addToPlayListActivityItem = nil
+                
                 PlaylistItem.addItem(item, cachedData: nil) {
                     PlaylistManager.shared.autoDownload(item: item)
                     completion?(true)
@@ -104,10 +116,21 @@ extension BrowserViewController: PlaylistHelperDelegate {
             }))
             self.present(alert, animated: true, completion: nil)
         } else {
+            openInPlaylistActivityItem = (enabled: true, item: item)
+            addToPlayListActivityItem = nil
+            
             PlaylistItem.addItem(item, cachedData: nil) {
                 PlaylistManager.shared.autoDownload(item: item)
                 completion?(true)
             }
+        }
+    }
+    
+    func openInPlaylist(item: PlaylistInfo, completion: (() -> Void)?) {
+        let playlistController = (UIApplication.shared.delegate as? AppDelegate)?.playlistRestorationController ?? PlaylistViewController()
+        playlistController.modalPresentationStyle = .fullScreen
+        present(playlistController, animated: true) {
+            completion?()
         }
     }
 }

--- a/Client/Frontend/Share/AddToPlaylistActivity.swift
+++ b/Client/Frontend/Share/AddToPlaylistActivity.swift
@@ -30,3 +30,28 @@ class AddToPlaylistActivity: UIActivity {
     }
 }
 
+class OpenInPlaylistActivity: UIActivity {
+    fileprivate let callback: () -> Void
+
+    init(callback: @escaping () -> Void) {
+        self.callback = callback
+    }
+
+    override var activityTitle: String? {
+        return Strings.PlayList.toastExitingItemPlaylistTitle
+    }
+
+    override var activityImage: UIImage? {
+        return #imageLiteral(resourceName: "playlist_menu")
+    }
+
+    override func perform() {
+        callback()
+        activityDidFinish(true)
+    }
+
+    override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+        return true
+    }
+}
+


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Adds new activity to share menu for `View In Playlist`.
- Fixes Add to Playlist allowing you to add duplicate items by checking if the item exists first in the JS callback.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3570

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
