### PR TITLE
Fix #4179: Hiding and showing recent-searches section.

### DIFF
--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -114,6 +114,9 @@ class FavoritesViewController: UIViewController {
         hasPasteboardURL = UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs
         
         KeyboardHelper.defaultHelper.addDelegate(self)
+        
+        Preferences.Search.shouldShowRecentSearches.observe(from: self)
+        Preferences.Search.shouldShowRecentSearchesOptIn.observe(from: self)
     }
     
     @available(*, unavailable)
@@ -148,7 +151,7 @@ class FavoritesViewController: UIViewController {
             self?.supplementaryViewProvider(collectionView: collectionView, kind: kind, indexPath: indexPath)
         }
         
-        initialSnapshotSetup()
+        updateUIWithSnapshot()
     }
     
     override func viewDidLayoutSubviews() {
@@ -522,6 +525,12 @@ extension FavoritesViewController {
     }
 }
 
+extension FavoritesViewController: PreferencesObserver {
+    func preferencesDidChange(for key: String) {
+        updateUIWithSnapshot()
+    }
+}
+
 // MARK: - Diffable data source + NSFetchedResultsControllerDelegate
 extension FavoritesViewController: NSFetchedResultsControllerDelegate {
     private var favoritesSectionExists: Bool {
@@ -532,8 +541,7 @@ extension FavoritesViewController: NSFetchedResultsControllerDelegate {
         availableSections.contains(.recentSearches)
     }
     
-    /// Performs first frc fetches and handles setting first snaphot.
-    private func initialSnapshotSetup() {
+    private func updateUIWithSnapshot() {
         do {
             try favoritesFRC.performFetch()
         } catch {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4179 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
