### PR TITLE
Fix #3877 Add autofocus on URL bar when hardware keyboard connected

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -8,6 +8,7 @@ import Storage
 import Shared
 import BraveShared
 import BraveUI
+import GameController
 
 struct TabTrayControllerUX {
     static let cornerRadius = CGFloat(6.0)
@@ -346,9 +347,10 @@ class TabTrayController: UIViewController {
         }, completion: { finished in
             // The addTab delegate method will pop to the BVC no need to do anything here.
             self.toolbar.isUserInteractionEnabled = true
-            if finished, request == nil, NewTabAccessors.getNewTabPage() == .blankPage,
+            if finished, request == nil, NewTabAccessors.getNewTabPage() == .topSites,
                 let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-                let bvc = appDelegate.browserViewController {
+                let bvc = appDelegate.browserViewController,
+                self.isHardwareKeyboardConnected() {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                     bvc.topToolbar.tabLocationViewDidTapLocation(bvc.topToolbar.locationView)
                 }
@@ -358,6 +360,13 @@ class TabTrayController: UIViewController {
                 self.delegate?.tabTrayDidAddTab(self, tab: tab)
             }
         })
+    }
+    
+    func isHardwareKeyboardConnected() -> Bool {
+        if #available(iOS 14.0, *) {
+            return GCKeyboard.coalesced != nil
+        }
+        return false
     }
 
     func closeTabsForCurrentTray() {


### PR DESCRIPTION
## Summary of Changes

New PR as suggested in #3928.
This pull request fixes #3877
If hardware keyboard is connected and new tab is opened, url bar will be in focus. If there's no hardware keyboard, url bar will not be in focus.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

Must be on iPad iOS 14+
Connect hardware keyboard, can be magic keyboard too.
When you open new tab it should set focus on url bar.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
