### PR TITLE
Fix #4171: Playlist Indicator not working on audio only websites when using reader-mode

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -101,25 +101,21 @@ class PlaylistCarplayController: NSObject {
         }
         
         PlaylistManager.shared.contentWillChange
-        .receive(on: RunLoop.main)
         .sink { _ in
             reloadData()
         }.store(in: &playlistObservers)
         
         PlaylistManager.shared.contentDidChange
-        .receive(on: RunLoop.main)
         .sink { _ in
             reloadData()
         }.store(in: &playlistObservers)
         
         PlaylistManager.shared.objectDidChange
-        .receive(on: RunLoop.main)
         .sink { _ in
             reloadData()
         }.store(in: &playlistObservers)
         
         PlaylistManager.shared.downloadStateChanged
-        .receive(on: RunLoop.main)
         .sink { _ in
             reloadData()
         }.store(in: &playlistObservers)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController..swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController..swift
@@ -66,19 +66,16 @@ class PlaylistListViewController: UIViewController {
         super.viewDidLoad()
         
         PlaylistManager.shared.contentWillChange
-        .receive(on: RunLoop.main)
         .sink { [weak self] in
             self?.controllerWillChangeContent()
         }.store(in: &observers)
         
         PlaylistManager.shared.contentDidChange
-        .receive(on: RunLoop.main)
         .sink { [weak self] in
             self?.controllerDidChangeContent()
         }.store(in: &observers)
         
         PlaylistManager.shared.objectDidChange
-        .receive(on: RunLoop.main)
         .sink { [weak self] in
             self?.controllerDidChange($0.object,
                                       at: $0.indexPath,
@@ -87,14 +84,12 @@ class PlaylistListViewController: UIViewController {
         }.store(in: &observers)
         
         PlaylistManager.shared.downloadProgressUpdated
-        .receive(on: RunLoop.main)
         .sink { [weak self] in
             self?.onDownloadProgressUpdate(id: $0.id,
                                            percentComplete: $0.percentComplete)
         }.store(in: &observers)
         
         PlaylistManager.shared.downloadStateChanged
-        .receive(on: RunLoop.main)
         .sink { [weak self] in
             self?.onDownloadStateChanged(id: $0.id,
                                          state: $0.state,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Playlist Indicator not working on audio only websites when switching to/from Reader-Mode
- This fix is necessary, because Reader-mode pages use `Cache` and does NOT call any `WKScriptMessage` delegates. Also the page is loaded from our `GCDWebServer`.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4171

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
