### PR TITLE
Fix #4234: Add option to disable Playlist URL-Bar button

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1214,6 +1214,18 @@ extension Strings {
                               value: "This will delete the media from offline storage. Are you sure you want to continue?",
                               comment: "Message for the alert shown when the user tries to remove offline data of an item from playlist")
         
+        public static let urlBarButtonOptionTitle =
+            NSLocalizedString("playlist.urlBarButtonOptionTitle",
+                              bundle: .braveShared,
+                              value: "Show Playlist button in the URL bar",
+                              comment: "Title for playlist URL-Bar option")
+        
+        public static let urlBarButtonOptionFooterText =
+            NSLocalizedString("playlist.urlBarButtonOptionFooterText",
+                              bundle: .braveShared,
+                              value: "When enabled, a button will be displayed in URL bar, indicating media on the page may be added to Brave Playlist.",
+                              comment: "Description footer for playlist URL-Bar option")
+        
         public static let menuBadgeOptionTitle =
             NSLocalizedString("playlist.menuBadgeOptionTitle",
                               bundle: .braveShared,

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1217,8 +1217,14 @@ extension Strings {
         public static let urlBarButtonOptionTitle =
             NSLocalizedString("playlist.urlBarButtonOptionTitle",
                               bundle: .braveShared,
-                              value: "Enable toolbar button",
-                              comment: "Title for playlist URL-Bar option")
+                              value: "Enable quick-access button",
+                              comment: "Title for option to disable URL-Bar button")
+        
+        public static let urlBarButtonOptionFooter =
+            NSLocalizedString("playlist.urlBarButtonOptionFooter",
+                              bundle: .braveShared,
+                              value: "Adds a playlist button (it looks like 4 lines with a + symbol) beside the address bar in the Brave browser. This button gives you quick access to open Playlist, or add or remove media.",
+                              comment: "Footer for option to disable URL-Bar button")
         
         public static let menuBadgeOptionTitle =
             NSLocalizedString("playlist.menuBadgeOptionTitle",

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1217,14 +1217,8 @@ extension Strings {
         public static let urlBarButtonOptionTitle =
             NSLocalizedString("playlist.urlBarButtonOptionTitle",
                               bundle: .braveShared,
-                              value: "Show Playlist button in the URL bar",
+                              value: "Enable toolbar button",
                               comment: "Title for playlist URL-Bar option")
-        
-        public static let urlBarButtonOptionFooterText =
-            NSLocalizedString("playlist.urlBarButtonOptionFooterText",
-                              bundle: .braveShared,
-                              value: "When enabled, a button will be displayed in URL bar, indicating media on the page may be added to Brave Playlist.",
-                              comment: "Description footer for playlist URL-Bar option")
         
         public static let menuBadgeOptionTitle =
             NSLocalizedString("playlist.menuBadgeOptionTitle",

--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -270,6 +270,9 @@ extension Preferences {
         /// The option to enable or disable the 3-dot menu badge for playlist
         static let enablePlaylistMenuBadge =
             Option<Bool>(key: "playlist.enablePlaylistMenuBadge", default: true)
+        /// The option to enable or disable the URL-Bar button for playlist
+        static let enablePlaylistURLBarButton =
+            Option<Bool>(key: "playlist.enablePlaylistURLBarButton", default: true)
         /// The option to enable or disable the continue where left-off playback in CarPlay
         static let enableCarPlayRestartPlayback =
             Option<Bool>(key: "playlist.enableCarPlayRestartPlayback", default: false)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -376,6 +376,7 @@ class BrowserViewController: UIViewController {
         Preferences.Rewards.hideRewardsIcon.observe(from: self)
         Preferences.Rewards.rewardsToggledOnce.observe(from: self)
         Preferences.Playlist.enablePlaylistMenuBadge.observe(from: self)
+        Preferences.Playlist.enablePlaylistURLBarButton.observe(from: self)
         rewardsEnabledObserveration = rewards.observe(\.isEnabled, options: [.new]) { [weak self] _, _ in
             guard let self = self else { return }
             self.updateRewardsButtonState()
@@ -2924,7 +2925,8 @@ extension BrowserViewController: PreferencesObserver {
                 $0.userScriptManager?.isMediaBackgroundPlaybackEnabled = Preferences.General.mediaAutoBackgrounding.value
                 $0.webView?.reload()
             }
-        case Preferences.Playlist.enablePlaylistMenuBadge.key:
+        case Preferences.Playlist.enablePlaylistMenuBadge.key,
+            Preferences.Playlist.enablePlaylistURLBarButton.key:
             let selectedTab = tabManager.selectedTab
             updatePlaylistURLBar(tab: selectedTab,
                                  state: selectedTab?.playlistItemState ?? .none,

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -80,7 +80,9 @@ extension BrowserViewController: PlaylistHelperDelegate {
             tab.playlistItemState = state
             tab.playlistItem = item
             
-            let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true
+            let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true &&
+                                                 Preferences.Playlist.enablePlaylistURLBarButton.value
+            
             let playlistButton = topToolbar.locationView.playlistButton
             switch state {
             case .none:
@@ -233,7 +235,8 @@ extension BrowserViewController: PlaylistHelperDelegate {
     func showPlaylistOnboarding(tab: Tab?) {
         // Do NOT show the playlist onboarding popup if the tab isn't visible
         
-        guard let selectedTab = tabManager.selectedTab,
+        guard Preferences.Playlist.enablePlaylistURLBarButton.value,
+              let selectedTab = tabManager.selectedTab,
               selectedTab === tab,
               selectedTab.playlistItemState != .none else {
             return

--- a/Client/Frontend/Settings/PlaylistSettingsViewController.swift
+++ b/Client/Frontend/Settings/PlaylistSettingsViewController.swift
@@ -66,6 +66,12 @@ class PlaylistSettingsViewController: TableViewController {
         dataSource.sections = [
             Section(
                 rows: [
+                    .boolRow(title: Strings.PlayList.urlBarButtonOptionTitle, option: Preferences.Playlist.enablePlaylistURLBarButton),
+                ],
+                footer: .title(Strings.PlayList.urlBarButtonOptionFooterText)
+            ),
+            Section(
+                rows: [
                     .boolRow(title: Strings.PlayList.menuBadgeOptionTitle, option: Preferences.Playlist.enablePlaylistMenuBadge),
                 ],
                 footer: .title(Strings.PlayList.menuBadgeOptionFooterText)

--- a/Client/Frontend/Settings/PlaylistSettingsViewController.swift
+++ b/Client/Frontend/Settings/PlaylistSettingsViewController.swift
@@ -67,8 +67,7 @@ class PlaylistSettingsViewController: TableViewController {
             Section(
                 rows: [
                     .boolRow(title: Strings.PlayList.urlBarButtonOptionTitle, option: Preferences.Playlist.enablePlaylistURLBarButton),
-                ],
-                footer: .title(Strings.PlayList.urlBarButtonOptionFooterText)
+                ]
             ),
             Section(
                 rows: [

--- a/Client/Frontend/Settings/PlaylistSettingsViewController.swift
+++ b/Client/Frontend/Settings/PlaylistSettingsViewController.swift
@@ -67,7 +67,8 @@ class PlaylistSettingsViewController: TableViewController {
             Section(
                 rows: [
                     .boolRow(title: Strings.PlayList.urlBarButtonOptionTitle, option: Preferences.Playlist.enablePlaylistURLBarButton),
-                ]
+                ],
+                footer: .title(Strings.PlayList.urlBarButtonOptionFooter)
             ),
             Section(
                 rows: [


### PR DESCRIPTION
## Summary of Changes
- Added a preference to disable the URL-Bar Playlist button and Playlist onboarding.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4234

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
