### PR TITLE
Fix #3878: database app upgrade regression,

### DIFF
--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -23,6 +23,10 @@ public class DataController {
     private static let databaseName = "Brave.sqlite"
     private static let modelName = "Model"
     
+    /// This code is checked when the persistent store is loaded.
+    /// For all codes except this one we crash the app because of database failure.
+    private static let storeExistsErrorCode = 134081
+    
     // MARK: - Initialization
     
     /// Managed Object Model of the database stack.
@@ -235,27 +239,6 @@ public class DataController {
         return DataController.sharedInMemory.container.viewContext
     }
     
-    static func save(context: NSManagedObjectContext?) {
-        guard let context = context else {
-            log.warning("No context on save")
-            return
-        }
-        
-        if context.concurrencyType == .mainQueueConcurrencyType {
-            log.warning("Writing to view context, this should be avoided.")
-        }
-        
-        context.perform {
-            if !context.hasChanges { return }
-            
-            do {
-                try context.save()
-            } catch {
-                assertionFailure("Error saving DB: \(error)")
-            }
-        }
-    }
-    
     func addPersistentStore(for container: NSPersistentContainer, store: URL) {
         let storeDescription = NSPersistentStoreDescription(url: store)
         
@@ -274,10 +257,18 @@ public class DataController {
     private func configureContainer(_ container: NSPersistentContainer, store: URL) {
         addPersistentStore(for: container, store: store)
         
-        // Dev note: This completion handler might be misleading: the persistent store is loaded synchronously by default.
-        container.loadPersistentStores(completionHandler: { _, error in
+        container.loadPersistentStores(completionHandler: { store, error in
             if let error = error {
-                fatalError("Load persistent store error: \(error)")
+                // Do not crash the app if the store already exists.
+                if (error as NSError).code != Self.storeExistsErrorCode {
+                    fatalError("Load persistent store error: \(error)")
+                }
+            }
+            
+            if store.type != NSInMemoryStoreType {
+                // This makes the database file encrypted until device is unlocked.
+                let completeProtection = FileProtectionType.complete as NSObject
+                store.setOption(completeProtection, forKey: NSPersistentStoreFileProtectionKey)
             }
         })
         // We need this so the `viewContext` gets updated on changes from background tasks.

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -23,10 +23,6 @@ public class DataController {
     private static let databaseName = "Brave.sqlite"
     private static let modelName = "Model"
     
-    /// This code is checked when the persistent store is loaded.
-    /// For all codes except this one we crash the app because of database failure.
-    private static let storeExistsErrorCode = 134081
-    
     // MARK: - Initialization
     
     /// Managed Object Model of the database stack.
@@ -65,7 +61,7 @@ public class DataController {
         return FileManager.default.fileExists(atPath: storeURL.path)
     }
     
-    let container = NSPersistentContainer(name: DataController.modelName,
+    private let container = NSPersistentContainer(name: DataController.modelName,
                                                   managedObjectModel: DataController.model)
     
     // MARK: - Old Database migration methods
@@ -239,24 +235,49 @@ public class DataController {
         return DataController.sharedInMemory.container.viewContext
     }
     
+    static func save(context: NSManagedObjectContext?) {
+        guard let context = context else {
+            log.warning("No context on save")
+            return
+        }
+        
+        if context.concurrencyType == .mainQueueConcurrencyType {
+            log.warning("Writing to view context, this should be avoided.")
+        }
+        
+        context.perform {
+            if !context.hasChanges { return }
+            
+            do {
+                try context.save()
+            } catch {
+                assertionFailure("Error saving DB: \(error)")
+            }
+        }
+    }
+    
+    func addPersistentStore(for container: NSPersistentContainer, store: URL) {
+        let storeDescription = NSPersistentStoreDescription(url: store)
+        
+        // This makes the database file encrypted until device is unlocked.
+        let completeProtection = FileProtectionType.complete as NSObject
+        storeDescription.setOption(completeProtection, forKey: NSPersistentStoreFileProtectionKey)
+        
+        container.persistentStoreDescriptions = [storeDescription]
+    }
+    
     var storeURL: URL {
         let supportDirectory = Preferences.Database.DocumentToSupportDirectoryMigration.completed.value
         return supportDirectory ? supportStoreURL : oldDocumentStoreURL
     }
     
     private func configureContainer(_ container: NSPersistentContainer, store: URL) {
-        container.loadPersistentStores(completionHandler: { store, error in
+        addPersistentStore(for: container, store: store)
+        
+        // Dev note: This completion handler might be misleading: the persistent store is loaded synchronously by default.
+        container.loadPersistentStores(completionHandler: { _, error in
             if let error = error {
-                // Do not crash the app if the store already exists.
-                if (error as NSError).code != Self.storeExistsErrorCode {
-                    fatalError("Load persistent store error: \(error)")
-                }
-            }
-            
-            if store.type != NSInMemoryStoreType {
-                // This makes the database file encrypted until device is unlocked.
-                let completeProtection = FileProtectionType.complete as NSObject
-                store.setOption(completeProtection, forKey: NSPersistentStoreFileProtectionKey)
+                fatalError("Load persistent store error: \(error)")
             }
         })
         // We need this so the `viewContext` gets updated on changes from background tasks.

--- a/Data/models/InMemoryDataController.swift
+++ b/Data/models/InMemoryDataController.swift
@@ -8,14 +8,15 @@ import Shared
 import XCGLogger
 
 public class InMemoryDataController: DataController {
-    
-    override init() {
-        super.init()
-        
+    override func addPersistentStore(for container: NSPersistentContainer, store: URL) {
         let description = NSPersistentStoreDescription()
         description.type = NSInMemoryStoreType
         
         container.persistentStoreDescriptions = [description]
+    }
+    
+    override init() {
+        super.init()
         
         // Calling `initialize` in constructor.
         // Initialize code in constructor can't happen in persistent database


### PR DESCRIPTION
Revert "Fix #3828: Potential CoreData initialization crash. (#3829)" except for duplicate store error

This reverts commit 9e415f25c51995864554b49598314d8d2a242ff7.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This saves data in wrong location, does not load the previous store, so will always fail on upgrade, have to revert it.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3878 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
