### PR TITLE
Fix #3866 - Added IPv6 support to the URL bar

### DIFF
--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -6,16 +6,16 @@ import Foundation
 import Shared
 
 class URIFixup {
-    private static func isValidIPAddressURL(_ string: String) -> Bool {
-        func isValidIPAddress(_ host: String) -> Bool {
-            var buffer = [UInt8](repeating: 0, count: Int(INET6_ADDRSTRLEN))
-            if inet_pton(AF_INET, host, &buffer) != 0 ||
-                inet_pton(AF_INET6, host, &buffer) != 0 {
-                return true
-            }
-            return false
+    private static func isValidIPAddress(_ host: String) -> Bool {
+        var buffer = [UInt8](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        if inet_pton(AF_INET, host, &buffer) != 0 ||
+            inet_pton(AF_INET6, host, &buffer) != 0 {
+            return true
         }
-        
+        return false
+    }
+    
+    private static func isValidIPAddressURL(_ string: String) -> Bool {
         // IPv4 addresses MUST have a `.` character delimiting the octets.
         // RFC-2732 states an IPv6 URL should contain brackets as in: `[IP_ADDRESS_HERE]`
         if !(string.contains(".") || (string.contains("[") && string.contains("]"))) {
@@ -52,8 +52,7 @@ class URIFixup {
             }
             
             // The host is a valid IPv4 or IPv6 address
-            var buffer = [UInt8](repeating: 0, count: Int(INET6_ADDRSTRLEN))
-            if inet_pton(AF_INET, host, &buffer) != 0 || inet_pton(AF_INET6, host, &buffer) != 0 {
+            if isValidIPAddress(host) {
                 return url
             }
         }

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -33,6 +33,14 @@ class SearchTests: XCTestCase {
         checkValidURL("foo.bar", afterFixup: "http://foo.bar")
         checkValidURL(" foo.bar ", afterFixup: "http://foo.bar")
         checkValidURL("1.2.3", afterFixup: "http://1.2.3")
+        checkValidURL("[::1]:80", afterFixup: "http://[::1]:80")
+        checkValidURL("[2a04:4e42:400::288]", afterFixup: "http://[2a04:4e42:400::288]")
+        checkValidURL("[2a04:4e42:600::288]:80", afterFixup: "http://[2a04:4e42:600::288]:80")
+        checkValidURL("[2605:2700:0:3::4713:93e3]:443", afterFixup: "http://[2605:2700:0:3::4713:93e3]:443")
+        checkValidURL("[::192.9.5.5]", afterFixup: "http://[::192.9.5.5]")
+        checkValidURL("[::192.9.5.5]:80", afterFixup: "http://[::192.9.5.5]:80")
+        checkValidURL("[::192.9.5.5]/png", afterFixup: "http://[::192.9.5.5]/png")
+        checkValidURL("[::192.9.5.5]:80/png", afterFixup: "http://[::192.9.5.5]:80/png")
 
         // Check invalid URLs. These are passed along to the default search engine.
         checkInvalidURL("foobar")
@@ -59,6 +67,9 @@ class SearchTests: XCTestCase {
         checkInvalidURL("\"foo@brave.com\"")
         checkInvalidURL(#""创业咖啡.中国"#)
         checkInvalidURL(#""创业咖啡.中国""#)
+        checkInvalidURL("foo:5000")
+        checkInvalidURL("http://::192.9.5.5")
+        checkInvalidURL("http://::192.9.5.5:8080")
     }
 
     fileprivate func checkValidURL(_ beforeFixup: String, afterFixup: String) {


### PR DESCRIPTION
## Summary of Changes
- Security Review: https://github.com/brave/security/issues/516
- Added IPAddress validation and allow typing in VALID IPv6 addresses into the URL bar.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3866
Addresses the same FF issue: mozilla-mobile/firefox-ios#6015

## Submitter Checklist:

- [X] *Unit Tests* are updated to cover new or changed functionality
- [X] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
