### PR TITLE
Fix #3978 - Fix #3979: Private Mode Only Fixes for Shortcuts

### DIFF
--- a/Client/Application/Shortcuts/ActivityShortcutManager.swift
+++ b/Client/Application/Shortcuts/ActivityShortcutManager.swift
@@ -131,7 +131,7 @@ class ActivityShortcutManager: NSObject {
             case .clearBrowsingHistory:
                 bvc.clearHistoryAndOpenNewTab()
             case .enableBraveVPN:
-                bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: false, isExternal: true)
+                bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing, isExternal: true)
                 bvc.popToBVC()
 
                 switch BraveVPN.vpnState {
@@ -145,6 +145,11 @@ class ActivityShortcutManager: NSObject {
                         }
                 }
             case .openBraveNews:
+                // Do nothing as browser when browser to PB only and Brave News isn't available on private tabs
+                guard !Preferences.Privacy.privateBrowsingOnly.value else {
+                    return
+                }
+                
                 if Preferences.BraveNews.isEnabled.value {
                     bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: false, isExternal: true)
                     bvc.popToBVC()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1588,11 +1588,18 @@ class BrowserViewController: UIViewController {
     }
     
     func clearHistoryAndOpenNewTab() {
-        History.deleteAll { [weak self] in
-            guard let self = self else { return }
-            
-            self.tabManager.clearTabHistory() {
-                self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: false)
+        // When PB Only mode is enabled
+        // All private tabs closed and a new private tab is created
+        if Preferences.Privacy.privateBrowsingOnly.value {
+            tabManager.removeAll()
+            openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true)
+        } else {
+            History.deleteAll { [weak self] in
+                guard let self = self else { return }
+                
+                self.tabManager.clearTabHistory() {
+                    self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: false)
+                }
             }
         }
     }


### PR DESCRIPTION
PB Only mode is enabled All private tabs closed and a new private tab is created
Do nothing as browser when browser to PB only and Brave News isn't available on private tabs
Open Tab in current mode when VPN shortcuts is called

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3978
This pull request fixes #3979

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Follow the Test Plan in the ticket

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
