### PR TITLE
[No-Bug] - Add JDK instructions to Read-Me

### DIFF
--- a/BraveCore/Updating the BraveRewards framework.md
+++ b/BraveCore/Updating the BraveRewards framework.md
@@ -2,6 +2,7 @@
 
 1. Clone [brave-browser](https://github.com/brave/brave-browser) if you haven't already
 1. Make sure you meet [brave-browser's prerequisites](https://github.com/brave/brave-browser/wiki/macOS-Development-Environment)
+1. Install Java [JDK](https://www.oracle.com/java/technologies/downloads/) and make sure it is in your `PATH` environment variable.
 1. Run `npm install` if you haven't already
 1. Make sure its up to date:
     ```shell


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add instructions to install Java-JDK in the read-me when building Brave-Core

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
