### PR TITLE
Fix #3839: Favorites reorder crash.

### DIFF
--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -537,7 +537,10 @@ extension FavoritesViewController: UICollectionViewDragDelegate, UICollectionVie
         case .pasteboard:
             break
         case .favorites:
-            let bookmark = favoritesFRC.object(at: indexPath)
+            // Fetch results controller indexpath is independent from our collection view.
+            // All results of it are stored in first section.
+            let adjustedIndexPath = IndexPath(row: indexPath.row, section: 0)
+            let bookmark = favoritesFRC.object(at: adjustedIndexPath)
             let itemProvider = NSItemProvider(object: "\(indexPath)" as NSString)
             let dragItem = UIDragItem(itemProvider: itemProvider)
             dragItem.previewProvider = { () -> UIDragPreview? in


### PR DESCRIPTION
This is a regression caused by the new search overlay. 
We added new section above favorites, and fetching objects from frc
by IndexPath causes problems now, non-existing section.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3839 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
In the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
