### PR TITLE
Fix #4065: Remove History Migration Error Pop-Up

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -2190,14 +2190,6 @@ extension Strings {
                               value: "Failed to migrate bookmarks. Please try again later.",
                               comment: "Message for popup when the bookmark migration fails")
         /// History Migration localization text
-        public static let historyMigrationErrorTitle =
-            NSLocalizedString("sync.historyMigrationErrorTitle", tableName: "BraveShared", bundle: .braveShared,
-                              value: "Migration (almost) complete",
-                              comment: "The title for popup when the history migration fails")
-        public static let historyMigrationErrorMessage =
-            NSLocalizedString("sync.historyMigrationErrorMessage", tableName: "BraveShared", bundle: .braveShared,
-                              value: "Most history migrated. However, a few pages weren’t due to missing page info.",
-                              comment: "Message for popup when the history migration fails")
         public static let syncConfigurationInformationText =
             NSLocalizedString("sync.syncConfigurationInformationText", tableName: "BraveShared", bundle: .braveShared,
                               value: "Manage what information you would like to sync between devices. These settings only affect this device.",

--- a/Client/Frontend/Browser/BrowserViewController/Sync/BrowserViewController+CoreMigration.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Sync/BrowserViewController+CoreMigration.swift
@@ -20,7 +20,7 @@ extension BrowserViewController {
         // We stop ever attempting migration after 3 times.
         if Preferences.Chromium.syncV2ObjectMigrationCount.value < 3 {
             self.migrateToSyncObjects { error in
-                if let error = error {
+                if let error = error, error == .failedBookmarksMigration {
                     DispatchQueue.main.async {
                         let alert = UIAlertController(title: error.failureReason,
                                                       message: error.localizedDescription,

--- a/Client/Frontend/Sync/BraveCore/BraveCoreMigrator.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveCoreMigrator.swift
@@ -29,22 +29,12 @@ class BraveCoreMigrator {
         case failedBookmarksMigration
         case failedHistoryMigration
         
-        public var failureReason: String? {
-            switch self {
-                case .failedBookmarksMigration:
-                    return Strings.Sync.v2MigrationErrorTitle
-                case .failedHistoryMigration:
-                    return Strings.Sync.historyMigrationErrorTitle
-            }
+        public var failureReason: String {
+            return Strings.Sync.v2MigrationErrorTitle
         }
         
-        public var errorDescription: String? {
-            switch self {
-            case .failedBookmarksMigration:
-                return Strings.Sync.v2MigrationErrorMessage
-            case .failedHistoryMigration:
-                return Strings.Sync.historyMigrationErrorMessage
-            }
+        public var errorDescription: String {
+            return Strings.Sync.v2MigrationErrorMessage
         }
     }
     


### PR DESCRIPTION
Removing Error-Pop up for rare migration cases for history.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4065

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
