### PR TITLE
Fix #3682: Bump brave-core library to 1.25.69

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,8 +1043,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.23.70/brave-core-ios-1.23.70.tgz",
-      "integrity": "sha512-056SzMxVtrPy3+kxptD2GSPWekuJSeF+obePV1CXv1B3ghJnIVg9Pyjx3DB5Sy96sEoW3wdFAPJr0oVBpHf++w=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.25.69/brave-core-ios-1.25.69.tgz",
+      "integrity": "sha512-suFJJ/uvWoTA5PSakyJjmH0M5htP6S28WgtVuGeBS89fw/GOPAW2tVl7VBDherMFcCG/ScSii1tnF6nq9bhHgA=="
     },
     "browserslist": {
       "version": "3.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.23.70/brave-core-ios-1.23.70.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.25.69/brave-core-ios-1.25.69.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^3.3.10"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3682

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
