### PR TITLE
Fix #4099 - Fixing bug where error is not shown when an HLS encrypted stream fails to play

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -86,6 +86,14 @@ class PlaylistViewController: UIViewController {
             PlaylistCarplayManager.shared.currentPlaylistItem = nil
         }
         
+        // Simulator cannot "detect" if Car-Play is enabled, therefore we need to STOP playback
+        // When this controller deallocates. The user can still manually resume playback in CarPlay.
+        #if targetEnvironment(simulator)
+        // Stop media playback
+        stop(playerView)
+        PlaylistCarplayManager.shared.currentPlaylistItem = nil
+        #endif
+        
         // If this controller is retained in app-delegate for Picture-In-Picture support
         // then we need to re-attach the player layer
         // and deallocate it.
@@ -396,7 +404,7 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
     }
     
     func displayLoadingResourceError() {
-        let isPrimaryDisplayMode = splitController.displayMode == .primaryOverlay
+        let isPrimaryDisplayMode = splitController.preferredDisplayMode == .primaryOverlay
         if isPrimaryDisplayMode {
             listController.displayLoadingResourceError()
         } else {
@@ -405,7 +413,7 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
     }
     
     func displayExpiredResourceError(item: PlaylistInfo) {
-        let isPrimaryDisplayMode = splitController.displayMode == .primaryOverlay
+        let isPrimaryDisplayMode = splitController.preferredDisplayMode == .primaryOverlay
         if isPrimaryDisplayMode {
             listController.displayExpiredResourceError(item: item)
         } else {


### PR DESCRIPTION
## Summary of Changes
- Fixes a bug where HLS stream is encrypted and doesn't play due to server misconfiguration
- Fixes CarPlay for simulator so if you kill the playlist controller, it stops playing instead of keeps playing and having to manually stop it.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4099

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
