### PR TITLE
Fix #4237: Resume Playlist Playback when AudioSession interrupted

### DIFF
--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -450,6 +450,44 @@ extension MediaPlayer {
             self.attachLayer()
         }.store(in: &notificationObservers)
         
+        NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification, object: AVAudioSession.sharedInstance())
+        .receive(on: RunLoop.main)
+        .sink { [weak self] notification in
+            
+            guard let self = self,
+                  let userInfo = notification.userInfo,
+                  let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+                  let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+                      
+                return
+            }
+
+            switch type {
+            case .began:
+                // An interruption began. Update the UI as necessary.
+                self.pause()
+                break
+
+            case .ended:
+               // An interruption ended. Resume playback, if appropriate.
+                guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
+                    return
+                }
+                
+                let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+                if options.contains(.shouldResume) {
+                    // An interruption ended. Resume playback.
+                    self.play()
+                } else {
+                    // An interruption ended. Don't resume playback.
+                    log.debug("Interuption ended, but suggests not to resume playback.")
+                }
+
+            default:
+                break
+            }
+        }.store(in: &notificationObservers)
+        
         NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)
         .receive(on: RunLoop.main)
         .sink { [weak self] _ in

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -466,7 +466,6 @@ extension MediaPlayer {
             case .began:
                 // An interruption began. Update the UI as necessary.
                 self.pause()
-                break
 
             case .ended:
                // An interruption ended. Resume playback, if appropriate.


### PR DESCRIPTION
## Summary of Changes
- Resume Playlist Playback when AudioSession interrupted (Phone-Calls for Example).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4237

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- In Ticket

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
