### PR TITLE
Fix #3633 - iPad Offline File Location

### DIFF
--- a/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
+++ b/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
@@ -38,6 +38,12 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     private var didRestoreSession = false
     weak var delegate: PlaylistDownloadManagerDelegate?
     
+    static var playlistDirectory: URL? {
+        FileManager.default.getOrCreateFolder(name: "Playlist",
+                                              excludeFromBackups: true,
+                                              location: .applicationSupportDirectory)
+    }
+    
     public enum DownloadState: String {
         case downloaded
         case inProgress
@@ -180,9 +186,7 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     
     fileprivate static func uniqueDownloadPathForFilename(_ filename: String) throws -> URL? {
         let filename = HTTPDownload.stripUnicode(fromFilename: filename)
-        let playlistDirectory = FileManager.default.getOrCreateFolder(name: "Playlist",
-                                                                      excludeFromBackups: true,
-                                                                      location: .applicationSupportDirectory)
+        let playlistDirectory = PlaylistDownloadManager.playlistDirectory
         return try playlistDirectory?.uniquePathForFilename(filename)
     }
 }

--- a/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
+++ b/Client/Frontend/Browser/Playlist/Cache/PlaylistDownloadManager.swift
@@ -501,7 +501,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         guard let asset = activeDownloadTasks.removeValue(forKey: downloadTask) else { return }
         
-        let cleanupAndFailDownload = { (location: URL?, error: Error) in
+        func cleanupAndFailDownload(location: URL?, error: Error) {
             if let location = location {
                 do {
                     try FileManager.default.removeItem(at: location)
@@ -568,11 +568,11 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
                     }
                 } catch {
                     log.error("Failed to create bookmarkData for download URL.")
-                    cleanupAndFailDownload(path, error)
+                    cleanupAndFailDownload(location: path, error: error)
                 }
             } catch {
                 log.error("An error occurred attempting to download a playlist item: \(error)")
-                cleanupAndFailDownload(location, error)
+                cleanupAndFailDownload(location: location, error: error)
             }
         } else {
             var error = "UnknownError"
@@ -582,7 +582,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
                 error = "Invalid Response: \(response)"
             }
             
-            cleanupAndFailDownload(nil, error)
+            cleanupAndFailDownload(location: nil, error: error)
         }
     }
 }

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -196,6 +196,15 @@ class PlayListCacheClearable: Clearable {
     func clear() -> Success {
         DispatchQueue.main.async {
             PlaylistManager.shared.deleteAllItems(cacheOnly: true)
+            
+            // Backup in case there is folder corruption, so we delete the cache anyway
+            if let playlistDirectory = PlaylistDownloadManager.playlistDirectory {
+                do {
+                    try FileManager.default.removeItem(at: playlistDirectory)
+                } catch {
+                    log.error("Error Deleting Playlist directory: \(error)")
+                }
+            }
         }
         return succeed()
     }
@@ -211,7 +220,16 @@ class PlayListDataClearable: Clearable {
     
     func clear() -> Success {
         DispatchQueue.main.async {
-            PlaylistManager.shared.deleteAllItems()
+            PlaylistManager.shared.deleteAllItems(cacheOnly: false)
+            
+            // Backup in case there is folder corruption, so we delete the cache anyway
+            if let playlistDirectory = PlaylistDownloadManager.playlistDirectory {
+                do {
+                    try FileManager.default.removeItem(at: playlistDirectory)
+                } catch {
+                    log.error("Error Deleting Playlist directory: \(error)")
+                }
+            }
         }
         return succeed()
     }

--- a/Client/Frontend/Settings/PlaylistSettingsViewController.swift
+++ b/Client/Frontend/Settings/PlaylistSettingsViewController.swift
@@ -164,7 +164,7 @@ class PlaylistSettingsViewController: TableViewController {
                         preferredStyle: style)
                     
                     alert.addAction(UIAlertAction(title: Strings.PlayList.playlistResetAlertTitle, style: .default, handler: { _ in
-                        PlaylistManager.shared.deleteAllItems()
+                        PlaylistManager.shared.deleteAllItems(cacheOnly: false)
                     }))
                     alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
                     self.present(alert, animated: true, completion: nil)

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -69,6 +69,18 @@ final public class PlaylistItem: NSManagedObject, CRUD {
         return false
     }
     
+    public static func cachedItem(cacheURL: URL) -> PlaylistItem? {
+        return PlaylistItem.all()?.first(where: {
+            var isStale = false
+            
+            if let cacheData = $0.cachedData,
+               let url = try? URL(resolvingBookmarkData: cacheData, bookmarkDataIsStale: &isStale) {
+                return url.path == cacheURL.path
+            }
+            return false
+        })
+    }
+    
     public static func updateItem(_ item: PlaylistInfo, completion: (() -> Void)? = nil) {
         if itemExists(item) {
             DataController.perform(context: .new(inMemory: false), save: false) { context in


### PR DESCRIPTION
## Summary of Changes
- Moved iPad playlist downloads under m3u8 downloader to same folder as all other files.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3633

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
