### PR TITLE
Fix #4071: Don't share canonical URL unless base domains differ

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -69,6 +69,20 @@ class Tab: NSObject {
         }
         return self.url
     }
+    
+    /// The URL that should be shared when requested by the user via the share sheet
+    ///
+    /// If the canonical URL of the page points to a different base domain entirely, this will result in
+    /// sharing the canonical URL. This is to ensure pages such as Google's AMP share the correct URL while
+    /// also ensuring single page applications which don't update their canonical URLs on navigation share
+    /// the current pages URL
+    var shareURL: URL? {
+        guard let url = url else { return nil }
+        if let canonicalURL = canonicalURL, canonicalURL.baseDomain != url.baseDomain {
+            return canonicalURL
+        }
+        return url
+    }
 
     var userActivity: NSUserActivity?
 

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -26,7 +26,7 @@ class ShareExtensionHelper: NSObject {
 //    fileprivate func isFile(url: URL) -> Bool { url.scheme == "file" }
 
     init(url: URL, tab: Tab?) {
-        self.selectedURL = tab?.canonicalURL?.displayURL ?? url
+        self.selectedURL = tab?.shareURL?.displayURL ?? url
         self.selectedTab = tab
     }
 


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4071

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit `youtube.com` directly, then visit a video from the home page. Verify that `Share With… > Copy` shares the watch URL
- Go to google.com and search for something that would result in news articles appearing. Switch to the "News" tab results and select an AMP page. Verify that `Share With… > Copy` shares the underlying news article URL and not the Google AMP url

## Screenshots

| YouTube | AMP |
| --- | --- |
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-08-19 at 11 03 44](https://user-images.githubusercontent.com/529104/130092797-4f3e4c2e-092c-4434-9a39-17f255bfef86.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-08-19 at 11 04 22](https://user-images.githubusercontent.com/529104/130092807-97a89316-7055-4f23-8780-882d6a30c0e1.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
