### PR TITLE
Fix #3444: Dont reset the cursor if we arent removing an autofill

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -151,17 +151,21 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
         // Clear the current completion, then set the text without the attributed style.
         let text = (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
-        removeCompletion()
+        let didRemoveCompletion = removeCompletion()
         self.text = text
         hideCursor = false
         // Move the cursor to the end of the completion.
-        selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+        if didRemoveCompletion {
+            selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+        }
     }
 
-    /// Removes the autocomplete-highlighted
-    fileprivate func removeCompletion() {
+    /// Removes the autocomplete-highlighted. Returns true if a completion was actually removed
+    @objc @discardableResult fileprivate func removeCompletion() -> Bool {
+        let hasActiveCompletion = isSelectionActive
         autocompleteTextLabel?.removeFromSuperview()
         autocompleteTextLabel = nil
+        return hasActiveCompletion
     }
 
     // `shouldChangeCharactersInRange` is called before the text changes, and textDidChange is called after.


### PR DESCRIPTION
This is a prior fix from Firefox:
https://github.com/mozilla-mobile/firefox-ios/commit/adfe64a12b190e24cdafe47f1298a58de942c48a

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3444

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan

- Visit any website
- Tap url bar
- Tap highlighted text and verify menu appears instead of resetting cursor position
- Type in something that triggers text to be auto-filled (something in history for instance)
- Tap highlighted text, verify its inserted and the cursor is reset to the end (or to where you tapped)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
