### PR TITLE
Fix #3790 - Fixes blank recent searches

### DIFF
--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -386,6 +386,8 @@ extension FavoritesViewController: UICollectionViewDataSource, UICollectionViewD
                     title.append(NSAttributedString(string: website,
                                                     attributes: [.font: UIFont.systemFont(ofSize: 15.0)]))
                     cell.setAttributedTitle(title)
+                } else if let websiteUrl = recentSearch.websiteUrl {
+                    cell.setTitle(websiteUrl)
                 } else {
                     cell.setTitle(recentSearch.text)
                 }

--- a/Data/models/RecentSearches.swift
+++ b/Data/models/RecentSearches.swift
@@ -52,6 +52,17 @@ final public class RecentSearch: NSManagedObject, CRUD {
     }
     
     public static func addItem(type: RecentSearchType, text: String?, websiteUrl: String?) {
+        let isNullOrEmpty = { (string: String?) in
+            return (string ?? "").trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty
+        }
+        
+        // If both are empty, do NOT add it to Recent Searches
+        // It's better to check here since a RecentSearch can be added from multiple places
+        // and can contain either field.
+        if isNullOrEmpty(text) && isNullOrEmpty(websiteUrl) {
+            return
+        }
+        
         if let recentSearch = getItem(text: text, websiteUrl: websiteUrl) {
             recentSearch.update(dateAdded: Date())
         } else {


### PR DESCRIPTION
## Summary of Changes
- Fixes blank recent searches being added

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3790

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
