### PR TITLE
Fix #3461: Shields tooltip shown when tab tray is opened

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		2F44FCC51A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */; };
 		2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */; };
 		2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */; };
+		2F45B40A263AF1C20033A594 /* BrowserViewController+ToolbarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F45B409263AF1C20033A594 /* BrowserViewController+ToolbarDelegate.swift */; };
 		2F51767425E4024B00429692 /* PlaylistSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F51767325E4024B00429692 /* PlaylistSettingsViewController.swift */; };
 		2F55443225913BD5000E4689 /* OpenSearchEngineButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F55443125913BD5000E4689 /* OpenSearchEngineButton.swift */; };
 		2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */; };
@@ -1942,6 +1943,7 @@
 		2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableSectionHeaderFooterView.swift; sourceTree = "<group>"; };
 		2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginePicker.swift; sourceTree = "<group>"; };
+		2F45B409263AF1C20033A594 /* BrowserViewController+ToolbarDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+ToolbarDelegate.swift"; sourceTree = "<group>"; };
 		2F51767325E4024B00429692 /* PlaylistSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistSettingsViewController.swift; sourceTree = "<group>"; };
 		2F55443125913BD5000E4689 /* OpenSearchEngineButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSearchEngineButton.swift; sourceTree = "<group>"; };
 		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
@@ -4847,6 +4849,7 @@
 				C8F457A71F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift */,
 				2F098F8A255F2D730084FB37 /* BrowserViewController+ReaderMode.swift */,
 				2FB9C2A02587E742009DA1FE /* BrowserViewController+ProductNotification.swift */,
+				2F45B409263AF1C20033A594 /* BrowserViewController+ToolbarDelegate.swift */,
 				0A91598822B834CE00CCC119 /* BVC+Rewards.swift */,
 				2F55443025913BAA000E4689 /* OpenSearch */,
 			);
@@ -7227,6 +7230,7 @@
 				27036EA325671817004EF6B6 /* FeedCardFooterButton.swift in Sources */,
 				0AADC4D520D2A6A200FDE368 /* PreloadedFavorites.swift in Sources */,
 				0AC77602242A6AE000139377 /* BuyVPNView.swift in Sources */,
+				2F45B40A263AF1C20033A594 /* BrowserViewController+ToolbarDelegate.swift in Sources */,
 				278C467823EDF0060083347F /* SimpleShieldsView.swift in Sources */,
 				5D24AF8421BA489A00F9506A /* ContentBlocker.swift in Sources */,
 				27829DE92548AA4F007CF0B2 /* BraveRewardsViewController.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -52,9 +52,10 @@ class BrowserViewController: UIViewController {
     var statusBarOverlay: UIView!
     fileprivate(set) var toolbar: BottomToolbarView?
     var searchController: SearchViewController?
-    fileprivate var screenshotHelper: ScreenshotHelper!
+    var favoritesController: FavoritesViewController?
+    var screenshotHelper: ScreenshotHelper!
     fileprivate var homePanelIsInline = false
-    fileprivate var searchLoader: SearchLoader?
+    var searchLoader: SearchLoader?
     let alertStackView = UIStackView() // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
     fileprivate var findInPageBar: FindInPageBar?
     
@@ -82,11 +83,11 @@ class BrowserViewController: UIViewController {
     var openInHelper: OpenInHelper?
 
     // location label actions
-    fileprivate var pasteGoAction: AccessibleAction!
-    fileprivate var pasteAction: AccessibleAction!
-    fileprivate var copyAddressAction: AccessibleAction!
+    var pasteGoAction: AccessibleAction!
+    var pasteAction: AccessibleAction!
+    var copyAddressAction: AccessibleAction!
 
-    fileprivate weak var tabTrayController: TabTrayController!
+    weak var tabTrayController: TabTrayController!
     let profile: Profile
     let tabManager: TabManager
     
@@ -161,7 +162,7 @@ class BrowserViewController: UIViewController {
     /// Current session ad count is compared with live ad count
     /// So user will not be introduced with a pop-over directly
     let benchmarkCurrentSessionAdCount = BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection
-
+        
     init(profile: Profile, tabManager: TabManager, crashedLastSession: Bool,
          safeBrowsingManager: SafeBrowsing? = SafeBrowsing()) {
         self.profile = profile
@@ -1154,7 +1155,7 @@ class BrowserViewController: UIViewController {
     }
     
     /// A layout guide defining where the favorites and NTP overlay are placed
-    private let pageOverlayLayoutGuide = UILayoutGuide()
+    let pageOverlayLayoutGuide = UILayoutGuide()
 
     override func updateViewConstraints() {
         webViewContainer.snp.remakeConstraints { make in
@@ -1202,52 +1203,7 @@ class BrowserViewController: UIViewController {
         
         super.updateViewConstraints()
     }
-    
-    private(set) var favoritesController: FavoritesViewController?
-    
-    private func displayFavoritesController() {
-        if favoritesController == nil {
-            let favoritesController = FavoritesViewController { [weak self] bookmark, action in
-                self?.handleFavoriteAction(favorite: bookmark, action: action)
-            }
-            favoritesController.applyTheme(Theme.of(tabManager.selectedTab))
-            self.favoritesController = favoritesController
-            
-            addChild(favoritesController)
-            view.addSubview(favoritesController.view)
-            favoritesController.didMove(toParent: self)
-            
-            favoritesController.view.snp.makeConstraints {
-                $0.top.leading.trailing.equalTo(pageOverlayLayoutGuide)
-                $0.bottom.equalTo(view)
-            }
-        }
-        guard let favoritesController = favoritesController else { return }
-        favoritesController.view.alpha = 0.0
-        let animator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1.0) {
-            favoritesController.view.alpha = 1
-        }
-        animator.addCompletion { _ in
-            self.webViewContainer.accessibilityElementsHidden = true
-            UIAccessibility.post(notification: .screenChanged, argument: nil)
-        }
-        animator.startAnimation()
-    }
-    
-    private func hideFavoritesController() {
-        guard let controller = favoritesController else { return }
-        self.favoritesController = nil
-        UIView.animate(withDuration: 0.1, delay: 0, options: [.beginFromCurrentState], animations: {
-            controller.view.alpha = 0.0
-        }, completion: { _ in
-            controller.willMove(toParent: nil)
-            controller.view.removeFromSuperview()
-            controller.removeFromParent()
-            self.webViewContainer.accessibilityElementsHidden = false
-            UIAccessibility.post(notification: .screenChanged, argument: nil)
-        })
-    }
-    
+
     fileprivate func showNewTabPageController() {
         guard let selectedTab = tabManager.selectedTab else { return }
         if selectedTab.newTabPageViewController == nil {
@@ -1319,7 +1275,7 @@ class BrowserViewController: UIViewController {
         })
     }
 
-    fileprivate func updateInContentHomePanel(_ url: URL?) {
+    func updateInContentHomePanel(_ url: URL?) {
         if !topToolbar.inOverlayMode {
             guard let url = url else {
                 hideActiveNewTabPageController()
@@ -1331,35 +1287,6 @@ class BrowserViewController: UIViewController {
                 hideActiveNewTabPageController(url.isReaderModeURL)
             }
         }
-    }
-
-    fileprivate func showSearchController() {
-        if searchController != nil { return }
-
-        let tabType = TabType.of(tabManager.selectedTab)
-        searchController = SearchViewController(forTabType: tabType)
-        
-        guard let searchController = searchController else { return }
-
-        searchController.searchEngines = profile.searchEngines
-        searchController.searchDelegate = self
-        searchController.profile = self.profile
-
-        searchLoader = SearchLoader()
-        searchLoader?.addListener(searchController)
-        searchLoader?.autocompleteSuggestionHandler = { [weak self] completion in
-            self?.topToolbar.setAutocompleteSuggestion(completion)
-        }
-
-        addChild(searchController)
-        view.addSubview(searchController.view)
-        searchController.view.snp.makeConstraints { make in
-            make.top.equalTo(self.topToolbar.snp.bottom)
-            make.left.right.bottom.equalTo(self.view)
-            return
-        }
-        
-        searchController.didMove(toParent: self)
     }
     
     func updateTabsBarVisibility() {
@@ -1402,17 +1329,7 @@ class BrowserViewController: UIViewController {
             delegate.updateShortcutItems(UIApplication.shared)
         }
     }
-
-    fileprivate func hideSearchController() {
-        if let searchController = searchController {
-            searchController.willMove(toParent: nil)
-            searchController.view.removeFromSuperview()
-            searchController.removeFromParent()
-            self.searchController = nil
-            searchLoader = nil
-        }
-    }
-
+    
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType) {
         if url.isBookmarklet {
             topToolbar.leaveOverlayMode()
@@ -1745,7 +1662,7 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    fileprivate func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {
+    func presentActivityViewController(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {
         let helper = ShareExtensionHelper(url: url, tab: tab)
         
         let findInPageActivity = FindInPageActivity() { [unowned self] in
@@ -2090,53 +2007,6 @@ class BrowserViewController: UIViewController {
         duckDuckGoPopup = popup
         popup.showWithType(showType: .flyUp)
     }
-    
-    private func showBookmarkController() {
-        let bookmarkViewController = BookmarksViewController(
-            folder: Bookmarkv2.lastVisitedFolder(),
-            isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        
-        bookmarkViewController.toolbarUrlActionsDelegate = self
-        
-        presentSettingsNavigation(with: bookmarkViewController)
-    }
-    
-    func openAddBookmark() {
-        guard let selectedTab = tabManager.selectedTab,
-              let selectedUrl = selectedTab.url,
-              !(selectedUrl.isLocal || selectedUrl.isReaderModeURL) else {
-            return
-        }
-        
-        let bookmarkUrl = selectedUrl.decodeReaderModeURL ?? selectedUrl
-        
-        let mode = BookmarkEditMode.addBookmark(title: selectedTab.displayTitle, url: bookmarkUrl.absoluteString)
-        
-        let addBookMarkController = AddEditBookmarkTableViewController(mode: mode)
-        
-        presentSettingsNavigation(with: addBookMarkController, cancelEnabled: true)
-    }
-    
-    private func presentSettingsNavigation(with controller: UIViewController, cancelEnabled: Bool = false) {
-        let navigationController = SettingsNavigationController(rootViewController: controller)
-        navigationController.modalPresentationStyle = .formSheet
-        
-        let cancelBarbutton = UIBarButtonItem(
-            barButtonSystemItem: .cancel,
-            target: navigationController,
-            action: #selector(SettingsNavigationController.done))
-        
-        let doneBarbutton = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: navigationController,
-            action: #selector(SettingsNavigationController.done))
-        
-        navigationController.navigationBar.topItem?.leftBarButtonItem = cancelEnabled ? cancelBarbutton : nil
-        
-        navigationController.navigationBar.topItem?.rightBarButtonItem = doneBarbutton
-        
-        present(navigationController, animated: true)
-    }
 }
 
 extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
@@ -2184,411 +2054,6 @@ extension BrowserViewController: SettingsDelegate {
 extension BrowserViewController: PresentingModalViewControllerDelegate {
     func dismissPresentedModalViewController(_ modalViewController: UIViewController, animated: Bool) {
         self.dismiss(animated: animated, completion: nil)
-    }
-}
-
-extension BrowserViewController: TopToolbarDelegate {
-    func showTabTray() {
-        if tabManager.tabsForCurrentMode.isEmpty {
-            return
-        }
-        updateFindInPageVisibility(visible: false)
-        
-        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
-        
-        if tabManager.selectedTab == nil {
-            tabManager.selectTab(tabManager.tabsForCurrentMode.first)
-        }
-        if let tab = tabManager.selectedTab {
-            screenshotHelper.takeScreenshot(tab)
-        }
-        
-        navigationController?.pushViewController(tabTrayController, animated: true)
-        self.tabTrayController = tabTrayController
-    }
-    
-    func topToolbarDidPressReload(_ topToolbar: TopToolbarView) {
-        tabManager.selectedTab?.reload()
-    }
-    
-    func topToolbarDidPressStop(_ topToolbar: TopToolbarView) {
-        tabManager.selectedTab?.stop()
-    }
-    
-    func topToolbarDidLongPressReloadButton(_ topToolbar: TopToolbarView, from button: UIButton) {
-        guard let tab = tabManager.selectedTab else { return }
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
-        
-        let toggleActionTitle = tab.isDesktopSite == true ?
-            Strings.appMenuViewMobileSiteTitleString : Strings.appMenuViewDesktopSiteTitleString
-        alert.addAction(UIAlertAction(title: toggleActionTitle, style: .default, handler: { _ in
-            tab.switchUserAgent()
-        }))
-        
-        UIImpactFeedbackGenerator(style: .heavy).bzzt()
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            alert.popoverPresentationController?.sourceView = self.view
-            alert.popoverPresentationController?.sourceRect = self.view.convert(button.frame, from: button.superview)
-            alert.popoverPresentationController?.permittedArrowDirections = [.up]
-        }
-        present(alert, animated: true)
-    }
-
-    func topToolbarDidPressTabs(_ topToolbar: TopToolbarView) {
-        showTabTray()
-    }
-
-    func topToolbarDidPressReaderMode(_ topToolbar: TopToolbarView) {
-        if let tab = tabManager.selectedTab {
-            if let readerMode = tab.getContentScript(name: "ReaderMode") as? ReaderMode {
-                switch readerMode.state {
-                case .available:
-                    enableReaderMode()
-                case .active:
-                    disableReaderMode()
-                case .unavailable:
-                    break
-                }
-            }
-        }
-    }
-
-    func topToolbarDidLongPressReaderMode(_ topToolbar: TopToolbarView) -> Bool {
-        // Maybe we want to add something here down the road
-        return false
-    }
-
-    func locationActions(for topToolbar: TopToolbarView) -> [AccessibleAction] {
-        if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
-            return [pasteGoAction, pasteAction, copyAddressAction]
-        } else {
-            return [copyAddressAction]
-        }
-    }
-
-    func topToolbarDisplayTextForURL(_ topToolbar: URL?) -> (String?, Bool) {
-        // use the initial value for the URL so we can do proper pattern matching with search URLs
-        var searchURL = self.tabManager.selectedTab?.currentInitialURL
-        if searchURL?.isErrorPageURL ?? true {
-            searchURL = topToolbar
-        }
-        if let query = profile.searchEngines.queryForSearchURL(searchURL as URL?) {
-            return (query, true)
-        } else {
-            return (topToolbar?.absoluteString, false)
-        }
-    }
-
-    func topToolbarDidLongPressLocation(_ topToolbar: TopToolbarView) {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        
-        for action in locationActions(for: topToolbar) {
-            alert.addAction(action.alertAction(style: .default))
-        }
-        
-        alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
-        
-        let setupPopover = { [unowned self] in
-            if let popoverPresentationController = alert.popoverPresentationController {
-                popoverPresentationController.sourceView = topToolbar
-                popoverPresentationController.sourceRect = topToolbar.frame
-                popoverPresentationController.permittedArrowDirections = .any
-                popoverPresentationController.delegate = self
-            }
-        }
-        
-        setupPopover()
-        
-        if alert.popoverPresentationController != nil {
-            displayedPopoverController = alert
-            updateDisplayedPopoverProperties = setupPopover
-        }
-        
-        self.present(alert, animated: true)
-    }
-
-    func topToolbarDidPressScrollToTop(_ topToolbar: TopToolbarView) {
-        if let selectedTab = tabManager.selectedTab, favoritesController == nil {
-            // Only scroll to top if we are not showing the home view controller
-            selectedTab.webView?.scrollView.setContentOffset(CGPoint.zero, animated: true)
-        }
-    }
-
-    func topToolbarLocationAccessibilityActions(_ topToolbar: TopToolbarView) -> [UIAccessibilityCustomAction]? {
-        return locationActions(for: topToolbar).map { $0.accessibilityCustomAction }
-    }
-
-    func topToolbar(_ topToolbar: TopToolbarView, didEnterText text: String) {
-        if text.isEmpty {
-            hideSearchController()
-        } else {
-            showSearchController()
-            searchController?.searchQuery = text
-            searchLoader?.query = text
-        }
-    }
-
-    func topToolbar(_ topToolbar: TopToolbarView, didSubmitText text: String) {
-        processAddressBar(text: text, visitType: nil)
-    }
-
-    func processAddressBar(text: String, visitType: VisitType?) {
-        if let fixupURL = URIFixup.getURL(text) {
-            // The user entered a URL, so use it.
-            finishEditingAndSubmit(fixupURL, visitType: visitType ?? .typed)
-            return
-        }
-
-        // We couldn't build a URL, so pass it on to the search engine.
-        submitSearchText(text)
-    }
-
-    fileprivate func submitSearchText(_ text: String) {
-        let engine = profile.searchEngines.defaultEngine()
-
-        if let searchURL = engine.searchURLForQuery(text) {
-            // We couldn't find a matching search keyword, so do a search query.
-            finishEditingAndSubmit(searchURL, visitType: VisitType.typed)
-        } else {
-            // We still don't have a valid URL, so something is broken. Give up.
-            print("Error handling URL entry: \"\(text)\".")
-            assertionFailure("Couldn't generate search URL: \(text)")
-        }
-    }
-
-    func topToolbarDidEnterOverlayMode(_ topToolbar: TopToolbarView) {
-        if .blankPage == NewTabAccessors.getNewTabPage() {
-            UIAccessibility.post(notification: .screenChanged, argument: nil)
-        } else {
-            if let toast = clipboardBarDisplayHandler?.clipboardToast {
-                toast.removeFromSuperview()
-            }
-            displayFavoritesController()
-        }
-    }
-
-    func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView) {
-        hideSearchController()
-        hideFavoritesController()
-        updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
-    }
-
-    func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView) {
-        dismissVisibleMenus()
-    }
-    
-    func topToolbarDidTapBraveShieldsButton(_ topToolbar: TopToolbarView) {
-        presentBraveShieldsViewController()
-    }
-    
-    func presentBraveShieldsViewController() {
-        guard let selectedTab = tabManager.selectedTab, var url = selectedTab.url else { return }
-        if url.isErrorPageURL, let originalURL = url.originalURLFromErrorURL {
-            url = originalURL
-        }
-        if url.isLocalUtility {
-            return
-        }
-        let shields = ShieldsViewController(tab: selectedTab)
-        shields.shieldsSettingsChanged = { [unowned self] _ in
-            // Update the shields status immediately
-            self.topToolbar.refreshShieldsStatus()
-            
-            // Reload this tab. This will also trigger an update of the brave icon in `TabLocationView` if
-            // the setting changed is the global `.AllOff` shield
-            self.tabManager.selectedTab?.reload()
-            
-            // In 1.6 we "reload" the whole web view state, dumping caches, etc. (reload():BraveWebView.swift:495)
-            // BRAVE TODO: Port over proper tab reloading with Shields
-        }
-        shields.showGlobalShieldsSettings = { [unowned self] vc in
-            vc.dismiss(animated: true) {
-                let shieldsAndPrivacy = BraveShieldsAndPrivacySettingsController(
-                    profile: self.profile,
-                    tabManager: self.tabManager,
-                    feedDataSource: self.feedDataSource
-                )
-                let container = SettingsNavigationController(rootViewController: shieldsAndPrivacy)
-                container.isModalInPresentation = true
-                container.modalPresentationStyle =
-                    UIDevice.current.userInterfaceIdiom == .phone ? .pageSheet : .formSheet
-                shieldsAndPrivacy.navigationItem.rightBarButtonItem = .init(
-                    barButtonSystemItem: .done,
-                    target: container,
-                    action: #selector(SettingsNavigationController.done)
-                )
-                self.present(container, animated: true)
-            }
-        }
-        let container = PopoverNavigationController(rootViewController: shields)
-        let popover = PopoverController(contentController: container, contentSizeBehavior: .preferredContentSize)
-        popover.present(from: topToolbar.locationView.shieldsButton, on: self)
-    }
-    
-    // TODO: This logic should be fully abstracted away and share logic from current MenuViewController
-    // See: https://github.com/brave/brave-ios/issues/1452
-    func topToolbarDidTapBookmarkButton(_ topToolbar: TopToolbarView) {
-        showBookmarkController()
-    }
-    
-    func topToolbarDidTapBraveRewardsButton(_ topToolbar: TopToolbarView) {
-        showBraveRewardsPanel()
-    }
-    
-    func topToolbarDidLongPressBraveRewardsButton(_ topToolbar: TopToolbarView) {
-        showRewardsDebugSettings()
-    }
-    
-    func topToolbarDidTapMenuButton(_ topToolbar: TopToolbarView) {
-        tabToolbarDidPressMenu(topToolbar)
-    }
-}
-
-extension BrowserViewController: ToolbarDelegate {
-    func tabToolbarDidPressSearch(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        topToolbar.tabLocationViewDidTapLocation(topToolbar.locationView)
-    }
-    
-    func tabToolbarDidPressBack(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        tabManager.selectedTab?.goBack()
-    }
-
-    func tabToolbarDidLongPressBack(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        UIImpactFeedbackGenerator(style: .heavy).bzzt()
-        showBackForwardList()
-    }
-    
-    func tabToolbarDidPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        tabManager.selectedTab?.goForward()
-    }
-    
-    func tabToolbarDidPressShare() {
-        func share(url: URL) {
-            presentActivityViewController(
-                url,
-                tab: url.isFileURL ? nil : tabManager.selectedTab,
-                sourceView: view,
-                sourceRect: view.convert(topToolbar.menuButton.frame, from: topToolbar.menuButton.superview),
-                arrowDirection: [.up]
-            )
-        }
-        
-        guard let tab = tabManager.selectedTab, let url = tab.url else { return }
-        
-        if let temporaryDocument = tab.temporaryDocument {
-            temporaryDocument.getURL().uponQueue(.main, block: { tempDocURL in
-                // If we successfully got a temp file URL, share it like a downloaded file,
-                // otherwise present the ordinary share menu for the web URL.
-                if tempDocURL.isFileURL {
-                    share(url: tempDocURL)
-                } else {
-                    share(url: url)
-                }
-            })
-        } else {
-            share(url: url)
-        }
-    }
-    
-    func tabToolbarDidPressMenu(_ tabToolbar: ToolbarProtocol) {
-        let homePanel = MenuViewController(bvc: self, tab: tabManager.selectedTab)
-        let popover = PopoverController(contentController: homePanel, contentSizeBehavior: .preferredContentSize)
-        // Not dynamic, but trivial at this point, given how UI is currently setup
-        popover.color = Theme.of(tabManager.selectedTab).colors.home
-        popover.present(from: tabToolbar.menuButton, on: self)
-    }
-    
-    func tabToolbarDidPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
-    }
-
-    func tabToolbarDidLongPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        showAddTabContextMenu(sourceView: toolbar ?? topToolbar, button: button)
-    }
-    
-    private func addTabAlertActions() -> [UIAlertAction] {
-        var actions: [UIAlertAction] = []
-        if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-            let newPrivateTabAction = UIAlertAction(title: Strings.newPrivateTabTitle, style: .default, handler: { [unowned self] _ in
-                // BRAVE TODO: Add check for DuckDuckGo popup (and based on 1.6, whether the browser lock is enabled?)
-                // before focusing on the url bar
-                self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true)
-            })
-            actions.append(newPrivateTabAction)
-        }
-        let bottomActionTitle = PrivateBrowsingManager.shared.isPrivateBrowsing ? Strings.newPrivateTabTitle : Strings.newTabTitle
-        actions.append(UIAlertAction(title: bottomActionTitle, style: .default, handler: { [unowned self] _ in
-            self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        }))
-        return actions
-    }
-    
-    func showAddTabContextMenu(sourceView: UIView, button: UIButton) {
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alertController.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
-        addTabAlertActions().forEach(alertController.addAction)
-        alertController.popoverPresentationController?.sourceView = sourceView
-        alertController.popoverPresentationController?.sourceRect = button.frame
-        UIImpactFeedbackGenerator(style: .heavy).bzzt()
-        present(alertController, animated: true)
-    }
-    
-    func tabToolbarDidLongPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        UIImpactFeedbackGenerator(style: .heavy).bzzt()
-        showBackForwardList()
-    }
-
-    func tabToolbarDidPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        showTabTray()
-    }
-    
-    func tabToolbarDidLongPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        guard self.presentedViewController == nil else {
-            return
-        }
-        let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        
-        if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar.view.isHidden) ||
-            (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {
-            addTabAlertActions().forEach(controller.addAction)
-        }
-        
-        if tabManager.tabsForCurrentMode.count > 1 {
-            controller.addAction(UIAlertAction(title: String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count), style: .destructive, handler: { _ in
-                self.tabManager.removeAll()
-            }), accessibilityIdentifier: "toolbarTabButtonLongPress.closeTab")
-        }
-        controller.addAction(UIAlertAction(title: Strings.closeTabTitle, style: .destructive, handler: { _ in
-            if let tab = self.tabManager.selectedTab {
-                self.tabManager.removeTab(tab)
-            }
-        }), accessibilityIdentifier: "toolbarTabButtonLongPress.closeTab")
-        controller.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil), accessibilityIdentifier: "toolbarTabButtonLongPress.cancel")
-        controller.popoverPresentationController?.sourceView = toolbar ?? topToolbar
-        controller.popoverPresentationController?.sourceRect = button.frame
-        UIImpactFeedbackGenerator(style: .heavy).bzzt()
-        present(controller, animated: true, completion: nil)
-    }
-
-    func showBackForwardList() {
-        if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
-            let backForwardViewController = BackForwardListViewController(profile: profile, backForwardList: backForwardList)
-            backForwardViewController.tabManager = tabManager
-            backForwardViewController.bvc = self
-            backForwardViewController.modalPresentationStyle = .overCurrentContext
-            backForwardViewController.backForwardTransitionDelegate = BackForwardListAnimator()
-            self.present(backForwardViewController, animated: true, completion: nil)
-        }
-    }
-    
-    func tabToolbarDidSwipeToChangeTabs(_ tabToolbar: ToolbarProtocol, direction: UISwipeGestureRecognizer.Direction) {
-        let tabs = tabManager.tabsForCurrentMode
-        guard let selectedTab = tabManager.selectedTab, let index = tabs.firstIndex(where: { $0 === selectedTab }) else { return }
-        let newTabIndex = index + (direction == .left ? -1 : 1)
-        if newTabIndex >= 0 && newTabIndex < tabs.count {
-            tabManager.selectTab(tabs[newTabIndex])
-        }
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -162,6 +162,10 @@ class BrowserViewController: UIViewController {
     /// Current session ad count is compared with live ad count
     /// So user will not be introduced with a pop-over directly
     let benchmarkCurrentSessionAdCount = BraveGlobalShieldStats.shared.adblock + BraveGlobalShieldStats.shared.trackingProtection
+    
+    /// Boolean tracking  if Tab Tray is active on the screen
+    /// Used to determine If pop-over should be presented
+    var isTabTrayActive = false
         
     init(profile: Profile, tabManager: TabManager, crashedLastSession: Bool,
          safeBrowsingManager: SafeBrowsing? = SafeBrowsing()) {
@@ -2674,6 +2678,8 @@ extension BrowserViewController: TabTrayDelegate {
     // This function animates and resets the tab chrome transforms when
     // the tab tray dismisses.
     func tabTrayDidDismiss(_ tabTray: TabTrayController) {
+        isTabTrayActive = false
+        
         // BRAVE TODO: Add update tabs method?
         resetBrowserChrome()
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -74,6 +74,7 @@ extension BrowserViewController {
         guard let selectedTab = tabManager.selectedTab,
               !benchmarkNotificationPresented,
               !topToolbar.inOverlayMode,
+              !isTabTrayActive,
               selectedTab.webView?.scrollView.isDragging == false,
               tabManager.selectedTab?.url?.isAboutHomeURL == false else {
             return

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -28,6 +28,8 @@ extension BrowserViewController: TopToolbarDelegate {
             screenshotHelper.takeScreenshot(tab)
         }
         
+        isTabTrayActive = true
+        
         navigationController?.pushViewController(tabTrayController, animated: true)
         self.tabTrayController = tabTrayController
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -1,0 +1,550 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveShared
+import BraveUI
+import Shared
+import BraveRewards
+import Storage
+
+// MARK: - TopToolbarDelegate
+
+extension BrowserViewController: TopToolbarDelegate {
+    
+    func showTabTray() {
+        if tabManager.tabsForCurrentMode.isEmpty {
+            return
+        }
+        updateFindInPageVisibility(visible: false)
+        
+        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
+        
+        if tabManager.selectedTab == nil {
+            tabManager.selectTab(tabManager.tabsForCurrentMode.first)
+        }
+        if let tab = tabManager.selectedTab {
+            screenshotHelper.takeScreenshot(tab)
+        }
+        
+        navigationController?.pushViewController(tabTrayController, animated: true)
+        self.tabTrayController = tabTrayController
+    }
+    
+    func topToolbarDidPressReload(_ topToolbar: TopToolbarView) {
+        tabManager.selectedTab?.reload()
+    }
+    
+    func topToolbarDidPressStop(_ topToolbar: TopToolbarView) {
+        tabManager.selectedTab?.stop()
+    }
+    
+    func topToolbarDidLongPressReloadButton(_ topToolbar: TopToolbarView, from button: UIButton) {
+        guard let tab = tabManager.selectedTab else { return }
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
+        
+        let toggleActionTitle = tab.isDesktopSite == true ?
+            Strings.appMenuViewMobileSiteTitleString : Strings.appMenuViewDesktopSiteTitleString
+        alert.addAction(UIAlertAction(title: toggleActionTitle, style: .default, handler: { _ in
+            tab.switchUserAgent()
+        }))
+        
+        UIImpactFeedbackGenerator(style: .heavy).bzzt()
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            alert.popoverPresentationController?.sourceView = self.view
+            alert.popoverPresentationController?.sourceRect = self.view.convert(button.frame, from: button.superview)
+            alert.popoverPresentationController?.permittedArrowDirections = [.up]
+        }
+        present(alert, animated: true)
+    }
+
+    func topToolbarDidPressTabs(_ topToolbar: TopToolbarView) {
+        showTabTray()
+    }
+
+    func topToolbarDidPressReaderMode(_ topToolbar: TopToolbarView) {
+        if let tab = tabManager.selectedTab {
+            if let readerMode = tab.getContentScript(name: "ReaderMode") as? ReaderMode {
+                switch readerMode.state {
+                case .available:
+                    enableReaderMode()
+                case .active:
+                    disableReaderMode()
+                case .unavailable:
+                    break
+                }
+            }
+        }
+    }
+
+    func topToolbarDidLongPressReaderMode(_ topToolbar: TopToolbarView) -> Bool {
+        // Maybe we want to add something here down the road
+        return false
+    }
+
+    func locationActions(for topToolbar: TopToolbarView) -> [AccessibleAction] {
+        if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
+            return [pasteGoAction, pasteAction, copyAddressAction]
+        } else {
+            return [copyAddressAction]
+        }
+    }
+
+    func topToolbarDisplayTextForURL(_ topToolbar: URL?) -> (String?, Bool) {
+        // use the initial value for the URL so we can do proper pattern matching with search URLs
+        var searchURL = self.tabManager.selectedTab?.currentInitialURL
+        if searchURL?.isErrorPageURL ?? true {
+            searchURL = topToolbar
+        }
+        if let query = profile.searchEngines.queryForSearchURL(searchURL as URL?) {
+            return (query, true)
+        } else {
+            return (topToolbar?.absoluteString, false)
+        }
+    }
+
+    func topToolbarDidLongPressLocation(_ topToolbar: TopToolbarView) {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        for action in locationActions(for: topToolbar) {
+            alert.addAction(action.alertAction(style: .default))
+        }
+        
+        alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
+        
+        let setupPopover = { [unowned self] in
+            if let popoverPresentationController = alert.popoverPresentationController {
+                popoverPresentationController.sourceView = topToolbar
+                popoverPresentationController.sourceRect = topToolbar.frame
+                popoverPresentationController.permittedArrowDirections = .any
+                popoverPresentationController.delegate = self
+            }
+        }
+        
+        setupPopover()
+        
+        if alert.popoverPresentationController != nil {
+            displayedPopoverController = alert
+            updateDisplayedPopoverProperties = setupPopover
+        }
+        
+        self.present(alert, animated: true)
+    }
+
+    func topToolbarDidPressScrollToTop(_ topToolbar: TopToolbarView) {
+        if let selectedTab = tabManager.selectedTab, favoritesController == nil {
+            // Only scroll to top if we are not showing the home view controller
+            selectedTab.webView?.scrollView.setContentOffset(CGPoint.zero, animated: true)
+        }
+    }
+
+    func topToolbarLocationAccessibilityActions(_ topToolbar: TopToolbarView) -> [UIAccessibilityCustomAction]? {
+        return locationActions(for: topToolbar).map { $0.accessibilityCustomAction }
+    }
+
+    func topToolbar(_ topToolbar: TopToolbarView, didEnterText text: String) {
+        if text.isEmpty {
+            hideSearchController()
+        } else {
+            showSearchController()
+            searchController?.searchQuery = text
+            searchLoader?.query = text
+        }
+    }
+
+    func topToolbar(_ topToolbar: TopToolbarView, didSubmitText text: String) {
+        processAddressBar(text: text, visitType: nil)
+    }
+
+    func processAddressBar(text: String, visitType: VisitType?) {
+        if let fixupURL = URIFixup.getURL(text) {
+            // The user entered a URL, so use it.
+            finishEditingAndSubmit(fixupURL, visitType: visitType ?? .typed)
+            return
+        }
+
+        // We couldn't build a URL, so pass it on to the search engine.
+        submitSearchText(text)
+    }
+
+    func submitSearchText(_ text: String) {
+        let engine = profile.searchEngines.defaultEngine()
+
+        if let searchURL = engine.searchURLForQuery(text) {
+            // We couldn't find a matching search keyword, so do a search query.
+            finishEditingAndSubmit(searchURL, visitType: VisitType.typed)
+        } else {
+            // We still don't have a valid URL, so something is broken. Give up.
+            print("Error handling URL entry: \"\(text)\".")
+            assertionFailure("Couldn't generate search URL: \(text)")
+        }
+    }
+
+    func topToolbarDidEnterOverlayMode(_ topToolbar: TopToolbarView) {
+        if .blankPage == NewTabAccessors.getNewTabPage() {
+            UIAccessibility.post(notification: .screenChanged, argument: nil)
+        } else {
+            if let toast = clipboardBarDisplayHandler?.clipboardToast {
+                toast.removeFromSuperview()
+            }
+            displayFavoritesController()
+        }
+    }
+
+    func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView) {
+        hideSearchController()
+        hideFavoritesController()
+        updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
+    }
+
+    func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView) {
+        dismissVisibleMenus()
+    }
+    
+    func topToolbarDidTapBraveShieldsButton(_ topToolbar: TopToolbarView) {
+        presentBraveShieldsViewController()
+    }
+    
+    func presentBraveShieldsViewController() {
+        guard let selectedTab = tabManager.selectedTab, var url = selectedTab.url else { return }
+        if url.isErrorPageURL, let originalURL = url.originalURLFromErrorURL {
+            url = originalURL
+        }
+        if url.isLocalUtility {
+            return
+        }
+        let shields = ShieldsViewController(tab: selectedTab)
+        shields.shieldsSettingsChanged = { [unowned self] _ in
+            // Update the shields status immediately
+            self.topToolbar.refreshShieldsStatus()
+            
+            // Reload this tab. This will also trigger an update of the brave icon in `TabLocationView` if
+            // the setting changed is the global `.AllOff` shield
+            self.tabManager.selectedTab?.reload()
+            
+            // In 1.6 we "reload" the whole web view state, dumping caches, etc. (reload():BraveWebView.swift:495)
+            // BRAVE TODO: Port over proper tab reloading with Shields
+        }
+        shields.showGlobalShieldsSettings = { [unowned self] vc in
+            vc.dismiss(animated: true) {
+                let shieldsAndPrivacy = BraveShieldsAndPrivacySettingsController(
+                    profile: self.profile,
+                    tabManager: self.tabManager,
+                    feedDataSource: self.feedDataSource
+                )
+                let container = SettingsNavigationController(rootViewController: shieldsAndPrivacy)
+                container.isModalInPresentation = true
+                container.modalPresentationStyle =
+                    UIDevice.current.userInterfaceIdiom == .phone ? .pageSheet : .formSheet
+                shieldsAndPrivacy.navigationItem.rightBarButtonItem = .init(
+                    barButtonSystemItem: .done,
+                    target: container,
+                    action: #selector(SettingsNavigationController.done)
+                )
+                self.present(container, animated: true)
+            }
+        }
+        let container = PopoverNavigationController(rootViewController: shields)
+        let popover = PopoverController(contentController: container, contentSizeBehavior: .preferredContentSize)
+        popover.present(from: topToolbar.locationView.shieldsButton, on: self)
+    }
+    
+    // TODO: This logic should be fully abstracted away and share logic from current MenuViewController
+    // See: https://github.com/brave/brave-ios/issues/1452
+    func topToolbarDidTapBookmarkButton(_ topToolbar: TopToolbarView) {
+        showBookmarkController()
+    }
+    
+    func topToolbarDidTapBraveRewardsButton(_ topToolbar: TopToolbarView) {
+        showBraveRewardsPanel()
+    }
+    
+    func topToolbarDidLongPressBraveRewardsButton(_ topToolbar: TopToolbarView) {
+        showRewardsDebugSettings()
+    }
+    
+    func topToolbarDidTapMenuButton(_ topToolbar: TopToolbarView) {
+        tabToolbarDidPressMenu(topToolbar)
+    }
+    
+    private func hideSearchController() {
+        if let searchController = searchController {
+            searchController.willMove(toParent: nil)
+            searchController.view.removeFromSuperview()
+            searchController.removeFromParent()
+            self.searchController = nil
+            searchLoader = nil
+        }
+    }
+    
+    private func showSearchController() {
+        if searchController != nil { return }
+
+        let tabType = TabType.of(tabManager.selectedTab)
+        searchController = SearchViewController(forTabType: tabType)
+        
+        guard let searchController = searchController else { return }
+
+        searchController.searchEngines = profile.searchEngines
+        searchController.searchDelegate = self
+        searchController.profile = self.profile
+
+        searchLoader = SearchLoader()
+        searchLoader?.addListener(searchController)
+        searchLoader?.autocompleteSuggestionHandler = { [weak self] completion in
+            self?.topToolbar.setAutocompleteSuggestion(completion)
+        }
+
+        addChild(searchController)
+        view.addSubview(searchController.view)
+        searchController.view.snp.makeConstraints { make in
+            make.top.equalTo(self.topToolbar.snp.bottom)
+            make.left.right.bottom.equalTo(self.view)
+            return
+        }
+        
+        searchController.didMove(toParent: self)
+    }
+    
+    private func displayFavoritesController() {
+        if favoritesController == nil {
+            let favoritesController = FavoritesViewController { [weak self] bookmark, action in
+                self?.handleFavoriteAction(favorite: bookmark, action: action)
+            }
+            favoritesController.applyTheme(Theme.of(tabManager.selectedTab))
+            self.favoritesController = favoritesController
+            
+            addChild(favoritesController)
+            view.addSubview(favoritesController.view)
+            favoritesController.didMove(toParent: self)
+            
+            favoritesController.view.snp.makeConstraints {
+                $0.top.leading.trailing.equalTo(pageOverlayLayoutGuide)
+                $0.bottom.equalTo(view)
+            }
+        }
+        guard let favoritesController = favoritesController else { return }
+        favoritesController.view.alpha = 0.0
+        let animator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1.0) {
+            favoritesController.view.alpha = 1
+        }
+        animator.addCompletion { _ in
+            self.webViewContainer.accessibilityElementsHidden = true
+            UIAccessibility.post(notification: .screenChanged, argument: nil)
+        }
+        animator.startAnimation()
+    }
+    
+    private func hideFavoritesController() {
+        guard let controller = favoritesController else { return }
+        self.favoritesController = nil
+        UIView.animate(withDuration: 0.1, delay: 0, options: [.beginFromCurrentState], animations: {
+            controller.view.alpha = 0.0
+        }, completion: { _ in
+            controller.willMove(toParent: nil)
+            controller.view.removeFromSuperview()
+            controller.removeFromParent()
+            self.webViewContainer.accessibilityElementsHidden = false
+            UIAccessibility.post(notification: .screenChanged, argument: nil)
+        })
+    }
+    
+    private func showBookmarkController() {
+        let bookmarkViewController = BookmarksViewController(
+            folder: Bookmarkv2.lastVisitedFolder(),
+            isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        
+        bookmarkViewController.toolbarUrlActionsDelegate = self
+        
+        presentSettingsNavigation(with: bookmarkViewController)
+    }
+    
+    func openAddBookmark() {
+        guard let selectedTab = tabManager.selectedTab,
+              let selectedUrl = selectedTab.url,
+              !(selectedUrl.isLocal || selectedUrl.isReaderModeURL) else {
+            return
+        }
+
+        let bookmarkUrl = selectedUrl.decodeReaderModeURL ?? selectedUrl
+
+        let mode = BookmarkEditMode.addBookmark(title: selectedTab.displayTitle, url: bookmarkUrl.absoluteString)
+
+        let addBookMarkController = AddEditBookmarkTableViewController(mode: mode)
+
+        presentSettingsNavigation(with: addBookMarkController, cancelEnabled: true)
+    }
+    
+    private func presentSettingsNavigation(with controller: UIViewController, cancelEnabled: Bool = false) {
+        let navigationController = SettingsNavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .formSheet
+        
+        let cancelBarbutton = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: navigationController,
+            action: #selector(SettingsNavigationController.done))
+        
+        let doneBarbutton = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: navigationController,
+            action: #selector(SettingsNavigationController.done))
+        
+        navigationController.navigationBar.topItem?.leftBarButtonItem = cancelEnabled ? cancelBarbutton : nil
+        
+        navigationController.navigationBar.topItem?.rightBarButtonItem = doneBarbutton
+        
+        present(navigationController, animated: true)
+    }
+}
+
+// MARK: ToolbarDelegate
+
+extension BrowserViewController: ToolbarDelegate {
+    
+    func tabToolbarDidPressSearch(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        topToolbar.tabLocationViewDidTapLocation(topToolbar.locationView)
+    }
+    
+    func tabToolbarDidPressBack(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        tabManager.selectedTab?.goBack()
+    }
+
+    func tabToolbarDidLongPressBack(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        UIImpactFeedbackGenerator(style: .heavy).bzzt()
+        showBackForwardList()
+    }
+    
+    func tabToolbarDidPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        tabManager.selectedTab?.goForward()
+    }
+    
+    func tabToolbarDidPressShare() {
+        func share(url: URL) {
+            presentActivityViewController(
+                url,
+                tab: url.isFileURL ? nil : tabManager.selectedTab,
+                sourceView: view,
+                sourceRect: view.convert(topToolbar.menuButton.frame, from: topToolbar.menuButton.superview),
+                arrowDirection: [.up]
+            )
+        }
+        
+        guard let tab = tabManager.selectedTab, let url = tab.url else { return }
+        
+        if let temporaryDocument = tab.temporaryDocument {
+            temporaryDocument.getURL().uponQueue(.main, block: { tempDocURL in
+                // If we successfully got a temp file URL, share it like a downloaded file,
+                // otherwise present the ordinary share menu for the web URL.
+                if tempDocURL.isFileURL {
+                    share(url: tempDocURL)
+                } else {
+                    share(url: url)
+                }
+            })
+        } else {
+            share(url: url)
+        }
+    }
+    
+    func tabToolbarDidPressMenu(_ tabToolbar: ToolbarProtocol) {
+        let homePanel = MenuViewController(bvc: self, tab: tabManager.selectedTab)
+        let popover = PopoverController(contentController: homePanel, contentSizeBehavior: .preferredContentSize)
+        // Not dynamic, but trivial at this point, given how UI is currently setup
+        popover.color = Theme.of(tabManager.selectedTab).colors.home
+        popover.present(from: tabToolbar.menuButton, on: self)
+    }
+    
+    func tabToolbarDidPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+    }
+
+    func tabToolbarDidLongPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        showAddTabContextMenu(sourceView: toolbar ?? topToolbar, button: button)
+    }
+    
+    private func addTabAlertActions() -> [UIAlertAction] {
+        var actions: [UIAlertAction] = []
+        if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+            let newPrivateTabAction = UIAlertAction(title: Strings.newPrivateTabTitle, style: .default, handler: { [unowned self] _ in
+                // BRAVE TODO: Add check for DuckDuckGo popup (and based on 1.6, whether the browser lock is enabled?)
+                // before focusing on the url bar
+                self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true)
+            })
+            actions.append(newPrivateTabAction)
+        }
+        let bottomActionTitle = PrivateBrowsingManager.shared.isPrivateBrowsing ? Strings.newPrivateTabTitle : Strings.newTabTitle
+        actions.append(UIAlertAction(title: bottomActionTitle, style: .default, handler: { [unowned self] _ in
+            self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        }))
+        return actions
+    }
+    
+    func showAddTabContextMenu(sourceView: UIView, button: UIButton) {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alertController.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
+        addTabAlertActions().forEach(alertController.addAction)
+        alertController.popoverPresentationController?.sourceView = sourceView
+        alertController.popoverPresentationController?.sourceRect = button.frame
+        UIImpactFeedbackGenerator(style: .heavy).bzzt()
+        present(alertController, animated: true)
+    }
+    
+    func tabToolbarDidLongPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        UIImpactFeedbackGenerator(style: .heavy).bzzt()
+        showBackForwardList()
+    }
+
+    func tabToolbarDidPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        showTabTray()
+    }
+    
+    func tabToolbarDidLongPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton) {
+        guard self.presentedViewController == nil else {
+            return
+        }
+        let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar.view.isHidden) ||
+            (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {
+            addTabAlertActions().forEach(controller.addAction)
+        }
+        
+        if tabManager.tabsForCurrentMode.count > 1 {
+            controller.addAction(UIAlertAction(title: String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count), style: .destructive, handler: { _ in
+                self.tabManager.removeAll()
+            }), accessibilityIdentifier: "toolbarTabButtonLongPress.closeTab")
+        }
+        controller.addAction(UIAlertAction(title: Strings.closeTabTitle, style: .destructive, handler: { _ in
+            if let tab = self.tabManager.selectedTab {
+                self.tabManager.removeTab(tab)
+            }
+        }), accessibilityIdentifier: "toolbarTabButtonLongPress.closeTab")
+        controller.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil), accessibilityIdentifier: "toolbarTabButtonLongPress.cancel")
+        controller.popoverPresentationController?.sourceView = toolbar ?? topToolbar
+        controller.popoverPresentationController?.sourceRect = button.frame
+        UIImpactFeedbackGenerator(style: .heavy).bzzt()
+        present(controller, animated: true, completion: nil)
+    }
+
+    private func showBackForwardList() {
+        if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
+            let backForwardViewController = BackForwardListViewController(profile: profile, backForwardList: backForwardList)
+            backForwardViewController.tabManager = tabManager
+            backForwardViewController.bvc = self
+            backForwardViewController.modalPresentationStyle = .overCurrentContext
+            backForwardViewController.backForwardTransitionDelegate = BackForwardListAnimator()
+            present(backForwardViewController, animated: true, completion: nil)
+        }
+    }
+    
+    func tabToolbarDidSwipeToChangeTabs(_ tabToolbar: ToolbarProtocol, direction: UISwipeGestureRecognizer.Direction) {
+        let tabs = tabManager.tabsForCurrentMode
+        guard let selectedTab = tabManager.selectedTab, let index = tabs.firstIndex(where: { $0 === selectedTab }) else { return }
+        let newTabIndex = index + (direction == .left ? -1 : 1)
+        if newTabIndex >= 0 && newTabIndex < tabs.count {
+            tabManager.selectTab(tabs[newTabIndex])
+        }
+    }
+}


### PR DESCRIPTION
This PR also extracting the ToolBar and TopToolBar Delegate logic into a new extension for readability.

And adding a boolean to determine If TabTray is open and act pop over logic accordingly.

## Summary of Changes

This pull request fixes #3461

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Clean install
- Visit cnn.com 
- Before tab finishes loading open tab tray
- Tooltip does not show on tab tray

## Screenshots:

![1 1](https://user-images.githubusercontent.com/6643505/116575438-a33eb780-a8dc-11eb-92ca-3656c3c53b4c.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
