### PR TITLE
Fix #3863 Changing logic regarding accepting url and text from share extension

### DIFF
--- a/BraveShareTo/ShareToBraveViewController.swift
+++ b/BraveShareTo/ShareToBraveViewController.swift
@@ -70,15 +70,15 @@ class ShareToBraveViewController: SLComposeServiceViewController {
             cancel()
             return []
         }
-        
-        provider.loadItem(forTypeIdentifier: String(kUTTypeText), options: nil, completionHandler: { item, error in
+
+        provider.loadItem(forTypeIdentifier: String(kUTTypeText), options: nil) { item, error in
             guard let item = item, let schemeUrl = Scheme(item: item)?.schemeUrl else {
                 self.cancel()
                 return
              }
                         
             self.handleUrl(schemeUrl)
-        })
+        }
         
         return []
     }

--- a/BraveShareTo/ShareToBraveViewController.swift
+++ b/BraveShareTo/ShareToBraveViewController.swift
@@ -18,11 +18,13 @@ class ShareToBraveViewController: SLComposeServiceViewController {
             
             init?(item: NSSecureCoding) {
                 if let text = item as? String {
-                    urlOrQuery = text
-                    type = .query
-                } else if let url = (item as? URL)?.absoluteString.firstURL?.absoluteString {
-                    urlOrQuery = url
-                    type = .url
+                    if let url = URL(string: text)?.absoluteString {
+                        urlOrQuery = url
+                        type = .url
+                    } else {
+                        urlOrQuery = text
+                        type = .query
+                    }
                 } else {
                     return nil
                 }
@@ -62,21 +64,21 @@ class ShareToBraveViewController: SLComposeServiceViewController {
         
         // Look for the first URL the host application is sharing.
         // If there isn't a URL grab the first text item
-        guard let provider = attachments.first(where: { $0.isUrl }) ?? attachments.first(where: { $0.isText }) else {
+        guard let provider = attachments.first(where: { $0.isText }) else {
             // If no item was processed. Cancel the share action to prevent the extension from locking the host application
             // due to the hidden ViewController.
             cancel()
             return []
         }
         
-        provider.loadItem(of: provider.isUrl ? kUTTypeURL : kUTTypeText) { item, error in
+        provider.loadItem(forTypeIdentifier: String(kUTTypeText), options: nil, completionHandler: { item, error in
             guard let item = item, let schemeUrl = Scheme(item: item)?.schemeUrl else {
                 self.cancel()
                 return
              }
                         
             self.handleUrl(schemeUrl)
-        }
+        })
         
         return []
     }
@@ -113,14 +115,6 @@ class ShareToBraveViewController: SLComposeServiceViewController {
 extension NSItemProvider {
     var isText: Bool {
         return hasItemConformingToTypeIdentifier(String(kUTTypeText))
-    }
-    
-    var isUrl: Bool {
-        return hasItemConformingToTypeIdentifier(String(kUTTypeURL))
-    }
-    
-    func loadItem(of type: CFString, completion: CompletionHandler?) {
-        loadItem(forTypeIdentifier: String(type), options: nil, completionHandler: completion)
     }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3863 
Logic changed from checking whether shared item is URL or text in NSItemProvider.loadItem to check it in Scheme initializer after accepting text data to app.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

Verify that sharing url or text from other apps have not regressed


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
