### PR TITLE
Fix #4407 - Sometimes on iOS 14, playback state is not properly updating the title when Carplay is Open

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -235,11 +235,15 @@ class PlaylistViewController: UIViewController {
     
     private func observePlayerStates() {
         player.publisher(for: .play).sink { [weak self] event in
-            self?.playerView.controlsView.playPauseButton.setImage(#imageLiteral(resourceName: "playlist_pause"), for: .normal)
+            guard let self = self else { return }
+            self.playerView.controlsView.playPauseButton.setImage(#imageLiteral(resourceName: "playlist_pause"), for: .normal)
             
             if !PlaylistCarplayManager.shared.isCarPlayAvailable {
                 MPNowPlayingInfoCenter.default().playbackState = .playing
                 PlaylistMediaStreamer.updateNowPlayingInfo(event.mediaPlayer)
+            } else if let item = PlaylistCarplayManager.shared.currentPlaylistItem {
+                self.playerView.setVideoInfo(videoDomain: item.pageSrc,
+                                             videoTitle: item.pageTitle)
             }
         }.store(in: &playerStateObservers)
         

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -340,9 +340,9 @@ class VideoView: UIView, VideoTrackerBarDelegate {
         isSeeking = true
         
         if delegate.isPlaying {
-            delegate.pause(self)
             wasPlayingBeforeSeeking = true
             playbackRate = delegate.playbackRate
+            delegate.pause(self)
         }
         
         toggleOverlays(showOverlay: false, except: [infoView, controlsView], display: [controlsView])


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix playback title not updating due to video pausing when playback ends and title not updating when playback plays again.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4407

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
