### PR TITLE
Fix #3775 - Fix Brave Search Suggestions title in Search Overlay

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -92,6 +92,7 @@ extension Strings {
     public static let searchesForSuggestionButtonAccessibilityText = NSLocalizedString("SearchesForSuggestionButtonAccessibilityText", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Searches for the suggestion", comment: "Accessibility hint describing the action performed when a search suggestion is clicked")
     public static let searchSuggestionSectionTitleFormat = NSLocalizedString("SearchSuggestionSectionTitleFormat", tableName: "BraveShared", bundle: Bundle.braveShared, value: "%@ Search", comment: "Section Title when showing search suggestions. The parameter substituted for \"%@\" is the name of the search engine. E.g.: Google Search")
     public static let turnOnSearchSuggestions = NSLocalizedString("Turn on search suggestions?", bundle: Bundle.braveShared, comment: "Prompt shown before enabling provider search queries")
+    public static let searchSuggestionSectionTitleNoSearchFormat = NSLocalizedString("SearchSuggestionSectionTitleNoSearchFormat", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Search", comment: "Section Title when showing search suggestions and the engine does not contain the word 'Search'.")
 }
 
 // MARK:-  Authenticator.swift

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -472,7 +472,8 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         case .searchSuggestionsOptIn: return nil
         case .searchSuggestions:
             if let defaultSearchEngine = searchEngines?.defaultEngine() {
-                if defaultSearchEngine.shortName.hasSuffix(Strings.searchSuggestionSectionTitleNoSearchFormat) {
+                if defaultSearchEngine.shortName.hasSuffix(Strings.searchSuggestionSectionTitleNoSearchFormat) ||
+                    defaultSearchEngine.shortName.hasSuffix("Search") {
                     return defaultSearchEngine.shortName
                 }
                 return String(format: Strings.searchSuggestionSectionTitleFormat, defaultSearchEngine.shortName)

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -472,6 +472,9 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         case .searchSuggestionsOptIn: return nil
         case .searchSuggestions:
             if let defaultSearchEngine = searchEngines?.defaultEngine() {
+                if defaultSearchEngine.shortName.hasSuffix(Strings.searchSuggestionSectionTitleNoSearchFormat) {
+                    return defaultSearchEngine.shortName
+                }
                 return String(format: Strings.searchSuggestionSectionTitleFormat, defaultSearchEngine.shortName)
             }
             return Strings.searchSuggestionsSectionHeader


### PR DESCRIPTION
If the search engine's title already contains "Search", then just display the title without appending "Search".

## Summary of Changes
- If the title already contains "Search" as prefix, then do not format the string to append "Search".

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3775

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Must be tested after https://github.com/brave/brave-ios/pull/3535 is merged

- Set Brave Search as default
- Tap on url bar, enable search suggestions
- Verify it says `Brave Search` not `Brave Search Search`

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="343" alt="Zrzut ekranu 2021-06-14 o 18 16 15" src="https://user-images.githubusercontent.com/6950387/121925039-ca423300-cd3c-11eb-98b3-d7c41a9101ae.png">

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
