### PR TITLE
Fix #3843: Do not scroll quick search bar vertically.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -62,7 +62,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     // Views for displaying the bottom scrollable search engine list. searchEngineScrollView is the
     // scrollable container; searchEngineScrollViewContent contains the actual set of search engine buttons.
     private let searchEngineScrollView = ButtonScrollView().then { scrollView in
-        scrollView.decelerationRate = UIScrollView.DecelerationRate.fast
+        scrollView.decelerationRate = .fast
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.clipsToBounds = false
@@ -241,11 +241,11 @@ class SearchViewController: SiteTableViewController, LoaderListener {
             make.center.equalTo(searchEngineScrollView).priority(.low)
             // Left-align the engines on iphones, center on ipad
             if UIScreen.main.traitCollection.horizontalSizeClass == .compact {
-                make.left.equalTo(searchEngineScrollView).priority(.required)
+                make.leading.equalTo(searchEngineScrollView).priority(.required)
             } else {
-                make.left.greaterThanOrEqualTo(searchEngineScrollView).priority(.required)
+                make.leading.greaterThanOrEqualTo(searchEngineScrollView).priority(.required)
             }
-            make.bottom.right.top.equalTo(searchEngineScrollView)
+            make.bottom.trailing.top.equalTo(searchEngineScrollView)
         }
     }
 
@@ -254,9 +254,9 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         
         let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(view) ?? 0
         searchEngineScrollView.snp.remakeConstraints { make in
-            make.left.right.equalTo(view)
+            make.leading.trailing.equalTo(view)
             make.bottom.equalTo(view).offset(-keyboardHeight)
-            make.height.equalTo(SearchViewControllerUX.engineButtonHeight)
+            
         }
     }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3843 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that quick search bar can be scrolled horizontally and no vertically

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
