### PR TITLE
Fix #3901 - Fixed URL Bar suggestions being lowercased by default

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -154,7 +154,7 @@ extension BrowserViewController: TopToolbarDelegate {
         } else {
             showSearchController()
             searchController?.searchQuery = text
-            searchLoader?.query = text
+            searchLoader?.query = text.lowercased()
         }
     }
 

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -358,14 +358,14 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     private func querySuggestClient() {
         suggestClient?.cancelPendingRequest()
 
-        let searchQuery = searchQuery.lowercased()
-        if searchQuery.isEmpty || searchEngines?.shouldShowSearchSuggestionsOptIn == true || searchQuery.looksLikeAURL() {
+        let localSearchQuery = searchQuery.lowercased()
+        if localSearchQuery.isEmpty || searchEngines?.shouldShowSearchSuggestionsOptIn == true || localSearchQuery.looksLikeAURL() {
             suggestions = []
             tableView.reloadData()
             return
         }
 
-        suggestClient?.query(searchQuery, callback: { [weak self] suggestions, error in
+        suggestClient?.query(localSearchQuery, callback: { [weak self] suggestions, error in
             guard let self = self else { return }
 
             self.tableView.reloadData()
@@ -391,7 +391,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
 
             // If there are no suggestions, just use whatever the user typed.
             if suggestions?.isEmpty ?? true {
-                self.suggestions = [searchQuery]
+                self.suggestions = [localSearchQuery]
             }
 
             // Reload the tableView to show the new list of search suggestions.
@@ -415,14 +415,14 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         }
 
         let engine = quickSearchEngines[index - 1]
-        let searchQuery = searchQuery.lowercased()
-        guard let url = engine.searchURLForQuery(searchQuery) else {
+        let localSearchQuery = searchQuery.lowercased()
+        guard let url = engine.searchURLForQuery(localSearchQuery) else {
             assertionFailure()
             return
         }
 
         if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-            RecentSearch.addItem(type: .website, text: searchQuery, websiteUrl: url.absoluteString)
+            RecentSearch.addItem(type: .website, text: localSearchQuery, websiteUrl: url.absoluteString)
         }
         searchDelegate?.searchViewController(self, didSelectURL: url)
     }
@@ -465,8 +465,8 @@ class SearchViewController: SiteTableViewController, LoaderListener {
                 searchDelegate?.searchViewController(self, didSelectURL: url)
             }
         case .findInPage:
-            let searchQuery = searchQuery.lowercased()
-            searchDelegate?.searchViewController(self, shouldFindInPage: searchQuery)
+            let localSearchQuery = searchQuery.lowercased()
+            searchDelegate?.searchViewController(self, shouldFindInPage: localSearchQuery)
         }
     }
 

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -358,6 +358,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     private func querySuggestClient() {
         suggestClient?.cancelPendingRequest()
 
+        let searchQuery = searchQuery.lowercased()
         if searchQuery.isEmpty || searchEngines?.shouldShowSearchSuggestionsOptIn == true || searchQuery.looksLikeAURL() {
             suggestions = []
             tableView.reloadData()
@@ -390,7 +391,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
 
             // If there are no suggestions, just use whatever the user typed.
             if suggestions?.isEmpty ?? true {
-                self.suggestions = [self.searchQuery]
+                self.suggestions = [searchQuery]
             }
 
             // Reload the tableView to show the new list of search suggestions.
@@ -414,7 +415,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
         }
 
         let engine = quickSearchEngines[index - 1]
-
+        let searchQuery = searchQuery.lowercased()
         guard let url = engine.searchURLForQuery(searchQuery) else {
             assertionFailure()
             return
@@ -464,6 +465,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
                 searchDelegate?.searchViewController(self, didSelectURL: url)
             }
         case .findInPage:
+            let searchQuery = searchQuery.lowercased()
             searchDelegate?.searchViewController(self, shouldFindInPage: searchQuery)
         }
     }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -156,7 +156,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     fileprivate func normalizeString(_ string: String) -> String {
-        return string.lowercased().stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
+        return string.stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
     }
 
     /// Commits the completion by setting the text and removing the highlight.
@@ -197,7 +197,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             return
         }
 
-        let normalized = normalizeString(text)
+        let normalized = normalizeString(text).lowercased()
         guard suggestion.hasPrefix(normalized) && normalized.count < suggestion.count else {
             hideCursor = false
             return


### PR DESCRIPTION
## Summary of Changes
- Fixed URL Bar suggestions being lowercased by default when they shouldn't be.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3901

## Submitter Checklist:

- [X] *Unit Tests* are updated to cover new or changed functionality
- [X] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Type a Case-Sensitive string in the URL bar.
2. The search icon below the URL bar should show the **EXACT** string you typed.
3. If the URL bar contains a URL, and you tap on the search icon below the URL bar, it should go to that **EXACT** URL as per the ticket.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
