### PR TITLE
Fix #3760 - Fix Brave-Talk and Youtube not working when tabs are switched

### DIFF
--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -47,24 +47,3 @@ class BraveWebView: WKWebView {
         return super.hitTest(point, with: event)
     }
 }
-
-extension WKWebView {
-    var isPlayingAudio: Bool {
-        struct Private {
-            static var hasChecked = false
-            static var canCheckPlayingAudio = false
-        }
-        
-        if !Private.hasChecked {
-            Private.hasChecked = true
-            Private.canCheckPlayingAudio = responds(to: Selector(("_isPlayingAudio")))
-        }
-        
-        if Private.canCheckPlayingAudio {
-            if let isPlayingAudio = value(forKey: "_isPlayingAudio") as? Bool {
-                return isPlayingAudio
-            }
-        }
-        return false
-    }
-}

--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -47,3 +47,24 @@ class BraveWebView: WKWebView {
         return super.hitTest(point, with: event)
     }
 }
+
+extension WKWebView {
+    var isPlayingAudio: Bool {
+        struct Private {
+            static var hasChecked = false
+            static var canCheckPlayingAudio = false
+        }
+        
+        if !Private.hasChecked {
+            Private.hasChecked = true
+            Private.canCheckPlayingAudio = responds(to: Selector(("_isPlayingAudio")))
+        }
+        
+        if Private.canCheckPlayingAudio {
+            if let isPlayingAudio = value(forKey: "_isPlayingAudio") as? Bool {
+                return isPlayingAudio
+            }
+        }
+        return false
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2108,6 +2108,7 @@ extension BrowserViewController: TabManagerDelegate {
             // audio and video to stop playing, etc..
             for tab in tabManager.allTabs where tab != selected {
                 if let webView = tab.webView {
+                    #if swift(>=5.4)
                     if #available(iOS 14.5, *) {
                         webView.requestMediaPlaybackState { state in
                             if state == .playing {
@@ -2117,7 +2118,12 @@ extension BrowserViewController: TabManagerDelegate {
                                 webView.removeFromSuperview()
                             }
                         }
+                    } else {
+                        webView.removeFromSuperview()
                     }
+                    #else
+                    webView.removeFromSuperview()
+                    #endif
                 }
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2107,13 +2107,16 @@ extension BrowserViewController: TabManagerDelegate {
             // but this causes PDFs to stop rendering,
             // audio and video to stop playing, etc..
             
-            // wv.removeFromSuperview()
-            
-            wv.isHidden = true
-            wv.alpha = 0.0
-            
-            // We can try to set frame to (x: 0, y: 0, width: 1, height: 1)
-            // doesn't seem to help????
+            for tab in tabManager.allTabs where tab != selected {
+                if let webView = tab.webView {
+                    if webView.isPlayingAudio {
+                        webView.isHidden = true
+                        webView.alpha = 0.0
+                    } else {
+                        webView.removeFromSuperview()
+                    }
+                }
+            }
         }
         
         toolbar?.setSearchButtonState(url: selected?.url)
@@ -2136,7 +2139,7 @@ extension BrowserViewController: TabManagerDelegate {
 
             scrollController.tab = selected
             webViewContainer.addSubview(webView)
-            webView.snp.makeConstraints { make in
+            webView.snp.remakeConstraints { make in
                 make.left.right.top.bottom.equalTo(self.webViewContainer)
             }
             webView.accessibilityLabel = Strings.webContentAccessibilityLabel

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2102,7 +2102,18 @@ extension BrowserViewController: TabManagerDelegate {
             wv.accessibilityLabel = nil
             wv.accessibilityElementsHidden = true
             wv.accessibilityIdentifier = nil
-            wv.removeFromSuperview()
+            
+            // Firefox code removed webview from superview,
+            // but this causes PDFs to stop rendering,
+            // audio and video to stop playing, etc..
+            
+            // wv.removeFromSuperview()
+            
+            wv.isHidden = true
+            wv.alpha = 0.0
+            
+            // We can try to set frame to (x: 0, y: 0, width: 1, height: 1)
+            // doesn't seem to help????
         }
         
         toolbar?.setSearchButtonState(url: selected?.url)
@@ -2131,6 +2142,10 @@ extension BrowserViewController: TabManagerDelegate {
             webView.accessibilityLabel = Strings.webContentAccessibilityLabel
             webView.accessibilityIdentifier = "contentView"
             webView.accessibilityElementsHidden = false
+            
+            // Restore WebView visibility state
+            webView.isHidden = false
+            webView.alpha = 1.0
 
             if webView.url == nil {
                 // The web view can go gray if it was zombified due to memory pressure.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2106,14 +2106,17 @@ extension BrowserViewController: TabManagerDelegate {
             // Firefox code removed webview from superview,
             // but this causes PDFs to stop rendering,
             // audio and video to stop playing, etc..
-            
             for tab in tabManager.allTabs where tab != selected {
                 if let webView = tab.webView {
-                    if webView.isPlayingAudio {
-                        webView.isHidden = true
-                        webView.alpha = 0.0
-                    } else {
-                        webView.removeFromSuperview()
+                    if #available(iOS 14.5, *) {
+                        webView.requestMediaPlaybackState { state in
+                            if state == .playing {
+                                webView.isHidden = true
+                                webView.alpha = 0.0
+                            } else {
+                                webView.removeFromSuperview()
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary of Changes
- On iOS 14.5+ Allow tabs to keep playing media even when it is not the currently visible.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3760

## Submitter Checklist:

- [X] *Unit Tests* are updated to cover new or changed functionality
- [X] User-facing strings use `NSLocalizableString()`

## Test Plan:
Must be done on a iOS 14.5+ device

1. Go to youtube, play a video.
2. Switch tabs.
**Expected**: Video MUST still be playing without stopping or pausing.

--

1. Go to together.brave.com on computer.
2. Join call with “Desktop” user name or w/e.
3. Go to the same URL on mobile.
4. Join call with “Mobile” user name or w/e.
5. Turn on microphone on Mobile, but disable on Desktop.
6. Switch tabs on Mobile.
**Expected**: MUST still hear microphone coming from Mobile through to Desktop.

8. Turn on webcam on Mobile, switch tabs.
**Expected**: MUST see yourself on Desktop from Mobile camera even with mobile tab inactive.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
