### PR TITLE
Fix #3936: Set the correct theme based on PBO on launch

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -233,15 +233,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     
     private var cancellables: Set<AnyCancellable> = []
     
-    private func updateTheme() {
-        guard let window = window,
-              let themeOverride = DefaultTheme(rawValue: Preferences.General.themeNormalMode.value)?.userInterfaceStyleOverride else {
-            return
-        }
+    private var expectedThemeOverride: UIUserInterfaceStyle {
+        let themeOverride = DefaultTheme(
+            rawValue: Preferences.General.themeNormalMode.value
+        )?.userInterfaceStyleOverride ?? .unspecified
         let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
-        let override: UIUserInterfaceStyle = isPrivateBrowsing ? .dark : themeOverride
+        return isPrivateBrowsing ? .dark : themeOverride
+    }
+    
+    private func updateTheme() {
+        guard let window = window else { return }
         UIView.transition(with: window, duration: 0.15, options: [.transitionCrossDissolve], animations: {
-            window.overrideUserInterfaceStyle = override
+            window.overrideUserInterfaceStyle = self.expectedThemeOverride
         }, completion: nil)
     }
 
@@ -288,9 +291,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             }
             .store(in: &cancellables)
         
-        if let themeOverride = DefaultTheme(rawValue: Preferences.General.themeNormalMode.value)?.userInterfaceStyleOverride {
-            window?.overrideUserInterfaceStyle = themeOverride
-        }
+        window?.overrideUserInterfaceStyle = expectedThemeOverride
         window?.tintColor = UIColor {
             if $0.userInterfaceStyle == .dark {
                 return .braveLighterBlurple


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3936

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
