### PR TITLE
Fix #3795 - Bug deleting auto-selected text.

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -626,6 +626,10 @@ extension TopToolbarView: AutocompleteTextFieldDelegate {
         updateLocationBarRightView(showQrCodeButton: text.isEmpty)
     }
     
+    func autocompleteTextField(_ autocompleteTextField: AutocompleteTextField, didDeleteAutoSelectedText text: String) {
+        updateLocationBarRightView(showQrCodeButton: text.isEmpty)
+    }
+    
     func autocompleteTextFieldDidBeginEditing(_ autocompleteTextField: AutocompleteTextField) {
         autocompleteTextField.highlightAll()
         updateLocationBarRightView(showQrCodeButton: locationView.urlTextField.text?.isEmpty == true)


### PR DESCRIPTION
There is a bug when deleting auto-suggested, auto-selected text.
This does NOT happen when text is selected by the user or by any other means (pasting, copying, etc).
It only happens when text is automatically selected in the URL bar when the user FIRST time taps on the URL bar and auto-suggestion is selected automatically. It happens because I call `notifyTextChange` when `deleteBackwards` is called in order to show the QRCode when the text field becomes empty due to deleting which is NOT the same as when it is cleared or just empty, because the original code never calls `super.deleteBackwards` when text is auto-selected :(

## Summary of Changes
- Adds a new delegate for when text is deleted backwards but only when it is auto-selected.
- Revert code that attempted to detect deleting auto-selected text. There is no other way to fix this without rewriting the AutoCompleteTextField's `debounce` and calling super.. but that **might** have **worse** side-effects.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3795

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
