### PR TITLE
Fix #3598: Initialize DB after store existence check for passcode reset

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -71,9 +71,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         
         // Must happen before passcode check, otherwise may unnecessarily reset keychain
         Migration.moveDatabaseToApplicationDirectory()
-        // We have to wait until pre1.12 migration is done until we proceed with database
-        // initialization. This is because Database container may change. See bugs #3416, #3377.
-        DataController.shared.initialize()
         
         // Passcode checking, must happen on immediate launch
         if !DataController.shared.storeExists() {
@@ -84,6 +81,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             //  literally never use Brave. This bypasses this situation, while not using a modifiable pref.
             KeychainWrapper.sharedAppContainerKeychain.setAuthenticationInfo(nil)
         }
+        
+        // We have to wait until pre1.12 migration is done until we proceed with database
+        // initialization. This is because Database container may change. See bugs #3416, #3377.
+        DataController.shared.initialize()
         
         return startApplication(application, withLaunchOptions: launchOptions)
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3598 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable passcode (kill app and re-launch to verify)
- Delete app
- Reinstall app, verify no PIN is required

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
