### PR TITLE
[No Bug]: Pass Window Protection per Window Scene

### DIFF
--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -165,6 +165,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         if let scene = scene as? UIWindowScene {
             scene.browserViewController?.showWalletTransferExpiryPanelIfNeeded()
+            scene.browserViewController?.windowProtection = windowProtection
         }
     }
 
@@ -458,12 +459,6 @@ extension UIWindowScene {
     /// Returns the first instance of `BrowserViewController` that is found in the current scene
     var browserViewController: BrowserViewController? {
         return browserViewControllers.first
-    }
-    
-    /// Returns window protection for the window scene
-    /// Used to handle biometric operations inside some controller
-    var windowProtection: WindowProtection? {
-        return windowProtection
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -161,6 +161,9 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     
     let vpnProductInfo = VPNProductInfo()
     
+    /// Window Protection instance which will be used for controller requires biometric authentication
+    var windowProtection: WindowProtection?
+    
     // Product Notification Related Properties
     
     /// Boolean which is tracking If a product notification is presented

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -74,7 +74,8 @@ extension BrowserViewController {
                                                 feedDataSource: self.feedDataSource,
                                                 rewards: self.rewards,
                                                 legacyWallet: self.legacyWallet,
-                                                historyAPI: self.historyAPI)
+                                                historyAPI: self.historyAPI,
+                                                windowProtection: self.windowProtection)
                 vc.settingsDelegate = self
                 menuController.pushInnerMenu(vc)
             }

--- a/Client/Frontend/Login/LoginAuthViewController.swift
+++ b/Client/Frontend/Login/LoginAuthViewController.swift
@@ -10,9 +10,12 @@ import Shared
 
 class LoginAuthViewController: UITableViewController {
         
+    private let windowProtection: WindowProtection?
+
     // MARK: Lifecycle
     
-    init(requiresAuthentication: Bool = false) {
+    init(windowProtection: WindowProtection?, requiresAuthentication: Bool = false) {
+        self.windowProtection = windowProtection
         self.requiresAuthentication = requiresAuthentication
         super.init(nibName: nil, bundle: nil)
     }
@@ -50,7 +53,7 @@ class LoginAuthViewController: UITableViewController {
     
     @discardableResult
     func askForAuthentication() -> Bool {
-        guard let windowProtection = self.currentScene?.windowProtection else {
+        guard let windowProtection = windowProtection else {
             return false
         }
 

--- a/Client/Frontend/Login/LoginInfoViewController.swift
+++ b/Client/Frontend/Login/LoginInfoViewController.swift
@@ -70,10 +70,10 @@ class LoginInfoViewController: LoginAuthViewController {
     
     // MARK: Lifecycle
 
-    init(profile: Profile, loginEntry: Login) {
+    init(profile: Profile, loginEntry: Login, windowProtection: WindowProtection?) {
         self.loginEntry = loginEntry
         self.profile = profile
-        super.init()
+        super.init(windowProtection: windowProtection)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Login/LoginListViewController.swift
+++ b/Client/Frontend/Login/LoginListViewController.swift
@@ -37,6 +37,8 @@ class LoginListViewController: LoginAuthViewController {
     // MARK: Private
     
     private let profile: Profile
+    private let windowProtection: WindowProtection?
+    
     private var loginEntries = [Login]()
     private var isFetchingLoginEntries = false
     private var searchLoginTimer: Timer?
@@ -46,9 +48,10 @@ class LoginListViewController: LoginAuthViewController {
     
     // MARK: Lifecycle
     
-    init(profile: Profile) {
+    init(profile: Profile, windowProtection: WindowProtection?) {
         self.profile = profile
-        super.init(requiresAuthentication: true)
+        self.windowProtection = windowProtection
+        super.init(windowProtection: windowProtection, requiresAuthentication: true)
     }
     
     required init?(coder: NSCoder) {
@@ -244,7 +247,10 @@ extension LoginListViewController {
 
     override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         if indexPath.section == Section.savedLogins.rawValue, let loginEntry = loginEntries[safe: indexPath.row] {
-            let loginDetailsViewController = LoginInfoViewController(profile: profile, loginEntry: loginEntry)
+            let loginDetailsViewController = LoginInfoViewController(
+                profile: profile,
+                loginEntry: loginEntry,
+                windowProtection: windowProtection)
             loginDetailsViewController.settingsDelegate = settingsDelegate
             navigationController?.pushViewController(loginDetailsViewController, animated: true)
             

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -59,19 +59,22 @@ class SettingsViewController: TableViewController {
     private let legacyWallet: BraveLedger?
     private let feedDataSource: FeedDataSource
     private let historyAPI: BraveHistoryAPI
-    
+    private let windowProtection: WindowProtection?
+
     init(profile: Profile,
          tabManager: TabManager,
          feedDataSource: FeedDataSource,
          rewards: BraveRewards? = nil,
          legacyWallet: BraveLedger? = nil,
-         historyAPI: BraveHistoryAPI) {
+         historyAPI: BraveHistoryAPI,
+         windowProtection: WindowProtection?) {
         self.profile = profile
         self.tabManager = tabManager
         self.feedDataSource = feedDataSource
         self.rewards = rewards
         self.legacyWallet = legacyWallet
         self.historyAPI = historyAPI
+        self.windowProtection = windowProtection
         
         super.init(style: .insetGrouped)
     }
@@ -423,7 +426,9 @@ class SettingsViewController: TableViewController {
             rows: [
                 .boolRow(title: Strings.browserLock, detailText: Strings.browserLockDescription, option: Preferences.Privacy.lockWithPasscode, image: #imageLiteral(resourceName: "settings-passcode").template),
                 Row(text: Strings.Login.loginListNavigationTitle, selection: { [unowned self] in
-                    let loginsPasswordsViewController = LoginListViewController(profile: self.profile)
+                    let loginsPasswordsViewController = LoginListViewController(
+                        profile: self.profile,
+                        windowProtection: self.windowProtection)
                     loginsPasswordsViewController.settingsDelegate = self.settingsDelegate
                     self.navigationController?.pushViewController(loginsPasswordsViewController, animated: true)
                 }, image: #imageLiteral(resourceName: "settings-save-logins").template, accessory: .disclosureIndicator)


### PR DESCRIPTION
Passing windowProtection property instead of fetching static Scene delegate for controller.
Fixes the problems  related with Biometric authentication in Password Screen.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Test biometrics work on Password Screen


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
