### PR TITLE
Fix #4158: - Blank Web Pages on iOS 13

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2187,10 +2187,10 @@ extension BrowserViewController: TabManagerDelegate {
             wv.accessibilityLabel = nil
             wv.accessibilityElementsHidden = true
             wv.accessibilityIdentifier = nil
-            wv.alpha = 0.0
             
             #if swift(>=5.4)
             if #available(iOS 14.5, *) {
+                wv.alpha = 0.0
                 wv.requestMediaPlaybackState { state in
                     if state != .playing && wv != tabManager.selectedTab?.webView {
                         wv.alpha = 1.0

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2275,23 +2275,17 @@ extension BrowserViewController: TabManagerDelegate {
 
         updateInContentHomePanel(selected?.url as URL?)
         
+        #if swift(>=5.4)
         for tab in tabManager.allTabs {
-            if let wv = tab.webView {
-                #if swift(>=5.4)
-                if #available(iOS 14.5, *) {
-                    wv.requestMediaPlaybackState { state in
-                        if state != .playing && wv != tabManager.selectedTab?.webView {
-                            wv.alpha = 1.0
-                        }
+            if #available(iOS 14.5, *), let wv = tab.webView {
+                wv.requestMediaPlaybackState { state in
+                    if state != .playing && wv != tabManager.selectedTab?.webView {
+                        wv.alpha = 1.0
                     }
-                } else {
-                    wv.removeFromSuperview()
                 }
-                #else
-                wv.removeFromSuperview()
-                #endif
             }
         }
+        #endif
     }
 
     func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes blank tabs when switching tabs on iOS 13

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4158

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
