### PR TITLE
Fix #4241: Resolve Privileged Request against BaseURL.

### DIFF
--- a/Shared/PrivilegedRequest.swift
+++ b/Shared/PrivilegedRequest.swift
@@ -38,7 +38,7 @@ public class PrivilegedRequest: NSMutableURLRequest {
     }
 
     private static func store(url: URL) -> URL? {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return nil }
 
         var queryItems = (components.queryItems ?? []).filter({ $0.name != PrivilegedRequest.key })
         queryItems.append(URLQueryItem(name: PrivilegedRequest.key,
@@ -49,7 +49,7 @@ public class PrivilegedRequest: NSMutableURLRequest {
     }
 
     public static func removePrivileges(url: URL) -> URL? {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true),
                 let items = components.queryItems else { return url }
 
         components.queryItems = items.filter { $0.name != PrivilegedRequest.key }


### PR DESCRIPTION
## Summary of Changes

- Local host URLs like `about:home` require resolving against baseURL. Not exactly sure why `http://localhost:6596/about/home` requires this, but it does because the `URLComponents` class will strip the host. It does not do this for any other URLs which is why sharing URLs with Brave works fine.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4241

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
