### PR TITLE
Fix #3892: Improve progress bar reactivity

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1307,9 +1307,10 @@ class BrowserViewController: UIViewController {
         switch path {
         case .estimatedProgress:
             guard tab === tabManager.selectedTab,
-                let progress = change?[.newKey] as? Float else { break }
+                  // `WKWebView.estimatedProgress` is a `Double` type so it must be casted as such
+                let progress = change?[.newKey] as? Double else { break }
             if webView.url?.isLocalUtility == false {
-                topToolbar.updateProgressBar(progress)
+                topToolbar.updateProgressBar(Float(progress))
             } else {
                 topToolbar.hideProgressBar()
             }


### PR DESCRIPTION
Since `WKWebView.estimatedProgress` is a Double, the cast to a `Float` was failing when the value was 0.1 for unknown reasons. Most likely something to do with the bridging between `NSNumber` and `Float` when the underlying value stored in the `NSNumber` is a `Double`

## Summary of Changes

This pull request fixes #3892

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit websites, upon submitting the request verify that the progress bar immediately moves to 10% instead of waiting

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
