### PR TITLE
Fix #3872: Add support for Brave News display ads

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		27F94A3A21909A5900F4FADF /* SearchSuggestionsPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F94A3921909A5900F4FADF /* SearchSuggestionsPromptView.swift */; };
 		27FCA8E02447708300A8CA48 /* FavoritesSectionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FCA8DF2447708300A8CA48 /* FavoritesSectionProvider.swift */; };
 		27FCA8E3244770AB00A8CA48 /* FavoritesOverflowSectionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FCA8E2244770AB00A8CA48 /* FavoritesOverflowSectionProvider.swift */; };
+		27FCFB0C2673F265008E43AB /* AdCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FCFB0B2673F265008E43AB /* AdCardView.swift */; };
 		27FD2CAB2146C31C00A5A779 /* RequestDesktopSiteActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FD2CA12146C31C00A5A779 /* RequestDesktopSiteActivity.swift */; };
 		27FD2CAC2146C31C00A5A779 /* FindInPageActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FD2CA92146C31C00A5A779 /* FindInPageActivity.swift */; };
 		27FD2CAD2146C31C00A5A779 /* AddToFavoritesActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FD2CAA2146C31C00A5A779 /* AddToFavoritesActivity.swift */; };
@@ -1898,6 +1899,7 @@
 		27F94A3921909A5900F4FADF /* SearchSuggestionsPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsPromptView.swift; sourceTree = "<group>"; };
 		27FCA8DF2447708300A8CA48 /* FavoritesSectionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesSectionProvider.swift; sourceTree = "<group>"; };
 		27FCA8E2244770AB00A8CA48 /* FavoritesOverflowSectionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesOverflowSectionProvider.swift; sourceTree = "<group>"; };
+		27FCFB0B2673F265008E43AB /* AdCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdCardView.swift; sourceTree = "<group>"; };
 		27FD2CA12146C31C00A5A779 /* RequestDesktopSiteActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestDesktopSiteActivity.swift; sourceTree = "<group>"; };
 		27FD2CA92146C31C00A5A779 /* FindInPageActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageActivity.swift; sourceTree = "<group>"; };
 		27FD2CAA2146C31C00A5A779 /* AddToFavoritesActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddToFavoritesActivity.swift; sourceTree = "<group>"; };
@@ -3851,6 +3853,7 @@
 				27A1AC0824859D0900344503 /* FeedHeadlineViews.swift */,
 				2719DA08249D37490080AB48 /* SponsorCardView.swift */,
 				27036EC2256718DA004EF6B6 /* PartnerCardView.swift */,
+				27FCFB0B2673F265008E43AB /* AdCardView.swift */,
 			);
 			path = Cards;
 			sourceTree = "<group>";
@@ -7255,6 +7258,7 @@
 				27C647832550AF34006D72FC /* WalletTransferCompleteView.swift in Sources */,
 				4422D4B821BFFB7600BF1855 /* histogram.cc in Sources */,
 				27FD3FBA25C8D20200696156 /* FeedDataSource+RSS.swift in Sources */,
+				27FCFB0C2673F265008E43AB /* AdCardView.swift in Sources */,
 				0A0D3D3921A4BD0600BEE65B /* SafeBrowsing.swift in Sources */,
 				278C6FFF24F6EA3700A246C8 /* ReportBrokenSiteView.swift in Sources */,
 				27676D472555F34D00BC955A /* BraveRewardsStatusView.swift in Sources */,

--- a/Client/Application/Shortcuts/ActivityShortcutManager.swift
+++ b/Client/Application/Shortcuts/ActivityShortcutManager.swift
@@ -157,7 +157,7 @@ class ActivityShortcutManager: NSObject {
                     guard let newTabPageController = bvc.tabManager.selectedTab?.newTabPageViewController else { return }
                     newTabPageController.scrollToBraveNews()
                 } else {
-                    let controller = BraveNewsSettingsViewController(dataSource: bvc.feedDataSource)
+                    let controller = BraveNewsSettingsViewController(dataSource: bvc.feedDataSource, rewards: bvc.rewards)
                     let container = UINavigationController(rootViewController: controller)
                     bvc.present(container, animated: true)
                 }

--- a/Client/Frontend/Brave Today/Cards/AdCardView.swift
+++ b/Client/Frontend/Brave Today/Cards/AdCardView.swift
@@ -1,0 +1,108 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+class AdCardView: FeedCardBackgroundButton, FeedCardContent {
+    var actionHandler: ((Int, FeedItemAction) -> Void)?
+    var contextMenu: FeedItemMenu?
+    
+    let feedView = FeedItemView(layout: .ad).then {
+        $0.thumbnailImageView.contentMode = .scaleAspectFit
+    }
+    
+    private let adCalloutView = BraveAdCalloutView()
+    private var contextMenuDelegate: NSObject?
+    
+    required init() {
+        super.init(frame: .zero)
+        
+        addSubview(feedView)
+        feedView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        addTarget(self, action: #selector(tappedSelf), for: .touchUpInside)
+        feedView.callToActionButton.addTarget(self, action: #selector(tappedSelf), for: .touchUpInside)
+        
+        let contextMenuDelegate = FeedContextMenuDelegate(
+            performedPreviewAction: { [weak self] in
+                self?.actionHandler?(0, .opened())
+            },
+            menu: { [weak self] in
+                return self?.contextMenu?.menu?(0)
+            }
+        )
+        addInteraction(UIContextMenuInteraction(delegate: contextMenuDelegate))
+        self.contextMenuDelegate = contextMenuDelegate
+        
+        isAccessibilityElement = false
+        accessibilityElements = [feedView, feedView.callToActionButton]
+        feedView.accessibilityTraits.insert(.button)
+        shouldGroupAccessibilityChildren = true
+        
+        addSubview(adCalloutView)
+        adCalloutView.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview().inset(8)
+            $0.leading.greaterThanOrEqualToSuperview().inset(8)
+            $0.bottom.lessThanOrEqualToSuperview().inset(8)
+        }
+    }
+    
+    override var accessibilityLabel: String? {
+        get { feedView.accessibilityLabel }
+        set { assertionFailure("Accessibility label is inherited from a subview: \(String(describing: newValue)) ignored") }
+    }
+    
+    @objc private func tappedSelf() {
+        actionHandler?(0, .opened())
+    }
+}
+
+private class BraveAdCalloutView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = .white
+        layer.cornerRadius = 4
+        layer.cornerCurve = .continuous
+        layer.borderColor = UIColor.braveLighterBlurple.cgColor
+        layer.borderWidth = 1
+        layer.masksToBounds = true
+        
+        let stackView = UIStackView()
+        stackView.spacing = 3
+        stackView.alignment = .center
+        stackView.layoutMargins = .init(equalInset: 5)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.addStackViewItems(
+            .view(UIImageView(image: UIImage(imageLiteralResourceName: "bat-small")).then {
+                $0.contentMode = .scaleAspectFit
+                $0.snp.makeConstraints {
+                    $0.size.equalTo(14)
+                }
+            }),
+            .view(UILabel().then {
+                $0.text = "Ad"
+                $0.textColor = .braveBlurple
+                $0.font = {
+                    let metrics = UIFontMetrics(forTextStyle: .footnote)
+                    let desc = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote)
+                    let font = UIFont.systemFont(ofSize: desc.pointSize, weight: .semibold)
+                    return metrics.scaledFont(for: font)
+                }()
+                $0.adjustsFontForContentSizeCategory = true
+            })
+        )
+        addSubview(stackView)
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+}

--- a/Client/Frontend/Brave Today/Composer/FeedCard.swift
+++ b/Client/Frontend/Brave Today/Composer/FeedCard.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import BraveCore
 
 /// A set of 2 items
 struct FeedPair: Equatable {
@@ -26,6 +27,8 @@ enum FeedCard: Equatable {
     case deals(_ feeds: [FeedItem], title: String)
     /// A brave partner item
     case partner(_ feed: FeedItem)
+    /// A brave display ad card
+    case ad(InlineContentAd)
     /// A single item displayed prompinently with an image
     case headline(_ feed: FeedItem)
     /// A pair of `headline` items that should be displayed side by side horizontally with equal sizes
@@ -44,6 +47,8 @@ enum FeedCard: Equatable {
             return FeedItemView.Layout.brandedHeadline.estimatedHeight(for: width)
         case .partner:
             return FeedItemView.Layout.partner.estimatedHeight(for: width)
+        case .ad:
+            return FeedItemView.Layout.ad.estimatedHeight(for: width)
         case .headlinePair:
             return 300
         case .group, .numbered, .deals:
@@ -60,6 +65,8 @@ enum FeedCard: Equatable {
             return [pair.first, pair.second]
         case .group(let items, _, _, _), .numbered(let items, _), .deals(let items, _):
             return items
+        case .ad:
+            return []
         }
     }
     
@@ -99,6 +106,8 @@ enum FeedCard: Equatable {
             return self
         case .partner:
             return .partner(replacementItem)
+        case .ad(let ad):
+            return .ad(ad)
         }
     }
 }

--- a/Client/Frontend/Brave Today/FeedItemView.swift
+++ b/Client/Frontend/Brave Today/FeedItemView.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import BraveUI
 
 /// Defines the view for displaying a specific feed item given a specific layout
 ///
@@ -50,6 +51,9 @@ class FeedItemView: UIView {
     lazy var promotedButton = PromotedButton().then {
         $0.setContentHuggingPriority(.required, for: .horizontal)
     }
+    lazy var callToActionButton = CallToActionButton().then {
+        $0.setContentHuggingPriority(.required, for: .horizontal)
+    }
     
     /// Generates the view hierarchy given a layout component
     private func view(for component: Layout.Component) -> UIView {
@@ -83,6 +87,8 @@ class FeedItemView: UIView {
             return descriptionLabel
         case .promotedButton:
             return promotedButton
+        case .callToActionButton:
+            return callToActionButton
         case .stack(let stack):
             return UIStackView().then {
                 $0.axis = stack.axis
@@ -144,6 +150,28 @@ class FeedItemView: UIView {
 }
 
 extension FeedItemView {
+    
+    class CallToActionButton: BraveButton {
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            setTitleColor(.white, for: .normal)
+            titleLabel?.font = .systemFont(ofSize: 13, weight: .semibold)
+            layer.borderWidth = 1.0
+            layer.borderColor = UIColor.white.withAlphaComponent(0.7).cgColor
+            layer.masksToBounds = true
+            contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+        }
+        
+        @available(*, unavailable)
+        required init(coder: NSCoder) {
+            fatalError()
+        }
+        
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            layer.cornerRadius = bounds.height / 2
+        }
+    }
     
     class PromotedButton: UIControl {
         
@@ -260,6 +288,7 @@ extension FeedItemView {
             case description(_ labelConfiguration: LabelConfiguration = .description)
             case brand(viewingMode: BrandContainerView.ViewingMode = .automatic, labelConfiguration: LabelConfiguration = .brand)
             case promotedButton
+            case callToActionButton
         }
         /// The root stack for a given layout
         var root: Stack
@@ -292,6 +321,8 @@ extension FeedItemView {
                     }
                 case .promotedButton:
                     return 22.0
+                case .callToActionButton:
+                    return 36.0
                 }
             }
             return _height(for: .stack(root))
@@ -334,7 +365,7 @@ extension FeedItemView {
                 ]
             )
         )
-        
+
         /// Uses the same layout as a `brandedHeadline` but includes a promoted button
         static let partner = Layout(
             root: .init(
@@ -358,6 +389,39 @@ extension FeedItemView {
                                         children: [
                                             .brand(),
                                             .promotedButton
+                                        ]
+                                    )
+                                )
+                            ]
+                        )
+                    )
+                ]
+            )
+        )
+        /// Uses the same layout as a `brandedHeadline` but includes a call to action button and
+        /// has a slightly different thumbnail aspect ratio
+        static let ad = Layout(
+            root: .init(
+                axis: .vertical,
+                children: [
+                    .thumbnail(.aspectRatio(1.2)),
+                    .stack(
+                        .init(
+                            axis: .vertical,
+                            spacing: 4,
+                            padding: UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12),
+                            children: [
+                                .title(.init(numberOfLines: 5, font: .systemFont(ofSize: 18.0, weight: .semibold))),
+                                .date(),
+                                .flexibleSpace(minHeight: 12),
+                                .stack(
+                                    .init(
+                                        axis: .horizontal,
+                                        spacing: 10,
+                                        alignment: .center,
+                                        children: [
+                                            .brand(),
+                                            .callToActionButton
                                         ]
                                     )
                                 )

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -249,12 +249,19 @@ class BrowserViewController: UIViewController {
             self?.setupLedger()
         }
         
-        // Only start ledger service automatically if ads is enabled
-        if rewards.isEnabled {
-            rewards.startLedgerService {
-                self.legacyWallet?.initializeLedgerService(nil)
+        let shouldStartAds = rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value
+        if shouldStartAds {
+            // Only start ledger service automatically if ads is enabled
+            if rewards.isEnabled {
+                rewards.startLedgerService {
+                    self.legacyWallet?.initializeLedgerService(nil)
+                }
+            } else {
+                rewards.ads.initialize { _ in }
             }
         }
+        
+        feedDataSource.rewards = rewards
     }
     
     static func legacyWallet(for config: BraveRewards.Configuration) -> BraveLedger? {

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -136,7 +136,7 @@ class NewTabPageViewController: UIViewController {
             sections.append(
                 BraveNewsSectionProvider(
                     dataSource: feedDataSource,
-                    ads: rewards.ads,
+                    rewards: rewards,
                     actionHandler: { [weak self] in
                         self?.handleBraveNewsAction($0)
                     }
@@ -480,7 +480,10 @@ class NewTabPageViewController: UIViewController {
             Preferences.BraveNews.userOptedIn.value = true
             Preferences.BraveNews.isShowingOptIn.value = false
             Preferences.BraveNews.isEnabled.value = true
-            loadFeedContents()
+            rewards.ads.initialize { [weak self] _ in
+                // Initialize ads if it hasn't already been done
+                self?.loadFeedContents()
+            }
         case .emptyCardTappedSourcesAndSettings:
             tappedBraveNewsSettings()
         case .errorCardTappedRefresh:
@@ -529,6 +532,23 @@ class NewTabPageViewController: UIViewController {
                 )
                 alert.present(on: self)
             }
+        case .inlineContentAdAction(.opened(let inNewTab, let switchingToPrivateMode), let ad):
+            guard let url = ad.targetURL.asURL else { return }
+            if !switchingToPrivateMode {
+                rewards.ads.reportInlineContentAdEvent(
+                    ad.uuid,
+                    creativeInstanceId: ad.creativeInstanceID,
+                    eventType: .clicked
+                )
+            }
+            delegate?.navigateToInput(
+                url.absoluteString,
+                inNewTab: inNewTab,
+                switchingToPrivateMode: switchingToPrivateMode
+            )
+        case .inlineContentAdAction(.toggledSource, _):
+            // Inline content ads have no source
+            break
         }
     }
     
@@ -629,6 +649,7 @@ class NewTabPageViewController: UIViewController {
         if !feedDataSource.shouldLoadContent {
             return
         }
+        rewards.ads.purgeOrphanedAdEvents(.inlineContentAd)
         feedDataSource.load(completion)
     }
     
@@ -651,7 +672,7 @@ class NewTabPageViewController: UIViewController {
     }
     
     @objc private func tappedBraveNewsSettings() {
-        let controller = BraveNewsSettingsViewController(dataSource: feedDataSource)
+        let controller = BraveNewsSettingsViewController(dataSource: feedDataSource, rewards: rewards)
         let container = UINavigationController(rootViewController: controller)
         present(container, animated: true)
     }
@@ -744,6 +765,9 @@ extension NewTabPageViewController {
         #endif
     }
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        for section in sections {
+            section.scrollViewDidScroll?(scrollView)
+        }
         guard isBraveNewsVisible, let newsSection = layout.braveNewsSection else { return }
         if collectionView.numberOfItems(inSection: newsSection) > 0 {
             // Hide the buttons as Brave News feeds appear

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -193,7 +193,7 @@ class SettingsViewController: TableViewController {
         #if !NO_BRAVE_NEWS
         section.rows.append(
             Row(text: Strings.BraveNews.braveNews, selection: {
-                let todaySettings = BraveNewsSettingsViewController(dataSource: self.feedDataSource)
+                let todaySettings = BraveNewsSettingsViewController(dataSource: self.feedDataSource, rewards: self.rewards)
                 self.navigationController?.pushViewController(todaySettings, animated: true)
             }, image: #imageLiteral(resourceName: "settings-brave-today").template, accessory: .disclosureIndicator)
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,8 +1043,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.28.103/brave-core-ios-1.28.103.tgz",
-      "integrity": "sha512-M6FP4VMgQzI5yTytibIi/QKGLqDFHWuiQhaDXdK0aLfUdArkcsdJe3F21J4y2ZB+sPDnX5LMyx0TisposDWt5g=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.28.104/brave-core-ios-1.28.104.tgz",
+      "integrity": "sha512-OOvKtKfuI7M8mFnq+lF5eL7fzd2os5k7mBhYaj8dTPezbnCtRIne6l+N+NV+kCqk3RQwRlWcQljUzsddw4+aoQ=="
     },
     "browserslist": {
       "version": "3.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.28.103/brave-core-ios-1.28.103.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.28.104/brave-core-ios-1.28.104.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^3.3.10"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3872 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- See spec
- Test to ensure notification ads dont display unless Brave Rewards is enabled
- Test to ensure display ads appear 
- Verify new sequence

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue is assigned to a milestone (should happen at merge time).
