### PR TITLE
Fix #4170: Refactor fetching brave-core APIs for sync related classes

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -754,7 +754,7 @@
 		5DE768B020B4601700FF5533 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE768AF20B4601600FF5533 /* UIColorExtensions.swift */; };
 		5DE768B120B4713000FF5533 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		5E096174252B63A300F3AFBB /* BraveCoreMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E096173252B63A300F3AFBB /* BraveCoreMigrator.swift */; };
-		5E096180252B63F200F3AFBB /* BraveSyncAPI+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E09617F252B63F200F3AFBB /* BraveSyncAPI+Utilities.swift */; };
+		5E096180252B63F200F3AFBB /* BraveSyncAPIExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E09617F252B63F200F3AFBB /* BraveSyncAPIExtensions.swift */; };
 		5E0FCD212342526700AC831E /* FullscreenHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 5EB57D0122FDC0CB00A07325 /* FullscreenHelper.js */; };
 		5E0FCD23234253DC00AC831E /* CertificatePinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FCD22234253DC00AC831E /* CertificatePinning.swift */; };
 		5E0FCD252342544C00AC831E /* URLSession+Requests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FCD242342544C00AC831E /* URLSession+Requests.swift */; };
@@ -2467,7 +2467,7 @@
 		5DE768AD20B443E500FF5533 /* JSONSerializationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializationExtensions.swift; sourceTree = "<group>"; };
 		5DE768AF20B4601600FF5533 /* UIColorExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
 		5E096173252B63A300F3AFBB /* BraveCoreMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveCoreMigrator.swift; sourceTree = "<group>"; };
-		5E09617F252B63F200F3AFBB /* BraveSyncAPI+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BraveSyncAPI+Utilities.swift"; sourceTree = "<group>"; };
+		5E09617F252B63F200F3AFBB /* BraveSyncAPIExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveSyncAPIExtensions.swift; sourceTree = "<group>"; };
 		5E0FCD22234253DC00AC831E /* CertificatePinning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatePinning.swift; sourceTree = "<group>"; };
 		5E0FCD242342544C00AC831E /* URLSession+Requests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Requests.swift"; sourceTree = "<group>"; };
 		5E11C3FF23314D970003C363 /* onboarding-ads.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "onboarding-ads.json"; sourceTree = "<group>"; };
@@ -4845,7 +4845,7 @@
 				2FD1C5FA2638599100E3C25F /* Bookmarks */,
 				2FD1C60726385AEC00E3C25F /* History */,
 				5E096173252B63A300F3AFBB /* BraveCoreMigrator.swift */,
-				5E09617F252B63F200F3AFBB /* BraveSyncAPI+Utilities.swift */,
+				5E09617F252B63F200F3AFBB /* BraveSyncAPIExtensions.swift */,
 				5E72D54E253657FF00F8D62D /* BraveCoreImportExportUtility.swift */,
 				2FB0E26B2653132500B722AF /* BraveServiceStateObserver.swift */,
 			);
@@ -7305,7 +7305,7 @@
 				4422D4E121BFFB7600BF1855 /* filter_block.cc in Sources */,
 				0A8C69BE225E350300988715 /* IndentedImageTableViewCell.swift in Sources */,
 				0AE5C69124F0059D004CBC9B /* OnboardingPrivacyConsentViewController.swift in Sources */,
-				5E096180252B63F200F3AFBB /* BraveSyncAPI+Utilities.swift in Sources */,
+				5E096180252B63F200F3AFBB /* BraveSyncAPIExtensions.swift in Sources */,
 				0A1E843D2190A57F0042F782 /* SyncSettingsTableViewController.swift in Sources */,
 				4422D56C21BFFB7F00BF1855 /* bitstate.cc in Sources */,
 				D314E7F71A37B98700426A76 /* BottomToolbarView.swift in Sources */,

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -33,8 +33,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
     var rootViewController: UIViewController!
     weak var profile: Profile?
     var tabManager: TabManager!
-    var braveCore = BraveCoreMain()
-
+    
+    let braveCore = BraveCoreMain()
+    var migration: Migration?
+    
     weak var application: UIApplication?
     var launchOptions: [AnyHashable: Any]?
 
@@ -83,14 +85,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         }
         
         braveCore.setUserAgent(UserAgent.mobile)
-
+        migration = Migration(syncAPI: braveCore.syncAPI)
+        
         AdBlockStats.shared.startLoading()
         HttpsEverywhereStats.shared.startLoading()
         
         updateShortcutItems(application)
         
         // Must happen before passcode check, otherwise may unnecessarily reset keychain
-        Migration.moveDatabaseToApplicationDirectory()
+        migration?.moveDatabaseToApplicationDirectory()
         
         // Passcode checking, must happen on immediate launch
         if !DataController.shared.storeExists() {
@@ -130,7 +133,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
 
         let profile = getProfile(application)
         let profilePrefix = profile.prefs.getBranchPrefix()
-        Migration.launchMigrations(keyPrefix: profilePrefix)
+        migration?.launchMigrations(keyPrefix: profilePrefix)
         
         setUpWebServer(profile)
         
@@ -178,8 +181,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         browserViewController = BrowserViewController(
             profile: self.profile!,
             tabManager: self.tabManager,
-            historyAPI: braveCore.historyAPI!,
-            bookmarkAPI: braveCore.bookmarksAPI!,
+            historyAPI: braveCore.historyAPI,
+            bookmarkAPI: braveCore.bookmarksAPI,
+            syncAPI: braveCore.syncAPI,
+            migration: migration,
             crashedLastSession: crashedLastSession)
         browserViewController.edgesForExtendedLayout = []
 
@@ -215,7 +220,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         SKPaymentQueue.default().remove(iapObserver)
         
         // Clean up BraveCore
-        BraveSyncAPI.removeAllObservers()
+        braveCore.syncAPI.removeAllObservers()
     }
 
     /**

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -85,7 +85,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         }
         
         braveCore.setUserAgent(UserAgent.mobile)
-        migration = Migration(syncAPI: braveCore.syncAPI)
+        migration = Migration(bookmarksAPI: braveCore.bookmarksAPI,
+                              historyAPI: braveCore.historyAPI,
+                              syncAPI: braveCore.syncAPI)
         
         AdBlockStats.shared.startLoading()
         HttpsEverywhereStats.shared.startLoading()

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -178,8 +178,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         let crashedLastSession = !Preferences.AppState.backgroundedCleanly.value && AppConstants.buildChannel != .debug
         Preferences.AppState.backgroundedCleanly.value = false
 
-        // TODO: Remove brave-core APIs force-unwrapping after IOS-4166 merged
-        // History API and Bookmarks API should not be nullable on brave-core side
         browserViewController = BrowserViewController(
             profile: self.profile!,
             tabManager: self.tabManager,

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -14,9 +14,13 @@ private let log = Logger.browserLogger
 class Migration {
     
     private(set) public var braveCoreSyncObjectsMigrator: BraveCoreMigrator?
+    private let bookmarksAPI: BraveBookmarksAPI
+    private let historyAPI: BraveHistoryAPI
     private let syncAPI: BraveSyncAPI
     
-    public init(syncAPI: BraveSyncAPI) {
+    public init(bookmarksAPI: BraveBookmarksAPI, historyAPI: BraveHistoryAPI, syncAPI: BraveSyncAPI) {
+        self.bookmarksAPI = bookmarksAPI
+        self.historyAPI = historyAPI
         self.syncAPI = syncAPI
     }
     
@@ -35,7 +39,9 @@ class Migration {
         
         // `.migrate` is called in `BrowserViewController.viewDidLoad()`
         if !Migration.isChromiumMigrationCompleted {
-            braveCoreSyncObjectsMigrator = BraveCoreMigrator()
+            braveCoreSyncObjectsMigrator = BraveCoreMigrator(bookmarksAPI: bookmarksAPI,
+                                                             historyAPI: historyAPI,
+                                                             syncAPI: syncAPI)
         }
         
         if !Preferences.Migration.playlistV1FileSettingsLocationCompleted.value {

--- a/Client/Extensions/Rewards/BraveLedgerExtensions.swift
+++ b/Client/Extensions/Rewards/BraveLedgerExtensions.swift
@@ -40,7 +40,7 @@ extension BraveLedger {
                 $0.percent = 1 // exclude 0% sites.
                 $0.orderBy = [sort]
                 $0.nonVerified = allowUnverifiedPublishers
-                $0.reconcileStamp = autoContributeProperties.reconcileStamp
+                $0.reconcileStamp = autoContributeProperties?.reconcileStamp ?? 0
             }
             return filter
         }()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -97,6 +97,8 @@ class BrowserViewController: UIViewController {
     let tabManager: TabManager
     let historyAPI: BraveHistoryAPI
     let bookmarkAPI: BraveBookmarksAPI
+    let syncAPI: BraveSyncAPI
+    let migration: Migration?
     
     /// Whether last session was a crash or not
     fileprivate let crashedLastSession: Bool
@@ -186,12 +188,16 @@ class BrowserViewController: UIViewController {
          tabManager: TabManager,
          historyAPI: BraveHistoryAPI,
          bookmarkAPI: BraveBookmarksAPI,
+         syncAPI: BraveSyncAPI,
+         migration: Migration?,
          crashedLastSession: Bool,
          safeBrowsingManager: SafeBrowsing? = SafeBrowsing()) {
         self.profile = profile
         self.tabManager = tabManager
         self.historyAPI = historyAPI
         self.bookmarkAPI = bookmarkAPI
+        self.syncAPI = syncAPI
+        self.migration = migration
         self.readerModeCache = ReaderMode.cache(for: tabManager.selectedTab)
         self.crashedLastSession = crashedLastSession
         self.safeBrowsing = safeBrowsingManager

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -222,7 +222,7 @@ class BrowserViewController: UIViewController {
             }
         }
 
-        let buildChannel = Ads.BraveAdsBuildChannel().then {
+        let buildChannel = Ads.BuildChannel().then {
           $0.name = AppConstants.buildChannel.rawValue
           $0.isRelease = AppConstants.buildChannel == .release
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -68,8 +68,13 @@ extension BrowserViewController {
                     }
                 }
             }
+            MenuItemButton(icon: #imageLiteral(resourceName: "settings-save-logins").template, title: Strings.passwordsMenuItem) {
+                let vc = LoginListViewController(profile: self.profile)
+                vc.settingsDelegate = self
+                menuController.pushInnerMenu(vc)
+            }
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
-                let vc = SettingsViewController(profile: self.profile, tabManager: self.tabManager, feedDataSource: self.feedDataSource, rewards: self.rewards, legacyWallet: self.legacyWallet, historyAPI: self.historyAPI)
+                let vc = SettingsViewController(profile: self.profile, tabManager: self.tabManager, feedDataSource: self.feedDataSource, rewards: self.rewards, legacyWallet: self.legacyWallet, historyAPI: self.historyAPI, syncAPI: self.syncAPI)
                 vc.settingsDelegate = self
                 menuController.pushInnerMenu(vc)
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -68,11 +68,6 @@ extension BrowserViewController {
                     }
                 }
             }
-            MenuItemButton(icon: #imageLiteral(resourceName: "settings-save-logins").template, title: Strings.passwordsMenuItem) {
-                let vc = LoginListViewController(profile: self.profile)
-                vc.settingsDelegate = self
-                menuController.pushInnerMenu(vc)
-            }
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
                 let vc = SettingsViewController(profile: self.profile, tabManager: self.tabManager, feedDataSource: self.feedDataSource, rewards: self.rewards, legacyWallet: self.legacyWallet, historyAPI: self.historyAPI, syncAPI: self.syncAPI)
                 vc.settingsDelegate = self

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -377,7 +377,7 @@ class NewTabPageViewController: UIViewController {
         backgroundView.imageConstraints?.landscapeCenter.update(offset: inset)
     }
     
-    private func reportSponsoredImageBackgroundEvent(_ event: Ads.BraveAdsNewTabPageAdEventType) {
+    private func reportSponsoredImageBackgroundEvent(_ event: Ads.NewTabPageAdEventType) {
         guard let backgroundType = background.currentBackground?.type,
               case .withBrandLogo = backgroundType,
               let creativeInstanceId = background.currentBackground?.wallpaper.creativeInstanceId else {

--- a/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Client/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -102,11 +102,12 @@ class BraveRewardsSettingsViewController: TableViewController {
         }
         
         if let ledger = rewards.ledger {
-            ledger.rewardsInternalInfo { info in
+            ledger.rewardsInternalInfo { [weak self] info in
                 if let info = info, !info.paymentId.isEmpty {
-                    dataSource.sections += [
+                    self?.dataSource.sections += [
                         Section(rows: [
                             Row(text: Strings.RewardsInternals.title, selection: {
+                                guard let self = self else { return }
                                 let controller = RewardsInternalsViewController(ledger: ledger, legacyLedger: self.legacyWallet)
                                 self.navigationController?.pushViewController(controller, animated: true)
                             }, accessory: .disclosureIndicator)

--- a/Client/Frontend/Settings/Rewards Internals/QA/RewardsInternalsAutoContributeController.swift
+++ b/Client/Frontend/Settings/Rewards Internals/QA/RewardsInternalsAutoContributeController.swift
@@ -67,8 +67,12 @@ class RewardsInternalsAutoContributeController: UITableViewController {
         switch indexPath.section {
         case 0:
             cell.textLabel?.text = "Next Contribution Date"
-            let date = Date(timeIntervalSince1970: TimeInterval(ledger.autoContributeProperties.reconcileStamp))
-            cell.detailTextLabel?.text = dateFormatter.string(from: date)
+            if let reconcileStamp = ledger.autoContributeProperties?.reconcileStamp {
+                let date = Date(timeIntervalSince1970: TimeInterval(reconcileStamp))
+                cell.detailTextLabel?.text = dateFormatter.string(from: date)
+            } else {
+                cell.detailTextLabel?.text = "–"
+            }
             return cell
         case 1:
             guard let publisher = publishers[safe: indexPath.item] else { return cell }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -59,19 +59,22 @@ class SettingsViewController: TableViewController {
     private let legacyWallet: BraveLedger?
     private let feedDataSource: FeedDataSource
     private let historyAPI: BraveHistoryAPI
-    
+    private let syncAPI: BraveSyncAPI
+
     init(profile: Profile,
          tabManager: TabManager,
          feedDataSource: FeedDataSource,
          rewards: BraveRewards? = nil,
          legacyWallet: BraveLedger? = nil,
-         historyAPI: BraveHistoryAPI) {
+         historyAPI: BraveHistoryAPI,
+         syncAPI: BraveSyncAPI) {
         self.profile = profile
         self.tabManager = tabManager
         self.feedDataSource = feedDataSource
         self.rewards = rewards
         self.legacyWallet = legacyWallet
         self.historyAPI = historyAPI
+        self.syncAPI = syncAPI
         
         super.init(style: .insetGrouped)
     }
@@ -234,16 +237,16 @@ class SettingsViewController: TableViewController {
                     self.navigationController?.pushViewController(viewController, animated: true)
                 }, image: #imageLiteral(resourceName: "settings-search").template, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: Strings.sync, selection: { [unowned self] in
-                    if BraveSyncAPI.shared.isInSyncGroup {
+                    if syncAPI.isInSyncGroup {
                         if !DeviceInfo.hasConnectivity() {
                             self.present(SyncAlerts.noConnection, animated: true)
                             return
                         }
                         
                         self.navigationController?
-                            .pushViewController(SyncSettingsTableViewController(), animated: true)
+                            .pushViewController(SyncSettingsTableViewController(syncAPI: syncAPI), animated: true)
                     } else {
-                        self.navigationController?.pushViewController(SyncWelcomeViewController(), animated: true)
+                        self.navigationController?.pushViewController(SyncWelcomeViewController(syncAPI: syncAPI), animated: true)
                     }
                     }, image: #imageLiteral(resourceName: "settings-sync").template, accessory: .disclosureIndicator,
                        cellClass: MultilineValue1Cell.self),

--- a/Client/Frontend/Sync/BraveCore/BraveCoreMigrator.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveCoreMigrator.swift
@@ -177,12 +177,13 @@ extension BraveCoreMigrator {
     private func performBookmarkMigrationIfNeeded(_ completion: ((Bool) -> Void)?) {
         log.info("Migrating to Chromium Bookmarks v1 - Exporting")
         exportBookmarks { [weak self] success in
+            guard let self = self else { return }
             if success {
                 log.info("Migrating to Chromium Bookmarks v1 - Start")
-                self?.migrateBookmarks() { success in
+                self.migrateBookmarks() { success in
                     Preferences.Chromium.syncV2BookmarksMigrationCompleted.value = success
                     
-                    if let url = BraveCoreMigrator.bookmarksURL {
+                    if let url = self.bookmarksURL {
                         do {
                             try FileManager.default.removeItem(at: url)
                         } catch {
@@ -340,7 +341,7 @@ extension BraveCoreMigrator {
 
 extension BraveCoreMigrator {
     
-    public static var bookmarksURL: URL? {
+    public var bookmarksURL: URL? {
         let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
         guard let documentsDirectory = paths.first else {
             log.error("Unable to access documents directory")
@@ -355,7 +356,7 @@ extension BraveCoreMigrator {
         return url
     }
     
-    public static var datedBookmarksURL: URL? {
+    public var datedBookmarksURL: URL? {
         let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
         guard let documentsDirectory = paths.first else {
             log.error("Unable to access documents directory")
@@ -383,7 +384,7 @@ extension BraveCoreMigrator {
     }
     
     private func exportBookmarks(_ completion: @escaping (_ success: Bool) -> Void) {
-        guard let url = BraveCoreMigrator.bookmarksURL else {
+        guard let url = bookmarksURL else {
             return completion(false)
         }
         

--- a/Client/Frontend/Sync/BraveCore/BraveCoreMigrator.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveCoreMigrator.swift
@@ -53,12 +53,11 @@ class BraveCoreMigrator {
     private var historyObserver: HistoryServiceListener?
     
     public init(bookmarksAPI: BraveBookmarksAPI, historyAPI: BraveHistoryAPI, syncAPI: BraveSyncAPI) {
+        self.bookmarksAPI = bookmarksAPI
+        self.historyAPI = historyAPI
+        self.syncAPI = syncAPI
         
-            self.bookmarksAPI = bookmarksAPI
-            self.historyAPI = historyAPI
-            self.syncAPI = syncAPI
-        
-        // Check If Chromium Sync Objects Migration is complete (Bookmarks-History-PAssword)
+        // Check If Chromium Sync Objects Migration is complete (Bookmarks-History)
         if Migration.isChromiumMigrationCompleted {
             migrationObserver = .completed
         }
@@ -153,7 +152,7 @@ extension BraveCoreMigrator {
         if !Preferences.Chromium.syncV2BookmarksMigrationCompleted.value {
             // If the bookmark model has already loaded, the observer does NOT get called!
             // Therefore we should continue to migrate the bookmarks
-            if bookmarksAPI.isLoaded == true {
+            if bookmarksAPI.isLoaded {
                 performBookmarkMigrationIfNeeded { success in
                     completion(success)
                 }
@@ -276,7 +275,7 @@ extension BraveCoreMigrator {
         if !Preferences.Chromium.syncV2HistoryMigrationCompleted.value {
             // If the history model has already loaded, the observer does NOT get called!
             // Therefore we should continue to migrate the history
-            if historyAPI.isBackendLoaded == true {
+            if historyAPI.isBackendLoaded {
                 performHistoryMigrationIfNeeded { success in
                     completion(success)
                 }

--- a/Client/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -9,10 +9,6 @@ import BraveShared
 
 extension BraveSyncAPI {
     
-    public static let seedByteLength = 32
-    private static var serviceObservers = NSHashTable<BraveSyncServiceListener>.weakObjects()
-    private static var deviceObservers = NSHashTable<BraveSyncDeviceListener>.weakObjects()
-    
     var isInSyncGroup: Bool {
         return Preferences.Chromium.syncEnabled.value
     }
@@ -29,14 +25,14 @@ extension BraveSyncAPI {
     }
     
     func removeDeviceFromSyncGroup(deviceGuid: String) {
-        BraveSyncAPI.shared.deleteDevice(deviceGuid)
+        deleteDevice(deviceGuid)
     }
     
     func leaveSyncGroup() {
         // Remove all observers before leaving the sync chain
-        BraveSyncAPI.removeAllObservers()
+        removeAllObservers()
         
-        BraveSyncAPI.shared.resetSync()
+        resetSync()
         Preferences.Chromium.syncEnabled.value = false
     }
     
@@ -58,72 +54,105 @@ extension BraveSyncAPI {
         }
     }
     
-    static func addServiceStateObserver(_ observer: @escaping () -> Void) -> AnyObject {
-        let result = BraveSyncServiceListener(observer, onRemoved: { observer in
-            serviceObservers.remove(observer)
+    func addServiceStateObserver(_ observer: @escaping () -> Void) -> AnyObject {
+        let serviceStateListener = BraveSyncServiceListener(onRemoved: { [weak self] observer in
+            self?.serviceObservers.remove(observer)
         })
-        serviceObservers.add(result)
-        return result
+        serviceStateListener.observer = createSyncServiceObserver(observer)
+
+        serviceObservers.add(serviceStateListener)
+        return serviceStateListener
     }
     
-    static func addDeviceStateObserver(_ observer: @escaping () -> Void) -> AnyObject {
-        let result = BraveSyncDeviceListener(observer, onRemoved: { observer in
-            deviceObservers.remove(observer)
+    func addDeviceStateObserver(_ observer: @escaping () -> Void) -> AnyObject {
+        let deviceStateListener = BraveSyncDeviceListener(observer, onRemoved: { [weak self] observer in
+            self?.deviceObservers.remove(observer)
         })
-        deviceObservers.add(result)
-        return result
+        deviceStateListener.observer = createSyncDeviceObserver(observer)
+        
+        deviceObservers.add(deviceStateListener)
+        return deviceStateListener
     }
     
-    static func removeAllObservers() {
+    func removeAllObservers() {
         serviceObservers.objectEnumerator().forEach({
-            ($0 as? BraveSyncServiceListener)?.remove()
+            ($0 as? BraveSyncServiceListener)?.observer = nil
         })
         
         deviceObservers.objectEnumerator().forEach({
-            ($0 as? BraveSyncDeviceListener)?.remove()
+            ($0 as? BraveSyncDeviceListener)?.observer = nil
         })
         
         serviceObservers.removeAllObjects()
         deviceObservers.removeAllObjects()
     }
+    
+    private struct AssociatedObjectKeys {
+        static var serviceObservers: Int = 0
+        static var deviceObservers: Int = 1
+    }
+    
+    private var serviceObservers: NSHashTable<BraveSyncServiceListener> {
+        if let observers = objc_getAssociatedObject(self, &AssociatedObjectKeys.serviceObservers) as? NSHashTable<BraveSyncServiceListener> {
+            return observers
+        }
+        
+        let defaultValue = NSHashTable<BraveSyncServiceListener>.weakObjects()
+        objc_setAssociatedObject(self, &AssociatedObjectKeys.serviceObservers, defaultValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        
+        return defaultValue
+    }
+    
+    private var deviceObservers: NSHashTable<BraveSyncDeviceListener> {
+        if let observers = objc_getAssociatedObject(self, &AssociatedObjectKeys.deviceObservers) as? NSHashTable<BraveSyncDeviceListener> {
+            return observers
+        }
+        
+        let defaultValue = NSHashTable<BraveSyncDeviceListener>.weakObjects()
+        objc_setAssociatedObject(self, &AssociatedObjectKeys.deviceObservers, defaultValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        
+        return defaultValue
+    }
+
 }
 
 extension BraveSyncAPI {
     private class BraveSyncServiceListener: NSObject {
-        private var observer: Any?
+        
+        // MARK: Internal
+        
+        var observer: Any?
         private var onRemoved: (BraveSyncServiceListener) -> Void
-        fileprivate init(_ onSyncServiceStateChanged: @escaping () -> Void,
-                         onRemoved: @escaping (BraveSyncServiceListener) -> Void) {
+        
+        // MARK: Lifecycle
+        
+        fileprivate init(onRemoved: @escaping (BraveSyncServiceListener) -> Void) {
             self.onRemoved = onRemoved
-            self.observer = BraveSyncAPI.shared.createSyncServiceObserver(onSyncServiceStateChanged)
             super.init()
         }
         
         deinit {
             self.onRemoved(self)
         }
-        
-        fileprivate func remove() {
-            observer = nil
-        }
     }
-    
+
     private class BraveSyncDeviceListener: NSObject {
-        private var observer: Any?
+        
+        // MARK: Internal
+        
+        var observer: Any?
         private var onRemoved: (BraveSyncDeviceListener) -> Void
+        
+        // MARK: Lifecycle
+        
         fileprivate init(_ onDeviceInfoChanged: @escaping () -> Void,
                          onRemoved: @escaping (BraveSyncDeviceListener) -> Void) {
             self.onRemoved = onRemoved
-            self.observer = BraveSyncAPI.shared.createSyncDeviceObserver(onDeviceInfoChanged)
             super.init()
         }
         
         deinit {
             self.onRemoved(self)
-        }
-        
-        fileprivate func remove() {
-            observer = nil
         }
     }
 }

--- a/Client/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -9,6 +9,8 @@ import BraveShared
 
 extension BraveSyncAPI {
     
+    public static let seedByteLength = 32
+    
     var isInSyncGroup: Bool {
         return Preferences.Chromium.syncEnabled.value
     }

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -62,19 +62,18 @@ class SyncAddDeviceViewController: SyncViewController {
     }
 
     private var clipboardClearTimer: Timer?
-    
-    // Pass in doneHandler here
-    convenience init(title: String, type: DeviceType) {
-        self.init()
+    private let syncAPI: BraveSyncAPI
+
+    init(title: String, type: DeviceType, syncAPI: BraveSyncAPI) {
+        self.syncAPI = syncAPI
+        super.init(nibName: nil, bundle: nil)
+        
         pageTitle = title
         deviceType = type
     }
     
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
@@ -99,12 +98,12 @@ class SyncAddDeviceViewController: SyncViewController {
         containerView.layer.cornerCurve = .continuous
         containerView.layer.masksToBounds = true
 
-        if !BraveSyncAPI.shared.isInSyncGroup {
+        if !syncAPI.isInSyncGroup {
             showInitializationError()
             return
         }
         
-        qrCodeView = SyncQRCodeView(syncApi: BraveSyncAPI.shared)
+        qrCodeView = SyncQRCodeView(syncApi: syncAPI)
         containerView.addSubview(qrCodeView!)
         qrCodeView?.snp.makeConstraints { make in
             make.top.bottom.equalTo(0).inset(22)
@@ -112,13 +111,13 @@ class SyncAddDeviceViewController: SyncViewController {
             make.size.equalTo(barcodeSize)
         }
         
-        self.codewordsView.text = BraveSyncAPI.shared.getSyncCode()
+        self.codewordsView.text = syncAPI.getSyncCode()
         self.setupVisuals()
     }
     
     private func showInitializationError() {
         present(SyncAlerts.initializationError, animated: true) {
-            BraveSyncAPI.shared.leaveSyncGroup()
+            self.syncAPI.leaveSyncGroup()
         }
     }
     

--- a/Client/Frontend/Sync/SyncPairCameraViewController.swift
+++ b/Client/Frontend/Sync/SyncPairCameraViewController.swift
@@ -20,6 +20,18 @@ class SyncPairCameraViewController: SyncViewController {
         $0.color = .white
     }
     
+    private let syncAPI: BraveSyncAPI
+
+    init(syncAPI: BraveSyncAPI) {
+        self.syncAPI = syncAPI
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -75,7 +87,7 @@ class SyncPairCameraViewController: SyncViewController {
             
             // If multiple calls get in here due to race conditions it isn't a big deal
             
-            let codeWords = BraveSyncAPI.shared.syncCode(fromHexSeed: data)
+            let codeWords = self.syncAPI.syncCode(fromHexSeed: data)
             if codeWords.isEmpty {
                 self.cameraView.cameraOverlayError()
             } else {
@@ -154,7 +166,7 @@ class SyncPairCameraViewController: SyncViewController {
     }
     
     @objc func SEL_enterWords() {
-        let wordsVC = SyncPairWordsViewController()
+        let wordsVC = SyncPairWordsViewController(syncAPI: syncAPI)
         wordsVC.syncHandler = self.syncHandler
         navigationController?.pushViewController(wordsVC, animated: true)
     }

--- a/Client/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/Client/Frontend/Sync/SyncPairWordsViewController.swift
@@ -14,7 +14,8 @@ class SyncPairWordsViewController: SyncViewController {
     var scrollView: UIScrollView!
     var containerView: UIView!
     var codewordsView: SyncCodewordsView!
-    
+    private let seedByteLength = 32
+
     lazy var wordCountLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 13, weight: UIFont.Weight.regular)
@@ -40,6 +41,18 @@ class SyncPairWordsViewController: SyncViewController {
     
     var loadingView: UIView!
     let loadingSpinner = UIActivityIndicatorView(style: .large)
+    
+    private let syncAPI: BraveSyncAPI
+
+    init(syncAPI: BraveSyncAPI) {
+        self.syncAPI = syncAPI
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
@@ -161,7 +174,7 @@ class SyncPairWordsViewController: SyncViewController {
         log.debug("check codes")
         
         func alert(title: String? = nil, message: String? = nil) {
-            if BraveSyncAPI.shared.isInSyncGroup {
+            if syncAPI.isInSyncGroup {
                 // No alert
                 return
             }
@@ -175,7 +188,7 @@ class SyncPairWordsViewController: SyncViewController {
         let codes = self.codewordsView.codeWords()
 
         // Maybe temporary validation, sync server has issues without this validation
-        if codes.count < BraveSyncAPI.seedByteLength / 2 {
+        if codes.count < seedByteLength / 2 {
             alert(title: Strings.notEnoughWordsTitle, message: Strings.notEnoughWordsDescription)
             return
         }
@@ -189,7 +202,7 @@ class SyncPairWordsViewController: SyncViewController {
             alert()
         })
         
-        if BraveSyncAPI.shared.isValidSyncCode(codes.joined(separator: " ")) {
+        if syncAPI.isValidSyncCode(codes.joined(separator: " ")) {
             syncHandler?(codes.joined(separator: " "))
         } else {
             alert(message: Strings.invalidSyncCodeDescription)

--- a/Client/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/Client/Frontend/Sync/SyncPairWordsViewController.swift
@@ -14,7 +14,6 @@ class SyncPairWordsViewController: SyncViewController {
     var scrollView: UIScrollView!
     var containerView: UIView!
     var codewordsView: SyncCodewordsView!
-    private let seedByteLength = 32
 
     lazy var wordCountLabel: UILabel = {
         let label = UILabel()
@@ -188,7 +187,7 @@ class SyncPairWordsViewController: SyncViewController {
         let codes = self.codewordsView.codeWords()
 
         // Maybe temporary validation, sync server has issues without this validation
-        if codes.count < seedByteLength / 2 {
+        if codes.count < BraveSyncAPI.seedByteLength / 2 {
             alert(title: Strings.notEnoughWordsTitle, message: Strings.notEnoughWordsDescription)
             return
         }

--- a/Client/Rewards/BraveRewards.swift
+++ b/Client/Rewards/BraveRewards.swift
@@ -25,7 +25,7 @@ class BraveRewards: NSObject {
     
     private let configuration: Configuration
     
-    init(configuration: Configuration, buildChannel: Ads.BraveAdsBuildChannel?) {
+    init(configuration: Configuration, buildChannel: Ads.BuildChannel?) {
         self.configuration = configuration
         
         BraveAds.isDebug = configuration.ledgerEnvironment != .production
@@ -264,8 +264,8 @@ extension BraveRewards {
     struct Configuration {
         var storageURL: URL
         var ledgerEnvironment: Ledger.Environment
-        var adsEnvironment: Ads.BraveAdsEnvironment
-        var adsBuildChannel: Ads.BraveAdsBuildChannel = .init()
+        var adsEnvironment: Ads.Environment
+        var adsBuildChannel: Ads.BuildChannel = .init()
         var isTesting: Bool = false
         var overridenNumberOfSecondsBetweenReconcile: Int = 0
         var retryInterval: Int = 0
@@ -274,7 +274,7 @@ extension BraveRewards {
             .init(
                 storageURL: FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!,
                 ledgerEnvironment: .development,
-                adsEnvironment: .development
+                adsEnvironment: .staging
             )
         }
         static var staging: Configuration {
@@ -293,7 +293,7 @@ extension BraveRewards {
             .init(
                 storageURL: URL(fileURLWithPath: NSTemporaryDirectory()),
                 ledgerEnvironment: .development,
-                adsEnvironment: .development,
+                adsEnvironment: .staging,
                 isTesting: true,
                 overridenNumberOfSecondsBetweenReconcile: 30,
                 retryInterval: 30

--- a/ClientTests/SchemePermissionTests.swift
+++ b/ClientTests/SchemePermissionTests.swift
@@ -64,14 +64,21 @@ class SchemePermissionTests: XCTestCase {
             return
         }
         
-        historyAPI = appDelegate.braveCore.historyAPI
         bookmarksAPI = appDelegate.braveCore.bookmarksAPI
+        historyAPI = appDelegate.braveCore.historyAPI
+        syncAPI = appDelegate.braveCore.syncAPI
+        
+        let migration = Migration(bookmarksAPI: bookmarksAPI,
+                              historyAPI: historyAPI,
+                              syncAPI: syncAPI)
         
         subject = BrowserViewController(
             profile: profile,
             tabManager: tabManager,
             historyAPI: historyAPI,
             bookmarkAPI: bookmarksAPI,
+            syncAPI: syncAPI,
+            migration: migration,
             crashedLastSession: false)
     }
     
@@ -121,4 +128,5 @@ class SchemePermissionTests: XCTestCase {
     private var imageStore: DiskImageStore!
     private var historyAPI: BraveHistoryAPI!
     private var bookmarksAPI: BraveBookmarksAPI!
+    private var syncAPI: BraveSyncAPI!
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -960,8 +960,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.29.76/brave-core-ios-1.29.76.tgz",
-      "integrity": "sha512-3tHnrfpqQjmpiYlJdJxd4yPFuxn/Pd3sXfQwQu3b6peWG2nKEOILhl2Psa+Eghn7GIHKkaVBjgCLPHVKY7lJSg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.32.25/brave-core-ios-1.32.25.tgz",
+      "integrity": "sha512-LJI1lOjZ4n7CF0r36/KUKjx8KSxyn86jjRzzxCYxPrhA1fz8i32s193PNQ3A3uPDWZK2Q+lXBgldol6jTcNEoQ=="
     },
     "browserslist": {
       "version": "3.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.29.76/brave-core-ios-1.29.76.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.32.25/brave-core-ios-1.32.25.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
BraveCoreMigrator and BraveSyncAPI Extension should be refactored in order to stop using shared delegate for AppDelegate.

For BraveCoreMigrator the constructor should be changed so historyAPI and bookmarksAPI can be assigned where the migrator is initialized. To achieve this Migration class instance should be created inside BrowserViewController and static migrator property should be changed to non-static and also class functions should be changed.

For BraveSyncAPI the API class should not be a singleton and should be constructed like other Core API classes. And after that the API property should be passes properly from AppDelegate to designated place that will be used.
## Summary of Changes

This pull request fixes #4170
This pull request fixes #4166

This PR depends on the brave-core https://github.com/brave/brave-core/pull/10233 to be merged and bump containing this change will be fetched in iOS. 

For this reason it is in Draft stage but it can be reviewed.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Sanity Check on Sync Features

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
