### PR TITLE
Fix  #3995: Browser crash when clear history voice command is given with tab tray open 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1598,7 +1598,8 @@ class BrowserViewController: UIViewController {
                 guard let self = self else { return }
                 
                 self.tabManager.clearTabHistory() {
-                    self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: false)
+                    self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: false, isExternal: true)
+                    self.popToBVC()
                 }
             }
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3995

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Open tab tray
- Use Siri shortcut voice command for clear history

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/127886120-84fb0b89-ad25-4e94-8971-0d49afefc59a.MP4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
