### PR TITLE
Fix #3729: Restructure VPN button so that Toggle isn't inside a Button

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
@@ -60,20 +60,26 @@ struct VPNMenuButton: View {
     }
     
     var body: some View {
-        Button(action: { toggleVPN(!BraveVPN.isConnected) }) {
-            HStack {
-                MenuItemHeaderView(icon: #imageLiteral(resourceName: "vpn_menu_icon").template, title: "Brave VPN")
-                Spacer()
-                if isVPNStatusChanging {
-                    ActivityIndicatorView(isAnimating: true)
-                }
-                vpnToggle
-                    .labelsHidden()
+        HStack {
+            MenuItemHeaderView(icon: #imageLiteral(resourceName: "vpn_menu_icon").template, title: "Brave VPN")
+            Spacer()
+            if isVPNStatusChanging {
+                ActivityIndicatorView(isAnimating: true)
             }
-            .padding(.horizontal, 14)
-            .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)
+            vpnToggle
+                .labelsHidden()
         }
-        .buttonStyle(TableCellButtonStyle())
+        .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)
+        .background(
+            Button(action: { toggleVPN(!BraveVPN.isConnected) }) {
+                Color.clear
+            }
+            .buttonStyle(TableCellButtonStyle())
+        )
+        .accessibilityElement()
+        .accessibility(addTraits: .isButton)
+        .accessibility(label: Text("Brave VPN"))
         .alert(isPresented: $isErrorShowing) {
             Alert(
                 title: Text(verbatim: Strings.VPN.errorCantGetPricesTitle),


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3729

Button gestures don't cancel quick enough when tapping on other interactive elements within their content/label so this restructures the VPN button so that the content lives on top of the `Button`

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
