### PR TITLE
Fix #4081 - URL parsing for arithmetic URLs and URLs with more than one dot

### DIFF
--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -120,6 +120,25 @@ class URIFixup {
             URL(string: "http://\(escaped)")?.user != nil {
             return nil
         }
+        
+        // If the user enters anything arithmetic
+        // Such as 125.5, do not construct a URL from it
+        // It is a mathematical expression
+        if let url = URL(string: trimmed),
+           url.scheme == nil,
+           Double(trimmed) != nil {
+            return nil
+        }
+        
+        // URL contains more than 1 dot, but is NOT a valid IP.
+        // IE: brave.com.com.com.com or 123.4.5 or "hello.world.whatever"
+        // However, a valid URL can be "brave.com" or "hello.world"
+        if let url = URL(string: escaped),
+           url.scheme == nil,
+           escaped.reduce(0, { $1 == "." ? $0 + 1 : $0 }) > 1,
+           !isValidIPAddress(escaped) {
+            return nil
+        }
 
         // If there is a "." or ":", prepend "http://" and try again. Since this
         // is strictly an "http://" URL, we also require a host.

--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -134,10 +134,18 @@ class URIFixup {
         // IE: brave.com.com.com.com or 123.4.5 or "hello.world.whatever"
         // However, a valid URL can be "brave.com" or "hello.world"
         if let url = URL(string: escaped),
-           url.scheme == nil,
-           escaped.reduce(0, { $1 == "." ? $0 + 1 : $0 }) > 1,
-           !isValidIPAddress(escaped) {
-            return nil
+           url.scheme == nil {
+            let dotCount = escaped.reduce(0, { $1 == "." ? $0 + 1 : $0 })
+            if dotCount > 0 && !isValidIPAddress(escaped) {
+                // If there is a "." or ":", prepend "http://" and try again. Since this
+                // is strictly an "http://" URL, we also require a host.
+                if let url = URL(string: "http://\(escaped)"),
+                   let host = url.host,
+                   host.rangeOfCharacter(from: CharacterSet(charactersIn: "1234567890.[]:").inverted) != nil {
+                    return validateURL(url)
+                }
+                return nil
+            }
         }
 
         // If there is a "." or ":", prepend "http://" and try again. Since this

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -32,7 +32,6 @@ class SearchTests: XCTestCase {
         checkValidURL("ftp://ftp.mozilla.org", afterFixup: "ftp://ftp.mozilla.org")
         checkValidURL("foo.bar", afterFixup: "http://foo.bar")
         checkValidURL(" foo.bar ", afterFixup: "http://foo.bar")
-        checkValidURL("1.2.3", afterFixup: "http://1.2.3")
         checkValidURL("[::1]:80", afterFixup: "http://[::1]:80")
         checkValidURL("[2a04:4e42:400::288]", afterFixup: "http://[2a04:4e42:400::288]")
         checkValidURL("[2a04:4e42:600::288]:80", afterFixup: "http://[2a04:4e42:600::288]:80")
@@ -41,6 +40,7 @@ class SearchTests: XCTestCase {
         checkValidURL("[::192.9.5.5]:80", afterFixup: "http://[::192.9.5.5]:80")
         checkValidURL("[::192.9.5.5]/png", afterFixup: "http://[::192.9.5.5]/png")
         checkValidURL("[::192.9.5.5]:80/png", afterFixup: "http://[::192.9.5.5]:80/png")
+        checkValidURL("192.168.2.1", afterFixup: "http://192.168.2.1")
 
         // Check invalid URLs. These are passed along to the default search engine.
         checkInvalidURL("foobar")
@@ -53,6 +53,8 @@ class SearchTests: XCTestCase {
         checkInvalidURL("创业咖啡. 中国")
         checkInvalidURL("data:text/html;base64,SGVsbG8gV29ybGQhCg==")
         checkInvalidURL("data://https://www.example.com,fake example.com")
+        checkInvalidURL("1.2.3")
+        checkInvalidURL("1.1")
         
         // Check invalid quoted URLs, emails, and quoted domains.
         // These are passed along to the default search engine.

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -41,6 +41,17 @@ class SearchTests: XCTestCase {
         checkValidURL("[::192.9.5.5]/png", afterFixup: "http://[::192.9.5.5]/png")
         checkValidURL("[::192.9.5.5]:80/png", afterFixup: "http://[::192.9.5.5]:80/png")
         checkValidURL("192.168.2.1", afterFixup: "http://192.168.2.1")
+        checkValidURL("brave.io", afterFixup: "http://brave.io")
+        checkValidURL("brave.new.world", afterFixup: "http://brave.new.world")
+        checkValidURL("brave.new.world.test", afterFixup: "http://brave.new.world.test")
+        checkValidURL("brave.new.world.test.io", afterFixup: "http://brave.new.world.test.io")
+        checkValidURL("brave.new.world.test.whatever.io", afterFixup: "http://brave.new.world.test.whatever.io")
+        checkValidURL("http://2130706433:8000/", afterFixup: "http://2130706433:8000/")
+        checkValidURL("http://127.0.0.1:8080", afterFixup: "http://127.0.0.1:8080")
+        checkValidURL("http://127.0.1", afterFixup: "http://127.0.1")
+        checkValidURL("http://127.1", afterFixup: "http://127.1")
+        checkValidURL("http://127.1:8000", afterFixup: "http://127.1:8000")
+        checkValidURL("http://1.1:80", afterFixup: "http://1.1:80")
 
         // Check invalid URLs. These are passed along to the default search engine.
         checkInvalidURL("foobar")
@@ -55,6 +66,8 @@ class SearchTests: XCTestCase {
         checkInvalidURL("data://https://www.example.com,fake example.com")
         checkInvalidURL("1.2.3")
         checkInvalidURL("1.1")
+        checkInvalidURL("127.1")
+        checkInvalidURL("127.1.1")
         
         // Check invalid quoted URLs, emails, and quoted domains.
         // These are passed along to the default search engine.


### PR DESCRIPTION
## Summary of Changes
- If a URL can be converted to a number, it is not considered a valid URL: `120`, `120.5`.
- If a URL is a mathematical expression, it is not considered a valid URL: `125.5 * 100`.
- If a URL contains more than one dot but is not a valid IP address, is schemeless, it is not a valid URL: `127.0.1`
- If the URL contains more than one dot, is not a valid IP address, and is NOT schemeless, it is a valid URL: `http://127.0.1`
- If the URL contains more than one dot and is not a valid IP address or number or versioning scheme, but is a valid URL, and has no scheme, it is a valid URL: `jumde.github.io` and `brave.whatever.something.to.test.com.help.me.parse.these.urls.please`.

This mimics the behaviour observed in Safari iOS.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4081

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test plan here
https://github.com/brave/brave-ios/pull/4121#issuecomment-917012712

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
