### PR TITLE
Fix #4040: Add a separate section for history items created earlier than last month

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -615,6 +615,7 @@ extension Strings {
     public static let yesterday = NSLocalizedString("Yesterday", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Yesterday", comment: "History tableview section header")
     public static let lastWeek = NSLocalizedString("LastWeek", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Last week", comment: "History tableview section header")
     public static let lastMonth = NSLocalizedString("LastMonth", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Last month", comment: "History tableview section header")
+    public static let earlier = NSLocalizedString("Earlier", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Earlier", comment: "History tableview section header that indicated history items earlier than last month")
     public static let savedLogins = NSLocalizedString("SavedLogins", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Saved Logins", comment: "Settings item for clearing passwords and login data")
     public static let downloadedFiles = NSLocalizedString("DownloadedFiles", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Downloaded files", comment: "Settings item for clearing downloaded files.")
     public static let browsingHistory = NSLocalizedString("BrowsingHistory", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Browsing History", comment: "Settings item for clearing browsing history")

--- a/Client/Frontend/Sync/BraveCore/History/HistoryFetchers.swift
+++ b/Client/Frontend/Sync/BraveCore/History/HistoryFetchers.swift
@@ -134,7 +134,8 @@ class Historyv2Fetcher: NSObject, HistoryV2FetchResultsController {
     private var sectionDetails: OrderedDictionary<Historyv2.Section, Int> = [.today: 0,
                                                                              .yesterday: 0,
                                                                              .lastWeek: 0,
-                                                                             .thisMonth: 0]
+                                                                             .thisMonth: 0,
+                                                                             .earlier: 0]
     
     private func clearHistoryData() {
         historyList.removeAll()

--- a/Client/Frontend/Sync/BraveCore/History/Historyv2.swift
+++ b/Client/Frontend/Sync/BraveCore/History/Historyv2.swift
@@ -26,6 +26,8 @@ class Historyv2: WebsitePresentable {
         case lastWeek
         /// History happened between end of this week and end of this month
         case thisMonth
+        /// History happened after the end of this month
+        case earlier
         
         /// The list of titles time period
         var title: String {
@@ -38,6 +40,8 @@ class Historyv2: WebsitePresentable {
                      return Strings.lastWeek
                 case .thisMonth:
                      return Strings.lastMonth
+                case .earlier:
+                     return Strings.earlier
             }
         }
     }
@@ -98,7 +102,7 @@ class Historyv2: WebsitePresentable {
             return .thisMonth
         }
         
-        return nil
+        return .earlier
     }
     
     private func getDate(_ dayOffset: Int) -> Date {


### PR DESCRIPTION
Right now in history list, we have sections showing items from (Today / Yesterday / Last Week / Last Month). If any item is dated before last month it is now shown in the list even it is fetched within the limits.

Adding a new section after Last Month to gather items that has older date called Earlier will be useful for some user who doesnt have many History entries.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4040

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Have History items older than 1 Month
- Check If these items are displayed If existing time slots has less 200 items

## Screenshots:

![historytest21211122](https://user-images.githubusercontent.com/6643505/129240760-04e123b9-baed-44a3-bcb0-8fdf5e97a4c9.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
