### PR TITLE
Fix #3592: Change initial visibility of wallet transfer button to hidden

### DIFF
--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
@@ -31,7 +31,9 @@ extension BraveRewardsViewController {
         
         let publisherView = BraveRewardsPublisherView()
         let statusView = BraveRewardsStatusView()
-        let legacyWalletTransferButton = LegacyWalletTransferButton()
+        let legacyWalletTransferButton = LegacyWalletTransferButton().then {
+            $0.isHidden = true
+        }
         let legacyWalletTransferStatusButton = LegacyWalletTransferStatusButton().then {
             $0.isHidden = true
         }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3592

Regression fix from #3456 where the legacy transfer button does not hide until ledger initializes

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
