### PR TITLE
Fix #3803 - Show Recent Search URLs when using Quick-Search

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -403,9 +403,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
             return
         }
 
-        // If the user typed a URL and selected the search engine,
-        // do not save it as a recent search
-        if URIFixup.getURL(searchQuery) == nil, !PrivateBrowsingManager.shared.isPrivateBrowsing {
+        if !PrivateBrowsingManager.shared.isPrivateBrowsing {
             RecentSearch.addItem(type: .website, text: searchQuery, websiteUrl: url.absoluteString)
         }
         searchDelegate?.searchViewController(self, didSelectURL: url)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Shows Recent Search URLs when using Quick-Search: https://bravesoftware.slack.com/archives/G01F4JUNXAQ/p1623871630327500?thread_ts=1623866911.316500&cid=G01F4JUNXAQ

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3803

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
