### PR TITLE
Fix #3821 - Added Recent-Search from Search Engine Suggestions.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -421,7 +421,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         switch section {
         case .quickBar:
             if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                RecentSearch.addItem(type: .text, text: searchQuery, websiteUrl:nil)
+                RecentSearch.addItem(type: .text, text: searchQuery, websiteUrl: nil)
             }
             searchDelegate?.searchViewController(self, didSubmit: searchQuery)
         case .searchSuggestionsOptIn: return

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -420,6 +420,9 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         
         switch section {
         case .quickBar:
+            if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+                RecentSearch.addItem(type: .text, text: searchQuery, websiteUrl:nil)
+            }
             searchDelegate?.searchViewController(self, didSubmit: searchQuery)
         case .searchSuggestionsOptIn: return
         case .searchSuggestions:
@@ -433,6 +436,9 @@ class SearchViewController: SiteTableViewController, LoaderListener {
             }
 
             if let url = url {
+                if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+                    RecentSearch.addItem(type: .website, text: suggestion, websiteUrl: url.absoluteString)
+                }
                 searchDelegate?.searchViewController(self, didSelectURL: url)
             }
         case .bookmarksAndHistory:


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Added Recent-Search from Search Engine Suggestions.
- When a user taps on the QuickBar OR the Search Engine Suggestion, if it is not a URL, and it is a query, it is added to the Recent Search list.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3821

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
