### PR TITLE
Fix #3906: Detect default search engine by engine id.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -73,7 +73,7 @@ class SearchEngines {
         let engineType = type ?? (PrivateBrowsingManager.shared.isPrivateBrowsing ? .privateMode : .standard)
             
         if let name = engineType.option.value,
-            let defaultEngine = orderedEngines.first(where: { $0.engineID == name }) {
+           let defaultEngine = orderedEngines.first(where: { $0.engineID == name || $0.shortName == name }) {
             return defaultEngine
         }
         
@@ -298,8 +298,9 @@ class SearchEngines {
     /// Get all known search engines, possibly as ordered by the user.
     fileprivate func getOrderedEngines() -> [OpenSearchEngine] {
         let selectedSearchEngines = [Preferences.Search.defaultEngineName, Preferences.Search.defaultPrivateEngineName].compactMap { $0.value }
-        let unorderedEngines = customEngines
-            + SearchEngines.getUnorderedBundledEngines(for: selectedSearchEngines, isOnboarding: false)
+        let unorderedEngines =
+        SearchEngines.getUnorderedBundledEngines(for: selectedSearchEngines, isOnboarding: false) +
+        customEngines
 
         // might not work to change the default.
         guard let orderedEngineNames = Preferences.Search.orderedEngines.value else {

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -73,7 +73,7 @@ class SearchEngines {
         let engineType = type ?? (PrivateBrowsingManager.shared.isPrivateBrowsing ? .privateMode : .standard)
             
         if let name = engineType.option.value,
-            let defaultEngine = orderedEngines.first(where: { $0.shortName == name }) {
+            let defaultEngine = orderedEngines.first(where: { $0.engineID == name }) {
             return defaultEngine
         }
         


### PR DESCRIPTION
This caused a bug when SE onboarding was skipped.
Wrong values were compared: engine-id vs shortName.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3906 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
