### PR TITLE
Fix #3762 - Fixes Search Overlay spacing, prompt, actions, and ordering

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -2616,4 +2616,5 @@ extension Strings {
     public static let recentSearchScannerTitle = NSLocalizedString("RecentSearchScannerTitle", bundle: .braveShared, value: "Scan QR Code", comment: "Scanning a QRCode for searching")
     public static let recentSearchScannerDescriptionTitle = NSLocalizedString("RecentSearchScannerDescriptionTitle", bundle: .braveShared, value: "Instructions", comment: "Scanning a QRCode for title")
     public static let recentSearchScannerDescriptionBody = NSLocalizedString("RecentSearchScannerDescriptionBody", bundle: .braveShared, value: "To search by QRCode, align the QR in the center of the frame.", comment: "Scanning a QRCode for searching body")
+    public static let recentSearchClearAlertButton = NSLocalizedString("RecentSearchClearAlertButton", bundle: .braveShared, value: "Clear Recent", comment: "The button title that shows when you clear all recent searches")
 }

--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -35,7 +35,7 @@ private class FavoritesHeaderView: UICollectionReusableView {
 class FavoritesViewController: UIViewController {
     
     var action: (Favorite, BookmarksAction) -> Void
-    var recentSearchAction: (RecentSearch?) -> Void
+    var recentSearchAction: (RecentSearch?, Bool) -> Void
     
     private enum Section: Int, CaseIterable {
         case pasteboard = 0
@@ -49,7 +49,7 @@ class FavoritesViewController: UIViewController {
     }
     
     private let layout = UICollectionViewFlowLayout().then {
-        $0.sectionInset = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
+        $0.sectionInset = UIEdgeInsets(top: 12, left: 0, bottom: 22, right: 0)
         $0.minimumInteritemSpacing = 0
         $0.minimumLineSpacing = 8
     }
@@ -62,7 +62,7 @@ class FavoritesViewController: UIViewController {
     }
     private var hasPasteboardURL = false
     
-    init(tabType: TabType, action: @escaping (Favorite, BookmarksAction) -> Void, recentSearchAction: @escaping (RecentSearch?) -> Void) {
+    init(tabType: TabType, action: @escaping (Favorite, BookmarksAction) -> Void, recentSearchAction: @escaping (RecentSearch?, Bool) -> Void) {
         self.tabType = tabType
         self.action = action
         self.recentSearchAction = recentSearchAction
@@ -269,7 +269,7 @@ extension FavoritesViewController: UICollectionViewDataSource, UICollectionViewD
             guard let searchItem = recentSearchesFRC.fetchedObjects?[safe: indexPath.item] else {
                 return
             }
-            recentSearchAction(searchItem)
+            recentSearchAction(searchItem, false)
         }
         
     }
@@ -359,6 +359,10 @@ extension FavoritesViewController: UICollectionViewDataSource, UICollectionViewD
                 return cell
             }
             
+            cell.setOpenButtonAction { [weak self] in
+                self?.onOpenRecentSearch(recentSearch)
+            }
+            
             switch searchType {
             case .text:
                 cell.setTitle(recentSearch.text)
@@ -391,7 +395,6 @@ extension FavoritesViewController: UICollectionViewDataSource, UICollectionViewD
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        let indexPath = IndexPath(item: 0, section: section)
         guard let section = availableSections[safe: section] else {
             assertionFailure("Invalid Section")
             return .zero
@@ -679,9 +682,13 @@ extension FavoritesViewController: NSFetchedResultsControllerDelegate {
 
 // Recent Searches
 extension FavoritesViewController {
+    func onOpenRecentSearch(_ recentSearch: RecentSearch) {
+        recentSearchAction(recentSearch, true)
+    }
+    
     @objc
     func onPasteboardAction() {
-        recentSearchAction(nil)
+        recentSearchAction(nil, false)
     }
     
     @objc
@@ -705,14 +712,24 @@ extension FavoritesViewController {
     func onRecentSearchHideOrClearPressed() {
         if Preferences.Search.shouldShowRecentSearches.value {
             // User cleared recent searches
-            RecentSearch.removeAll()
-            fetchRecentSearches()
-            collectionView.reloadData()
+            
+            // brave-ios/issues/3762
+            // No title, no message
+            let alert = UIAlertController(title: "", message: "", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: Strings.recentSearchClearAlertButton, style: .default, handler: { [weak self] _ in
+                guard let self = self else { return }
+                
+                RecentSearch.removeAll()
+                self.fetchRecentSearches()
+                self.collectionView.reloadData()
+            }))
+            
+            alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .destructive, handler: nil))
+            present(alert, animated: true, completion: nil)
         } else {
             // User doesn't want to see the recent searches option again
             Preferences.Search.shouldShowRecentSearchesOptIn.value = false
             collectionView.reloadData()
-            
         }
     }
 }

--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -359,8 +359,8 @@ extension FavoritesViewController: UICollectionViewDataSource, UICollectionViewD
                 return cell
             }
             
-            cell.setOpenButtonAction { [weak self] in
-                self?.onOpenRecentSearch(recentSearch)
+            cell.openButtonAction = { [unowned self] in
+                self.onOpenRecentSearch(recentSearch)
             }
             
             switch searchType {

--- a/Client/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
+++ b/Client/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
@@ -10,7 +10,7 @@ import BraveUI
 
 class RecentSearchCell: UICollectionViewCell, CollectionViewReusable {
     static let identifier = "RecentSearchCell"
-    private var openButtonAction: (() -> Void)?
+    var openButtonAction: (() -> Void)?
     
     private let stackView = UIStackView().then {
         $0.spacing = 20.0
@@ -53,10 +53,6 @@ class RecentSearchCell: UICollectionViewCell, CollectionViewReusable {
     
     func setAttributedTitle(_ title: NSAttributedString?) {
         titleLabel.attributedText = title
-    }
-    
-    func setOpenButtonAction(_ action: (() -> Void)?) {
-        openButtonAction = action
     }
     
     @objc

--- a/Client/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
+++ b/Client/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
@@ -10,6 +10,7 @@ import BraveUI
 
 class RecentSearchCell: UICollectionViewCell, CollectionViewReusable {
     static let identifier = "RecentSearchCell"
+    private var openButtonAction: (() -> Void)?
     
     private let stackView = UIStackView().then {
         $0.spacing = 20.0
@@ -21,15 +22,17 @@ class RecentSearchCell: UICollectionViewCell, CollectionViewReusable {
         $0.font = .systemFont(ofSize: 15.0)
     }
     
-    private let openButton = UIImageView().then {
-        $0.image = #imageLiteral(resourceName: "recent-search-arrow")
-        $0.contentMode = .scaleAspectFit
+    private let openButton = UIButton().then {
+        $0.setImage(#imageLiteral(resourceName: "recent-search-arrow"), for: .normal)
+        $0.imageView?.contentMode = .scaleAspectFit
         $0.setContentHuggingPriority(.required, for: .horizontal)
         $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
+        openButton.addTarget(self, action: #selector(onOpenButtonPressed(_:)), for: .touchUpInside)
         
         contentView.addSubview(stackView)
         stackView.addArrangedSubview(titleLabel)
@@ -50,5 +53,14 @@ class RecentSearchCell: UICollectionViewCell, CollectionViewReusable {
     
     func setAttributedTitle(_ title: NSAttributedString?) {
         titleLabel.attributedText = title
+    }
+    
+    func setOpenButtonAction(_ action: (() -> Void)?) {
+        openButtonAction = action
+    }
+    
+    @objc
+    private func onOpenButtonPressed(_ button: UIButton) {
+        openButtonAction?()
     }
 }

--- a/Client/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
+++ b/Client/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
@@ -90,7 +90,6 @@ class RecentSearchHeaderView: UICollectionReusableView {
             vStackView.addArrangedSubview(hStackView)
             
             [titleLabel, spacer, showButton, hideClearButton].forEach(hStackView.addArrangedSubview(_:))
-
             
             showButton.snp.makeConstraints {
                 $0.width.equalTo(hideClearButton)
@@ -162,7 +161,7 @@ class RecentSearchHeaderView: UICollectionReusableView {
         } else {
             showButton.do {
                 $0.setTitle(Strings.recentSearchShow, for: .normal)
-                $0.setTitleColor(.braveBackground, for: .normal)
+                $0.setTitleColor(.white, for: .normal)
                 $0.titleLabel?.font = .systemFont(ofSize: 12.0, weight: .semibold)
                 $0.layer.cornerCurve = .continuous
                 $0.layer.cornerRadius = DesignUX.buttonHeight / 2.0

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -50,8 +50,8 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         case quickBar
         case searchSuggestionsOptIn
         case searchSuggestions
-        case bookmarksAndHistory
         case findInPage
+        case bookmarksAndHistory
     }
 
     // MARK: Properties
@@ -155,8 +155,8 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         if !tabType.isPrivate && searchEngines?.shouldShowSearchSuggestions == true {
             sections.append(.searchSuggestions)
         }
-        sections.append(.bookmarksAndHistory)
         sections.append(.findInPage)
+        sections.append(.bookmarksAndHistory)
         return sections
     }
 

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -188,6 +188,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
             make.edges.equalTo(view)
         }
         
+        tableView.keyboardDismissMode = .interactive
         tableView.separatorStyle = .none
         tableView.addGestureRecognizer(suggestionLongPressGesture)
         tableView.register(SearchSuggestionPromptCell.self, forCellReuseIdentifier: SearchSuggestionPromptCell.identifier)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes the arrow button on search overlay to immediately submit the search engine url and QRCode urls.
- Fixes spacing in favourites section
- Fixes text colour to be `.white` instead of `.braveBackground`

## Other
- Cannot reproduce not all searches are showing in recent search
- Cannot add swipe-to-delete on collection views.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3762

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
