### PR TITLE
Fix #4336: Put 'Set as default' setting on top of settings screen.

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -114,6 +114,7 @@ class SettingsViewController: TableViewController {
     
     private var sections: [Static.Section] {
         var list = [
+            defaultBrowserSection,
             featuresSection,
             generalSection,
             displaySection,
@@ -167,6 +168,21 @@ class SettingsViewController: TableViewController {
         header.bounds = CGRect(size: calculatedSize)
         
         return Static.Section(header: .view(header))
+    }()
+    
+    private lazy var defaultBrowserSection: Static.Section = {
+        var section = Static.Section(
+            rows: [
+                .init(text: Strings.setDefaultBrowserSettingsCell, selection: { [unowned self] in
+                    guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+                        return
+                    }
+                    UIApplication.shared.open(settingsUrl)
+                }, cellClass: MultilineButtonCell.self)
+            ]
+        )
+        
+        return section
     }()
     
     private lazy var featuresSection: Static.Section = {
@@ -273,15 +289,6 @@ class SettingsViewController: TableViewController {
                      option: Preferences.General.mediaAutoPlays,
                      image: #imageLiteral(resourceName: "settings-autoplay").template)
         ])
-        
-        if AppConstants.iOSVersionGreaterThanOrEqual(to: 14) && AppConstants.buildChannel == .release {
-            general.rows.append(.init(text: Strings.setDefaultBrowserSettingsCell, selection: { [unowned self] in
-                guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
-                    return
-                }
-                UIApplication.shared.open(settingsUrl)
-            }, cellClass: MultilineButtonCell.self))
-        }
 
         return general
     }()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4336 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that 'Set as default' button is at the top of settings, but below the vpn callout.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
