### PR TITLE
Fix #3914: Custom search engines url should not be capped at 150 characters

### DIFF
--- a/Client/Frontend/Settings/SearchCustomEngineViewController.swift
+++ b/Client/Frontend/Settings/SearchCustomEngineViewController.swift
@@ -35,7 +35,6 @@ class SearchCustomEngineViewController: UIViewController {
     // MARK: Constants
     
     struct Constants {
-        static let urlEntryMaxCharacterCount  = 150
         static let titleEntryMaxCharacterCount = 50
     }
     
@@ -506,7 +505,7 @@ extension SearchCustomEngineViewController: UITextViewDelegate {
         let textLengthInRange = textView.text.count + (text.count - range.length)
             
         // The default text "https://" cant ne deleted or changed so nothing without a secure scheme can be added
-        return textLengthInRange <= Constants.urlEntryMaxCharacterCount && textLengthInRange >= 8
+        return textLengthInRange >= 8
     }
     
     func textViewDidChange(_ textView: UITextView) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Removing Character Limit on Search Engine Addition

This pull request fixes #3914

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Enter something more than 150 characters

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
