### PR TITLE
No Bug: Use Xcode 13 in GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
         # The XCode version to use. If you want to update it please refer to this document:
         # https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software
         # and set proper version.
-        XCODE_VERSION: 12.5
+        XCODE_VERSION: "13.0"
 
     steps:
       - name: Select XCode


### PR DESCRIPTION
Switches CI to use `Xcode 13.0 (13A233)` which should be available on macOS-11 virtual environment