### PR TITLE
Fix #3616 - Fixing seeking and long-press conflicting

### DIFF
--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -83,9 +83,6 @@ class PlaylistHelper: TabContentScript {
         
         log.debug("FOUND VIDEO ITEM ON PAGE: \(message.body)")
         
-        // Has to be done otherwise it is impossible to play a video after selecting its elements
-        UIMenuController.shared.hideMenu()
-        
         if PlaylistItem.itemExists(item) {
             delegate?.openInPlayListActivity(info: item)
             delegate?.addToPlayListActivity(info: nil, itemDetected: false)
@@ -105,6 +102,9 @@ class PlaylistHelper: TabContentScript {
             if item.detected {
                 self.delegate?.showPlaylistToast(info: item, itemState: .pendingUserAction)
             } else {
+                // Has to be done otherwise it is impossible to play a video after selecting its elements
+                UIMenuController.shared.hideMenu()
+                
                 let style: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
                 let alert = UIAlertController(
                     title: Strings.PlayList.addToPlayListAlertTitle, message: Strings.PlayList.addToPlayListAlertDescription, preferredStyle: style)

--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -83,6 +83,9 @@ class PlaylistHelper: TabContentScript {
         
         log.debug("FOUND VIDEO ITEM ON PAGE: \(message.body)")
         
+        // Has to be done otherwise it is impossible to play a video after selecting its elements
+        UIMenuController.shared.hideMenu()
+        
         if PlaylistItem.itemExists(item) {
             delegate?.openInPlayListActivity(info: item)
             delegate?.addToPlayListActivity(info: nil, itemDetected: false)

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -171,18 +171,17 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
         
         // When the long-press gesture is recognized, we want to disable all selections and context menus on the page
         function clearSelection() {
-            var sel;
-            if ((sel = document.selection) && sel.empty) {
-                sel.empty();
+            var selection;
+            if ((selection = document.selection) && selection.empty) {
+                selection.empty();
             } else {
                 if (window.getSelection) {
                     window.getSelection().removeAllRanges();
                 }
                 
-                var activeEl = document.activeElement;
-                if (activeEl) {
-                    var tagName = activeEl.nodeName.toLowerCase();
-                    activeEl.selectionStart = activeEl.selectionEnd;
+                var element = document.activeElement;
+                if (element) {
+                    element.selectionStart = element.selectionEnd;
                 }
             }
         }


### PR DESCRIPTION
Fixing Long-Press on video gesture recognizers in Javascript and iOS side.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Disable selection/find-in-page/copy/look-up context menu for video and audio elements when .
- Fixed long-pressing and seeking on a video so the gestures don't conflict. It is extremely PLATFORM SPECIFIC how often `touchmove` is called in Javascript, so added some fallback logic and used `changedTouches`.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3616

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
