### PR TITLE
Fix #3468: Reset RSS feed enabled state when feed is removed

### DIFF
--- a/Client/Frontend/Brave Today/Composer/FeedDataSource+RSS.swift
+++ b/Client/Frontend/Brave Today/Composer/FeedDataSource+RSS.swift
@@ -56,12 +56,13 @@ extension FeedDataSource {
     }
     
     /// Remove a users custom RSS feed to the list of sources
-    func removeRSSFeed(with url: URL) {
-        let feedUrl = url.absoluteString
+    func removeRSSFeed(_ location: RSSFeedLocation) {
+        let feedUrl = location.url.absoluteString
         if RSSFeedSource.get(with: feedUrl) == nil {
             return
         }
-        RSSFeedSource.delete(with: url.absoluteString)
+        RSSFeedSource.delete(with: feedUrl)
+        FeedSourceOverride.resetStatus(forId: location.id)
         setNeedsReloadCards()
     }
     

--- a/Client/Frontend/Settings/Brave Today/BraveTodaySettingsViewController.swift
+++ b/Client/Frontend/Settings/Brave Today/BraveTodaySettingsViewController.swift
@@ -91,7 +91,7 @@ class BraveTodaySettingsViewController: TableViewController {
                         cellClass: SubtitleCell.self,
                         editActions: [.init(title: Strings.BraveToday.deleteUserSourceTitle, style: .destructive, selection: { [unowned self] indexPath in
                             guard let location = feedDataSource.rssFeedLocations[safe: indexPath.row] else { return }
-                            self.feedDataSource.removeRSSFeed(with: location.url)
+                            self.feedDataSource.removeRSSFeed(location)
                             self.reloadSections()
                         })]
                     )

--- a/Data/models/FeedSourceOverride.swift
+++ b/Data/models/FeedSourceOverride.swift
@@ -30,6 +30,10 @@ public final class FeedSourceOverride: NSManagedObject, CRUD {
         }
     }
     
+    public class func resetStatus(forId id: String) {
+        getInternal(fromId: id)?.delete()
+    }
+    
     public class func resetSourceSelection() {
         deleteAll()
     }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3468 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
