### PR TITLE
Ref #3838: Fix overall menu height on smaller devices

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
         "package": "PanModal",
         "repositoryURL": "https://github.com/brave/PanModal",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "e4c07f8e6c5df937051fabc47e1e92901e1d068b",
           "version": null
         }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -215,11 +215,15 @@ extension MenuViewController: PanModalPresentable {
         topVC.view.layoutIfNeeded()
         return _scrollViewChild(in: topVC.view)
     }
+    var topOffset: CGFloat {
+        let topInset = view.window?.safeAreaInsets.top ?? 0
+        return topInset + 32
+    }
     var longFormHeight: PanModalHeight {
-        .maxHeightWithTopInset(32)
+        .maxHeight
     }
     var shortFormHeight: PanModalHeight {
-        isPresentingInnerMenu ? .maxHeightWithTopInset(32) : .contentHeight(initialHeight)
+        isPresentingInnerMenu ? .maxHeight : .contentHeight(initialHeight)
     }
     var allowsExtendedPanScrolling: Bool {
         true


### PR DESCRIPTION
PanModal uses `topOffset` to determine the height of the presenting controller rather than the `longFormHeight`, so adjusting where I add that 32pt's for accessibility to fix the bug caused by adding that 32pt's in the wrong location.

## Summary of Changes

This pull request fixes a small bug caused by the #3845

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Verify on devices that have no bottom safe area that toolbars are in the correct spot

## Screenshots:

| iPhone 6s | iPhone 11 Pro |
| --- | --- |
| ![Simulator Screen Shot - iPhone 6s - 2021-06-25 at 10 09 43](https://user-images.githubusercontent.com/529104/123437437-aa610980-d59d-11eb-877d-c640db69aa6a.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-06-25 at 10 09 49](https://user-images.githubusercontent.com/529104/123437451-ad5bfa00-d59d-11eb-8d32-1c1bc0890cae.png) |

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
