### PR TITLE
Fix #3834: Adding Open Search References to Default Search Engines

### DIFF
--- a/Client/Frontend/Browser/Search/InitialSearchEngines.swift
+++ b/Client/Frontend/Browser/Search/InitialSearchEngines.swift
@@ -12,6 +12,21 @@ class InitialSearchEngines {
     enum SearchEngineID: String {
         case google, braveSearch, bing, duckduckgo, yandex, qwant, startpage, yahoo, ecosia
         
+        /// Return time interval when to remove old tabs, or nil if no tabs should be removed.
+        var openSearchReference: String {
+            switch self {
+                case .google: return "google"
+                case .braveSearch: return "search.brave"
+                case .bing: return "bing"
+                case .duckduckgo: return "duckduckgo.com/opensearch"
+                case .yandex: return "yandex.com/search"
+                case .qwant: return "qwant.com/opensearch"
+                case .startpage: return "startpage.com/en/opensearch"
+                case .yahoo: return "search.yahoo.com/opensearch"
+                case .ecosia: return "ecosia.org/opensearch"
+            }
+        }
+        
         func excludedFromOnboarding(for locale: Locale) -> Bool {
             switch self {
             case .google, .bing, .duckduckgo, .yandex, .qwant, .startpage, .ecosia:
@@ -31,6 +46,10 @@ class InitialSearchEngines {
         /// Some search engines have regional variations which correspond to different xml files in `SearchPlugins` folder.
         /// If you provide this custom id, it will be used instead of `regular` id when accessing the open search xml file.
         var customId: String?
+        
+        var reference: String? {
+            return id.openSearchReference
+        }
         
         // Only `id` mattera when comparing search engines.
         // This is to prevent adding more than 2 engines of the same type.

--- a/Client/Frontend/Browser/Search/InitialSearchEngines.swift
+++ b/Client/Frontend/Browser/Search/InitialSearchEngines.swift
@@ -15,9 +15,9 @@ class InitialSearchEngines {
         /// Return time interval when to remove old tabs, or nil if no tabs should be removed.
         var openSearchReference: String {
             switch self {
-                case .google: return "google"
+                case .google: return "google.com"
                 case .braveSearch: return "search.brave"
-                case .bing: return "bing"
+                case .bing: return "bing.com"
                 case .duckduckgo: return "duckduckgo.com/opensearch"
                 case .yandex: return "yandex.com/search"
                 case .qwant: return "qwant.com/opensearch"

--- a/Client/Frontend/Browser/Search/InitialSearchEngines.swift
+++ b/Client/Frontend/Browser/Search/InitialSearchEngines.swift
@@ -12,7 +12,7 @@ class InitialSearchEngines {
     enum SearchEngineID: String {
         case google, braveSearch, bing, duckduckgo, yandex, qwant, startpage, yahoo, ecosia
         
-        /// Return time interval when to remove old tabs, or nil if no tabs should be removed.
+        /// Open Search Reference  for default search Engines
         var openSearchReference: String {
             switch self {
                 case .google: return "google.com"
@@ -46,7 +46,8 @@ class InitialSearchEngines {
         /// Some search engines have regional variations which correspond to different xml files in `SearchPlugins` folder.
         /// If you provide this custom id, it will be used instead of `regular` id when accessing the open search xml file.
         var customId: String?
-        
+        /// This is used to determine If a seach engine is added already
+        /// Added to espeically to prevent Default Search engines using Open Search Auto-Add
         var reference: String? {
             return id.openSearchReference
         }

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -244,7 +244,7 @@ class OpenSearchParser {
         self.pluginMode = pluginMode
     }
     
-    func parse(_ file: String, engineID: String, referenceURL: String = "") -> OpenSearchEngine? {
+    func parse(_ file: String, engineID: String, referenceURL: String?) -> OpenSearchEngine? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: file)) else {
             print("Invalid search file")
             return nil

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -295,12 +295,12 @@ class SearchEngines {
 
         let se = InitialSearchEngines()
         let engines = isOnboarding ? se.onboardingEngines : se.engines
-        let engineNames = engines.map { ($0.customId ?? $0.id.rawValue).lowercased() }
-        assert(!engineNames.isEmpty, "No search engines")
+        let engineIdentifiers: [(id: String, reference: String?)] = engines.map { (id: ($0.customId ?? $0.id.rawValue).lowercased(), reference: $0.reference) }
+        assert(!engineIdentifiers.isEmpty, "No search engines")
 
-        return engineNames.map({ (name: $0, path: pluginDirectory.appendingPathComponent("\($0).xml").path) })
+        return engineIdentifiers.map({ (name: $0.id, path: pluginDirectory.appendingPathComponent("\($0.id).xml").path, reference: $0.reference) })
             .filter({ FileManager.default.fileExists(atPath: $0.path) })
-            .compactMap({ parser.parse($0.path, engineID: $0.name) })
+            .compactMap({ parser.parse($0.path, engineID: $0.name, referenceURL: $0.reference) })
     }
 
     /// Get all known search engines, possibly as ordered by the user.

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -12,7 +12,7 @@ class SearchTests: XCTestCase {
     func testParsing() {
         let parser = OpenSearchParser(pluginMode: true)
         let file = Bundle.main.path(forResource: "google", ofType: "xml", inDirectory: "SearchPlugins/")
-        let engine: OpenSearchEngine! = parser.parse(file!, engineID: "google")
+        let engine: OpenSearchEngine! = parser.parse(file!, engineID: "google", referenceURL: "google.com")
         XCTAssertEqual(engine.shortName, "Google")
 
         // Test regular search queries.
@@ -111,7 +111,7 @@ class SearchTests: XCTestCase {
     func testExtractingOfSearchTermsFromURL() {
         let parser = OpenSearchParser(pluginMode: true)
         var file = Bundle.main.path(forResource: "google", ofType: "xml", inDirectory: "SearchPlugins/")
-        let googleEngine: OpenSearchEngine! = parser.parse(file!, engineID: "google")
+        let googleEngine: OpenSearchEngine! = parser.parse(file!, engineID: "google", referenceURL: "google.com")
 
         // create URL
         let searchTerm = "Foo Bar"
@@ -128,7 +128,7 @@ class SearchTests: XCTestCase {
 
         // check that it matches given a different configuration
         file = Bundle.main.path(forResource: "duckduckgo", ofType: "xml", inDirectory: "SearchPlugins/")
-        let duckDuckGoEngine: OpenSearchEngine! = parser.parse(file!, engineID: "duckduckgo")
+        let duckDuckGoEngine: OpenSearchEngine! = parser.parse(file!, engineID: "duckduckgo", referenceURL: "duckduckgo.com/opensearch")
         XCTAssertEqual(searchTerm, duckDuckGoEngine.queryForSearchURL(duckDuckGoSearchURL))
 
         // check it doesn't match search URLs for different configurations


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3834

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
### Steps to Reproduce 
  1. Go brave.search.com
  2. Press Search Textfield
  3. The Add button for Open Search is not active

## Screenshots:
![1](https://user-images.githubusercontent.com/6643505/123005698-85de1500-d384-11eb-8eaa-dc174d60dac8.png)



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
