### PR TITLE
Fix: #4422 Send Screen with Unapproved Transaction API

### DIFF
--- a/BraveWallet/Crypto/BuySwapSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySwapSwap/SendTokenView.swift
@@ -34,7 +34,7 @@ struct SendTokenView: View {
       return true
     }
     
-    return sendAmount > balance || amountInput.isEmpty || !sendAddress.isAddress
+    return sendAmount > balance || amountInput.isEmpty || !sendAddress.isETHAddress
   }
   
   var body: some View {

--- a/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
+++ b/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
@@ -219,7 +219,7 @@ private class AddressQRCodeScannerViewController: UIViewController {
 
 extension AddressQRCodeScannerViewController: AVCaptureMetadataOutputObjectsDelegate {
   func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
-    if let stringValue = (metadataObjects.first as? AVMetadataMachineReadableCodeObject)?.stringValue, stringValue.isAddress {
+    if let stringValue = (metadataObjects.first as? AVMetadataMachineReadableCodeObject)?.stringValue, stringValue.isETHAddress {
       address = stringValue
       dismiss()
     } else {

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -22,7 +22,14 @@ extension String {
   var isAddress: Bool {
     // An address has to start with `0x`
     guard starts(with: "0x") else { return false }
-    // Check the rest of the char is a hex digit
-    return dropFirst(2).allSatisfy(\.isHexDigit)
+    
+    // removing `0x`
+    let hex = removingHexPrefix
+    if hex.count >= 40 {
+      // Check the rest of the char is a hex digit
+      return hex.allSatisfy(\.isHexDigit)
+    } else {
+      return false
+    }
   }
 }

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -18,18 +18,14 @@ extension String {
     hasPrefix("0x") ? String(dropFirst(2)) : self
   }
   
-  /// Check if the string is a valid address
-  var isAddress: Bool {
+  /// Check if the string is a valid ETH address
+  var isETHAddress: Bool {
     // An address has to start with `0x`
     guard starts(with: "0x") else { return false }
     
     // removing `0x`
     let hex = removingHexPrefix
-    if hex.count >= 40 {
-      // Check the rest of the char is a hex digit
-      return hex.allSatisfy(\.isHexDigit)
-    } else {
-      return false
-    }
+    // Check the length and the rest of the char is a hex digit
+    return hex.count == 40 && hex.allSatisfy(\.isHexDigit)
   }
 }

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -129,12 +129,17 @@ public class SendTokenStore: ObservableObject {
     }
   }
   
-  func sendToken(account: BraveWallet.AccountInfo, to: String, amount: String, completion: @escaping (_ success: Bool) -> Void) {
+  func sendToken(
+    from account: BraveWallet.AccountInfo,
+    to address: String,
+    amount: String,
+    completion: @escaping (_ success: Bool) -> Void
+  ) {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     guard let token = selectedSendToken, let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: 18) else { return }
     
     if token.isETH {
-      let data = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: to, value: "0x\(weiHexString)", data: [NSNumber]())
+      let data = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: address, value: "0x\(weiHexString)", data: .init())
       transactionController.addUnapprovedTransaction(data, from: account.address) { success, txMetaId, errorMessage in
         completion(success)
       }
@@ -146,7 +151,7 @@ public class SendTokenStore: ObservableObject {
         }
         rpcController.chainId { [self] chainId in
           let txData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
-          self.transactionController.addUnapprovedTransaction(txData, from: account.address) { success, txMetaId, errorMessage in
+          transactionController.addUnapprovedTransaction(txData, from: account.address) { success, txMetaId, errorMessage in
             completion(success)
           }
         }

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -17,24 +17,23 @@ public class SendTokenStore: ObservableObject {
     }
   }
   /// The current selected token balance. Default with nil value.
-  @Published var selectedSendTokenBalance: String? {
-    didSet {
-      // TODO: convert from wei Ref: https://github.com/brave/brave-ios/issues/4370
-    }
-  }
+  @Published var selectedSendTokenBalance: Double?
   
   private let keyringController: BraveWalletKeyringController
   private let rpcController: BraveWalletEthJsonRpcController
   private let walletService: BraveWalletBraveWalletService
+  private let transactionController: BraveWalletEthTxController
   
   public init(
     keyringController: BraveWalletKeyringController,
     rpcController: BraveWalletEthJsonRpcController,
-    walletService: BraveWalletBraveWalletService
+    walletService: BraveWalletBraveWalletService,
+    transactionController: BraveWalletEthTxController
   ) {
     self.keyringController = keyringController
     self.rpcController = rpcController
     self.walletService = walletService
+    self.transactionController = transactionController
     
     self.keyringController.add(self)
     self.rpcController.add(self)
@@ -81,6 +80,19 @@ public class SendTokenStore: ObservableObject {
         self.selectedSendTokenBalance = nil
         return
       }
+      
+      let balanceFormatter = WeiFormatter(decimalFormatStyle: .balance)
+      func updateBalance(_ success: Bool, _ balance: String) {
+        guard success, let decimalString = balanceFormatter.decimalString(
+          for: balance.removingHexPrefix,
+             radix: .hex,
+             decimals: Int(token.decimals)
+        ), !decimalString.isEmpty, let decimal = Double(decimalString) else {
+          return
+        }
+        selectedSendTokenBalance = decimal
+      }
+      
       // Get balance for ETH token
       if token.isETH {
         self.rpcController.balance(accountAddress) { success, balance in
@@ -88,7 +100,7 @@ public class SendTokenStore: ObservableObject {
             self.selectedSendTokenBalance = nil
             return
           }
-          self.selectedSendTokenBalance = balance
+          updateBalance(success, balance)
         }
       }
       // Get balance for erc20 token
@@ -99,7 +111,7 @@ public class SendTokenStore: ObservableObject {
             self.selectedSendTokenBalance = nil
             return
           }
-          self.selectedSendTokenBalance = balance
+          updateBalance(success, balance)
         }
       }
       // Get balance for erc721 token
@@ -111,7 +123,32 @@ public class SendTokenStore: ObservableObject {
             self.selectedSendTokenBalance = nil
             return
           }
-          self.selectedSendTokenBalance = balance
+          updateBalance(success, balance)
+        }
+      }
+    }
+  }
+  
+  func sendToken(account: BraveWallet.AccountInfo, to: String, amount: String, completion: @escaping (_ success: Bool) -> Void) {
+    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    guard let token = selectedSendToken, let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: 18) else { return }
+    
+    if token.isETH {
+      let data = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: to, value: "0x\(weiHexString)", data: [NSNumber]())
+      transactionController.addUnapprovedTransaction(data, from: account.address) { success, txMetaId, errorMessage in
+        completion(success)
+      }
+    } else {
+      transactionController.makeErc20TransferData(account.address, amount: "0x\(weiHexString)") { [self] success, data in
+        guard success else {
+          completion(false)
+          return
+        }
+        rpcController.chainId { [self] chainId in
+          let txData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
+          self.transactionController.addUnapprovedTransaction(txData, from: account.address) { success, txMetaId, errorMessage in
+            completion(success)
+          }
         }
       }
     }

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -58,7 +58,8 @@ public class WalletStore {
     self.sendTokenStore = .init(
       keyringController: keyringController,
       rpcController: rpcController,
-      walletService: walletService
+      walletService: walletService,
+      transactionController: transactionController
     )
   }
 }

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -55,7 +55,8 @@ extension SendTokenStore {
     .init(
       keyringController: TestKeyringController(),
       rpcController: TestEthJsonRpcController(),
-      walletService: TestBraveWalletService()
+      walletService: TestBraveWalletService(),
+      transactionController: TestEthTxController()
     )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -925,12 +925,19 @@ extension Strings {
       value: "Enter address or url",
       comment: "A placeholder of the address text field."
     )
-    public static let sendCryptoPreviewButtonTitle = NSLocalizedString(
-      "wallet.sendCryptoPreviewButtonTitle",
+    public static let sendCryptoSendButtonTitle = NSLocalizedString(
+      "wallet.sendCryptoSendButtonTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Preview", // TODO: Get real copy
-      comment: "The title of the button for users to click when they want to preview the sending-transaction"
+      value: "Send",
+      comment: "The title of the button for users to click when they want to send the sending-transaction"
+    )
+    public static let sendCryptoSendError = NSLocalizedString(
+      "wallet.sendCryptoSendError",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "We currently cannot proceed with your transaction",
+      comment: "The error message will appear when there is any error occurs during unpproved transaction"
     )
   }
 }

--- a/BraveWalletTests/AddressTests.swift
+++ b/BraveWalletTests/AddressTests.swift
@@ -22,4 +22,15 @@ class AddressTests: XCTestCase {
         let prefixlessAddress = "abcdef0123456789"
         XCTAssertEqual(prefixlessAddress.removingHexPrefix, "abcdef0123456789")
     }
+    
+    func testIsAddress() {
+        let isAddressTrue = "0x0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
+        XCTAssertTrue(isAddressTrue.isAddress)
+        
+        let isAddressFalseNotHex = "0x0csadgasg"
+        XCTAssertFalse(isAddressFalseNotHex.isAddress)
+        
+        let isAddressFalseWrongPrefix = "0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
+        XCTAssertFalse(isAddressFalseWrongPrefix.isAddress)
+    }
 }

--- a/BraveWalletTests/AddressTests.swift
+++ b/BraveWalletTests/AddressTests.swift
@@ -23,20 +23,20 @@ class AddressTests: XCTestCase {
         XCTAssertEqual(prefixlessAddress.removingHexPrefix, "abcdef0123456789")
     }
     
-    func testIsAddress() {
+    func testIsETHAddress() {
         let isAddressTrue = "0x0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
-        XCTAssertTrue(isAddressTrue.isAddress)
+        XCTAssertTrue(isAddressTrue.isETHAddress)
         
         let isAddressFalseNotHex = "0x0csadgasg"
-        XCTAssertFalse(isAddressFalseNotHex.isAddress)
+        XCTAssertFalse(isAddressFalseNotHex.isETHAddress)
         
         let isAddressFalseWrongPrefix = "0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
-        XCTAssertFalse(isAddressFalseWrongPrefix.isAddress)
+        XCTAssertFalse(isAddressFalseWrongPrefix.isETHAddress)
         
         let isAddressFalseTooShort = "0x84cD05f2"
-        XCTAssertFalse(isAddressFalseTooShort.isAddress)
+        XCTAssertFalse(isAddressFalseTooShort.isETHAddress)
         
         let isAddressFalseNoHexDigits = "0x"
-        XCTAssertFalse(isAddressFalseNoHexDigits.isAddress)
+        XCTAssertFalse(isAddressFalseNoHexDigits.isETHAddress)
     }
 }

--- a/BraveWalletTests/AddressTests.swift
+++ b/BraveWalletTests/AddressTests.swift
@@ -32,5 +32,11 @@ class AddressTests: XCTestCase {
         
         let isAddressFalseWrongPrefix = "0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
         XCTAssertFalse(isAddressFalseWrongPrefix.isAddress)
+        
+        let isAddressFalseTooShort = "0x84cD05f2"
+        XCTAssertFalse(isAddressFalseTooShort.isAddress)
+        
+        let isAddressFalseNoHexDigits = "0x"
+        XCTAssertFalse(isAddressFalseNoHexDigits.isAddress)
     }
 }


### PR DESCRIPTION
## Summary of Changes
This PR integrated Send Crypto Screen with unapproved transaction API.
Transaction confirmation UI and integration will be in separated tickets.
Also added unit test against `isAddress` 

This pull request fixes #4422

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

## Screenshots:

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
