### PR TITLE
Fix #3970 - #3971 - #3972: Shortcuts Related Bug fixes and changes

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1575,8 +1575,8 @@ extension Strings {
         public static let shortcutSettingsClearBrowserHistoryDescription =
             NSLocalizedString("shortcuts.shortcutSettingsClearBrowserHistoryDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to open a new tab via Siri - Voice Assistant",
-                              comment: "")
+                              value: "Use Shortcuts to Open a New Tab & Clear Browser History via Siri - Voice Assistant",
+                              comment: "Description of Clear Browser History Siri Shortcut in Settings Screen")
         
         public static let shortcutSettingsEnableVPNTitle =
             NSLocalizedString("shortcuts.shortcutSettingsEnableVPNTitle",

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -680,7 +680,7 @@ extension AppDelegate {
 
             browserViewController.switchToTabForURLOrOpen(
                 url,
-                isPrivate: Preferences.Privacy.privateBrowsingOnly.value ? true :  false,
+                isPrivate: Preferences.Privacy.privateBrowsingOnly.value,
                 isPrivileged: false)
             return true
         }

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -678,7 +678,10 @@ extension AppDelegate {
                 return false
             }
 
-            browserViewController.switchToTabForURLOrOpen(url, isPrivileged: false)
+            browserViewController.switchToTabForURLOrOpen(
+                url,
+                isPrivate: Preferences.Privacy.privateBrowsingOnly.value ? true :  false,
+                isPrivileged: false)
             return true
         }
         

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
@@ -74,6 +74,7 @@ extension BrowserViewController {
         
         guard let selectedTab = tabManager.selectedTab,
               !benchmarkNotificationPresented,
+              !Preferences.AppState.backgroundedCleanly.value,
               !topToolbar.inOverlayMode,
               !isTabTrayActive,
               selectedTab.webView?.scrollView.isDragging == false,


### PR DESCRIPTION
Open Website opens a private tab when Private Browsing only is enabled
Tooltip doesn't show when Siri overlay is recording command
Siri shortcut for Clear browser history message change

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3972
This pull request fixes #3971
This pull request fixes #3970

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Follow the Test plans inside the ticket for all the tickets

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
