### PR TITLE
Fix #3763: Update initial height of menu when page actions are visible

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -516,7 +516,8 @@ extension BrowserViewController: ToolbarDelegate {
         if let url = selectedTabURL, let tab = tabManager.selectedTab {
             activities = shareActivities(for: url, tab: tab, sourceView: view, sourceRect: self.view.convert(self.topToolbar.menuButton.frame, from: self.topToolbar.menuButton.superview), arrowDirection: .up)
         }
-        let menuController = MenuViewController(content: { menuController in
+        let initialHeight: CGFloat = selectedTabURL != nil ? 470 : 370
+        let menuController = MenuViewController(initialHeight: initialHeight, content: { menuController in
             VStack(spacing: 6) {
                 featuresMenuSection(menuController)
                 Divider()

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -65,8 +65,10 @@ struct MenuItemButton: View {
 class MenuViewController: UINavigationController, UIPopoverPresentationControllerDelegate {
     
     private var menuNavigationDelegate: MenuNavigationControllerDelegate?
+    private let initialHeight: CGFloat
     
-    init<MenuContent: View>(@ViewBuilder content: (MenuViewController) -> MenuContent) {
+    init<MenuContent: View>(initialHeight: CGFloat, @ViewBuilder content: (MenuViewController) -> MenuContent) {
+        self.initialHeight = initialHeight
         super.init(nibName: nil, bundle: nil)
         viewControllers = [MenuHostingController(content: content(self))]
         menuNavigationDelegate = MenuNavigationControllerDelegate(panModal: self)
@@ -199,7 +201,7 @@ extension MenuViewController: PanModalPresentable {
         .maxHeight
     }
     var shortFormHeight: PanModalHeight {
-        isPresentingInnerMenu ? .maxHeight : .contentHeight(370)
+        isPresentingInnerMenu ? .maxHeight : .contentHeight(initialHeight)
     }
     var allowsExtendedPanScrolling: Bool {
         true


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3763

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

**On iPhone only**

- Open menu on NTP, height should be the same as previous versions
- Visit a web page
- Open menu, verify it is taller and you can access "Share to…" without scrolling

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
