### PR TITLE
No Bug: Revert "Fix #3877: Add autofocus on URL bar if hardware keybo…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -23,7 +23,6 @@ import NetworkExtension
 import YubiKit
 import FeedKit
 import SwiftUI
-import GameController
 import class Combine.AnyCancellable
 
 private let log = Logger.browserLogger
@@ -1564,29 +1563,18 @@ class BrowserViewController: UIViewController {
         openURLInNewTab(nil, isPrivate: isPrivate, isPrivileged: true)
         let freshTab = tabManager.selectedTab
         
-        // Focus field if requested and background images are not supported or there is hardware keyboard connected
-        if attemptLocationFieldFocus || isHardwareKeyboardConnected() {
+        // Focus field only if requested and background images are not supported
+        if attemptLocationFieldFocus {
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
                 // Without a delay, the text field fails to become first responder
                 // Check that the newly created tab is still selected.
                 // This let's the user spam the Cmd+T button without lots of responder changes.
                 guard freshTab == self.tabManager.selectedTab else { return }
-                // submit location if there's search query or just focus on location otherwise
                 if let text = searchText {
                     self.topToolbar.submitLocation(text)
-                } else {
-                    self.topToolbar.tabLocationViewDidTapLocation(self.topToolbar.locationView)
                 }
             }
         }
-    }
-        
-    func isHardwareKeyboardConnected() -> Bool {
-        if #available(iOS 14.0, *) {
-            let bool = GCKeyboard.coalesced != nil
-            return bool
-        }
-        return false
     }
     
     func clearHistoryAndOpenNewTab() {

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -8,7 +8,6 @@ import Storage
 import Shared
 import BraveShared
 import BraveUI
-import GameController
 
 struct TabTrayControllerUX {
     static let cornerRadius = CGFloat(6.0)
@@ -347,10 +346,9 @@ class TabTrayController: UIViewController {
         }, completion: { finished in
             // The addTab delegate method will pop to the BVC no need to do anything here.
             self.toolbar.isUserInteractionEnabled = true
-            if finished, request == nil, NewTabAccessors.getNewTabPage() == .topSites,
+            if finished, request == nil, NewTabAccessors.getNewTabPage() == .blankPage,
                 let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-                let bvc = appDelegate.browserViewController,
-                self.isHardwareKeyboardConnected() {
+                let bvc = appDelegate.browserViewController {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                     bvc.topToolbar.tabLocationViewDidTapLocation(bvc.topToolbar.locationView)
                 }
@@ -360,13 +358,6 @@ class TabTrayController: UIViewController {
                 self.delegate?.tabTrayDidAddTab(self, tab: tab)
             }
         })
-    }
-    
-    func isHardwareKeyboardConnected() -> Bool {
-        if #available(iOS 14.0, *) {
-            return GCKeyboard.coalesced != nil
-        }
-        return false
     }
 
     func closeTabsForCurrentTray() {


### PR DESCRIPTION
…ard is connected (#4140)"

This reverts commit 197d03e39e056cbd9f641ed91151e1076ef4a6f2.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
I did not test it well enough, does not work on opening regular tab.
Reverting this, i may fix it later

I general UX wise i feel autofocus on url bar is not great in brave-ios because it shows the search overlay immediately, on desktop it's different because only url bar is focused

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #3877 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
