### PR TITLE
[No Bug]: Adding Application Settings Navigation Siri and Localization changes 

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1412,7 +1412,7 @@ extension Strings {
     }
 }
 
-// MARK: - Shorcuts
+// MARK: - Shortcuts
 
 extension Strings {
     public struct Shortcuts {
@@ -1537,9 +1537,9 @@ extension Strings {
                               comment: "")
         
         public static let shortcutSettingsTitle =
-            NSLocalizedString("shortcuts.shorcutSettingsTitle",
+            NSLocalizedString("shortcuts.shortcutSettingsTitle",
                               bundle: .braveShared,
-                              value: "Siri Shorcuts",
+                              value: "Siri Shortcuts",
                               comment: "")
         
         public static let shortcutSettingsOpenNewTabTitle =
@@ -1608,11 +1608,23 @@ extension Strings {
                               value: "Open Playlist",
                               comment: "")
         
-        public static let shorcutSettingsOpenPlaylistDescription =
-            NSLocalizedString("shortcuts.shorcutSettingsOpenPlaylistDescription",
+        public static let shortcutSettingsOpenPlaylistDescription =
+            NSLocalizedString("shortcuts.shortcutSettingsOpenPlaylistDescription",
                               bundle: .braveShared,
                               value: "Use Shortcuts to enable Brave VPN via Siri - Voice Assistant",
                               comment: "Use Shortcuts to Open Playlist via Siri - Voice Assistant")
+        
+        public static let shortcutOpenApplicationSettingsTitle =
+            NSLocalizedString("shortcuts.shortcutOpenApplicationSettingsTitle",
+                              bundle: .braveShared,
+                              value: "Open Settings",
+                              comment: "Button title that open application settings")
+        
+        public static let shortcutOpenApplicationSettingsDescription =
+            NSLocalizedString("shortcuts.shortcutOpenApplicationSettingsDescription",
+                              bundle: .braveShared,
+                              value: "This option will open Brave Settings. In order to change various Siri options, please select 'Siri & Search' menu item and customize your choices.",
+                              comment: "Description for opening Brave Settings for altering Siri shortcut.")
     }
 }
 

--- a/Client/Application/Shortcuts/ActivityShortcutManager.swift
+++ b/Client/Application/Shortcuts/ActivityShortcutManager.swift
@@ -204,7 +204,7 @@ class ActivityShortcutManager: NSObject {
                 return
             }
             
-            log.error("Failed to donate shorcut open website, error: \(error)")
+            log.error("Failed to donate shortcut open website, error: \(error)")
         }
     }
 }

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -784,7 +784,7 @@ extension NewTabPageViewController {
         }
     }
     
-    /// Moves New Tab Page Scroll to start of Brave News - Used for shorcut
+    /// Moves New Tab Page Scroll to start of Brave News - Used for shortcut
     func scrollToBraveNews() {
         // Offset of where Brave News starts
         let todayStart = collectionView.frame.height - feedOverlayView.headerView.bounds.height - 32 - 16

--- a/Client/Frontend/Settings/ShortcutSettingsViewController.swift
+++ b/Client/Frontend/Settings/ShortcutSettingsViewController.swift
@@ -76,6 +76,26 @@ class ShortcutSettingsViewController: TableViewController {
                         }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self)],
                     footer: .title(Strings.Shortcuts.shorcutSettingsOpenPlaylistDescription))
         )
+        
+        dataSource.sections.append(
+            Section(rows: [
+                Row(text: "Open Settings", selection: { [unowned self] in
+                    let style: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
+                    let alert = UIAlertController(
+                        title: "Open Settings",
+                        message: "This option will open Brave Settings. In order to change various Siri options, please select 'Siri & Search' menu item and customize your choices.",
+                        preferredStyle: style)
+                    
+                    alert.addAction(UIAlertAction(title: "Open Settings", style: .default, handler: { _ in
+                        if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(settingsURL)
+                        }
+                    }))
+                    alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
+                    present(alert, animated: true, completion: nil)
+                }, cellClass: ButtonCell.self)],
+                    footer: .title("This option will open Brave Settings. In order to change various Siri options, please select 'Siri & Search' menu item and customize your choices."))
+        )
     }
     
     private func manageShortcutActivity(for type: ActivityType) {

--- a/Client/Frontend/Settings/ShortcutSettingsViewController.swift
+++ b/Client/Frontend/Settings/ShortcutSettingsViewController.swift
@@ -74,19 +74,19 @@ class ShortcutSettingsViewController: TableViewController {
                         Row(text: Strings.Shortcuts.shortcutSettingsOpenPlaylistTitle, selection: { [unowned self] in
                             manageShortcutActivity(for: .openPlayList)
                         }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self)],
-                    footer: .title(Strings.Shortcuts.shorcutSettingsOpenPlaylistDescription))
+                    footer: .title(Strings.Shortcuts.shortcutSettingsOpenPlaylistDescription))
         )
         
         dataSource.sections.append(
             Section(rows: [
-                Row(text: "Open Settings", selection: { [unowned self] in
+                Row(text: Strings.Shortcuts.shortcutOpenApplicationSettingsTitle, selection: { [unowned self] in
                     let style: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
                     let alert = UIAlertController(
-                        title: "Open Settings",
-                        message: "This option will open Brave Settings. In order to change various Siri options, please select 'Siri & Search' menu item and customize your choices.",
+                        title: Strings.Shortcuts.shortcutOpenApplicationSettingsTitle,
+                        message: Strings.Shortcuts.shortcutOpenApplicationSettingsDescription,
                         preferredStyle: style)
                     
-                    alert.addAction(UIAlertAction(title: "Open Settings", style: .default, handler: { _ in
+                    alert.addAction(UIAlertAction(title: Strings.Shortcuts.shortcutOpenApplicationSettingsTitle, style: .default, handler: { _ in
                         if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
                             UIApplication.shared.open(settingsURL)
                         }
@@ -94,7 +94,7 @@ class ShortcutSettingsViewController: TableViewController {
                     alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
                     present(alert, animated: true, completion: nil)
                 }, cellClass: ButtonCell.self)],
-                    footer: .title("This option will open Brave Settings. In order to change various Siri options, please select 'Siri & Search' menu item and customize your choices."))
+                    footer: .title(Strings.Shortcuts.shortcutOpenApplicationSettingsDescription))
         )
     }
     
@@ -104,29 +104,29 @@ class ShortcutSettingsViewController: TableViewController {
                 guard let shortcuts = shortcuts else { return }
                 
                 guard let shortcut = shortcuts.first(where: { $0.shortcut.userActivity?.activityType == type.identifier }) else {
-                    presentAddShorcutActivity(for: type)
+                    presentAddShortcutActivity(for: type)
                     return
                 }
                 
-                self.presentEditShorcutActivity(for: shortcut)
+                self.presentEditShortcutActivity(for: shortcut)
             }
         }
     }
     
-    private func presentAddShorcutActivity(for type: ActivityType) {
+    private func presentAddShortcutActivity(for type: ActivityType) {
         let userActivity = ActivityShortcutManager.shared.createShortcutActivity(type: type)
                         
-        let addShorcutViewController = INUIAddVoiceShortcutViewController(shortcut: INShortcut(userActivity: userActivity))
-        addShorcutViewController.delegate = self
+        let addShortcutViewController = INUIAddVoiceShortcutViewController(shortcut: INShortcut(userActivity: userActivity))
+        addShortcutViewController.delegate = self
 
-        present(addShorcutViewController, animated: true, completion: nil)
+        present(addShortcutViewController, animated: true, completion: nil)
     }
     
-    private func presentEditShorcutActivity(for voiceShortcut: INVoiceShortcut) {
-        let addShorcutViewController = INUIEditVoiceShortcutViewController(voiceShortcut: voiceShortcut)
-        addShorcutViewController.delegate = self
+    private func presentEditShortcutActivity(for voiceShortcut: INVoiceShortcut) {
+        let addShortcutViewController = INUIEditVoiceShortcutViewController(voiceShortcut: voiceShortcut)
+        addShortcutViewController.delegate = self
 
-        present(addShorcutViewController, animated: true, completion: nil)
+        present(addShortcutViewController, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
## Summary of Changes

This pull request is adding Open Settings in Siri Settings. And changes localization mistakes.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:


![testsa2221222](https://user-images.githubusercontent.com/6643505/126535748-f3f8f71a-370b-448b-b14d-510e2c8c27fe.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
