### PR TITLE
Fix #4320: Add numbers next to backup phrase during onboarding

### DIFF
--- a/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -55,7 +55,7 @@ struct BackupRecoveryPhraseView: View {
         warningView
           .padding(.vertical)
         RecoveryPhraseGrid(data: recoveryWords, id: \.self) { word in
-          Text(verbatim: word.value)
+          Text(verbatim: "\(word.index + 1). \(word.value)")
             .font(.footnote.bold())
             .padding(8)
             .frame(maxWidth: .infinity)

--- a/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
@@ -166,7 +166,7 @@ private struct SelectedWordsBox: View {
           .hidden()
       case .word(let word, let index, let isCorrect):
         Button(action: { tappedWord(atIndex: index) }) {
-          Text(verbatim: word)
+          Text(verbatim: "\(index + 1). \(word)")
             .padding(8)
             .frame(maxWidth: .infinity)
             .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4320 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
