### PR TITLE
Fix #4082 - Fix double percent encoding of URLs that are already escaped.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -353,14 +353,6 @@ extension BrowserViewController: TopToolbarDelegate {
                     self?.submitSearchText(text)
                 }
                 
-                let submitWebsite = { [weak self] (url: String) in
-                    if let url = URL(string: url) {
-                        self?.finishEditingAndSubmit(url, visitType: .unknown)
-                    } else {
-                        submitSearch(url)
-                    }
-                }
-                
                 if let recentSearch = recentSearch,
                    let searchType = RecentSearchType(rawValue: recentSearch.searchType) {
                     if shouldSubmitSearch {
@@ -390,7 +382,7 @@ extension BrowserViewController: TopToolbarDelegate {
                             self.topToolbar(self.topToolbar, didEnterText: websiteUrl)
                             
                             if shouldSubmitSearch {
-                                submitWebsite(websiteUrl)
+                                submitSearch(websiteUrl)
                             }
                         }
                     case .website:
@@ -399,7 +391,7 @@ extension BrowserViewController: TopToolbarDelegate {
                             self.topToolbar(self.topToolbar, didEnterText: websiteUrl)
                             
                             if shouldSubmitSearch {
-                                submitWebsite(websiteUrl)
+                                submitSearch(websiteUrl)
                             }
                         }
                     }
@@ -410,7 +402,7 @@ extension BrowserViewController: TopToolbarDelegate {
                     self.topToolbar(self.topToolbar, didEnterText: searchQuery)
                     
                     if shouldSubmitSearch {
-                        submitWebsite(searchQuery)
+                        submitSearch(searchQuery)
                     }
                 }
             })

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -353,6 +353,14 @@ extension BrowserViewController: TopToolbarDelegate {
                     self?.submitSearchText(text)
                 }
                 
+                let submitWebsite = { [weak self] (url: String) in
+                    if let url = URL(string: url) {
+                        self?.finishEditingAndSubmit(url, visitType: .unknown)
+                    } else {
+                        submitSearch(url)
+                    }
+                }
+                
                 if let recentSearch = recentSearch,
                    let searchType = RecentSearchType(rawValue: recentSearch.searchType) {
                     if shouldSubmitSearch {
@@ -382,7 +390,7 @@ extension BrowserViewController: TopToolbarDelegate {
                             self.topToolbar(self.topToolbar, didEnterText: websiteUrl)
                             
                             if shouldSubmitSearch {
-                                submitSearch(websiteUrl)
+                                submitWebsite(websiteUrl)
                             }
                         }
                     case .website:
@@ -391,7 +399,7 @@ extension BrowserViewController: TopToolbarDelegate {
                             self.topToolbar(self.topToolbar, didEnterText: websiteUrl)
                             
                             if shouldSubmitSearch {
-                                submitSearch(websiteUrl)
+                                submitWebsite(websiteUrl)
                             }
                         }
                     }
@@ -402,7 +410,7 @@ extension BrowserViewController: TopToolbarDelegate {
                     self.topToolbar(self.topToolbar, didEnterText: searchQuery)
                     
                     if shouldSubmitSearch {
-                        submitSearch(searchQuery)
+                        submitWebsite(searchQuery)
                     }
                 }
             })

--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -71,7 +71,8 @@ class URIFixup {
         // However, we ensure that the scheme is one that is listed in
         // the official URI scheme list, so that other such search phrases
         // like "filetype:" are recognised as searches rather than URLs.
-        if let url = URL(string: escaped), url.schemeIsValid {
+        // Use `URL(string: entry)` so it doesn't double percent escape URLs.
+        if let url = URL(string: entry) ?? URL(string: escaped), url.schemeIsValid {
             return validateURL(url)
         }
 


### PR DESCRIPTION
## Summary of Changes
- Stop double encoding URLs that are already percent escaped.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4082

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test plan here
https://github.com/brave/brave-ios/pull/4118#issuecomment-917007494

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
