### PR TITLE
Fix #3670: Add 'enable long press to add to playlist gesture' setting.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1229,8 +1229,20 @@ extension Strings {
         public static let playlistToastShowSettingsOptionFooterText =
             NSLocalizedString("playlist.playlistToastShowSettingsOptionFooterText",
                               bundle: .braveShared,
-                              value: "This option will ask you to 'Add to Brave Playlist' on some media websites. You can still add media (video/audio) by long-pressing media, or from the \"Share With…\" menu button.",
+                              value: "When enabled, a bar will automatically show on most media websites making it easier to add those video/audio files to your Playlist.",
                               comment: "Footer Text for the Playlist Settings Option for Enable/Disable Add Toast")
+        
+        public static let playlistLongPressSettingsOptionTitle =
+            NSLocalizedString("playlist.playlistToastShowSettingsOptionTitle",
+                              bundle: .braveShared,
+                              value: "Enable Long Press",
+                              comment: "Title for the Playlist Settings Option for long press gesture")
+        
+        public static let playlistLongPressSettingsOptionFooterText =
+            NSLocalizedString("playlist.playlistToastShowSettingsOptionFooterText",
+                              bundle: .braveShared,
+                              value: "When enabled, you can long-press on most video/audio files to add them to your Playlist.",
+                              comment: "Footer Text for the Playlist Settings Option for long press gesture")
         
         public static let playlistAutoPlaySettingsOptionTitle =
             NSLocalizedString("playlist.playlistAutoPlaySettingsOptionTitle",

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -247,6 +247,9 @@ extension Preferences {
         static let webMediaSourceCompatibility = Option<Bool>(key: "playlist.webMediaSourceCompatibility", default: UIDevice.isIpad)
         /// The option to start the playback where user left-off
         static let playbackLeftOff = Option<Bool>(key: "playlist.playbackLeftOff", default: true)
+        /// The option to disable long-press-to-add-to-playlist gesture.
+        static let enableLongPressAddToPlaylist =
+            Option<Bool>(key: "playlist.longPressAddToPlaylist", default: true)
     }
 }
 

--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -134,12 +134,9 @@ class PlaylistHelper: NSObject, TabContentScript {
 extension PlaylistHelper: UIGestureRecognizerDelegate {
     @objc
     func onLongPressedWebView(_ gestureRecognizer: UILongPressGestureRecognizer) {
-        if !Preferences.Playlist.enableLongPressAddToPlaylist.value {
-            return
-        }
-        
         if gestureRecognizer.state == .began,
-           let webView = tab?.webView {
+           let webView = tab?.webView,
+           Preferences.Playlist.enableLongPressAddToPlaylist.value {
             let touchPoint = gestureRecognizer.location(in: webView)
             
             let token = UserScriptManager.securityToken.uuidString.replacingOccurrences(of: "-", with: "", options: .literal)

--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -107,11 +107,6 @@ class PlaylistHelper: NSObject, TabContentScript {
             if item.detected {
                 self.delegate?.showPlaylistToast(info: item, itemState: .pendingUserAction)
             } else {
-                // Action sheet
-                if !Preferences.Playlist.enableLongPressAddToPlaylist.value {
-                    return
-                }
-                
                 // Has to be done otherwise it is impossible to play a video after selecting its elements
                 UIMenuController.shared.hideMenu()
                 
@@ -139,6 +134,10 @@ class PlaylistHelper: NSObject, TabContentScript {
 extension PlaylistHelper: UIGestureRecognizerDelegate {
     @objc
     func onLongPressedWebView(_ gestureRecognizer: UILongPressGestureRecognizer) {
+        if !Preferences.Playlist.enableLongPressAddToPlaylist.value {
+            return
+        }
+        
         if gestureRecognizer.state == .began,
            let webView = tab?.webView {
             let touchPoint = gestureRecognizer.location(in: webView)

--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -107,6 +107,11 @@ class PlaylistHelper: NSObject, TabContentScript {
             if item.detected {
                 self.delegate?.showPlaylistToast(info: item, itemState: .pendingUserAction)
             } else {
+                // Action sheet
+                if !Preferences.Playlist.enableLongPressAddToPlaylist.value {
+                    return
+                }
+                
                 // Has to be done otherwise it is impossible to play a video after selecting its elements
                 UIMenuController.shared.hideMenu()
                 

--- a/Client/Frontend/Settings/PlaylistSettingsViewController.swift
+++ b/Client/Frontend/Settings/PlaylistSettingsViewController.swift
@@ -67,9 +67,16 @@ class PlaylistSettingsViewController: TableViewController {
             Section(
                 rows: [
                     .boolRow(title: Strings.PlayList.playlistToastShowSettingsOptionTitle,
-                             option: Preferences.Playlist.showToastForAdd)
+                             option: Preferences.Playlist.showToastForAdd),
                 ],
                 footer: .title(Strings.PlayList.playlistToastShowSettingsOptionFooterText)
+            ),
+            Section(
+                rows: [
+                    .boolRow(title: Strings.PlayList.playlistLongPressSettingsOptionTitle,
+                             option: Preferences.Playlist.enableLongPressAddToPlaylist),
+                ],
+                footer: .title(Strings.PlayList.playlistLongPressSettingsOptionFooterText)
             ),
             Section(
                 rows: [


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3670 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that long-press action works when the setting is enabled, and that it does not work when the setting is disabled.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="367" alt="Zrzut ekranu 2021-05-11 o 20 40 33" src="https://user-images.githubusercontent.com/6950387/117868210-9dac7e80-b299-11eb-8379-6e8000d5fc80.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
