### PR TITLE
Fix #4073: Intermittent Issue while displaying the History when Sync is enabled

### DIFF
--- a/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
+++ b/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
@@ -564,9 +564,12 @@ extension UIImageView {
     func loadFavicon(for siteURL: URL,
                      domain: Domain? = nil,
                      fallbackMonogramCharacter: Character? = nil,
+                     shouldClearMonogramFavIcon: Bool = true,
                      cachedOnly: Bool = false,
                      completion: (() -> Void)? = nil) {
-        clearMonogramFavicon()
+        if shouldClearMonogramFavIcon {
+            clearMonogramFavicon()
+        }
         faviconFetcher = FaviconFetcher(siteURL: siteURL, kind: .favicon, domain: domain)
         faviconFetcher?.load(cachedOnly) { [weak self] _, attributes in
             guard let self = self,
@@ -574,6 +577,10 @@ extension UIImageView {
                   !cancellable.isCancelled  else {
                 completion?()
                 return
+            }
+            
+            if !shouldClearMonogramFavIcon {
+                self.clearMonogramFavicon()
             }
             
             if let image = attributes.image {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -187,6 +187,13 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     }
     
     func configureCell(_ cell: UITableViewCell, atIndexPath indexPath: IndexPath) {
+        // Make sure History at index path exists,
+        // `frc.object(at:)` crashes otherwise, doesn't fail safely with nil
+        if let objectsCount = historyFRC?.fetchedObjectsCount, indexPath.row >= objectsCount {
+            assertionFailure("History FRC index out of bounds")
+            return
+        }
+        
         guard let cell = cell as? TwoLineTableViewCell else { return }
         
         if !tableView.isEditing {
@@ -208,8 +215,13 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             $0.imageView?.layer.cornerCurve = .continuous
             $0.imageView?.layer.masksToBounds = true
             
-            if let url = historyItem.domain?.asURL {
-                cell.imageView?.loadFavicon(for: url)
+            if let domain = historyItem.domain, let url = domain.url?.asURL {
+                cell.imageView?.loadFavicon(
+                    for: url,
+                    domain: domain,
+                    fallbackMonogramCharacter: historyItem.title?.first,
+                    shouldClearMonogramFavIcon: false,
+                    cachedOnly: true)
             } else {
                 cell.imageView?.clearMonogramFavicon()
                 cell.imageView?.image = FaviconFetcher.defaultFaviconImage

--- a/Client/Frontend/Sync/BraveCore/History/HistoryFetchers.swift
+++ b/Client/Frontend/Sync/BraveCore/History/HistoryFetchers.swift
@@ -110,7 +110,7 @@ class Historyv2Fetcher: NSObject, HistoryV2FetchResultsController {
             totalItemIndex += filteredDetails[safe: sectionIndex]?.value ?? 0
         }
 
-        return fetchedObjects?[totalItemIndex + indexPath.row]
+        return fetchedObjects?[safe: totalItemIndex + indexPath.row]
     }
     
     func objectCount(for section: Int) -> Int {

--- a/Client/Frontend/Sync/BraveCore/History/Historyv2.swift
+++ b/Client/Frontend/Sync/BraveCore/History/Historyv2.swift
@@ -69,7 +69,7 @@ class Historyv2: WebsitePresentable {
     }
     
     public var domain: Domain? {
-        return Domain.getOrCreate(forUrl: historyNode.url, persistent: true)
+        return Domain.getOrCreate(forUrl: historyNode.url, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
     }
     
     public var sectionID: Section? {

--- a/Client/Frontend/Sync/BraveCore/History/Historyv2.swift
+++ b/Client/Frontend/Sync/BraveCore/History/Historyv2.swift
@@ -68,8 +68,8 @@ class Historyv2: WebsitePresentable {
         }
     }
     
-    public var domain: String? {
-        historyNode.url.domainURL.absoluteString
+    public var domain: Domain? {
+        return Domain.getOrCreate(forUrl: historyNode.url, persistent: true)
     }
     
     public var sectionID: Section? {


### PR DESCRIPTION
This PR is adding extra checks to History cell configuration in order to prevent any potential crashes while setting the tableview.

In addition loadFavIcon logic is changed in History List so it will be helpful with the flickering of favicons when list tries to refresh itself after a reload notification is fetched.


## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4073

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable History Sync
- Open History Screen from the options menu and check if data is displayed

## Screenshots:

https://user-images.githubusercontent.com/6643505/130099449-bcb9c04b-7c56-4def-8008-c411c56ac233.MP4




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
