### PR TITLE
Fix #4463 / #4464: Fixes the interaction of Favourites reordering with default browser modal 

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabCenteredCollectionViewCell.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabCenteredCollectionViewCell.swift
@@ -17,6 +17,8 @@ class NewTabCenteredCollectionViewCell<View: UIView>: UICollectionViewCell, Coll
         view.snp.remakeConstraints {
             $0.top.bottom.equalToSuperview()
             $0.centerX.equalToSuperview()
+            $0.leading.greaterThanOrEqualToSuperview()
+            $0.trailing.lessThanOrEqualToSuperview()
         }
     }
     

--- a/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
@@ -43,7 +43,10 @@ class NTPDefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
         
-        return fittingSizeForCollectionView(collectionView, section: indexPath.section)
+        var size = fittingSizeForCollectionView(collectionView, section: indexPath.section)
+        size.height = 54
+        
+        return size
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {

--- a/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
@@ -10,9 +10,7 @@ import BraveShared
 
 class NTPDefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
     var sectionDidChange: (() -> Void)?
-    private lazy var defaultCalloutView: DefaultBrowserCalloutView? = {
-        NTPDefaultBrowserCalloutProvider.shouldShowCallout ? DefaultBrowserCalloutView() : nil
-    }()
+    private var defaultCalloutView = DefaultBrowserCalloutView()
     
     private typealias DefaultBrowserCalloutCell = NewTabCenteredCollectionViewCell<DefaultBrowserCalloutView>
     
@@ -47,9 +45,7 @@ class NTPDefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
         
         var size = fittingSizeForCollectionView(collectionView, section: indexPath.section)
-        if let extraSize = defaultCalloutView?.systemLayoutSizeFitting(size) {
-            size.height = extraSize.height
-        }
+        size.height = defaultCalloutView.systemLayoutSizeFitting(size).height
         
         return size
     }

--- a/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
@@ -10,6 +10,9 @@ import BraveShared
 
 class NTPDefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
     var sectionDidChange: (() -> Void)?
+    private lazy var defaultCalloutView: DefaultBrowserCalloutView? = {
+        NTPDefaultBrowserCalloutProvider.shouldShowCallout ? DefaultBrowserCalloutView() : nil
+    }()
     
     private typealias DefaultBrowserCalloutCell = NewTabCenteredCollectionViewCell<DefaultBrowserCalloutView>
     
@@ -44,7 +47,9 @@ class NTPDefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
         
         var size = fittingSizeForCollectionView(collectionView, section: indexPath.section)
-        size.height = 54
+        if let extraSize = defaultCalloutView?.systemLayoutSizeFitting(size) {
+            size.height = extraSize.height
+        }
         
         return size
     }


### PR DESCRIPTION
NTP Default Browser needs a constant size like other sections so it will not stretch whie drag drop behaviour is happening.

## Summary of Changes

This pull request fixes #4463
This pull request fixes #4464

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Clean install so default browser modal is shown on NTP
- Long press on a favourite and try to drag it
- Default browser modal gets stretched and doesn't allow to reorder favourite

## Screenshots-Video:

https://user-images.githubusercontent.com/6643505/140378515-6126a094-671c-4fb4-9a58-6e403ae4dc00.MP4





## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
