### PR TITLE
[No Bug]: Localization Change for Open Playlist Shortcut Settings Description

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1611,8 +1611,8 @@ extension Strings {
         public static let shortcutSettingsOpenPlaylistDescription =
             NSLocalizedString("shortcuts.shortcutSettingsOpenPlaylistDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to enable Brave VPN via Siri - Voice Assistant",
-                              comment: "Use Shortcuts to Open Playlist via Siri - Voice Assistant")
+                              value: "Use Shortcuts to Open Playlist via Siri - Voice Assistant",
+                              comment: "Description of Open Playlist Siri Shortcut in Settings Screen")
         
         public static let shortcutOpenApplicationSettingsTitle =
             NSLocalizedString("shortcuts.shortcutOpenApplicationSettingsTitle",


### PR DESCRIPTION
Localization Change for Open Playlist Shortcut Settings Description

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 12 - 2021-07-27 at 14 14 19](https://user-images.githubusercontent.com/6643505/127206400-a412dc8d-d940-4b93-997f-df7d6f0744d9.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
