### PR TITLE
Fix #4134 - Add support for iOS 14+ CarPlay Interface only

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1134,7 +1134,13 @@ extension Strings {
             NSLocalizedString("playList.noItemLabelTitle",
                               bundle: .braveShared,
                               value: "No Items Available",
-                              comment: "Text indicator on the table cell If a video is already downloaded")
+                              comment: "Text when there are no items in the playlist")
+        
+        public static let noItemLabelDetailLabel =
+            NSLocalizedString("playList.noItemLabelTitle",
+                              bundle: .braveShared,
+                              value: "You can add items to your Brave Playlist within the browser",
+                              comment: "Detail Text when there are no items in the playlist")
         
         public static let expiredLabelTitle =
             NSLocalizedString("playList.expiredLabelTitle",

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -892,6 +892,9 @@
 		CA9A234126B97B8400923D70 /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9A234026B97B8400923D70 /* MenuButton.swift */; };
 		CAA0BD9026F2562D00F14212 /* PrivilegedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA0BD8F26F2562D00F14212 /* PrivilegedRequest.swift */; };
 		CAA10597266FE94700A0372D /* RecentSearchQRCodeScannerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA1058B266FE94700A0372D /* RecentSearchQRCodeScannerController.swift */; };
+		CAADEFB326E26A9D0020DC4C /* CPTemplateApplicationSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAADEFB226E26A9D0020DC4C /* CPTemplateApplicationSceneDelegate.swift */; };
+		CAADEFE026E2707F0020DC4C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAADEFDF26E2707F0020DC4C /* SceneDelegate.swift */; };
+		CAADEFE226E2857F0020DC4C /* PlaylistCarplayControllerIOS14.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAADEFE126E2857F0020DC4C /* PlaylistCarplayControllerIOS14.swift */; };
 		CAB127632639F37C00BBFC75 /* RecentSearches.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB127622639F37C00BBFC75 /* RecentSearches.swift */; };
 		CAB127652639FB7000BBFC75 /* RecentSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB127642639FB7000BBFC75 /* RecentSearchCell.swift */; };
 		CAB54B8626A5BFA800F08BF3 /* PlaylistURLBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB54B8526A5BFA800F08BF3 /* PlaylistURLBarButton.swift */; };
@@ -2599,6 +2602,9 @@
 		CA9A234026B97B8400923D70 /* MenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButton.swift; sourceTree = "<group>"; };
 		CAA0BD8F26F2562D00F14212 /* PrivilegedRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivilegedRequest.swift; sourceTree = "<group>"; };
 		CAA1058B266FE94700A0372D /* RecentSearchQRCodeScannerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentSearchQRCodeScannerController.swift; sourceTree = "<group>"; };
+		CAADEFB226E26A9D0020DC4C /* CPTemplateApplicationSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPTemplateApplicationSceneDelegate.swift; sourceTree = "<group>"; };
+		CAADEFDF26E2707F0020DC4C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		CAADEFE126E2857F0020DC4C /* PlaylistCarplayControllerIOS14.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistCarplayControllerIOS14.swift; sourceTree = "<group>"; };
 		CAB127622639F37C00BBFC75 /* RecentSearches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearches.swift; sourceTree = "<group>"; };
 		CAB127642639FB7000BBFC75 /* RecentSearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchCell.swift; sourceTree = "<group>"; };
 		CAB54B8526A5BFA800F08BF3 /* PlaylistURLBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistURLBarButton.swift; sourceTree = "<group>"; };
@@ -4884,6 +4890,7 @@
 				5E5E6E7925BA156F0035B6A0 /* PlaylistCacheLoader.swift */,
 				5E99C88A25C83BE3003F30B4 /* PlaylistManager.swift */,
 				5E99CDEF25DD8C81003F30B4 /* PlaylistDownloadManager.swift */,
+				CAADEFB226E26A9D0020DC4C /* CPTemplateApplicationSceneDelegate.swift */,
 			);
 			path = "Managers & Cache";
 			sourceTree = "<group>";
@@ -5029,6 +5036,7 @@
 				CA8D5C1526D7CE04009BF13D /* PlaylistListViewController..swift */,
 				CA8D5C1726D7CE2E009BF13D /* PlaylistViewController+AVDelegates.swift */,
 				CA8D5C1926D7CE46009BF13D /* PlaylistViewController.swift */,
+				CAADEFE126E2857F0020DC4C /* PlaylistCarplayControllerIOS14.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -5411,6 +5419,7 @@
 			children = (
 				F84B21E51A0910F600AAB793 /* AppDelegate.swift */,
 				D3BE7B451B054F8600641031 /* TestAppDelegate.swift */,
+				CAADEFDF26E2707F0020DC4C /* SceneDelegate.swift */,
 			);
 			path = Delegates;
 			sourceTree = "<group>";
@@ -7428,6 +7437,7 @@
 				27676D472555F34D00BC955A /* BraveRewardsStatusView.swift in Sources */,
 				4422D4E821BFFB7600BF1855 /* log_writer.cc in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
+				CAADEFE026E2707F0020DC4C /* SceneDelegate.swift in Sources */,
 				0A7B5D6722689C5D00AADF22 /* AddEditHeaderView.swift in Sources */,
 				F930CDD12270F09000A23FE1 /* WebAuthnAuthenticateRequest.swift in Sources */,
 				D8C75DF3207584C400BB8AD0 /* UIImageViewAligned.m in Sources */,
@@ -7513,6 +7523,7 @@
 				4422D4C221BFFB7600BF1855 /* comparator.cc in Sources */,
 				0A1E84452190A57F0042F782 /* SyncPairWordsViewController.swift in Sources */,
 				2746D27524A2A9FE00E38852 /* RewardsInternalsContributionPublishersListController.swift in Sources */,
+				CAADEFE226E2857F0020DC4C /* PlaylistCarplayControllerIOS14.swift in Sources */,
 				270A0F392605267D0091D880 /* LegacyWalletTransferStatusButton.swift in Sources */,
 				4422D4DF21BFFB7600BF1855 /* table_builder.cc in Sources */,
 				27448536245B608E001920B5 /* QRCodePopupView.swift in Sources */,
@@ -7561,6 +7572,7 @@
 				CA8D5C1026D7CDAF009BF13D /* PlaylistListViewController+DragDropDelegate.swift in Sources */,
 				4422D56521BFFB7F00BF1855 /* filtered_re2.cc in Sources */,
 				277223722469B4FB0059A7EB /* FaviconFetcher.swift in Sources */,
+				CAADEFB326E26A9D0020DC4C /* CPTemplateApplicationSceneDelegate.swift in Sources */,
 				274398F524E71D8700E79605 /* FailableDecodable.swift in Sources */,
 				CA752EA526CEABF8009356EF /* PlaylistToast.swift in Sources */,
 				0A918DCD252C81FA00496088 /* BraveVPNRegionPickerViewController.swift in Sources */,

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -270,6 +270,9 @@ extension Preferences {
         /// The option to enable or disable the 3-dot menu badge for playlist
         static let enablePlaylistMenuBadge =
             Option<Bool>(key: "playlist.enablePlaylistMenuBadge", default: true)
+        /// The option to enable or disable the continue where left-off playback in CarPlay
+        static let enableCarPlayRestartPlayback =
+            Option<Bool>(key: "playlist.enableCarPlayRestartPlayback", default: false)
     }
 }
 

--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -1,0 +1,93 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Combine
+import BraveShared
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+    private var cancellables: Set<AnyCancellable> = []
+    
+    private var expectedThemeOverride: UIUserInterfaceStyle {
+        let themeOverride = DefaultTheme(
+            rawValue: Preferences.General.themeNormalMode.value
+        )?.userInterfaceStyleOverride ?? .unspecified
+        let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
+        return isPrivateBrowsing ? .dark : themeOverride
+    }
+    
+    private func updateTheme() {
+        guard let window = UIApplication.shared.windows.first(where: { (window) -> Bool in window.isKeyWindow}) else { return }
+        UIView.transition(with: window, duration: 0.15, options: [.transitionCrossDissolve], animations: {
+            window.overrideUserInterfaceStyle = self.expectedThemeOverride
+        }, completion: nil)
+    }
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        Preferences.General.themeNormalMode.objectWillChange
+            .merge(with: PrivateBrowsingManager.shared.objectWillChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateTheme()
+            }
+            .store(in: &cancellables)
+        
+        let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        window = UIWindow(windowScene: windowScene).then {
+            SceneObserver.setupApplication(window: $0)
+            
+            $0.backgroundColor = .black
+            $0.frame = UIScreen.main.bounds
+            $0.overrideUserInterfaceStyle = expectedThemeOverride
+            $0.tintColor = UIColor {
+                if $0.userInterfaceStyle == .dark {
+                    return .braveLighterBlurple
+                }
+                return .braveBlurple
+            }
+            
+            $0.rootViewController = appDelegate?.rootViewController
+        }
+        
+        appDelegate?.window = window
+        appDelegate?.windowProtection = WindowProtection(window: window!)
+        window?.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}

--- a/Client/Entitlements/Debug.entitlements
+++ b/Client/Entitlements/Debug.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.playable-content</key>
+	<true/>
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
 	<key>aps-environment</key>
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>

--- a/Client/Entitlements/Release (AppStore).entitlements
+++ b/Client/Entitlements/Release (AppStore).entitlements
@@ -26,5 +26,7 @@
 	</array>
 	<key>com.apple.developer.playable-content</key>
 	<true/>
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
 </dict>
 </plist>

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1487,7 +1487,18 @@ class BrowserViewController: UIViewController {
         guard let tab = tabManager.selectedTab else { return }
         
         updateRewardsButtonState()
-        updatePlaylistURLBar(tab: tab, state: tab.playlistItemState, item: tab.playlistItem)
+        
+        DispatchQueue.main.async {
+            if let item = tab.playlistItem {
+                if PlaylistItem.itemExists(item) {
+                    self.updatePlaylistURLBar(tab: tab, state: .existingItem, item: item)
+                } else {
+                    self.updatePlaylistURLBar(tab: tab, state: .newItem, item: item)
+                }
+            } else {
+                self.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
+            }
+        }
         
         topToolbar.currentURL = tab.url?.displayURL
         if tabManager.selectedTab === tab {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -109,17 +109,7 @@ class PlaylistCarplayController: NSObject {
             self.contentManager.reloadData()
         }
         
-        PlaylistManager.shared.contentWillChange
-        .sink { _ in
-            reloadData()
-        }.store(in: &playlistObservers)
-        
         PlaylistManager.shared.contentDidChange
-        .sink { _ in
-            reloadData()
-        }.store(in: &playlistObservers)
-        
-        PlaylistManager.shared.objectDidChange
         .sink { _ in
             reloadData()
         }.store(in: &playlistObservers)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -54,8 +54,11 @@ class PlaylistCarplayController: NSObject {
     }
     
     func observePlayerStates() {
-        player.publisher(for: .play).sink { _ in
+        player.publisher(for: .play).sink { event in
             MPNowPlayingInfoCenter.default().playbackState = .playing
+            var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = event.mediaPlayer.rate
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
         }.store(in: &playerStateObservers)
         
         player.publisher(for: .pause).sink { _ in
@@ -66,8 +69,8 @@ class PlaylistCarplayController: NSObject {
             MPNowPlayingInfoCenter.default().playbackState = .stopped
         }.store(in: &playerStateObservers)
         
-        player.publisher(for: .changePlaybackRate).sink { [weak self] _ in
-            MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = self?.player.rate
+        player.publisher(for: .changePlaybackRate).sink { event in
+            MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = event.mediaPlayer.rate
         }.store(in: &playerStateObservers)
         
         player.publisher(for: .previousTrack).sink { [weak self] _ in
@@ -81,6 +84,13 @@ class PlaylistCarplayController: NSObject {
         player.publisher(for: .finishedPlaying).sink { [weak self] event in
             event.mediaPlayer.pause()
             event.mediaPlayer.seek(to: .zero)
+            
+            var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
+            nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackProgress] = 0.0
+            nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = 0.0
+            nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+            
             self?.onNextTrack(isUserInitiated: false)
         }.store(in: &playerStateObservers)
     }
@@ -138,7 +148,14 @@ extension PlaylistCarplayController: MPPlayableContentDelegate {
                     return
                 }
                 
-                self.contentManager.nowPlayingIdentifiers = [mediaItem.pageSrc]
+                // Item is already playing.
+                // Show now-playing screen and don't restart playback.
+                if PlaylistCarplayManager.shared.currentlyPlayingItemIndex == indexPath.item ||
+                    PlaylistCarplayManager.shared.currentPlaylistItem?.src == mediaItem.src {
+                    completionHandler(nil)
+                    return
+                }
+                
                 self.playItem(item: mediaItem) { [weak self] error in
                     PlaylistCarplayManager.shared.currentPlaylistItem = nil
                     
@@ -251,6 +268,7 @@ extension PlaylistCarplayController {
            let item = PlaylistManager.shared.itemAtIndex(index) {
             PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
             playItem(item: item) { [weak self] error in
+                PlaylistCarplayManager.shared.currentPlaylistItem = nil
                 guard let self = self else { return }
                 
                 switch error {
@@ -261,6 +279,7 @@ extension PlaylistCarplayController {
                     self.displayExpiredResourceError(item: item)
                 case .none:
                     PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
+                    PlaylistCarplayManager.shared.currentPlaylistItem = item
                     self.updateLastPlayedItem(item: item)
                 case .cancelled:
                     log.debug("User Cancelled Playlist Playback")
@@ -279,7 +298,7 @@ extension PlaylistCarplayController {
             if isAtEnd {
                 player.pictureInPictureController?.delegate = nil
                 player.pictureInPictureController?.stopPictureInPicture()
-                player.stop()
+                player.pause()
 
                 PlaylistCarplayManager.shared.playlistController = nil
                 return
@@ -296,6 +315,7 @@ extension PlaylistCarplayController {
         if index >= 0,
            let item = PlaylistManager.shared.itemAtIndex(index) {
             self.playItem(item: item) { [weak self] error in
+                PlaylistCarplayManager.shared.currentPlaylistItem = nil
                 guard let self = self else { return }
 
                 switch error {
@@ -313,6 +333,7 @@ extension PlaylistCarplayController {
                     }
                 case .none:
                     PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
+                    PlaylistCarplayManager.shared.currentPlaylistItem = item
                     self.updateLastPlayedItem(item: item)
                 case .cancelled:
                     log.debug("User Cancelled Playlist Playback")

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
@@ -245,6 +245,13 @@ class PlaylistCarplayControllerIOS14: NSObject {
             settingsTemplate
         ]
         
+        // If we have any controllers presented, we need to remove them.
+        interfaceController.popToRootTemplate(animated: true) { success, error in
+            if !success, let error = error {
+                log.error(error)
+            }
+        }
+        
         // Reload the templates instead of replacing the RootTemplate
         tabBarTemplate.updateTemplates(tabTemplates)
     }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
@@ -294,52 +294,10 @@ class PlaylistCarplayControllerIOS14: NSObject {
                     completion()
                     
                     if error == nil && self.interfaceController.topTemplate != CPNowPlayingTemplate.shared {
-                        
                         self.interfaceController.pushTemplate(CPNowPlayingTemplate.shared, animated: true) { success, error in
                             
                             if !success, let error = error {
-                                // Some Cars (and the iOS Simulator) does not support CPActionSheetTemplate
-                                // So we MUST use CPAlertTemplate
-                                if PlaylistCarplayControllerIOS14.mustUseCPAlertTemplate {
-                                    let alert = CPAlertTemplate(titleVariants: [Strings.PlayList.sorryAlertTitle], actions: [
-                                        CPAlertAction(title: Strings.PlayList.okayButtonTitle, style: .default, handler: { [weak self] _ in
-                                            self?.interfaceController.dismissTemplate(animated: true, completion: { success, error in
-                                                if !success, let error = error {
-                                                    log.error(error)
-                                                }
-                                            })
-                                        })
-                                    ])
-                                    
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                                        self.interfaceController.presentTemplate(alert, animated: true, completion: { success, error in
-                                            if !success, let error = error {
-                                                log.error(error)
-                                            }
-                                        })
-                                    }
-                                } else {
-                                    // Can also use CPAlertTemplate, but it doesn't have a "Message" parameter.
-                                    let alert = CPActionSheetTemplate(title: Strings.PlayList.sorryAlertTitle,
-                                                                      message: error.localizedDescription,
-                                                                      actions: [
-                                        CPAlertAction(title: Strings.PlayList.okayButtonTitle, style: .default, handler: { [weak self] _ in
-                                            self?.interfaceController.dismissTemplate(animated: true, completion: { success, error in
-                                                if !success, let error = error {
-                                                    log.error(error)
-                                                }
-                                            })
-                                        })
-                                    ])
-                                    
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                                        self.interfaceController.presentTemplate(alert, animated: true, completion: { success, error in
-                                            if !success, let error = error {
-                                                log.error(error)
-                                            }
-                                        })
-                                    }
-                                }
+                                log.error(error)
                             }
                         }
                     }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
@@ -143,26 +143,12 @@ class PlaylistCarplayControllerIOS14: NSObject {
             self?.reloadData()
         }
         
-        PlaylistManager.shared.contentWillChange
-        .receive(on: RunLoop.main)
-        .sink { _ in
-            reloadData()
-        }.store(in: &playlistObservers)
-        
         PlaylistManager.shared.contentDidChange
-        .receive(on: RunLoop.main)
-        .sink { _ in
-            reloadData()
-        }.store(in: &playlistObservers)
-        
-        PlaylistManager.shared.objectDidChange
-        .receive(on: RunLoop.main)
         .sink { _ in
             reloadData()
         }.store(in: &playlistObservers)
         
         PlaylistManager.shared.downloadStateChanged
-        .receive(on: RunLoop.main)
         .sink { _ in
             reloadData()
         }.store(in: &playlistObservers)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayControllerIOS14.swift
@@ -61,9 +61,7 @@ class PlaylistCarplayControllerIOS14: NSObject {
             guard let self = self else { return }
             
             MPNowPlayingInfoCenter.default().playbackState = .playing
-            var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-            nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = event.mediaPlayer.rate
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+            PlaylistMediaStreamer.updateNowPlayingInfo(event.mediaPlayer)
             
             // Update the playing item indicator & Cache State Icon
             guard let tabTemplate = self.interfaceController.rootTemplate as? CPTabBarTemplate else {
@@ -104,8 +102,9 @@ class PlaylistCarplayControllerIOS14: NSObject {
             }
         }.store(in: &playerStateObservers)
         
-        player.publisher(for: .pause).sink { _ in
+        player.publisher(for: .pause).sink { event in
             MPNowPlayingInfoCenter.default().playbackState = .paused
+            PlaylistMediaStreamer.updateNowPlayingInfo(event.mediaPlayer)
         }.store(in: &playerStateObservers)
         
         player.publisher(for: .stop).sink { _ in

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -114,6 +114,7 @@ extension PlaylistListViewController: UITableViewDelegate {
                 return
             }
             
+            PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
             self?.delegate?.playItem(item: item) { [weak self] error in
                 guard let self = self else { return }
                 self.activityIndicator.stopAnimating()

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -116,6 +116,7 @@ extension PlaylistListViewController: UITableViewDelegate {
             
             PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
             self?.delegate?.playItem(item: item) { [weak self] error in
+                PlaylistCarplayManager.shared.currentPlaylistItem = nil
                 guard let self = self else { return }
                 self.activityIndicator.stopAnimating()
                 
@@ -128,6 +129,8 @@ extension PlaylistListViewController: UITableViewDelegate {
                     self.commitPlayerItemTransaction(at: indexPath, isExpired: true)
                     self.delegate?.displayExpiredResourceError(item: item)
                 case .none:
+                    PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
+                    PlaylistCarplayManager.shared.currentPlaylistItem = item
                     self.commitPlayerItemTransaction(at: indexPath, isExpired: false)
                     self.delegate?.updateLastPlayedItem(item: item)
                 case .cancelled:

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -114,10 +114,12 @@ extension PlaylistListViewController: UITableViewDelegate {
                 return
             }
             
-            PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
             self?.delegate?.playItem(item: item) { [weak self] error in
-                PlaylistCarplayManager.shared.currentPlaylistItem = nil
-                guard let self = self else { return }
+                guard let self = self else {
+                    PlaylistCarplayManager.shared.currentPlaylistItem = nil
+                    PlaylistCarplayManager.shared.currentlyPlayingItemIndex = -1
+                    return
+                }
                 self.activityIndicator.stopAnimating()
                 
                 switch error {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController..swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController..swift
@@ -209,6 +209,7 @@ class PlaylistListViewController: UIViewController {
                                                      isExpired: true)
                     delegate.displayExpiredResourceError(item: item)
                 case .none:
+                    PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
                     PlaylistCarplayManager.shared.currentPlaylistItem = item
                     self.commitPlayerItemTransaction(at: indexPath,
                                                      isExpired: false)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController..swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController..swift
@@ -42,6 +42,7 @@ class PlaylistListViewController: UIViewController {
     var playerController: AVPlayerViewController?
     
     let activityIndicator = UIActivityIndicatorView(style: .medium).then {
+        $0.color = .white
         $0.isHidden = true
         $0.hidesWhenStopped = true
     }
@@ -393,6 +394,8 @@ extension PlaylistListViewController {
             return
         }
         
+        playerView.stop()
+        playerView.bringSubviewToFront(activityIndicator)
         activityIndicator.startAnimating()
         activityIndicator.isHidden = false
 

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -777,6 +777,7 @@ extension PlaylistViewController: VideoViewDelegate {
                         return
                     }
                     
+                    PlaylistMediaStreamer.clearNowPlayingInfo()
                     self.playerView.setVideoInfo(videoDomain: item.pageSrc,
                                                  videoTitle: item.pageTitle)
                     PlaylistMediaStreamer.setNowPlayingInfo(item, withPlayer: self.player)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -221,14 +221,17 @@ class PlaylistViewController: UIViewController {
             
             if !PlaylistCarplayManager.shared.isCarPlayAvailable {
                 MPNowPlayingInfoCenter.default().playbackState = .playing
-                var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-                nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = event.mediaPlayer.rate
-                MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+                PlaylistMediaStreamer.updateNowPlayingInfo(event.mediaPlayer)
             }
         }.store(in: &playerStateObservers)
         
-        player.publisher(for: .pause).sink { [weak self] _ in
+        player.publisher(for: .pause).sink { [weak self] event in
             self?.playerView.controlsView.playPauseButton.setImage(#imageLiteral(resourceName: "playlist_play"), for: .normal)
+            
+            if !PlaylistCarplayManager.shared.isCarPlayAvailable {
+                MPNowPlayingInfoCenter.default().playbackState = .paused
+                PlaylistMediaStreamer.updateNowPlayingInfo(event.mediaPlayer)
+            }
         }.store(in: &playerStateObservers)
         
         player.publisher(for: .stop).sink { [weak self] _ in

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -452,6 +452,8 @@ extension PlaylistViewController: VideoViewDelegate {
                 
                 PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
                 self.playItem(item: item) { [weak self] error in
+                    PlaylistCarplayManager.shared.currentPlaylistItem = nil
+                    
                     guard let self = self else { return }
                     
                     switch error {
@@ -463,8 +465,9 @@ extension PlaylistViewController: VideoViewDelegate {
                         self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: true)
                         self.displayExpiredResourceError(item: item)
                     case .none:
-                        self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)
                         PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
+                        PlaylistCarplayManager.shared.currentPlaylistItem = item
+                        self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)
                         self.updateLastPlayedItem(item: item)
                     case .cancelled:
                         self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)
@@ -512,7 +515,9 @@ extension PlaylistViewController: VideoViewDelegate {
                     return
                 }
                 
+                PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
                 self.playItem(item: item) { [weak self] error in
+                    PlaylistCarplayManager.shared.currentPlaylistItem = nil
                     guard let self = self else { return }
                     
                     switch error {
@@ -534,6 +539,7 @@ extension PlaylistViewController: VideoViewDelegate {
                     case .none:
                         self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)
                         PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
+                        PlaylistCarplayManager.shared.currentPlaylistItem = item
                         self.updateLastPlayedItem(item: item)
                     case .cancelled:
                         self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/CPTemplateApplicationSceneDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/CPTemplateApplicationSceneDelegate.swift
@@ -11,29 +11,31 @@ import Shared
 private let log = Logger.browserLogger
 
 class CarplayTemplateApplicationSceneDelegate: NSObject {
+    private static let configurationName = "CPTemplateSceneConfiguration"
     
     // MARK: UISceneDelegate
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        if scene is CPTemplateApplicationScene, session.configuration.name == "CPTemplateSceneConfiguration" {
+        if scene is CPTemplateApplicationScene,
+            session.configuration.name == CarplayTemplateApplicationSceneDelegate.configurationName {
             log.debug("Template application scene will connect.")
         }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        if scene.session.configuration.name == "CPTemplateSceneConfiguration" {
+        if scene.session.configuration.name == CarplayTemplateApplicationSceneDelegate.configurationName {
             log.debug("Template application scene did disconnect.")
         }
     }
     
     func sceneDidBecomeActive(_ scene: UIScene) {
-        if scene.session.configuration.name == "CPTemplateSceneConfiguration" {
+        if scene.session.configuration.name == CarplayTemplateApplicationSceneDelegate.configurationName {
             log.debug("Template application scene did become active.")
         }
     }
     
     func sceneWillResignActive(_ scene: UIScene) {
-        if scene.session.configuration.name == "CPTemplateSceneConfiguration" {
+        if scene.session.configuration.name == CarplayTemplateApplicationSceneDelegate.configurationName {
             log.debug("Template application scene will resign active.")
         }
     }

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/CPTemplateApplicationSceneDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/CPTemplateApplicationSceneDelegate.swift
@@ -1,0 +1,58 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import CarPlay
+import Shared
+
+private let log = Logger.browserLogger
+
+class CarplayTemplateApplicationSceneDelegate: NSObject {
+    
+    // MARK: UISceneDelegate
+    
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        if scene is CPTemplateApplicationScene, session.configuration.name == "CPTemplateSceneConfiguration" {
+            log.debug("Template application scene will connect.")
+        }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        if scene.session.configuration.name == "CPTemplateSceneConfiguration" {
+            log.debug("Template application scene did disconnect.")
+        }
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        if scene.session.configuration.name == "CPTemplateSceneConfiguration" {
+            log.debug("Template application scene did become active.")
+        }
+    }
+    
+    func sceneWillResignActive(_ scene: UIScene) {
+        if scene.session.configuration.name == "CPTemplateSceneConfiguration" {
+            log.debug("Template application scene will resign active.")
+        }
+    }
+}
+
+// MARK: CPTemplateApplicationSceneDelegate
+
+extension CarplayTemplateApplicationSceneDelegate: CPTemplateApplicationSceneDelegate {
+    
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {
+        log.debug("Template application scene did connect.")
+        
+        PlaylistCarplayManager.shared.connect(interfaceController: interfaceController)
+    }
+    
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
+                                  didDisconnectInterfaceController interfaceController: CPInterfaceController) {
+        log.debug("Template application scene did disconnect.")
+        
+        PlaylistCarplayManager.shared.disconnect(interfaceController: interfaceController)
+    }
+}

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -82,6 +82,11 @@ class PlaylistCarplayManager: NSObject {
         // and we don't get notified when it disconnects :(
         attemptInterfaceConnection(isCarPlayAvailable: true)
         #else
+        guard let contentManager = contentManager else {
+            log.error("Invalid MPPlayableContentManager!")
+            return
+        }
+        
         // We need to observe when CarPlay is connected
         // That way, we can  determine where the controls are coming from for Playlist
         // OR determine where the AudioSession is outputting

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -193,24 +193,26 @@ class PlaylistCarplayManager: NSObject {
     }
     
     private func attemptInterfaceConnection(isCarPlayAvailable: Bool) {
-        self.isCarPlayAvailable = isCarPlayAvailable
-        
-        // If there is no media player, create one,
-        // pass it to the carplay controller
-        if isCarPlayAvailable {
-            // Protect against reentrancy.
-            if carPlayController == nil {
-                carPlayController = self.getCarPlayController()
+        ensureMainThread {
+            self.isCarPlayAvailable = isCarPlayAvailable
+            
+            // If there is no media player, create one,
+            // pass it to the carplay controller
+            if isCarPlayAvailable {
+                // Protect against reentrancy.
+                if self.carPlayController == nil {
+                    self.carPlayController = self.getCarPlayController()
+                }
+            } else {
+                self.carPlayController = nil
+                self.mediaPlayer = nil
             }
-        } else {
-            carPlayController = nil
-            mediaPlayer = nil
-        }
 
-        // Sometimes the `endpointAvailable` WILL RETURN TRUE!
-        // Even when the car is NOT connected.
-        log.debug("CARPLAY CONNECTED: \(isCarPlayAvailable)")
-        log.debug("CARPLAY ENDPOINT AVAILABLE: \(contentManager?.context.endpointAvailable == true)")
+            // Sometimes the `endpointAvailable` WILL RETURN TRUE!
+            // Even when the car is NOT connected.
+            log.debug("CARPLAY CONNECTED: \(isCarPlayAvailable)")
+            log.debug("CARPLAY ENDPOINT AVAILABLE: \(self.contentManager?.context.endpointAvailable == true)")
+        }
     }
 }
 

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -21,9 +21,19 @@ class PlaylistCarplayManager: NSObject {
     private weak var mediaPlayer: MediaPlayer?
     private(set) var isCarPlayAvailable = false
     
-    var currentlyPlayingItemIndex = -1
-    var currentPlaylistItem: PlaylistInfo?
     var browserController: BrowserViewController?
+    
+    var currentlyPlayingItemIndex = -1
+    var currentPlaylistItem: PlaylistInfo? {
+        didSet {
+            if let item = currentPlaylistItem {
+                // Show the Now-Playing item indicator in Car-Play screen
+                contentManager.nowPlayingIdentifiers = [item.pageSrc]
+            } else {
+                contentManager.nowPlayingIdentifiers = []
+            }
+        }
+    }
     
     // When Picture-In-Picture is enabled, we need to store a reference to the controller to keep it alive, otherwise if it deallocates, the system automatically kills Picture-In-Picture.
     var playlistController: PlaylistViewController? {

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -31,7 +31,8 @@ class PlaylistCarplayManager: NSObject {
     var currentPlaylistItem: PlaylistInfo? {
         didSet {
             if #available(iOS 14, *) {
-                //#error("FIX")
+                // There doesn't seem to be a reason OR a way to do this on iOS 14+
+                // Possibly need to index the `CPListItem` and set `.isPlaying`
             } else {
                 if let item = currentPlaylistItem {
                     // Show the Now-Playing item indicator in Car-Play screen
@@ -67,7 +68,9 @@ class PlaylistCarplayManager: NSObject {
         super.init()
         
         if #available(iOS 14, *) {
-            //#error("FIX")
+            // iOS 14 does NOT require initialization :)
+            // This is because the CPTemplate gets called properly
+            // So we know exactly when CarPlay is connected, and when it is disconnected.
             return
         } else {
             contentManager = MPPlayableContentManager.shared()
@@ -112,6 +115,8 @@ class PlaylistCarplayManager: NSObject {
     
     func getCarPlayController() -> NSObject? {
         if #available(iOS 14, *) {
+            // On iOS 14, we use CPTemplate (Custom UI)
+            // We control what gets displayed
             guard let carplayInterface = carplayInterface else {
                 return nil
             }
@@ -123,6 +128,8 @@ class PlaylistCarplayManager: NSObject {
             self.mediaPlayer = mediaPlayer
             return carPlayController
         } else {
+            // On iOS 13, we cannot use anything custom, so we must resort to display
+            // data base on models and `NowPlayingInfoCenter`
             guard let contentManager = contentManager else {
                 return nil
             }

--- a/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -125,12 +125,27 @@ class PlaylistMediaStreamer {
             MPMediaItemPropertyTitle: item.name,
             MPMediaItemPropertyArtist: URL(string: item.pageSrc)?.baseDomain ?? item.pageSrc,
             MPMediaItemPropertyPlaybackDuration: item.duration,
-            MPNowPlayingInfoPropertyPlaybackProgress: 0.0,
+            MPNowPlayingInfoPropertyPlaybackRate: player.rate,
             MPNowPlayingInfoPropertyAssetURL: URL(string: item.pageSrc) as Any,
             MPNowPlayingInfoPropertyElapsedPlaybackTime: player.currentTime.seconds,
         ])
         
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+    
+    static func updateNowPlayingInfo(_ player: MediaPlayer) {
+        let mediaType: MPNowPlayingInfoMediaType = player.currentItem?.asset.isVideoTracksAvailable() == true ? .video : .audio
+        let duration = player.currentItem?.asset.duration.seconds ?? 0.0
+        
+        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+        nowPlayingInfo.merge(with: [
+            MPNowPlayingInfoPropertyMediaType: NSNumber(value: mediaType.rawValue),
+            MPMediaItemPropertyPlaybackDuration: duration,
+            MPNowPlayingInfoPropertyPlaybackRate: player.rate,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: player.currentTime.seconds,
+        ])
+        
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
     }
     

--- a/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -127,8 +127,10 @@ class PlaylistMediaStreamer {
             MPMediaItemPropertyPlaybackDuration: item.duration,
             MPNowPlayingInfoPropertyPlaybackProgress: 0.0,
             MPNowPlayingInfoPropertyAssetURL: URL(string: item.pageSrc) as Any,
-            MPNowPlayingInfoPropertyElapsedPlaybackTime: 0.0,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: player.currentTime.seconds,
         ])
+        
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
     }
     

--- a/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -119,7 +119,8 @@ class PlaylistMediaStreamer {
         let mediaType: MPNowPlayingInfoMediaType =
             item.mimeType.contains("video") ? .video : .audio
         
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+        nowPlayingInfo.merge(with: [
             MPNowPlayingInfoPropertyMediaType: NSNumber(value: mediaType.rawValue),
             MPMediaItemPropertyTitle: item.name,
             MPMediaItemPropertyArtist: URL(string: item.pageSrc)?.baseDomain ?? item.pageSrc,
@@ -127,7 +128,8 @@ class PlaylistMediaStreamer {
             MPNowPlayingInfoPropertyPlaybackProgress: 0.0,
             MPNowPlayingInfoPropertyAssetURL: URL(string: item.pageSrc) as Any,
             MPNowPlayingInfoPropertyElapsedPlaybackTime: 0.0,
-        ]
+        ])
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
     }
     
     static func clearNowPlayingInfo() {
@@ -142,6 +144,8 @@ class PlaylistMediaStreamer {
                 return image
             })
             setNowPlayingMediaArtwork(artwork: artwork)
+        } else {
+            setNowPlayingMediaArtwork(artwork: nil)
         }
     }
     

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -184,11 +184,10 @@ class MediaPlayer: NSObject {
     func stop() {
         if isPlaying {
             previousRate = player.rate == 0.0 ? -1.0 : player.rate
+            player.pause()
+            player.replaceCurrentItem(with: nil)
+            stopSubscriber.send(EventNotification(mediaPlayer: self, event: .stop))
         }
-        
-        player.pause()
-        player.replaceCurrentItem(with: nil)
-        stopSubscriber.send(EventNotification(mediaPlayer: self, event: .stop))
     }
     
     func seekPreviousTrack() {

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -184,10 +184,11 @@ class MediaPlayer: NSObject {
     func stop() {
         if isPlaying {
             previousRate = player.rate == 0.0 ? -1.0 : player.rate
-            player.pause()
-            player.replaceCurrentItem(with: nil)
-            stopSubscriber.send(EventNotification(mediaPlayer: self, event: .stop))
         }
+        
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        stopSubscriber.send(EventNotification(mediaPlayer: self, event: .stop))
     }
     
     func seekPreviousTrack() {

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -422,6 +422,7 @@ class VideoView: UIView, VideoTrackerBarDelegate {
     func resetVideoInfo() {
         infoView.titleLabel.text = ""
         infoView.clearFavIcon()
+        controlsView.trackBar.setTimeRange(currentTime: .zero, endTime: .zero)
     }
     
     func setControlsEnabled(_ enabled: Bool) {

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -227,7 +227,7 @@ window.__firefox__.includeOnce("Playlist", function() {
                 }
             }
 
-            if (src !== "") {
+            if (src && src !== "") {
                 $<tagNode>(node);
                 $<sendMessage>({
                     "securitytoken": "$<security_token>",

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -188,5 +188,33 @@
 		<string>A000000527471117</string>
 		<string>A0000006472F0001</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>CPTemplateSceneConfiguration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarplayTemplateApplicationSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -63,7 +63,7 @@ final public class PlaylistItem: NSManagedObject, CRUD {
     }
     
     public static func itemExists(_ item: PlaylistInfo) -> Bool {
-        if let count = PlaylistItem.count(predicate: NSPredicate(format: "pageSrc == %@", item.pageSrc)), count > 0 {
+        if let count = PlaylistItem.count(predicate: NSPredicate(format: "pageSrc == %@ OR mediaSrc == %@", item.pageSrc, item.src)), count > 0 {
             return true
         }
         return false
@@ -84,7 +84,7 @@ final public class PlaylistItem: NSManagedObject, CRUD {
     public static func updateItem(_ item: PlaylistInfo, completion: (() -> Void)? = nil) {
         if itemExists(item) {
             DataController.perform(context: .new(inMemory: false), save: false) { context in
-                if let existingItem = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@", item.pageSrc), context: context) {
+                if let existingItem = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@ OR mediaSrc == %@", item.pageSrc, item.src), context: context) {
                     existingItem.name = item.name
                     existingItem.pageTitle = item.pageTitle
                     existingItem.pageSrc = item.pageSrc
@@ -106,7 +106,7 @@ final public class PlaylistItem: NSManagedObject, CRUD {
     
     public static func updateCache(pageSrc: String, cachedData: Data?) {
         DataController.perform(context: .new(inMemory: false), save: true) { context in
-            let item = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@", pageSrc), context: context)
+            let item = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@ OR mediaSrc == %@", pageSrc), context: context)
             
             if let cachedData = cachedData, !cachedData.isEmpty {
                 item?.cachedData = cachedData

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -106,7 +106,7 @@ final public class PlaylistItem: NSManagedObject, CRUD {
     
     public static func updateCache(pageSrc: String, cachedData: Data?) {
         DataController.perform(context: .new(inMemory: false), save: true) { context in
-            let item = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@ OR mediaSrc == %@", pageSrc), context: context)
+            let item = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@", pageSrc), context: context)
             
             if let cachedData = cachedData, !cachedData.isEmpty {
                 item?.cachedData = cachedData


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes #4131, #4130, #4129, #4134
- Fixes adding duplicate items to car-play for iOS 13 and 14.
- Adds new interface support for iOS 14+.
- Adds support for UISceneDelegate which is required for CarPlay on iOS 14+.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4134

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
