### PR TITLE
Fix #3397: Add ability to search bookmarks by title or URL in the bookmarks list

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -87,6 +87,8 @@ extension Strings {
     public static let searchSuggestionSectionTitleFormat = NSLocalizedString("SearchSuggestionSectionTitleFormat", tableName: "BraveShared", bundle: Bundle.braveShared, value: "%@ Search", comment: "Section Title when showing search suggestions. The parameter substituted for \"%@\" is the name of the search engine. E.g.: Google Search")
     public static let turnOnSearchSuggestions = NSLocalizedString("Turn on search suggestions?", bundle: Bundle.braveShared, comment: "Prompt shown before enabling provider search queries")
     public static let searchSuggestionSectionTitleNoSearchFormat = NSLocalizedString("SearchSuggestionSectionTitleNoSearchFormat", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Search", comment: "Section Title when showing search suggestions and the engine does not contain the word 'Search'.")
+    public static let noSearchResultsfound = NSLocalizedString("noSearchResultsfound", tableName: "BraveShared", bundle: .braveShared, value: "No search results found.", comment: "The information title displayed when there is no search reault found")
+    public static let searchBookmarksTitle = NSLocalizedString("searchBookmarksTitle", tableName: "BraveShared", bundle: .braveShared, value: "Search Bookmarks", comment: "The placeholder text for bookmark search")
 }
 
 // MARK:-  Authenticator.swift

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -65,7 +65,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         return items
     }
     
-    private var isLoading: Bool = false {
+    private var isLoading = false {
         didSet {
             if isLoading {
                 view.addSubview(spinner)
@@ -84,7 +84,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     
     private weak var addBookmarksFolderOkAction: UIAlertAction?
     
-    private var isEditingIndividualBookmark: Bool = false
+    private var isEditingIndividualBookmark = false
     
     private var currentFolder: Bookmarkv2?
     
@@ -99,11 +99,11 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     private var documentInteractionController: UIDocumentInteractionController?
     
     private var searchBookmarksTimer: Timer?
-    private var isBookmarksBeingSearched: Bool = false
+    private var isBookmarksBeingSearched = false
     private let bookmarksSearchController = UISearchController(searchResultsController: nil)
     private var bookmarksSearchQuery = ""
     private var searchBookmarkList: [Bookmarkv2] = []
-    private lazy var noSearchResultOverlayView: UIView = createNoSearchResultOverlayView()
+    private lazy var noSearchResultOverlayView = createNoSearchResultOverlayView()
 
     // MARK: Lifecycle
     
@@ -169,7 +169,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
             $0.searchBar.autocapitalizationType = .none
             $0.searchResultsUpdater = self
             $0.obscuresBackgroundDuringPresentation = false
-            $0.searchBar.placeholder = "Search Bookmarks"
+            $0.searchBar.placeholder = Strings.searchBookmarksTitle
             $0.delegate = self
             $0.hidesNavigationBarDuringPresentation = true
         }
@@ -240,7 +240,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         }
         
         let welcomeLabel = UILabel().then {
-            $0.text = "No search results found."
+            $0.text = Strings.noSearchResultsfound
             $0.textAlignment = .center
             $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
             $0.textColor = .braveLabel

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -326,10 +326,17 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     @objc private func longPressedCell(_ gesture: UILongPressGestureRecognizer) {
         guard gesture.state == .began,
               let cell = gesture.view as? UITableViewCell,
-              let indexPath = tableView.indexPath(for: cell),
-              let bookmark = bookmarksFRC?.object(at: indexPath) else {
+              let indexPath = tableView.indexPath(for: cell) else {
             return
         }
+                
+        var fetchedBookmarkItem: Bookmarkv2?
+        if isBookmarksBeingSearched {
+            fetchedBookmarkItem = searchBookmarkList[safe: indexPath.row]
+        } else {
+            fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath)
+        }
+        guard let bookmark = fetchedBookmarkItem else { return }
         
         presentLongPressActions(gesture, urlString: bookmark.url, isPrivateBrowsing: isPrivateBrowsing,
                                 customActions: bookmark.isFolder ? folderLongPressActions(bookmark) : nil)
@@ -920,7 +927,7 @@ extension BookmarksViewController: UISearchControllerDelegate {
     func willDismissSearchController(_ searchController: UISearchController) {
         isBookmarksBeingSearched = false
         updateEmptyPanelState()
-        tableView.reloadData()
+        reloadData()
         
         // Re-enable bottom var options when search is done
         navigationController?.setToolbarHidden(false, animated: true)

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -639,14 +639,12 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         var fetchedBookmarkItem: Bookmarkv2?
         if isBookmarksBeingSearched {
-            fetchedBookmarkItem = searchBookmarkList[safe: indexPath.row]
+            return true
         } else {
             fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath)
+            return fetchedBookmarkItem?.canBeDeleted ?? false
+
         }
-    
-        guard let item = fetchedBookmarkItem else { return false }
-        
-        return item.canBeDeleted
     }
 }
 
@@ -782,6 +780,11 @@ extension BookmarksViewController: BookmarksV2FetchResultsDelegate {
     }
     
     func controllerDidReloadContents(_ controller: BookmarksV2FetchResultsController) {
+        if isBookmarksBeingSearched {
+            refreshBookmarkSearchResult(with: bookmarksSearchQuery)
+            return
+        }
+        
         // We're in some sort of invalid state in sync..
         // Somehow this folder was deleted but the user is currently viewing it..
         // Might be a good idea to let the user know in the future that the folder they are currently viewing

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -552,19 +552,15 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     }
         
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
     
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return nil
-    }
-    
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return super.tableView(tableView, heightForRowAt: indexPath)
+        nil
     }
     
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        return indexPath
+        indexPath
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -634,7 +630,15 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     }
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        guard let item = bookmarksFRC?.object(at: indexPath) else { return false }
+        var fetchedBookmarkItem: Bookmarkv2?
+        if isBookmarksBeingSearched {
+            fetchedBookmarkItem = searchBookmarkList[safe: indexPath.row]
+        } else {
+            fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath)
+        }
+    
+        guard let item = fetchedBookmarkItem else { return false }
+        
         return item.canBeDeleted
     }
 }
@@ -648,12 +652,18 @@ extension BookmarksViewController {
     }
     
     func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        return .delete
+        .delete
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        guard let item = bookmarksFRC?.object(at: indexPath),
-              item.canBeDeleted else { return nil }
+        var fetchedBookmarkItem: Bookmarkv2?
+        if isBookmarksBeingSearched {
+            fetchedBookmarkItem = searchBookmarkList[safe: indexPath.row]
+        } else {
+            fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath)
+        }
+    
+        guard let item = fetchedBookmarkItem, item.canBeDeleted else { return nil }
 
         let deleteAction = UIContextualAction(style: .destructive, title: Strings.delete) { [weak self] _, _, completion in
             guard let self = self else {

--- a/Client/Frontend/Sync/BraveCore/Bookmarks/BookmarkManager.swift
+++ b/Client/Frontend/Sync/BraveCore/Bookmarks/BookmarkManager.swift
@@ -184,6 +184,21 @@ class BookmarkManager {
         })
     }
     
+    public func fetchBookmarks(with query: String = "", completion: @escaping ([Bookmarkv2]) -> Void) {
+        guard let bookmarksAPI = bookmarksAPI else {
+            completion([])
+            return
+        }
+        
+        bookmarksAPI.search(withQuery: query, maxCount: 200, completion: { nodes in
+            var fetchedBookmarks: [Bookmarkv2] = []
+
+            fetchedBookmarks = nodes.compactMap({ return !$0.isFolder ? Bookmarkv2($0) : nil })
+            
+            completion(fetchedBookmarks)
+        })
+    }
+    
     public func reorderBookmarks(frc: BookmarksV2FetchResultsController?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath) {
         guard let frc = frc, let bookmarksAPI = bookmarksAPI else {
             return


### PR DESCRIPTION
Adding Search Bar and functionality to Bookmark View Controller

## Summary of Changes

This pull request fixes #3397

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

As indicated in the ticket, the search is global for all bookmarks. So whichever screen you are in the search query should bring results up to 200 among all the bookmarks.

The folders should not be shown in the result and when search br clicked empty query will bring empty results. If there is no results from the query empty search results screen should be presented. Edit and delete actions should work on searched objects and should effect corresponding object.

- Open Bookmarks, Click Search Bar
- Search a keyword and check If desired search results are listed 
- Swipe the table row element and edit the screen name and press save
- Check desired element name is updated.
- Write a non existing search keyword and check No Results found is displayed.
- Press cancel and check If we navigated back to originated controller.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/6643505/139488989-c3b01e3c-067b-417d-a3cb-88f0ab959ebe.MP4

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
