### PR TITLE
Fix #4098 - Added playlist menu preference for badge icon.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1204,17 +1204,17 @@ extension Strings {
                               value: "This will delete the media from offline storage. Are you sure you want to continue?",
                               comment: "Message for the alert shown when the user tries to remove offline data of an item from playlist")
         
-        public static let playlistToastShowSettingsOptionTitle =
-            NSLocalizedString("playlist.playlistToastShowSettingsOptionTitle",
+        public static let menuBadgeOptionTitle =
+            NSLocalizedString("playlist.menuBadgeOptionTitle",
                               bundle: .braveShared,
-                              value: "Show \"Add to Brave Playlist\"",
-                              comment: "Title for the Playlist Settings Option for Enable/Disable Add Toast")
+                              value: "Show Menu Notification Badge",
+                              comment: "Title for playlist menu badge option")
         
-        public static let playlistToastShowSettingsOptionFooterText =
-            NSLocalizedString("playlist.playlistToastShowSettingsOptionFooterText",
+        public static let menuBadgeOptionFooterText =
+            NSLocalizedString("playlist.menuBadgeOptionFooterText",
                               bundle: .braveShared,
-                              value: "When enabled, a bar will automatically show on most media websites making it easier to add those video/audio files to your Playlist.",
-                              comment: "Footer Text for the Playlist Settings Option for Enable/Disable Add Toast")
+                              value: "When enabled, a badge will be displayed on the main menu icon, indicating media on the page may be added to Brave Playlist.",
+                              comment: "Description footer for playlist menu badge option")
         
         public static let playlistLongPressSettingsOptionTitle =
             NSLocalizedString("playlist.playlistLongPressSettingsOptionTitle",
@@ -1413,18 +1413,6 @@ extension Strings {
                               bundle: .braveShared,
                               value: "Brave Playlist",
                               comment: "The title of the playlist when in Carplay mode")
-        
-        public static let menuBadgeOptionTitle =
-            NSLocalizedString("playlist.",
-                              bundle: .braveShared,
-                              value: "Show Menu Notification Badge",
-                              comment: "Title for playlist menu badge option")
-        
-        public static let menuBadgeOptionFooterText =
-            NSLocalizedString("playlist.",
-                              bundle: .braveShared,
-                              value: "When enabled, a badge will be displayed on the main menu icon, indicating media on the page may be added to Brave Playlist.",
-                              comment: "Description footer for playlist menu badge option")
     }
 }
 

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1413,6 +1413,18 @@ extension Strings {
                               bundle: .braveShared,
                               value: "Brave Playlist",
                               comment: "The title of the playlist when in Carplay mode")
+        
+        public static let menuBadgeOptionTitle =
+            NSLocalizedString("playlist.",
+                              bundle: .braveShared,
+                              value: "Show Menu Notification Badge",
+                              comment: "Title for playlist menu badge option")
+        
+        public static let menuBadgeOptionFooterText =
+            NSLocalizedString("playlist.",
+                              bundle: .braveShared,
+                              value: "When enabled, a badge will be displayed on the main menu icon, indicating media on the page may be added to Brave Playlist.",
+                              comment: "Description footer for playlist menu badge option")
     }
 }
 

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -269,6 +269,9 @@ extension Preferences {
         /// The option to disable long-press-to-add-to-playlist gesture.
         static let enableLongPressAddToPlaylist =
             Option<Bool>(key: "playlist.longPressAddToPlaylist", default: true)
+        /// The option to enable or disable the 3-dot menu badge for playlist
+        static let enablePlaylistMenuBadge =
+            Option<Bool>(key: "playlist.enablePlaylistMenuBadge", default: true)
     }
 }
 

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -250,8 +250,6 @@ extension Preferences {
     final class Playlist {
         /// The Option to show video list left or right side
         static let listViewSide = Option<String>(key: "playlist.listViewSide", default: PlayListSide.left.rawValue)
-        /// Whether to show Add to playlist Toast
-        static let showToastForAdd = Option<Bool>(key: "playlist.showToastForAdd", default: true)
         /// The count of how many times  Add to Playlist URL-Bar onboarding has been shown
         static let addToPlaylistURLBarOnboardingCount = Option<Int>(key: "playlist.addToPlaylistURLBarOnboardingCount", default: 0)
         /// The last played item url

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -367,6 +367,7 @@ class BrowserViewController: UIViewController {
         Preferences.Privacy.blockAllCookies.observe(from: self)
         Preferences.Rewards.hideRewardsIcon.observe(from: self)
         Preferences.Rewards.rewardsToggledOnce.observe(from: self)
+        Preferences.Playlist.enablePlaylistMenuBadge.observe(from: self)
         rewardsEnabledObserveration = rewards.observe(\.isEnabled, options: [.new]) { [weak self] _, _ in
             guard let self = self else { return }
             self.updateRewardsButtonState()
@@ -2854,6 +2855,11 @@ extension BrowserViewController: PreferencesObserver {
                 $0.userScriptManager?.isMediaBackgroundPlaybackEnabled = Preferences.General.mediaAutoBackgrounding.value
                 $0.webView?.reload()
             }
+        case Preferences.Playlist.enablePlaylistMenuBadge.key:
+            let selectedTab = tabManager.selectedTab
+            updatePlaylistURLBar(tab: selectedTab,
+                                 state: selectedTab?.playlistItemState ?? .none,
+                                 item: selectedTab?.playlistItem)
         default:
             log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
             break

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -33,8 +33,13 @@ extension BrowserViewController: PlaylistHelperDelegate {
                 toolbar?.menuButton.removeBadge(.playlist, animated: true)
             case .newItem:
                 playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addToPlaylist : .none
-                topToolbar.menuButton.addBadge(.playlist, animated: true)
-                toolbar?.menuButton.addBadge(.playlist, animated: true)
+                if Preferences.Playlist.enablePlaylistMenuBadge.value {
+                    topToolbar.menuButton.addBadge(.playlist, animated: true)
+                    toolbar?.menuButton.addBadge(.playlist, animated: true)
+                } else {
+                    topToolbar.menuButton.removeBadge(.playlist, animated: true)
+                    toolbar?.menuButton.removeBadge(.playlist, animated: true)
+                }
             case .existingItem:
                 playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addedToPlaylist : .none
                 topToolbar.menuButton.removeBadge(.playlist, animated: true)

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -49,8 +49,7 @@ extension BrowserViewController: PlaylistHelperDelegate {
     }
     
     func showPlaylistPopover(tab: Tab?, state: PlaylistPopoverState) {
-        guard Preferences.Playlist.showToastForAdd.value,
-              let selectedTab = tabManager.selectedTab,
+        guard let selectedTab = tabManager.selectedTab,
               tab == selectedTab else {
             return
         }

--- a/Client/Frontend/Settings/PlaylistSettingsViewController.swift
+++ b/Client/Frontend/Settings/PlaylistSettingsViewController.swift
@@ -66,10 +66,9 @@ class PlaylistSettingsViewController: TableViewController {
         dataSource.sections = [
             Section(
                 rows: [
-                    .boolRow(title: Strings.PlayList.playlistToastShowSettingsOptionTitle,
-                             option: Preferences.Playlist.showToastForAdd),
+                    .boolRow(title: Strings.PlayList.menuBadgeOptionTitle, option: Preferences.Playlist.enablePlaylistMenuBadge),
                 ],
-                footer: .title(Strings.PlayList.playlistToastShowSettingsOptionFooterText)
+                footer: .title(Strings.PlayList.menuBadgeOptionFooterText)
             ),
             Section(
                 rows: [
@@ -77,12 +76,6 @@ class PlaylistSettingsViewController: TableViewController {
                              option: Preferences.Playlist.enableLongPressAddToPlaylist),
                 ],
                 footer: .title(Strings.PlayList.playlistLongPressSettingsOptionFooterText)
-            ),
-            Section(
-                rows: [
-                    .boolRow(title: Strings.PlayList.menuBadgeOptionTitle, option: Preferences.Playlist.enablePlaylistMenuBadge),
-                ],
-                footer: .title(Strings.PlayList.menuBadgeOptionFooterText)
             ),
             Section(
                 rows: [

--- a/Client/Frontend/Settings/PlaylistSettingsViewController.swift
+++ b/Client/Frontend/Settings/PlaylistSettingsViewController.swift
@@ -80,6 +80,12 @@ class PlaylistSettingsViewController: TableViewController {
             ),
             Section(
                 rows: [
+                    .boolRow(title: Strings.PlayList.menuBadgeOptionTitle, option: Preferences.Playlist.enablePlaylistMenuBadge),
+                ],
+                footer: .title(Strings.PlayList.menuBadgeOptionFooterText)
+            ),
+            Section(
+                rows: [
                     .boolRow(title: Strings.PlayList.playlistAutoPlaySettingsOptionTitle,
                              option: Preferences.Playlist.firstLoadAutoPlay)
                 ],


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Adds a preference to allow users to enable or disable the playlist badge icon on the 3-dot menu.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4098

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Visit `youtube.com` or any video site.
2. Make sure do NOT add current video item to playlist.
3. Notice 3-dot menu has a playlist icon badge on it.
4. Disable the preference from `Settings -> Playlist -> Show Menu Notification Badge`.
5. Notice 3-dot menu badge is gone.
6. Enable the preference from `Settings -> Playlist -> Show Menu Notification Badge`.
7. Notice the 3-dot menu badge is showing again.


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
