### PR TITLE
Fix #3735: Add search button doesn't resize correctly when moving between text fields

### DIFF
--- a/Client/Extensions/UIViewExtensions.swift
+++ b/Client/Extensions/UIViewExtensions.swift
@@ -79,16 +79,18 @@ extension UIView {
      */
     static func findSubViewWithFirstResponder(_ view: UIView) -> UIView? {
         let subviews = view.subviews
-        if subviews.isEmpty {
+
+        guard !subviews.isEmpty else {
             return nil
         }
         
-        guard let firstSubview = subviews.first else { return nil }
-        if firstSubview.isFirstResponder {
-            return firstSubview
-        } else {
-            return findSubViewWithFirstResponder(firstSubview)
+        if let firstResponderSubview = subviews.first(where: { $0.isFirstResponder }) {
+            return firstResponderSubview
         }
+        
+        guard let firstSubview = subviews.first( where: { !($0 is UIRefreshControl) }) else { return nil }
+
+        return findSubViewWithFirstResponder(firstSubview)
     }
     
     /// Creates empty view with specified height or width parameter.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -73,14 +73,16 @@ class BrowserViewController: UIViewController {
     
     /// Custom Search Engine
     var openSearchEngine: OpenSearchReference?
-    var openSearchTextFieldInputAssistantBarButtonGroup = [UIBarButtonItemGroup]()
 
     lazy var customSearchEngineButton = OpenSearchEngineButton(hidesWhenDisabled: false).then {
         $0.addTarget(self, action: #selector(addCustomSearchEngineForFocusedElement), for: .touchUpInside)
         $0.accessibilityIdentifier = "BrowserViewController.customSearchEngineButton"
+        $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
-    var customSearchBarButton: UIBarButtonItem?
-
+    
+    var customSearchBarButtonItemGroup: UIBarButtonItemGroup?
+    
     // popover rotation handling
     var displayedPopoverController: UIViewController?
     var updateDisplayedPopoverProperties: (() -> Void)?

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -85,14 +85,19 @@ extension BrowserViewController {
              */
             return supportsAutoAdd
         }
-        
-        if openSearchTextFieldInputAssistantBarButtonGroup.isEmpty {
-            openSearchTextFieldInputAssistantBarButtonGroup = webContentView.inputAssistantItem.trailingBarButtonGroups
-        }
-        
+                
         if UIDevice.isIpad {
-            webContentView.inputAssistantItem.trailingBarButtonGroups = openSearchTextFieldInputAssistantBarButtonGroup +
-                [UIBarButtonItemGroup(barButtonItems: [UIBarButtonItem(customView: customSearchEngineButton)], representativeItem: nil)]
+            if customSearchBarButtonItemGroup == nil {
+                customSearchBarButtonItemGroup = UIBarButtonItemGroup(
+                    barButtonItems: [UIBarButtonItem(customView: customSearchEngineButton)], representativeItem: nil)
+            } else {
+                webContentView.inputAssistantItem.trailingBarButtonGroups.removeAll(
+                    where: { $0.barButtonItems.contains(where: { $0.customView != nil })})
+            }
+            
+            if let barButtonItemGroup = customSearchBarButtonItemGroup {
+                webContentView.inputAssistantItem.trailingBarButtonGroups.append(barButtonItemGroup)
+            }
         } else {
             let argumentNextItem: [Any] = ["_n", "extI", "tem"]
             let argumentView: [Any] = ["v", "ie", "w"]
@@ -241,15 +246,12 @@ extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         keyboardState = nil
         updateViewConstraints()
-        // If the searchEngineButton exists remove it form the keyboard
-        if let buttonGroup = customSearchBarButton?.buttonGroup {
-            buttonGroup.barButtonItems = buttonGroup.barButtonItems.filter { $0 != customSearchBarButton }
-            customSearchBarButton = nil
-        }
 
-        if self.customSearchEngineButton.superview != nil {
-            self.customSearchEngineButton.removeFromSuperview()
-            openSearchTextFieldInputAssistantBarButtonGroup.removeAll()
+        customSearchBarButtonItemGroup?.barButtonItems.removeAll()
+        customSearchBarButtonItemGroup = nil
+        
+        if customSearchEngineButton.superview != nil {
+            customSearchEngineButton.removeFromSuperview()
         }
 
         UIViewPropertyAnimator(duration: state.animationDuration, curve: state.animationCurve) {


### PR DESCRIPTION
Changing view responder method to satisfy new refresh control condition and fixing trailing button bug in iPad

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #3735 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Visit GitHub and open search to bring up keyboard
Use Up/Down arrow keys to move between text fields
Disabled add search button is not resized

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
