### PR TITLE
Fix #4188: Update navigation bars and toolbars to be opaque by default

### DIFF
--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -18,24 +18,36 @@ extension AppDelegate {
         // important! for privacy concerns, otherwise UI can bleed through
         UIToolbar.appearance().do {
             $0.tintColor = .braveOrange
-            $0.standardAppearance = {
+            let appearance: UIToolbarAppearance = {
                 let appearance = UIToolbarAppearance()
-                appearance.configureWithDefaultBackground()
+                appearance.configureWithOpaqueBackground()
                 appearance.backgroundColor = .braveBackground
+                appearance.backgroundEffect = nil
                 return appearance
             }()
+            $0.standardAppearance = appearance
+            $0.compactAppearance = appearance
+            #if swift(>=5.5)
+            if #available(iOS 15.0, *) {
+                $0.scrollEdgeAppearance = appearance
+            }
+            #endif
         }
         
         UINavigationBar.appearance().do {
             $0.tintColor = .braveOrange
-            $0.standardAppearance = {
+            let appearance: UINavigationBarAppearance = {
                 let appearance = UINavigationBarAppearance()
-                appearance.configureWithDefaultBackground()
+                appearance.configureWithOpaqueBackground()
                 appearance.titleTextAttributes = [.foregroundColor: UIColor.braveLabel]
                 appearance.largeTitleTextAttributes = [.foregroundColor: UIColor.braveLabel]
                 appearance.backgroundColor = .braveBackground
+                appearance.backgroundEffect = nil
                 return appearance
             }()
+            $0.standardAppearance = appearance
+            $0.compactAppearance = appearance
+            $0.scrollEdgeAppearance = appearance
         }
         
         UISwitch.appearance().onTintColor = UIColor.braveOrange

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -557,6 +557,7 @@ extension BrowserViewController: ToolbarDelegate {
                     PageActionsMenuSection(browserViewController: self, tabURL: tabURL, activities: activities)
                 }
             }
+            .navigationBarHidden(true)
         })
         presentPanModal(menuController, sourceView: tabToolbar.menuButton, sourceRect: tabToolbar.menuButton.bounds)
         if menuController.modalPresentationStyle == .popover {


### PR DESCRIPTION
Also fixes the bug where the nav bar is visible on the menu

## Summary of Changes

This pull request fixes #4188

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- On iPad tap the menu button to show menu popup
- Verify empty nav bar is not visible
- Tap settings
- Verify nav bar is white and not weird transparent blur

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
