### PR TITLE
Immediately focus the password field on unlock screen

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -241,6 +241,19 @@ public class KeyringStore: ObservableObject {
   /// Stores the users wallet password in the keychain so that they may unlock using biometrics/passcode
   static func storePasswordInKeychain(_ password: String) -> Bool {
     guard let passwordData = password.data(using: .utf8) else { return false }
+    #if targetEnvironment(simulator)
+    // There is a bug with iOS 15 simulators when attempting to add a keychain item with
+    // `kSecAttrAccessControl` set. This of course means that on simulator we will not ask for biometrics
+    // and it will just auto-fill the password field but at least to set it up you still need to enable
+    // biometrics on the simulator
+    //
+    // Last checked: Xcode 13.1 (13A1030d)
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: passwordKeychainKey,
+      kSecValueData as String: passwordData
+    ]
+    #else
     let accessControl = SecAccessControlCreateWithFlags(
       nil,
       kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
@@ -253,6 +266,7 @@ public class KeyringStore: ObservableObject {
       kSecAttrAccessControl as String: accessControl as Any,
       kSecValueData as String: passwordData
     ]
+    #endif
     let status = SecItemAdd(query as CFDictionary, nil)
     return status == errSecSuccess
   }

--- a/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/BraveWallet/Crypto/UnlockWalletView.swift
@@ -55,6 +55,9 @@ struct UnlockWalletView: View {
             .fixedSize(horizontal: false, vertical: true)
           SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: unlock)
             .font(.subheadline)
+            .introspectTextField(customize: { tf in
+              tf.becomeFirstResponder()
+            })
             .textFieldStyle(BraveValidatedTextFieldStyle(error: unlockError))
             .padding(.horizontal, 48)
         }


### PR DESCRIPTION
Also add a workaround for using biometrics unlock in the simulator

## Summary of Changes

Quality-of-life fix to focus the password field immediately on opening the wallet screen

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
