### PR TITLE
Fix #3626: Control JS execution in iOS 14 via new web page prefs API

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -106,14 +106,14 @@ extension BrowserViewController: WKNavigationDelegate {
         return url.scheme == "rewards" && url.host == "uphold"
     }
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
         guard let url = navigationAction.request.url else {
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
         
         if let customHeader = UserReferralProgram.shouldAddCustomHeader(for: navigationAction.request) {
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             var newRequest = navigationAction.request
             UrpLog.log("Adding custom header: [\(customHeader.field): \(customHeader.value)] for domain: \(newRequest.url?.absoluteString ?? "404")")
             newRequest.addValue(customHeader.value, forHTTPHeaderField: customHeader.field)
@@ -122,24 +122,24 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         if url.scheme == "about" {
-            decisionHandler(.allow)
+            decisionHandler(.allow, preferences)
             return
         }
         
         if url.isBookmarklet {
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
 
         if !navigationAction.isAllowed && navigationAction.navigationType != .backForward {
             log.warning("Denying unprivileged request: \(navigationAction.request)")
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
         
         if let safeBrowsing = safeBrowsing, safeBrowsing.shouldBlock(url) {
             safeBrowsing.showMalwareWarningPage(forUrl: url, inWebView: webView)
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
         
@@ -149,7 +149,7 @@ extension BrowserViewController: WKNavigationDelegate {
             switch universalLink {
             case .buyVPN:
                 presentCorrespondingVPNViewController()
-                decisionHandler(.cancel)
+                decisionHandler(.cancel, preferences)
                 return
             }
         }
@@ -158,7 +158,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // gives us the exact same behaviour as Safari.
         if url.scheme == "tel" || url.scheme == "facetime" || url.scheme == "facetime-audio" {
             handleExternalURL(url)
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
 
@@ -168,20 +168,20 @@ extension BrowserViewController: WKNavigationDelegate {
 
         if isAppleMapsURL(url) {
             handleExternalURL(url)
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
 
         if isStoreURL(url) {
             handleExternalURL(url)
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
 
         // Handles custom mailto URL schemes.
         if url.scheme == "mailto" {
             handleExternalURL(url)
-            decisionHandler(.cancel)
+            decisionHandler(.cancel, preferences)
             return
         }
         
@@ -239,7 +239,12 @@ extension BrowserViewController: WKNavigationDelegate {
                         domainForShields.isShieldExpected(.FpProtection, considerAllShieldsOption: true)
                 }
 
-                webView.configuration.preferences.javaScriptEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
+                let isScriptsEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
+                if #available(iOS 14.0, *) {
+                    preferences.allowsContentJavaScript = isScriptsEnabled
+                } else {
+                    webView.configuration.preferences.javaScriptEnabled = isScriptsEnabled
+                }
             }
             
             // Cookie Blocking code below
@@ -260,7 +265,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 self.tabManager.selectedTab?.blockAllAlerts = false
             }
             
-            decisionHandler(.allow)
+            decisionHandler(.allow, preferences)
             return
         }
 
@@ -278,7 +283,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 }
             }
         }
-        decisionHandler(.cancel)
+        decisionHandler(.cancel, preferences)
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
@@ -350,13 +355,6 @@ extension BrowserViewController: WKNavigationDelegate {
         // If none of our helpers are responsible for handling this response,
         // just let the webview handle it as normal.
         decisionHandler(.allow)
-    }
-    
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
-        
-        self.webView(webView, decidePolicyFor: navigationAction) {
-            decisionHandler($0, preferences)
-        }
     }
 
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -1030,19 +1030,6 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
         }
         return .allow
     }
-
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        var res = defaultAllowPolicy()
-        for delegate in delegates {
-            delegate.webView?(webView, decidePolicyFor: navigationAction, decisionHandler: { policy in
-                if policy == .cancel {
-                    res = policy
-                }
-            })
-        }
-
-        decisionHandler(res)
-    }
     
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
         


### PR DESCRIPTION
iOS 14+ change

## Summary of Changes

This pull request fixes #3626 

This also fixes the following issues in iOS 14+:

- Fixes #3257 
- Fixes #3256
- Fixes #2968

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan

- With the Block Scripts shield enabled, make sure that JS related features such as reader mode, find in page, etc. work (easier to just verify above linked tickets)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
