### PR TITLE
Fix #3585 - Fix crash deleting playlist cache on a different thread

### DIFF
--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -194,7 +194,9 @@ class PlayListCacheClearable: Clearable {
     }
     
     func clear() -> Success {
-        PlaylistManager.shared.deleteAllItems(cacheOnly: true)
+        DispatchQueue.main.async {
+            PlaylistManager.shared.deleteAllItems(cacheOnly: true)
+        }
         return succeed()
     }
 }
@@ -208,7 +210,9 @@ class PlayListDataClearable: Clearable {
     }
     
     func clear() -> Success {
-        PlaylistManager.shared.deleteAllItems()
+        DispatchQueue.main.async {
+            PlaylistManager.shared.deleteAllItems()
+        }
         return succeed()
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes crash by dispatching deleting to the main thread.
- Can only reproduce it intermittently.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3585

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Since the crash is hard to reproduce, please only verify that clearing playlist data still works correctly.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
