### PR TITLE
Fix #4226: ReaderMode taking precedence over playlist

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1176,10 +1176,12 @@ class BrowserViewController: UIViewController {
             UIAccessibility.post(notification: .screenChanged, argument: nil)
             
             // Refresh the reading view toolbar since the article record may have changed
-            if let readerMode = self.tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) as? ReaderMode,
+            if let tab = self.tabManager.selectedTab,
+               let readerMode = tab.getContentScript(name: ReaderMode.name()) as? ReaderMode,
                readerMode.state == .active,
                isReaderModeURL {
                 self.showReaderModeBar(animated: false)
+                self.updatePlaylistURLBar(tab: tab, state: tab.playlistItemState, item: tab.playlistItem)
             }
         })
     }
@@ -1486,6 +1488,7 @@ class BrowserViewController: UIViewController {
             }
 
             updateInContentHomePanel(url as URL)
+            updatePlaylistURLBar(tab: tab, state: tab.playlistItemState, item: tab.playlistItem)
         }
     }
     
@@ -2269,13 +2272,16 @@ extension BrowserViewController: TabManagerDelegate {
         
         let shouldShowPlaylistURLBarButton = selected?.url?.isPlaylistSupportedSiteURL == true
         
-        if let readerMode = selected?.getContentScript(name: ReaderMode.name()) as? ReaderMode, !shouldShowPlaylistURLBarButton {
+        if let selected = selected,
+            let readerMode = selected.getContentScript(name: ReaderMode.name()) as? ReaderMode, !shouldShowPlaylistURLBarButton {
             topToolbar.updateReaderModeState(readerMode.state)
             if readerMode.state == .active {
                 showReaderModeBar(animated: false)
             } else {
                 hideReaderModeBar(animated: false)
             }
+            
+            updatePlaylistURLBar(tab: selected, state: selected.playlistItemState, item: selected.playlistItem)
         } else {
             topToolbar.updateReaderModeState(ReaderModeState.unavailable)
         }

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -88,6 +88,9 @@ extension BrowserViewController: PlaylistHelperDelegate {
                 topToolbar.menuButton.removeBadge(.playlist, animated: true)
                 toolbar?.menuButton.removeBadge(.playlist, animated: true)
             case .newItem:
+                if shouldShowPlaylistURLBarButton {
+                    topToolbar.locationView.readerModeState = .unavailable
+                }
                 playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addToPlaylist : .none
                 if Preferences.Playlist.enablePlaylistMenuBadge.value {
                     topToolbar.menuButton.addBadge(.playlist, animated: true)
@@ -97,6 +100,9 @@ extension BrowserViewController: PlaylistHelperDelegate {
                     toolbar?.menuButton.removeBadge(.playlist, animated: true)
                 }
             case .existingItem:
+                if shouldShowPlaylistURLBarButton {
+                    topToolbar.locationView.readerModeState = .unavailable
+                }
                 playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addedToPlaylist : .none
                 topToolbar.menuButton.removeBadge(.playlist, animated: true)
                 toolbar?.menuButton.removeBadge(.playlist, animated: true)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Reader-Mode sometimes takes precedence over Playlist on sites where the content changes, but does not cause a reload. IE: Youtube.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4226

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
