### PR TITLE
Fix # 4111 - Playlist delete item and live stream playback.

### DIFF
--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -13,6 +13,62 @@ private let log = Logger.browserLogger
 
 extension BrowserViewController: PlaylistHelperDelegate {
     
+    private func createPlaylistPopover(tab: Tab?, state: PlaylistPopoverState) -> PopoverController {
+        return PopoverController(contentController: PlaylistPopoverViewController(state: state).then {
+            $0.rootView.onPrimaryButtonPressed = { [weak self, weak tab] in
+                guard let self = self,
+                      let selectedTab = tab,
+                      let item = selectedTab.playlistItem else { return }
+                
+                switch state {
+                case .addToPlaylist:
+                    // Dismiss popover
+                    UIImpactFeedbackGenerator(style: .medium).bzzt()
+                    self.dismiss(animated: true, completion: nil)
+                    
+                    // Update playlist with new items.
+                    self.addToPlaylist(item: item) { [weak self] didAddItem in
+                        guard let self = self else { return }
+                        
+                        if didAddItem {
+                            self.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
+                        }
+                    }
+                    
+                case .addedToPlaylist:
+                    // Dismiss popover
+                    UIImpactFeedbackGenerator(style: .medium).bzzt()
+                    
+                    self.dismiss(animated: true) {
+                        DispatchQueue.main.async {
+                            if let webView = tab?.webView {
+                                PlaylistHelper.getCurrentTime(webView: webView, nodeTag: item.tagId) { [weak self] currentTime in
+                                    self?.openPlaylist(item: item, playbackOffset: currentTime)
+                                }
+                            } else {
+                                self.openPlaylist(item: item, playbackOffset: 0.0)
+                            }
+                        }
+                    }
+                }
+            }
+            
+            $0.rootView.onSecondaryButtonPressed = { [weak tab] in
+                guard let selectedTab = tab,
+                      let item = selectedTab.playlistItem else { return }
+                UIImpactFeedbackGenerator(style: .medium).bzzt()
+                
+                self.dismiss(animated: true)
+                
+                DispatchQueue.main.async {
+                    if PlaylistManager.shared.delete(item: item) {
+                        self.updatePlaylistURLBar(tab: tab, state: .newItem, item: item)
+                    }
+                }
+            }
+        })
+    }
+    
     func updatePlaylistURLBar(tab: Tab?, state: PlaylistItemAddedState, item: PlaylistInfo?) {
         // `tab` is nil when closed, along with the `.none` state and nil `item`
         guard let tab = tab else { return }
@@ -50,83 +106,30 @@ extension BrowserViewController: PlaylistHelperDelegate {
     
     func showPlaylistPopover(tab: Tab?, state: PlaylistPopoverState) {
         guard let selectedTab = tabManager.selectedTab,
-              tab == selectedTab else {
+              tab == selectedTab,
+              let playlistItem = selectedTab.playlistItem else {
             return
         }
         
         if state == .addToPlaylist {
-            if !shouldShowPlaylistOnboardingThisSession {
-                if let item = selectedTab.playlistItem {
-                    UIImpactFeedbackGenerator(style: .medium).bzzt()
+            UIImpactFeedbackGenerator(style: .medium).bzzt()
+            
+            // Update playlist with new items.
+            self.addToPlaylist(item: playlistItem) { [weak self] didAddItem in
+                guard let self = self else { return }
+                
+                if didAddItem {
+                    self.updatePlaylistURLBar(tab: tab, state: .existingItem, item: playlistItem)
                     
-                    // Update playlist with new items.
-                    self.addToPlaylist(item: item) { [weak self] didAddItem in
-                        guard let self = self else { return }
-                        
-                        if didAddItem {
-                            self.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
-                            
-                            DispatchQueue.main.async {
-                                self.showPlaylistPopover(tab: tab, state: .addedToPlaylist)
-                            }
-                        }
+                    DispatchQueue.main.async {
+                        self.showPlaylistPopover(tab: tab, state: .addedToPlaylist)
                     }
                 }
-                return
             }
+            return
         }
         
-        let popover = PopoverController(contentController: PlaylistPopoverViewController(state: state).then {
-            $0.rootView.onPrimaryButtonPressed = { [weak self] in
-                guard let self = self,
-                      let item = selectedTab.playlistItem else { return }
-                
-                switch state {
-                case .addToPlaylist:
-                    // Dismiss popover
-                    UIImpactFeedbackGenerator(style: .medium).bzzt()
-                    self.dismiss(animated: true, completion: nil)
-                    
-                    // Update playlist with new items.
-                    self.addToPlaylist(item: item) { [weak self] didAddItem in
-                        guard let self = self else { return }
-                        
-                        if didAddItem {
-                            self.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
-                        }
-                    }
-                    
-                case .addedToPlaylist:
-                    // Dismiss popover
-                    UIImpactFeedbackGenerator(style: .medium).bzzt()
-                    
-                    self.dismiss(animated: true) {
-                        DispatchQueue.main.async {
-                            if let webView = tab?.webView {
-                                PlaylistHelper.getCurrentTime(webView: webView, nodeTag: item.tagId) { [weak self] currentTime in
-                                    self?.openPlaylist(item: item, playbackOffset: currentTime)
-                                }
-                            } else {
-                                self.openPlaylist(item: item, playbackOffset: 0.0)
-                            }
-                        }
-                    }
-                }
-            }
-            
-            $0.rootView.onSecondaryButtonPressed = {
-                guard let item = selectedTab.playlistItem else { return }
-                UIImpactFeedbackGenerator(style: .medium).bzzt()
-                
-                self.dismiss(animated: true)
-                
-                DispatchQueue.main.async {
-                    if PlaylistManager.shared.delete(item: item) {
-                        self.updatePlaylistURLBar(tab: tab, state: .newItem, item: item)
-                    }
-                }
-            }
-        })
+        let popover = createPlaylistPopover(tab: tab, state: state)
         popover.present(from: topToolbar.locationView.playlistButton, on: self)
     }
     
@@ -227,7 +230,9 @@ extension BrowserViewController: PlaylistHelperDelegate {
         if shouldShowOnboarding {
             if Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value < 2 && shouldShowPlaylistOnboardingThisSession {
                 Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value += 1
-                showPlaylistPopover(tab: tab, state: .addToPlaylist)
+                
+                let popover = createPlaylistPopover(tab: tab, state: .addToPlaylist)
+                popover.present(from: topToolbar.locationView.playlistButton, on: self)
             }
             
             shouldShowPlaylistOnboardingThisSession = false

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -482,7 +482,7 @@ extension PlaylistCarplayController {
             }
             
             // Attempt to play the stream
-            if let url = URL(string: item.pageSrc) {
+            if let url = URL(string: item.src) {
                 self.load(url: url, autoPlayEnabled: true)
                 .handleEvents(receiveCancel: {
                     PlaylistMediaStreamer.clearNowPlayingInfo()

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
@@ -76,7 +76,7 @@ extension PlaylistListViewController: UITableViewDataSource {
                 }
                 return nil
             }
-        } else {
+        } else if trackStatus != .loading {
             log.debug("AVAsset.statusOfValue not loaded. Status: \(trackStatus)")
         }
         
@@ -99,7 +99,7 @@ extension PlaylistListViewController: UITableViewDataSource {
                 completion(asset.duration.seconds, asset)
                 return nil
             }
-        } else {
+        } else if durationStatus != .loading {
             log.debug("AVAsset.statusOfValue not loaded. Status: \(durationStatus)")
         }
         

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -81,10 +81,10 @@ class PlaylistViewController: UIViewController {
         player.pictureInPictureController?.stopPictureInPicture()
         
         // Stop media playback
-        if !PlaylistCarplayManager.shared.isCarPlayAvailable {
-            stop(playerView)
-            PlaylistCarplayManager.shared.currentPlaylistItem = nil
-        }
+        #if targetEnvironment(simulator)
+        stop(playerView)
+        PlaylistCarplayManager.shared.currentPlaylistItem = nil
+        #endif
         
         // If this controller is retained in app-delegate for Picture-In-Picture support
         // then we need to re-attach the player layer
@@ -775,7 +775,7 @@ extension PlaylistViewController: VideoViewDelegate {
             }
             
             // Attempt to play the stream
-            if let url = URL(string: item.pageSrc) {
+            if let url = URL(string: item.src) {
                 self.load(self.playerView,
                           url: url,
                           autoPlayEnabled: self.listController.autoPlayEnabled)

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -26,7 +26,19 @@ class PlaylistCarplayManager: NSObject {
     var browserController: BrowserViewController?
     
     // When Picture-In-Picture is enabled, we need to store a reference to the controller to keep it alive, otherwise if it deallocates, the system automatically kills Picture-In-Picture.
-    var playlistController: PlaylistViewController?
+    var playlistController: PlaylistViewController? {
+        didSet {
+            let selectedTab = browserController?.tabManager.selectedTab
+            if let selectedTab = selectedTab,
+               let playlistItem = selectedTab.playlistItem,
+               PlaylistManager.shared.index(of: playlistItem.pageSrc) == nil {
+                
+                browserController?.updatePlaylistURLBar(tab: selectedTab,
+                                                        state: .newItem,
+                                                        item: playlistItem)
+            }
+        }
+    }
     
     // There can only ever be one instance of this class
     // Because there can only be a single AudioSession and MediaPlayer

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
@@ -158,7 +158,8 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
     
     func localAsset(for pageSrc: String) -> AVURLAsset? {
         guard let item = PlaylistItem.getItem(pageSrc: pageSrc),
-              let cachedData = item.cachedData else { return nil }
+              let cachedData = item.cachedData,
+              !cachedData.isEmpty else { return nil }
 
         var bookmarkDataIsStale = false
         do {

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -242,7 +242,8 @@ class PlaylistManager: NSObject {
         cancelDownload(item: item)
         
         if let cacheItem = PlaylistItem.getItem(pageSrc: item.pageSrc),
-           let cachedData = cacheItem.cachedData {
+           let cachedData = cacheItem.cachedData,
+           !cachedData.isEmpty {
             var isStale = false
             
             do {

--- a/Client/Frontend/Browser/Playlist/Utilities/PlaylistThumbnailUtility.swift
+++ b/Client/Frontend/Browser/Playlist/Utilities/PlaylistThumbnailUtility.swift
@@ -92,7 +92,7 @@ public class PlaylistThumbnailRenderer {
     }
     
     private func loadAssetThumbnail(url: URL, completion: @escaping (UIImage?) -> Void) {
-        let time = CMTime(seconds: timeout, preferredTimescale: CMTimeScale(1))
+        let time = CMTimeMakeWithSeconds(timeout, preferredTimescale: 1)
         assetGenerator = AVAssetImageGenerator(asset: AVAsset(url: url))
         assetGenerator?.appliesPreferredTrackTransform = false
         assetGenerator?.generateCGImagesAsynchronously(forTimes: [NSValue(time: time)]) { _, cgImage, _, result, error in
@@ -179,7 +179,7 @@ private class HLSThumbnailGenerator {
 
     private func generateThumbnail(at time: TimeInterval) {
         queue.async {
-            let time = CMTime(seconds: time, preferredTimescale: 1)
+            let time = CMTimeMakeWithSeconds(time, preferredTimescale: 1)
             self.player?.seek(to: time) { [weak self] finished in
                 guard let self = self else { return }
                 

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -208,7 +208,10 @@ class MediaPlayer: NSObject {
             }
             
             let absoluteTime = CMTimeMakeWithSeconds(seekTime, preferredTimescale: currentItem.currentTime().timescale)
-            player.seek(to: absoluteTime, toleranceBefore: .zero, toleranceAfter: .zero)
+            
+            // Seeking to .zero, .zero can cause a performance hit
+            // So give a nice tolerance to seeking
+            player.seek(to: absoluteTime, toleranceBefore: .positiveInfinity, toleranceAfter: .positiveInfinity)
             
             seekBackwardSubscriber.send(EventNotification(mediaPlayer: self, event: .seekBackward))
         }
@@ -221,7 +224,10 @@ class MediaPlayer: NSObject {
 
             if seekTime < (currentItem.duration.seconds - seekInterval) {
                 let absoluteTime = CMTimeMakeWithSeconds(seekTime, preferredTimescale: currentItem.currentTime().timescale)
-                player.seek(to: absoluteTime, toleranceBefore: .zero, toleranceAfter: .zero)
+                
+                // Seeking to .zero, .zero can cause a performance hit
+                // So give a nice tolerance to seeking
+                player.seek(to: absoluteTime, toleranceBefore: .positiveInfinity, toleranceAfter: .positiveInfinity)
                 
                 seekForwardSubscriber.send(EventNotification(mediaPlayer: self, event: .seekForward))
             }
@@ -240,7 +246,10 @@ class MediaPlayer: NSObject {
             }
             
             let absoluteTime = CMTimeMakeWithSeconds(seekTime, preferredTimescale: currentItem.currentTime().timescale)
-            player.seek(to: absoluteTime, toleranceBefore: .zero, toleranceAfter: .zero)
+            
+            // Seeking to .zero, .zero can cause a performance hit
+            // So give a nice tolerance to seeking
+            player.seek(to: absoluteTime, toleranceBefore: .positiveInfinity, toleranceAfter: .positiveInfinity)
             
             self.changePlaybackPositionSubscriber.send(EventNotification(mediaPlayer: self,
                                                                          event: .changePlaybackPosition))

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -41,7 +41,7 @@ window.__firefox__.includeOnce("Playlist", function() {
         // UUID string format generated with array appending
         // Results in "10000000-1000-4000-8000-100000000000".replace(...)
         return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, (X) => {
-            (X ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (X >> 2)))).toString(16)
+            return (X ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (X >> 2)))).toString(16);
         });
     }
     

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -107,7 +107,12 @@ final public class PlaylistItem: NSManagedObject, CRUD {
     public static func updateCache(pageSrc: String, cachedData: Data?) {
         DataController.perform(context: .new(inMemory: false), save: true) { context in
             let item = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@", pageSrc), context: context)
-            item?.cachedData = cachedData
+            
+            if let cachedData = cachedData, !cachedData.isEmpty {
+                item?.cachedData = cachedData
+            } else {
+                item?.cachedData = nil
+            }
         }
     }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes UUID generation for playing where left off. Sometimes without a `return` statement in a lambda in JS, it returns a huge string of "undefined" but other times returns a proper UUID. No idea why.
- Fixes Deleting the item by checking if the cached URL is length 0. This is literally impossible in the first place, but just in case.
- Fixes Streaming live URL to be the direct URL instead of page URL (another fix for bug discovered by Soner: https://github.com/brave/brave-ios/pull/4100)
- Fix possible reason for removing not working (Removing from playlist but not from URLBar - URLBar not updating).
- Fixed possible reason for removing not working (Invalid cache/offline status).
- Fix onboarding showing up when deleting item from playlist but not from URLBar.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4111

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
