### PR TITLE
Fix #3865 Remove "%" character from URL allowed characters

### DIFF
--- a/BraveSharedTests/StringExtensionTests.swift
+++ b/BraveSharedTests/StringExtensionTests.swift
@@ -28,6 +28,12 @@ class StringExtensionTests: XCTestCase {
         XCTAssertNotNil(schemelessURL.firstURL)
     }
     
+    func testURLEncoding() {
+        let urlString = "https://example.com/test%"
+        let urlStringEncoded = "https://example.com/test%25"
+        XCTAssertEqual(urlString.addingPercentEncoding(withAllowedCharacters: .URLAllowed), urlStringEncoded)
+    }
+    
     func testWords() {
         let longMultilinedText = """
         Multiple words

--- a/ClientTests/NavigationRouterTests.swift
+++ b/ClientTests/NavigationRouterTests.swift
@@ -33,7 +33,8 @@ class NavigationRouterTests: XCTestCase {
         let url = "http://google.com?a=1&b=2&c=foo%20bar".escape()!
         let appURL = "\(appScheme)://open-url?url=\(url)"
         let navItem = NavigationPath(url: URL(string: appURL)!)!
-        XCTAssertEqual(navItem, NavigationPath.url(webURL: URL(string: url.unescape()!)!, isPrivate: false))
+        let encodedUrl = url.unescape()!.addingPercentEncoding(withAllowedCharacters: .URLAllowed)!
+        XCTAssertEqual(navItem, NavigationPath.url(webURL: URL(string: encodedUrl)!, isPrivate: false))
         
         let emptyNav = NavigationPath(url: URL(string: "\(appScheme)://open-url?private=true")!)
         XCTAssertEqual(emptyNav, NavigationPath.url(webURL: nil, isPrivate: true))

--- a/Shared/Extensions/NSCharacterSetExtensions.swift
+++ b/Shared/Extensions/NSCharacterSetExtensions.swift
@@ -5,6 +5,6 @@
 import Foundation
 
 extension CharacterSet {
-    public static let URLAllowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=%")
+    public static let URLAllowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=")
     public static let searchTermsAllowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789*-_.")
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #3865.
Function URL(string:) failed since "%" is used to encoding other signs and unencoded is illegal in url.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- visit example.com/test%
- verify that the website opens instead of a search query

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
