### PR TITLE
Fix #3965 - Better consistency of capitalization in strings (Siri Shortcuts settings)

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1517,7 +1517,7 @@ extension Strings {
         public static let shortcutSettingsOpenNewTabDescription =
             NSLocalizedString("shortcuts.shortcutSettingsOpenNewTabDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to open a new tab via Siri - Voice Assistant",
+                              value: "Use Shortcuts to Open a New Tab via Siri - Voice Assistant",
                               comment: "")
         
         public static let shortcutSettingsOpenNewPrivateTabTitle =
@@ -1529,7 +1529,7 @@ extension Strings {
         public static let shortcutSettingsOpenNewPrivateTabDescription =
             NSLocalizedString("shortcuts.shortcutSettingsOpenNewPrivateTabDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to open a new private tab via Siri - Voice Assistant",
+                              value: "Use Shortcuts to Open a New Private Tab via Siri - Voice Assistant",
                               comment: "")
         
         public static let shortcutSettingsClearBrowserHistoryTitle =
@@ -1553,7 +1553,7 @@ extension Strings {
         public static let shortcutSettingsEnableVPNDescription =
             NSLocalizedString("shortcuts.shortcutSettingsEnableVPNDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to enable Brave VPN via Siri - Voice Assistant",
+                              value: "Use Shortcuts to Enable Brave VPN via Siri - Voice Assistant",
                               comment: "")
 
         public static let shortcutSettingsOpenBraveNewsTitle =


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes https://github.com/brave/brave-ios/issues/3965

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Go to Settings > Siri Shortcuts

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Before fix on the top and after fix on the bottom:

![Simulator Screen Shot - iPhone 11 - 2021-08-02 at 02 49 06](https://user-images.githubusercontent.com/47181362/127791735-2fbfb2e4-547a-41e3-b5e0-7bedbf73dab9.png)

![Simulator Screen Shot - iPhone 11 - 2021-08-02 at 02 53 56](https://user-images.githubusercontent.com/47181362/127791751-6e5192cc-7981-4758-a106-d55b6414b815.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
