### PR TITLE
Ref #3632: Fix quick search bar background & separator on iPad

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -61,11 +61,12 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.clipsToBounds = false
+        scrollView.backgroundColor = .braveBackground
         let border = UIView.separatorLine
         scrollView.addSubview(border)
         border.snp.makeConstraints {
             $0.bottom.equalTo(scrollView.snp.top)
-            $0.leading.trailing.equalToSuperview()
+            $0.leading.trailing.equalTo(scrollView.frameLayoutGuide)
         }
     }
     private let searchEngineScrollViewContent = UIView().then {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request refs #3632 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- View the quick search bar on iPad, verify it has one unified bg & separator extends entire length

## Screenshots:

![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-05-13 at 11 01 14](https://user-images.githubusercontent.com/529104/118144516-8b862980-b3da-11eb-8aee-e2e43cfb77ac.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
