### PR TITLE
Fix #4202: Crash when opting out from Brave News on NTP.

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -468,6 +468,9 @@ class NewTabPageViewController: UIViewController {
                 collectionView.deleteItems(at: [IndexPath(item: 0, section: section)])
             }
             
+            // We check if first item exists before scrolling up to it.
+            // This should never happen since first item is our shields stats view.
+            // However we saw it crashing in XCode logs, see #4202.
             let firstItemIndexPath = IndexPath(item: 0, section: 0)
             if collectionView.dataSource?
                 .collectionView(collectionView, cellForItemAt: firstItemIndexPath) != nil {

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -467,7 +467,12 @@ class NewTabPageViewController: UIViewController {
             if let section = layout.braveNewsSection, collectionView.numberOfItems(inSection: section) != 0 {
                 collectionView.deleteItems(at: [IndexPath(item: 0, section: section)])
             }
-            collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: true)
+            
+            let firstItemIndexPath = IndexPath(item: 0, section: 0)
+            if collectionView.dataSource?
+                .collectionView(collectionView, cellForItemAt: firstItemIndexPath) != nil {
+                collectionView.scrollToItem(at: firstItemIndexPath, at: .top, animated: true)
+            }
             collectionView.verticalScrollIndicatorInsets = .zero
             UIView.animate(withDuration: 0.25) {
                 self.feedOverlayView.headerView.alpha = 0.0


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4202 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
This is hard to reproduce, never managed to repro it.

Please only test that when you close the Brave News opt-in card on NTP it does not crash

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
