### PR TITLE
Fix #4045: Correct pull to refresh ordering in general settings section

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -251,6 +251,12 @@ class SettingsViewController: TableViewController {
             )
         }
         
+        general.rows.append(
+            .boolRow(title: Strings.enablePullToRefresh,
+                     option: Preferences.General.enablePullToRefresh,
+                     image: #imageLiteral(resourceName: "settings-pull-to-refresh").template)
+        )
+        
         if AppConstants.iOSVersionGreaterThanOrEqual(to: 14) && AppConstants.buildChannel == .release {
             general.rows.append(.init(text: Strings.setDefaultBrowserSettingsCell, selection: { [unowned self] in
                 guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
@@ -259,12 +265,6 @@ class SettingsViewController: TableViewController {
                 UIApplication.shared.open(settingsUrl)
             }, cellClass: MultilineButtonCell.self))
         }
-        
-        general.rows.append(
-            .boolRow(title: Strings.enablePullToRefresh,
-                     option: Preferences.General.enablePullToRefresh,
-                     image: #imageLiteral(resourceName: "settings-pull-to-refresh").template)
-        )
 
         return general
     }()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4045

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Verify that the default browser button is the final item in that section

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
