### PR TITLE
Fix #4483: After filling logins, fire js 'change' event.

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -550,12 +550,16 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
 
           if (!disabledOrReadOnly && !userEnteredDifferentCase && userNameDiffers) {
             usernameField.value = selectedLogin.username;
+            // Fire 'change' event to trigger client-side validation on this field.
+            usernameField.dispatchEvent(new Event("change"));
             dispatchKeyboardEvent(usernameField, "keydown", KEYCODE_ARROW_DOWN);
             dispatchKeyboardEvent(usernameField, "keyup", KEYCODE_ARROW_DOWN);
           }
         }
         if (passwordField.value != selectedLogin.password) {
           passwordField.value = selectedLogin.password;
+          // Fire 'change' event to trigger client-side validation on this field.
+          passwordField.dispatchEvent(new Event("change"));
           dispatchKeyboardEvent(passwordField, "keydown", KEYCODE_ARROW_DOWN);
           dispatchKeyboardEvent(passwordField, "keyup", KEYCODE_ARROW_DOWN);
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4483 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Create account on https://www.uniqlo.com/jp
Login entering credentials manually, it should ask to save the login
Log out

Now go to this site again and try to login, it should fill your username and password.
Verify you were able to log in.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
