### PR TITLE
Fix #3779: Expand menu when tapping on settings, history, etc.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -13,7 +13,7 @@ extension BrowserViewController {
         VStack(spacing: 0) {
             VPNMenuButton(vpnProductInfo: self.vpnProductInfo) { vc in
                 (self.presentedViewController as? MenuViewController)?
-                    .pushViewController(vc, animated: true)
+                    .pushInnerMenu(vc)
             }
         }
     }
@@ -28,11 +28,11 @@ extension BrowserViewController {
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-history").template, title: Strings.historyMenuItem) {
                 let vc = HistoryViewController(isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
                 vc.toolbarUrlActionsDelegate = self
-                menuController.pushViewController(vc, animated: true)
+                menuController.pushInnerMenu(vc)
             }
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-downloads").template, title: Strings.downloadsMenuItem) {
                 let vc = DownloadsPanel(profile: self.profile)
-                menuController.pushViewController(vc, animated: true)
+                menuController.pushInnerMenu(vc)
             }
             MenuItemButton(icon: #imageLiteral(resourceName: "playlist_menu").template, title: Strings.playlistMenuItem) {
                 let playlistController = (UIApplication.shared.delegate as? AppDelegate)?.playlistRestorationController ?? PlaylistViewController()
@@ -44,7 +44,7 @@ extension BrowserViewController {
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) {
                 let vc = SettingsViewController(profile: self.profile, tabManager: self.tabManager, feedDataSource: self.feedDataSource, rewards: self.rewards, legacyWallet: self.legacyWallet)
                 vc.settingsDelegate = self
-                menuController.pushViewController(vc, animated: true)
+                menuController.pushInnerMenu(vc)
             }
         }
     }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -112,6 +112,19 @@ class MenuViewController: UINavigationController, UIPopoverPresentationControlle
         }
     }
     
+    func pushInnerMenu(_ viewController: UIViewController,
+                       expandToLongForm: Bool = true) {
+        super.pushViewController(viewController, animated: true)
+        if expandToLongForm {
+            panModalTransition(to: .longForm)
+        }
+    }
+    
+    @available(*, unavailable, message: "Use 'pushInnerMenu(_:expandToLongForm:)' instead")
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        super.pushViewController(viewController, animated: animated)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationBar.isTranslucent = false


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3779

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Verify that tapping on Settings, History, Downloads and VPN (when applicable) now expand the menu to full size immediately

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
