### PR TITLE
Fix #3838: Improve menu accessibility

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -536,6 +536,11 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
             self.navigationController?.pushViewController(vc, animated: true)
         }
     }
+    
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true)
+        return true
+    }
 }
 
 extension BookmarksViewController: BookmarksV2FetchResultsDelegate {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -160,6 +160,11 @@ class MenuViewController: UINavigationController, UIPopoverPresentationControlle
     private var isPresentingInnerMenu: Bool {
         presentedViewController is InnerMenuNavigationController
     }
+    
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true)
+        return true
+    }
 }
 
 extension MenuViewController: PanModalPresentable {
@@ -198,10 +203,10 @@ extension MenuViewController: PanModalPresentable {
         return _scrollViewChild(in: topVC.view)
     }
     var longFormHeight: PanModalHeight {
-        .maxHeight
+        .maxHeightWithTopInset(32)
     }
     var shortFormHeight: PanModalHeight {
-        isPresentingInnerMenu ? .maxHeight : .contentHeight(initialHeight)
+        isPresentingInnerMenu ? .maxHeightWithTopInset(32) : .contentHeight(initialHeight)
     }
     var allowsExtendedPanScrolling: Bool {
         true


### PR DESCRIPTION
- Adds support for accessibility escape while VoiceOver is active
- Increases the top inset so there is always space to tap to dismiss the menu

## Summary of Changes

This pull request fixes #3838 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- With VoiceOver active, verify that you can perform a two finger scrub (drawing z shape with two fingers) to dismiss the menu
- Verify there is now sufficient space at the top of the menu to tap the background to dismiss even when the menu is expanded

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
