### PR TITLE
Fix #3803 - Remove adding URLs in Recent Search

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -166,10 +166,6 @@ extension BrowserViewController: TopToolbarDelegate {
         if let fixupURL = URIFixup.getURL(text) {
             // The user entered a URL, so use it.
             finishEditingAndSubmit(fixupURL, isBookmark: false)
-            
-            if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                RecentSearch.addItem(type: .website, text: nil, websiteUrl: fixupURL.absoluteString)
-            }
             return
         }
 

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -403,7 +403,9 @@ class SearchViewController: SiteTableViewController, LoaderListener {
             return
         }
 
-        if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+        // If the user typed a URL and selected the search engine,
+        // do not save it as a recent search
+        if URIFixup.getURL(searchQuery) == nil, !PrivateBrowsingManager.shared.isPrivateBrowsing {
             RecentSearch.addItem(type: .website, text: searchQuery, websiteUrl: url.absoluteString)
         }
         searchDelegate?.searchViewController(self, didSelectURL: url)


### PR DESCRIPTION
## Summary of Changes
- Remove adding URLs to RecentSearch when manually typed.
- A URL will NOT be saved even if searched via quick-search.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3803

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:

URLs like `brave.com` and `https://brave.com` won't show in the Recent Search.
However, `brave.com` via Search Engine WILL show up because it is a search engine query. Therefore you WILL see `brave.com on google.com` when `google.com` is the search engine that is selected for example.

![image](https://user-images.githubusercontent.com/1530031/122269935-ca147580-ceab-11eb-8de8-fa52cb59fc03.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
