### PR TITLE
Fix #4259: Replace hard-coded user facing strings with NSLocalizedString

### DIFF
--- a/BraveUI/SwiftUI/PopupView.swift
+++ b/BraveUI/SwiftUI/PopupView.swift
@@ -107,13 +107,13 @@ struct PopupPreviews: PreviewProvider {
         VStack {
           Circle()
             .frame(width: 100, height: 100)
-          Text("Title")
+          Text(verbatim: "Title")
             .font(.headline)
-          Text("Subtitle Subtitle Subtitle Subtitle Subtitle")
+          Text(verbatim: "Subtitle Subtitle Subtitle Subtitle Subtitle")
             .font(.subheadline)
             .multilineTextAlignment(.center)
           Button(action: { }) {
-            Text("Test")
+            Text(verbatim: "Test")
           }
           .padding(.top)
           .buttonStyle(BraveFilledButtonStyle(size: .normal))

--- a/BraveWallet/Chart/DateRangeView.swift
+++ b/BraveWallet/Chart/DateRangeView.swift
@@ -6,6 +6,7 @@
 import Foundation
 import SwiftUI
 import BraveCore
+import struct Shared.Strings
 
 struct DateRangeView: View {
   @Binding var selectedRange: BraveWallet.AssetPriceTimeframe
@@ -63,29 +64,27 @@ extension BraveWallet.AssetPriceTimeframe: CaseIterable {
   }
   
   var accessibilityLabel: String {
-    // NSLocalizedString
     switch self {
-    case .live: return "1 Hour"
-    case .oneDay: return "1 Day"
-    case .oneWeek: return "1 Week"
-    case .oneMonth: return "1 Month"
-    case .threeMonths: return "3 Months"
-    case .oneYear: return "1 Year"
-    case .all: return "All"
+    case .live: return Strings.Wallet.dateIntervalHourAccessibilityLabel
+    case .oneDay: return Strings.Wallet.dateIntervalDayAccessibilityLabel
+    case .oneWeek: return Strings.Wallet.dateIntervalWeekAccessibilityLabel
+    case .oneMonth: return Strings.Wallet.dateIntervalMonthAccessibilityLabel
+    case .threeMonths: return Strings.Wallet.dateIntervalThreeMonthsAccessibilityLabel
+    case .oneYear: return Strings.Wallet.dateIntervalYearAccessibilityLabel
+    case .all: return Strings.Wallet.dateIntervalAll
     @unknown default: return ""
     }
   }
   
   var displayString: String {
-    // NSLocalizedString
     switch self {
-    case .live: return "1H"
-    case .oneDay: return "1D"
-    case .oneWeek: return "1W"
-    case .oneMonth: return "1M"
-    case .threeMonths: return "3M"
-    case .oneYear: return "1Y"
-    case .all: return "ALL"
+    case .live: return Strings.Wallet.dateIntervalHour
+    case .oneDay: return Strings.Wallet.dateIntervalDay
+    case .oneWeek: return Strings.Wallet.dateIntervalWeek
+    case .oneMonth: return Strings.Wallet.dateIntervalMonth
+    case .threeMonths: return Strings.Wallet.dateIntervalThreeMonths
+    case .oneYear: return Strings.Wallet.dateIntervalYear
+    case .all: return Strings.Wallet.dateIntervalAll.uppercased()
     @unknown default: return ""
     }
   }

--- a/BraveWallet/Chart/LineChartView.swift
+++ b/BraveWallet/Chart/LineChartView.swift
@@ -177,7 +177,7 @@ struct LineChartView<DataType: DataPoint, FillStyle: View>: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .offset(x: offset)
         } else {
-          Text("00:00")
+          Text(verbatim: "00:00")
             .hidden()
         }
       }

--- a/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import SwiftUI
+import struct Shared.Strings
 
 struct AccountsHeaderView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -17,7 +18,7 @@ struct AccountsHeaderView: View {
         HStack {
           Image("brave.safe")
             .foregroundColor(Color(.braveLabel))
-          Text("Backup") // NSLocalizedString
+          Text(Strings.Wallet.accountBackup)
             .font(.subheadline.weight(.medium))
             .foregroundColor(Color(.braveLighterBlurple))
         }

--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -8,6 +8,7 @@ import BraveCore
 import Combine
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct AccountsView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -56,7 +57,7 @@ struct AccountsView: View {
       }
       Section(
         header: WalletListHeaderView(
-          title: Text("Primary Crypto Accounts") // NSLocalizedString
+          title: Text(Strings.Wallet.primaryCryptoAccountsTitle)
         )
       ) {
         ForEach(primaryAccounts) { account in
@@ -66,13 +67,13 @@ struct AccountsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(
-          title: Text("Secondary Accounts"), // NSLocalizedString
-          subtitle: Text("Import your external wallet account with a separate seed phrase.") // NSLocalizedString
+          title: Text(Strings.Wallet.secondaryCryptoAccountsTitle),
+          subtitle: Text(Strings.Wallet.secondaryCryptoAccountsSubtitle)
         )
       ) {
         let secondaryAccounts = secondaryAccounts
         if secondaryAccounts.isEmpty {
-          Text("No secondary accounts") // NSLocalizedString
+          Text(Strings.Wallet.noSecondaryAccounts)
             .foregroundColor(Color(.secondaryBraveLabel))
             .multilineTextAlignment(.center)
             .frame(maxWidth: .infinity)
@@ -86,7 +87,7 @@ struct AccountsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
-    .navigationTitle("Accounts") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.accountsPageTitle)
     .osAvailabilityModifiers { content in
       if #available(iOS 15.0, *) {
         content

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -7,6 +7,7 @@ import UIKit
 import BraveCore
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct AccountActivityView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -51,15 +52,15 @@ struct AccountActivityView: View {
         .listRowBackground(Color(.braveGroupedBackground))
       }
       Section(
-        header: WalletListHeaderView(title: Text("Assets")) // NSLocalizedString
+        header: WalletListHeaderView(title: Text(Strings.Wallet.assetsTitle))
       ) {
-        emptyTextView("No Assets") // NSLocalizedString
+        emptyTextView(Strings.Wallet.noAssets)
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
-        header: WalletListHeaderView(title: Text("Transactions")) // NSLocalizedString
+        header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
       ) {
-        emptyTextView("No Transactions") // NSLocalizedString
+        emptyTextView(Strings.Wallet.noTransactions)
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
@@ -101,7 +102,7 @@ private struct AccountActivityHeaderView: View {
           HStack {
             Image("brave.qr-code")
               .font(.body)
-            Text("Details") // NSLocalizedString
+            Text(Strings.Wallet.detailsButtonTitle)
               .font(.footnote.weight(.bold))
           }
         }
@@ -109,7 +110,7 @@ private struct AccountActivityHeaderView: View {
           HStack {
             Image("brave.edit")
               .font(.body)
-            Text("Rename") // NSLocalizedString
+            Text(Strings.Wallet.renameButtonTitle)
               .font(.footnote.weight(.bold))
           }
         }

--- a/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct AddAccountView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -21,7 +22,7 @@ struct AddAccountView: View {
   private func addAccount() {
     if privateKey.isEmpty {
       // Add normal account
-      let accountName = name.isEmpty ? "Account \(keyringStore.keyring.accountInfos.filter(\.isPrimary).count + 1)" : name 
+      let accountName = name.isEmpty ? String.localizedStringWithFormat(Strings.Wallet.defaultAccountName, keyringStore.keyring.accountInfos.filter(\.isPrimary).count + 1) : name
       keyringStore.addPrimaryAccount(accountName) { success in
         // TODO: Error state
         if success {
@@ -36,7 +37,8 @@ struct AddAccountView: View {
           failedToImport = true
         }
       }
-      let accountName = name.isEmpty ? "Secondary Account \(keyringStore.keyring.accountInfos.filter(\.isImported).count + 1)" : name // NSLocalizedString
+      let accountName = name.isEmpty ?
+      String.localizedStringWithFormat(Strings.Wallet.defaultSecondaryAccountName, keyringStore.keyring.accountInfos.filter(\.isImported).count + 1) : name
       if isJSONImported {
         keyringStore.addSecondaryAccount(accountName, json: privateKey, password: originPassword, completion: handler)
       } else {
@@ -88,27 +90,27 @@ struct AddAccountView: View {
     }
     .animation(.default, value: isJSONImported)
     .navigationBarTitleDisplayMode(.inline)
-    .navigationTitle("Add Account") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.addAccountTitle)
     .navigationBarItems(
       // Have to use this instead of toolbar placement to have a custom button style
       trailing: Button(action: addAccount) {
-        Text("Add")
+        Text(Strings.Wallet.addAccountAddButton)
       }
       .buttonStyle(BraveFilledButtonStyle(size: .small))
     )
     .toolbar {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: { presentationMode.dismiss() }) {
-          Text("Cancel")
+          Text(Strings.CancelString)
             .foregroundColor(Color(.braveOrange))
         }
       }
     }
     .alert(isPresented: $failedToImport) {
       Alert(
-        title: Text("Failed to import account."), // NSLocalizedString
-        message: Text("Please try again."), // NSLocalizedString
-        dismissButton: .cancel(Text("OK")) // NSLocalizedString
+        title: Text(Strings.Wallet.failedToImportAccountErrorTitle),
+        message: Text(Strings.Wallet.failedToImportAccountErrorMessage),
+        dismissButton: .cancel(Text(Strings.OKString))
       )
     }
   }
@@ -116,7 +118,7 @@ struct AddAccountView: View {
   private var accountNameSection: some View {
     Section(
       header: WalletListHeaderView(
-        title: Text("Account Name") // NSLocalizedString
+        title: Text(Strings.Wallet.accountDetailsNameTitle)
           .font(.subheadline.weight(.semibold))
           .foregroundColor(Color(.bravePrimary))
       )
@@ -129,7 +131,7 @@ struct AddAccountView: View {
         }
       }
     ) {
-      TextField("Enter account name", text: $name) // NSLocalizedString
+      TextField(Strings.Wallet.accountDetailsNamePlaceholder, text: $name)
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
   }
@@ -137,12 +139,12 @@ struct AddAccountView: View {
   private var originPasswordSection: some View {
     Section(
       header: WalletListHeaderView(
-        title: Text("Origin Password") // NSLocalizedString
+        title: Text(Strings.Wallet.importAccountOriginPasswordTitle)
           .font(.subheadline.weight(.semibold))
           .foregroundColor(Color(.bravePrimary))
       )
     ) {
-      SecureField("Password", text: $originPassword)
+      SecureField(Strings.Wallet.passwordPlaceholder, text: $originPassword)
     }
     .listRowBackground(Color(.secondaryBraveGroupedBackground))
   }
@@ -150,7 +152,7 @@ struct AddAccountView: View {
   private var privateKeySection: some View {
     Section(
       header: WalletListHeaderView(
-        title: Text("You can create a secondary account by importing your private key.") // NSLocalizedString
+        title: Text(Strings.Wallet.importAccountSectionTitle)
           .font(.subheadline.weight(.semibold))
           .foregroundColor(Color(.bravePrimary))
       )
@@ -159,7 +161,7 @@ struct AddAccountView: View {
         .font(.system(.body, design: .monospaced))
         .frame(height: privateKeyFieldHeight)
         .background(
-          Text("Enter, paste, or import your private key string file or JSON.") // NSLocalizedString
+          Text(Strings.Wallet.importAccountPlaceholder)
             .padding(.vertical, 8)
             .padding(.horizontal, 4) // To match the TextEditor's editing insets
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -172,7 +174,7 @@ struct AddAccountView: View {
         }
       Button(action: { isPresentingImport = true }) {
         HStack {
-          Text("Import…") // NSLocalizedString
+          Text(Strings.Wallet.importButtonTitle)
             .foregroundColor(.accentColor)
             .font(.callout)
           if isLoadingFile {

--- a/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -10,6 +10,8 @@ import CoreImage
 // For some reason SwiftLint thinks this is a duplicate import
 // swiftlint:disable:next duplicate_imports
 import CoreImage.CIFilterBuiltins
+import struct Shared.Strings
+import BraveShared
 
 struct AccountDetailsView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -46,12 +48,12 @@ struct AccountDetailsView: View {
         }
         Section(
           header: WalletListHeaderView(
-            title: Text("Account Name") // NSLocalizedString
+            title: Text(Strings.Wallet.accountDetailsNameTitle)
               .font(.subheadline.weight(.semibold))
               .foregroundColor(Color(.bravePrimary))
           )
         ) {
-          TextField("Enter account name", text: $name) // NSLocalizedString
+          TextField(Strings.Wallet.accountDetailsNamePlaceholder, text: $name)
             .introspectTextField { tf in
               if editMode && !isFieldFocused && !tf.isFirstResponder {
                 isFieldFocused = tf.becomeFirstResponder()
@@ -61,24 +63,24 @@ struct AccountDetailsView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section {
           NavigationLink(destination: AccountPrivateKeyView(keyringStore: keyringStore, account: account)) {
-            Text("Private Key")
+            Text(Strings.Wallet.accountPrivateKey)
           }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         if account.isImported {
           Section {
             Button(action: { isPresentingRemoveConfirmation = true }) {
-              Text("Remove Account") // NSLocalizedString
+              Text(Strings.Wallet.accountRemoveButtonTitle)
                 .foregroundColor(.red)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
             }
             .alert(isPresented: $isPresentingRemoveConfirmation) {
               Alert(
-                title: Text("Remove this account?"), // NSLocalizedString
-                message: Text("Are you sure?"), // NSLocalizedString
-                primaryButton: .destructive(Text("Yes"), action: removeAccount), // NSLocalizedString
-                secondaryButton: .cancel(Text("No")) // NSLocalizedString
+                title: Text(Strings.Wallet.accountRemoveAlertConfirmation),
+                message: Text(Strings.Wallet.accountRemoveAlertConfirmationMessage),
+                primaryButton: .destructive(Text(Strings.yes), action: removeAccount),
+                secondaryButton: .cancel(Text(Strings.no))
               )
             }
             // TODO: iOS 15/Xcode 13, set button role to `destructive`
@@ -87,18 +89,18 @@ struct AccountDetailsView: View {
         }
       }
       .listStyle(InsetGroupedListStyle())
-      .navigationTitle("Account Details") // NSLocalizedString
+      .navigationTitle(Strings.Wallet.accountDetailsTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { presentationMode.dismiss() }) {
-            Text("Cancel") // NSLocalizedString
+            Text(Strings.CancelString)
               .foregroundColor(Color(.braveOrange))
           }
         }
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: renameAccountAndDismiss) {
-            Text("Done") // NSLocalizedString
+            Text(Strings.done)
               .foregroundColor(Color(.braveOrange))
           }
         }

--- a/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveCore
 import BraveUI
+import struct Shared.Strings
 
 struct AccountPrivateKeyView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -18,7 +19,7 @@ struct AccountPrivateKeyView: View {
   
   var body: some View {
     VStack {
-      Text("\(Image(systemName: "exclamationmark.triangle.fill")) Warning: Never disclose this key. Anyone with your private key can steal any assets held in your account.") // NSLocalizedString
+      Text(verbatim: "\(Image(systemName: "exclamationmark.triangle.fill")) \(Strings.Wallet.accountPrivateKeyDisplayWarning)")
         .font(.subheadline.weight(.medium))
         .foregroundColor(Color(.braveLabel))
         .padding(12)
@@ -38,7 +39,7 @@ struct AccountPrivateKeyView: View {
         Button(action: {
           UIPasteboard.general.string = key
         }) {
-          Text("Copy to Clipboard \(Image("brave.clipboard"))")
+          Text(verbatim: "\(Strings.Wallet.copyToPasteboard) \(Image("brave.clipboard"))")
             .font(.subheadline)
             .foregroundColor(Color(.braveBlurple))
         }
@@ -54,7 +55,8 @@ struct AccountPrivateKeyView: View {
           isKeyVisible.toggle()
         }
       }) {
-        Text(isKeyVisible ? "Hide Private Key" : "Show Private Key") // NSLocalizedString
+        Text(isKeyVisible ? Strings.Wallet.hidePrivateKeyButtonTitle :
+              Strings.Wallet.showPrivateKeyButtonTitle)
       }
       .buttonStyle(BraveFilledButtonStyle(size: .normal))
       .animation(nil, value: isKeyVisible)
@@ -68,7 +70,7 @@ struct AccountPrivateKeyView: View {
       }
     }
     .background(Color(.braveBackground))
-    .navigationTitle("Private Key")
+    .navigationTitle(Strings.Wallet.accountPrivateKey)
     .navigationBarTitleDisplayMode(.inline)
   }
 }

--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import BraveCore
 import BraveUI
+import struct Shared.Strings
 
 struct AssetDetailHeaderView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -42,7 +43,7 @@ struct AssetDetailHeaderView: View {
   private var deltaText: some View {
     HStack(spacing: 2) {
       Image(systemName: "arrow.up")
-      Text("0.46%")
+      Text(verbatim: "0.46%")
     }
     .foregroundColor(.white)
     .font(.caption2)
@@ -102,16 +103,17 @@ struct AssetDetailHeaderView: View {
             }
           }
         }
-        Text("\(currency.name) Price (\(currency.symbol))")
+        Text(String.localizedStringWithFormat(Strings.Wallet.assetDetailSubtitle,
+                                              currency.name, currency.symbol))
           .font(.footnote)
           .foregroundColor(Color(.secondaryBraveLabel))
         HStack {
-          Text("$1,812.31")
+          Text(verbatim: "$1,812.31")
             .font(.title2.bold())
           deltaText
           Spacer()
         }
-        Text("0.03265 BTC")
+        Text(verbatim: "0.03265 BTC")
           .font(.footnote)
           .foregroundColor(Color(.secondaryBraveLabel))
         LineChartView(data: data, numberOfColumns: 12, selectedDataPoint: $selectedCandle) {
@@ -129,13 +131,13 @@ struct AssetDetailHeaderView: View {
         .padding(.bottom)
       HStack {
         Button(action: { }) {
-          Text("Buy")
+          Text(Strings.Wallet.buy)
         }
         Button(action: { }) {
-          Text("Send")
+          Text(Strings.Wallet.send)
         }
         Button(action: { }) {
-          Text("Swap")
+          Text(Strings.Wallet.swap)
         }
       }
       .buttonStyle(BraveFilledButtonStyle(size: .normal))

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -8,6 +8,7 @@ import UIKit
 import SwiftUI
 import BraveCore
 import BraveUI
+import struct Shared.Strings
 
 struct AssetDetailView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -27,7 +28,7 @@ struct AssetDetailView: View {
       ) {
       }
       Section(
-        header: WalletListHeaderView(title: Text("Accounts")) // NSLocalizedString
+        header: WalletListHeaderView(title: Text(Strings.Wallet.accountsPageTitle))
           .osAvailabilityModifiers { content in
             if #available(iOS 15.0, *) {
               content // padding already applied
@@ -36,23 +37,23 @@ struct AssetDetailView: View {
             }
           },
         footer: Button(action: {}) {
-          Text("Add Account") // NSLocalizedString
+          Text(Strings.Wallet.addAccountTitle)
         }
         .listRowInsets(.zero)
         .buttonStyle(BraveOutlineButtonStyle(size: .small))
         .padding(.vertical, 8)
       ) {
-        Text("No accounts") // NSLocalizedString
+        Text(Strings.Wallet.noAccounts)
       }
       Section(
-        header: WalletListHeaderView(title: Text("Transactions")) // NSLocalizedString
+        header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
       ) {
-        Text("No transactions")
+        Text(Strings.Wallet.noTransactions)
       }
       Section(
-        header: WalletListHeaderView(title: Text("Info")) // NSLocalizedString
+        header: WalletListHeaderView(title: Text(Strings.Wallet.infoTitle))
       ) {
-        Text("No info") // NSLocalizedString
+        Text(verbatim: "No info") // TODO: Just hide the info section when there isn't any available
       }
     }
     .listStyle(InsetGroupedListStyle())

--- a/BraveWallet/Crypto/Asset Details/TransactionView.swift
+++ b/BraveWallet/Crypto/Asset Details/TransactionView.swift
@@ -36,10 +36,10 @@ struct TransactionView: View {
         HStack {
           Text(accountName)
             .fontWeight(.semibold)
-          Text("sent \(timeFormatter.localizedString(for: date, relativeTo: Date()))")
+          Text(verbatim: "sent \(timeFormatter.localizedString(for: date, relativeTo: Date()))")
         }
-        Text("0x\(fromAddress.truncatedAddress)")
-        Text("→ 0x\(toAddress.truncatedAddress)")
+        Text(verbatim: "0x\(fromAddress.truncatedAddress)")
+        Text(verbatim: "→ 0x\(toAddress.truncatedAddress)")
       }
       Spacer()
       VStack(alignment: .trailing, spacing: 2) {

--- a/BraveWallet/Crypto/BuySendSwapView.swift
+++ b/BraveWallet/Crypto/BuySendSwapView.swift
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import SwiftUI
+import struct Shared.Strings
 
 struct BuySendSwapView: View {
   enum Action: CaseIterable {
@@ -14,22 +15,22 @@ struct BuySendSwapView: View {
     var title: String {
       switch self {
       case .buy:
-        return "Buy" // NSLocalizedString
+        return Strings.Wallet.buy
       case .send:
-        return "Send" // NSLocalizedString
+        return Strings.Wallet.send
       case .swap:
-        return "Swap" // NSLocalizedString
+        return Strings.Wallet.swap
       }
     }
     
     var description: String {
       switch self {
       case .buy:
-        return "Buy crypto with Apple Pay, credit or debit card." // NSLocalizedString
+        return Strings.Wallet.buyDescription
       case .send:
-        return "Send crypto or transfer from one account to another." // NSLocalizedString
+        return Strings.Wallet.sendDescription
       case .swap:
-        return "Swap crypto assets with Brave DEX aggregator." // NSLocalizedString
+        return Strings.Wallet.swapDescription
       }
     }
   }

--- a/BraveWallet/Crypto/BuySwapSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySwapSwap/AccountPicker.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import BraveCore
+import struct Shared.Strings
 
 struct AccountPicker: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -63,7 +64,7 @@ struct AccountPicker: View {
   
   private var menuContents: some View {
     Button(action: copyAddress) {
-      Label("Copy Address", image: "brave.clipboard")
+      Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
     }
   }
   
@@ -100,7 +101,7 @@ struct AccountPicker: View {
     NavigationView {
       List {
         Section(
-          header: WalletListHeaderView(title: Text("Accounts"))
+          header: WalletListHeaderView(title: Text(Strings.Wallet.accountsPageTitle))
         ) {
           ForEach(keyringStore.keyring.accountInfos) { account in
             Button(action: {
@@ -113,12 +114,12 @@ struct AccountPicker: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .navigationTitle("Select Account")
+      .navigationTitle(Strings.Wallet.selectAccountTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { isPresentingPicker = false }) {
-            Text("Cancel")
+            Text(Strings.CancelString)
               .foregroundColor(Color(.braveOrange))
           }
         }

--- a/BraveWallet/Crypto/BuySwapSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySwapSwap/SwapCryptoView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveCore
 import BraveUI
+import struct Shared.Strings
 
 struct ShortcutAmountGrid: View {
   enum Amount: Double, CaseIterable {
@@ -90,17 +91,17 @@ struct SwapCryptoView: View {
         ) {
         }
         Section(
-          header: WalletListHeaderView(title: Text("From"))
+          header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoFromTitle))
         ) {
           NavigationLink(destination: EmptyView()) {
             HStack {
               Circle()
                 .frame(width: 26, height: 26)
-              Text("BAT")
+              Text(verbatim: "BAT")
                 .font(.title3.weight(.semibold))
                 .foregroundColor(Color(.braveLabel))
               Spacer()
-              Text("1.2832")
+              Text(verbatim: "1.2832")
                 .font(.footnote)
                 .foregroundColor(Color(.secondaryBraveLabel))
             }
@@ -109,28 +110,28 @@ struct SwapCryptoView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
-          header: WalletListHeaderView(title: Text("Enter amount of BAT to swap")),
+          header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoAmountTitle)),
           footer: ShortcutAmountGrid(action: { amount in
             
           })
           .listRowInsets(.zero)
           .padding(.bottom, 8)
         ) {
-          TextField("Amount in BAT", text: .constant(""))
+          TextField(Strings.Wallet.swapCryptoAmountPlaceholder, text: .constant(""))
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
-          header: WalletListHeaderView(title: Text("To"))
+          header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoToTitle))
         ) {
           NavigationLink(destination: EmptyView()) {
             HStack {
               Circle()
                 .frame(width: 26, height: 26)
-              Text("ETH")
+              Text(verbatim: "ETH")
                 .font(.title3.weight(.semibold))
                 .foregroundColor(Color(.braveLabel))
               Spacer()
-              Text("0.0000")
+              Text(verbatim: "0.0000")
                 .font(.footnote)
                 .foregroundColor(Color(.secondaryBraveLabel))
             }
@@ -139,15 +140,15 @@ struct SwapCryptoView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
-          header: WalletListHeaderView(title: Text("Amount receiving in ETH (estimated)"))
+          header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoAmountReceivingTitle))
         ) {
-          TextField("Amount in ETH", text: .constant(""))
+          TextField(Strings.Wallet.swapCryptoAmountPlaceholder, text: .constant(""))
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
-          header: Picker("Order Type", selection: $orderType) {
-            Text("Market").tag(OrderType.market)
-            Text("Limit").tag(OrderType.limit)
+          header: Picker(Strings.Wallet.swapOrderTypeLabel, selection: $orderType) {
+            Text(Strings.Wallet.swapMarketOrderType).tag(OrderType.market)
+            Text(Strings.Wallet.swapLimitOrderType).tag(OrderType.limit)
           }
             .pickerStyle(SegmentedPickerStyle())
             .resetListHeaderStyle()
@@ -156,12 +157,12 @@ struct SwapCryptoView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .navigationTitle("Swap")
+      .navigationTitle(Strings.Wallet.swap)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { }) {
-            Text("Cancel") // NSLocalizedString
+            Text(Strings.CancelString)
               .foregroundColor(Color(.braveOrange))
           }
         }

--- a/BraveWallet/Crypto/CryptoPagesViewController.swift
+++ b/BraveWallet/Crypto/CryptoPagesViewController.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import BraveCore
 import PanModal
 import BraveUI
+import struct Shared.Strings
 
 class CryptoPagesViewController: TabbedPageViewController {
   private let walletStore: WalletStore
@@ -61,10 +62,10 @@ class CryptoPagesViewController: TabbedPageViewController {
     
     pages = [
       UIHostingController(rootView: PortfolioView(keyringStore: walletStore.keyringStore, networkStore: walletStore.networkStore, portfolioStore: walletStore.portfolioStore)).then {
-        $0.title = "Portfolio" // NSLocalizedString
+        $0.title = Strings.Wallet.portfolioPageTitle
       },
       UIHostingController(rootView: AccountsView(keyringStore: walletStore.keyringStore)).then {
-        $0.title = "Accounts" // NSLocalizedString
+        $0.title = Strings.Wallet.accountsPageTitle
       }
     ]
     

--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import BraveCore
+import struct Shared.Strings
 
 extension BraveWallet.EthereumChain {
   fileprivate var shortChainName: String {
@@ -18,7 +19,10 @@ struct NetworkPicker: View {
   
   var body: some View {
     Menu {
-      Picker("Selected Network", selection: $selectedNetwork) { // NSLocalizedString
+      Picker(
+        Strings.Wallet.selectedNetworkAccessibilityLabel,
+        selection: $selectedNetwork
+      ) {
         ForEach(networks) {
           Text($0.chainName).tag($0)
         }

--- a/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -6,6 +6,7 @@
 import Foundation
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct BackupRecoveryPhraseView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -18,15 +19,15 @@ struct BackupRecoveryPhraseView: View {
       Image(systemName: "exclamationmark.circle")
         .font(.subheadline.weight(.semibold))
         .foregroundColor(.red)
-      Group {
-        Text("WARNING:") // NSLocalizedString
-          .font(.subheadline.weight(.semibold))
-          .foregroundColor(.red) +
-          Text(" Never disclose your backup phrase. Anyone with this phrase can take your funds forever.") // NSLocalizedString
-          .font(.subheadline)
-          .foregroundColor(.secondary)
-      }
-      .fixedSize(horizontal: false, vertical: true)
+      
+      let warningPartOne = Text(Strings.Wallet.backupRecoveryPhraseWarningPartOne)
+        .fontWeight(.semibold)
+        .foregroundColor(.red)
+      let warningPartTwo = Text(Strings.Wallet.backupRecoveryPhraseWarningPartTwo)
+      Text(verbatim: "\(warningPartOne) \(warningPartTwo)")
+        .font(.subheadline)
+        .foregroundColor(Color(.secondaryBraveLabel))
+        .fixedSize(horizontal: false, vertical: true)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding()
@@ -44,9 +45,9 @@ struct BackupRecoveryPhraseView: View {
     ScrollView(.vertical) {
       VStack(spacing: 16) {
         Group {
-          Text("Your recovery phrase") // NSLocalizedString
+          Text(Strings.Wallet.backupRecoveryPhraseTitle)
             .font(.headline)
-          Text("Write down or copy these words in the right order and save them somewhere safe.") // NSLocalizedString
+          Text(Strings.Wallet.backupRecoveryPhraseSubtitle)
             .font(.subheadline)
         }
         .fixedSize(horizontal: false, vertical: true)
@@ -66,17 +67,17 @@ struct BackupRecoveryPhraseView: View {
         }
         .padding(.horizontal)
         Button(action: copyRecoveryPhrase) {
-          Text("Copy")
+          Text(verbatim: "\(Strings.Wallet.copyToPasteboard) \(Image(systemName: "brave.clipboard"))")
             .font(.subheadline.bold())
             .foregroundColor(.primary)
         }
-        Toggle("I have backed up my phrase somewhere safe", isOn: $confirmedPhraseBackup) // NSLocalizedString
+        Toggle(Strings.Wallet.backupRecoveryPhraseDisclaimer, isOn: $confirmedPhraseBackup)
           .fixedSize(horizontal: false, vertical: true)
           .font(.footnote)
           .padding(.vertical, 30)
           .padding(.horizontal, 20)
         NavigationLink(destination: VerifyRecoveryPhraseView(keyringStore: keyringStore)) {
-          Text("Continue") // NSLocalizedString
+          Text(Strings.Wallet.continueButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
         .disabled(!confirmedPhraseBackup)
@@ -84,7 +85,7 @@ struct BackupRecoveryPhraseView: View {
           Button(action: {
             keyringStore.markOnboardingCompleted()
           }) {
-            Text("Skip") // NSLocalizedString
+            Text(Strings.Wallet.skipButtonTitle)
               .font(Font.subheadline.weight(.medium))
               .foregroundColor(Color(.braveLabel))
           }
@@ -98,10 +99,10 @@ struct BackupRecoveryPhraseView: View {
       }
     }
     .modifier(ToolbarModifier(isShowingCancel: !keyringStore.isOnboardingVisible))
-    .navigationTitle("Crypto") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
     .introspectViewController { vc in
-      vc.navigationItem.backButtonTitle = "Recovery Phrase" // NSLocalizedString
+      vc.navigationItem.backButtonTitle = Strings.Wallet.backupRecoveryPhraseBackButtonTitle
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
@@ -120,7 +121,7 @@ struct BackupRecoveryPhraseView: View {
               Button(action: {
                 presentationMode.dismiss()
               }) {
-                Text("Cancel")
+                Text(Strings.CancelString)
                   .foregroundColor(Color(.braveOrange))
               }
             }

--- a/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -6,6 +6,7 @@
 import Foundation
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct BackupWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -17,28 +18,28 @@ struct BackupWalletView: View {
         Image("graphic-save")
           .padding(.vertical)
         VStack(spacing: 14) {
-          Text("Backup your wallet now!") // NSLocalizedString
+          Text(Strings.Wallet.backupWalletTitle)
             .font(.headline)
             .foregroundColor(.primary)
-          Text("In the next step you will see 12 words that allows you to recover your crypto wallet.") // NSLocalizedString
+          Text(Strings.Wallet.backupWalletSubtitle)
             .font(.subheadline)
             .foregroundColor(.secondary)
         }
         .fixedSize(horizontal: false, vertical: true)
         .multilineTextAlignment(.center)
-        Toggle("I understand that if I lose my recovery words, I will not be able to access my crypto wallet.", isOn: $acknowledgedWarning) // NSLocalizedString
+        Toggle(Strings.Wallet.backupWalletDisclaimer, isOn: $acknowledgedWarning)
           .foregroundColor(.secondary)
           .font(.footnote)
         VStack(spacing: 12) {
           NavigationLink(destination: BackupRecoveryPhraseView(keyringStore: keyringStore)) {
-            Text("Continue") // NSLocalizedString
+            Text(Strings.Wallet.continueButtonTitle)
           }
           .buttonStyle(BraveFilledButtonStyle(size: .normal))
           .disabled(!acknowledgedWarning)
           Button(action: {
             keyringStore.markOnboardingCompleted()
           }) {
-            Text("Skip") // NSLocalizedString
+            Text(Strings.Wallet.skipButtonTitle)
               .font(Font.subheadline.weight(.medium))
               .foregroundColor(Color(.braveLabel))
           }
@@ -48,10 +49,10 @@ struct BackupWalletView: View {
       .padding(.vertical)
     }
     .navigationBarBackButtonHidden(true)
-    .navigationTitle("Crypto") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
     .introspectViewController { vc in
-      vc.navigationItem.backButtonTitle = "Backup Wallet" // NSLocalizedString
+      vc.navigationItem.backButtonTitle = Strings.Wallet.backupWalletBackButtonTitle
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))

--- a/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import LocalAuthentication
 import BraveUI
+import struct Shared.Strings
 
 struct CreateWalletContainerView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -17,10 +18,10 @@ struct CreateWalletContainerView: View {
         .background(Color(.braveBackground))
     }
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
-    .navigationTitle("Crypto") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
     .introspectViewController { vc in
-      vc.navigationItem.backButtonTitle = "Create Password" // NSLocalizedString
+      vc.navigationItem.backButtonTitle = Strings.Wallet.createWalletBackButtonTitle
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
   }
@@ -36,10 +37,9 @@ private struct CreateWalletView: View {
     var errorDescription: String? {
       switch self {
       case .passwordTooShort:
-        return "Password must be 7 or more characters" // NSLocalizedString
+        return Strings.Wallet.passwordDoesNotMeetRequirementsError
       case .inputsDontMatch:
-        // TODO: Get real copy
-        return "Passwords don't match" // NSLocalizedString
+        return Strings.Wallet.passwordsDontMatchError
       }
     }
   }
@@ -98,22 +98,22 @@ private struct CreateWalletView: View {
         Image("graphic-lock")
           .padding(.bottom)
         VStack {
-          Text("Secure your crypto with a password") // NSLocalizedString
+          Text(Strings.Wallet.createWalletTitle)
             .font(.headline)
             .padding(.bottom)
             .multilineTextAlignment(.center)
             .fixedSize(horizontal: false, vertical: true)
           VStack {
-            SecureField("Password", text: $password) // NSLocalizedString
+            SecureField(Strings.Wallet.passwordPlaceholder, text: $password)
               .textFieldStyle(BraveValidatedTextFieldStyle(error: validationError, when: .passwordTooShort))
-            SecureField("Re-type password", text: $repeatedPassword, onCommit: createWallet) // NSLocalizedString
+            SecureField(Strings.Wallet.repeatedPasswordPlaceholder, text: $repeatedPassword, onCommit: createWallet)
               .textFieldStyle(BraveValidatedTextFieldStyle(error: validationError, when: .inputsDontMatch))
           }
           .font(.subheadline)
           .padding(.horizontal, 48)
         }
         Button(action: createWallet) {
-          Text("Continue")
+          Text(Strings.Wallet.continueButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
       }
@@ -124,9 +124,12 @@ private struct CreateWalletView: View {
         if enabled {
           // Store password in keychain
           if !KeyringStore.storePasswordInKeychain(password) {
-            // TODO: Get real copy
-            let alert = UIAlertController(title: "Failed to enable biometrics", message: "There was an error while trying to enable biometrics. Please try again later", preferredStyle: .alert)
-            alert.addAction(.init(title: "OK", style: .default, handler: nil))
+            let alert = UIAlertController(
+              title: Strings.Wallet.biometricsSetupErrorTitle,
+              message: Strings.Wallet.biometricsSetupErrorMessage,
+              preferredStyle: .alert
+            )
+            alert.addAction(.init(title: Strings.OKString, style: .default, handler: nil))
             navController?.presentedViewController?.present(alert, animated: true)
             return false
           }

--- a/BraveWallet/Crypto/Onboarding/EnableBiometricsView.swift
+++ b/BraveWallet/Crypto/Onboarding/EnableBiometricsView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import LocalAuthentication
 import BraveUI
+import struct Shared.Strings
 
 struct EnableBiometricsView: View {
   var action: (_ enable: Bool) -> Void
@@ -18,13 +19,13 @@ struct EnableBiometricsView: View {
         .aspectRatio(contentMode: .fit)
         .frame(maxWidth: 250)
         .padding()
-      Text("Unlock Brave Wallet with your Face ID, Touch ID, or passcode.")
+      Text(Strings.Wallet.biometricsSetupTitle)
         .font(.headline)
         .fixedSize(horizontal: false, vertical: true)
         .multilineTextAlignment(.center)
         .padding(.bottom)
       Button(action: { action(true) }) {
-        Text("Enable")
+        Text(Strings.Wallet.biometricsSetupEnableButtonTitle)
       }
       .buttonStyle(BraveFilledButtonStyle(size: .normal))
     }

--- a/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -6,6 +6,7 @@
 import Foundation
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct RestoreWalletContainerView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -19,7 +20,7 @@ struct RestoreWalletContainerView: View {
     .navigationTitle("")
     .navigationBarTitleDisplayMode(.inline)
     .introspectViewController { vc in
-      vc.navigationItem.backButtonTitle = "Restore Wallet" // NSLocalizedString
+      vc.navigationItem.backButtonTitle = Strings.Wallet.restoreWalletBackButtonTitle
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
   }
@@ -36,13 +37,11 @@ private struct RestoreWalletView: View {
     var errorDescription: String? {
       switch self {
       case .invalidPhrase:
-        // TODO: Get real copy
-        return "Phrase Invalid" // NSLocalizedString
+        return Strings.Wallet.restoreWalletPhraseInvalidError
       case .passwordTooShort:
-        return "Password must be 7 or more characters" // NSLocalizedString
+        return Strings.Wallet.passwordDoesNotMeetRequirementsError
       case .inputsDontMatch:
-        // TODO: Get real copy
-        return "Passwords don't match" // NSLocalizedString
+        return Strings.Wallet.passwordsDontMatchError
       }
     }
   }
@@ -112,10 +111,10 @@ private struct RestoreWalletView: View {
   var body: some View {
     VStack(spacing: 48) {
       VStack(spacing: 14) {
-        Text("Restore Crypto Account") // NSLocalizedString
+        Text(Strings.Wallet.restoreWalletTitle)
           .font(.headline)
           .foregroundColor(.primary)
-        Text("Enter your recovery phrase to restore your Brave Wallet crypto account.") // NSLocalizedString
+        Text(Strings.Wallet.restoreWalletSubtitle)
           .font(.subheadline)
           .foregroundColor(.secondary)
       }
@@ -124,19 +123,19 @@ private struct RestoreWalletView: View {
       VStack(spacing: 10) {
         Group {
           if showingRecoveryPhase {
-            TextField("Enter your recovery phrase", text: $phrase) // NSLocalizedString
+            TextField(Strings.Wallet.restoreWalletPhrasePlaceholder, text: $phrase)
           } else {
-            SecureField("Enter your recovery phrase", text: $phrase) // NSLocalizedString
+            SecureField(Strings.Wallet.restoreWalletPhrasePlaceholder, text: $phrase)
           }
         }
         .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .invalidPhrase))
         if isShowingLegacyWalletToggle {
           HStack {
-            Toggle("Import from legacy Brave Crypto Wallet?", isOn: $isBraveLegacyWallet) // NSLocalizedString
+            Toggle(Strings.Wallet.restoreWalletImportFromLegacyBraveWallet, isOn: $isBraveLegacyWallet)
               .labelsHidden()
               .scaleEffect(0.75)
               .padding(-6)
-            Text("Import from legacy Brave Crypto Wallet?") // NSLocalizedString
+            Text(Strings.Wallet.restoreWalletImportFromLegacyBraveWallet)
               .font(.footnote)
               .onTapGesture {
                 withAnimation {
@@ -147,11 +146,11 @@ private struct RestoreWalletView: View {
           .frame(maxWidth: .infinity, alignment: .leading)
         }
         HStack {
-          Toggle("Show Recovery Phase", isOn: $showingRecoveryPhase) // NSLocalizedString
+          Toggle(Strings.Wallet.restoreWalletShowRecoveryPhrase, isOn: $showingRecoveryPhase)
             .labelsHidden()
             .scaleEffect(0.75)
             .padding(-6)
-          Text("Show Recovery Phase") // NSLocalizedString
+          Text(Strings.Wallet.restoreWalletShowRecoveryPhrase)
             .font(.footnote)
             .onTapGesture {
               withAnimation {
@@ -169,17 +168,17 @@ private struct RestoreWalletView: View {
         }
       }
       VStack {
-        Text("New Password") // NSLocalizedString
+        Text(Strings.Wallet.restoreWalletNewPasswordTitle)
           .font(.subheadline.weight(.medium))
-        SecureField("Password", text: $password) // NSLocalizedString
+        SecureField(Strings.Wallet.passwordPlaceholder, text: $password)
           .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .passwordTooShort))
-        SecureField("Re-type password", text: $repeatedPassword) // NSLocalizedString
+        SecureField(Strings.Wallet.repeatedPasswordPlaceholder, text: $repeatedPassword)
           .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .inputsDontMatch))
       }
       .font(.subheadline)
       .padding(.horizontal, 48)
       Button(action: restore) {
-        Text("Restore")
+        Text(Strings.Wallet.restoreWalletButtonTitle)
       }
       .buttonStyle(BraveFilledButtonStyle(size: .normal))
     }

--- a/BraveWallet/Crypto/Onboarding/SetupCryptoView.swift
+++ b/BraveWallet/Crypto/Onboarding/SetupCryptoView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import Introspect
 import BraveUI
+import struct Shared.Strings
 
 struct SetupCryptoView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -16,10 +17,10 @@ struct SetupCryptoView: View {
       Image("setup-welcome")
         .padding(.bottom)
       VStack(spacing: 14) {
-        Text("DeFi & Secure Crypto Storage") // NSLocalizedString
+        Text(Strings.Wallet.setupCryptoTitle)
           .foregroundColor(.primary)
           .font(.headline)
-        Text("Hold crypto in your custody. Trade assets. View Prices and portfolio performance. Invest, Borrow, and lend with DeFi.")  // NSLocalizedString
+        Text(Strings.Wallet.setupCryptoSubtitle)
           .foregroundColor(.secondary)
           .font(.subheadline)
       }
@@ -27,11 +28,11 @@ struct SetupCryptoView: View {
       .multilineTextAlignment(.center)
       VStack(spacing: 26) {
         NavigationLink(destination: CreateWalletContainerView(keyringStore: keyringStore)) {
-          Text("Setup Crypto") // NSLocalizedString
+          Text(Strings.Wallet.setupCryptoButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
         NavigationLink(destination: RestoreWalletContainerView(keyringStore: keyringStore)) {
-          Text("Restore") // NSLocalizedString
+          Text(Strings.Wallet.restoreWalletButtonTitle)
             .font(.subheadline.weight(.medium))
             .foregroundColor(Color(.braveLabel))
         }
@@ -40,10 +41,10 @@ struct SetupCryptoView: View {
     .padding()
     .frame(maxHeight: .infinity)
     .accessibilityEmbedInScrollView()
-    .navigationTitle("Crypto") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
     .introspectViewController { vc in
-      vc.navigationItem.backButtonTitle = "Welcome" // NSLocalizedString
+      vc.navigationItem.backButtonTitle = Strings.Wallet.setupCryptoButtonBackButtonTitle
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))

--- a/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
@@ -6,6 +6,7 @@
 import Foundation
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct VerifyRecoveryPhraseView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -40,11 +41,11 @@ struct VerifyRecoveryPhraseView: View {
     ScrollView(.vertical) {
       VStack(spacing: 16) {
         Group {
-          Text("Verify recovery phrase") // NSLocalizedString
+          Text(Strings.Wallet.verifyRecoveryPhraseTitle)
             .font(.headline)
-          Text("Tap the words to put them next to each other in the correct order.") // NSLocalizedString
+          Text(Strings.Wallet.verifyRecoveryPhraseSubtitle)
             .font(.subheadline)
-            .foregroundColor(.secondary)
+            .foregroundColor(Color(.secondaryBraveLabel))
         }
         .fixedSize(horizontal: false, vertical: true)
         .multilineTextAlignment(.center)
@@ -80,7 +81,7 @@ struct VerifyRecoveryPhraseView: View {
         }
         .padding()
         Button(action: tappedVerify) {
-          Text("Verify") // NSLocalizedString
+          Text(Strings.Wallet.verifyButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
         .disabled(!wordsSelectedInCorrectOrder)
@@ -89,7 +90,7 @@ struct VerifyRecoveryPhraseView: View {
           Button(action: {
             keyringStore.markOnboardingCompleted()
           }) {
-            Text("Skip") // NSLocalizedString
+            Text(Strings.Wallet.skipButtonTitle)
               .font(Font.subheadline.weight(.medium))
               .foregroundColor(Color(.braveLabel))
           }
@@ -104,7 +105,7 @@ struct VerifyRecoveryPhraseView: View {
       }
     }
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
-    .navigationTitle("Crypto") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
   }
 }
@@ -159,7 +160,7 @@ private struct SelectedWordsBox: View {
     return Group {
       switch entry {
       case .placeholder:
-        Text("Word")
+        Text(verbatim: "Word")
           .padding(8)
           .frame(maxWidth: .infinity)
           .hidden()
@@ -195,10 +196,9 @@ private struct SelectedWordsBox: View {
             .stroke(lineWidth: pixelLength / 2)
         )
     )
-    .navigationTitle("Crypto") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
     .introspectViewController { vc in
-      vc.navigationItem.backButtonTitle = "Verify Phrase" // NSLocalizedString
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
   }

--- a/BraveWallet/Crypto/Portfolio/BackupNotifyView.swift
+++ b/BraveWallet/Crypto/Portfolio/BackupNotifyView.swift
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import SwiftUI
+import struct Shared.Strings
 
 struct BackupNotifyView: View {
   var action: () -> Void
@@ -18,7 +19,7 @@ struct BackupNotifyView: View {
     ZStack(alignment: .topTrailing) {
       Button(action: action) {
         HStack {
-          Text("Backup your wallet now to protect your crypto portfolio from loss of access.") // NSLocalizedString
+          Text(Strings.Wallet.backupWalletWarningMessage)
             .font(.subheadline.weight(.semibold))
             .foregroundColor(Color(.braveLabel))
             .fixedSize(horizontal: false, vertical: true)

--- a/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 import SwiftUI
+import struct Shared.Strings
+import BraveShared
 
 private struct TokenView: View {
   @ObservedObject var assetStore: AssetStore
@@ -63,7 +65,7 @@ struct EditUserAssetsView: View {
       List {
         Section(
           header: WalletListHeaderView(
-            title: Text("Assets") // NSLocalizedString
+            title: Text(Strings.Wallet.assetsTitle)
           )
             .osAvailabilityModifiers { content in
               if #available(iOS 15.0, *) {
@@ -81,7 +83,7 @@ struct EditUserAssetsView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .animation(.default, value: tokenStores)
-      .navigationTitle("Edit Visible Assets") // NSLocalizedString
+      .navigationTitle(Strings.Wallet.editVisibleAssetsButtonTitle)
       .navigationBarTitleDisplayMode(.inline)
       .filterable(text: $query)
       .toolbar {
@@ -90,7 +92,7 @@ struct EditUserAssetsView: View {
             assetsUpdated()
             presentationMode.dismiss()
           }) {
-            Text("Done") // NSLocalizedString
+            Text(Strings.done)
               .foregroundColor(Color(.braveOrange))
           }
         }

--- a/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
@@ -32,7 +32,7 @@ struct PortfolioAssetView: View {
       Spacer()
       VStack(alignment: .trailing) {
         Text(amount.isEmpty ? "0.0" : amount)
-        Text("\(quantity) \(symbol)")
+        Text(verbatim: "\(quantity) \(symbol)")
       }
       .font(.footnote)
       .foregroundColor(Color(.braveLabel))

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -7,6 +7,7 @@ import UIKit
 import SwiftUI
 import BraveCore
 import SnapKit
+import struct Shared.Strings
 
 struct Currency {
   var image: UIImage
@@ -67,7 +68,7 @@ struct PortfolioView: View {
       ) {
       }
       Section(
-        header: WalletListHeaderView(title: Text("Assets"))
+        header: WalletListHeaderView(title: Text(Strings.Wallet.assetsTitle))
       ) {
         ForEach(portfolioStore.userVisibleAssets) { asset in
           PortfolioAssetView(
@@ -79,7 +80,7 @@ struct PortfolioView: View {
           )
         }
         Button(action: { isPresentingEditUserAssets = true }) {
-          Text("Edit Visible Assets")
+          Text(Strings.Wallet.editVisibleAssetsButtonTitle)
             .multilineTextAlignment(.center)
             .font(.footnote.weight(.semibold))
             .foregroundColor(Color(.bravePrimary))
@@ -177,7 +178,7 @@ struct BalanceHeaderView: View {
           .foregroundColor(.green)
         Text(verbatim: "1.3%")
           .foregroundColor(.green)
-        Text(verbatim: "Today") // NSLocalizedString
+        Text(Strings.Wallet.today)
           .foregroundColor(.secondary)
       }
       .font(.subheadline)

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -6,6 +6,7 @@
 import Foundation
 import SwiftUI
 import BraveCore
+import struct Shared.Strings
 
 private struct TokenView: View {
   var token: BraveWallet.ERCToken
@@ -55,7 +56,7 @@ struct AssetSearchView: View {
       List {
         Section(
           header: WalletListHeaderView(
-            title: Text("Assets") // NSLocalizedString
+            title: Text(Strings.Wallet.assetsTitle)
           )
           .osAvailabilityModifiers { content in
             if #available(iOS 15.0, *) {
@@ -68,17 +69,11 @@ struct AssetSearchView: View {
         ) {
           let tokens = self.tokens
           if tokens.isEmpty {
-            Group {
-              if query.isEmpty {
-                Text("No assets found") // NSLocalizedString
-              } else {
-                Text("No assets found for \"\(query)\" query") // NSLocalizedString
-              }
-            }
-            .font(.footnote)
-            .foregroundColor(Color(.secondaryBraveLabel))
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
+            Text(Strings.Wallet.assetSearchEmpty)
+              .font(.footnote)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .multilineTextAlignment(.center)
+              .frame(maxWidth: .infinity)
           } else {
             ForEach(tokens) { token in
               NavigationLink(
@@ -96,7 +91,7 @@ struct AssetSearchView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .navigationBarTitleDisplayMode(.inline)
-      .navigationTitle("Search") // NSLocalizedString
+      .navigationTitle(Strings.Wallet.searchTitle)
       .listStyle(InsetGroupedListStyle())
       .animation(nil, value: query)
       .filterable(text: $query)

--- a/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/BraveWallet/Crypto/UnlockWalletView.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import BraveUI
+import struct Shared.Strings
 
 struct UnlockWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -19,7 +20,7 @@ struct UnlockWalletView: View {
     var errorDescription: String? {
       switch self {
       case .incorrectPassword:
-        return "Incorrect Password" // NSLocalizedString
+        return Strings.Wallet.incorrectPasswordErrorMessage
       }
     }
   }
@@ -47,24 +48,24 @@ struct UnlockWalletView: View {
         Image("graphic-lock")
           .padding(.bottom)
         VStack {
-          Text("Enter your password to unlock")
+          Text(Strings.Wallet.unlockWalletTitle)
             .font(.headline)
             .padding(.bottom)
             .multilineTextAlignment(.center)
             .fixedSize(horizontal: false, vertical: true)
-          SecureField("Password", text: $password, onCommit: unlock) // NSLocalizedString
+          SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: unlock)
             .font(.subheadline)
             .textFieldStyle(BraveValidatedTextFieldStyle(error: unlockError))
             .padding(.horizontal, 48)
         }
         VStack(spacing: 30) {
           Button(action: unlock) {
-            Text("Unlock") // NSLocalizedString
+            Text(Strings.Wallet.unlockWalletButtonTitle)
           }
           .buttonStyle(BraveFilledButtonStyle(size: .normal))
           .disabled(!isPasswordValid)
           NavigationLink(destination: RestoreWalletContainerView(keyringStore: keyringStore)) {
-            Text("Restore") // NSLocalizedString
+            Text(Strings.Wallet.restoreWalletButtonTitle)
               .font(.subheadline.weight(.medium))
           }
           .foregroundColor(Color(.braveLabel))
@@ -74,7 +75,7 @@ struct UnlockWalletView: View {
       .padding()
       .padding(.vertical)
     }
-    .navigationTitle("Crypto") // NSLocalizedString
+    .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
     .onChange(of: password) { _ in

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import SwiftUI
+import struct Shared.Strings
 
 public struct WalletSettingsView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -18,24 +19,24 @@ public struct WalletSettingsView: View {
     List {
       Section {
         Button(action: { isShowingResetAlert = true }) {
-          Text("Reset") // NSLocalizedString
+          Text(Strings.Wallet.settingsResetButtonTitle)
             .foregroundColor(.red)
         }
         // iOS 15: .role(.destructive)
       }
     }
     .listStyle(InsetGroupedListStyle())
-    .navigationTitle("Wallet") // NSLocalizedString
+    .navigationTitle("Brave Wallet")
     .navigationBarTitleDisplayMode(.inline)
     // TODO: Needs real copy for whole reset prompt
     .alert(isPresented: $isShowingResetAlert) {
       Alert(
-        title: Text("Reset Wallet"), // NSLocalizedString
-        message: Text("Are you sure you want to reset your wallet? If you have not backed up your recovery prhase you will not be able to restore it at a later time."), // NSLocalizedString
-        primaryButton: .destructive(Text("Reset"), action: { // NSLocalizedString
+        title: Text(Strings.Wallet.settingsResetWalletAlertTitle),
+        message: Text(Strings.Wallet.settingsResetWalletAlertMessage),
+        primaryButton: .destructive(Text(Strings.Wallet.settingsResetWalletAlertButtonTitle), action: {
           keyringStore.reset()
         }),
-        secondaryButton: .cancel(Text("No")) // NSLocalizedString
+        secondaryButton: .cancel(Text(Strings.no))
       )
     }
   }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1,0 +1,838 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import struct Shared.Strings
+
+extension Strings {
+  struct Wallet {
+    public static let portfolioPageTitle = NSLocalizedString(
+      "wallet.portfolioPageTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Portfolio",
+      comment: "The title of the portfolio page in the Crypto tab"
+    )
+    public static let accountsPageTitle = NSLocalizedString(
+      "wallet.accountsPageTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Accounts",
+      comment: "The title of the accounts page in the Crypto tab"
+    )
+    public static let selectedNetworkAccessibilityLabel = NSLocalizedString(
+      "wallet.selectedNetwork",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Selected Network",
+      comment: "The accessibility label for the ethereum network picker"
+    )
+    public static let assetsTitle = NSLocalizedString(
+      "wallet.assetsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Assets",
+      comment: "The title which is displayed above a list of assets/tokens"
+    )
+    public static let transactionsTitle = NSLocalizedString(
+      "wallet.transactionsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Transactions",
+      comment: "The title which is displayed above a list of transactions"
+    )
+    public static let assetSearchEmpty = NSLocalizedString(
+      "wallet.assetSearchEmpty",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "No assets found",
+      comment: "The text displayed when a user uses a query to search for assets that yields no results"
+    )
+    public static let searchTitle = NSLocalizedString(
+      "wallet.searchTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Search",
+      comment: "The title of the asset search page"
+    )
+    public static let noAssets = NSLocalizedString(
+      "wallet.noAssets",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "No Assets",
+      comment: "The empty state displayed when the user has no assets associated with an account"
+    )
+    public static let noAccounts = NSLocalizedString(
+      "wallet.noAccounts",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "No Accounts",
+      comment: "The empty state displayed when the user has no accounts associated with a transaction or asset"
+    )
+    public static let noTransactions = NSLocalizedString(
+      "wallet.noTransactions",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "No Transactions",
+      comment: "The empty state displayed when the user has no transactions associated with an account"
+    )
+    public static let detailsButtonTitle = NSLocalizedString(
+      "wallet.detailsButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Details",
+      comment: "A button title which when pressed displays a new screen with additional details/information"
+    )
+    public static let renameButtonTitle = NSLocalizedString(
+      "wallet.renameButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Rename",
+      comment: "A button on an account screen which when pressed presents a new screen to  rename the account"
+    )
+    public static let accountDetailsTitle = NSLocalizedString(
+      "wallet.accountDetailsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Account Details",
+      comment: "The title displayed on the account details screen"
+    )
+    public static let accountDetailsNameTitle = NSLocalizedString(
+      "wallet.accountDetailsNameTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Account Name",
+      comment: "The title displayed above a text field that contains the account's name"
+    )
+    public static let accountDetailsNamePlaceholder = NSLocalizedString(
+      "wallet.accountDetailsNamePlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter account name",
+      comment: "The placeholder of the text field which allows the user to edit the account's name"
+    )
+    public static let accountPrivateKey = NSLocalizedString(
+      "wallet.accountPrivateKey",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Private Key",
+      comment: "A button title for displaying their accounts private key"
+    )
+    public static let accountRemoveButtonTitle = NSLocalizedString(
+      "wallet.accountRemoveButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Remove Account",
+      comment: "A button title to trigger deleting a secondary account"
+    )
+    public static let accountRemoveAlertConfirmation = NSLocalizedString(
+      "wallet.accountRemoveAlertConfirmation",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Remove this account?",
+      comment: "The title of a confirmation dialog when attempting to remove an account"
+    )
+    public static let accountRemoveAlertConfirmationMessage = NSLocalizedString(
+      "wallet.accountRemoveAlertConfirmationMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Are you sure?",
+      comment: "The message of a confirmation dialog when attempting to remove an account"
+    )
+    public static let accountPrivateKeyDisplayWarning = NSLocalizedString(
+      "wallet.accountPrivateKeyDisplayWarning",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Warning: Never disclose this key. Anyone with your private key can steal any assets held in your account.",
+      comment: "A warning message displayed at the top of the Private Key screen"
+    )
+    public static let copyToPasteboard = NSLocalizedString(
+      "wallet.copyToPasteboard",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Copy",
+      comment: "A button title that when tapped will copy some data to the users clipboard"
+    )
+    public static let showPrivateKeyButtonTitle = NSLocalizedString(
+      "wallet.showPrivateKeyButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Show Private Key",
+      comment: "A button title that will make a private key visible on the screen"
+    )
+    public static let hidePrivateKeyButtonTitle = NSLocalizedString(
+      "wallet.hidePrivateKeyButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Hide Private Key",
+      comment: "A button title that will redact a private key on the screen"
+    )
+    public static let accountBackup = NSLocalizedString(
+      "wallet.accountBackup",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Backup",
+      comment: "A button title that shows a screen that allows the user to backup their recovery phrase"
+    )
+    public static let defaultAccountName = NSLocalizedString(
+      "wallet.defaultAccountName",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Account %lld",
+      comment: "The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\")"
+    )
+    public static let defaultSecondaryAccountName = NSLocalizedString(
+      "wallet.defaultSecondaryAccountName",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Secondary Account %lld",
+      comment: "The default account name when adding a secondary account and not entering a custom name. '%lld' refers to a number (for example \"Secondary Account 3\")"
+    )
+    public static let addAccountTitle = NSLocalizedString(
+      "wallet.addAccountTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Add Account",
+      comment: "The title of the add account screen"
+    )
+    public static let addAccountAddButton = NSLocalizedString(
+      "wallet.addAccountAddButton",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Add",
+      comment: "The title of the button which when tapped will add a new account to the users list of crypto accounts"
+    )
+    public static let failedToImportAccountErrorTitle = NSLocalizedString(
+      "wallet.failedToImportAccountErrorTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Failed to import account.",
+      comment: "The title of an alert when the account the user attempted to import fails for some reason"
+    )
+    public static let failedToImportAccountErrorMessage = NSLocalizedString(
+      "wallet.failedToImportAccountErrorMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Please try again.",
+      comment: "The message of an alert when the account the user attempted to import fails for some reason"
+    )
+    public static let importAccountOriginPasswordTitle = NSLocalizedString(
+      "wallet.importAccountOriginPasswordTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Origin Password",
+      comment: "A title above a text field that is used to enter a password"
+    )
+    public static let passwordPlaceholder = NSLocalizedString(
+      "wallet.passwordPlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Password",
+      comment: "A placeholder string that will be used on password text fields"
+    )
+    public static let repeatedPasswordPlaceholder = NSLocalizedString(
+      "wallet.repeatedPasswordPlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Re-type password",
+      comment: "A placeholder string that will be used on repeat password text fields"
+    )
+    public static let importAccountSectionTitle = NSLocalizedString(
+      "wallet.importAccountSectionTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "You can create a secondary account by importing your private key.",
+      comment: "A title above a text field that will be used to import a users secondary accounts"
+    )
+    public static let importAccountPlaceholder = NSLocalizedString(
+      "wallet.importAccountPlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter, paste, or import your private key string file or JSON.",
+      comment: "A placeholder on a text box for entering the users private key/json data to import accounts"
+    )
+    public static let importButtonTitle = NSLocalizedString(
+      "wallet.importButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Import…",
+      comment: "A button title that when tapped will display a file import dialog"
+    )
+    public static let primaryCryptoAccountsTitle = NSLocalizedString(
+      "wallet.primaryCryptoAccountsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Primary Crypto Accounts",
+      comment: "A title above a list of crypto accounts that are not imported"
+    )
+    public static let secondaryCryptoAccountsTitle = NSLocalizedString(
+      "wallet.secondaryCryptoAccountsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Secondary Accounts",
+      comment: "A title above a list of crypto accounts that are imported"
+    )
+    public static let secondaryCryptoAccountsSubtitle = NSLocalizedString(
+      "wallet.secondaryCryptoAccountsSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Import your external wallet account with a separate seed phrase.",
+      comment: "A subtitle above a list of crypto accounts that are imported"
+    )
+    public static let noSecondaryAccounts = NSLocalizedString(
+      "wallet.noSecondaryAccounts",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "No secondary accounts.",
+      comment: "The empty state shown when you have no imported accounts"
+    )
+    public static let incorrectPasswordErrorMessage = NSLocalizedString(
+      "wallet.incorrectPasswordErrorMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Incorrect Password",
+      comment: "The error message displayed when the user enters the wrong password while unlocking the wallet"
+    )
+    public static let unlockWalletTitle = NSLocalizedString(
+      "wallet.unlockWalletTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter your password to unlock",
+      comment: "The title displayed on the unlock wallet screen"
+    )
+    public static let unlockWalletButtonTitle = NSLocalizedString(
+      "wallet.unlockWalletButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Unlock",
+      comment: "The button title of the unlock wallet button. As in to enter a password and gain access to your wallet's assets."
+    )
+    public static let restoreWalletButtonTitle = NSLocalizedString(
+      "wallet.restoreWalletButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Restore",
+      comment: "The button title for showing the restore wallet screen. As in to use your recovery phrase to bring a wallet into Brave"
+    )
+    public static let cryptoTitle = NSLocalizedString(
+      "wallet.cryptoTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Crypto",
+      comment: "The title of the crypto tab"
+    )
+    public static let backupWalletWarningMessage = NSLocalizedString(
+      "wallet.backupWalletWarningMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Backup your wallet now to protect your crypto portfolio from loss of access.",
+      comment: "The message displayed on the crypto tab if you have not yet completed the backup process"
+    )
+    public static let editVisibleAssetsButtonTitle = NSLocalizedString(
+      "wallet.editVisibleAssetsButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Edit Visible Assets",
+      comment: "The button title for showing the screen to change what assets are visible"
+    )
+    public static let buy = NSLocalizedString(
+      "wallet.buy",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Buy",
+      comment: "As in buying cryptocurrency"
+    )
+    public static let buyDescription = NSLocalizedString(
+      "wallet.buyDescription",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Buy crypto with Apple Pay, credit or debit card.",
+      comment: "The description of a buy button on the buy/send/swap modal"
+    )
+    public static let send = NSLocalizedString(
+      "wallet.send",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Send",
+      comment: "As in sending cryptocurrency to another account"
+    )
+    public static let sendDescription = NSLocalizedString(
+      "wallet.sendDescription",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Send crypto or transfer from one account to another.",
+      comment: "The description of a send button on the buy/send/swap modal"
+    )
+    public static let swap = NSLocalizedString(
+      "wallet.swap",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Swap",
+      comment: "As in swapping cryptocurrency from one asset to another"
+    )
+    public static let swapDescription = NSLocalizedString(
+      "wallet.swapDescription",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Swap crypto assets with Brave DEX aggregator.",
+      comment: "The description of a swap button on the buy/send/swap modal"
+    )
+    public static let infoTitle = NSLocalizedString(
+      "wallet.infoTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Info",
+      comment: "A title above additional information about an asset"
+    )
+    public static let verifyRecoveryPhraseTitle = NSLocalizedString(
+      "wallet.verifyRecoveryPhraseTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Verify recovery phrase",
+      comment: "The title of the verify recovery phrase screen"
+    )
+    public static let verifyRecoveryPhraseSubtitle = NSLocalizedString(
+      "wallet.verifyRecoveryPhraseSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Tap the words to put them next to each other in the correct order.",
+      comment: "The subtitle of the verify recovery phrase screen"
+    )
+    public static let verifyButtonTitle = NSLocalizedString(
+      "wallet.verifyButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Verify",
+      comment: "The button title to verify if the user has put all recovery words in the right order"
+    )
+    public static let skipButtonTitle = NSLocalizedString(
+      "wallet.skipButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Skip",
+      comment: "The button title to skip recovery phrase backup"
+    )
+    public static let backupWalletTitle = NSLocalizedString(
+      "wallet.backupWalletTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Backup your wallet now!",
+      comment: "The title of the backup wallet screen"
+    )
+    public static let backupWalletSubtitle = NSLocalizedString(
+      "wallet.backupWalletSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "In the next step you will see 12 words that allows you to recover your crypto wallet.",
+      comment: "The subtitle of the backup wallet screen"
+    )
+    public static let backupWalletDisclaimer = NSLocalizedString(
+      "wallet.backupWalletDisclaimer",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "I understand that if I lose my recovery words, I will not be able to access my crypto wallet.",
+      comment: "The label next to a toggle which the user must acknowledge"
+    )
+    public static let continueButtonTitle = NSLocalizedString(
+      "wallet.continueButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Continue",
+      comment: "A button title when a user will continue to the next step of something"
+    )
+    public static let backupWalletBackButtonTitle = NSLocalizedString(
+      "wallet.backupWalletBackButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Backup Wallet",
+      comment: "The title that will be displayed when long-pressing the back button in the navigation bar"
+    )
+    public static let setupCryptoTitle = NSLocalizedString(
+      "wallet.setupCryptoTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "DeFi & Secure Crypto Storage",
+      comment: "The title displayed on the 'setup crypto' onboarding screen"
+    )
+    public static let setupCryptoSubtitle = NSLocalizedString(
+      "wallet.setupCryptoSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Hold crypto in your custody. Trade assets. View Prices and portfolio performance. Invest, Borrow, and lend with DeFi.",
+      comment: "The subtitle displayed on the 'setup crypto' onboarding screen"
+    )
+    public static let setupCryptoButtonTitle = NSLocalizedString(
+      "wallet.setupCryptoButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Setup Crypto",
+      comment: "The button title to continue to the next step on the 'setup crypto' screen. As in to begin the process of creating a wallet/setting up the cryptocurrency feature"
+    )
+    public static let setupCryptoButtonBackButtonTitle = NSLocalizedString(
+      "wallet.setupCryptoButtonBackButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Welcome",
+      comment: "The title that will be displayed when long-pressing the back button in the navigation bar. As in the first step of an onboarding process is to welcome a user."
+    )
+    public static let backupRecoveryPhraseTitle = NSLocalizedString(
+      "wallet.backupRecoveryPhraseTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Your recovery phrase",
+      comment: "The title of the backup recovery phrase screen"
+    )
+    public static let backupRecoveryPhraseSubtitle = NSLocalizedString(
+      "wallet.backupRecoveryPhraseSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Write down or copy these words in the right order and save them somewhere safe.",
+      comment: "The subtitle of the backup recovery phrase screen"
+    )
+    public static let backupRecoveryPhraseDisclaimer = NSLocalizedString(
+      "wallet.backupRecoveryPhraseDisclaimer",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "I have backed up my phrase somewhere safe",
+      comment: "The disclaimer next to a toggle that the user must acknowledge before proceeding"
+    )
+    public static let backupRecoveryPhraseWarningPartOne = NSLocalizedString(
+      "wallet.backupRecoveryPhraseWarningPartOne",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "WARNING:",
+      comment: "The first part of the warning displayed on the backup recovery phrase page. As in to pay attention to the following text"
+    )
+    public static let backupRecoveryPhraseWarningPartTwo = NSLocalizedString(
+      "wallet.backupRecoveryPhraseWarningPartTwo",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Never disclose your backup phrase. Anyone with this phrase can take your funds forever.",
+      comment: "The second part of the warning displayed on the backup recovery phrase page."
+    )
+    public static let backupRecoveryPhraseBackButtonTitle = NSLocalizedString(
+      "wallet.backupRecoveryPhraseBackButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Recovery Phrase",
+      comment: "The title that will be displayed when long-pressing the back button in the navigation bar. As in the a list of words to recovery your account on another device/wallet"
+    )
+    public static let restoreWalletBackButtonTitle = NSLocalizedString(
+      "wallet.restoreWalletBackButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Restore Wallet",
+      comment: "The title that will be displayed when long-pressing the back button in the navigation bar. As to gain access to your assets from a different device"
+    )
+    public static let restoreWalletPhraseInvalidError = NSLocalizedString(
+      "wallet.restoreWalletPhraseInvalidError",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Phrase Invalid", // TODO: Get real copy
+      comment: "The error message displayed when a user enters an invalid phrase to restore from. By phrase we mean 'recovery phrase' or 'recovery mnemonic'"
+    )
+    public static let passwordDoesNotMeetRequirementsError = NSLocalizedString(
+      "wallet.passwordDoesNotMeetRequirementsError",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Password must be 7 or more characters", // TODO: Get real copy
+      comment: "The error message displayed when a user enters a password that does not meet the requirements"
+    )
+    public static let passwordsDontMatchError = NSLocalizedString(
+      "wallet.passwordsDontMatchError",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Passwords don't match", // TODO: Get real copy
+      comment: "The error displayed when entering two passwords that do not match that are expected to match"
+    )
+    public static let restoreWalletTitle = NSLocalizedString(
+      "wallet.restoreWalletTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Restore Crypto Account",
+      comment: "The title on the restore wallet screen."
+    )
+    public static let restoreWalletSubtitle = NSLocalizedString(
+      "wallet.restoreWalletSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter your recovery phrase to restore your Brave Wallet crypto account.",
+      comment: "The subtitle on the restore wallet screen."
+    )
+    public static let restoreWalletPhrasePlaceholder = NSLocalizedString(
+      "wallet.restoreWalletPhrasePlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter your recovery phrase",
+      comment: "The placeholder on the mneomic/recovery phrase text field"
+    )
+    public static let restoreWalletImportFromLegacyBraveWallet = NSLocalizedString(
+      "wallet.restoreWalletImportFromLegacyBraveWallet",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Import from legacy Brave Crypto Wallet?",
+      comment: "A toggle label to ask the user if their 24-word phrase is a legacy Brave crypto wallet"
+    )
+    public static let restoreWalletShowRecoveryPhrase = NSLocalizedString(
+      "wallet.restoreWalletShowRecoveryPhrase",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Show Recovery Phrase",
+      comment: "A toggle label that will enable or disable visibility of the contents in the recovery phrase text field"
+    )
+    public static let restoreWalletNewPasswordTitle = NSLocalizedString(
+      "wallet.restoreWalletNewPasswordTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "New Password",
+      comment: "A title displayed above 2 text fields for entering a new wallet password"
+    )
+    public static let createWalletBackButtonTitle = NSLocalizedString(
+      "wallet.createWalletBackButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Create Password",
+      comment: "The title that will be displayed when long-pressing the back button in the navigation bar. As to make up a new password to create a wallet"
+    )
+    public static let createWalletTitle = NSLocalizedString(
+      "wallet.createWalletTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Secure your crypto with a password",
+      comment: "The title of the create wallet screen"
+    )
+    public static let biometricsSetupErrorTitle = NSLocalizedString(
+      "wallet.biometricsSetupErrorTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Failed to enable biometrics", // TODO: Get real copy
+      comment: "The title of an alert when the user has an error setting up biometric unlock"
+    )
+    public static let biometricsSetupErrorMessage = NSLocalizedString(
+      "wallet.biometricsSetupErrorMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "There was an error while trying to enable biometrics. Please try again later", // TODO: Get real copy
+      comment: "The message of an alert when the user has an error setting up biometric unlock"
+    )
+    public static let settingsResetButtonTitle = NSLocalizedString(
+      "wallet.settingsResetButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Reset", // TODO: Get real copy
+      comment: "The title of a button that will reset the wallet. As in to erase the users wallet from the device"
+    )
+    public static let settingsResetWalletAlertTitle = NSLocalizedString(
+      "wallet.settingsResetWalletAlertTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Reset Wallet", // TODO: Get real copy
+      comment: "The title the confirmation dialog when resetting the wallet. As in to erase the users wallet from the device"
+    )
+    public static let settingsResetWalletAlertMessage = NSLocalizedString(
+      "wallet.settingsResetWalletAlertMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Are you sure you want to reset your wallet? If you have not backed up your recovery prhase you will not be able to restore it at a later time.", // TODO: Get real copy
+      comment: "The message the confirmation dialog when resetting the wallet."
+    )
+    public static let settingsResetWalletAlertButtonTitle = NSLocalizedString(
+      "wallet.settingsResetWalletAlertButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Reset", // TODO: Get real copy
+      comment: "The title of a button that will reset the wallet. As in to erase the users wallet from the device"
+    )
+    public static let dateIntervalHour = NSLocalizedString(
+      "wallet.dateIntervalHour",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1H",
+      comment: "An abbreivated form of \"1 Hour\" used to describe what range of data to show on the graph (past hour)"
+    )
+    public static let dateIntervalHourAccessibilityLabel = NSLocalizedString(
+      "wallet.dateIntervalHourAccessibilityLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1 Hour",
+      comment: "Describes what range of data to show on the graph (past hour)"
+    )
+    public static let dateIntervalDay = NSLocalizedString(
+      "wallet.dateIntervalDay",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1D",
+      comment: "An abbreivated form of \"1 Day\" used to describe what range of data to show on the graph (past day)"
+    )
+    public static let dateIntervalDayAccessibilityLabel = NSLocalizedString(
+      "wallet.dateIntervalDayAccessibilityLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1 Day",
+      comment: "Describes what range of data to show on the graph (past day)"
+    )
+    public static let dateIntervalWeek = NSLocalizedString(
+      "wallet.dateIntervalWeek",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1W",
+      comment: "An abbreivated form of \"1 Week\" used to describe what range of data to show on the graph (past week)"
+    )
+    public static let dateIntervalWeekAccessibilityLabel = NSLocalizedString(
+      "wallet.dateIntervalWeekAccessibilityLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1 Week",
+      comment: "Describes what range of data to show on the graph (past week)"
+    )
+    public static let dateIntervalMonth = NSLocalizedString(
+      "wallet.dateIntervalMonth",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1M",
+      comment: "An abbreivated form of \"1 Month\" used to describe what range of data to show on the graph (past month)"
+    )
+    public static let dateIntervalMonthAccessibilityLabel = NSLocalizedString(
+      "wallet.dateIntervalMonthAccessibilityLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1 Month",
+      comment: "Describes what range of data to show on the graph (past month)"
+    )
+    public static let dateIntervalThreeMonths = NSLocalizedString(
+      "wallet.dateIntervalThreeMonths",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "3M",
+      comment: "An abbreivated form of \"3 Months\" used to describe what range of data to show on the graph (past 3 months)"
+    )
+    public static let dateIntervalThreeMonthsAccessibilityLabel = NSLocalizedString(
+      "wallet.dateIntervalThreeMonthsAccessibilityLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "3 Months",
+      comment: "Describes what range of data to show on the graph (past 3 months)"
+    )
+    public static let dateIntervalYear = NSLocalizedString(
+      "wallet.dateIntervalYear",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1Y",
+      comment: "An abbreivated form of \"1 Year\" used to describe what range of data to show on the graph (past year)"
+    )
+    public static let dateIntervalYearAccessibilityLabel = NSLocalizedString(
+      "wallet.dateIntervalYearAccessibilityLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "1 Year",
+      comment: "Describes what range of data to show on the graph (past year)"
+    )
+    public static let dateIntervalAll = NSLocalizedString(
+      "wallet.dateIntervalAll",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "All",
+      comment: "Describes what range of data to show on the graph (all data available)"
+    )
+    public static let swapCryptoFromTitle = NSLocalizedString(
+      "wallet.swapCryptoFromTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "From",
+      comment: "A title above the cryptocurrency token/asset you are swapping from. For example this would appear over a cell that has the 'BAT' token selected"
+    )
+    public static let swapCryptoToTitle = NSLocalizedString(
+      "wallet.swapCryptoToTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "To",
+      comment: "A title above the cryptocurrency token/asset you are swapping to. For example this would appear over a cell that has the 'BAT' token selected"
+    )
+    public static let swapCryptoAmountTitle = NSLocalizedString(
+      "wallet.swapCryptoAmountTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter amount of %@ to swap",
+      comment: "A title above the amount of asset you want to swap. '%@' will be replaced with a token symbol such as 'ETH' or 'BAT'"
+    )
+    public static let swapCryptoAmountPlaceholder = NSLocalizedString(
+      "wallet.swapCryptoAmountPlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Amount in %@",
+      comment: "A placeholder of the amount text field. '%@' will be replaced with a token symbol such as 'ETH' or 'BAT'"
+    )
+    public static let swapCryptoAmountReceivingTitle = NSLocalizedString(
+      "wallet.swapCryptoAmountReceivingTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Amount receiving in %@ (estimated)",
+      comment: "A title above the amount of asset you will receive from the swap. '%@' will be replaced with a token symbol such as 'ETH' or 'BAT'"
+    )
+    public static let swapOrderTypeLabel = NSLocalizedString(
+      "wallet.swapOrderTypeLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Order Type",
+      comment: "The type of order you want to place. Options are: 'Market' and 'Limit'"
+    )
+    public static let swapLimitOrderType = NSLocalizedString(
+      "wallet.swapLimitOrderType",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Limit",
+      comment: "The 'Limit' order type. Limit orders only execute when the price requirements are met"
+    )
+    public static let swapMarketOrderType = NSLocalizedString(
+      "wallet.swapMarketOrderType",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Market",
+      comment: "The 'Market' order type. Market orders execute immediately based on the price at the time of the order."
+    )
+    public static let today = NSLocalizedString(
+      "wallet.today",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Today",
+      comment: "A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today'"
+    )
+    public static let selectAccountTitle = NSLocalizedString(
+      "wallet.selectAccountTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Select Account",
+      comment: "The title of the account selection screen. Will show above a list of accounts the user may pick from"
+    )
+    public static let assetDetailSubtitle = NSLocalizedString(
+      "wallet.assetDetailSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "%@ Price (%@)",
+      comment: "A subtitle on the asset details screen that uses the name and symbol. Example: Basic Attention Token Price (BAT)"
+    )
+    public static let biometricsSetupTitle = NSLocalizedString(
+      "wallet.biometricsSetupTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Unlock Brave Wallet with your Face ID, Touch ID, or passcode.",
+      comment: "The title shown when a user is asked if they would like to setup biometric unlock"
+    )
+    public static let biometricsSetupEnableButtonTitle = NSLocalizedString(
+      "wallet.biometricsSetupEnableButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enable",
+      comment: "The button title that enables the biometric unlock feature"
+    )
+    public static let copyAddressButtonTitle = NSLocalizedString(
+      "wallet.copyAddressButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Copy Address",
+      comment: "The button title that appears when long-pressing a wallet address that will copy said address to the users clipboard"
+    )
+  }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		2766847C270B76D900DF45C5 /* FilterableViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2766847B270B76D900DF45C5 /* FilterableViewModifier.swift */; };
 		27668489270CD9AA00DF45C5 /* EditUserAssetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27668488270CD9AA00DF45C5 /* EditUserAssetsView.swift */; };
 		2766848B270CDA3500DF45C5 /* UserAssetsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2766848A270CDA3500DF45C5 /* UserAssetsStore.swift */; };
+		276684AE270F6F6000DF45C5 /* WalletStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276684AD270F6F6000DF45C5 /* WalletStrings.swift */; };
 		27676D472555F34D00BC955A /* BraveRewardsStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27676D462555F34D00BC955A /* BraveRewardsStatusView.swift */; };
 		276A790A244660B100AC9446 /* SpringButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A7909244660B100AC9446 /* SpringButton.swift */; };
 		276A790C244660B500AC9446 /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A790B244660B500AC9446 /* UICollectionViewExtensions.swift */; };
@@ -1883,6 +1884,7 @@
 		2766847B270B76D900DF45C5 /* FilterableViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterableViewModifier.swift; sourceTree = "<group>"; };
 		27668488270CD9AA00DF45C5 /* EditUserAssetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUserAssetsView.swift; sourceTree = "<group>"; };
 		2766848A270CDA3500DF45C5 /* UserAssetsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAssetsStore.swift; sourceTree = "<group>"; };
+		276684AD270F6F6000DF45C5 /* WalletStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletStrings.swift; sourceTree = "<group>"; };
 		27676D462555F34D00BC955A /* BraveRewardsStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveRewardsStatusView.swift; sourceTree = "<group>"; };
 		276A7909244660B100AC9446 /* SpringButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringButton.swift; sourceTree = "<group>"; };
 		276A790B244660B500AC9446 /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
@@ -3580,6 +3582,7 @@
 				271F689026EBD27E00AA2A50 /* SwapButton.swift */,
 				271F688026EBD27D00AA2A50 /* TabbedPageViewController.swift */,
 				271F688E26EBD27D00AA2A50 /* WalletTableViewHeaderView.swift */,
+				276684AD270F6F6000DF45C5 /* WalletStrings.swift */,
 				271F683726EBD0E400AA2A50 /* BraveWallet.h */,
 				271F683826EBD0E400AA2A50 /* Info.plist */,
 			);
@@ -7340,6 +7343,7 @@
 				271F689826EBD27E00AA2A50 /* NetworkStore.swift in Sources */,
 				271F68AD26EBD27E00AA2A50 /* VerifyRecoveryPhraseView.swift in Sources */,
 				271F689626EBD27E00AA2A50 /* SwapCryptoView.swift in Sources */,
+				276684AE270F6F6000DF45C5 /* WalletStrings.swift in Sources */,
 				271F689426EBD27E00AA2A50 /* PreviewModifiers.swift in Sources */,
 				271F68A826EBD27E00AA2A50 /* PortfolioView.swift in Sources */,
 				277190EA2702512900DC81D5 /* TestStores.swift in Sources */,

--- a/Shared/Extensions/BundleExtension.swift
+++ b/Shared/Extensions/BundleExtension.swift
@@ -8,6 +8,7 @@ extension Bundle {
     public static let shared: Bundle = Bundle(identifier: "com.brave.Shared")!
     public static let data: Bundle = Bundle(identifier: "com.brave.Data")!
     public static let braveShared: Bundle = Bundle(identifier: "com.brave.BraveShared")!
+    public static let braveWallet: Bundle = Bundle(identifier: "com.brave.BraveWallet")!
     public static let storage: Bundle = Bundle(identifier: "com.brave.Storage")!
     
     public func getPlistString(for key: String) -> String? {

--- a/l10n/cleanup-nslocalizedstring.py
+++ b/l10n/cleanup-nslocalizedstring.py
@@ -9,7 +9,7 @@ import sys
 import json
 
 blacklisted_parent_directories = ["ThirdParty", "Carthage", "fastlane", "L10nSnapshotTests", "l10n"]
-frameworks = ["BraveShared", "Data", "Shared", "Storage"]
+frameworks = ["BraveShared", "BraveWallet", "Data", "Shared", "Storage"]
 
 def pascal_case(string):
   # Convert full stops, hyphens and underscores to spaces so that words are correctly pascal cased

--- a/l10n/cleanup-nslocalizedstring2.py
+++ b/l10n/cleanup-nslocalizedstring2.py
@@ -9,7 +9,7 @@ import sys
 import json
 
 blacklisted_parent_directories = ["ThirdParty", "Carthage", "fastlane", "L10nSnapshotTests", "l10n"]
-frameworks = ["BraveShared", "Data", "Shared", "Storage"]
+frameworks = ["BraveShared", "BraveWallet", "Data", "Shared", "Storage"]
 
 def pascal_case(string):
   # Convert full stops, hyphens and underscores to spaces so that words are correctly pascal cased


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4259

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
