### PR TITLE
Fix #4301: Fix session restore with special characters not working

### DIFF
--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -439,7 +439,7 @@ extension URL {
         
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         if self.isErrorPageURL, let queryURL = components?.queryItems?.find({ $0.name == "url" })?.value {
-            return URL(string: queryURL)
+            return URL(string: queryURL) ?? URL(string: queryURL.escape() ?? queryURL)
         }
         return nil
     }


### PR DESCRIPTION
## Summary of Changes
- Fixes session restore with special characters not working properly.
- Ideally, we want to do what Firefox does and get rid of GCDWebServer and do the same logic for `PrivilegedRequest` via `InternalURL`

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4301

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
In ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
