### PR TITLE
Fix #3814: Ads reporting for SPAs and redirection requests.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1341,7 +1341,7 @@ class BrowserViewController: UIViewController {
                 // Notify Rewards of new page load.
                 if let rewardsURL = rewardsXHRLoadURL,
                     url.host == rewardsURL.host {
-                    tabManager.selectedTab?.reportPageNaviagtion(to: rewards)
+                    tabManager.selectedTab?.reportPageNavigation(to: rewards)
                     // Not passing redirection chain here, in page navigation should not use them.
                     tabManager.selectedTab?.reportPageLoad(to: rewards, redirectionURLs: [])
                 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1270,6 +1270,10 @@ class BrowserViewController: UIViewController {
         }
         return false
     }
+    
+    // This variable is used to keep track of current page. It is used to detect internal site navigation
+    // to report internal page load to Rewards lib
+    var rewardsXHRLoadURL: URL?
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         
@@ -1330,6 +1334,17 @@ class BrowserViewController: UIViewController {
                 // Catch history pushState navigation, but ONLY for same origin navigation,
                 // for reasons above about URL spoofing risk.
                 navigateInTab(tab: tab)
+            }
+            
+            // Rewards reporting
+            if let url = change?[.newKey] as? URL, !url.isLocal {
+                // Notify Rewards of new page load.
+                if let rewardsURL = rewardsXHRLoadURL,
+                    url.host == rewardsURL.host {
+                    tabManager.selectedTab?.reportPageNaviagtion(to: rewards)
+                    // Not passing redirection chain here, in page navigation should not use them.
+                    tabManager.selectedTab?.reportPageLoad(to: rewards, redirectionURLs: [])
+                }
             }
         case .title:
             // Ensure that the tab title *actually* changed to prevent repeated calls
@@ -1462,22 +1477,9 @@ class BrowserViewController: UIViewController {
         }
     }
     
-    // This variable is used to keep track of current page. It is used to detect internal site navigation
-    // to report internal page load to Rewards lib
-    var rewardsXHRLoadURL: URL?
-    
     /// Updates the URL bar security, text and button states.
     fileprivate func updateURLBar() {
         guard let tab = tabManager.selectedTab else { return }
-        if let url = tab.url, !url.isLocal {
-            // Notify Rewards of new page load.
-            if let rewardsURL = rewardsXHRLoadURL,
-                url.host == rewardsURL.host,
-                url.isMediaSiteURL {
-                tabManager.selectedTab?.reportPageNaviagtion(to: rewards)
-                tabManager.selectedTab?.reportPageLoad(to: rewards)
-            }
-        }
         
         updateRewardsButtonState()
         

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -324,7 +324,7 @@ extension Tab {
         }
     }
     
-    func reportPageNaviagtion(to rewards: BraveRewards) {
+    func reportPageNavigation(to rewards: BraveRewards) {
         rewards.reportTabNavigation(tabId: self.rewardsId)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -288,7 +288,7 @@ extension BrowserViewController {
 }
 
 extension Tab {
-    func reportPageLoad(to rewards: BraveRewards) {
+    func reportPageLoad(to rewards: BraveRewards, redirectionURLs urls: [URL]) {
         guard let webView = webView, let url = webView.url else { return }
         if url.isLocal || PrivateBrowsingManager.shared.isPrivateBrowsing { return }
                 
@@ -318,7 +318,9 @@ extension Tab {
             if faviconURL == nil {
                 log.warning("No favicon found in \(self) to report to rewards panel")
             }
-            rewards.reportLoadedPage(url: url, redirectionURLs: [], faviconURL: faviconURL, tabId: Int(self.rewardsId), html: htmlBlob ?? "", adsInnerText: classifierText)
+            rewards.reportLoadedPage(url: url, redirectionURLs: urls,
+                                     faviconURL: faviconURL, tabId: Int(self.rewardsId),
+                                     html: htmlBlob ?? "", adsInnerText: classifierText)
         }
     }
     

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -464,7 +464,8 @@ extension BrowserViewController: WKNavigationDelegate {
                     isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing
                 )
             }
-            tab.reportPageLoad(to: rewards)
+            tab.reportPageLoad(to: rewards, redirectionURLs: tab.redirectURLs)
+            tab.redirectURLs = []
             if webView.url?.isLocal == false {
                 // Reset should classify
                 tab.shouldClassifyLoadsForAds = true
@@ -474,5 +475,10 @@ extension BrowserViewController: WKNavigationDelegate {
             
             tabsBar.reloadDataAndRestoreSelectedTab()
         }
+    }
+    
+    func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+        guard let tab = tabManager[webView], let url = webView.url, rewards.isEnabled else { return }
+        tab.redirectURLs.append(url)
     }
 }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -50,6 +50,8 @@ class Tab: NSObject {
     var blockAllAlerts: Bool = false
     private(set) var type: TabType = .regular
     
+    var redirectURLs = [URL]()
+    
     var isPrivate: Bool {
         return type.isPrivate
     }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -428,16 +428,6 @@ extension URL {
         return nil
     }
     
-    // This is a helper function for determining wetherr the url is a Media URL
-    // as handled in Rewards lib.
-    public var isMediaSiteURL: Bool {
-        // Don't need to include Github as it does a page load instead of XHR load.
-        guard let domain = self.baseDomain else {
-            return true
-        }
-        return ["youtube", "vimeo", "twitch", "twitter", "reddit"].contains(where: domain.contains)
-    }
-    
     // Check if the website is a video streaming content site used inside product notifications
     public var isVideoSteamingSiteURL: Bool {
         guard let domain = self.baseDomain else {

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -638,34 +638,6 @@ class NSURLExtensionsTests: XCTestCase {
         }
     }
     
-    func testMediaSiteURL() {
-        let goodURLs = [
-            "https://www.youtube.com",
-            "https://www.vimeo.com",
-            "https://m.youtube.com",
-            "https://m.twitch.tv",
-            "https://www.twitch.tv"
-        ]
-        
-        let badURLs = [
-            "https://youtube.xyz.com",
-            "https://www.google.com",
-            "https://www.you.tube.com"
-        ]
-        
-        func getURL(url: String) -> URL? {
-            return URL(string: url)
-        }
-        
-        goodURLs.forEach {
-            XCTAssertTrue(getURL(url: $0)?.isMediaSiteURL ?? true, "failed for \($0)")
-        }
-        
-        badURLs.forEach {
-            XCTAssertFalse((getURL(url: $0)?.isMediaSiteURL) ?? false, "failed for \($0)")
-        }
-    }
-    
     func testVideoSteamingSiteURL() {
         let streamingSiteURLs = [
             "https://www.youtube.com",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3814 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Confirm when loading a webpage the most recent url in the redirect change is processed for purchase intent
- Confirm when loading a webpage the page content is classified (including all pages for single page applications)
- Confirm ads transfer (land) after clicking an ad and waiting for ~10 seconds (match the URL against the original URL, i.e. first URL in the redirect chain)
- Confirm ads conversions work as expected (matching the pattern against all URLs in the redirect chain)

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
