### PR TITLE
Fix #4346 - Fix carplay crashing when Scene info.plist conflicts with AppDelegate configuration

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -465,9 +465,10 @@ extension AppDelegate {
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role).then {
-            $0.sceneClass = UIWindowScene.self
-            $0.delegateClass = SceneDelegate.self
+        return UISceneConfiguration(name: connectingSceneSession.configuration.name,
+                                    sessionRole: connectingSceneSession.role).then {
+            $0.sceneClass = connectingSceneSession.configuration.sceneClass
+            $0.delegateClass = connectingSceneSession.configuration.delegateClass
         }
     }
 


### PR DESCRIPTION
## Summary of Changes
- Fix support for multiple Scenes. Specifying a hardcoded scene on iOS will crash if it differs from Info.plist.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4346

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
