### PR TITLE
Fix #3600 - Stop Picture-In-Picture on playback end

### DIFF
--- a/Client/Frontend/Browser/Playlist/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistViewController.swift
@@ -209,9 +209,16 @@ private class ListController: UIViewController {
             Preferences.Playlist.lastPlayedItemTime.value = 0.0
         }
         
-        playerView.stop()
         playerView.pictureInPictureController?.delegate = nil
         playerView.pictureInPictureController?.stopPictureInPicture()
+        playerView.stop()
+        
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            if UIDevice.isIpad {
+                playerView.attachLayer()
+            }
+            delegate.playlistRestorationController = nil
+        }
     }
     
     override func viewDidLoad() {
@@ -1077,6 +1084,16 @@ extension ListController: VideoViewDelegate {
         switch playerView.repeatState {
         case .none:
             if isAtEnd {
+                playerView.pictureInPictureController?.delegate = nil
+                playerView.pictureInPictureController?.stopPictureInPicture()
+                playerView.stop()
+                
+                if let delegate = UIApplication.shared.delegate as? AppDelegate {
+                    if UIDevice.isIpad {
+                        playerView.attachLayer()
+                    }
+                    delegate.playlistRestorationController = nil
+                }
                 return
             }
             index += 1


### PR DESCRIPTION
## Summary of Changes
- Stop Picture-In-Picture when the last video has finished playing and there is no active repeat mode.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3600

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
