### PR TITLE
Fix #4193: Create PDF activity broke with XCode 13 compiler.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -131,9 +131,8 @@ extension BrowserViewController {
                     }
                     ForEach(activities, id: \.activityTitle) { activity in
                         MenuItemButton(icon: activity.activityImage?.template ?? UIImage(), title: activity.activityTitle ?? "") {
-                            browserViewController.dismiss(animated: true) {
-                                activity.perform()
-                            }
+                            browserViewController.dismiss(animated: true)
+                            activity.perform()
                         }
                     }
                 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
The UIActivity deallocates before createPDF action is called.
I moved the create pdf action outside, this is what other UIActivities do as well

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4193 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Must be tested on iOS 14 or higher

Open a site
Tap on 3dot menu
Scroll down, tap on 'Create PDF action'
Verify share sheet with pdf showed up

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
