### PR TITLE
Refactor buy/send/swap actions into SwiftUI presentation context

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -87,7 +87,6 @@ struct AccountsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
-    .navigationTitle(Strings.Wallet.accountsPageTitle)
     .osAvailabilityModifiers { content in
       if #available(iOS 15.0, *) {
         content

--- a/BraveWallet/Crypto/BuySwapSwap/BuySendSwapDestination.swift
+++ b/BraveWallet/Crypto/BuySwapSwap/BuySendSwapDestination.swift
@@ -1,0 +1,40 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import struct Shared.Strings
+
+/// Used to determine where a user is navigated to when they tap on a buy, send or swap button
+enum BuySendSwapDestination: String, Identifiable, CaseIterable {
+  case buy
+  case send
+  case swap
+  
+  var id: String {
+    rawValue
+  }
+  
+  var localizedTitle: String {
+    switch self {
+    case .buy:
+      return Strings.Wallet.buy
+    case .send:
+      return Strings.Wallet.send
+    case .swap:
+      return Strings.Wallet.swap
+    }
+  }
+  
+  var localizedDescription: String {
+    switch self {
+    case .buy:
+      return Strings.Wallet.buyDescription
+    case .send:
+      return Strings.Wallet.sendDescription
+    case .swap:
+      return Strings.Wallet.swapDescription
+    }
+  }
+}

--- a/BraveWallet/Crypto/BuySwapSwap/BuySendSwapView.swift
+++ b/BraveWallet/Crypto/BuySwapSwap/BuySendSwapView.swift
@@ -7,53 +7,25 @@ import SwiftUI
 import struct Shared.Strings
 
 struct BuySendSwapView: View {
-  enum Action: CaseIterable {
-    case buy
-    case send
-    case swap
-    
-    var title: String {
-      switch self {
-      case .buy:
-        return Strings.Wallet.buy
-      case .send:
-        return Strings.Wallet.send
-      case .swap:
-        return Strings.Wallet.swap
-      }
-    }
-    
-    var description: String {
-      switch self {
-      case .buy:
-        return Strings.Wallet.buyDescription
-      case .send:
-        return Strings.Wallet.sendDescription
-      case .swap:
-        return Strings.Wallet.swapDescription
-      }
-    }
-  }
-  
-  var action: (Action) -> Void
+  var action: (BuySendSwapDestination) -> Void
   
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
-      ForEach(Action.allCases, id: \.self) { action in
+      ForEach(BuySendSwapDestination.allCases, id: \.self) { action in
         Button(action: { self.action(action) }) {
           VStack(alignment: .leading, spacing: 3) {
-            Text(action.title)
+            Text(action.localizedTitle)
               .foregroundColor(Color(.bravePrimary))
               .font(.headline)
               .multilineTextAlignment(.leading)
-            Text(action.description)
+            Text(action.localizedDescription)
               .foregroundColor(Color(.braveLabel))
               .font(.footnote)
               .multilineTextAlignment(.leading)
           }
           .padding([.leading, .trailing], 20)
         }
-        if action != Action.allCases.last {
+        if action != BuySendSwapDestination.allCases.last {
           Divider()
             .padding(.leading, 20)
         }

--- a/BraveWallet/Crypto/BuySwapSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySwapSwap/SwapCryptoView.swift
@@ -70,6 +70,8 @@ struct SwapCryptoView: View {
   @State private var toQuantity: String = ""
   @State private var orderType: OrderType = .market
   
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
   enum OrderType {
     case market
     case limit
@@ -160,7 +162,9 @@ struct SwapCryptoView: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
-          Button(action: { }) {
+          Button(action: {
+            presentationMode.dismiss()
+          }) {
             Text(Strings.CancelString)
               .foregroundColor(Color(.braveOrange))
           }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		2760056625D1FFF500D47A75 /* AddFeedToBraveNewsActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2760056525D1FFF500D47A75 /* AddFeedToBraveNewsActivity.swift */; };
 		2760D2BF215ACCE20068E131 /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2760D2BE215ACCE20068E131 /* BundleExtensions.swift */; };
 		2762FF30271A054A001EF41D /* AssetIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2762FF2F271A054A001EF41D /* AssetIconView.swift */; };
+		2762FF32271A2448001EF41D /* BuySendSwapDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2762FF31271A2448001EF41D /* BuySendSwapDestination.swift */; };
 		2765825D2171263A00754B2F /* UserReferralProgram.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2765825C2171263A00754B2F /* UserReferralProgram.swift */; };
 		276582692171266900754B2F /* ReferralData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276582652171266900754B2F /* ReferralData.swift */; };
 		2765826A2171266900754B2F /* UrpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276582662171266900754B2F /* UrpService.swift */; };
@@ -1882,6 +1883,7 @@
 		2760056525D1FFF500D47A75 /* AddFeedToBraveNewsActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedToBraveNewsActivity.swift; sourceTree = "<group>"; };
 		2760D2BE215ACCE20068E131 /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
 		2762FF2F271A054A001EF41D /* AssetIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetIconView.swift; sourceTree = "<group>"; };
+		2762FF31271A2448001EF41D /* BuySendSwapDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuySendSwapDestination.swift; sourceTree = "<group>"; };
 		2765825C2171263A00754B2F /* UserReferralProgram.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserReferralProgram.swift; sourceTree = "<group>"; };
 		276582652171266900754B2F /* ReferralData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferralData.swift; sourceTree = "<group>"; };
 		276582662171266900754B2F /* UrpService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UrpService.swift; sourceTree = "<group>"; };
@@ -3628,7 +3630,6 @@
 				271F686326EBD27D00AA2A50 /* Accounts */,
 				271F686D26EBD27D00AA2A50 /* UnlockWalletView.swift */,
 				271F686E26EBD27D00AA2A50 /* Portfolio */,
-				271F687226EBD27D00AA2A50 /* BuySendSwapView.swift */,
 				271F687326EBD27D00AA2A50 /* Asset Details */,
 				271F687726EBD27D00AA2A50 /* Onboarding */,
 				2762FF2F271A054A001EF41D /* AssetIconView.swift */,
@@ -3639,6 +3640,8 @@
 		271F685726EBD27D00AA2A50 /* BuySwapSwap */ = {
 			isa = PBXGroup;
 			children = (
+				2762FF31271A2448001EF41D /* BuySendSwapDestination.swift */,
+				271F687226EBD27D00AA2A50 /* BuySendSwapView.swift */,
 				271F685826EBD27D00AA2A50 /* SwapCryptoView.swift */,
 				2729E7D226F502AC00200648 /* AccountPicker.swift */,
 				7D758907271A172C00B643C3 /* BuyTokenView.swift */,
@@ -7384,6 +7387,7 @@
 				271F68C026EBD27E00AA2A50 /* WalletTableViewHeaderView.swift in Sources */,
 				271F68A726EBD27E00AA2A50 /* BackupNotifyView.swift in Sources */,
 				2729E7D326F502AC00200648 /* AccountPicker.swift in Sources */,
+				2762FF32271A2448001EF41D /* BuySendSwapDestination.swift in Sources */,
 				271F68A426EBD27E00AA2A50 /* AccountsView.swift in Sources */,
 				2766848B270CDA3500DF45C5 /* UserAssetsStore.swift in Sources */,
 				271F68AC26EBD27E00AA2A50 /* AssetDetailHeaderView.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes

Moves the destination sheet presentation of buy/send/swap to the main `CryptoPagesView`. This means environment/`PresentationMode` will work correctly.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
