### PR TITLE
Fix #3997: Browser crash when clear history voice command is given with tab tray open in PB only mode 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1592,7 +1592,8 @@ class BrowserViewController: UIViewController {
         // All private tabs closed and a new private tab is created
         if Preferences.Privacy.privateBrowsingOnly.value {
             tabManager.removeAll()
-            openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true)
+            openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true, isExternal: true)
+            popToBVC()
         } else {
             History.deleteAll { [weak self] in
                 guard let self = self else { return }


### PR DESCRIPTION
Fix crash when clear history voice command is given with tab tray in Private Only Browser Enabled

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #3997

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Switch to PB only mode
- Open tab tray
- Use Siri shortcut voice command for clear history

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
