### PR TITLE
Fix #3877 Added autofocus on url bar, when hardware keyboard connected

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -23,6 +23,7 @@ import NetworkExtension
 import YubiKit
 import FeedKit
 import SwiftUI
+import GameController
 import class Combine.AnyCancellable
 
 private let log = Logger.browserLogger
@@ -1547,18 +1548,29 @@ class BrowserViewController: UIViewController {
         openURLInNewTab(nil, isPrivate: isPrivate, isPrivileged: true)
         let freshTab = tabManager.selectedTab
         
-        // Focus field only if requested and background images are not supported
-        if attemptLocationFieldFocus {
+        // Focus field if requested and background images are not supported or there is hardware keyboard connected
+        if attemptLocationFieldFocus || isHardwareKeyboardConnected() {
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
                 // Without a delay, the text field fails to become first responder
                 // Check that the newly created tab is still selected.
                 // This let's the user spam the Cmd+T button without lots of responder changes.
                 guard freshTab == self.tabManager.selectedTab else { return }
+                // submit location if there's search query or just focus on location otherwise
                 if let text = searchText {
                     self.topToolbar.submitLocation(text)
+                } else {
+                    self.topToolbar.tabLocationViewDidTapLocation(self.topToolbar.locationView)
                 }
             }
         }
+    }
+    
+    func isHardwareKeyboardConnected() -> Bool {
+        if #available(iOS 14.0, *) {
+            let bool = GCKeyboard.coalesced != nil
+            return bool
+        }
+        return false
     }
 
     func popToBVC() {

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -347,7 +347,7 @@ class TabTrayController: UIViewController {
         }, completion: { finished in
             // The addTab delegate method will pop to the BVC no need to do anything here.
             self.toolbar.isUserInteractionEnabled = true
-            if finished, request == nil, NewTabAccessors.getNewTabPage() == .blankPage,
+            if finished, request == nil, NewTabAccessors.getNewTabPage() == .topSites,
                 let appDelegate = UIApplication.shared.delegate as? AppDelegate,
                 let bvc = appDelegate.browserViewController,
                 self.isHardwareKeyboardConnected() {
@@ -364,9 +364,7 @@ class TabTrayController: UIViewController {
     
     func isHardwareKeyboardConnected() -> Bool {
         if #available(iOS 14.0, *) {
-            if GCKeyboard.coalesced != nil {
-                return true
-            }
+            return GCKeyboard.coalesced != nil
         }
         return false
     }

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -8,6 +8,7 @@ import Storage
 import Shared
 import BraveShared
 import BraveUI
+import GameController
 
 struct TabTrayControllerUX {
     static let cornerRadius = CGFloat(6.0)
@@ -348,7 +349,8 @@ class TabTrayController: UIViewController {
             self.toolbar.isUserInteractionEnabled = true
             if finished, request == nil, NewTabAccessors.getNewTabPage() == .blankPage,
                 let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-                let bvc = appDelegate.browserViewController {
+                let bvc = appDelegate.browserViewController,
+                self.isHardwareKeyboardConnected() {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                     bvc.topToolbar.tabLocationViewDidTapLocation(bvc.topToolbar.locationView)
                 }
@@ -358,6 +360,15 @@ class TabTrayController: UIViewController {
                 self.delegate?.tabTrayDidAddTab(self, tab: tab)
             }
         })
+    }
+    
+    func isHardwareKeyboardConnected() -> Bool {
+        if #available(iOS 14.0, *) {
+            if GCKeyboard.coalesced != nil {
+                return true
+            }
+        }
+        return false
     }
 
     func closeTabsForCurrentTray() {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3877 
If hardware keyboard is connected and new tab is opened, url bar will be in focus. If there's no hardware keyboard, url bar will not be in focus.
Works on iOS 14.0+.
I'm not sure though about this placement of a isHardwareKeyboardConnected() function, so opinion would be appreciated.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Must be on iPad iOS 14+
Connect hardware keyboard, can be magic keyboard too.
When you open new tab it should set focus on url bar.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
