### PR TITLE
No Bug: Fix duplicated localized string keys for playlist.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1236,13 +1236,13 @@ extension Strings {
                               comment: "Footer Text for the Playlist Settings Option for Enable/Disable Add Toast")
         
         public static let playlistLongPressSettingsOptionTitle =
-            NSLocalizedString("playlist.playlistToastShowSettingsOptionTitle",
+            NSLocalizedString("playlist.playlistLongPressSettingsOptionTitle",
                               bundle: .braveShared,
                               value: "Enable Long Press",
                               comment: "Title for the Playlist Settings Option for long press gesture")
         
         public static let playlistLongPressSettingsOptionFooterText =
-            NSLocalizedString("playlist.playlistToastShowSettingsOptionFooterText",
+            NSLocalizedString("playlist.playlistLongPressSettingsOptionFooterText",
                               bundle: .braveShared,
                               value: "When enabled, you can long-press on most video/audio files to add them to your Playlist.",
                               comment: "Footer Text for the Playlist Settings Option for long press gesture")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
