### PR TITLE
Fix #4339: Opening URLs on launch doesn't always open a new tab

### DIFF
--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -94,6 +94,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // As each instance should have its own protection?
         self.windowProtection = WindowProtection(window: window)
         window.makeKeyAndVisible()
+        
+        // Open shared URLs on launch if there are any
+        if !connectionOptions.urlContexts.isEmpty {
+            self.scene(windowScene, openURLContexts: connectionOptions.urlContexts)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Sometimes `scene(scene: UIScene, openURLContexts: Set<UIOpenURLContext>)` doesn't get called
- We can call this manually with the launch options for that scene, so the app opens the URL on cold launch.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4339

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
