### PR TITLE
Fix #4367, #4363, #4366 - Fix Album Art on Next Track, Deleted Item playback, Carplay Playing Indicator

### DIFF
--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -46,6 +46,10 @@ class MediaPlayer: NSObject {
         player.timeControlStatus == .playing
     }
     
+    public var isWaitingToPlay: Bool {
+        player.timeControlStatus == .waitingToPlayAtSpecifiedRate
+    }
+    
     public var currentItem: AVPlayerItem? {
         player.currentItem
     }


### PR DESCRIPTION
## Summary of Changes
- Fixed album art not showing correctly when going to the next track.
- Fixed CarPlay playing indicator to show when an item is playing on the list view on iOS 15.
- Fixed Deleting Items not stopping playback (couldn't reproduce but it seems this is fixed due to playing index anyway?)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4367, #4363, #4366

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
