### PR TITLE
No Bug: Remove shadows from menu item images

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -11,23 +11,23 @@ import BraveUI
 import SwiftUI
 
 struct MenuItemHeaderView: View {
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     var icon: UIImage
     var title: String
     var subtitle: String?
     
     var body: some View {
         HStack(spacing: 14) {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color(.secondaryBraveGroupedBackground))
+            Image(uiImage: icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .padding(6)
                 .frame(width: 32, height: 32)
-                .overlay(
-                    Image(uiImage: icon)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .padding(6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color(.secondaryBraveGroupedBackground))
+                        .shadow(color: Color.black.opacity(0.1), radius: 1, x: 0, y: 1)
                 )
-                .shadow(color: Color.black.opacity(0.1), radius: 1, x: 0, y: 1)
             VStack(alignment: .leading, spacing: 3) {
                 Text(verbatim: title)
                 if let subTitle = subtitle {


### PR DESCRIPTION
## Summary of Changes

Bugged me that shadows were being applied to images as well as the background, this fixes that

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
