### PR TITLE
Fix #3731: NTP Tutorial Page is not loading after on-boardin is skipped

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -147,29 +147,14 @@ extension BrowserViewController: OnboardingControllerDelegate {
             }
         }
         
-        // Present private browsing prompt if necessary when onboarding has been completed
-        onboardingController.dismiss(animated: true) { [weak self] in
-            guard let self = self else { return }
-            
-            // NTP Education Load after onboarding screen
-            if self.shouldShowNTPEducation,
-               self.showNTPEducation().isEnabled,
-               let url = self.showNTPEducation().url {
-                self.tabManager.selectedTab?.loadRequest(PrivilegedRequest(url: url) as URLRequest)
-            }
-            
-            self.presentDuckDuckGoCalloutIfNeeded()
-        }
+        dismissOnboarding(onboardingController)
     }
     
     func onboardingSkipped(_ onboardingController: OnboardingNavigationController) {
         Preferences.General.basicOnboardingCompleted.value = OnboardingState.skipped.rawValue
         Preferences.General.basicOnboardingNextOnboardingPrompt.value = Date(timeIntervalSinceNow: BrowserViewController.onboardingDaysInterval)
         
-        // Present private browsing prompt if necessary when onboarding has been skipped
-        onboardingController.dismiss(animated: true) {
-            self.presentDuckDuckGoCalloutIfNeeded()
-        }
+        dismissOnboarding(onboardingController)
     }
     
     func presentDuckDuckGoCalloutIfNeeded() {
@@ -177,6 +162,26 @@ extension BrowserViewController: OnboardingControllerDelegate {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                 self.presentDuckDuckGoCallout()
             }
+        }
+    }
+    
+    private func presentEducationNTPIfNeeded() {
+        // NTP Education Load after onboarding screen
+        if shouldShowNTPEducation,
+           showNTPEducation().isEnabled,
+           let url = showNTPEducation().url {
+            tabManager.selectedTab?.loadRequest(PrivilegedRequest(url: url) as URLRequest)
+        }
+    }
+    
+    private func dismissOnboarding(_ onboardingController: OnboardingNavigationController) {
+        // Present NTP Education If Locale is JP and onboading is finished or skipped
+        // Present private browsing prompt if necessary when onboarding has been skipped
+        onboardingController.dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
+            
+            self.presentEducationNTPIfNeeded()
+            self.presentDuckDuckGoCalloutIfNeeded()
         }
     }
     


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3731

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Fresh Install and use JP Locale
- Skip Onboarding
- No NTP page is loaded


## Screenshots:


https://user-images.githubusercontent.com/6643505/119706123-95227f00-be27-11eb-9678-8dd690b6053a.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
