### PR TITLE
No Bug: Regression, set PlaylistInfo `duration` to double.

### DIFF
--- a/Data/models/Model.xcdatamodeld/Model12.xcdatamodel/contents
+++ b/Data/models/Model.xcdatamodeld/Model12.xcdatamodel/contents
@@ -90,7 +90,7 @@
     <entity name="PlaylistItem" representedClassName=".PlaylistItem" syncable="YES">
         <attribute name="cachedData" optional="YES" attributeType="Binary"/>
         <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="duration" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="mediaSrc" attributeType="String"/>
         <attribute name="mimeType" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
@@ -129,7 +129,7 @@
         <element name="Favicon" positionX="439" positionY="-414" width="128" height="104"/>
         <element name="FeedSourceOverride" positionX="-279" positionY="-297" width="128" height="28"/>
         <element name="History" positionX="493" positionY="-150" width="128" height="135"/>
-        <element name="PlaylistItem" positionX="-279" positionY="-297" width="128" height="178"/>
+        <element name="PlaylistItem" positionX="-279" positionY="-297" width="128" height="164"/>
         <element name="RSSFeedSource" positionX="-270" positionY="-288" width="128" height="73"/>
         <element name="TabMO" positionX="-488" positionY="-229" width="128" height="224"/>
     </elements>


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
