### PR TITLE
Fix #4009: Disable History sync when user switches to PB only 

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -2224,6 +2224,11 @@ extension Strings {
             NSLocalizedString("history.historyEmptyStateTitle", tableName: "BraveShared", bundle: .braveShared,
                               value: "History will show up here.",
                               comment: "Title which is displayed when History screen is empty.")
+        
+        public static let historyPrivateModeOnlyStateTitle =
+            NSLocalizedString("history.historyPrivateModeOnlyStateTitle", tableName: "BraveShared", bundle: .braveShared,
+                              value: "History is not available in Private Browsing Only mode.",
+                              comment: "Title which is displayed on History screen as a overlay when Private Browsing Only enabled")
     }
 }
 

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -48,13 +48,16 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
         tableView.accessibilityIdentifier = "History List"
         title = Strings.historyScreenTitle
                 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(image: #imageLiteral(resourceName: "playlist_delete_item").template, style: .done, target: self, action: #selector(performDeleteAll))
+        if !Preferences.Privacy.privateBrowsingOnly.value {
+            navigationItem.rightBarButtonItem =
+                UIBarButtonItem(image: #imageLiteral(resourceName: "playlist_delete_item").template, style: .done, target: self, action: #selector(performDeleteAll))
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        guard Preferences.Privacy.privateBrowsingOnly.value else {
+        guard !Preferences.Privacy.privateBrowsingOnly.value else {
             showEmptyPanelState()
             return
         }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -54,6 +54,11 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        guard Preferences.Privacy.privateBrowsingOnly.value else {
+            showEmptyPanelState()
+            return
+        }
+        
         refreshHistory()
     }
     
@@ -95,7 +100,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
         }
     }
     
-    fileprivate func createEmptyStateOverlayView() -> UIView {
+    private func createEmptyStateOverlayView() -> UIView {
         let overlayView = UIView().then {
             $0.backgroundColor = .secondaryBraveBackground
         }
@@ -105,7 +110,9 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
         }
         
         let welcomeLabel = UILabel().then {
-            $0.text = Strings.History.historyEmptyStateTitle
+            $0.text = Preferences.Privacy.privateBrowsingOnly.value
+                ? Strings.History.historyPrivateModeOnlyStateTitle
+                : Strings.History.historyEmptyStateTitle
             $0.textAlignment = .center
             $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
             $0.textColor = .braveLabel
@@ -135,17 +142,21 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
         return overlayView
     }
     
-    fileprivate func updateEmptyPanelState() {
-        if  historyFRC?.fetchedObjectsCount == 0 {
-            if emptyStateOverlayView.superview == nil {
-                view.addSubview(emptyStateOverlayView)
-                view.bringSubviewToFront(emptyStateOverlayView)
-                emptyStateOverlayView.snp.makeConstraints { make -> Void in
-                    make.edges.equalTo(tableView)
-                }
-            }
+    private func updateEmptyPanelState() {
+        if historyFRC?.fetchedObjectsCount == 0 {
+            showEmptyPanelState()
         } else {
             emptyStateOverlayView.removeFromSuperview()
+        }
+    }
+    
+    private func showEmptyPanelState() {
+        if emptyStateOverlayView.superview == nil {
+            view.addSubview(emptyStateOverlayView)
+            view.bringSubviewToFront(emptyStateOverlayView)
+            emptyStateOverlayView.snp.makeConstraints { make -> Void in
+                make.edges.equalTo(tableView)
+            }
         }
     }
     

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -57,12 +57,11 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        guard !Preferences.Privacy.privateBrowsingOnly.value else {
+        if Preferences.Privacy.privateBrowsingOnly.value {
             showEmptyPanelState()
-            return
+        } else {
+            refreshHistory()
         }
-        
-        refreshHistory()
     }
     
     private func refreshHistory() {


### PR DESCRIPTION
History Private Browsing Only overlay is added in case PB Only Mode is enabled.
And hiding the "Delete All" button.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4009

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Check History When B Only mode is enabled and sync items are being seen or an overlay is hown

## Screenshots:

![16](https://user-images.githubusercontent.com/6643505/128553332-e3ad02eb-00f9-46f1-bf56-0f9f857e9d28.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
