### PR TITLE
Fix #4287: Retrieve the current tab that made the request, instead of the selected tab

### DIFF
--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
@@ -59,7 +59,7 @@ extension ContentBlockerHelper: TabContentScript {
         var req = URLRequest(url: url)
         req.mainDocumentURL = mainDocumentUrl
 
-        TPStatsBlocklistChecker.shared.isBlocked(request: req, domain: domain, resourceType: resourceType) { listItem in
+        TPStatsBlocklistChecker.shared.isBlocked(tab: tab, request: req, domain: domain, resourceType: resourceType) { listItem in
             DispatchQueue.main.async {
                 if let listItem = listItem {
                     if listItem == .https {

--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
@@ -59,7 +59,7 @@ extension ContentBlockerHelper: TabContentScript {
         var req = URLRequest(url: url)
         req.mainDocumentURL = mainDocumentUrl
 
-        TPStatsBlocklistChecker.shared.isBlocked(tab: tab, request: req, domain: domain, resourceType: resourceType) { listItem in
+        TPStatsBlocklistChecker.shared.isBlocked(request: req, domain: domain, resourceType: resourceType) { listItem in
             DispatchQueue.main.async {
                 if let listItem = listItem {
                     if listItem == .https {

--- a/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
@@ -54,7 +54,7 @@ class TPStatsBlocklistChecker {
     static let shared = TPStatsBlocklistChecker()
     private let adblockSerialQueue = AdBlockStats.adblockSerialQueue
 
-    func isBlocked(tab: Tab?, request: URLRequest, domain: Domain, resourceType: TPStatsResourceType? = nil, _ completion: @escaping (BlocklistName?) -> Void) {
+    func isBlocked(request: URLRequest, domain: Domain, resourceType: TPStatsResourceType? = nil, _ completion: @escaping (BlocklistName?) -> Void) {
         
         guard let url = request.url, let host = url.host, !host.isEmpty else {
             // TP Stats init isn't complete yet
@@ -66,8 +66,8 @@ class TPStatsBlocklistChecker {
         // to avoid threading problems(#1094, #1096)
         assertIsMainThread("Getting enabled blocklists should happen on main thread")
         let domainBlockLists = BlocklistName.blocklists(forDomain: domain).on
-        let currentTabUrl = tab?.url
-        
+        let currentTabUrl = request.mainDocumentURL
+
         adblockSerialQueue.async {
             let enabledLists = domainBlockLists
             

--- a/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
@@ -54,7 +54,7 @@ class TPStatsBlocklistChecker {
     static let shared = TPStatsBlocklistChecker()
     private let adblockSerialQueue = AdBlockStats.adblockSerialQueue
 
-    func isBlocked(request: URLRequest, domain: Domain, resourceType: TPStatsResourceType? = nil, _ completion: @escaping (BlocklistName?) -> Void) {
+    func isBlocked(tab: Tab?, request: URLRequest, domain: Domain, resourceType: TPStatsResourceType? = nil, _ completion: @escaping (BlocklistName?) -> Void) {
         
         guard let url = request.url, let host = url.host, !host.isEmpty else {
             // TP Stats init isn't complete yet
@@ -66,12 +66,7 @@ class TPStatsBlocklistChecker {
         // to avoid threading problems(#1094, #1096)
         assertIsMainThread("Getting enabled blocklists should happen on main thread")
         let domainBlockLists = BlocklistName.blocklists(forDomain: domain).on
-        
-        guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
-            completion(nil)
-            return
-        }
-        let currentTabUrl = delegate.browserViewController.tabManager.selectedTab?.url
+        let currentTabUrl = tab?.url
         
         adblockSerialQueue.async {
             let enabledLists = domainBlockLists


### PR DESCRIPTION
## Summary of Changes
- Retrieve the current tab that made the request, instead of the selected tab
- The content blocker should run on the current tab passed in as a parameter.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4287

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
