### PR TITLE
Fix #4068 - Remove pinning certain URLs just like in Brave-Core.

### DIFF
--- a/BraveShared/Analytics/UserReferralProgram.swift
+++ b/BraveShared/Analytics/UserReferralProgram.swift
@@ -18,7 +18,7 @@ public class UserReferralProgram {
     private static let clipboardPrefix = "F83AB73F-9852-4F01-ABA8-7830B8825993"
     
     struct HostUrl {
-        static let staging = "https://laptop-updates-staging.brave.com"
+        static let staging = "https://laptop-updates.bravesoftware.com"
         static let prod = "https://laptop-updates.brave.com"
     }
     

--- a/BraveShared/CertificatePinning.swift
+++ b/BraveShared/CertificatePinning.swift
@@ -12,7 +12,7 @@ private let log = Logger.browserLogger
 public class PinningCertificateEvaluator: NSObject, URLSessionDelegate {
     struct ExcludedPinningHostUrls {
         static let urls = ["laptop-updates.brave.com",
-                           "laptop-updates-staging.brave.com",
+                           "laptop-updates.bravesoftware.com",
                            "updates.bravesoftware.com",
                            "updates-cdn.bravesoftware.com"]
     }

--- a/BraveShared/CertificatePinning.swift
+++ b/BraveShared/CertificatePinning.swift
@@ -11,7 +11,10 @@ private let log = Logger.browserLogger
 
 public class PinningCertificateEvaluator: NSObject, URLSessionDelegate {
     struct ExcludedPinningHostUrls {
-        static let urls = ["laptop-updates.brave.com", "laptop-updates-staging.brave.com", "updates.bravesoftware.com", "updates-cdn.bravesoftware.com"]
+        static let urls = ["laptop-updates.brave.com",
+                           "laptop-updates-staging.brave.com",
+                           "updates.bravesoftware.com",
+                           "updates-cdn.bravesoftware.com"]
     }
     
     private let hosts: [String]

--- a/BraveShared/CertificatePinning.swift
+++ b/BraveShared/CertificatePinning.swift
@@ -10,6 +10,10 @@ private let log = Logger.browserLogger
 // Taken from: https://github.com/Brandon-T/Jarvis and modified to simplify
 
 public class PinningCertificateEvaluator: NSObject, URLSessionDelegate {
+    struct ExcludedPinningHostUrls {
+        static let urls = ["laptop-updates.brave.com", "laptop-updates-staging.brave.com", "updates.bravesoftware.com", "updates-cdn.bravesoftware.com"]
+    }
+    
     private let hosts: [String]
     private let certificates: [SecCertificate]
     private let options: PinningOptions
@@ -46,6 +50,10 @@ public class PinningCertificateEvaluator: NSObject, URLSessionDelegate {
             if let serverTrust = challenge.protectionSpace.serverTrust {
                 do {
                     let host = challenge.protectionSpace.host
+                    if ExcludedPinningHostUrls.urls.contains(host) {
+                        return completionHandler(.performDefaultHandling, nil)
+                    }
+                    
                     if !canPinHost(host) {
                         throw error(reason: "Host not specified for pinning: \(host)")
                     }

--- a/BraveShared/CertificatePinning.swift
+++ b/BraveShared/CertificatePinning.swift
@@ -12,7 +12,6 @@ private let log = Logger.browserLogger
 public class PinningCertificateEvaluator: NSObject, URLSessionDelegate {
     struct ExcludedPinningHostUrls {
         static let urls = ["laptop-updates.brave.com",
-                           "laptop-updates.bravesoftware.com",
                            "updates.bravesoftware.com",
                            "updates-cdn.bravesoftware.com"]
     }

--- a/BraveShared/Shields/WebcompatReporter.swift
+++ b/BraveShared/Shields/WebcompatReporter.swift
@@ -10,7 +10,7 @@ private let log = Logger.browserLogger
 
 public class WebcompatReporter {
     private struct BaseURL {
-        static let staging = "laptop-updates-staging.brave.com"
+        static let staging = "laptop-updates.bravesoftware.com"
         static let prod = "laptop-updates.brave.com"
     }
     

--- a/BraveSharedTests/CertificatePinningTest.swift
+++ b/BraveSharedTests/CertificatePinningTest.swift
@@ -133,4 +133,78 @@ class CertificatePinningTest: XCTestCase {
             XCTFail("Validation failed but should have succeeded: \(error)")
         }
     }
+    
+    // Test whether or not exception URLs are NOT pinned!
+    func testLivePinningSuccess() {
+        let urls = PinningCertificateEvaluator.ExcludedPinningHostUrls.urls.map({ "https://\($0)" })
+        
+        var expectations = [XCTestExpectation]()
+        for host in urls {
+            let expectation = XCTestExpectation(description: "Test Pinning Live URLs: \(host)")
+            expectations.append(expectation)
+            
+            guard let hostUrl = URL(string: host),
+                  let normalizedHost = hostUrl.normalizedHost() else {
+                
+                XCTFail("Invalid URL/Host for pinning: \(host)")
+                expectation.fulfill()
+                return
+            }
+            
+            let certificateEvaluator = PinningCertificateEvaluator(hosts: [normalizedHost])
+            let sessionManager = URLSession(configuration: .default, delegate: certificateEvaluator, delegateQueue: .main)
+
+            sessionManager.request(hostUrl, method: .put, parameters: ["unit-test":"unit-value"], encoding: .json) { response in
+                switch response {
+                case .success:
+                    break
+                    
+                case .failure(let error as NSError):
+                    if error.code == NSURLErrorCancelled {
+                        XCTFail("Invalid URL/Host for pinning: \(error) for host: \(host)")
+                    }
+                }
+                
+                expectation.fulfill()
+            }.resume()
+            sessionManager.finishTasksAndInvalidate()
+        }
+        
+        wait(for: expectations, timeout: 10.0)
+    }
+    
+    // Test whether or not pinning actually works on a live URL
+    func testLivePinningFailure() {
+        let urls = ["https://brave.com"]
+        
+        var managers = [URLSession]()
+        var expectations = [XCTestExpectation]()
+        for host in urls {
+            let expectation = XCTestExpectation(description: "Test Pinning Live URLs: \(host)")
+            expectations.append(expectation)
+            
+            guard let hostUrl = URL(string: host),
+                  let normalizedHost = hostUrl.normalizedHost() else {
+                
+                XCTFail("Invalid URL/Host for pinning: \(host)")
+                expectation.fulfill()
+                return
+            }
+            
+            let certificateEvaluator = PinningCertificateEvaluator(hosts: [normalizedHost])
+            let sessionManager = URLSession(configuration: .default, delegate: certificateEvaluator, delegateQueue: .main)
+            managers.append(sessionManager)
+
+            sessionManager.dataTask(with: hostUrl) { data, response, error in
+                if let error = error as NSError?, error.code == NSURLErrorCancelled {
+                    XCTFail("Invalid URL/Host for pinning: \(error) for host: \(host)")
+                }
+                
+                expectation.fulfill()
+            }.resume()
+            sessionManager.finishTasksAndInvalidate()
+        }
+        
+        wait(for: expectations, timeout: 10.0)
+    }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Security ticket https://github.com/brave/security/issues/556

## Summary of Changes
- Removes pinning of: 
```Swift
"laptop-updates.brave.com"
"laptop-updates.bravesoftware.com"  // (URL given in slack channel)
"updates.bravesoftware.com"
"updates-cdn.bravesoftware.com"
```

- Adds unit tests to make sure it works and that pinning still works on live websites.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4068

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
N/A


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
