### PR TITLE
Fix #3675 - Allow tapping of the background view to change player time/position.

### DIFF
--- a/Client/Frontend/Browser/Playlist/VideoPlayer/VideoPlayerTrackbar.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/VideoPlayerTrackbar.swift
@@ -24,6 +24,7 @@ private class VideoSliderBar: UIControl {
         super.init(frame: frame)
         
         tracker.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(onPanned(_:))))
+        background.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onPanned(_:))))
         
         addSubview(background)
         addSubview(boundaryView)
@@ -84,6 +85,11 @@ private class VideoSliderBar: UIControl {
             }
         }
         
+        let adjustedBounds = background.bounds.inset(by: touchInsets)
+        if adjustedBounds.contains(point) {
+            return background
+        }
+        
         return super.hitTest(point, with: event)
     }
     
@@ -96,11 +102,16 @@ private class VideoSliderBar: UIControl {
             }
         }
         
+        let adjustedBounds = background.bounds.inset(by: touchInsets)
+        if adjustedBounds.contains(point) {
+            return true
+        }
+        
         return super.point(inside: point, with: event)
     }
     
     @objc
-    private func onPanned(_ recognizer: UIPanGestureRecognizer) {
+    private func onPanned(_ recognizer: UIGestureRecognizer) {
         let offset = min(boundaryView.bounds.size.width, max(0.0, recognizer.location(in: boundaryView).x))
         
         value = offset / boundaryView.bounds.size.width


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Allow tapping of the background view to change player time/position. So the user doesn't have to drag the slider. They can tap somewhere for it to change as well.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3675

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
