### PR TITLE
Fix #3867 - Fixes using lots of RAM for NTP

### DIFF
--- a/Client/Frontend/Browser/HomePanel/NTPModels.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPModels.swift
@@ -86,6 +86,6 @@ class NTPLogo: Codable {
     }
     
     var image: UIImage? {
-        NTPImage(contentsOfFile: imageUrl)
+        UIImage(contentsOfFile: imageUrl)
     }
 }

--- a/Client/Frontend/Browser/HomePanel/NTPModels.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPModels.swift
@@ -56,10 +56,19 @@ class NTPBackground: Codable {
         let y: CGFloat?
     }
     
-    lazy var image: UIImage? = {
+    var image: UIImage? {
         // Remote resources are downloaded files, so must be loaded differently
-        packaged == true ? UIImage(named: imageUrl) : UIImage(contentsOfFile: imageUrl)
-    }()
+        if packaged == true {
+            // Load without cache if possible
+            if let path = Bundle.main.path(forResource: imageUrl, ofType: nil) {
+                return UIImage(contentsOfFile: path)
+            }
+            
+            // Load with cache
+            return UIImage(named: imageUrl)
+        }
+        return UIImage(contentsOfFile: imageUrl)
+    }
 }
 
 class NTPLogo: Codable {
@@ -76,7 +85,7 @@ class NTPLogo: Codable {
         self.destinationUrl = destinationUrl
     }
     
-    lazy var image: UIImage? = {
-        UIImage(contentsOfFile: imageUrl)
-    }()
+    var image: UIImage? {
+        NTPImage(contentsOfFile: imageUrl)
+    }
 }

--- a/Client/Frontend/Browser/HomePanel/NTPModels.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPModels.swift
@@ -58,7 +58,7 @@ class NTPBackground: Codable {
     
     var image: UIImage? {
         // Remote resources are downloaded files, so must be loaded differently
-        if packaged == true {
+        if packaged {
             // Load without cache if possible
             if let path = Bundle.main.path(forResource: imageUrl, ofType: nil) {
                 return UIImage(contentsOfFile: path)

--- a/Client/Frontend/Browser/HomePanel/NTPModels.swift
+++ b/Client/Frontend/Browser/HomePanel/NTPModels.swift
@@ -58,7 +58,7 @@ class NTPBackground: Codable {
     
     var image: UIImage? {
         // Remote resources are downloaded files, so must be loaded differently
-        if packaged {
+        if packaged == true {
             // Load without cache if possible
             if let path = Bundle.main.path(forResource: imageUrl, ofType: nil) {
                 return UIImage(contentsOfFile: path)

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -216,14 +216,6 @@ class NewTabPageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         checkForUpdatedFeed()
-        
-        backgroundView.imageView.image = background.backgroundImage
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        backgroundView.imageView.image = nil
     }
     
     override func viewDidLayoutSubviews() {
@@ -248,6 +240,12 @@ class NewTabPageViewController: UIViewController {
         super.viewSafeAreaInsetsDidChange()
         
         backgroundButtonsView.collectionViewSafeAreaInsets = view.safeAreaInsets
+    }
+    
+    override func willMove(toParent parent: UIViewController?) {
+        super.willMove(toParent: parent)
+        
+        backgroundView.imageView.image = parent == nil ? nil : background.backgroundImage
     }
     
     // MARK: - Background

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -216,6 +216,14 @@ class NewTabPageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         checkForUpdatedFeed()
+        
+        backgroundView.imageView.image = background.backgroundImage
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        backgroundView.imageView.image = nil
     }
     
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes opening tabs taking too much memory due to loading NTP images every single time for all tabs.
- This changes it so that only the currently displayed tab's image is shown, and all other tabs that are not being disabled will have their images purged from memory.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3867

## Submitter Checklist:

- [X] *Unit Tests* are updated to cover new or changed functionality
- [X] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
