### PR TITLE
Fix #3647: Update user agent to iOS 14.6.

### DIFF
--- a/Shared/UserAgentBuilder.swift
+++ b/Shared/UserAgentBuilder.swift
@@ -43,12 +43,12 @@ public struct UserAgentBuilder {
     // These are not super precise because each iOS version can have slighly different desktop UA.
     // The only differences are with exact `Version/XX` and `MAC OS X 10_XX` numbers.
     private var desktopUA: String {
-        // Taken from Safari 14.3
+        // Taken from Safari 14.6
         let iOS14DesktopUA =
         """
         Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
         AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0.2 \
+        Version/14.1.1 \
         Safari/605.1.15
         """
         
@@ -61,21 +61,10 @@ public struct UserAgentBuilder {
         Safari/605.1.15
         """
         
-        // Taken from Safari 12.4
-        let iOS12DesktopUA =
-        """
-        Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) \
-        AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/12.1.2 \
-        Safari/605.1.15
-        """
-        
         switch os.majorVersion {
-        case 12: return iOS12DesktopUA
         case 13: return iOS13DesktopUA
         case 14: return iOS14DesktopUA
-        // Fallback to iOS13 UA, next desktop UA will be added once iOS 14 is ready.
-        default: return iOS13DesktopUA
+        default: return iOS14DesktopUA
         }
     }
     
@@ -94,9 +83,8 @@ public struct UserAgentBuilder {
     /// 'Version/13.0' part of UA. It seems to be based on Safaris build number.
     private var osVersion: String {
         switch os.majorVersion {
-            case 12: return "12_4_1"
             case 13: return "13_6_1"
-            case 14: return "14_3"
+            case 14: return "14_6"
             default: return "\(os.majorVersion)_0"
                 
         }
@@ -105,9 +93,8 @@ public struct UserAgentBuilder {
     /// 'Version/13.0' part of UA. It seems to be based on Safaris build number.
     private var safariVersion: String {
         switch os.majorVersion {
-            case 12: return "12.1.2"
             case 13: return "13.1.2"
-            case 14: return "14.0.2"
+            case 14: return "14.1.1"
             default: return "\(os.majorVersion).0"
                 
         }

--- a/SharedTests/UserAgentBuilderTests.swift
+++ b/SharedTests/UserAgentBuilderTests.swift
@@ -34,7 +34,7 @@ class UserAgentBuilderTests: XCTestCase {
         """
         Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
         AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0.2 \
+        Version/14.1.1 \
         Safari/605.1.15
         """
         
@@ -71,15 +71,15 @@ class UserAgentBuilderTests: XCTestCase {
         
         // MARK: - iOS 14
         let iPhone_safari_14_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0.2 \
+        Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.1.1 \
         Mobile/15E148 \
         Safari/604.1
         """
         
         let iPad_safari_14_UA = """
-        Mozilla/5.0 (iPad; CPU OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0.2 \
+        Mozilla/5.0 (iPad; CPU OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.1.1 \
         Mobile/15E148 \
         Safari/604.1
         """
@@ -146,21 +146,21 @@ class UserAgentBuilderTests: XCTestCase {
     }
     
     func testFutureProofDesktopUA() {
-        let iOS13DesktopUA =
-        """
-        Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) \
-        AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/13.1 \
-        Safari/605.1.15
-        """
+        let iOS14DesktopUA =
+            """
+            Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
+            AppleWebKit/605.1.15 (KHTML, like Gecko) \
+            Version/14.1.1 \
+            Safari/605.1.15
+            """
         
         let iOS15 = OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
         
-        XCTAssertEqual(iOS13DesktopUA,
+        XCTAssertEqual(iOS14DesktopUA,
                        UserAgentBuilder(device: iPhone, iOSVersion: iOS15).build(desktopMode: true),
                        "iOS 14 fallback desktop User Agent on iPhone doesn't match")
         
-        XCTAssertEqual(iOS13DesktopUA,
+        XCTAssertEqual(iOS14DesktopUA,
                        UserAgentBuilder(device: iPad, iOSVersion: iOS15).build(desktopMode: true),
                        "iOS 14 fallback desktop User Agent on iPad doesn't match")
     }
@@ -194,8 +194,8 @@ class UserAgentBuilderTests: XCTestCase {
         // MARK: - iPhone iOS 14.8, non existent version(14.8)
         let ios14_8 = OperatingSystemVersion(majorVersion: 14, minorVersion: 8, patchVersion: 0)
         let iPhone_safari_14_8_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0.2 \
+        Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.1.1 \
         Mobile/15E148 \
         Safari/604.1
         """
@@ -206,8 +206,8 @@ class UserAgentBuilderTests: XCTestCase {
         
         // MARK: - iPad iOS 14.8, non existent version(14.8)
         let iPad_safari_14_8_UA = """
-        Mozilla/5.0 (iPad; CPU OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/14.0.2 \
+        Mozilla/5.0 (iPad; CPU OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+        Version/14.1.1 \
         Mobile/15E148 \
         Safari/604.1
         """
@@ -240,53 +240,28 @@ class UserAgentBuilderTests: XCTestCase {
         XCTAssertEqual(iPad_safari_13_9_9_UA,
                        UserAgentBuilder(device: iPad, iOSVersion: ios13_9_9).build(desktopMode: false),
                        "User agent for non existent iOS 13.9.9 iPad doesn't match.")
-        
-        // MARK: - iPhone iOS 12, non existent version(12.9)
-        let ios12_9 = OperatingSystemVersion(majorVersion: 12, minorVersion: 9, patchVersion: 0)
-        let iPhone_safari_12_9_UA = """
-        Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/12.1.2 \
-        Mobile/15E148 \
-        Safari/604.1
-        """
-        
-        XCTAssertEqual(iPhone_safari_12_9_UA,
-                       UserAgentBuilder(device: iPhone, iOSVersion: ios12_9).build(desktopMode: false),
-                       "User agent for non existent iOS 12.9 iPhone doesn't match.")
-        
-        // MARK: - iPad iOS 12, non existent version(12.9)
-        let iPad_safari_12_6_UA = """
-        Mozilla/5.0 (iPad; CPU OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-        Version/12.1.2 \
-        Mobile/15E148 \
-        Safari/604.1
-        """
-        
-        XCTAssertEqual(iPad_safari_12_6_UA,
-                       UserAgentBuilder(device: iPad, iOSVersion: ios12_9).build(desktopMode: false),
-                       "User agent for non existent iOS 12.9 iPad doesn't match.")
     }
     
     func testUADifferences() {
-        let ios12_1_1 = OperatingSystemVersion(majorVersion: 12, minorVersion: 1, patchVersion: 1)
-        let ios12_1_3 = OperatingSystemVersion(majorVersion: 12, minorVersion: 1, patchVersion: 3)
         let ios13_1_1 = OperatingSystemVersion(majorVersion: 13, minorVersion: 1, patchVersion: 1)
+        let ios13_1_3 = OperatingSystemVersion(majorVersion: 13, minorVersion: 1, patchVersion: 3)
+        let ios14_1_1 = OperatingSystemVersion(majorVersion: 14, minorVersion: 1, patchVersion: 1)
         
         // Minor version difference
-        XCTAssertEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios12_1_1).build(desktopMode: false),
-                          UserAgentBuilder(device: iPhone, iOSVersion: ios12_1_3).build(desktopMode: false))
+        XCTAssertEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios13_1_1).build(desktopMode: false),
+                          UserAgentBuilder(device: iPhone, iOSVersion: ios13_1_3).build(desktopMode: false))
         
         // Major version difference
-        XCTAssertNotEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios12_1_1).build(desktopMode: false),
-                          UserAgentBuilder(device: iPhone, iOSVersion: ios13_1_1).build(desktopMode: false))
+        XCTAssertNotEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios13_1_1).build(desktopMode: false),
+                          UserAgentBuilder(device: iPhone, iOSVersion: ios14_1_1).build(desktopMode: false))
         
         // Device difference
-        XCTAssertNotEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios13_1_1).build(desktopMode: false),
-                          UserAgentBuilder(device: iPad, iOSVersion: ios13_1_1).build(desktopMode: false))
+        XCTAssertNotEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios14_1_1).build(desktopMode: false),
+                          UserAgentBuilder(device: iPad, iOSVersion: ios14_1_1).build(desktopMode: false))
         
         // Desktop mode difference
-        XCTAssertNotEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios13_1_1).build(desktopMode: false),
-                          UserAgentBuilder(device: iPhone, iOSVersion: ios13_1_1).build(desktopMode: true))
+        XCTAssertNotEqual(UserAgentBuilder(device: iPhone, iOSVersion: ios14_1_1).build(desktopMode: false),
+                          UserAgentBuilder(device: iPhone, iOSVersion: ios14_1_1).build(desktopMode: true))
     }
     
 }


### PR DESCRIPTION
This commit also removes user agents for iOS 12 since we do not
support this version anymore.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3647 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please note that user agents might be slightly different.

If you have iOS 14.6 device, please compare user agents with this build vs Safari's

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Brave vs Safari

iPhone, mobile UA

<img width="862" alt="Zrzut ekranu 2021-05-25 o 17 38 45" src="https://user-images.githubusercontent.com/6950387/119526945-22aa9400-bd80-11eb-9437-79848ef04f61.png">

iPad mobile UA
<img width="1080" alt="Zrzut ekranu 2021-05-25 o 17 42 52" src="https://user-images.githubusercontent.com/6950387/119527472-a4022680-bd80-11eb-86d7-b36143d5daee.png">

desktop UA, both iPad and iPhone
<img width="1000" alt="Zrzut ekranu 2021-05-25 o 17 45 23" src="https://user-images.githubusercontent.com/6950387/119527826-fd6a5580-bd80-11eb-978f-ce5291af6535.png">



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
