### PR TITLE
Fix #4075: Sanitize Device Name while displaying in Sync Settings Screen

### DIFF
--- a/BraveSharedTests/StringExtensionTests.swift
+++ b/BraveSharedTests/StringExtensionTests.swift
@@ -56,4 +56,18 @@ class StringExtensionTests: XCTestCase {
         
         XCTAssertEqual(originalString.javaScriptEscapedString, expectedString)
     }
+    
+    func testHTMLEntityEncodedString(){
+        let testString1 = "Sauron & Saruman's Device"
+        let testString2 = " 1 > 2 < 3"
+        let testString3 = "Brave New World`"
+
+        let expectedString1 = "Sauron &amp; Saruman&#39;s Device"
+        let expectedString2 = " 1 &gt; 2 &lt; 3"
+        let expectedString3 = "Brave New World&lsquo;"
+
+        XCTAssertEqual(testString1.htmlEntityEncodedString, expectedString1)
+        XCTAssertEqual(testString2.htmlEntityEncodedString, expectedString2)
+        XCTAssertEqual(testString3.htmlEntityEncodedString, expectedString3)
+    }
 }

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -107,7 +107,7 @@ class SyncSettingsTableViewController: UITableViewController {
         var title: String?
         var message: String?
         var removeButtonName: String?
-        let deviceName = device.name ?? Strings.syncRemoveDeviceDefaultName
+        let deviceName = device.name?.encodeContaminatedString() ?? Strings.syncRemoveDeviceDefaultName
         
         switch type {
             case .lastDeviceLeft:

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -107,7 +107,7 @@ class SyncSettingsTableViewController: UITableViewController {
         var title: String?
         var message: String?
         var removeButtonName: String?
-        let deviceName = device.name?.encodeContaminatedString() ?? Strings.syncRemoveDeviceDefaultName
+        let deviceName = device.name?.htmlEntityEncodedString ?? Strings.syncRemoveDeviceDefaultName
         
         switch type {
             case .lastDeviceLeft:

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -178,4 +178,21 @@ extension String {
             return nil
         }
     }
+    
+    /// Encode Strings which are not sanitized for displaying
+    /// - Returns: Encoded String
+    public func encodeContaminatedString() -> String {
+        var sanitizedString = self
+        let entityList:[(value: String, replacement: String)] = [(value: "&", replacement: "&amp;"),
+                                                                 (value: "\"", replacement: "&quot;"),
+                                                                 (value: "'", replacement: "&#39;"),
+                                                                 (value: "<", replacement: "&lt;"),
+                                                                 (value: ">", replacement: "&gt;"),
+                                                                 (value: "`", replacement: "&lsquo;")]
+        for entity in entityList {
+            sanitizedString = sanitizedString.replacingOccurrences(of: entity.value, with: entity.replacement)
+        }
+        
+        return sanitizedString
+    }
 }

--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -179,20 +179,16 @@ extension String {
         }
     }
     
-    /// Encode Strings which are not sanitized for displaying
+    /// Encode HTMLStrings
+    /// Also used for Strings which are not sanitized for displaying
     /// - Returns: Encoded String
-    public func encodeContaminatedString() -> String {
-        var sanitizedString = self
-        let entityList:[(value: String, replacement: String)] = [(value: "&", replacement: "&amp;"),
-                                                                 (value: "\"", replacement: "&quot;"),
-                                                                 (value: "'", replacement: "&#39;"),
-                                                                 (value: "<", replacement: "&lt;"),
-                                                                 (value: ">", replacement: "&gt;"),
-                                                                 (value: "`", replacement: "&lsquo;")]
-        for entity in entityList {
-            sanitizedString = sanitizedString.replacingOccurrences(of: entity.value, with: entity.replacement)
-        }
-        
-        return sanitizedString
+    public var htmlEntityEncodedString: String {
+       return self
+        .replacingOccurrences(of: "&", with: "&amp;", options: .literal)
+        .replacingOccurrences(of: "\"", with: "&quot;", options: .literal)
+        .replacingOccurrences(of: "'", with: "&#39;", options: .literal)
+        .replacingOccurrences(of: "<", with: "&lt;", options: .literal)
+        .replacingOccurrences(of: ">", with: "&gt;", options: .literal)
+        .replacingOccurrences(of: "`", with: "&lsquo;", options: .literal)
     }
 }

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -39,7 +39,7 @@ public extension WKWebView {
                 }
             }
             context?.evaluateScript("JSON.parse('\"\($0)\"')")
-            sanitizedArgs.append("'\(String(describing: $0).encodingHTMLEntities())'")
+            sanitizedArgs.append("'\(String(describing: $0).htmlEntityEncodedString)'")
             return
         }
         
@@ -77,17 +77,3 @@ public extension WKWebView {
         }
     }
 }
-
-extension String {
-    /// Encode HTMLStrings
-    fileprivate func encodingHTMLEntities() -> String {
-       return self
-        .replacingOccurrences(of: "&", with: "&amp;", options: .literal)
-        .replacingOccurrences(of: "\"", with: "&quot;", options: .literal)
-        .replacingOccurrences(of: "'", with: "&#39;", options: .literal)
-        .replacingOccurrences(of: "<", with: "&lt;", options: .literal)
-        .replacingOccurrences(of: ">", with: "&gt;", options: .literal)
-        .replacingOccurrences(of: "`", with: "&lsquo;", options: .literal)
-    }
-}
-


### PR DESCRIPTION
Fixes low priority security issue for History Sync PR.
https://github.com/brave/brave-ios/pull/3703#discussion_r682862673

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4075

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
