### PR TITLE
Fix #4200: Add small delay before applying favs snapshot on iOS 13.

### DIFF
--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -566,7 +566,14 @@ extension FavoritesViewController: NSFetchedResultsControllerDelegate {
                                  toSection: .recentSearches)
         }
         
-        dataSource.apply(snapshot, animatingDifferences: false)
+        if #available(iOS 14.0, *) {
+            dataSource.apply(snapshot, animatingDifferences: false)
+        } else {
+            // On iOS13 the app leaks memory and crashes, adding small delay helps.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.dataSource.apply(snapshot, animatingDifferences: false)
+            }
+        }
     }
     
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4200 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
str in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
