### PR TITLE
Fix #4027: History syncs even when browser is set to PB only mode

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -57,29 +57,29 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if Preferences.Privacy.privateBrowsingOnly.value {
-            showEmptyPanelState()
-        } else {
-            refreshHistory()
-        }
+        refreshHistory()
     }
     
     private func refreshHistory() {
-        if !isHistoryRefreshing {
-            view.addSubview(spinner)
-            spinner.snp.makeConstraints {
-                $0.center.equalTo(view.snp.center)
-            }
-            spinner.startAnimating()
-            isHistoryRefreshing = true
+        if Preferences.Privacy.privateBrowsingOnly.value {
+            showEmptyPanelState()
+        } else {
+            if !isHistoryRefreshing {
+                view.addSubview(spinner)
+                spinner.snp.makeConstraints {
+                    $0.center.equalTo(view.snp.center)
+                }
+                spinner.startAnimating()
+                isHistoryRefreshing = true
 
-            Historyv2.waitForHistoryServiceLoaded { [weak self] in
-                guard let self = self else { return }
-                
-                self.reloadData() {
-                    self.isHistoryRefreshing = false
-                    self.spinner.stopAnimating()
-                    self.spinner.removeFromSuperview()
+                Historyv2.waitForHistoryServiceLoaded { [weak self] in
+                    guard let self = self else { return }
+                    
+                    self.reloadData() {
+                        self.isHistoryRefreshing = false
+                        self.spinner.stopAnimating()
+                        self.spinner.removeFromSuperview()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4027

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Set browser to PB only mode
- Join Sync chain
- Enable history sync
- Visit pages on other device by typing in urls
- Open history page on iOS device
- Visit a new page on other device, all typed in URL's from other device gets sync'd
- And check the list stays empty

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
