### PR TITLE
Fix #3665 - Performance issues with playlist

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -277,7 +277,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
         }
         
         function $<observePage>() {
-            $<observeDynamicElements>(document);
+            //$<observeDynamicElements>(document);
 
             
             Object.defineProperty(HTMLVideoElement.prototype, 'src', {

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -237,29 +237,6 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
             $<notifyNodeSource>(node, node.src, node.type);
         }
 
-        /*function $<observeDynamicElements>(node) {
-            var original = node.createElement;
-            node.createElement = function (tag) {
-                if (tag === 'audio' || tag === 'video') {
-                    var result = original.call(node, tag);
-                    $<notifyNode>(result);
-                    return result;
-                }
-                return original.call(node, tag);
-            };
-            
-            var originalAppend = Node.prototype.appendChild;
-            Node.prototype.appendChild = function(child) {
-                if (child.constructor.name == "HTMLVideoElement" || child.constructor.name == "HTMLAudioElement") {
-                    var result = originalAppend.call(this, child);
-                    $<notifyNode>(result);
-                    return result;
-                }
-                
-                return originalAppend.call(this, child);
-            }
-        }*/
-
         function $<getAllVideoElements>() {
             return document.querySelectorAll('video');
         }
@@ -277,9 +254,6 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
         }
         
         function $<observePage>() {
-            //$<observeDynamicElements>(document);
-
-            
             Object.defineProperty(HTMLVideoElement.prototype, 'src', {
                 enumerable: true,
                 configurable: false,

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -237,50 +237,28 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
             $<notifyNodeSource>(node, node.src, node.type);
         }
 
-        function $<observeNode>(node) {
-            if (node.observer == null || node.observer === undefined) {
-                node.observer = new MutationObserver(function (mutations) {
-                    $<notifyNode>(node);
-                });
-                node.observer.observe(node, { attributes: true, attributeFilter: ["src"] });
-                $<notifyNode>(node);
-
-                node.addEventListener('loadedmetadata', function() {
-                    $<notifyNode>(node);
-                });
-            }
-        }
-
-        function $<observeDocument>(node) {
-            if (node.observer == null || node.observer === undefined) {
-                node.observer = new MutationObserver(function (mutations) {
-                    mutations.forEach(function (mutation) {
-                        mutation.addedNodes.forEach(function (node) {
-                            if (node.constructor.name == "HTMLVideoElement") {
-                                $<observeNode>(node);
-                            }
-                            else if (node.constructor.name == "HTMLAudioElement") {
-                                $<observeNode>(node);
-                            }
-                        });
-                    });
-                });
-                node.observer.observe(node, { subtree: true, childList: true });
-            }
-        }
-
-        function $<observeDynamicElements>(node) {
+        /*function $<observeDynamicElements>(node) {
             var original = node.createElement;
             node.createElement = function (tag) {
                 if (tag === 'audio' || tag === 'video') {
                     var result = original.call(node, tag);
-                    $<observeNode>(result);
                     $<notifyNode>(result);
                     return result;
                 }
                 return original.call(node, tag);
             };
-        }
+            
+            var originalAppend = Node.prototype.appendChild;
+            Node.prototype.appendChild = function(child) {
+                if (child.constructor.name == "HTMLVideoElement" || child.constructor.name == "HTMLAudioElement") {
+                    var result = originalAppend.call(this, child);
+                    $<notifyNode>(result);
+                    return result;
+                }
+                
+                return originalAppend.call(this, child);
+            }
+        }*/
 
         function $<getAllVideoElements>() {
             return document.querySelectorAll('video');
@@ -299,17 +277,31 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
         }
         
         function $<observePage>() {
-            $<observeDocument>(document);
             $<observeDynamicElements>(document);
 
-            $<onReady>(function() {
-                $<getAllVideoElements>().forEach(function(node) {
-                    $<observeNode>(node);
-                });
-
-                $<getAllAudioElements>().forEach(function(node) {
-                    $<observeNode>(node);
-                });
+            
+            Object.defineProperty(HTMLVideoElement.prototype, 'src', {
+                enumerable: true,
+                configurable: false,
+                get: function(){
+                    return this.getAttribute('src')
+                },
+                set: function(value) {
+                    this.setAttribute('src', value);
+                    $<notifyNode>(this);
+                }
+            });
+            
+            Object.defineProperty(HTMLAudioElement.prototype, 'src', {
+                enumerable: true,
+                configurable: false,
+                get: function(){
+                    return this.getAttribute('src')
+                },
+                set: function(value) {
+                    this.setAttribute('src', value);
+                    $<notifyNode>(this);
+                }
             });
         }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Removed all mutation observers in favour of overridden properties.
- Move all JS communication to a background queue and dispatch to main only when necessary.
- Changed `AVAsset.isPlayable` to load asynchronously.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3665

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
For testing:

Go to YouTube or any media site
Make sure network link conditioner is set to very very bad network
While the site is loading, keep trying to scroll the page.
if the page doesn't scroll properly or exhibits freezing, we have a problem.
If the page does scroll and load correctly, the toast will come up properly without lagging.
Page overall should be much snappier.
Tested:

I tested on YouTube, SoundCloud, Vimeo, dailymotion, twitch. Note for SoundCloud you have to press play first then attempt to scroll while it is loading.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
