### PR TITLE
Fix #3899: Updated default browser notification to display iOS version

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -157,7 +157,7 @@ extension Strings {
         public static let notificationBody =
             NSLocalizedString("defaultBrowserCallout.notificationBody",
                               tableName: "BraveShared", bundle: .braveShared,
-                              value: "Optimized for iOS 14. Make Brave your default browser today.",
+                              value: "Optimized for iOS \(floor(Double(UIDevice.current.systemVersion) ?? 13)). Make Brave your default browser today.",
                               comment: "Notification body to promote setting Brave app as default browser")
     }
 }

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -154,10 +154,11 @@ extension Strings {
                               tableName: "BraveShared", bundle: .braveShared,
                               value: "Brave Web Browser",
                               comment: "Notification title to promote setting Brave app as default browser")
+        
         public static let notificationBody =
             NSLocalizedString("defaultBrowserCallout.notificationBody",
                               tableName: "BraveShared", bundle: .braveShared,
-                              value: "Optimized for iOS \(floor(Double(UIDevice.current.systemVersion) ?? 13)). Make Brave your default browser today.",
+                              value: "Optimized for iOS %@. Make Brave your default browser today.",
                               comment: "Notification body to promote setting Brave app as default browser")
     }
 }

--- a/BraveShared/de.lproj/BraveShared.strings
+++ b/BraveShared/de.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Öffnen Sie die Einstellungen, tippen Sie auf „Standardbrowser“ und wählen Sie Brave aus.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Optimiert für iOS 14. Legen Sie Brave gleich als Ihren Standardbrowser fest.";
+"defaultBrowserCallout.notificationBody" = "Optimiert für iOS %@. Legen Sie Brave gleich als Ihren Standardbrowser fest.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Brave-Webbrowser";

--- a/BraveShared/es.lproj/BraveShared.strings
+++ b/BraveShared/es.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Abre Ajustes, toca en \"Aplicación de navegador predeterminado\" y selecciona Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Versión optimizada para iOS 14. Establece Brave como tu navegador predeterminado hoy mismo.";
+"defaultBrowserCallout.notificationBody" = "Versión optimizada para iOS %@. Establece Brave como tu navegador predeterminado hoy mismo.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Navegador web Brave";

--- a/BraveShared/fr.lproj/BraveShared.strings
+++ b/BraveShared/fr.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Ouvrez les paramètres, appuyez sur Application de navigateur par défaut et sélectionnez Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Optimisé pour iOS 14. Faites de Brave votre navigateur par défaut.";
+"defaultBrowserCallout.notificationBody" = "Optimisé pour iOS %@. Faites de Brave votre navigateur par défaut.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Navigateur Web Brave";

--- a/BraveShared/id-ID.lproj/BraveShared.strings
+++ b/BraveShared/id-ID.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Buka pengaturan, ketuk Default Browser App, dan pilih Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Telah dioptimalkan untuk iOS 14. Jadikan Brave peramban utama Anda sekarang juga.";
+"defaultBrowserCallout.notificationBody" = "Telah dioptimalkan untuk iOS %@. Jadikan Brave peramban utama Anda sekarang juga.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Brave Peramban Web";

--- a/BraveShared/it.lproj/BraveShared.strings
+++ b/BraveShared/it.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Apri Impostazioni, seleziona App per il browser di default, poi scegli Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Ottimizzato per iOS 14. Imposta subito Brave come browser predefinito.";
+"defaultBrowserCallout.notificationBody" = "Ottimizzato per iOS %@. Imposta subito Brave come browser predefinito.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Browser web Brave";

--- a/BraveShared/ja.lproj/BraveShared.strings
+++ b/BraveShared/ja.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "アプリ設定画面で、「デフォルトのブラウザApp」をタップし、Braveを選択してください。";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "BraveはiOS14に最適化されています。今すぐBraveをデフォルトブラウザに設定しましょう";
+"defaultBrowserCallout.notificationBody" = "BraveはiOS%@に最適化されています。今すぐBraveをデフォルトブラウザに設定しましょう";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Braveブラウザ";

--- a/BraveShared/ko-KR.lproj/BraveShared.strings
+++ b/BraveShared/ko-KR.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "설정을 열고 기본 브라우저 앱을 탭한 다음 Brave를 선택하세요.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "iOS 14에 최적. Brave를 기본 브라우저로 설정하세요.";
+"defaultBrowserCallout.notificationBody" = "iOS %@에 최적. Brave를 기본 브라우저로 설정하세요.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Brave 웹브라우저";

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Buka Tetapan, ketik Aplikasi Penyemak Imbas Lalai, dan pilih Brave.  ";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Dioptimumkan untuk iOS 14. Jadikan Brave sebagai penyemak imbas lalai anda hari ini.  ";
+"defaultBrowserCallout.notificationBody" = "Dioptimumkan untuk iOS %@. Jadikan Brave sebagai penyemak imbas lalai anda hari ini.  ";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Penyemk Imbas Web Brave";

--- a/BraveShared/nb.lproj/BraveShared.strings
+++ b/BraveShared/nb.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Åpne Innstillinger, trykk på Standard Nettleser-appen, og velg Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Optimalisert for iOS 14. Gjør Brave til din standard nettleser i dag.";
+"defaultBrowserCallout.notificationBody" = "Optimalisert for iOS %@. Gjør Brave til din standard nettleser i dag.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Brave-nettleser";

--- a/BraveShared/pl.lproj/BraveShared.strings
+++ b/BraveShared/pl.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Otwórz „Ustawienia”, dotknij „Domyślna aplikacja przeglądarki” i wybierz „Brave”.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Zoptymalizowana pod kątem iOS 14. Już dziś ustaw Brave jako domyślną przeglądarkę.";
+"defaultBrowserCallout.notificationBody" = "Zoptymalizowana pod kątem iOS %@. Już dziś ustaw Brave jako domyślną przeglądarkę.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Przeglądarka Brave";

--- a/BraveShared/pt-BR.lproj/BraveShared.strings
+++ b/BraveShared/pt-BR.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Abra os Ajustes, toque em \"App de Navegador Padrão\" e selecione \"Brave\".";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Otimizado para o iOS 14. Torne o Brave seu navegador padrão hoje mesmo.";
+"defaultBrowserCallout.notificationBody" = "Otimizado para o iOS %@. Torne o Brave seu navegador padrão hoje mesmo.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Navegador da web Brave";

--- a/BraveShared/ru.lproj/BraveShared.strings
+++ b/BraveShared/ru.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Откройте настройки, нажмите «Браузерное приложение по умолчанию» и выберите Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Оптимизировано для iOS 14. Сделайте Brave браузером по умолчанию.";
+"defaultBrowserCallout.notificationBody" = "Оптимизировано для iOS %@. Сделайте Brave браузером по умолчанию.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Браузер Brave";

--- a/BraveShared/sv.lproj/BraveShared.strings
+++ b/BraveShared/sv.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Öppna Inställningar, tryck på Standardwebbläsare och välj Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Optimerad för iOS 14. Gör Brave till din standardwebbläsare idag.";
+"defaultBrowserCallout.notificationBody" = "Optimerad för iOS %@. Gör Brave till din standardwebbläsare idag.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Webbläsaren Brave";

--- a/BraveShared/tr.lproj/BraveShared.strings
+++ b/BraveShared/tr.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Ayarlar'ı açın, Varsayılan Tarayıcı Uygulaması'nı dokunun ve Brave'i seçin.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "iOS 14 için optimize edilmiştir. Brave'i bugün varsayılan tarayıcınız yapın.";
+"defaultBrowserCallout.notificationBody" = "iOS %@ için optimize edilmiştir. Brave'i bugün varsayılan tarayıcınız yapın.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Brave Web Tarayıcısı";

--- a/BraveShared/uk.lproj/BraveShared.strings
+++ b/BraveShared/uk.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "Відкрийте меню «Параметри», торкніться пункту «Програма браузера за замовчуванням» і виберіть Brave.";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "Оптимізовано для iOS 14. Зробіть Brave браузером за замовчуванням уже сьогодні.";
+"defaultBrowserCallout.notificationBody" = "Оптимізовано для iOS %@. Зробіть Brave браузером за замовчуванням уже сьогодні.";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Браузер Brave";

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "開啟「設定」，點選「預設瀏覽器應用程序」，然後選取「Brave」。";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "已針對 iOS 14 最佳化。立即將 Brave 設為預設瀏覽器。";
+"defaultBrowserCallout.notificationBody" = "已針對 iOS %@ 最佳化。立即將 Brave 設為預設瀏覽器。";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Brave 網頁瀏覽器";

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -332,7 +332,7 @@
 "defaultBrowserCallout.introTertiaryText" = "打开设置、点击默认浏览器应用，然后选择 Brave。";
 
 /* Notification body to promote setting Brave app as default browser */
-"defaultBrowserCallout.notificationBody" = "已针对 iOS 14 进行了优yij化。立即将 Brave 设为您的默认浏览器。";
+"defaultBrowserCallout.notificationBody" = "已针对 iOS %@ 进行了优yij化。立即将 Brave 设为您的默认浏览器。";
 
 /* Notification title to promote setting Brave app as default browser */
 "defaultBrowserCallout.notificationTitle" = "Brave 网页浏览器";

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -801,7 +801,7 @@ class BrowserViewController: UIViewController {
                 
                 let content = UNMutableNotificationContent().then {
                     $0.title = Strings.DefaultBrowserCallout.notificationTitle
-                    $0.body = String(format: Strings.DefaultBrowserCallout.notificationBody, String(floor(Double(UIDevice.current.systemVersion) ?? 14)) ?? "14")
+                    $0.body = String(format: Strings.DefaultBrowserCallout.notificationBody, String(ProcessInfo().operatingSystemVersion.majorVersion))
                 }
                 
                 let timeToShow = AppConstants.buildChannel.isPublic ? 2.hours : 2.minutes

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -801,7 +801,7 @@ class BrowserViewController: UIViewController {
                 
                 let content = UNMutableNotificationContent().then {
                     $0.title = Strings.DefaultBrowserCallout.notificationTitle
-                    $0.body = Strings.DefaultBrowserCallout.notificationBody
+                    $0.body = String(format: Strings.DefaultBrowserCallout.notificationBody, String(floor(Double(UIDevice.current.systemVersion) ?? 14)) ?? "14")
                 }
                 
                 let timeToShow = AppConstants.buildChannel.isPublic ? 2.hours : 2.minutes


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3899 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that the default browser notification shows correct iOS version. This is the best tested on iOS 15, but 14 should work too

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `release-notes/(include|exclude)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue is assigned to a milestone (should happen at merge time).
