### PR TITLE
Ref #3491: Move share with button; Fix bookmarks dismiss on navigation

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -53,6 +53,10 @@ extension BrowserViewController {
         VStack(alignment: .leading, spacing: 0) {
             MenuTabDetailsView(tab: tabManager.selectedTab, url: tabURL)
             VStack(spacing: 0) {
+                MenuItemButton(icon: #imageLiteral(resourceName: "nav-share").template, title: Strings.shareWithMenuItem) {
+                    self.dismiss(animated: true)
+                    self.tabToolbarDidPressShare()
+                }
                 MenuItemButton(icon: #imageLiteral(resourceName: "menu-add-bookmark").template, title: Strings.addToMenuItem) {
                     self.dismiss(animated: true) {
                         self.openAddBookmark()
@@ -64,10 +68,6 @@ extension BrowserViewController {
                             activity.perform()
                         }
                     }
-                }
-                MenuItemButton(icon: #imageLiteral(resourceName: "nav-share").template, title: Strings.shareWithMenuItem) {
-                    self.dismiss(animated: true)
-                    self.tabToolbarDidPressShare()
                 }
             }
         }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -405,7 +405,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
                 style: .default,
                 handler: { [weak self] _ in
                     self?.toolbarUrlActionsDelegate?.batchOpen(urls)
-                    self?.dismiss(animated: true)
+                    self?.presentingViewController?.dismiss(animated: true)
                 }
             )
         ]
@@ -438,7 +438,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
                 self.showEditBookmarkController(bookmark: bookmark)
             } else {
                 if let url = URL(string: bookmark.url ?? "") {
-                    dismiss(animated: true) {
+                    presentingViewController?.dismiss(animated: true) {
                         self.toolbarUrlActionsDelegate?.select(url: url, visitType: .bookmark)
                     }
                 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request refs #3491 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enter bookmarks, tap on a link, verify it closes the menu instead of just bookmarks
- Verify Share with… is the first page action

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
