### PR TITLE
Fix #3543: Settings toggles do not persist when scrolling away from them then back

### DIFF
--- a/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -140,9 +140,11 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
         return Section(
             header: .title(Strings.clearPrivateData),
             rows: clearables.indices.map { idx in
-                Row(text: self.clearables[idx].clearable.label, accessory: .switchToggle(value: self.toggles[idx], { [unowned self] checked in
+                let title = self.clearables[idx].clearable.label
+                    
+                return .boolRow(title: title, toggleValue: self.toggles[idx], valueChange: { [unowned self] checked in
                     self.toggles[idx] = checked
-                }))
+                }, cellReuseId: "\(title.lowercased().trimmingCharacters(in: .whitespacesAndNewlines))\(idx)")
             } + [
                 Row(text: Strings.clearDataNow, selection: { [unowned self] in
                     self.tappedClearPrivateData()

--- a/Client/Frontend/Settings/SettingsRowViews.swift
+++ b/Client/Frontend/Settings/SettingsRowViews.swift
@@ -42,6 +42,17 @@ extension Row {
             uuid: option.key
         )
     }
+    
+    /// Creates a switch toggle `Row` which holds local value and no preference update
+    static func boolRow(title: String, detailText: String? = nil, toggleValue: Bool, valueChange: @escaping ValueChange, cellReuseId: String) -> Row {
+        return Row(
+            text: title,
+            detailText: detailText,
+            accessory: .view(SwitchAccessoryView(initialValue: toggleValue, valueChange: valueChange)),
+            cellClass: MultilineSubtitleCell.self,
+            reuseIdentifier: cellReuseId
+        )
+    }
 }
 
 class MultilineButtonCell: ButtonCell {

--- a/ThirdParty/Static/Static/Row.swift
+++ b/ThirdParty/Static/Static/Row.swift
@@ -144,9 +144,7 @@ public struct Row: Hashable, Equatable {
         return selection != nil
     }
 
-    var cellIdentifier: String {
-        return cellClass.description()
-    }
+    var cellIdentifier: String
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(uuid)
@@ -156,7 +154,7 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, accessory: Accessory = .none, cellClass: Cell.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], uuid: String = UUID().uuidString, accessibilityIdentifier: String? = nil) {
+                image: UIImage? = nil, accessory: Accessory = .none, cellClass: Cell.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], uuid: String = UUID().uuidString, accessibilityIdentifier: String? = nil, reuseIdentifier: String? = nil) {
         self.accessibilityIdentifier = accessibilityIdentifier
         self.uuid = uuid
         self.text = text
@@ -167,6 +165,12 @@ public struct Row: Hashable, Equatable {
         self.cellClass = cellClass ?? Value1Cell.self
         self.context = context
         self.editActions = editActions
+        
+        if let cellReuseIdentifier = reuseIdentifier {
+            self.cellIdentifier = cellReuseIdentifier
+        } else {
+            self.cellIdentifier = self.cellClass.description()
+        }
     }
 }
 


### PR DESCRIPTION
Adding Reuse identifier for the row type that handles toggle changes so values will not fluctuate with scroll hange. 

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3543

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Go Brave Shields Privacy
- Change the data for clear private data part
- Scroll up or down and make the toggle outside the screen
- Check no changes happen
- Go back in the screen and come back check default value is also retrieved

## Screenshots:

https://user-images.githubusercontent.com/6643505/125357151-3c566980-e335-11eb-9411-8ed2eb93f1f9.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
