### PR TITLE
Fix #3454: Moving between text fields causes search button to be hidden (eventually)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -66,8 +66,9 @@ class BrowserViewController: UIViewController {
 
     lazy var mailtoLinkHandler: MailtoLinkHandler = MailtoLinkHandler()
 
-    // Custom Search Engine
+    /// Custom Search Engine
     var openSearchEngine: OpenSearchReference?
+    var openSearchTextFieldInputAssistantBarButtonGroup = [UIBarButtonItemGroup]()
 
     lazy var customSearchEngineButton = OpenSearchEngineButton(hidesWhenDisabled: false).then {
         $0.addTarget(self, action: #selector(addCustomSearchEngineForFocusedElement), for: .touchUpInside)

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -86,10 +86,13 @@ extension BrowserViewController {
             return supportsAutoAdd
         }
         
+        if openSearchTextFieldInputAssistantBarButtonGroup.isEmpty {
+            openSearchTextFieldInputAssistantBarButtonGroup = webContentView.inputAssistantItem.trailingBarButtonGroups
+        }
+        
         if UIDevice.isIpad {
-            webContentView.inputAssistantItem.trailingBarButtonGroups +=
+            webContentView.inputAssistantItem.trailingBarButtonGroups = openSearchTextFieldInputAssistantBarButtonGroup +
                 [UIBarButtonItemGroup(barButtonItems: [UIBarButtonItem(customView: customSearchEngineButton)], representativeItem: nil)]
-
         } else {
             let argumentNextItem: [Any] = ["_n", "extI", "tem"]
             let argumentView: [Any] = ["v", "ie", "w"]
@@ -246,6 +249,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
 
         if self.customSearchEngineButton.superview != nil {
             self.customSearchEngineButton.removeFromSuperview()
+            openSearchTextFieldInputAssistantBarButtonGroup.removeAll()
         }
 
         UIView.animate(withDuration: state.animationDuration) {


### PR DESCRIPTION
Adding check for adding textfields input button group open search button only once

## Summary of Changes

This pull request fixes #3454

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Same test plan in the ticket

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
