### PR TITLE
Fix #4211: Update theme color of buy-vpn screen for iOS 15.

### DIFF
--- a/Client/Frontend/BraveVPN/BuyVPNViewController.swift
+++ b/Client/Frontend/BraveVPN/BuyVPNViewController.swift
@@ -60,6 +60,12 @@ class BuyVPNViewController: UIViewController {
         title = Strings.VPN.vpnName
         
         navigationItem.standardAppearance = BraveVPNCommonUI.navigationBarAppearance
+
+        #if swift(>=5.5)
+        if #available(iOS 15.0, *) {
+            navigationItem.scrollEdgeAppearance = BraveVPNCommonUI.navigationBarAppearance
+        }
+        #endif
         
         navigationItem.rightBarButtonItem = .init(title: Strings.VPN.restorePurchases, style: .done,
                                                   target: self, action: #selector(restorePurchasesAction))


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4211 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
