### PR TITLE
Fix #3787: PanModal table reorder gesture collision.

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -225,6 +225,15 @@ extension MenuViewController: PanModalPresentable {
     var shortFormHeight: PanModalHeight {
         isPresentingInnerMenu ? .maxHeight : .contentHeight(initialHeight)
     }
+    
+    func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        // This enables reordering elements without colliding with PanModal gestures, see bug #3787.
+        if let tableView = panScrollable as? UITableView, tableView.isEditing {
+            return false
+        }
+        return true
+    }
+    
     var allowsExtendedPanScrolling: Bool {
         true
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3787 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Go to bookmarks screen, add few bookmarks
- Tap on 'edit' mode
- Verify that bookmarks can be arranged

- Go to settings -> search engines -> quick search engines
- Verify that search engines can be reordered

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
