### PR TITLE
Fix #4305: Make Brave Search to show as first engine in SE picker.

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -65,12 +65,7 @@ class SearchSettingsTableViewController: UITableViewController {
         
         var orderedEngines = searchEngines.orderedEngines
             .sorted { $0.shortName < $1.shortName }
-        
-        if let initialDefaultEngine =
-            SearchEngines.getUnorderedBundledEngines(isOnboarding: false, locale: .current).first {
-            orderedEngines = orderedEngines
-                .sorted { engine, _ in engine.shortName == initialDefaultEngine.shortName }
-        }
+            .sorted { engine, _ in engine.shortName == OpenSearchEngine.EngineNames.brave }
         
         if isPrivate {
             orderedEngines = orderedEngines


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4305 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Go to search settings
- Verify that Brave Search is first on the list for both normal and private modes

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
