### PR TITLE
Fix #4008: Add 1.30 translations.

### DIFF
--- a/BraveShared/de.lproj/BraveShared.strings
+++ b/BraveShared/de.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Chronik";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Verlauf löschen";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Dadurch wird der gesamte Browserverlauf gelöscht.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Browserverlauf löschen";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Hier wird der Verlauf angezeigt.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Beim privaten Browsen ist kein Verlauf verfügbar.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Chronik";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Synchronisieren";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Der Großteil des Verlaufs wurde migriert, bis auf einige Seiten, da für sie Informationen fehlen.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migration fast vollständig";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Legen Sie fest, welche Daten Sie zwischen Geräten synchronisieren möchten. Diese Einstellungen betreffen nur dieses Gerät.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Synchronisierungseinstellungen";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Die Lesezeichen konnten nicht migriert werden. Bitte versuchen Sie es später erneut.";

--- a/BraveShared/es.lproj/BraveShared.strings
+++ b/BraveShared/es.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Historial";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Borrar historial";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "El historial de navegación se borrará por completo.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Borrar historial de navegación";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "El historial se mostrará aquí.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "El historial no está disponible en el modo Solo navegación privada.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Historial";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Sincronización";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Migración realizada de gran parte del historial. Algunas páginas no han migrado debido a falta de información.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migración (casi) completada";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Gestiona la información que deseas sincronizar entre dispositivos. Estos ajustes solo afectarán a este dispositivo.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Ajustes de sincronización";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Error al migrar los marcadores. Vuelve a intentarlo más tarde.";

--- a/BraveShared/fr.lproj/BraveShared.strings
+++ b/BraveShared/fr.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Historique";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Effacer l'historique";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Cette action effacera tout l'historique de navigation.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Effacer l'historique de navigation";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "L'historique sera affiché ici.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "L'historique n'est pas disponible en mode Navigation privée uniquement.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Historique";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Synchronisation";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "La majorité de l'historique a été migré. Cependant, quelques pages n'ont pas pu être migrées car il manque des informations concernant la page.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migration (preque) terminée";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Gérez les informations que vous souhaitez synchroniser entre les appareils. Ces paramètres ne concernent que cet appareil.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Paramètres de synchronisation";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Impossible de migrer les marque-pages. Veuillez réessayer plus tard.";

--- a/BraveShared/id-ID.lproj/BraveShared.strings
+++ b/BraveShared/id-ID.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Riwayat";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Hapus Riwayat";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Ini akan menghapus semua riwayat perambanan.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Hapus Riwayat Perambanan";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Riwayat akan ditampilkan di sini.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Riwayat tidak tersedia di mode Hanya Perambanan Privat.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Riwayat";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Sinkronisasi";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Sebagian besar riwayat telah dipindahkan. Namun, beberapa halaman tidak dipindahkan karena hilangnya info halaman.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migrasi (hampir) selesai";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Kelola informasi yang ingin Anda sinkronisasikan di antara perangkat. Pengaturan ini hanya memengaruhi perangkat ini.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Pengaturan Sinkronisasi";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Gagal memigrasi markah buku, Coba lagi nanti.";

--- a/BraveShared/it.lproj/BraveShared.strings
+++ b/BraveShared/it.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Cronologia";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Cancella la cronologia";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Questa azione cancellerà tutta la cronologia di navigazione.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Cancella la cronologia di navigazione";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "La cronologia comparirà qui.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "La cronologia non è disponibile nella modalità che prevede solo la navigazione privata.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Cronologia";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Sincronizza";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "La maggior parte della cronologia è stata trasferita. Alcune pagine però non sono state trasferite perché erano sprovviste di alcune informazioni.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migrazione (quasi) completata";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Gestisci le informazioni che desideri sincronizzare tra i dispositivi. Queste impostazioni varranno solo per questo dispositivo.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Sincronizza le impostazioni";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Migrazione dei segnalibri non riuscita. Riprova in seguito.";

--- a/BraveShared/ja.lproj/BraveShared.strings
+++ b/BraveShared/ja.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "履歴";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "履歴を消去する";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "全ての閲覧履歴を消去します。";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "閲覧履歴を消去する";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "ここに履歴が表示されます。";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "常にプライベート・ブラウジングを行うモードでは、履歴は利用できません。";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "履歴";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Brave Sync";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "ほとんどの履歴は移行されましたが、ページ情報が失われているためいくつかのページは移行されませんでした。";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "移行が（ほぼ）完了しました";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "複数のデバイス間でどの情報を同期させるかを管理します。ここでの設定は、このデバイスにのみ適用されます。";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Sync設定";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "ブックマークの移行に失敗しました。再度お試しください。";

--- a/BraveShared/ja.lproj/Localizable.strings
+++ b/BraveShared/ja.lproj/Localizable.strings
@@ -431,7 +431,7 @@
 "RestoredFavoritesFolderName" = "復元されたお気に入り";
 
 /* Displayed when Brave Rewards is disabled */
-"rewards.disabledBody" = "有効にしてことで、コンテンツクリエイターを支援することができます。";
+"rewards.disabledBody" = "有効にしてコンテンツクリエイターを支援";
 
 /* Displayed in the status container when rewards is disabled */
 "rewards.disabledStatusBody" = "Brave Rewardsを使うと、ブラウジングすることででクリエイターを支援";

--- a/BraveShared/ko-KR.lproj/BraveShared.strings
+++ b/BraveShared/ko-KR.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "방문기록";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "기록 지우기";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "방문 기록을 모두 지웁니다.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "방문 기록 지우기";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "기록이 여기 표시됩니다.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "비공개 브라우징 모드에서는 기록을 사용할 수 없습니다.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "방문기록";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "동기화";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "대부분의 기록이 마이그레이션되었지만 몇 개에는 페이지 정보가 누락되어 완료하지 못했습니다.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "마이그레이션 (대부분) 완료";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "기기 간에 동기화할 정보를 관리합니다. 이 설정은 이 기기에만 적용됩니다.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "동기화 설정";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "북마크를 마이그레이션하지 못했습니다. 나중에 다시 시도하세요.";

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Sejarah";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Kosongkan Sejarah";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Tindakan ini akan mengosongkan sejarah semakan imbas.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Kosongkan Sejarah Semakan Imbas";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Sejarah akan muncul di sini.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Sejarah tidak tersedia dalam mod Semakan Imbas Peribadi Sahaja.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Sejarah";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Segerak";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Kebanyakan sejarah dipindahkan. Walau bagaimanapun, beberapa halaman tidak dipindahkan kerana maklumat halaman yang tidak lengkap.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Pemindahan (hampir) lengkap";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Uruskan apa-apa maklumat yang ingin anda segerakkan antara peranti. Tetapan ini hanya menjejaskan peranti ini sahaja.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Tetapan Penyegerakan";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Gagal memindahkan penanda buku. Sila cuba lagi kemudian.";

--- a/BraveShared/nb.lproj/BraveShared.strings
+++ b/BraveShared/nb.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Logg";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Slett logg";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Dette sletter all nettleserhistorikken.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Slett logg";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Nettleserhistorikken vises her.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Logging er ikke tilgjengelig i privat modus.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Logg";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Synk";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Mesteparten av loggen er flyttet, med unntak av et par sider der det manglet sideinformasjon.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Overføringen er (nesten) fullført";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Bestem hvilken informasjon du vil synkronisere mellom enheter. Disse innstillingene gjelder bare for denne enheten.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Synkroniser innstillinger";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Kunne ikke flytte bokmerkene. Prøv igjen senere.";

--- a/BraveShared/pl.lproj/BraveShared.strings
+++ b/BraveShared/pl.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Historia";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Wyczyść historię";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Spowoduje to wyczyszczenie całej historii przeglądania.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Wyczyść historię przeglądania";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Historia wyświetli się tutaj.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Historia nie jest dostępna w wyłącznie prywatnym trybie przeglądania.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Historia";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Synchronizacja";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Większość historii została zaimportowana. Jednak kilka stron nie zostało zaimportowanych ze względu na brakujące informacje o stronie.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migracja (prawie) dobiegła końca";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Zarządzaj informacjami, które chcesz synchronizować między urządzeniami. Te ustawienia mają wpływ tylko na to urządzenie.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Ustawienia synchronizacji";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Nie udało się migrować zakładek. Spróbuj ponownie później.";

--- a/BraveShared/pt-BR.lproj/BraveShared.strings
+++ b/BraveShared/pt-BR.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Histórico";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Limpar histórico";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Isso limpará seu histórico de navegação.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Limpar histórico de navegação";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "O histórico será exibido aqui.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "O histórico não está disponível no modo de navegação somente privada.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Histórico";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Sincronizar";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "A maioria do histórico foi migrada. No entanto, algumas páginas não foram por falta de informações.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migração (quase) concluída";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Gerencie quais informações você quer sincronizar entre dispositivos. Essas configurações só afetarão este dispositivo.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Sincronizar configurações";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Não foi possível migrar os favoritos. Tente novamente mais tarde.";

--- a/BraveShared/ru.lproj/BraveShared.strings
+++ b/BraveShared/ru.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "История";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Очистить историю";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Вся история будет удалена.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Очиcтите историю браузера";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Здесь появится история";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "В режиме инкогнито история недоступна";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "История";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Синхронизация";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Некоторые страницы не импортированы, так как информации о них нет.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Импорт почти завершен";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Выбирайте, какие данные вы хотите синхронизировать. Настройки действуют только на этом устройстве.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Настройки синхронизации";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Не удалось переместить закладки. Повторите попытку позже.";

--- a/BraveShared/sv.lproj/BraveShared.strings
+++ b/BraveShared/sv.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Historik";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Rensa historik";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Detta rensar all webbhistorik.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Rensa webbhistorik";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Historiken visas här.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Historiken är inte tillgänglig i Endast privat surfläge";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Historik";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Synkronisera";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Den mesta av historiken har migrerats. Några sidor migrerades inte på grund av saknad sidinformation.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Migreringen (nästan) slutförd";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Hantera vilken information du vill synkronisera mellan enheter. Dessa inställningar påverkar bara den här enheten.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Synkronisera inställningar";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Det gick inte att migrera bokmärken. Försök igen senare.";

--- a/BraveShared/tr.lproj/BraveShared.strings
+++ b/BraveShared/tr.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Geçmiş";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Geçmişi Temizle";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Bu işlem tüm tarama geçmişini temizler.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Tarama Geçmişini Temizle";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Geçmiş burada görünür.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Yalnızca Özel Tarama modunda Geçmiş mevcut olmaz.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Geçmiş";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Eşitle";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Geçmişin çoğu taşındı. Ancak eksik sayfa bilgileri nedeniyle birkaç sayfa taşınamadı.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Taşıma (neredeyse) tamamlandı";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Cihazlar arasında hangi bilgileri senkronize etmek istediğinizi yönetin. Bu ayarlar yalnızca bu cihazı etkiler.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Senkronizasyon Ayarları";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Yer işaretleri aktarılamadı. Lütfen daha sonra yeniden deneyin.";

--- a/BraveShared/uk.lproj/BraveShared.strings
+++ b/BraveShared/uk.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "Історія";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "Очистити журнал";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "Журнал перегляду буде очищено.";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "Очистити журнал браузеру";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "Тут відображається історія.";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "Історія недоступна в режимі приватного перегляду.";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "Історія";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "Синхронізація";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "Більшу частину історії перенесено. Однак кілька сторінок не було перенесено через відсутність інформації про них.";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "Перенесення (майже) завершено";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "Виберіть інформацію, що синхронізуватиметься між пристроями. Ці налаштування стосуватимуться лише цього пристрою.";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "Налаштування синхронізації";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "Помилка перенесення закладок. Спробуйте ще раз пізніше.";

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "歷史記錄";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "清除歷史記錄";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "這會清除所有瀏覽記錄。";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "清除瀏覽記錄";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "這裡會顯示歷史記錄。";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "「僅限私密瀏覽」模式不會留下歷史記錄。";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "歷史記錄";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "同步";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "已遷移大部分歷史記錄。不過，有些頁面缺少頁面資訊，因此尚未遷移。";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "遷移作業已 (幾乎) 完成";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "管理要在裝置之間保持同步的資訊。這些設定只會影響這部裝置。";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "同步設定";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "無法移轉書籤，請稍後再試。";

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -496,6 +496,21 @@
 /* Title for history menu item */
 "HistortMenuItem" = "历史记录";
 
+/* Title for History Clear All Action */
+"history.historyClearActionTitle" = "清除历史记录";
+
+/* Description for Clear All History Alert Description */
+"history.historyClearAlertDescription" = "此操作会清除所有浏览历史记录。";
+
+/* Title for Clear All History Alert Title */
+"history.historyClearAlertTitle" = "清除浏览历史记录";
+
+/* Title which is displayed when History screen is empty. */
+"history.historyEmptyStateTitle" = "历史记录将显示在此处。";
+
+/* Title which is displayed on History screen as a overlay when Private Browsing Only enabled */
+"history.historyPrivateModeOnlyStateTitle" = "“仅私密浏览”模式下无法查看历史记录。";
+
 /* Title for history screen */
 "HistoryScreenTitle" = "历史记录";
 
@@ -1014,6 +1029,18 @@
 
 /* Sync settings section title */
 "Sync" = "同步";
+
+/* Message for popup when the history migration fails */
+"sync.historyMigrationErrorMessage" = "大部分历史记录已迁移。但是，部分页面由于缺少页面信息而无法迁移。";
+
+/* The title for popup when the history migration fails */
+"sync.historyMigrationErrorTitle" = "迁移（近乎）完成";
+
+/* Information Text underneath the toggles for enable/disable different sync types for the device */
+"sync.syncConfigurationInformationText" = "管理要在设备间同步的信息。这些设置仅会影响此设备。";
+
+/* Title for Sync Settings Toggle Header */
+"sync.syncSettingsTitle" = "同步设置";
 
 /* Message for popup when the bookmark migration fails */
 "sync.v2MigrationErrorMessage" = "无法迁移书签。请稍后再试。";


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4008 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Check if text on history screen are translated, button to delete all history, empty history state.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
