### PR TITLE
Fix #3713: Add option to drag/drop/rearrange favourites on New Tab Page Controller

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -148,6 +148,8 @@ class NewTabPageViewController: UIViewController {
         
         collectionView.delegate = self
         collectionView.dataSource = self
+        collectionView.dragDelegate = self
+        collectionView.dropDelegate = self
         
         background.changed = { [weak self] in
             self?.setupBackgroundImage()
@@ -868,6 +870,9 @@ extension NewTabPageViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         sections[indexPath.section].collectionView?(collectionView, didEndDisplaying: cell, forItemAt: indexPath)
     }
+    func collectionView(_ collectionView: UICollectionView, targetIndexPathForMoveFromItemAt currentIndexPath: IndexPath, toProposedIndexPath proposedIndexPath: IndexPath) -> IndexPath {
+        currentIndexPath.section == proposedIndexPath.section ? proposedIndexPath : currentIndexPath
+    }
 }
 
 // MARK: - UICollectionViewDataSource
@@ -907,6 +912,86 @@ extension NewTabPageViewController: UICollectionViewDataSource {
     }
 }
 
+// MARK: - UICollectionViewDragDelegate & UICollectionViewDropDelegate
+
+extension NewTabPageViewController: UICollectionViewDragDelegate, UICollectionViewDropDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+
+        // TODO: Check If the action is in right section
+        
+            let itemProvider = NSItemProvider(object: "\(indexPath)" as NSString)
+            let dragItem = UIDragItem(itemProvider: itemProvider)
+            dragItem.previewProvider = { () -> UIDragPreview? in
+                guard let cell = collectionView.cellForItem(at: indexPath) as? FavoriteCell else {
+                        return nil
+                }
+                return UIDragPreview(view: cell.imageView)
+            }
+        // TODO: Grab DragItem from Favourites
+            return [dragItem]
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
+        guard let sourceIndexPath = coordinator.items.first?.sourceIndexPath else { return }
+        let destinationIndexPath: IndexPath
+        if let indexPath = coordinator.destinationIndexPath {
+            destinationIndexPath = indexPath
+        } else {
+            let section = max(collectionView.numberOfSections - 1, 0)
+            let row = collectionView.numberOfItems(inSection: section)
+            destinationIndexPath = IndexPath(row: max(row - 1, 0), section: section)
+        }
+        
+        if sourceIndexPath.section != destinationIndexPath.section {
+            return
+        }
+        
+        switch coordinator.proposal.operation {
+        case .move:
+            guard let item = coordinator.items.first else { return }
+            _ = coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
+            Favorite.reorder(
+                sourceIndexPath: sourceIndexPath,
+                destinationIndexPath: destinationIndexPath,
+                isInteractiveDragReorder: true
+            )
+        case .copy:
+            break
+        default: return
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
+
+        // TODO: Can not drag cell drag if there is only one favourite
+        
+        return .init(operation: .move, intent: .insertAtDestinationIndexPath)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        let params = UIDragPreviewParameters()
+        params.backgroundColor = .clear
+        if let cell = collectionView.cellForItem(at: indexPath) as? FavoriteCell {
+            params.visiblePath = UIBezierPath(roundedRect: cell.imageView.frame, cornerRadius: 8)
+        }
+        return params
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        let params = UIDragPreviewParameters()
+        params.backgroundColor = .clear
+        if let cell = collectionView.cellForItem(at: indexPath) as? FavoriteCell {
+            params.visiblePath = UIBezierPath(roundedRect: cell.imageView.frame, cornerRadius: 8)
+        }
+        return params
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, dragSessionIsRestrictedToDraggingApplication session: UIDragSession) -> Bool {
+        return true
+    }
+}
+
 extension NewTabPageViewController {
     private class NewTabCollectionView: UICollectionView {
         override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
@@ -921,6 +1006,8 @@ extension NewTabPageViewController {
             showsVerticalScrollIndicator = false
             // Even on light mode we use a darker background now
             indicatorStyle = .white
+            // Drag should be enabled to rearrange favourite
+            dragInteractionEnabled = true
         }
         @available(*, unavailable)
         required init(coder: NSCoder) {

--- a/Client/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
@@ -21,6 +21,10 @@ class FavoritesSectionProvider: NSObject, NTPObservableSectionProvider {
     var action: (Favorite, BookmarksAction) -> Void
     var legacyLongPressAction: (UIAlertController) -> Void
     
+    var hasMoreThanOneFavouriteItems: Bool {
+        frc.fetchedObjects?.count ?? 0 > 0
+    }
+    
     private var frc: NSFetchedResultsController<Favorite>
     
     init(action: @escaping (Favorite, BookmarksAction) -> Void,


### PR DESCRIPTION
Adding drag and drop delegate method implementations for NewTabPageController. This will allow user to rearrange the visible favourites on NTP. Favourites outside of visible ones do not need to be handled.


## Summary of Changes

This pull request fixes #3713

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Rearrange Favourites on NTP page and check if it persists

## Screenshots:

https://user-images.githubusercontent.com/6643505/138739343-ca12edd9-a3fb-4e5e-b418-6667c8f3c5ba.mp4


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
