### PR TITLE
Fix #3246: Parse page metadata correctly to ensure URL is correct

### DIFF
--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -37,14 +37,21 @@ class MetadataParserHelper: TabEventHandler {
             }
             
             guard let dict = result as? [String: Any],
-                  let data = try? JSONSerialization.data(withJSONObject: dict, options: []),
-                  let pageMetadata = try? JSONDecoder().decode(PageMetadata.self, from: data) else {
+                  let data = try? JSONSerialization.data(withJSONObject: dict, options: []) else {
                 log.debug("Page contains no metadata!")
                 return
             }
-
-            tab.pageMetadata = pageMetadata
-            TabEvent.post(.didLoadPageMetadata(pageMetadata), for: tab)
+            
+            do {
+                let pageMetadata = try JSONDecoder().decode(PageMetadata.self, from: data)
+                tab.pageMetadata = pageMetadata
+                TabEvent.post(.didLoadPageMetadata(pageMetadata), for: tab)
+            } catch {
+                log.error("Failed to parse metadata: \(error)")
+                // To avoid issues where `pageMetadata` points to the last website to successfully
+                // parse metadata, set to nil
+                tab.pageMetadata = nil
+            }
         }
     }
 }

--- a/Storage/PageMetadata.swift
+++ b/Storage/PageMetadata.swift
@@ -14,18 +14,9 @@ public struct PageMetadata: Decodable {
     public let providerName: String?
     public let faviconURL: String?
     public let largeIconURL: String?
-    public let keywordsString: String?
+    public let keywords: Set<String>?
     public let search: Link?
     public let feeds: [Link]
-    
-    public var keywords: Set<String> {
-        guard let string = keywordsString else {
-            return Set()
-        }
-
-        let strings = string.split(separator: ",", omittingEmptySubsequences: true).map(String.init)
-        return Set(strings)
-    }
     
     enum CodingKeys: String, CodingKey {
         case mediaURL = "image"
@@ -36,7 +27,7 @@ public struct PageMetadata: Decodable {
         case providerName = "provider"
         case faviconURL = "icon"
         case largeIconURL = "largeIcon"
-        case keywordsString = "keywords"
+        case keywords
         case search
         case feeds
     }
@@ -49,7 +40,7 @@ public struct PageMetadata: Decodable {
                 providerName: String?,
                 faviconURL: String? = nil,
                 largeIconURL: String? = nil,
-                keywords: String? = nil,
+                keywords: Set<String>? = nil,
                 search: Link? = nil,
                 feeds: [Link] = []) {
         self.siteURL = siteURL
@@ -60,7 +51,7 @@ public struct PageMetadata: Decodable {
         self.providerName = providerName
         self.faviconURL = faviconURL
         self.largeIconURL = largeIconURL
-        self.keywordsString = keywords
+        self.keywords = keywords
         self.search = search
         self.feeds = feeds
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3246 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Search "Test"
- Visit Speedtest.net result 
- Tap share and verify the URL that is shared is speedtest and not google

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
