### PR TITLE
Fix #4092 - Weakify tab references due to memory leak.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -45,11 +45,40 @@ extension BrowserViewController {
                 let vc = DownloadsPanel(profile: self.profile)
                 menuController.pushInnerMenu(vc)
             }
-            MenuItemButton(icon: #imageLiteral(resourceName: "playlist_menu").template, title: Strings.playlistMenuItem) { [unowned self] in
-                let playlistController = (UIApplication.shared.delegate as? AppDelegate)?.playlistRestorationController ?? PlaylistViewController()
-                playlistController.modalPresentationStyle = .fullScreen
-                self.dismiss(animated: true) {
-                    self.present(playlistController, animated: true)
+            MenuItemButton(icon: #imageLiteral(resourceName: "playlist_menu").template, title: Strings.playlistMenuItem) { [weak self] in
+                guard let self = self else { return }
+                
+                let playlistController = (UIApplication.shared.delegate as? AppDelegate)?.playlistRestorationController
+                
+                // Present existing playlist controller
+                if let playlistController = playlistController {
+                    self.dismiss(animated: true) {
+                        self.present(playlistController, animated: true)
+                    }
+                } else {
+                    // Retrieve the item and offset-time from the current tab's webview.
+                    if let item = self.tabManager.selectedTab?.playlistItem,
+                       let webView = self.tabManager.selectedTab?.webView {
+                        
+                        PlaylistHelper.getCurrentTime(webView: webView, nodeTag: item.tagId) { [weak self] currentTime in
+                            guard let self = self else { return }
+                            
+                            let playlistController = PlaylistViewController(initialItem: item, initialItemPlaybackOffset: currentTime)
+                            playlistController.modalPresentationStyle = .fullScreen
+                            
+                            self.dismiss(animated: true) {
+                                self.present(playlistController, animated: true)
+                            }
+                        }
+                    } else {
+                        // Otherwise no item to play, so just open the playlist controller.
+                        let playlistController = PlaylistViewController(initialItem: nil, initialItemPlaybackOffset: 0.0)
+                        playlistController.modalPresentationStyle = .fullScreen
+                        
+                        self.dismiss(animated: true) {
+                            self.present(playlistController, animated: true)
+                        }
+                    }
                 }
             }
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
@@ -61,63 +90,62 @@ extension BrowserViewController {
     }
     
     struct PageActionsMenuSection: View {
-            var browserViewController: BrowserViewController
-            var tabURL: URL
-            var activities: [UIActivity]
-            
-            @State private var playlistItemAdded: Bool = false
-            
-            private var playlistActivity: (enabled: Bool, item: PlaylistInfo?)? {
-                browserViewController.addToPlayListActivityItem ??
-                    browserViewController.openInPlaylistActivityItem
-            }
-            
-            private var isPlaylistItemAdded: Bool {
-                browserViewController.openInPlaylistActivityItem != nil
-            }
-            
-            var body: some View {
-                VStack(alignment: .leading, spacing: 0) {
-                    MenuTabDetailsView(tab: browserViewController.tabManager.selectedTab, url: tabURL)
-                    VStack(spacing: 0) {
-                        if let activity = playlistActivity, activity.enabled, let item = activity.item {
-                            PlaylistMenuButton(isAdded: isPlaylistItemAdded) {
-                                if !isPlaylistItemAdded {
-                                    // Add to playlist
-                                    browserViewController.addToPlaylist(item: item) { didAddItem in
-                                        log.debug("Playlist Item Added")
-                                        if didAddItem {
-                                            playlistItemAdded = true
-                                        }
-                                    }
-                                } else {
-                                    browserViewController.dismiss(animated: true) {
-                                        if let webView = browserViewController.tabManager.selectedTab?.webView {
-                                            PlaylistHelper.getCurrentTime(webView: webView, nodeTag: item.tagId) { [weak browserViewController] currentTime in
-                                                browserViewController?.openPlaylist(item: item, playbackOffset: currentTime)
-                                            }
-                                        } else {
-                                            browserViewController.openPlaylist(item: item, playbackOffset: 0.0)
-                                        }
+        var browserViewController: BrowserViewController
+        var tabURL: URL
+        var activities: [UIActivity]
+        
+        @State private var playlistItemAdded: Bool = false
+        
+        private var playlistActivity: (enabled: Bool, item: PlaylistInfo?)? {
+            browserViewController.addToPlayListActivityItem ??
+                browserViewController.openInPlaylistActivityItem
+        }
+        
+        private var isPlaylistItemAdded: Bool {
+            browserViewController.openInPlaylistActivityItem != nil
+        }
+        
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                MenuTabDetailsView(tab: browserViewController.tabManager.selectedTab, url: tabURL)
+                VStack(spacing: 0) {
+                    if let activity = playlistActivity, activity.enabled, let item = activity.item {
+                        PlaylistMenuButton(isAdded: isPlaylistItemAdded) {
+                            if !isPlaylistItemAdded {
+                                // Add to playlist
+                                browserViewController.addToPlaylist(item: item) { didAddItem in
+                                    log.debug("Playlist Item Added")
+                                    if didAddItem {
+                                        playlistItemAdded = true
                                     }
                                 }
-                            }
-                            .animation(.default, value: playlistItemAdded)
-                        }
-                        MenuItemButton(icon: #imageLiteral(resourceName: "nav-share").template, title: Strings.shareWithMenuItem) {
-                            browserViewController.dismiss(animated: true)
-                            browserViewController.tabToolbarDidPressShare()
-                        }
-                        MenuItemButton(icon: #imageLiteral(resourceName: "menu-add-bookmark").template, title: Strings.addToMenuItem) {
-                            browserViewController.dismiss(animated: true) {
-                                browserViewController.openAddBookmark()
-                            }
-                        }
-                        ForEach(activities, id: \.activityTitle) { activity in
-                            MenuItemButton(icon: activity.activityImage?.template ?? UIImage(), title: activity.activityTitle ?? "") {
+                            } else {
                                 browserViewController.dismiss(animated: true) {
-                                    activity.perform()
+                                    if let webView = browserViewController.tabManager.selectedTab?.webView {
+                                        PlaylistHelper.getCurrentTime(webView: webView, nodeTag: item.tagId) { [weak browserViewController] currentTime in
+                                            browserViewController?.openPlaylist(item: item, playbackOffset: currentTime)
+                                        }
+                                    } else {
+                                        browserViewController.openPlaylist(item: item, playbackOffset: 0.0)
+                                    }
                                 }
+                            }
+                        }
+                        .animation(.default, value: playlistItemAdded)
+                    }
+                    MenuItemButton(icon: #imageLiteral(resourceName: "nav-share").template, title: Strings.shareWithMenuItem) {
+                        browserViewController.dismiss(animated: true)
+                        browserViewController.tabToolbarDidPressShare()
+                    }
+                    MenuItemButton(icon: #imageLiteral(resourceName: "menu-add-bookmark").template, title: Strings.addToMenuItem) {
+                        browserViewController.dismiss(animated: true) {
+                            browserViewController.openAddBookmark()
+                        }
+                    }
+                    ForEach(activities, id: \.activityTitle) { activity in
+                        MenuItemButton(icon: activity.activityImage?.template ?? UIImage(), title: activity.activityTitle ?? "") {
+                            browserViewController.dismiss(animated: true) {
+                                activity.perform()
                             }
                         }
                     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -127,7 +127,7 @@ extension BrowserViewController {
     
     struct MenuTabDetailsView: View {
         @SwiftUI.Environment(\.colorScheme) var colorScheme: ColorScheme
-        var tab: Tab?
+        weak var tab: Tab?
         var url: URL
         
         var body: some View {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -124,37 +124,8 @@ extension BrowserViewController {
                 }
             }
         }
-
-func activitiesMenuSection(_ menuController: MenuViewController, tabURL: URL, activities: [UIActivity]) -> some View {
-VStack(alignment: .leading, spacing: 0) {
-MenuTabDetailsView(tab: tabManager.selectedTab, url: tabURL)
-VStack(spacing: 0) {
-MenuItemButton(icon: #imageLiteral(resourceName: "nav-share").template, title: Strings.shareWithMenuItem) { [weak self] in
-guard let self = self else { return }
-
-self.dismiss(animated: true)
-self.tabToolbarDidPressShare()
-}
-MenuItemButton(icon: #imageLiteral(resourceName: "menu-add-bookmark").template, title: Strings.addToMenuItem) { [weak self] in
-guard let self = self else { return }
-
-self.dismiss(animated: true) {
-self.openAddBookmark()
-}
-}
-ForEach(activities, id: \.activityTitle) { activity in
-MenuItemButton(icon: activity.activityImage?.template ?? UIImage(), title: activity.activityTitle ?? "") { [weak self] in
-guard let self = self else { return }
-
-self.dismiss(animated: true) {
-activity.perform()
-}
-}
-}
-}
-}
-}
-
+    }
+    
     struct MenuTabDetailsView: View {
         @SwiftUI.Environment(\.colorScheme) var colorScheme: ColorScheme
         weak var tab: Tab?

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -80,6 +80,10 @@ class MenuViewController: UINavigationController, UIPopoverPresentationControlle
         fatalError()
     }
     
+    deinit {
+        print("MENU DEALLOCATED")
+    }
+    
     private var previousPreferredContentSize: CGSize?
     func presentInnerMenu(_ viewController: UIViewController,
                           expandToLongForm: Bool = true) {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -80,10 +80,6 @@ class MenuViewController: UINavigationController, UIPopoverPresentationControlle
         fatalError()
     }
     
-    deinit {
-        print("MENU DEALLOCATED")
-    }
-    
     private var previousPreferredContentSize: CGSize?
     func presentInnerMenu(_ viewController: UIViewController,
                           expandToLongForm: Bool = true) {

--- a/Client/Frontend/Share/RequestDesktopSiteActivity.swift
+++ b/Client/Frontend/Share/RequestDesktopSiteActivity.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 
 class RequestDesktopSiteActivity: UIActivity {
-    private let tab: Tab?
+    private weak var tab: Tab?
     fileprivate let callback: () -> Void
 
     init(tab: Tab?, callback: @escaping () -> Void) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Make menu hold a weak-reference to tab.
- Make share activities hold a weak-reference to tab.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4092

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Included in the ticket.

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
