### PR TITLE
Ref #3410: Ensure legacy wallet is also initialized when rewards is

### DIFF
--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
@@ -166,8 +166,13 @@ class BraveRewardsViewController: UIViewController, Themeable, PopoverContentCom
                     }
                 }
             }
-            
-            self.reloadData()
+            if let legacyWallet = self.legacyWallet, !legacyWallet.isInitialized {
+                legacyWallet.initializeLedgerService({
+                    self.reloadData()
+                })
+            } else {
+                self.reloadData()
+            }
         }
         
         view.snp.makeConstraints {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -226,7 +226,9 @@ class BrowserViewController: UIViewController {
         
         // Only start ledger service automatically if ads is enabled
         if rewards.isAdsEnabled {
-            rewards.startLedgerService(nil)
+            rewards.startLedgerService {
+                self.legacyWallet?.initializeLedgerService(nil)
+            }
         }
     }
     

--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -123,7 +123,14 @@ class BraveRewardsSettingsViewController: TableViewController {
         title = Strings.braveRewardsTitle
         
         rewards.startLedgerService { [weak self] in
-            self?.reloadSections()
+            guard let self = self else { return }
+            if let legacyWallet = self.legacyWallet, !legacyWallet.isInitialized {
+                legacyWallet.initializeLedgerService {
+                    self.reloadSections()
+                }
+            } else {
+                self.reloadSections()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of Changes

This amends #3410 to ensure the legacy wallet is also initialized when the regular wallet is which is required for legacy transfer to work

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Test basic transfer flow

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
