### PR TITLE
Fix #3815 - Truncate middle just like safari.

### DIFF
--- a/Client/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
+++ b/Client/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
@@ -20,6 +20,7 @@ class RecentSearchCell: UICollectionViewCell, CollectionViewReusable {
     
     private let titleLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 15.0)
+        $0.lineBreakMode = .byTruncatingMiddle
     }
     
     private let openButton = UIButton().then {

--- a/Client/Frontend/Browser/Search/SearchSuggestionCell.swift
+++ b/Client/Frontend/Browser/Search/SearchSuggestionCell.swift
@@ -21,6 +21,7 @@ class SuggestionCell: UITableViewCell {
     private let titleLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 15.0)
         $0.textColor = .bravePrimary
+        $0.lineBreakMode = .byTruncatingMiddle
     }
     
     private let openButton = UIButton().then {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Truncate the middle of search suggestions just like Safari does.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3815

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
Safari:
![Image from iOS](https://user-images.githubusercontent.com/1530031/122573482-d66c1000-d01c-11eb-9fa9-6931ae33bd60.png)

Suggestions:
![image](https://user-images.githubusercontent.com/1530031/122573215-8b51fd00-d01c-11eb-96d8-e1672d817e2b.png)

Recent Search:
![image](https://user-images.githubusercontent.com/1530031/122572321-a112f280-d01b-11eb-8cd0-5fe878ebd24e.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
