### PR TITLE
Fix #4364: CarPlay not able to launch when the app is not running.

### DIFF
--- a/Client/Frontend/Browser/Playlist/Managers & Cache/CPTemplateApplicationSceneDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/CPTemplateApplicationSceneDelegate.swift
@@ -48,13 +48,17 @@ extension CarplayTemplateApplicationSceneDelegate: CPTemplateApplicationSceneDel
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {
         log.debug("Template application scene did connect.")
         
-        PlaylistCarplayManager.shared.connect(interfaceController: interfaceController)
+        DispatchQueue.main.async {
+            PlaylistCarplayManager.shared.connect(interfaceController: interfaceController)
+        }
     }
     
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
                                   didDisconnectInterfaceController interfaceController: CPInterfaceController) {
         log.debug("Template application scene did disconnect.")
         
-        PlaylistCarplayManager.shared.disconnect(interfaceController: interfaceController)
+        DispatchQueue.main.async {
+            PlaylistCarplayManager.shared.disconnect(interfaceController: interfaceController)
+        }
     }
 }


### PR DESCRIPTION
## Summary of Changes
- On iOS 14+, when CarPlay is launched, the app is NOT launched. It can play independently of the app now.
- So to fix this, we need to initialize the database too because CarPlay will access it without launching the app.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4364

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
