### PR TITLE
Fix #3853 - Fix search overlay crash.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -729,7 +729,9 @@ extension SearchViewController {
         if gestureRecognizer.state == .began {
             let location = gestureRecognizer.location(in: self.tableView)
             if let indexPath = tableView.indexPathForRow(at: location),
-               let suggestion = suggestions[safe: indexPath.row] {
+               let section = availableSections[safe: indexPath.section],
+               let suggestion = suggestions[safe: indexPath.row],
+               section == .searchSuggestions {
                 searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
             }
         }

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -728,8 +728,9 @@ extension SearchViewController {
     func onSuggestionLongPressed(_ gestureRecognizer: UILongPressGestureRecognizer) {
         if gestureRecognizer.state == .began {
             let location = gestureRecognizer.location(in: self.tableView)
-            if let indexPath = tableView.indexPathForRow(at: location) {
-                searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestions[indexPath.row])
+            if let indexPath = tableView.indexPathForRow(at: location),
+               let suggestion = suggestions[safe: indexPath.row] {
+                searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
             }
         }
     }


### PR DESCRIPTION
Notes:
- I was never able to reproduce the crash as the indexPath was always valid since you're long-pressing on a search result.

## Summary of Changes
- Decided add `suggestions[safe: indexPath.row]` so it will check against the list of suggestions if the gesture is within range.
- Only allow long-press on suggestions fix.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3853

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
