### PR TITLE
Fix #4389: Update backup banner background color

### DIFF
--- a/BraveWallet/Crypto/Portfolio/BackupNotifyView.swift
+++ b/BraveWallet/Crypto/Portfolio/BackupNotifyView.swift
@@ -35,7 +35,7 @@ struct BackupNotifyView: View {
       }
     }
     .frame(maxWidth: .infinity)
-    .background(Color(.braveWarningBackground))
+    .background(Color(.braveErrorBackground))
     .clipShape(backgroundShape)
   }
 }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4389

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Screenshots:

| Light | Dark |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-10-29 at 12 47 46](https://user-images.githubusercontent.com/529104/139472823-705e9c4e-5e9b-4dd4-b090-d1f432a38c49.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-10-29 at 12 47 43](https://user-images.githubusercontent.com/529104/139472840-b7a61ddd-8e62-42e5-a8ce-75d3f178abaa.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
