### PR TITLE
Fix #3958: Do not reset to default when global settings are changed

### DIFF
--- a/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -104,15 +104,21 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
         return shields
     }()
     
-    private lazy var toggles: [Bool] = {
-        let savedToggles = Preferences.Privacy.clearPrivateDataToggles.value
-        // Ensure if we ever add an option to the list of clearables we don't crash
-        if savedToggles.count == clearables.count {
-            return savedToggles
+    private var toggles: [Bool] {
+        get {
+            let savedToggles = Preferences.Privacy.clearPrivateDataToggles.value
+            // Ensure if we ever add an option to the list of clearables we don't crash
+            if savedToggles.count == clearables.count {
+                return savedToggles
+            }
+            
+            return self.clearables.map { $0.checked }
         }
         
-        return self.clearables.map { $0.checked }
-    }()
+        set {
+            Preferences.Privacy.clearPrivateDataToggles.value = newValue
+        }
+    }
     
     private lazy var clearables: [(clearable: Clearable, checked: Bool)] = {
         var alwaysVisible: [(clearable: Clearable, checked: Bool)] =

--- a/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -104,21 +104,15 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
         return shields
     }()
     
-    private var toggles: [Bool] {
-        get {
-            let savedToggles = Preferences.Privacy.clearPrivateDataToggles.value
-            // Ensure if we ever add an option to the list of clearables we don't crash
-            if savedToggles.count == clearables.count {
-                return savedToggles
-            }
-            
-            return self.clearables.map { $0.checked }
+    private lazy var toggles: [Bool] = {
+        let savedToggles = Preferences.Privacy.clearPrivateDataToggles.value
+        // Ensure if we ever add an option to the list of clearables we don't crash
+        if savedToggles.count == clearables.count {
+            return savedToggles
         }
         
-        set {
-            Preferences.Privacy.clearPrivateDataToggles.value = newValue
-        }
-    }
+        return self.clearables.map { $0.checked }
+    }()
     
     private lazy var clearables: [(clearable: Clearable, checked: Bool)] = {
         var alwaysVisible: [(clearable: Clearable, checked: Bool)] =
@@ -150,6 +144,7 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
                     
                 return .boolRow(title: title, toggleValue: self.toggles[idx], valueChange: { [unowned self] checked in
                     self.toggles[idx] = checked
+                    Preferences.Privacy.clearPrivateDataToggles.value = self.toggles
                 }, cellReuseId: "\(title.lowercased().trimmingCharacters(in: .whitespacesAndNewlines))\(idx)")
             } + [
                 Row(text: Strings.clearDataNow, selection: { [unowned self] in


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #3958

Saving Global Settings for Private Data Toggles in Default Preferences.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open settings -Shields & Privacy
- Disable Browsing history and saved logins
- Close settings menu and reopen, settings are conserved value


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
