### PR TITLE
Fix #1086: Memory leak in restored tab.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -824,7 +824,7 @@ class BrowserViewController: UIViewController {
                 // Two scenarios if there are no tabs in tabmanager:
                 // 1. We have not restored tabs yet, attempt to restore or make a new tab if there is nothing.
                 // 2. We are in private browsing mode and need to add a new private tab.
-                tabToSelect = isPrivate ? self.tabManager.addTab(isPrivate: true) : self.tabManager.restoreAllTabs()
+                tabToSelect = isPrivate ? self.tabManager.addTab(isPrivate: true) : self.tabManager.restoreAllTabs
             } else {
                 tabToSelect = self.tabManager.tabsForCurrentMode.last
             }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -797,9 +797,9 @@ class TabManager: NSObject {
         imageStore?.clearExcluding(savedUUIDs)
     }
 
-    fileprivate lazy var restoreTabsInternal: () -> Tab? = {
+    fileprivate var restoreTabsInternal: Tab? {
         let savedTabs = TabMO.getAll()
-        if savedTabs.isEmpty { return { nil } }
+        if savedTabs.isEmpty { return nil }
 
         var tabToSelect: Tab?
         for savedTab in savedTabs {
@@ -849,10 +849,10 @@ class TabManager: NSObject {
             // No tab selection, since this is unfamiliar with launch timings (e.g. compiling blocklists)
             
             // Must return inside this `if` to potentially return the conditional fallback
-            return { tabToSelect }
+            return tabToSelect
         }
-        return { nil }
-    }()
+        return nil
+    }
     
     func restoreTab(_ tab: Tab) {
         // Tab was created with no active webview or session data. Restore tab data from CD and configure.
@@ -867,15 +867,17 @@ class TabManager: NSObject {
         }
     }
 
-    lazy var restoreAllTabs: () -> Tab = {
+    /// Restores all tabs.
+    /// Returns the tab that has to be selected after restoration.
+    var restoreAllTabs: Tab {
         isRestoring = true
-        let tabToSelect = self.restoreTabsInternal()
+        let tabToSelect = self.restoreTabsInternal
         isRestoring = false
         
         // Always make sure there is at least one tab.
         let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
-        return { tabToSelect ?? self.addTab(isPrivate: isPrivate) }
-    }()
+        return tabToSelect ?? self.addTab(isPrivate: isPrivate)
+    }
 
     func restoreDeletedTabs(_ savedTabs: [Tab]) {
         isRestoring = true


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Tab restoration code is now a computed property, avoids reference loop.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #1086 
It should most likely fix #3544 too.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
This code is hard to test without attaching to Xcode.

1. Please verify that tab restoration has not regressed
2. Try to see if audio is still leaking after closing a tab.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
