### PR TITLE
Fix #3524: Add 1.25 translations

### DIFF
--- a/BraveShared/de.lproj/BraveShared.strings
+++ b/BraveShared/de.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto von %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Wiedergabeliste";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Zu Lesezeichen hinzufügen";
 

--- a/BraveShared/de.lproj/Localizable.strings
+++ b/BraveShared/de.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "auf %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Möchten Sie dieses Video zu Ihrer Wiedergabeliste hinzufügen?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Zur Brave Playlist hinzufügen";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Dieses Video war ein Livestream oder das Zeitlimit wurde erreicht. Bitte öffnen Sie den Link erneut um ihn neu zu laden.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Abgelaufenes Video";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Abgelaufen";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Beim Laden der Ressource ist ein Fehler aufgetreten!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Es sind keine Elemente verfügbar";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Hinweis";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "Okay";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Es tut uns leid, bei der Bild-im-Bild-Darstellung ist ein Fehler aufgetreten.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Mit dieser Option können Sie die automatische Wiedergabe, wenn die Wiedergabeliste geöffnet wird, aktivieren bzw. deaktivieren. Sie hat keine Auswirkungen auf die automatische Wiedergabe des nächsten Videos der Wiedergabeliste.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Automatische Wiedergabe";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Aus";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "An";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Nur über WLAN";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Das Herunterladen von Video- und Audiodateien für die Offline-Wiedergabe kann große Mengen an Speicherplatz sowie Datenvolumen erfordern ";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Mit dieser Option werden die Elemente Ihrer Wiedergabeliste automatisch auf Ihrem Gerät gespeichert, sodass Sie sie auch ohne Internetverbindung wiedergeben können.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Automatisch offline speichern";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Speicherplatz fast voll";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Livestream";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Wiedergabelistenmedien und Offlinedaten";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Offlinedaten der Wiedergabeliste";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Zurücksetzen";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Diese Option löscht alle Videos aus der Wiedergabeliste sowie die Offlinedaten.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Es tut uns leid, dieses Element konnte nicht offline gespeichert werden.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Entschuldigen Sie, es ist ein Fehler aufgetreten";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Wiedergabeliste";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Diese Einstellung legt fest, ob die Videoliste links oder rechts angezeigt wird.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Links";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Rechts";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Position der Seitenleiste";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Diese Option aktiviert bzw. deaktiviert die Möglichkeit, die Wiedergabe von Video- und Audiodateien an der Stelle wiederaufzunehmen, an der Sie beim letzten Mal aufgehört haben.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Wiedergabe vom letzten Punkt fortsetzen";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Diese Option zeigt auf manchen Medienwebseiten die Aufforderung „Zur Brave-Wiedergabeliste hinzufügen“ an. Unahängig davon können Sie Videos und Audiodateien auch hinzufügen, indem Sie sie gedrückt halten oder die „Teilen mit…“-Schaltfläche verwenden.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "„Zur Brave-Wiedergabeliste hinzufügen“ anzeigen";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Deaktiviert die WebKit MediaSource-API";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Webkompatibilität";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Entfernen";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Hierdurch werden die Offline-Medien gelöscht. Wollen Sie wirklich fortfahren?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Offline-Daten löschen";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Dies entfernt die Medien aus der Liste. Wollen Sie wirklich fortfahren?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Medien aus der Wiedergabeliste entfernen?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Erneut öffnen";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "Offline gespeichert";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Wird offline gespeichert…";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Es tut uns leid";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Zur Brave-Wiedergabeliste hinzugefügt";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Öffnen";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Zur Brave-Wiedergabeliste hinzufügen";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "In Brave-Wiedergabeliste anzeigen";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Kontextmenü schließen";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Transfer der alten Wallet";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Der Transfer Ihrer alten Wallet wurde abgeschlossen!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Der Transfer Ihrer alten Wallet verzögert sich…";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Der Transfer Ihrer alten Wallet läuft";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Der Transfer Ihrer alten Wallet ist ungültig";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Der Transfer Ihrer alten Wallet steht aus";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Der Transfer Ihrer alten Wallet wurde abgeschlossen. Es kann noch ein paar Minuten dauern, bis Ihr aktuelles Guthaben in der Brave Rewards Wallet auf dem Desktop angezeigt wird.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Transfer abgeschlossen!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Der Transfer Ihrer alten Wallet verzögert sich und wird in ein paar Minuten fortgesetzt.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Transfer verzögert";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Der Transfer Ihrer alten Wallet läuft und wird in wenigen Minuten abgeschlossen sein.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Transfer läuft";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Der Transfer Ihrer alten Wallet ist ungültig und kann nicht abgeschlossen werden";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Ungültiger Transfer";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Der Transfer Ihrer alten Wallet steht aus und wird bald beginnen.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Ausstehender Transfer";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Abgeschlossen!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Verzögert";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "Läuft";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Ungültig";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Ausstehend";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Einmaliger ausgehenden Transfer für bestehende Tokens";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Einmaligen Transfercode scannen";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Wallet-Transfer";
+"rewards.walletTransferTitle" = "Status des Wallet-Transfers";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Anzahl";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Glückwunsch. Sie sind etwas Besonderes.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Sofern verfügbar, wählt Brave automatisch eine sichere Verbindung für Sie.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Ihre Verbindung wird nun verschlüsselt.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Schauen Sie sich das an";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Bitte nehmen Sie keine Änderungen an den Daten unten vor";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Es konnte keine E-Mail geschickt werden. Bitte überprüfen Sie Ihre E-Mail-Konfiguration.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Bitte wählen Sie die Daten, die Sie mit uns teilen möchten.\n\nJe mehr Daten Sie direkt mit uns teilen, umso einfacher fällt es dem Support-Team, Ihr Problem zu lösen.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Fehler";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "Abonnements werden über Ihr iTunes-Konto belastet.\n\nJeder nicht genutzte Teil der kostenlosen Testversion verfällt, wenn er angeboten wird, beim Kauf eines Abonnements.\n\nIhr Abonnement verlängert sich automatisch, es sei denn, es wird mindestens 24 Stunden vor dem Ende des aktuellen Zeitraums gekündigt.\n\nSie können Ihre Abonnements in den Einstellungen verwalten.\n\nDurch die Verwendung von Brave stimmen Sie den Nutzungsbedingungen und den Datenschutzbestimmungen zu.";
+"vpn.vpnIAPBoilerPlate" = "Abonnements werden über Ihr iTunes-Konto abgerechnet.\n\nWenn Ihnen eine kostenlose Testversion angeboten wurde, verfällt deren nicht genutzter Teil beim Kauf eines Abonnements.\n\nIhr Abonnement verlängert sich automatisch, wenn Sie es nicht mindestens 24 Stunden vor Ende des aktuellen Zeitraums kündigen.\n\nSie können Ihre Abonnements in den Einstellungen verwalten.\n\nDurch die Verwendung von Brave stimmen Sie den Nutzungsbedingungen und den Datenschutzbestimmungen zu.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Hiermit wird Ihre Konfiguration für Brave Firewall + VPN zurückgesetzt, womit Fehler behoben werden können. Dieser Vorgang kann etwa eine Minute dauern.";

--- a/BraveShared/es.lproj/BraveShared.strings
+++ b/BraveShared/es.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto de %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Lista de reproducción";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Añadir a Marcadores";
 

--- a/BraveShared/es.lproj/Localizable.strings
+++ b/BraveShared/es.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "en %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "¿Te gustaría añadir este vídeo a tu lista de reproducción?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Añadir a Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Este vídeo era una transmisión en directo o se ha alcanzado el tiempo límite. Vuelve a abrir el enlace para actualizarlo.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Vídeo expirado";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Expirado";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "¡Ha ocurrido un problema al cargar el recurso!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "No hay ningún elemento disponible";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Aviso";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "Aceptar";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Vaya, se ha producido un error al tratar de mostrar la imagen superpuesta.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Esta opción habilitará o deshabilitará la reproducción automática al abrir la lista de reproducción, aunque no afectará al siguiente vídeo de la misma.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Reproducción automática";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Desactivada";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Activada";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Solo Wifi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Los archivos audiovisuales para uso sin conexión pueden ocupar mucho espacio en tu dispositivo y consumir muchos datos de conexión móvil";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Esta opción guardará automáticamente los elementos de tu lista de reproducción en tu dispositivo para que puedas reproducirlos sin conexión.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Guardado automático para sin conexión";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Apenas hay espacio de almacenamiento";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Transmisión en directo";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Datos sin conexión y contenido de la lista de reproducción";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Datos sin conexión de la lista de reproducción";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Restablecer";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Esta opción eliminará todos los vídeos de la lista de reproducción y del almacenamiento del modo sin conexión.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Vaya, no ha sido posible guardar este elemento para el modo sin conexión.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Lo sentimos, algo salió mal";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Lista de reproducción";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Este ajuste cambiará la ubicación de la lista de vídeos al lado izquierdo o al derecho.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Izquierdo";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Derecho";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Ubicación en barra lateral";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Esta opción habilitará o deshabilitará la posibilidad de reanudar contenidos audiovisuales justo donde la reproducción se detuvo.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Reanudar reproducción donde la detuve";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Esta opción hará aparecer el mensaje \"Añadir aBrave Playlist\" en algunos sitios web de contenidos audiovisuales. En cualquier caso, puedes también añadir vídeos o audios a la lista de reproducción pulsando durante unos segundos encima de ellos o a través del botón \"Compartir con...\".";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Mostrar \"Añadir a Brave Playlist\"";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Deshabilita la API de WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Compatibilidad web";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Eliminar";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Esto eliminará los contenidos audiovisuales del almacenamiento sin conexión. ¿Seguro que quieres continuar?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Eliminar datos sin conexión";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Esto eliminará el elemento de la lista. ¿Seguro que quieres continuar?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "¿Eliminar elemento de la lista de reproducción?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Volver a abrir";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "Guardado para sin conexión";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Guardando para sin conexión...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Lo sentimos";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Añadido a Brave Playlist";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Abrir";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Añadir a Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Ver en Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Cerrar el menú de contexto";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Transferencia de cartera heredada";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "¡La transferencia de tu cartera heredada se ha completado!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "La transferencia de tu cartera heredada se ha demorado...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "La transferencia de tu cartera heredada está en proceso";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "La transferencia de tu cartera heredada no es válida";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "La transferencia de tu cartera heredada está en estado pendiente";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "¡La transferencia de tu cartera heredada se ha realizado correctamente! No obstante, es posible que tu saldo actual tarde unos minutos en aparecer reflejado en tu cartera de escritorio de Brave Rewards.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "¡Transferencia completada!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "La transferencia de tu cartera heredada se ha demorado y podría tardar varios minutos en reanudarse.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Transferencia demorada";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "La transferencia de tu cartera heredada está en proceso y podría tardar varios minutos en completarse.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Transferencia en proceso";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "La transferencia de tu cartera heredada no es válida y no se puede completar";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Transferencia no válida";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "La transferencia de tu cartera heredada está en estado pendiente y debería iniciarse en breve.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Transferencia pendiente";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "¡Completada!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Demorada";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "En proceso";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "No válida";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Pendiente";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Tokens existentes de transferencia saliente única";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Escanear código de transferencia de uso único";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Transferencia de cartera";
+"rewards.walletTransferTitle" = "Estado de la transferencia de la cartera";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Importe";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "¡Enhorabuena! Eres muy especial.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Siempre que sea posible, Brave te ofrecerá automáticamente una conexión segura.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Ahora, tu conexión está cifrada.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Echa un vistazo";
@@ -780,6 +984,9 @@
 
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "No edites la siguiente información";
+
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "No se puede enviar el mensaje. Verifica la configuración del correo electrónico.";
 
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Selecciona la información que quieres compartir con nosotros.\n\nCuanta más información compartas con nosotros en un primer momento, más fácil lo tendrá nuestro equipo de asistencia para ayudarte a resolver el problema.";

--- a/BraveShared/fr.lproj/BraveShared.strings
+++ b/BraveShared/fr.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Photo par %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Liste de lecture";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Ajouter aux marque-pages";
 

--- a/BraveShared/fr.lproj/Localizable.strings
+++ b/BraveShared/fr.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "sur %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Souhaitez-vous ajouter cette vidéo à votre liste de lecture ?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Ajouter à Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Cette vidéo était diffusée en direct ou la limite de temps a été atteinte. Veuillez rouvrir le lien pour l’actualiser.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Vidéo expirée";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Expirée";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Un problème est survenu lors du chargement de la ressource !";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Aucun élément disponible";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Notification";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "OK";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Une erreur est survenue lors de la tentative d’affichage Picture-in-Picture.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Cette option active/désactive la lecture automatique lorsque la liste de lecture est ouverte. Cependant, elle n’affecte pas la lecture automatique lorsque la vidéo suivante dans la liste est chargée.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Lecture automatique";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Désactiver";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Activer";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "WiFi uniquement";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "L’ajout de fichiers vidéo et audio pour une utilisation hors ligne peut nécessiter un espace de stockage important sur votre appareil ainsi qu’une utilisation de vos données cellulaires";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Cette option conserve automatiquement vos éléments de liste de lecture sur votre appareil, afin de pouvoir les lire lorsque vous ne disposez pas d’une connexion à Internet.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Enregistrement automatique pour une utilisation hors ligne";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Stockage presque plein";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Diffusion en direct";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Données hors ligne et fichiers de la liste de lecture";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Données hors ligne de la liste de lecture";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Réinitialiser";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Cette option supprime toutes les vidéos de la liste de lecture ainsi que du stockage en mode hors ligne.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Désolés, cet élément n’a pas pu être enregistré pour le mode hors ligne à l’heure actuelle.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Une erreur est survenue";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Liste de lecture";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Ce paramètre modifie l’emplacement de la liste de vidéos entre le côté gauche et le côté droit.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Gauche";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Droite";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Emplacement de la barre latérale";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Cette option active/désactive la capacité de reprendre la lecture des fichiers (vidéo/audio) au moment où vous l’avez interrompue.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Reprendre la lecture au moment où je l’ai interrompue";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Cette option vous propose d’« Ajouter à la liste de lecture Brave » sur certains sites Web. Vous pouvez toujours ajouter des fichiers (vidéo/audio) en appuyant de façon prolongée sur un fichier, ou à l’aide du bouton de menu « Partager avec… ».";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Afficher « Ajouter à la liste de lecture Brave »";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Désactive l’API WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Compatibilité Web";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Supprimer";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Le fichier sera supprimé du stockage hors ligne. Voulez-vous vraiment continuer ?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Supprimer les données hors ligne";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "L’élément multimédia sera supprimé de la liste. Voulez-vous vraiment continuer ?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Supprimer l’élément multimédia de la liste de lecture ?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Rouvrir";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "Enregistrés pour une utilisation hors ligne";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Enregistrement pour une utilisation hors ligne…";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Désolés";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Ajouté à la liste de lecture Brave";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Ouvrir";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Ajouter à Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Afficher dans Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Fermer le menu contextuel";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Transférer un ancien portefeuille";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Le transfert de votre ancien portefeuille est terminé !";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Le transfert de votre ancien portefeuille est retardé…";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Le transfert de votre ancien portefeuille est en cours";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Le transfert de votre ancien portefeuille n’est pas valide";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Le statut du transfert de votre ancien portefeuille est en attente";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Le transfert de votre ancien portefeuille est effectué ! Plusieurs minutes peuvent être nécessaires avant que votre solde existant s’affiche dans votre portefeuille Brave Rewards sur ordinateur.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Transfert terminé !";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Le transfert de votre ancien portefeuille est retardé et plusieurs minutes peuvent être nécessaires avant qu’il ne reprenne.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Transfert retardé";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Le transfert de votre ancien portefeuille est en cours et plusieurs minutes peuvent être nécessaires avant qu’il n’aboutisse.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Transfert en cours";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Le transfert de votre ancien portefeuille n’est pas valide et ne peut pas aboutir";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Transfert non valide";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Le statut du transfert de votre ancien portefeuille est en attente et devrait être traité prochainement.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Transfert en attente";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Terminé !";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Retardé";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "En cours";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Non valide";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "En attente";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Transfert unique des jetons existants";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Scanner le code de transfert unique";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Transférer un portefeuille";
+"rewards.walletTransferTitle" = "Statut du transfert de portefeuille";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Montant";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Félicitations, vous êtes exceptionnel.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Si une connexion sécurisée est disponible, Brave vous en fait profiter automatiquement.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Votre connexion est maintenant chiffrée.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Jetez-y un coup d'œil";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Merci de ne pas modifier les informations ci-dessous";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Échec d’envoi de l’e-mail. Vérifiez la configuration de votre messagerie.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Veuillez sélectionner les informations que vous souhaitez nous communiquer.\n\nPlus vous nous communiquez d'informations, plus il sera facile pour notre équipe d'assistance de vous aider à résoudre votre problème.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Erreur";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "Les abonnements seront facturés via votre compte iTunes.\n\nToute période d'essai gratuite non utilisée sera annulée en cas d'achat d'un abonnement.\n\nVotre abonnement sera automatiquement renouvelé, sauf en cas d'annulation au moins 24 heures avant la fin de la période en cours.\n\nVous pouvez gérer vos abonnements dans les Paramètres.\n\nEn utilisant Brave, vous acceptez les Conditions d'utilisation et la Politique de confidentialité.";
+"vpn.vpnIAPBoilerPlate" = "Les abonnements seront facturés via votre compte iTunes.\n\nToute période d’essai gratuite non utilisée sera annulée en cas d’achat d’un abonnement.\n\nVotre abonnement sera automatiquement renouvelé, sauf en cas d’annulation au moins 24 heures avant la fin de la période en cours.\n\nVous pouvez gérer vos abonnements dans Paramètres.\n\nEn utilisant Brave, vous acceptez les Conditions d’utilisation et la Politique de confidentialité.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Votre configuration Brave Firewall + VPN sera réinitialisée afin de résoudre les problèmes. Cette opération peut prendre quelques instants.";

--- a/BraveShared/id-ID.lproj/BraveShared.strings
+++ b/BraveShared/id-ID.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto oleh %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Daftar Putar";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Tambahkan ke Markah";
 

--- a/BraveShared/id-ID.lproj/Localizable.strings
+++ b/BraveShared/id-ID.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "pada %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Apakah Anda ingin menambahkan video ini ke daftar putar Anda?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Tambahkan ke Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Video ini merupakan siaran aliran langsung atau telah mecapai batas waktunya. Silakan buka tautannya kembali untuk melakukan penyegaran. ";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Video Telah Kedaluwarsa";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Kedaluwarsa";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Terjadi masalah saat memuat sumber!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Video Tidak Tersedia";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Perhatian";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "Oke";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Maaf, telah terjadi kesalahan saat mencoba menampilkan gambar-dalam-gambar.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Opsi ini akan mengaktifkan/menonaktifkan pemutar otomatis saat Daftar Putar dibuka. Namun piihan ini tidak aman memengaruhi pemutar otomatis saat video berikutnya dalam daftar tersebut telah dimuat.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Pemutar Otomatis";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Matikan";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Hidupkan";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Hanya Wifi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Menambahkan berkas video dan audio untuk penggunaan luring dapat menghabiskan banyak penyimpanan di perangkat Anda, selain juga menggunakan data seluler Anda";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Opsi ini akan secara otomatis menyimpan daftar putar Anda di perangkat Anda sehingga Anda dapat memutarnya saat sedang tidak tersambung ke Internet.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Simpan Otomatis untuk Luring";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Penyimpanan Hampir Penuh";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Siaran Aliran Langsung";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Data Media & Data Luring Daftar Putar";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Data Luring Daftar Putar";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Atur Ulang";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Opsi ini akan menghapus semua video dari Daftar Putar, begitu pula penyimpanan moda Luring.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Maaf, berkas ini tidak dapat disimpan untuk moda luring pada saat ini.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Maaf, telah terjadi kesalahan";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Daftar Putar";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Pengaturan ini akan mengubah lokasi daftar video di antara sisi kiri atau kanan.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Kiri";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Kanan";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Lokasi Bilah Sisi";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Opsi ini akan mengaktifkan/menonaktifkan kemampuan untuk mulai memutar kembali media (video/audio) dari saat Anda terakhir kali memutarnya.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Mulai Putar Ulang dari saat saya terakhir memutarnya";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Opsi ini akan meminta Anda untuk 'Menambahkan ke Daftar Putar Brave' Anda pada sejumlah situs web media. Anda dapat tetap menambahkan media (video/audio) dengan lama menekan media, atau dari tombol menu \"Bagikan Dengan...\".";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Tampilkan \"Tambahkan ke Daftar Putar Brave\"";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Nonaktifkan API WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Kompatibilitas Web";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Hapus";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Ini akan menghapus media dari penyimpanan luring. Anda yakin ingin melanjutkan?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Hapus Data Luring";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Ini akan menghapus media ini dari daftar. Anda yakin ingin melanjutkan?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Hapus Media Ini dari Daftar Putar?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Buka Ulang";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "Disimpan untuk Luring";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Menyimpan untuk Luring...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Maaf";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Ditambahkan ke Daftar Putar Brave";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Buka";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Tambahkan ke Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Lihat di Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Tutup Menu Konteks";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Transfer Dompet Lama";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Transfer dompet lama Anda telah selesai!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Transfer dompet lama Anda telah tertunda...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Transfer dompet lama Anda sedang berlangsung";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Transfer dompet lama Anda tidak valid";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Status transfer dompet lama Anda ditangguhkan";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Transfer dompet lama Anda telah selesai! Mungkin perlu beberapa waktu untuk menampilkan saldo Anda saat ini  di desktop dompet Brave Rewards Anda.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Transfer Selesai!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Transfer dompet lama Anda telah tertunda dan mungkin diperlukan beberapa menit untuk melanjutkannya.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Transfer Tertunda";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Transfer dompet lama Anda sedang berlangsung dan mungkin diperlukan beberapa menit untuk menyelesaikannya.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Transfer Sedang Berlangsung";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Transfer dompet lama Anda tidak valid dan tidak dapat diselesaikan";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Transfer Tidak Valid";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Status transfer dompet lama Anda ditangguhkan dan akan segera akan dimulai secepatnya.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Transfer Ditangguhkan";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Selesai!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Tertunda";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "Sedang Berlangsung";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Tidak Valid";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Ditangguhkan";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Token transfer sekali yang sudah ada";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Pindai Kode Sekali Transfer";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Transfer Dompet";
+"rewards.walletTransferTitle" = "Status Transfer Dompet";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Jumlah";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Selamat. Anda cukup spesial.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Jika tersedia, Brave membawa Anda pada tingkat koneksi paling aman secara otomatis.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Koneksi Anda kini dienkripsi.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Tengok";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Mohon jangan mengedit informasi apa pun di bawah ini";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Tidak dapat mengirim surel. Silakan periksa kembali konfigurasi surel Anda.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Silakan pilih informasi yang ingin Anda bagikan kepada kami.\n\nSemakin banyak informasi yang sejak awal Anda bagikan kepada kami, akan lebih mudah bagi staf pendukung kami untuk membantu Anda menyelesaikan masalah Anda.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Kesalahan";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "Langganan akan ditagihkan melalui akun iTunes Anda.\n\nBagian dari uji coba gratis yang tidak digunakan, akan dimasukkan ke paket saat Anda berlangganan.\n\nLangganan Anda akan diperbarui secara otomatis kecuali dibatalkan minimum 24 jam sebelum akhir periode berjalanan.\n\nAnda dapat mengelola langganan Anda di Pengaturan.\n\nDengan menggunakan Brave, anda menyetujui Syarat Penggunaan dan Kebijakan Privasi.";
+"vpn.vpnIAPBoilerPlate" = "Biaya berlangganan akan ditagihkan melalui akun iTunes Anda.\n\nBagian dari uji coba gratis yang tidak digunakan, jika ditawarkan, akan hangus saat Anda berlangganan.\n\nLangganan Anda akan diperbarui secara otomatis kecuali jika dibatalkan dalam minimum 24 jam sebelum akhir periode berjalanan.\n\nAnda dapat mengelola langganan Anda di Pengaturan.\n\nDengan menggunakan Brave, anda menyetujui Syarat Penggunaan dan Kebijakan Privasi ini.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Ini akan mengatur ulang konfigurasi Firewall + VPN Brave Anda dan memperbaiki kesalahan apa pun. Proses ini dapat memakan waktu beberapa saat.";

--- a/BraveShared/it.lproj/BraveShared.strings
+++ b/BraveShared/it.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Photo di %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Playlist";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Aggiungi ai Segnalibri";
 

--- a/BraveShared/it.lproj/Localizable.strings
+++ b/BraveShared/it.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "su %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Vuoi aggiungere questo video alla playlist?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Aggiungi alla Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Questo video era uno streaming in diretta oppure è stato superato il tempo massimo. Apri di nuovo il link per aggiornare.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Video scaduto";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Scaduto";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Si è verificato un problema durante il caricamento della risorsa!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Nessun elemento disponibile";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Avviso";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "OK";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Ci dispiace, si è verificato un errore nel tentativo di mostrare il picture-in-picture.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Questa opzione attiverà/disattiverà la riproduzione automatica quando la playlist viene aperta. Tuttavia questa opzione non avrà effetto sulla riproduzione automatica quando viene caricato il video successivo nell’elenco.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Riproduzione automatica";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Off";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "On";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Solo con Wi-Fi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Aggiungere un file video o audio per riprodurlo offline può richiedere molto spazio di archiviazione sul tuo dispositivo e anche l’utilizzo dei dati del cellulare.";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Questa opzione mantiene automaticamente gli elementi della playlist sul tuo dispositivo, così puoi riprodurli anche mentre non hai connessione internet.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Salvataggio automatico offline";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Spazio di archiviazione quasi pieno";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Streaming in diretta";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Elementi della playlist e dati offline";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Dati offline per playlist";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Azzeramento";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Questa opzione rimuoverà tutti i video dalla playlist e dallo spazio di archiviazione per la modalità offline.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Ci dispiace, al momento non è stato possibile salvare questo elemento per la modalità offline.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Ci dispiace, si è verificato un errore";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Playlist";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Questa impostazione cambierà la posizione dell’elenco dei video fra lato sinistro e lato destro.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Sinistra";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Destra";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Posizione della barra laterale";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Questa opzione attiverà/disattiverà la possibilità di iniziare la riproduzione di un elemento (video/audio) dal momento in cui l’avevi interrotta.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Inizia a riprodurre da dove avevo lasciato";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Questa opzione ti chiederà “Aggiungi alla Brave Playlist” sui siti web di alcuni media. Puoi ancora aggiungere elementi (video/audio) premendo a lungo sull’elemento, o dal menu “Condividi con…”.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Mostra “Aggiungi alla Brave Playlist”";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Disattiva l’API WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Compatibilità web";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Rimozione";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Questo eliminerà l’elemento dallo spazio di archiviazione offline. Vuoi continuare?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Rimuovi dati offline";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Questo rimuoverà l’elemento dalla playlist. Vuoi continuare?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Rimuovere elemento dalla playlist?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Aprire di nuovo";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "salvato offline";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Salvataggio offline…";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Ci dispiace";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Aggiunto alla Brave Playlist";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Apri";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Aggiungi alla Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Visualizza nella Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Chiudi il menu Contesto";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Trasferimento del portafoglio esistente";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Il trasferimento del portafoglio esistente è stato completato!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Il trasferimento del portafoglio esistente è stato ritardato…";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Il trasferimento del portafoglio esistente è in corso";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Il trasferimento del portafoglio esistente non è valido";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Il trasferimento del portafoglio esistente è in sospeso";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "È stato completato il trasferimento del tuo portafoglio esistente! Potrebbero passare alcuni minuti prima che il saldo attuale appaia sul tuo portafoglio desktop Brave Rewards.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Trasferimento completato!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "C’è un ritardo nel trasferimento del tuo portafoglio esistente e potrebbero passare alcuni minuti prima che possa proseguire.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Ritardo nel trasferimento";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Il trasferimento del tuo portafoglio esistente è in corso e potrebbero passare alcuni minuti prima che possa proseguire.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Trasferimento in corso";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Il trasferimento del tuo portafoglio esistente non è valido e non può essere completato";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Trasferimento non valido";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Il trasferimento del tuo portafoglio esistente è in sospeso e dovrebbe iniziare fra poco.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Trasferimento in sospeso";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Operazione completata!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Ritardo";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "In corso";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Non valido";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "In sospeso";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Trasferimento una tantum di token esistenti";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Codice di scansione una tantum";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Trasferimento del portafoglio";
+"rewards.walletTransferTitle" = "Stato del trasferimento del portafoglio";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Importo";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Congratulazioni, sei davvero speciale.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Se è possibile, Brave ti fa passare automaticamente a una connessione sicura.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "La tua connessione ora è crittografata";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Dai un’occhiata";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Non modificare le informazioni sottostanti";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Impossibile inviare l’email. Controlla la configurazione della tua email.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Seleziona i dati che vuoi condividere con noi.\n\nPiù dati condividi con noi dall’inizio, più facile sarà per l’assistenza aiutarti a risolvere il tuo problema.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Errore";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "I costi di abbonamento saranno addebitati sull’account iTunes.\n\nQuando si acquista l’abbonamento, le porzioni non utilizzate dell’eventuale prova gratuita andranno perse.\n\nSe non viene disdetto almeno 24 ore prima della scadenza, l’abbonamento si rinnoverà automaticamente.\n\nGli abbonamenti possono essere gestiti tramite la sezione Impostazioni.\n\nUtilizzando Brave, se ne accettano i termini d’uso e le norme sulla privacy.";
+"vpn.vpnIAPBoilerPlate" = "Gli abbonamenti verranno addebitati attraverso il tuo account iTunes.\n\nQualsiasi porzione non utilizzata della prova gratuita, se era stata offerta, viene annullata quando acquisti un abbonamento.\n\nL’abbonamento si rinnoverà automaticamente a meno che non sia annullato almeno 24 ore prima della fine del periodo in corso.\n\nPuoi gestire gli abbonamenti nelle Impostazioni.\n\nUtilizzando Brave, acconsenti ai Termini d’uso e l’Informativa sulla privacy.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Con quest’operazione sarà reimpostata la configurazione del firewall di Brave e della VPN e saranno corretti eventuali errori. Potrebbero servire alcuni minuti.";

--- a/BraveShared/ja.lproj/BraveShared.strings
+++ b/BraveShared/ja.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Photo by %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Playlist";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "ブックマークに追加";
 

--- a/BraveShared/ja.lproj/Localizable.strings
+++ b/BraveShared/ja.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "on %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "この動画をPlaylistに追加しますか？";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Brave Playlistに追加する";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "この動画はライブストリーミング動画であるか、期限切れです。再読み込みするには、リンクを再度開いてください。";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "期限切れの動画";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "期限切れ";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "リソースの読み込み中に問題が発生しました！";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "利用可能なアイテムがありません";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "注意";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "OK";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "すみません、エラーによりピクチャ・イン・ピクチャで表示できません。";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "この設定はPlaylistが開かれたときに自動で動画を再生する機能のオン/オフを切り替えますが、リスト上の次の動画がロードされたとき自動で再生する機能に対しての変更が行われません。";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "自動再生";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "オフ";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "オン";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Wifi接続時のみ";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "動画や音声ファイルをオフライン利用可能にする際、デバイスのデータ容量や通信量を大きく消費する可能性があります。";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "この設定を行うと、Playlistに追加されたアイテムを自動的にあなたのデバイスに保持し、インターネットに接続されていないときでも再生できるようになります。";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "オフライン再生のために自動保存する";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "データ容量がもうすぐいっぱいです";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "ライブストリーミング動画";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Playlistメディアとオフラインデータ";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Playlistオフラインデータ";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "リセットする";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "この設定を行うとPlaylistとオフライン再生用ストレージからすべての動画を削除します。";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "すみません、このアイテムは現在オフライン再生用に保存できません。";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "申し訳ありません、エラーが発生しました";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Playlist";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "この設定では動画リストの表示位置を左側/右側に切り替えます";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "左";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "右";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "サイドバーの位置";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "この設定は、前回の再生時に中断したメディア（動画もしくは音声）の続きから再生する機能のオン/オフを切り替えます。";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "前回の続きから再生";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "この設定を行うと、いくつかのサイトで「Brave Playlistに追加する」メッセージが表示されます。オフにしても、動画や音声プレイヤーを長押しもしくはメニューボタンの「共有」からPlaylistに追加することができます。";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "「Brave Playlistに追加する」を表示する";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "WebKit MediaSource APIを無効化します";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Web互換性";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "削除する";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "メディアをオフライン再生用のストレージから消去します。本当によろしいですか？";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "オフライン再生用データを消去する";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "リストからメディアを削除します。本当によろしいですか？";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "メディアをPlaylistから削除しますか？";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "再度開く";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "オフライン再生のために保存中";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "オフライン再生のために保存中...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "申し訳ありません";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Brave Playlistに追加されました";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "開く";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Brave Playlistに追加する";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Brave Playlistで見る";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "コンテキストメニューを閉じる";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "レガシーウォレットからの移行";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "旧ウォレットからの移行が完了しました！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "旧ウォレットからの移行に遅れが生じています...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "旧ウォレットからの移行は進行中です";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "旧ウォレットからの移行が無効となりました";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "旧ウォレットからの移行ステータスはペンディング中です";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "旧ウォレットからの移行が完了しました！もともとあった残高がデスクトップのBrave Rewardsウォレットに表示されるまでは数分かかることがあります。";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "移行が完了しました！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "旧ウォレットの移行に遅れが生じており、再開まで数分かかることがございます。";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "移行に遅れが生じています。";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "旧ウォレットの移行は進行中です。完了まで数分かかる場合があります。";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "移行中";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "旧ウォレットの移行が無効となり完了できませんでした";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "移行は無効となりました";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "旧ウォレットの移行ステータスはペンディング中です。まもなく処理が開始する見込みです。";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "移行はペンディング中です";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "完了しました！";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "遅れが生じています";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "進行中";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "無効";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "ペンディング";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "既存のトークンの一度限りの移管";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "一度限りの転送用のQRコードをスキャンする";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "ウォレット移行";
+"rewards.walletTransferTitle" = "ウォレット移行ステータス";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "総額";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "おめでとうございます。あなたは特別な存在です。";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "可能な場合、Braveは安全な接続に自動でアップグレードします。";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "接続は暗号化されています。";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "見てみる";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "この下の情報は編集・変更しないでください";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "メールを送信できませんでした。Eメールの設定をご確認ください。";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "私たちと共有してもよい情報を選択してください。\n\n最初に共有する情報が多ければ多いほど、サポートスタッフがお客様の課題解決をサポートしやすくなります。";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "エラー";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "サブスクリプションは、iTunesアカウントを介して請求されます。\n\n無料トライアルが提供されている場合、未使用の部分は、サブスクリプションを購入した時点で無効になります。\n\nサブスクリプションは、現在の期間終了の少なくとも24時間前にキャンセルされない限り、自動的に更新されます。\n\nサブスクリプションは「設定」で管理できます。\n\nBraveを使用することで、利用規約とプライバシーポリシーに同意したことになります。";
+"vpn.vpnIAPBoilerPlate" = "サブスクリプションはiTunesアカウントを通じて課金されます。\n無料トライアルが提供されている場合、未使用の部分は、サブスクリプションを購入した時点で無効になります。\nサブスクリプションは、現在の期間終了の少なくとも24時間前にキャンセルされない限り、自動的に更新されます。\nサブスクリプションは「設定」で管理できます。\nBraveを使用することで、利用規約とプライバシーポリシーに同意したことになります。";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "この操作を実行するとBrave ファイアウォール+ VPNの構成はリセットされ、すべてのエラーが修正されます。このプロセスには1分かかる場合があります。";

--- a/BraveShared/ko-KR.lproj/BraveShared.strings
+++ b/BraveShared/ko-KR.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "사진 제공: %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "재생목록";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "북마크에 추가";
 

--- a/BraveShared/ko-KR.lproj/Localizable.strings
+++ b/BraveShared/ko-KR.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "- %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "이 동영상을 재생목록에 추가하시겠습니까?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Brave Playlist에 추가";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "이 동영상은 라이브 스트림이었거나 시간 제한에 도달했습니다. 새로고침하려면 링크를 다시 여세요.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "만료된 동영상";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "만료됨";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "리소스를 로드하는 중에 문제가 발생했습니다.";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "사용 가능한 항목 없음";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "알림";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "확인";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "PIP(Picture-In-Picture)를 표시하려는 중에 오류가 발생했습니다.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "재생목록이 열렸을 때 자동 재생을 활성화/비활성화하는 옵션입니다. 이 옵션은 목록 내 다음 동영상이 로드되었을 때 자동 재생에는 영향을 미치지 않습니다.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "자동 재생";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "끔";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "켬";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Wi-Fi에서만";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "동영상 및 오디오를 오프라인 용도로 추가하면 기기 내 저장소 및 셀룰러 데이터를 많이 사용할 수 있습니다.";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "이 옵션을 선택하면 자동으로 재생목록 내 항목을 기기에 저장하여 인터넷 연결이 끊어진 상태에서도 재생할 수 있습니다.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "오프라인용으로 자동 저장";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "저장소 거의 가득 참";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "라이브 스트림";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "재생목록 미디어 및 오프라인 데이터";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "재생목록 오프라인 데이터";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "재설정";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "이 옵션을 선택하면 재생목록에서 모든 동영상이 제거되고 오프라인 모드 저장소에서 삭제됩니다.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "이 항목은 현재 오프라인 모드용으로 저장할 수 없습니다.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "문제가 발생했습니다.";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "재생목록";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "이 설정은 동영상 목록 위치를 왼쪽/오른쪽 간에 전환합니다.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "왼쪽";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "오른쪽";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "사이드바 위치";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "미디어(동영상/오디오)를 마지막에 종료한 시점부터 재생을 시작하는 기능을 활성화/비활성화하는 옵션입니다.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "종료한 위치에서 재생 시작";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "이 옵션을 선택하면 일부 미디어 웹사이트에서 'Brave Playlist에 추가'할지 물어봅니다. 미디어를 길게 누르거나 \"다음 대상과 공유...\" 메뉴 버튼을 사용하여 미디어(비디오/오디오)를 추가할 수도 있습니다.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "\"Brave Playlist에 추가\" 표시";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "WebKit MediaSource API를 비활성화합니다.";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "웹 호환성";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "제거";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "오프라인 저장소에서 미디어가 삭제됩니다. 계속하시겠습니까?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "오프라인 데이터 삭제";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "목록에서 미디어 항목이 제거됩니다. 계속하시겠습니까?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "재생목록에서 미디어 항목을 제거하시겠습니까?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "다시 열기";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "오프라인용으로 저장됨";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "오프라인용으로 저장 중...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "죄송합니다";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Brave Playlist에 추가됨";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "열기";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Brave Playlist에 추가";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Brave Playlist에서 보기";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "맥락 메뉴 닫기";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "레거시 월렛 이전";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "레거시 월렛 이전이 완료되었습니다!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "레거시 월렛 이전이 지연되었습니다...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "레거시 월렛 이전이 진행 중입니다.";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "레거시 월렛 이전이 유효하지 않습니다.";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "레거시 월렛 이전이 보류 중 상태입니다.";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "레거시 월렛 이전이 완료되었습니다! 기존 잔액은 몇 분 후 데스크톱 Brave Rewards 월렛에 나타납니다.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "이전 완료!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "레거시 월렛 이전이 지연되어 몇 분 후 재개합니다.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "이전 지연됨";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "레거시 월렛 이전이 진행 중이며 몇 분 후 완료됩니다.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "이전 진행 중";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "레거시 월렛 이전이 유효하지 않아 완료할 수 없습니다.";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "이전 유효하지 않음";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "레거시 월렛 이전이 보류 중 상태이며 곧 처리가 시작됩니다.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "이전 보류 중";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "완료!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "지연됨";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "진행 중";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "유효하지 않음";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "보류 중";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "기존 토큰 일회성 이전";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "일회성 이전 코드 스캔";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "월렛 이전";
+"rewards.walletTransferTitle" = "월렛 이전 상태";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "금액";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "축하합니다. 정말 특별하십니다.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "가능한 경우 Brave가 안전한 연결로 자동 업그레이드합니다.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "연결이 암호화되었습니다.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "살펴보기";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "아래 정보는 어떤 것도 편집하지 마세요.";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "이메일을 보낼 수 없습니다. 이메일 구성을 확인하세요.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "공유해도 괜찮은 정보를 선택하세요.\n\n초기에 공유해주시는 정보가 많을수록 지원 담당 직원이 문제를 해결해드리기 쉬워집니다.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "오류";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "구독 대금은 iTunes 계정을 통해 청구됩니다.\n\n구독을 구매하면 무료 평가판에서 미사용된 부분은 포기한 것으로 간주합니다.\n\n현재 구독 기간 종료 24시간 전에 취소하지 않으면 구독이 자동으로 갱신됩니다.\n\n구매 후 설정에서 구독을 관리할 수 있습니다.\n\nBrave를 사용하면 이용 약관 및 개인정보 취급방침을 읽고 이에 동의한 것으로 간주됩니다.";
+"vpn.vpnIAPBoilerPlate" = "구독 대금은 iTunes 계정을 통해 청구됩니다.\n\n구독을 구매하면 무료 평가판에서 미사용된 부분은 포기한 것으로 간주합니다.\n\n현재 구독 기간 종료 최소 24시간 전에 취소하지 않으면 구독이 자동으로 갱신됩니다.\n\n구매 후 설정에서 구독을 관리할 수 있습니다.\n\nBrave를 사용하면 이용 약관 및 개인정보 취급방침을 읽고 이에 동의한 것으로 간주됩니다.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Brave Firewall + VPN 구성이 재설정되고 모든 오류가 정정됩니다. 이 프로세스는 1분 정도 소요됩니다.";

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto oleh %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Senarai main";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Tambah kepada Penanda Buku";
 

--- a/BraveShared/ms.lproj/Localizable.strings
+++ b/BraveShared/ms.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "pada %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Adakah anda mahu menambah video ini ke senarai main anda?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Tambah ke Senarai Main Brave";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Video ini adalah strim langsung atau had masa dicapai. Sila buka semula pautan untuk segar semula.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Video Tamat Tempoh";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Tamat Tempoh";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Terdapat masalah memuatkan sumber!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Tiada Item Tersedia";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Notis";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "Okey";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Maaf, ralat berlaku semasa cuba memaparkan gambar-dalam-gambar.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Pilihan ini akan mendayakan/menyahdayakan main automatik apabila Senarai Main dibuka. Walau bagaimanapun, pilihan ini tidak akan mempengaruhi main automatik apabila video seterusnya dalam senarai dimuatkan.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Main Auto";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Dimatikan";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Dihidupkan";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Hanya Wifi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Menambahkan fail video dan audio untuk penggunaan luar talian boleh menggunakan banyak storan pada peranti anda dan juga menggunakan data selular anda";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Pilihan ini akan menyimpan item senarai main anda pada peranti anda secara automatik supaya anda dapat memainkannya semasa anda tidak mempunyai sambungan internet.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Simpan Auto untuk Luar Talian";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Storan Hampir Penuh";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Strim Langsung";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Media Senarai Main & Data Luar Talian";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Data Luar Talian Senarai Main";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Tetap semula";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Pilihan ini akan mengalih keluar semua video dari Senarai Main dan juga storan mod Luar Talian.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Maaf, item ini tidak boleh disimpan untuk mod luar talian pada masa ini.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Maaf, sesuatu tidak betul";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Senarai main";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Tetapan ini akan mengubah lokasi senarai video antara sebelah kiri/kanan.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Kiri";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Kanan";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Lokasi Bar Sisi";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Pilihan ini akan mendayakan/menyahdayakan kemampuan untuk memulakan main balik media (video/audio) dari saat terakhir anda berhenti.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Mulakan Main Balik di tempat terakhir saya berhenti";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Pilihan ini akan meminta anda untuk 'Tambah ke Senarai Main Brave' di sesetengah laman web media. Anda masih boleh menambah media (video/audio) dengan menekan lama media, atau dari butang menu \"Kongsi Dengan...\".";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Tunjukkan \"Tambah ke Senarai Main Brave\"";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Menyahdayakan API WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Keserasian Web";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Alih Keluar";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Ini akan memadamkan media dari storan luar talian. Adakah anda pasti mahu meneruskan?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Alih Keluar Data Luar Talian";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Ini akan mengalih keluar item media dari senarai. Adakah anda pasti anda mahu meneruskan?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Alih keluar Item Media dari Senarai Main?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Buka Semula";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "Disimpan untuk Luar Talian";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Menympan untuk Luar Talian...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Maaf";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Ditambah ke Senarai Main Brave";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Buka";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Tambah ke Senarai Main Brave";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Lihat dalam Senarai Main Brave";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Tutup Menu Konteks";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Pemindahan Dompet Legasi";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Pemindahan dompet legasi anda telah selesai!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Pemindahan dompet legasi anda telah ditangguhkan…";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Pemindahan dompet legasi anda sedang berjalan";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Pemindahan dompet legasi anda tidak sah";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Status pemindahan dompet lama anda belum selesai";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Pemindahan dompet legasi anda selesai! Baki anda yang sedia ada mungkin masih memerlukan beberapa minit untuk muncul pada dompet Brave Rewards desktop anda.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Pemindahan Selesai!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Pemindahan dompet legasi anda telah ditangguhkan dan mungkin mengambil beberapa minit untuk disambung semula.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Pemindahan Tertunda";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Pemindahan dompet legasi anda sedang berlangsung dan mungkin memerlukan beberapa minit untuk diselesaikan.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Pemindahan sedang Berlangsung";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Pemindahan dompet lehasi anda tidak sah dan tidak dapat diselesaikan";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Pemindahan Tidak Sah";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Status pemindahan dompet legasi anda belum selesai dan akan segera diproses sebentar tadi.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Pemindahan Belum Selesai";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Selesai!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Tertangguh";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "Sedang Berlangsung";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Tidak Sah";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Belum Selesai";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Pindah keluar sekali sahaja token sedia ada";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Imbas Kod Pemindahan Sekali Sahaja";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Pemindahan Dompet";
+"rewards.walletTransferTitle" = "Status Pemindahan Dompet";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Jumlah";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Tahniah. Anda agak berbakat.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Jika tersedia, Brave akan menaik taraf sambungan anda kepada sambungan selamat secara automatik. ";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Sambungan anda kini disulitkan.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Lihat";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Jangan edit maklumat di bawah";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Tidak dapat menghantar e-mel. Sila semak konfigurasi e-mel anda.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Sila pilih maklumat yang anda selesa berkongsi dengan kami.\n\nSemakin banyak maklumat anda kongsi pada awalnya, semakin mudah kakitangan sokongan kami membantu menyelesaikan masalah anda.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Ralat";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "Langganan akan dikenakan bayaran melalui akaun iTunes anda.\n\nSebarang bahagian percubaan percuma yang tidak digunakan, jika ditawarkan, akan lupus apabila anda membeli langganan.\n\nLangganan anda akan diperbaharui secara automatik melainkan dibatalkan sekurang-kurangnya 24 jam sebelum akhir tempoh semasa.\n\nAnda boleh mengurus langganan anda dalam Tetapan.\n\nDengan menggunakan Brave, anda bersetuju dengan Terma Penggunaan dan Dasar Privasi.";
+"vpn.vpnIAPBoilerPlate" = "Langganan akan dikenakan bayaran melalui akaun iTunes anda.\n\nSebarang bahagian percubaan percuma yang tidak digunakan, jika ditawarkan, akan dibatalkan semasa anda membeli langganan.\n\nLangganan anda akan diperbaharui secara automatik melainkan dibatalkan sekurang-kurangnya 24 jam sebelum akhir tempoh semasa.\n\nAnda boleh menguruskan langganan anda dalam Tetapan.\n\nDengan menggunakan Brave, anda bersetuju dengan Terma Penggunaan dan Dasar Privasi.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Ini akan menetapkan semula konfigurasi Brave Firewall + VPN anda dan memperbaiki sebarang kesalahan. Proses ini mungkin mengambil masa sebentar.";

--- a/BraveShared/nb.lproj/BraveShared.strings
+++ b/BraveShared/nb.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Bilde av %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Spilleliste";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Legg til bokmerker";
 

--- a/BraveShared/nb.lproj/Localizable.strings
+++ b/BraveShared/nb.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "%@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Vil du legge til denne videoen i spillelisten din?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Legg til i Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Enten var denne videoen en direktestrømming, ellers var det tidsfristen som ble nådd. Åpne koblingen på nytt for å oppdatere.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Utløpt video";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Utløpt";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Det oppstod et problem under innlastingen av ressursen!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Ingen tilgjengelige elementer";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Merknad";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "OK";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Beklager, det oppsto en feil under forsøk på å vise et bilde-i-bilde.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Dette alternativet aktiverer/deaktiverer automatisk avspilling når spillelisten åpnes. Dette alternativet påvirker imidlertid ikke automatisk avspilling når neste video på listen lastes inn.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Automatisk avspilling";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Av";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "På";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Kun Wifi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Å legge til video- og lydfiler for frakoblet bruk kan ta opp mye lagringsplass på enheten din, samt bruke din mobildata";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Dette alternativet beholder automatisk elementene i spillelisten på enheten din, slik at du kan spille dem av når du ikke er tilkoblet Internett.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Lagre automatisk for frakoblet modus";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Nesten tom for lagringsplass";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Direktestrømming";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Playlist-media og -data i frakoblet modus";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Data om spilleliste i frakoblet modus";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Tilbakestill";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Dette alternativet fjerner alle videoene fra spillelisten, samt lagringsplassen i frakoblet modus.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Beklager, dette elementet kunne ikke lagres for bruk i frakoblet modus nå.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Beklager, noe gikk galt";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Spilleliste";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Denne innstillingen plasserer videolisten på venstre/høyre side.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Venstre";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Høyre";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Plassering til sidestolpe";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Dette alternativet aktiverer/deaktiverer muligheten til å starte avspilling av media (video/lyd) fra der du var.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Start avspilling fra der jeg var";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Dette alternativet ber deg om å «Legge til i Brave-spilleliste» på enkelte medienettsteder. Du kan fortsatt legge til media (video/lyd) ved å trykke på og holde inne ønskede media, eller fra menyknappen «Del med ...».";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Vis «Legg til i Brave-spilleliste»";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Deaktiverer WebKit MediaSource-API";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Nettkompatibilitet";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Fjern";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Dette sletter media fra den frakoblede lagringsplassen. Er du sikker på at du vil fortsette?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Fjern data fra frakoblet modus";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Dette fjerne medieelementet fra listen. Er du sikker på at du vil fortsette?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Fjern medieelement fra spillelisten?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Åpne på nytt";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "Lagret for frakoblet modus";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Lagrer for frakoblet modus ...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Beklager";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Lagt til i Brave-spilleliste";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Åpne";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Legg til i Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Vis i Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Lukk kontekstmenyen";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Overføring fra Legacy-lommebok";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Din overføring fra den gamle lommeboken er nå fullført!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Din overføring til Legacy-lommeboken har blitt forsinket ...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Din overføring til Legacy-lommeboken pågår";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Din overføring fra den gamle lommeboken er ugyldig";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Din overføring til Legacy-lommeboken venter";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Din overføring til Legacy-lommeboken er ferdig! Det kan fortsatt ta flere minutter før den eksisterende saldoen din vises i Brave Rewards-lommeboken på skrivebordet.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Overføring fullført!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Overføringen fra Legacy-lommeboken din har blitt forsinket, og det kan ta flere minutter før den gjenopptas.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Overføring forsinket";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Overføringen fra Legacy-lommeboken din pågår, og det kan ta flere minutter før denne er fullført.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Overføring pågår";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Overføringen fra Legacy-lommeboken din er ugyldig og kan ikke fullføres";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Overføring ugyldig";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Overføringen fra Legacy-lommeboken din venter, og skal snart behandles.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Overføring venter";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Fullført!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Forsinket";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "Pågår";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Ugyldig";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Venter";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Engangsoverføring ut for eksisterende tokener";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Skann engangskode for overføring";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Overføring fra lommebok";
+"rewards.walletTransferTitle" = "Status på overføring til lommebok";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Mengde";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Gratulerer. Du er noe for deg selv.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Om tilgjengelig, oppgraderer Brave deg automatisk til en sikker tilkobling.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Tilkoblingen din er nå kryptert.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Ta en titt";
@@ -780,6 +984,9 @@
 
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Ikke rediger informasjonen nedenfor";
+
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Kan ikke sende e-post. Kontroller e-postkonfigurasjonen.";
 
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Velg informasjonen du vil dele med oss.\n\nJo mer informasjon du deler med oss i første omgang, jo lettere blir det for støttepersonellet å hjelpe deg med å løse problemet.";

--- a/BraveShared/pl.lproj/BraveShared.strings
+++ b/BraveShared/pl.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Zdjęcie zrobione przez %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = " Lista odtwarzania";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Dodaj do zakładek";
 

--- a/BraveShared/pl.lproj/Localizable.strings
+++ b/BraveShared/pl.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "na %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Czy chcesz dodać ten film do swojej listy odtwarzania?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Dodaj do Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Ten film był transmitowany na żywo lub osiągnięto limit czasu. Otwórz ponownie link, aby odświeżyć.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Film wygasł";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Wygasł";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Wystąpił problem z załadowaniem zasobu!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Brak dostępnych elementów";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Uwaga";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "Okej\n";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Przepraszamy, wystąpił błąd podczas próby wyświetlenia obrazu w obrazie.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Ta opcja włączy/wyłączy autoodtwarzanie, gdy zostanie otwarta lista odtwarzania. Opcja ta nie będzie jednak powodować automatycznego odtwarzania, gdy załadowany zostanie następny film z listy.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Automatyczne odtwarzanie";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Wył.";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Wł.";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Tylko Wi-Fi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Dodawanie plików wideo i audio do użytku w trybie offline może zajmować dużo miejsca na urządzeniu, a także wykorzystywać transfer danych przez sieć komórkową.";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Ta opcja automatycznie przechowuje pozycje na liście odtwarzania w urządzeniu, dzięki czemu możesz je odtwarzać, gdy nie masz połączenia z Internetem.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Automatyczne zapisywanie do użytku w trybie offline";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Pamięć masowa prawie pełna";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Transmisja na żywo";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Lista odtwarzania mediów i dane offline";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Dane listy odtwarzania w trybie offline";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Resetuj";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Opcja ta spowoduje usunięcie wszystkich filmów z listy odtwarzania oraz z pamięci masowej trybu offline.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Przepraszamy, ta pozycja nie może być teraz zapisana do użytku w trybie offline.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Przepraszamy, coś poszło nie tak";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Lista odtwarzania";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "To ustawienie zmienia położenie listy wideo pomiędzy lewą a prawą stroną.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Lewa";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Prawa";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Położenie paska bocznego";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Ta opcja włącza/wyłącza możliwość rozpoczęcia odtwarzania mediów (wideo/audio) od miejsca, w którym ostatnio przerwano odtwarzanie.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Rozpocznij odtwarzanie od miejsca, w którym ostatnio je przerwałem";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Ta opcja spowoduje wyświetlenie pytania o \"Dodaj do listy odtwarzania w Brave\" na niektórych stronach internetowych z multimediami. Nadal możesz dodawać media (wideo/audio), naciskając je długo lub korzystając z przycisku menu \"Udostępnij za pomocą...\".";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Pokaż \"Dodaj do listy odtwarzania w Brave\"";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Wyłącza API WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Kompatybilność z Internetem";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Usuń";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Spowoduje to usunięcie nośnika z pamięci masowej trybu offline. Czy na pewno chcesz kontynuować?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Usuń dane trybu offline";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Spowoduje to usunięcie pozycji multimedialnej z listy. Czy na pewno chcesz kontynuować?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Usunąć pozycję multimedialną z listy odtwarzania?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Otwórz ponownie";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "% Zapisane do użytku w trybie offline";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Zapis do użytku w trybie offline...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Przepraszamy";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Dodano do listy odtwarzania w Brave";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Otwórz";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Dodaj do Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Przeglądaj na Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Zamknij menu kontekstowe";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Transfer ze starszego portfela";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Przeniesienie Twojego dotychczasowego portfela zostało zakończone!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Przeniesienie Twojego dotychczasowego portfela zostało opóźnione...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Trwa przenoszenie Twojego dotychczasowego portfela";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Przeniesienie Twojego dotychczasowego portfela jest nieprawidłowe";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Status przeniesienia Twojego dotychczasowego portfela jest oczekujący";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Przeniesienie Twojego dotychczasowego portfela zostało wykonane! Pojawienie się Twojego salda na pulpicie portfela Brave Rewards może potrwać jeszcze kilka minut.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Przekazanie zakończone!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Przenoszenie Twojego dotychczasowego portfela zostało opóźnione, a jego wznowienie może potrwać kilka minut.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Przeniesienie opóźnione";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Przenoszenie Twojego dotychczasowego portfela jest w toku i może potrwać kilka minut.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Przenoszenie w toku";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Przenoszenie Twojego dotychczasowego portfela jest nieprawidłowe i nie może zostać zakończone.";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Przenoszenie nieprawidłowe";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Status przenoszenia Twojego dotychczasowego portfela jest w toku i powinien wkrótce się rozpocząć.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Przenoszenie w toku";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Zakończone!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Opóźnione";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "W toku";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Nieprawidłowe";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Oczekuje";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Jednorazowy transfer istniejących tokenów";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Zeskanuj jednorazowy kod transferowy";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Transfer portfela";
+"rewards.walletTransferTitle" = "Status przenoszenia portfela";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Kwota";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Gratulacje. Jesteś naprawdę wyjątkową osobą.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Jeśli to możliwe, Brave automatycznie przeprowadza aktualizację do bezpiecznego połączenia.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Twoje połączenie jest teraz szyfrowane.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Zobacz";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Proszę nie edytować poniższych informacji";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Nie można wysłać wiadomości e-mail. Proszę sprawdzić konfigurację poczty.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Wybierz informacje, które chcesz nam udostępnić.\n\nIm więcej informacji wstępnie udostępnisz, tym łatwiej będzie naszemu działowi pomocy technicznej rozwiązać Twój problem.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Błąd";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "Subskrypcje będą naliczane przez Twoje konto iTunes.\n\nWszelka niewykorzystana część okresu próbnego, jeśli taki posiadasz, przepadnie w momencie wykupienia subskrypcji.\n\nTwoja subskrypcja zostanie odnowiona automatycznie, chyba że zostanie anulowana na co najmniej 24 godziny przed końcem bieżącego okresu.\n\nMożesz zarządzać subskrypcjami w Ustawieniach.\n\nKorzystając z Brave, wyrażasz zgodę na Warunki świadczenia usług i Politykę prywatności.";
+"vpn.vpnIAPBoilerPlate" = "Opłaty za subskrypcje będą pobierane za pośrednictwem konta iTunes.\n\nKażda niewykorzystana część bezpłatnej wersji próbnej, jeśli jest oferowana, przepada w momencie zakupu subskrypcji.\nTwoja subskrypcja będzie się odnawiać automatycznie, chyba że zostanie anulowana co najmniej 24 godziny przed końcem bieżącego okresu.\n\nMożesz zarządzać swoimi subskrypcjami w menu Ustawienia.\n\nKorzystając z Brave, wyrażasz zgodę na Warunki użytkowania i Politykę prywatności.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Spowoduje to zresetowanie konfiguracji Brave Firewall i VPN oraz naprawienie wszelkich błędów. Ten proces może potrwać kilka chwil.";

--- a/BraveShared/pt-BR.lproj/BraveShared.strings
+++ b/BraveShared/pt-BR.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto de %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Playlist";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Adicionar aos favoritos";
 

--- a/BraveShared/pt-BR.lproj/Localizable.strings
+++ b/BraveShared/pt-BR.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "no %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Você deseja adicionar este vídeo à sua playlist?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Adicionar à Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Este vídeo era uma transmissão ao vivo ou o tempo limite dele foi atingido. Reabra o link para atualizar.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Vídeo expirado";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Expirado";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Houve um problema ao carregar o recurso.";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Nenhum item disponível";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Aviso";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "OK";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Ocorreu um erro ao tentar exibir o picture-in-picture.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Esta opção ativará/desativará a reprodução automática quando a playlist for aberta. No entanto, isso não afetará a reprodução automática quando o próximo vídeo da lista for carregado.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Reprodução automática";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Desativar";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Ativar";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Somente Wi-Fi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "A adição de arquivos de vídeo e áudio para uso off-line pode consumir muito espaço de armazenamento no seu dispositivo, além de utilizar seus dados móveis";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Esta opção manterá automaticamente os itens da sua playlist no seu dispositivo para que você possa reproduzi-los sem uma conexão com a internet.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Salvamento automático para uso off-line";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "O armazenamento está quase cheio";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Transmissão ao vivo";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Mídias e dados off-line da playlist";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Dados off-line da playlist";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Redefinir";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Esta opção removerá todos os vídeos da playlist, além do armazenamento do modo off-line.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Lamentamos, mas não foi possível salvar este item no modo off-line neste momento.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Algo deu errado";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Playlist";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Esta configuração alternará a localização da lista de vídeos entre o lado esquerdo e o direito.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Esquerda";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Direita";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Localização da barra lateral";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Esta opção ativará/desativará a possibilidade de retomar a reprodução de mídia (vídeo/áudio) do ponto em que você parou da última vez.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Continuar reprodução de onde parei da última vez";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Esta opção pedirá para você \"Adicionar à Brave Playlist\" em alguns sites de mídia. Você ainda poderá adicionar mídia (vídeo/áudio) mantendo o item pressionado ou usando o botão de menu \"Compartilhar com...\"";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Mostrar a mensagem \"Adicionar à Brave Playlist\"";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Desativa a API WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Compatibilidade com a web";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Remover";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Essa ação excluirá a mídia do armazenamento off-line. Tem certeza de que deseja continuar?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Remover dados off-line";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Essa ação removerá o item de mídia da lista. Tem certeza de que deseja continuar?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Remover item de mídia da playlist?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Reabrir";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "salvo para uso off-line";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Salvando para uso off-line…";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Lamentamos";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Adicionado à Brave Playlist";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Abrir";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Adicionar à Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Ver na Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Fechar menu de contexto";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Transferência de carteira legada";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "A transferência da sua carteira legada foi concluída.";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "A transferência da sua carteira legada foi adiada…";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "A transferência da sua carteira legada está em andamento.";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "A transferência da sua carteira legada é inválida.";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "O status da transferência da sua carteira legada está pendente.";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "A transferência da sua carteira legada foi concluída. Seu saldo atual poderá levar alguns minutos para ser exibido na sua carteira do Brave Rewards para computador.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Transferência concluída!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "A transferência da sua carteira legada foi adiada e poderá levar alguns minutos para ser retomada.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Transferência adiada";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "A transferência da sua carteira legada está em andamento, e sua conclusão poderá levar alguns minutos.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Transferência em andamento";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "A transferência da sua carteira legada é inválida e não poderá ser concluída.";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Transferência inválida";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "O status da transferência da sua carteira legada está pendente, e o processamento deverá ser iniciado em breve.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Transferência pendente";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Concluída!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Adiada";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "Em andamento";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Inválida";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Pendente";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Transferência única de tokens existentes";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Ler código de transferência única";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Transferência de carteira";
+"rewards.walletTransferTitle" = "Status da transferência da carteira";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Valor";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Parabéns. Você é muito especial.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Se houver disponibilidade, o Brave fará o upgrade para uma conexão segura automaticamente.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Agora sua conexão está criptografada.";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Conferir";
@@ -780,6 +984,9 @@
 
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Não edite as informações abaixo";
+
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Não é possível enviar e-mails. Verifique sua configuração de e-mail.";
 
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Selecione as informações que você aceita compartilhar conosco.\n\nQuanto mais informações você compartilhar conosco inicialmente, mais fácil será para nossa equipe de suporte ajudar você a resolver seu problema.";

--- a/BraveShared/ru.lproj/BraveShared.strings
+++ b/BraveShared/ru.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Автор фото: %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Плейлист";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Добавить в закладки";
 

--- a/BraveShared/ru.lproj/Localizable.strings
+++ b/BraveShared/ru.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "в %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Добавить это видео в плейлист?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Добавьте видео в плейлист Brave";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Это видео идет в прямом эфире, или время ожидания для него истекло. Чтобы обновить, откройте ссылку еще раз.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Время ожидания для видео истекло";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Время ожидания истекло";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "При загрузке этого ресурса произошла ошибка.";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Нет доступных объектов";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Уведомление";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "ОК";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "При переходе в режим «Картинка в картинке» произошла ошибка";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Вы можете включать и отключать функцию автовоспроизведения, когда открыт плейлист. Этот параметр не влияет на автовоспроизведение, если следующее видео в плейлисте уже загружено.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Автовоспроизведение";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Отключить";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Включить";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Только Wi-Fi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Сохраненные файлы занимают место в хранилище устройства. Кроме того, при скачивании аудио и видео может использоваться мобильный интернет.";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Этот параметр позволяет автоматически скачивать контент из плейлиста на устройство, чтобы вы могли воспроизводить видео без подключения к Интернету.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Автосохранение для офлайн-доступа";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Хранилище почти заполнено";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Прямая трансляция";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Контент плейлиста и офлайн-данные";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Офлайн-данные плейлиста";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Сброс";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Этот параметр позволяет удалить все видео из плейлиста и очистить офлайн-хранилище.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Не удалось сохранить контент для офлайн-доступа.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Произошла ошибка";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Плейлист";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Используя этот параметр, вы можете перенести панель плейлиста в правую или левую часть экрана.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Слева";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Справа";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Положение боковой панели";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Этот параметр позволяет включать и отключать автоматическое воспроизведение аудио и видео с того места, на котором вы остановились.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Начинать воспроизведение с того места, где вы остановились";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Если вы включите эту настройку, на некоторых сайтах будет появляться кнопка «Добавить в плейлист Brave». Вы по-прежнему сможете добавлять аудио и видео, используя долгое нажатие или кнопку «Поделиться…».";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Показывать кнопку «Добавить в плейлист Brave»";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Отключить WebKit MediaSource API";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Веб-совместимость";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Удалить";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Все файлы в офлайн-хранилище будут удалены. Продолжить?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Удаление офлайн-данных";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Контент будет удален из плейлиста. Продолжить?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Удалить контент из плейлиста?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Открыть повторно";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "— сохранено для офлайн-доступа";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Сохранение для офлайн-доступа…";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Произошла ошибка";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Добавлено в плейлист Brave";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Открыть";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Добавить в плейлист Brave";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Посмотреть в плейлисте Brave";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Закрыть контекстное меню";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Перенос устаревшего кошелька";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Перенос устаревшего кошелька завершен";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Перенос устаревшего кошелька был отложен";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Выполняется перенос устаревшего кошелька";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Перенести устаревший кошелек нельзя";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Обрабатывается статус переноса устаревшего кошелька";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Перенос устаревшего кошелька завершен. Средства появятся в веб-версии кошелька Brave Rewards в течение нескольких минут.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Перенос завершен";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Перенос устаревшего кошелька продолжится через несколько минут.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Перенос отложен";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Перенос устаревшего кошелька завершится через несколько минут.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Перенос выполняется";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Перенести устаревший кошелек нельзя.";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Перенос невозможен";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Запрос на перенос устаревшего кошелька скоро начнет обрабатываться.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Выполняется перенос";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Завершено";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Отложено";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "Выполняется";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Недоступно";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Ожидание";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Однократный перенос имеющихся баллов";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Отсканируйте код однократного переноса";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Перенос кошелька";
+"rewards.walletTransferTitle" = "Статус переноса кошелька";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Сумма";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Добро пожаловать в наш клуб!";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Brave устанавливает защищенное соединение автоматически (когда возможно).";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Ваше подключение зашифровано";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Посмотрите";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Не вносите никаких изменений в приведенную ниже информацию";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Нам не удалось отправить письмо. Проверьте настройки электронной почты.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Укажите, какой информацией вы хотели бы с нами поделиться.\n\nЧем больше информации вы изначально нам предоставите, тем легче нашей службе поддержки будет помогать вам в решении возникающих проблем.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Ошибка";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "Плата за подписку будет взиматься с вашего счета iTunes.\n\nПри покупке подписки неиспользованный остаток бесплатного пробного периода будет аннулирован.\n\nПодписка будет автоматически продлена на следующий период, если не отменить ее как минимум за 24 часа до окончания текущего периода.\n\nЧтобы управлять подписками, перейдите в настройки.\n\nИспользуя Brave, вы соглашаетесь с Условиями использования и Политикой конфиденциальности.";
+"vpn.vpnIAPBoilerPlate" = "Плата за подписки будет взиматься через ваш аккаунт iTunes.\n\nПри покупке подписки неиспользованный период бесплатной версии аннулируется.\n\nПодписка будет обновляться автоматически. Чтобы отменить подписку, откажитесь от нее как минимум за 24 часа до окончания текущего расчетного периода.\n\nВы можете управлять подписками в настройках.\n\nИспользуя Brave, вы соглашаетесь с нашими Условиями использования и Политикой конфиденциальности.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Это позволит сбросить настройки файрвола и VPN-расширения для браузера Brave и исправить любые ошибки. Процесс может занять около минуты.";

--- a/BraveShared/sv.lproj/BraveShared.strings
+++ b/BraveShared/sv.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto av %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Spellista";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Lägg till i bokmärken";
 

--- a/BraveShared/sv.lproj/Localizable.strings
+++ b/BraveShared/sv.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "på %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Vill du lägga till den här videon i din spellista?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Lägg till i Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Den här videon var en livestream eller tidsgränsen nåddes. Öppna länken igen för att uppdatera.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Utgången video";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Utgången";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Det uppstod ett problem med att läsa in resursen!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Inga objekt tillgängliga";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Meddelande";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "Okej";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "Tyvärr uppstod ett fel när bild i bild skulle visas.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Det här alternativet aktiverar/inaktiverar automatisk uppspelning när spellistan öppnas. Det här alternativet kommer dock inte att påverka automatisk uppspelning när nästa video i listan läses in.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Auto-uppspelning";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Av";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "På";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Endast Wifi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Att lägga till video- och ljudfiler för offlineanvändning kan använda mycket lagringsutrymme på din enhet samt förbruka dina mobildata";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Det här alternativet behåller automatiskt dina spellistobjekt på din enhet så att du kan spela dem utan internetanslutning.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Auto-spara för offline";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Lagringsutrymmet är nästan fullt";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Livestream";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Spellistmedia och offline-data";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Offline-data för spellista";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Återställ";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Det här alternativet tar bort alla videor från spellistan och offline-lagringsutrymmet.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "Tyvärr gick det inte att spara det här objektet för offlineläget just nu.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "Tyvärr, någonting gick fel";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Spellista";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Den här inställningen ändrar videolistans plats från vänster sida/höger sida.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Vänster";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Höger";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Sidofältets plats";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Det här alternativet aktiverar/inaktiverar möjligheten att starta uppspelning av media (video/ljud) från den tidpunkt då du senast slutade.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Starta uppspelningen där jag senast slutade";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Det här alternativet kommer att be dig att \"Lägg till i Brave-spellista\" på vissa mediawebbplatser. Du kan fortfarande lägga till media (video/ljud) genom att trycka länge på media eller från menyknappen \"Dela med...\".";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Visa \"Lägg till i Brave Playlist\"";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Inaktiverar WebKit MediaSource API";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Webbkompatibilitet";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Ta bort";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Detta tar bort mediet från offlinelagringen. Är du säker på att du vill fortsätta?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Ta bort offlinedata";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Detta tar bort medieobjektet från listan. Är du säker på att du vill fortsätta?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Ta bort medieobjektet från spellistan?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Öppna igen";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "Sparad för offline";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Sparat för offline ...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Tyvärr";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Tillagd i Brave Playlist";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Öppna";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Lägg till i Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Visa i Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Stäng kontextmenyn";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Äldre plånboksöverföring";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Din äldre plånboksöverföring har slutförts!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Din äldre plånboksöverföring har försenats ...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Din äldre plånboksöverföring pågår";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Din äldre plånboksöverföring är ogiltig";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Statusen för din äldre plånboksöverföring är väntande";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Din äldre plånboksöverföring är slutförd! Ditt befintliga saldo kan fortfarande dröja flera minuter innan det visas i din Brave Rewards-plånbok på dator.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Överföring slutförd!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Din äldre plånboksöverföring har försenats och det kan ta flera minuter innan den återupptas.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Överföring försenad";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Din äldre plånboksöverföring pågår och kan ta flera minuter att slutföra.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Överföring pågår";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Din äldre plånboksöverföring kan inte slutföras";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Överföring ogiltig";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Statusen för din äldre plånboksöverföring är väntande och bör börja behandlas inom kort.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Överföring väntande";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Slutförd!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Försenad";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "Pågående";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Ogiltig";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "Väntande";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Engångsöverföring av befintliga token";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Skanna engångskod för överföring";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Plånboksöverföring";
+"rewards.walletTransferTitle" = "Status för plånboksöverföring";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Belopp";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Grattis. Du är verkligen speciell.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "Brave uppgraderar dig till en säker anslutning automatiskt om den är tillgänglig.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Nu är din anslutning krypterad";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Ta en titt";
@@ -780,6 +984,9 @@
 
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Redigera inte någon information nedan";
+
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Det går inte att skicka e-post. Kontrollera din e-postkonfiguration.";
 
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Välj den information du är bekväm med att dela med oss.\n\nJu mer information du delar med dig till oss desto enklare blir det för vår supportpersonal att hjälpa dig med ditt problem.";

--- a/BraveShared/uk.lproj/BraveShared.strings
+++ b/BraveShared/uk.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Фото від %@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "Список відтворення";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "Додати до закладок";
 

--- a/BraveShared/uk.lproj/Localizable.strings
+++ b/BraveShared/uk.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "у %@";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "Хочете додати це відео до списку відтворення?";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "Додати у Brave Playlist";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "Це відео транслювалося в прямому ефірі, або було досягнуто ліміту тривалості. Для оновлення відкрийте посилання ще раз.";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "Термін дії відео закінчився";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "Термін дії закінчився";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "Виникла проблема із завантаженням ресурсу!";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "Немає жодного доступного файлу";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "Примітка";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "Добре";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "На жаль, під час спроби відобразити картинку в картинці сталася помилка.";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "Ця опція вмикає/вимикає автовідтворення під час відкриття списку відтворення. Але ця опція не впливає на автовідтворення під час завантаження наступного відео в списку.";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "Автовідтворення";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "Вимк.";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "Увімк.";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "Тільки через WiFi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "Додавання відео- й аудіофайлів для використання офлайн може потребувати багато місця на вашому пристрої, а також використовувати мобільні дані";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "Ця опція автоматично збереже елементи вашого списку відтворення на пристрої, щоб ви могли відтворювати їх за відсутності підключення до Інтернету.";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "Автозбереження для доступу офлайн";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "Пам’ять майже заповнена";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "Пряма трансляція";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "Медіафайли й офлайн-дані списків відтворення";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "Дані списків відтворення офлайн";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "Скинути";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "Ця опція видалить усі відео зі списку відтворення, а також із офлайн-сховища.";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "На жаль, наразі цей елемент не можна зберегти для режиму офлайн.";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "На жаль, сталася помилка.";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "Список відтворення";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "Це налаштування дає змогу змінити розташування списку відео з лівої сторони на праву.";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "Ліворуч";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "Праворуч";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "Розташування бічної панелі";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "Цей параметр вмикає/вимикає можливість почати відтворення медіафайлів (відео/аудіо) з того моменту, на якому ви зупинилися минулого разу.";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "Почати відтворення з місця останньої зупинки";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "Завдяки цій опції ви бачитимете елемент «Додати у Brave Playlist» на деяких медіасайтах. Ви як і раніше можете додавати медіафайли (відео/аудіо) тривалим натисканням на медіафайл або за допомогою кнопки меню «Поділитися з…».";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "Показати «Додати у Brave Playlist»";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "Відключення API WebKit MediaSource";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Вебсумісність";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "Видалити";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "Це призведе до видалення медіафайлу з офлайн-сховища. Ви впевнені, що хочете продовжити?";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "Видалити офлайн-дані";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "Це призведе до видалення медіафайлу зі списку. Ви впевнені, що хочете продовжити?";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "Видалити медіафайл зі списку відтворення?";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "Відкрити заново";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "збережено для доступу офлайн";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "Збереження для доступу офлайн…";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "Помилка";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "Додано у Brave Playlist";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "Відкрити";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "Додати у Brave Playlist";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "Подивитися у Brave Playlist";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "Закрити контекстне меню";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "Переказ коштів із застарілого гаманця";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "Перерахування коштів на ваш старий гаманець завершено!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "Перерахування коштів на ваш гаманець відкладено…";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "Перерахування коштів на ваш гаманець в процесі обробки";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "Перерахування коштів на ваш старий гаманець неможливе";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "Статус перерахування коштів на ваш гаманець «На розгляді»";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "Перерахування коштів на ваш гаманець завершено! Ваш оновлений баланс з’явиться в гаманці Brave Rewards протягом декількох хвилин.";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "Перерахування коштів завершено!";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "Перерахування коштів на ваш гаманець було відкладено, і відновлення процесу може зайняти кілька хвилин.";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "Перерахування коштів відкладено";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "Перерахування коштів на ваш гаманець у процесі, і завершення транзакції може зайняти кілька хвилин.";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "Перерахування коштів у процесі";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "Перерахування коштів на ваш гаманець неможливе і не може бути завершене";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "Перерахування коштів неможливе";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "Статус перерахування коштів на ваш гаманець «На розгляді», і операція має скоро завершитися.";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "Перерахування коштів на розгляді";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "Завершено!";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "Відкладено";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "У процесі";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "Неможливе";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "На розгляді";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "Одноразовий переказ наявних токенів";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "Сканування одноразового коду переказу";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "Переказ коштів із гаманця";
+"rewards.walletTransferTitle" = "Статус перерахування коштів на гаманець";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "Сума";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "Вітаємо! Неперевершеність — ваше друге ім’я.";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "За можливості бразуер Brave автоматично збільшить рівень безпеки підключення.";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "Ваше з’єднання зашифровано";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "Зверніть увагу";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "Не редагуйте наведену нижче інформацію";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "Неможливо надіслати лист на електронну пошту. Будь ласка, перевірте налаштування електронної пошти.";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "Вкажіть, якою інформацією ви хотіли би з нами поділитись.\n\nЧим більше інформації ви надасте нам спочатку, тим легше нашій службі підтримки буде допомагати вам у вирішенні різноманітних проблем.";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "Помилка";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "Оплата за підписки стягуватиметься з вашого рахунку iTunes.\n\nБудь-яку невикористану частину безкоштовного пробного періоду, якщо він є, буде втрачено після придбання підписки.\n\nПідписка поновлюватиметься автоматично, якщо її не буде скасовано щонайменше за 24 години до завершення поточного періоду.\n\nВи можете керувати підписками в меню налаштувань.\n\nКористуючись Brave, ви погоджуєтеся з Умовами використання й Політикою конфіденційності.";
+"vpn.vpnIAPBoilerPlate" = "Плата за підписку стягується з вашого рахунку в iTunes.\n\nБудь-яка невикористана частина безкоштовної пробної версії, якщо вона пропонується, втрачається під час покупки підписки.\n\nПідписка продовжується автоматично, якщо її не скасовано не менше ніж за 24 години до закінчення поточного періоду.\n\nВи можете керувати своїми підписками у налаштуваннях.\n\nВикористовуючи Brave, ви погоджуєтеся з Умовами користування та Політикою конфіденційності.";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Це дозволить скинути налаштування файрволу та VPN-розширення браузера Brave, а також виправити будь-які помилки. Цей процес може зайняти хвилину.";

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "圖片由 %@ 提供";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "播放清單";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "新增至書籤";
 

--- a/BraveShared/zh-TW.lproj/Localizable.strings
+++ b/BraveShared/zh-TW.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "(%@)";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "你想新增此影片至播放清單嗎？";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "新增至 Brave 播放清單";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "此為直播影片或已達時間限制。請重新開啟連結以重新整理。";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "影片已到期";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "已到期";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "加載資源時出現問題！";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "沒有可用項目";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "通知";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "確定";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "抱歉，嘗試顯示子母畫面時發生錯誤。";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "開啟播放清單時，此選項將啟用／停用自動播放。但是，在加載清單中的下一個影片時，此選項將不會自動播放。";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "自動播放";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "關閉";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "開啟";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "僅使用 Wifi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "離線使用新增影片及音頻檔案可能佔用裝置的大量儲存空間及手機使用數據";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "此選項將自動儲存播放清單項目到裝置，因此你可以在沒有網路連線的情況下播放。";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "自動離線儲存";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "儲存空間快要滿了";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "直播";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "播放清單媒體與離線數據";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "播放清單離線數據";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "重設";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "此選項將刪除播放清單及離線模式下儲存的所有影片。";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "抱歉，目前無法將該項目儲存為離線模式。";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "抱歉，出現錯誤";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "播放清單";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "此設定將在左側／右側之間更改影片清單的位置。";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "左";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "右";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "側邊欄位置";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "此選項將啟用／停用從上次停止播放時開始播放媒體（影片／音頻）的功能。";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "從上次停止播放的位置開始播放";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "此選項將要求在某些媒體網站上「新增至 Brave 播放清單」。你仍然可以長按媒體或從「與…共享」功能表按鈕新增媒體（影片／音頻）。";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "顯示「新增至 Brave 播放清單」";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "停用 WebKit MediaSource API";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "網路相容性";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "刪除";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "這將刪除離線儲存的媒體。你確定要繼續嗎？";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "刪除離線數據";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "這將從清單刪除媒體項目。你確定要繼續嗎？";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "要從播放清單刪除媒體項目嗎？";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "重新開啟";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "已離線儲存";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "離線儲存中....";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "抱歉";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "新增至 Brave 播放清單";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "開啟";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "新增至 Brave 播放清單";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "檢視 Brave 播放清單";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "關閉內容選單";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "舊版錢包轉帳";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "地址格式錢包轉帳已完成！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "地址格式錢包轉帳已延遲...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "地址格式錢包轉帳進行中";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "地址格式錢包轉帳失效";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "地址格式錢包轉帳狀態為等待中";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "地址格式錢包轉帳完成！ 你的現有餘額可能需要幾分鐘後才會顯示在桌面 Brave 獎勵錢包中。";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "轉帳已完成！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "地址格式錢包轉帳已延遲，可能需要幾分鐘後才能恢復。";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "轉帳已延遲";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "地址格式錢包轉帳進行中，可能需要幾分鐘才能完成。";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "轉帳進行中";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "地址格式錢包轉帳失效，無法完成";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "轉帳失效";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "地址格式錢包轉帳狀態為等待中，將盡快開始處理。";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "轉帳等待中";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "已完成！";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "已延遲";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "進行中";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "失效";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "等待中";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "一次轉出現有代幣";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "掃描一次性轉帳碼";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "錢包轉帳";
+"rewards.walletTransferTitle" = "錢包轉帳狀態";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "金額";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "恭喜，您已具有特別的地位。";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "如果條件允許，Brave 會自動將您升級為安全連線。";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "您的連線現已加密";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "立即查看";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "請勿編輯下方任何資訊";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "無法傳送電子郵件。請檢查電子郵件設定。";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "請選取您願意提供的資訊。\n\n您主動提供的資訊越多，越有利於我們的支援人員協助您解決問題。";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "錯誤";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "我們會透過您的 iTunes 帳戶收取訂閱費用。\n\n如果您在免費試用期結束前便選擇訂閱，剩餘的試用效期即告失效。\n\n只要未在目前約期結束前 24 小時取消訂閱，系統就會自動為您續約。\n\n您可以前往「設定」管理訂閱事宜。\n\n使用 Brave 即表示您同意使用條款和隱私政策。";
+"vpn.vpnIAPBoilerPlate" = "我們會透過你的 iTunes 帳戶收取訂閱費用。\n\n如果您在免費試用期結束前便選擇訂閱，剩餘的試用效期即告失效。\n\n只要未在目前約期結束前 24 小時取消訂閱，系統就會自動為您續約。\n\n您可以前往「設定」管理訂閱事宜。\n\n使用 Brave 即表示您同意使用條款及隱私權政策。";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "此程序會重設您的 Brave Firewall + VPN 組態，並修正任何錯誤。這會需要一點時間，請稍候。";

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -751,6 +751,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "摄影者：%@";
 
+/* Playlist menu item */
+"PlaylistMenuItem" = "播放列表";
+
 /* Label for preview action on Tab Tray Tab to add current tab to Bookmarks */
 "PreviewActionAddToBookmarksActionTitle" = "添加至书签";
 

--- a/BraveShared/zh.lproj/Localizable.strings
+++ b/BraveShared/zh.lproj/Localizable.strings
@@ -193,6 +193,156 @@
 /* This is a suffix statement. example: SomeChannel on Twitter */
 "OnProviderText" = "在 %@ 上";
 
+/* Alert Description for adding videos to playlist */
+"playList.addToPlayListAlertDescription" = "是否要将此视频添加至播放列表？";
+
+/* Alert Title for adding videos to playlist */
+"playList.addToPlayListAlertTitle" = "添加至 Brave 播放列表";
+
+/* The description for the alert that shows up when an item is expired */
+"playList.expiredAlertDescription" = "此视频是直播流媒体或超出了时长限制。请重新打开此链接以刷新。";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.expiredAlertTitle" = "视频已过期";
+
+/* Text indicator on the table cell If a video is expired */
+"playList.expiredLabelTitle" = "已过期";
+
+/* Description for load resources error alert */
+"playList.loadResourcesErrorAlertDescription" = "加载资源时出现问题。";
+
+/* Text indicator on the table cell If a video is already downloaded */
+"playList.noItemLabelTitle" = "无可用项目";
+
+/* Title for download video error alert */
+"playList.noticeAlertTitle" = "通知";
+
+/* Okay Alert button title */
+"playList.okayButtonTitle" = "确认";
+
+/* The title for the alert that shows up when an item is expired */
+"playList.pictureInPictureErrorTitle" = "抱歉，尝试显示画中画时出错。";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionFooterText" = "播放列表打开后，此选项会启用/禁用自动播放。但是，列表中的下一视频加载后，此选项不会影响自动播放功能。";
+
+/* Title for the Playlist Settings Option for Enable/Disable Auto-Play */
+"playlist.playlistAutoPlaySettingsOptionTitle" = "自动播放";
+
+/* Auto Download turn Off Option */
+"playlist.playlistAutoSaveOptionOff" = "关";
+
+/* Auto Save turn On Option */
+"playlist.playlistAutoSaveOptionOn" = "开";
+
+/* Option Text for Auto Save Only Wifi Option */
+"playlist.playlistAutoSaveOptionOnlyWifi" = "仅 Wi-Fi";
+
+/* Description for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsDescription" = "添加视频和音频文件供离线使用，可能使用设备大量存储空间以及使用您的蜂窝数据";
+
+/* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi)) */
+"playlist.playlistAutoSaveSettingsFooterText" = "此选项会自动将您的播放列表项目保留在设备中，即使您没有网络连接，依然能够播放这些内容。";
+
+/* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wifi) */
+"playlist.playlistAutoSaveSettingsTitle" = "自动离线保存";
+
+/* When the user's disk space is almost full */
+"playlist.playlistDiskSpaceWarningTitle" = "存储将满";
+
+/* When a video or audio is live and has no duration */
+"playlist.playlistLiveMediaStream" = "直播流媒体";
+
+/* Text for Playlist Media & Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistMediaAndOfflineDataToggleOption" = "播放列表媒体和离线数据";
+
+/* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
+"playlist.playlistOfflineDataToggleOption" = "播放列表离线数据";
+
+/* The title for the alert that shows up when removing all videos and their offline mode storage. */
+"playList.playlistResetAlertTitle" = "重置";
+
+/* Footer Text for the Playlist Settings Option for resetting Playlist. */
+"playlist.playlistResetPlaylistOptionFooterText" = "此选项会将播放列表以及离线模式存储的所有视频一并删除。";
+
+/* Error message when saving a playlist item for offline fails */
+"playlist.playlistSaveForOfflineErrorMessage" = "抱歉，此项目暂时无法保存以用于离线模式。";
+
+/* Title of alert when saving a playlist item for offline mode */
+"playlist.playlistSaveForOfflineErrorTitle" = "抱歉，出错了";
+
+/* Title For the Section that videos are listed */
+"playList.playListSectionTitle" = "播放列表";
+
+/* Footer Text for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationFooterText" = "此设置会将视频列表位置在左侧/右侧切换。";
+
+/* Option Text for Sidebar Location Left */
+"playlist.playlistSidebarLocationOptionLeft" = "左";
+
+/* Option Text for Sidebar Location Right */
+"playlist.playlistSidebarLocationOptionRight" = "右";
+
+/* Title for the Playlist Settings Option for Sidebar Location (Left/Right) */
+"playlist.playlistSidebarLocationTitle" = "侧边栏位置";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsFooterText" = "此选项将启用/禁用从上次停止播放的位置开始播放媒体（视频/音频）的功能。";
+
+/* Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off */
+"playlist.playlistStartPlaybackSettingsOptionTitle" = "从我上次停止播放的位置开始播放 ";
+
+/* Footer Text for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionFooterText" = "部分媒体网站上，此选项会询问您是否“添加至 Brave 播放列表”。您仍可通过长按媒体文件或从“共享对象...”菜单按钮添加媒体（视频/音频）。";
+
+/* Title for the Playlist Settings Option for Enable/Disable Add Toast */
+"playlist.playlistToastShowSettingsOptionTitle" = "显示“添加至 Brave 播放列表”";
+
+/* Description for Playlist setting */
+"playlist.playlistWebCompatibilityDescription" = "禁用 WebKit MediaSource API";
+
+/* Title for Playlist setting */
+"playlist.playlistWebCompatibilityTitle" = "Web 兼容性";
+
+/* Title for removing offline mode storage */
+"playList.removeActionButtonTitle" = "移除";
+
+/* Message for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertMessage" = "这会将所有媒体文件从离线存储中删除。您确定要继续吗？";
+
+/* Title for the alert shown when the user tries to remove offline data of an item from playlist */
+"playlist.removePlaylistOfflineDataAlertTitle" = "删除离线数据";
+
+/* Message for the alert shown when the user tries to remove a video from playlist */
+"playlist.removePlaylistVideoAlertMessage" = "这会将媒体项目从列表中移除。您确定要继续吗？";
+
+/* Title for the alert shown when the user tries to remove an item from playlist */
+"playlist.removePlaylistVideoAlertTitle" = "将媒体项目从播放列表移除？";
+
+/* Reopen Alert button title */
+"playList.reopenButtonTitle" = "重新打开";
+
+/* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
+"playList.savedForOfflineLabelTitle" = "已离线保存";
+
+/* Text indicator on the table cell while saving a video for offline */
+"playList.savingForOfflineLabelTitle" = "正在离线保存...";
+
+/* Title for load resources error alert */
+"playList.sorryAlertTitle" = "抱歉";
+
+/* The title for the toast that shows up on a page containing a playlist item that was added to playlist */
+"playList.toastAddedToPlaylistTitle" = "已添加至 Brave 播放列表";
+
+/* The title for the toast button when an item was added to playlist */
+"playList.toastAddToPlaylistOpenButton" = "打开";
+
+/* The title for the toast that shows up on a page containing a playlist item */
+"playList.toastAddToPlaylistTitle" = "添加至 Brave 播放列表";
+
+/* The title for the toast that shows up on a page when an item that has already been added, was updated. */
+"playList.toastExitingItemPlaylistTitle" = "在 Brave 播放列表中查看";
+
 /* Description for closing a popover menu that is displayed. */
 "PopoverDefaultClose" = "关闭 Context 菜单";
 
@@ -231,6 +381,66 @@
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransfer" = "旧版钱包转账";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonCompletedTitle" = "您的旧钱包转账已完成！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonDelayedTitle" = "您的旧钱包转账已延迟...";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInProgressTitle" = "您的旧钱包转账正在进行中";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonInvalidTitle" = "您的旧钱包转账无效";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusButtonPendingTitle" = "您的旧钱包转账状态为暂停";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusCompletedBody" = "您的旧钱包转账已完成！当前余额可能需要几分钟才会出现在桌面版 Brave Rewards 钱包中。";
+
+/* Title shown above body of text explaining that their transfer is completed */
+"rewards.legacyWalletTransferStatusCompletedTitle" = "转账完成！";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusDelayedBody" = "您的旧钱包转账已延迟，可能需要几分钟才会恢复。";
+
+/* Title shown above body of text explaining that their transfer is delayed */
+"rewards.legacyWalletTransferStatusDelayedTitle" = "转账已延迟";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInProgressBody" = "您的旧钱包转账正在进行中，可能需要几分钟才会完成。";
+
+/* Title shown above body of text explaining that their transfer is in progress */
+"rewards.legacyWalletTransferStatusInProgressTitle" = "转账进行中";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusInvalidBody" = "您的旧钱包转账无效，无法完成";
+
+/* Title shown above body of text explaining that their transfer is invalid */
+"rewards.legacyWalletTransferStatusInvalidTitle" = "转账无效";
+
+/* No comment provided by engineer. */
+"rewards.legacyWalletTransferStatusPendingBody" = "您的旧钱包转账待处理，将尽快处理。";
+
+/* Title shown above body of text explaining that their transfer is pending */
+"rewards.legacyWalletTransferStatusPendingTitle" = "转账待处理";
+
+/* Completed as in: stating that the status of the users transfer is in completed */
+"rewards.legacyWalletTransferStatusShortformCompleted" = "已完成！";
+
+/* Delayed as in: stating that the status of the users transfer is in delayed */
+"rewards.legacyWalletTransferStatusShortformDelayed" = "已延迟";
+
+/* In Progress as in: stating that the status of the users transfer is in progress */
+"rewards.legacyWalletTransferStatusShortformInProgress" = "进行中";
+
+/* Invalid as in: stating that the status of the users transfer is invalid */
+"rewards.legacyWalletTransferStatusShortformInvalid" = "无效";
+
+/* Pending as in: stating that the status of the users transfer is pending */
+"rewards.legacyWalletTransferStatusShortformPending" = "待处理";
 
 /* No comment provided by engineer. */
 "rewards.legacyWalletTransferSubtitle" = "一次性转出现有代币";
@@ -275,7 +485,7 @@
 "rewards.walletTransferStepsTitle" = "扫描一次性转账码";
 
 /* Title of the legacy wallet transfer screen */
-"rewards.walletTransferTitle" = "钱包转账";
+"rewards.walletTransferTitle" = "钱包转账状态";
 
 /* No comment provided by engineer. */
 "RewardsInternalsAmount" = "金额";
@@ -519,12 +729,6 @@
 
 /* Subtitle for tracker benchmark Share */
 "shieldEducation.benchmarkSpecialTierTitle" = "您很特别。恭喜您！";
-
-/* Subtitle for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningSubtitle" = "如果可用，Brave 会自动将您升级到安全连接。";
-
-/* Title for Shield Education Encrypted Connection Warning */
-"shieldEducation.encryptedConnectionWarningTitle" = "您的连接现已加密";
 
 /* Action title for inspectable Education warnings */
 "shieldEducation.inspectTitle" = "看一看";
@@ -781,6 +985,9 @@
 /* Text to tell user to not modify support info below email's body. */
 "vpn.contactFormDoNotEditText" = "请勿修改以下信息";
 
+/* Button name to send contact form. */
+"vpn.contactFormEmailNotConfiguredBody" = "无法发送电子邮件。请检查您的电子邮箱配置。";
+
 /* Footer for customer support contact form. */
 "vpn.contactFormFooter" = "请选择您愿意与我们分享的信息。\n\n您最初与我们分享的信息越多，我们的支持人员就越容易帮助您解决问题。";
 
@@ -983,7 +1190,7 @@
 "vpn.vpnErrorPurchaseFailedTitle" = "错误";
 
 /* Disclaimer for user purchasing the VPN plan. */
-"vpn.vpnIAPBoilerPlate" = "我们会通过您的 iTunes 帐户收取订阅费用。\n\n购买订阅后，免费试用的任何未使用部分（如已提供）会被没收。\n\n您的订阅会自动更新，除非在当前订阅期结束前至少 24 小时以前取消该订阅。\n\n您可以在“设置”中管理您的订阅。\n\n使用 Brave，即表示您同意使用条款和隐私政策。";
+"vpn.vpnIAPBoilerPlate" = "我们会通过您的 iTunes 账户收取订阅费用。\n\n购买订阅后，免费试用的任何未使用部分（如已提供）会被没收。\n\n您的订阅会自动更新，除非在当前订阅期结束前至少 24 小时以前取消该订阅。\n\n您可以在“设置”中管理您的订阅。\n\n使用 Brave，即表示您同意使用条款和隐私政策。";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "这将重置您的 Brave Firewall + VPN 配置并修复所有错误。此过程可能需要一分钟。";


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3524

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
