### PR TITLE
Fix #3950: Selecting a Bookmark should close Settings Menu

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -436,13 +436,18 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
                 self.showEditBookmarkController(bookmark: bookmark)
             } else {
                 if let url = URL(string: bookmark.url ?? "") {
-
-                    dismiss(animated: true) {
+                    let bookmarkClickEvent: (() -> Void)? = {
                         /// Donate Custom Intent Open Bookmark List
                         if !self.isPrivateBrowsing {
                             ActivityShortcutManager.shared.donateCustomIntent(for: .openBookmarks, with: url.absoluteString)
                         }
                         self.toolbarUrlActionsDelegate?.select(url: url, isBookmark: true)
+                    }
+                    
+                    if presentingViewController is MenuViewController {
+                        presentingViewController?.dismiss(animated: true, completion: bookmarkClickEvent)
+                    } else {
+                        dismiss(animated: true, completion: bookmarkClickEvent)
                     }
                 }
             }


### PR DESCRIPTION
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3950

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Open Settings Menu
2. Select Bookmark
3. Navigate one of the folders and click a bookmark
4. Check Menu is dismissed after selection and bookmark url is presented


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
