### PR TITLE
Fix #3726, #3727 - Playlist not showing in Toast or Share Menu for some sites

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -261,8 +261,10 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                     return this.getAttribute('src')
                 },
                 set: function(value) {
+                    // Typically we'd call the original setter.
+                    // But since the property represents an attribute, this is okay.
                     this.setAttribute('src', value);
-                    $<notifyNode>(this);
+                    //$<notifyNode>(this); // Handled by `setAudioAttribute`
                 }
             });
             
@@ -273,10 +275,76 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                     return this.getAttribute('src')
                 },
                 set: function(value) {
+                    // Typically we'd call the original setter.
+                    // But since the property represents an attribute, this is okay.
                     this.setAttribute('src', value);
-                    $<notifyNode>(this);
+                    //$<notifyNode>(this); // Handled by `setAudioAttribute`
                 }
             });
+            
+            var setVideoAttribute = HTMLVideoElement.prototype.setAttribute;
+            HTMLVideoElement.prototype.setAttribute = function(key, value) {
+                setVideoAttribute.call(this, key, value);
+                if (key.toLowerCase() == 'src') {
+                    $<notifyNode>(this);
+                }
+            }
+            
+            var setAudioAttribute = HTMLAudioElement.prototype.setAttribute;
+            HTMLAudioElement.prototype.setAttribute = function(key, value) {
+                setAudioAttribute.call(this, key, value);
+                if (key.toLowerCase() == 'src') {
+                    $<notifyNode>(this);
+                }
+            }
+            
+            // FOR DEBUGGING ONLY!
+            
+            /*var oldAudio = Audio;
+            var oldProto = Audio.prototype;
+            Audio = function(src) {
+                if (src) {
+                    var result = new oldAudio(src);
+                    $<notify>(result);
+                    return result;
+                }
+                return new oldAudio(src);
+            };
+            Audio.prototype = oldProto;
+            
+            var originalCreateElement = document.createElement;
+            document.createElement = function(element) {
+                if (typeof element == "string" && (element.toLowerCase() == "video" || element.toLowerCase() == "audio")) {
+                    var result = originalCreateElement.call(this, element);
+                    $<notifyNode>(result);
+                    return result;
+                }
+                return originalCreateElement.call(this, element);
+            }
+            
+            var originalAppendChild = Node.prototype.appendChild;
+            Node.prototype.appendChild = function(newNode) {
+                if (newNode.constructor.name == "HTMLVideoElement" || newNode.constructor.name == "HTMLAudioElement") {
+                    $<notifyNode>(newNode);
+                }
+                return originalAppendChild.call(this, newNode);
+            }
+            
+            var originalInsertBefore = Node.prototype.insertBefore;
+            Node.prototype.insertBefore = function(newNode, referenceNode) {
+                if (newNode.constructor.name == "HTMLVideoElement" || newNode.constructor.name == "HTMLAudioElement") {
+                    $<notifyNode>(newNode);
+                }
+                return originalInsertBefore.call(this, newNode, referenceNode);
+            }
+            
+            var originalReplaceChild = Node.prototype.replaceChild;
+            Node.prototype.replaceChild = function(newChild, oldChild) {
+                if (newChild.constructor.name == "HTMLVideoElement" || newChild.constructor.name == "HTMLAudioElement") {
+                    $<notifyNode>(newChild);
+                }
+                return originalReplaceChild.call(this, newChild, oldChild);
+            }*/
         }
 
         $<observePage>();

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -264,7 +264,7 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                     // Typically we'd call the original setter.
                     // But since the property represents an attribute, this is okay.
                     this.setAttribute('src', value);
-                    //$<notifyNode>(this); // Handled by `setAudioAttribute`
+                    //$<notifyNode>(this); // Handled by `setVideoAttribute`
                 }
             });
             
@@ -297,54 +297,6 @@ window.__firefox__.includeOnce("$<Playlist>", function() {
                     $<notifyNode>(this);
                 }
             }
-            
-            // FOR DEBUGGING ONLY!
-            
-            /*var oldAudio = Audio;
-            var oldProto = Audio.prototype;
-            Audio = function(src) {
-                if (src) {
-                    var result = new oldAudio(src);
-                    $<notify>(result);
-                    return result;
-                }
-                return new oldAudio(src);
-            };
-            Audio.prototype = oldProto;
-            
-            var originalCreateElement = document.createElement;
-            document.createElement = function(element) {
-                if (typeof element == "string" && (element.toLowerCase() == "video" || element.toLowerCase() == "audio")) {
-                    var result = originalCreateElement.call(this, element);
-                    $<notifyNode>(result);
-                    return result;
-                }
-                return originalCreateElement.call(this, element);
-            }
-            
-            var originalAppendChild = Node.prototype.appendChild;
-            Node.prototype.appendChild = function(newNode) {
-                if (newNode.constructor.name == "HTMLVideoElement" || newNode.constructor.name == "HTMLAudioElement") {
-                    $<notifyNode>(newNode);
-                }
-                return originalAppendChild.call(this, newNode);
-            }
-            
-            var originalInsertBefore = Node.prototype.insertBefore;
-            Node.prototype.insertBefore = function(newNode, referenceNode) {
-                if (newNode.constructor.name == "HTMLVideoElement" || newNode.constructor.name == "HTMLAudioElement") {
-                    $<notifyNode>(newNode);
-                }
-                return originalInsertBefore.call(this, newNode, referenceNode);
-            }
-            
-            var originalReplaceChild = Node.prototype.replaceChild;
-            Node.prototype.replaceChild = function(newChild, oldChild) {
-                if (newChild.constructor.name == "HTMLVideoElement" || newChild.constructor.name == "HTMLAudioElement") {
-                    $<notifyNode>(newChild);
-                }
-                return originalReplaceChild.call(this, newChild, oldChild);
-            }*/
         }
 
         $<observePage>();


### PR DESCRIPTION
## Summary of Changes
- Some sites are using `setAttribute` and others are setting the `src` property directly.
- This code hooks both so that playlist works properly on all sites.
- This was a regression due to the performance fix that removed mutation observers. 
- We will have no performance impact with this code, but we'll have support for more sites :)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3726, #3727

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
