### PR TITLE
Fix #3816: Clear recent searches crash on iPad.

### DIFF
--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -297,7 +297,7 @@ extension FavoritesViewController: UICollectionViewDataSource, UICollectionViewD
                     header.hideClearButton.removeTarget(self, action: nil, for: .touchUpInside)
                     
                     header.showButton.addTarget(self, action: #selector(onRecentSearchShowPressed), for: .touchUpInside)
-                    header.hideClearButton.addTarget(self, action: #selector(onRecentSearchHideOrClearPressed), for: .touchUpInside)
+                    header.hideClearButton.addTarget(self, action: #selector(onRecentSearchHideOrClearPressed(_:)), for: .touchUpInside)
                     
                     if Preferences.Search.shouldShowRecentSearches.value {
                         let totalCount = RecentSearch.totalCount()
@@ -711,7 +711,7 @@ extension FavoritesViewController {
     }
     
     @objc
-    func onRecentSearchHideOrClearPressed() {
+    func onRecentSearchHideOrClearPressed(_ button: UIButton) {
         if Preferences.Search.shouldShowRecentSearches.value {
             // User cleared recent searches
             
@@ -725,6 +725,9 @@ extension FavoritesViewController {
                 self.fetchRecentSearches()
                 self.collectionView.reloadData()
             }))
+            
+            alert.popoverPresentationController?.sourceView = button
+            alert.popoverPresentationController?.permittedArrowDirections = [.down, .up]
             
             alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .destructive, handler: nil))
             present(alert, animated: true, completion: nil)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3816 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="564" alt="Zrzut ekranu 2021-06-18 o 11 42 04" src="https://user-images.githubusercontent.com/6950387/122542159-aa578b80-d02a-11eb-9cc3-98248a124b56.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
