### PR TITLE
Fix #3312: Added Much Improved Find-In-Page

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -864,6 +864,7 @@
 		C8611C8E1F71904C00C3DE7D /* DiskImageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */; };
 		C8F457A81F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F457A71F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift */; };
 		C8F457AA1F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F457A91F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift */; };
+		CA02B512271F246E002DE506 /* BrowserViewController+FindInPageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA02B511271F246E002DE506 /* BrowserViewController+FindInPageDelegate.swift */; };
 		CA04E8A627022D9D00BFBB4D /* PlaylistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA04E8A527022D9D00BFBB4D /* PlaylistTests.swift */; };
 		CA10BE702704BA7900A265A6 /* AmazonRootCA4.cer in Resources */ = {isa = PBXBuildFile; fileRef = 4481F22A26CBD1C500658EAC /* AmazonRootCA4.cer */; };
 		CA10BE712704BA7900A265A6 /* GlobalSignRootCA_R1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 4481F24226CBD42C00658EAC /* GlobalSignRootCA_R1.cer */; };
@@ -2587,6 +2588,7 @@
 		C817B34C1FC609500086018E /* UIScrollViewSwizzled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSwizzled.swift; sourceTree = "<group>"; };
 		C8F457A71F1FD75A000CB895 /* BrowserViewController+WKNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+WKNavigationDelegate.swift"; sourceTree = "<group>"; };
 		C8F457A91F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+KeyCommands.swift"; sourceTree = "<group>"; };
+		CA02B511271F246E002DE506 /* BrowserViewController+FindInPageDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+FindInPageDelegate.swift"; sourceTree = "<group>"; };
 		CA04E8A527022D9D00BFBB4D /* PlaylistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistTests.swift; sourceTree = "<group>"; };
 		CA10BE7E2704BCAE00A265A6 /* leaf.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = leaf.cer; sourceTree = "<group>"; };
 		CA439A5825E6F29D00FE9150 /* VideoPlayerInfoBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerInfoBar.swift; sourceTree = "<group>"; };
@@ -5034,6 +5036,7 @@
 				2FFD2012260B914200E552A5 /* ProductNotifications */,
 				2F55443025913BAA000E4689 /* OpenSearch */,
 				2FBCB15C262783FD00F512D8 /* Sync */,
+				CA02B511271F246E002DE506 /* BrowserViewController+FindInPageDelegate.swift */,
 			);
 			path = BrowserViewController;
 			sourceTree = "<group>";
@@ -7518,6 +7521,7 @@
 				27829DE92548AA4F007CF0B2 /* BraveRewardsViewController.swift in Sources */,
 				4422D4B021BFFB7600BF1855 /* arena.cc in Sources */,
 				E47616C71AB74CA600E7DD25 /* ReaderModeBarView.swift in Sources */,
+				CA02B512271F246E002DE506 /* BrowserViewController+FindInPageDelegate.swift in Sources */,
 				E65075511E37F6D1006961AC /* NSURLExtensionsMailTo.swift in Sources */,
 				D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */,
 				D03F8EB22004014E003C2224 /* FaviconHandler.swift in Sources */,

--- a/Client/Frontend/Browser/BraveWebView.swift
+++ b/Client/Frontend/Browser/BraveWebView.swift
@@ -8,6 +8,9 @@ import Shared
 import BraveShared
 
 class BraveWebView: WKWebView {
+    lazy var findInPageDelegate: WKWebViewFindStringFindDelegate? = {
+        return WKWebViewFindStringFindDelegate(webView: self)
+    }()
     
     /// Stores last position when the webview was touched on.
     private(set) var lastHitPoint = CGPoint(x: 0, y: 0)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2740,7 +2740,18 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
 
     fileprivate func find(_ text: String, function: String) {
         guard let webView = tabManager.selectedTab?.webView else { return }
-        webView.evaluateSafeJavaScript(functionName: "__firefox__.\(function)", args: [text], sandboxed: false)
+        
+        if let delegate = webView.findInPageDelegate {
+            let backwards = function == TextSearchDirection.previous.rawValue
+            
+            delegate.find(string: text, backwards: backwards) { [weak self] index, total in
+                guard let self = self else { return }
+                self.findInPageBar?.totalResults = Int(total)
+                self.findInPageBar?.currentResult = index
+            }
+        } else {
+            webView.evaluateSafeJavaScript(functionName: "__firefox__.\(function)", args: [text], sandboxed: false)
+        }
     }
 
     func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateCurrentResult currentResult: Int) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPageDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPageDelegate.swift
@@ -1,0 +1,178 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import WebKit
+import Shared
+
+private let log = Logger.browserLogger
+
+/// List of Find Options used by WebKit to `Find-In-Page`
+/// Typically we use `caseInsensitive`, `wrapAround`, `backwards`, `showHighlight`
+private struct WKFindOptions: OptionSet {
+    let rawValue: UInt
+    
+    /// Case insensitive search option
+    static let caseInsensitive = WKFindOptions(rawValue: 0x01)
+    /// Searches for words "beginning with" option
+    static let atWordStarts = WKFindOptions(rawValue: 0x02)
+    /// Treats a Medial Captial as the beginning of a word option
+    /// "PlayStation" for example would be Play & Station as two separate words.
+    static let treatMedialCapitalAsWordStart = WKFindOptions(rawValue: 0x04)
+    /// Searches backwards
+    static let backwards = WKFindOptions(rawValue: 0x08)
+    /// When the user reaches the end of all search results, wraps around back to the beginning option.
+    static let wrapAround = WKFindOptions(rawValue: 0x10)
+    /// Shows an overlay (brighter) highlight on top of the matched words option
+    static let showOverlay = WKFindOptions(rawValue: 0x20)
+    /// Show the "selection" indicator on top of the currently matched word option
+    static let showFindIndicator = WKFindOptions(rawValue: 0x40)
+    /// Shows a yellow highlight on top of the matches words option
+    static let showHighlight = WKFindOptions(rawValue: 0x80)
+    /// Used when the index of the search has not changed at all
+    static let noIndexChange = WKFindOptions(rawValue: 0x100)
+    /// Forces webkit to determine the match index
+    static let determineMatchIndex = WKFindOptions(rawValue: 0x200)
+}
+
+/// A Delegate used to invoke `Find-In-Page` internally in WebKit
+/// This is used to allow WebKit to do Find-In-Page on PDFs and all Web-Content
+@objc
+class WKWebViewFindStringFindDelegate: NSObject {
+    /// Set to true when the constructor hasn't failed
+    /// Used to guard against a developer accidentally calling the API when they can't
+    private var didConstructorSucceed = false
+    
+    /// Not necessary, but just in case WebKit retains the delegate in the future,
+    /// it would be a good idea to restore the original state of the WebView upon destruction
+    private var originalDelegate: AnyObject?
+    
+    /// The WebView this delegate is installed in
+    private weak var webView: WKWebView?
+    
+    /// A callback function that is called when `find(string:...)` returns a result
+    private var findMatchesCallback: ((Int, Int) -> Void)?
+    
+    /// List of default options for `Find-In-Page`
+    /// Additionally, when searching backwards, `.backwards` is appended
+    private let options: WKFindOptions = [.caseInsensitive,
+                                          .showHighlight,
+                                          .wrapAround,
+                                          .showFindIndicator,
+                                          /*.showOverlay, // Options used by Safari
+                                          .atWordStarts*/]
+    
+    /// List of selectors used. The only ones really needed is `set` and `find`.
+    /// The `get` selector is just for extra security in case something changes in the future,
+    /// with regards to retaining the delegate.
+    private static let getFindDelegateSelector = Selector(("_findDelegate"))
+    private static let setFindDelegateSelector = Selector(("_setFindDelegate:"))
+    private static let findStringSelector = Selector(("_findString:options:maxCount:"))
+    
+    /// Determines if the selectors are valid and this class can be used
+    /// IF this returns `false` do NOT attempt to instantiate this class.
+    /// It will NOT work.
+    private static var canFindInPagePrivate: Bool {
+        let delegates = [getFindDelegateSelector,
+                         setFindDelegateSelector,
+                         findStringSelector]
+        return delegates.allSatisfy { WKWebView.instancesRespond(to: $0) }
+    }
+
+    /// Returns the existing Find-In-Page delegate for the specified WKWebView.
+    /// If none exists, returns nil.
+    /// MUST only be called after a call to `canFindInPagePrivate`
+    private static func findDelegate(for webView: WKWebView) -> WKWebViewFindStringFindDelegate? {
+        var originalDelegate: AnyObject?
+        if let delegate = webView.perform(WKWebViewFindStringFindDelegate.getFindDelegateSelector) {
+            originalDelegate = delegate.takeRetainedValue()
+        }
+        
+        if let originalDelegate = originalDelegate as? WKWebViewFindStringFindDelegate {
+            return originalDelegate
+        }
+        return nil
+    }
+    
+    /// Constructs a Delegate for a specified WebView
+    /// Can fail if the WebView already contains an instance of this delegate
+    /// Can fail if the Internal WebKit API changes
+    init?(webView: WKWebView) {
+        self.webView = webView
+        super.init()
+        
+        if !WKWebViewFindStringFindDelegate.canFindInPagePrivate {
+            log.error("CANNOT INSTANTIATE WKWebViewFindStringFindDelegate!")
+            return nil
+        }
+        
+        if WKWebViewFindStringFindDelegate.findDelegate(for: webView) != nil {
+            log.error("CANNOT SET FIND DELEGATE TWICE!")
+            return nil
+        }
+        
+        if let delegate = webView.perform(WKWebViewFindStringFindDelegate.getFindDelegateSelector) {
+            originalDelegate = delegate.takeRetainedValue()
+        }
+        
+        webView.perform(WKWebViewFindStringFindDelegate.setFindDelegateSelector, with: self)
+        didConstructorSucceed = true
+    }
+    
+    deinit {
+        if didConstructorSucceed {
+            webView?.perform(WKWebViewFindStringFindDelegate.setFindDelegateSelector, with: originalDelegate)
+            originalDelegate = nil
+            webView = nil
+        }
+    }
+    
+    /// Finds a string on a Page or PDF or any searchable content
+    /// `string` - The string to find
+    /// `backwards` - Whether to search backwards (up the page) or fowards (down the page)
+    /// `completion` -  Called asynchronously when the Find Results are updated.
+    ///              - First parameter is the Index of the currently highlighted item
+    ///              - Second parameter is the Total results found on the page
+    func find(string: String, backwards: Bool, _ completion: @escaping (Int, Int) -> Void) {
+        guard didConstructorSucceed, let webView = webView else { return }
+        findMatchesCallback = completion
+        
+        var options = self.options
+        if backwards {
+            options.update(with: .backwards)
+        }
+        
+        typealias _findString = @convention(c) (NSObject, Selector, NSString, UInt, UInt) -> Void
+        let selector = WKWebViewFindStringFindDelegate.findStringSelector
+        let findString = unsafeBitCast(webView.method(for: selector), to: _findString.self)
+        findString(webView,
+                   selector,
+                   string as NSString,
+                   options.rawValue,
+                   UInt.max - 1)
+    }
+    
+    @objc
+    private func _webView(_ webView: WKWebView, didCountMatches matches: UInt, forString string: NSString) {
+        log.debug("FIND-IN-PAGE COUNT-MATCHES: \(matches)")
+    }
+    
+    @objc
+    private func _webView(_ webView: WKWebView, didFindMatches matches: UInt, forString string: NSString, withMatchIndex matchIndex: NSInteger) {
+        var matches = matches
+        
+        // kWKMoreThanMaximumMatchCount = static_cast<unsigned>(-1)
+        if matches >= UInt.max - 1 {
+            matches = UInt(Int.max)
+        }
+        
+        findMatchesCallback?(matchIndex + 1, Int(matches))
+    }
+    
+    @objc
+    private func _webView(_ webView: WKWebView, didFailToFindString string: NSString) {
+        findMatchesCallback?(0, 0)
+    }
+}


### PR DESCRIPTION
## Summary of Changes
- Adds `Find-In-Page` feature for PDFs for pages using native code instead of JS
- Adds improved `Find-In-Page` for pages using native code instead of JS
- Fixes performance complaints of `Find-In-Page` as it doesn't use JS.
- Added documentation to all functions and enumerations used.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3312

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://i.imgur.com/wZJqMyj.mp4


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
