### PR TITLE
Fix #4396: Remove MediaPlaybackState API (iOS 15.0+)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2227,21 +2227,7 @@ extension BrowserViewController: TabManagerDelegate {
             wv.accessibilityLabel = nil
             wv.accessibilityElementsHidden = true
             wv.accessibilityIdentifier = nil
-            
-            #if swift(>=5.4)
-            if #available(iOS 15.0, *) {
-                wv.alpha = 0.0
-                wv.requestMediaPlaybackState { state in
-                    if state != .playing && wv != tabManager.selectedTab?.webView {
-                        wv.alpha = 1.0
-                    }
-                }
-            } else {
-                wv.removeFromSuperview()
-            }
-            #else
             wv.removeFromSuperview()
-            #endif
         }
         
         toolbar?.setSearchButtonState(url: selected?.url)
@@ -2270,9 +2256,6 @@ extension BrowserViewController: TabManagerDelegate {
             webView.accessibilityLabel = Strings.webContentAccessibilityLabel
             webView.accessibilityIdentifier = "contentView"
             webView.accessibilityElementsHidden = false
-            
-            // Restore WebView visibility state
-            webView.alpha = 1.0
 
             if webView.url == nil {
                 // The web view can go gray if it was zombified due to memory pressure.
@@ -2317,18 +2300,6 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         updateInContentHomePanel(selected?.url as URL?)
-        
-        #if swift(>=5.4)
-        for tab in tabManager.allTabs {
-            if #available(iOS 15.0, *), let wv = tab.webView {
-                wv.requestMediaPlaybackState { state in
-                    if state != .playing && wv != tabManager.selectedTab?.webView {
-                        wv.alpha = 1.0
-                    }
-                }
-            }
-        }
-        #endif
     }
 
     func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- First, it is worth noting that the URL bar isn't actually spoofed at all (at least not that I can see after hours of testing). The bug seems to be that the page does NOT finish loading and thus displays the content from the parent page. The URL bar will still show `about:blank` and not `badssl.com` when attempting to reproduce the issue, so I don't see any URL bar spoofing happening. However, the page MUST continue to load and behave like Safari and other browsers.

- Second, this only happens on iOS 15.0+

- Remove the tab/webView from the view hierarchy and get rid of the iOS 15.0+ (aka old 14.5+) API for media playback state (Might break Brave-Talk backgrounding).

- I don't see another fix for this URL spoofing bug atm. Somehow the API is returning that media is playing even when none is. WebKit still allows a WebView to control the JS and requests of its child WebView.

- We should probably find another way to fix this later on (maybe a follow up ticket).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4396

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See https://bravesoftware.slack.com/archives/G2KN13Z8C/p1634946451010500?thread_ts=1634932309.006300&channel=G2KN13Z8C&message_ts=1634946451.010500
for steps

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
