### PR TITLE
Fix #4125: Playlist onboarding showing on NTP

### DIFF
--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -225,6 +225,13 @@ extension BrowserViewController: PlaylistHelperDelegate {
     }
     
     func showPlaylistOnboarding(tab: Tab?) {
+        // Do NOT show the playlist onboarding popup if the tab isn't visible
+        
+        guard let selectedTab = tabManager.selectedTab,
+              selectedTab === tab else {
+            return
+        }
+        
         let shouldShowOnboarding = tab?.url?.isPlaylistSupportedSiteURL == true
         
         if shouldShowOnboarding {

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -228,7 +228,8 @@ extension BrowserViewController: PlaylistHelperDelegate {
         // Do NOT show the playlist onboarding popup if the tab isn't visible
         
         guard let selectedTab = tabManager.selectedTab,
-              selectedTab === tab else {
+              selectedTab === tab,
+              selectedTab.playlistItemState != .none else {
             return
         }
         


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Added a guard to make sure onboarding only shows on the playlist selected tab.
- Added guard to make sure the item state is correct. NTP pages will have `itemState == .none`, so it won't show on those pages either.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4125

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
