### PR TITLE
Fix #4271:  Integrate Swap Price Quote and related user cases.

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -142,7 +142,7 @@ struct MarketPriceView: View {
         swapTokenStore.fetchPriceQuote(base: .perSellAsset)
       }) {
         Image("wallet-refresh")
-          .foregroundColor(Color(.braveLighterBlurple))
+          .foregroundColor(Color(.braveBlurpleTint))
           .font(.title3)
       }
       .buttonStyle(.plain)
@@ -189,7 +189,7 @@ struct SwapCryptoView: View {
     switch swapTokensStore.state {
     case .error, .idle:
       return true
-    case .activateAllowance, .swap:
+    case .lowAllowance, .swap:
       return false
     }
   }
@@ -198,8 +198,8 @@ struct SwapCryptoView: View {
     switch swapTokensStore.state {
     case .error(let error):
       return error
-    case .activateAllowance:
-      return "Activate Token \(swapTokensStore.selectedFromToken?.symbol ?? "")"
+    case .lowAllowance:
+      return String.localizedStringWithFormat(Strings.Wallet.activateToken, swapTokensStore.selectedFromToken?.symbol ?? "")
     case .swap, .idle:
       return Strings.Wallet.swapCryptoSwapButtonTitle
     }
@@ -342,7 +342,7 @@ struct SwapCryptoView: View {
     Section(
       header:
         Button(action: {
-          swapTokensStore.onSwapBtnClicked()
+          swapTokensStore.prepareSwap()
         }) {
           Text(swapButtonTitle)
         }

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -99,7 +99,13 @@ struct SlippageGrid: View {
             customSlippage = nil
             return
           }
-          customSlippage = min((max(intValue, 0)), 100)
+          if intValue >= 0, intValue <= 100, customSlippage != intValue {
+            customSlippage = intValue
+          } else {
+            let acceptedValue = min((max(intValue, 0)), 100)
+            customSlippage = acceptedValue
+            input = String(acceptedValue)
+          }
         }
         .keyboardType(.numberPad)
         .multilineTextAlignment(.center)
@@ -303,7 +309,7 @@ struct SwapCryptoView: View {
       header: MarketPriceView(swapTokenStore: swapTokensStore)
         .listRowBackground(Color.clear)
         .resetListHeaderStyle()
-        .padding(.trailing, 10)
+        .padding(.horizontal)
         .padding(.bottom, 15),
       footer: Group {
         if !hideSlippage {
@@ -312,12 +318,14 @@ struct SwapCryptoView: View {
             customSlippage: $swapTokensStore.overrideSlippage
           )
             .listRowInsets(.zero)
-            .transition(.opacity.animation(.default))
+            .transition(.opacity)
         }
       }
     ) {
       Button(action: {
-        hideSlippage.toggle()
+        withAnimation(.easeInOut(duration: 0.25)) {
+          hideSlippage.toggle()
+        }
       }) {
         HStack {
           Text(Strings.Wallet.swapCryptoSlippageTitle)

--- a/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
@@ -25,8 +25,10 @@ struct SwapTokenSearchView: View {
       Button(action: {
         if searchType == .fromToken {
           swapTokenStore.selectedFromToken = token
+          swapTokenStore.fetchPriceQuote(base: .perSellAsset)
         } else {
           swapTokenStore.selectedToToken = token
+          swapTokenStore.fetchPriceQuote(base: .perBuyAsset)
         }
         presentationMode.dismiss()
       }) {

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -154,9 +154,7 @@ public class SwapTokenStore: ObservableObject {
     }
     
     rpcController.balance(for: token, in: account) { balance in
-      if let value = balance {
-        completion(BDouble(value))
-      }
+      completion(BDouble(balance ?? 0))
     }
   }
   

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import BraveCore
+import BigNumber
 
 /// A store contains data for swap tokens
 public class SwapTokenStore: ObservableObject {
@@ -17,7 +18,6 @@ public class SwapTokenStore: ObservableObject {
         fetchTokenBalance(for: token) { [weak self] balance in
           self?.selectedFromTokenBalance = balance
         }
-        fetchTokenMarketPrice(for: token)
       }
     }
   }
@@ -32,33 +32,109 @@ public class SwapTokenStore: ObservableObject {
     }
   }
   /// The current selected token balance to swap from. Default with nil value.
-  @Published var selectedFromTokenBalance: Double?
+  @Published var selectedFromTokenBalance: BDouble?
   /// The current selected token balance to swap to. Default with nil value.
-  @Published var selectedToTokenBalance: Double?
-  /// The current market price for selected token to swap from. Default with nil value
-  @Published var selectedFromTokenPrice: Double?
+  @Published var selectedToTokenBalance: BDouble?
+  /// The current market price for selected token to swap from.
+  @Published var selectedFromTokenPrice = "0"
+  /// The state of swap screen
+  @Published var state: SwapState = .idle
+  /// The sell amount in this swap
+  @Published var sellAmount = "" {
+    didSet {
+      guard !sellAmount.isEmpty else {
+        state = .idle
+        return
+      }
+      if oldValue != sellAmount && !updatingPriceQuote {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false, block: { [weak self] _ in
+          self?.fetchPriceQuote(base: .perSellAsset)
+        })
+      }
+    }
+  }
+  /// The buy aount in this swap
+  @Published var buyAmount = "" {
+    didSet {
+      guard !buyAmount.isEmpty else {
+        state = .idle
+        return
+      }
+      if oldValue != buyAmount && !updatingPriceQuote {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false, block: { [weak self] _ in
+          self?.fetchPriceQuote(base: .perBuyAsset)
+        })
+      }
+    }
+  }
+  /// The slippage percentage in this swap
+  @Published var slippageOption = SlippageGrid.Option.halfPercent {
+    didSet {
+      slippage = slippageOption.value
+    }
+  }
+  @Published var overrideSlippage: Int? {
+    didSet {
+      if let overrideSlippage = overrideSlippage {
+        slippage = Double(overrideSlippage) / 100.0
+      }
+    }
+  }
   
   private let tokenRegistry: BraveWalletERCTokenRegistry
   private let rpcController: BraveWalletEthJsonRpcController
   private let assetRatioController: BraveWalletAssetRatioController
   private let swapController: BraveWalletSwapController
+  private let transactionController: BraveWalletEthTxController
   private var accountInfo: BraveWallet.AccountInfo?
+  private var slippage = 0.005 {
+    didSet {
+      timer?.invalidate()
+      timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false, block: { [weak self] _ in
+        self?.fetchPriceQuote(base: .perSellAsset)
+      })
+    }
+  }
+  private var updatingPriceQuote = false
+  private var timer: Timer?
+  
+  enum SwapParamsBase {
+    case perSellAsset
+    case perBuyAsset
+  }
+  
+  enum SwapState {
+    // when there is an error occurs. associated with an error message
+    case error(String)
+    // when need to activate bigger allowance. associated with a spender address
+    case activateAllowance(String)
+    // when able to swap
+    case swap
+    // has not passed validation
+    case idle
+  }
   
   public init(
     tokenRegistry: BraveWalletERCTokenRegistry,
     rpcController: BraveWalletEthJsonRpcController,
     assetRatioController: BraveWalletAssetRatioController,
-    swapController: BraveWalletSwapController
+    swapController: BraveWalletSwapController,
+    transactionController: BraveWalletEthTxController
   ) {
     self.tokenRegistry = tokenRegistry
     self.rpcController = rpcController
     self.assetRatioController = assetRatioController
     self.swapController = swapController
+    self.transactionController = transactionController
+    
+    self.rpcController.add(self)
   }
   
   private func fetchTokenBalance(
     for token: BraveWallet.ERCToken,
-    completion: @escaping (_ balance: Double?) -> Void
+    completion: @escaping (_ balance: BDouble?) -> Void
   ) {
     guard let account = accountInfo else {
       completion(nil)
@@ -66,14 +142,263 @@ public class SwapTokenStore: ObservableObject {
     }
     
     rpcController.balance(for: token, in: account) { balance in
-      completion(balance)
+      if let value = balance {
+        completion(BDouble(value))
+      }
     }
   }
   
-  private func fetchTokenMarketPrice(for token: BraveWallet.ERCToken) {
+  private func stringToBytes(_ string: String) -> [NSNumber] {
+    let clean = string.removingHexPrefix
+    
+    var result = [NSNumber](repeating: 0, count: string.count / 2)
+    for i in stride(from: 0, to: clean.count, by: 2) {
+        let start = clean.index(clean.startIndex, offsetBy: i)
+        let end = clean.index(clean.startIndex, offsetBy: i+2)
+        let range = start..<end
+        let mysubstring = clean[range]
+        if let value = UInt8(mysubstring, radix: 16) {
+            result[i/2] = NSNumber(value: value)
+        }
+    }
+    
+    return result
   }
   
-  func prepare(with accountInfo: BraveWallet.AccountInfo) {
+  func onSwapBtnClicked() {
+    switch state {
+    case .error(_), .idle:
+      // will never come here
+      break
+    case .activateAllowance(let spenderAddress):
+      activeErc20Allowance(spenderAddress)
+    case .swap:
+      swapCrypto()
+    }
+  }
+  
+  func swapCrypto() {
+    guard
+      let accountInfo = accountInfo,
+      let swapParams = generateSwapParams(.perSellAsset)
+    else { return }
+    swapController.transactionPayload(swapParams) { [weak self] success, swapResponse, error in
+      guard success, let self = self else {
+        self?.clearAllAmount()
+        return
+      }
+      guard let response = swapResponse else { return }
+      let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 16))
+      let gasPrice = "0x\(weiFormatter.weiString(from: response.gasPrice, radix: .hex, decimals: 16) ?? "0")"
+      let gasLimit = "0x\(weiFormatter.weiString(from: response.estimatedGas, radix: .decimal, decimals: 16) ?? "0")"
+      let value = "0x\(weiFormatter.weiString(from: response.value, radix: .decimal, decimals: 16) ?? "0")"
+      let txData: BraveWallet.TxData = .init(
+        nonce: "",
+        gasPrice: gasPrice,
+        gasLimit: gasLimit,
+        to: response.to,
+        value: value,
+        data: self.stringToBytes(response.data))
+      self.transactionController.addUnapprovedTransaction(txData, from: accountInfo.address) { success, txMetaId, error in
+        // should be observed
+      }
+    }
+  }
+  
+  func fetchPriceQuote(base: SwapParamsBase) {
+    guard let swapParams = generateSwapParams(base) else { return }
+    
+    updatingPriceQuote = true
+    swapController.priceQuote(swapParams) { [weak self] success, swapResponse, error in
+      guard success else {
+        self?.clearAllAmount()
+        self?.updatingPriceQuote = false
+        return
+      }
+      self?.updateSwapControls(swapResponse: swapResponse, base: base)
+      self?.updatingPriceQuote = false
+    }
+  }
+  
+  private func generateSwapParams(_ base: SwapParamsBase) -> BraveWallet.SwapParams? {
+    guard
+      let accountInfo = accountInfo,
+      let sellToken = selectedFromToken,
+      let buyToken = selectedToToken
+    else { return nil }
+    
+    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    let sellAddress = sellToken.isETH ? BraveWallet.ethSwapAddress : sellToken.contractAddress
+    let buyAddress = buyToken.isETH ? BraveWallet.ethSwapAddress : buyToken.contractAddress
+    let sellAmountInWei: String
+    let buyAmountInWei: String
+    switch base {
+    case .perSellAsset:
+      sellAmountInWei = weiFormatter.weiString(from: sellAmount, radix: .decimal, decimals: Int(sellToken.decimals)) ?? "0"
+      buyAmountInWei = ""
+      
+    case .perBuyAsset:
+      sellAmountInWei = ""
+      buyAmountInWei = weiFormatter.weiString(from: buyAmount, radix: .decimal, decimals: Int(buyToken.decimals)) ?? "0"
+    }
+    let swapParams = BraveWallet.SwapParams(
+      takerAddress: accountInfo.address,
+      sellAmount: sellAmountInWei,
+      buyAmount: buyAmountInWei,
+      buyToken: buyAddress,
+      sellToken: sellAddress,
+      slippagePercentage: slippage,
+      gasPrice: ""
+    )
+    
+    return swapParams
+  }
+  
+  private func clearAllAmount() {
+    sellAmount = "0"
+    buyAmount = "0"
+    selectedFromTokenPrice = "0"
+  }
+  
+  private func updateSwapControls(swapResponse: BraveWallet.SwapResponse?, base: SwapParamsBase) {
+    guard let respnose = swapResponse else { return }
+    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    switch base {
+    case .perSellAsset:
+      var decimal = 18
+      if let fromToken = selectedFromToken {
+        decimal = Int(fromToken.decimals)
+      }
+      let decimalString = weiFormatter.decimalString(for: respnose.buyAmount, decimals: decimal) ?? ""
+      if let bv = BDouble(decimalString) {
+        buyAmount = bv.decimalDescription
+      }
+    case .perBuyAsset:
+      var decimal = 18
+      if let toToken = selectedToToken {
+        decimal = Int(toToken.decimals)
+      }
+      let decimalString = weiFormatter.decimalString(for: respnose.sellAmount, decimals: decimal) ?? ""
+      if let bv = BDouble(decimalString) {
+        sellAmount = bv.decimalDescription
+      }
+    }
+    
+    if let bv = BDouble(respnose.price) {
+      let price = base == .perSellAsset ? bv : 1 / bv
+      selectedFromTokenPrice = price.decimalDescription
+    }
+    
+    checkBalanceShowError(swapResponse: respnose)
+  }
+  
+  private func activeErc20Allowance(_ spenderAddress: String) {
+    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    guard
+      let fromToken = selectedFromToken,
+      let accountInfo = accountInfo,
+      let balanceInWeiHex = weiFormatter.weiString(
+        from: selectedFromTokenBalance?.decimalDescription ?? "",
+        radix: .hex,
+        decimals: Int(fromToken.decimals)
+      )
+    else { return }
+    transactionController.makeErc20ApproveData(
+      spenderAddress,
+      amount: balanceInWeiHex
+    ) { [weak self] success, data in
+        guard success else { return }
+        let txData = BraveWallet.TxData(
+          nonce: "",
+          gasPrice: "",
+          gasLimit: "",
+          to: fromToken.contractAddress,
+          value: "0x0",
+          data: data
+        )
+      self?.transactionController.addUnapprovedTransaction(
+          txData,
+          from: accountInfo.address,
+          completion: { success, txMetaId, error in
+            // should be observed
+          }
+      )
+    }
+  }
+  
+  private func gweiStringToDecimal(_ value: String) -> BDouble? {
+    guard !value.isEmpty, let bv = BDouble(value) else {
+      return nil
+    }
+    return bv / (BDouble(10) ** 9)
+  }
+  
+  private func checkBalanceShowError(swapResponse: BraveWallet.SwapResponse) {
+    guard
+      let accountInfo = accountInfo,
+      let sellAmountValue = BDouble(sellAmount),
+      let gasLimit = gweiStringToDecimal(swapResponse.estimatedGas),
+      let gasPrice = gweiStringToDecimal(swapResponse.gasPrice),
+      let fromToken = selectedFromToken
+    else { return }
+    
+    // Check if balance is insufficient
+    if sellAmountValue > (selectedFromTokenBalance ?? 0) {
+      state = .error("Insufficient balance")
+    }
+    
+    // Get ETH balance for this account because gas can only be paid in ETH
+    rpcController.balance(accountInfo.address) { [weak self] success, balance in
+      guard let self = self else { return }
+      if success {
+        let fee = gasLimit * gasPrice
+        let balanceFormatter = WeiFormatter(decimalFormatStyle: .balance)
+        let currentBalance = BDouble(balanceFormatter.decimalString(for: balance.removingHexPrefix, radix: .hex, decimals: 18) ?? "") ?? 0
+        if fromToken.isETH {
+          if currentBalance < fee + sellAmountValue {
+            self.state = .error("Insufficient funds for gas")
+            return
+          }
+        } else {
+          if currentBalance < fee {
+            self.state = .error("Insufficient funds for gas")
+            return
+          }
+        }
+      }
+      
+      self.state = .swap
+      // check for ERC20 token allowance
+      if fromToken.isErc20 {
+        self.checkAllowance(
+          contractAddress: accountInfo.address,
+          spenderAddress: swapResponse.allowanceTarget,
+          amountToSend: sellAmountValue,
+          fromToken: fromToken
+        )
+      }
+    }
+  }
+  
+  private func checkAllowance(
+    contractAddress: String,
+    spenderAddress: String,
+    amountToSend: BDouble,
+    fromToken: BraveWallet.ERCToken
+  ) {
+    rpcController.erc20TokenAllowance(
+      contractAddress,
+      ownerAddress: contractAddress,
+      spenderAddress: spenderAddress
+    ) { [weak self] success, allowance in
+      let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+      let allowanceValue = BDouble(weiFormatter.decimalString(for: allowance.removingHexPrefix, radix: .hex, decimals: Int(fromToken.decimals)) ?? "") ?? 0
+      guard success, amountToSend > allowanceValue else { return } // no need to bump allowance
+      self?.state = .activateAllowance(spenderAddress)
+    }
+  }
+  
+  func prepare(with accountInfo: BraveWallet.AccountInfo, completion: (() -> Void)? = nil) {
     self.accountInfo = accountInfo
     
     tokenRegistry.allTokens { [self] tokens in
@@ -82,16 +407,20 @@ public class SwapTokenStore: ObservableObject {
       
       if let fromToken = selectedFromToken { // refresh balance
         rpcController.balance(for: fromToken, in: accountInfo) { balance in
-          selectedFromTokenBalance = balance
+          if let value = balance {
+            selectedFromTokenBalance = BDouble(value)
+          }
         }
       } else {
-        selectedFromToken = allTokens.first(where: { $0.symbol == "ETH" })
+        selectedFromToken = allTokens.first(where: { $0.isETH })
       }
       
       rpcController.chainId { [self] chainId in
         if let toToken = selectedToToken {
           rpcController.balance(for: toToken, in: accountInfo) { balance in
-            selectedToTokenBalance = balance
+            if let value = balance {
+              selectedToTokenBalance = BDouble(value)
+            }
           }
         } else {
           if chainId == BraveWallet.MainnetChainId {
@@ -102,5 +431,25 @@ public class SwapTokenStore: ObservableObject {
         }
       }
     }
+  }
+}
+
+extension SwapTokenStore: BraveWalletEthJsonRpcControllerObserver {
+  public func chainChangedEvent(_ chainId: String) {
+    guard
+      let accountInfo = accountInfo,
+      chainId == BraveWallet.MainnetChainId || chainId == BraveWallet.RopstenChainId
+    else { return }
+    selectedFromToken = nil
+    selectedToToken = nil
+    prepare(with: accountInfo) { [weak self] in
+      self?.fetchPriceQuote(base: .perSellAsset)
+    }
+  }
+  
+  public func onAddEthereumChainRequestCompleted(_ chainId: String, error: String) {
+  }
+  
+  public func onIsEip1559Changed(_ chainId: String, isEip1559: Bool) {
   }
 }

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -246,7 +246,6 @@ public class SwapTokenStore: ObservableObject {
     case .perSellAsset:
       sellAmountInWei = weiFormatter.weiString(from: sellAmount, radix: .decimal, decimals: Int(sellToken.decimals)) ?? "0"
       buyAmountInWei = ""
-      
     case .perBuyAsset:
       sellAmountInWei = ""
       buyAmountInWei = weiFormatter.weiString(from: buyAmount, radix: .decimal, decimals: Int(buyToken.decimals)) ?? "0"
@@ -295,6 +294,9 @@ public class SwapTokenStore: ObservableObject {
     }
     
     if let bv = BDouble(respnose.price) {
+      // will need to invert price if price quote is based on buyAmount
+      // ref from slack:
+      // https://bravesoftware.slack.com/archives/C023VS4HJ6Q/p1636579425364500?thread_ts=1636570735.354500&cid=C023VS4HJ6Q
       let price = base == .perSellAsset ? bv : 1 / bv
       selectedFromTokenPrice = price.decimalDescription
     }

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -66,7 +66,8 @@ public class WalletStore {
       tokenRegistry: tokenRegistry,
       rpcController: rpcController,
       assetRatioController: assetRatioController,
-      swapController: swapController
+      swapController: swapController,
+      transactionController: transactionController
     )
   }
   

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -63,6 +63,7 @@ public class WalletStore {
       transactionController: transactionController
     )
     self.swapTokenStore = .init(
+      keyringController: keyringController,
       tokenRegistry: tokenRegistry,
       rpcController: rpcController,
       assetRatioController: assetRatioController,

--- a/BraveWallet/Extensions/WalletArrayExtension.swift
+++ b/BraveWallet/Extensions/WalletArrayExtension.swift
@@ -1,0 +1,23 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+extension Array where Element == NSNumber {
+  init?(hexString: String) {
+    var value = hexString.removingHexPrefix
+    if value.count % 2 != 0 {
+      value.insert("0", at: value.startIndex)
+    }
+    if !value.allSatisfy(\.isHexDigit) {
+      return nil
+    }
+    self.init(
+      value.chunks(ofCount: 2)
+        .compactMap { UInt8($0, radix: 16) }
+        .map(NSNumber.init(value:))
+    )
+  }
+}

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -75,6 +75,7 @@ extension AssetDetailStore {
 extension SwapTokenStore {
   static var previewStore: SwapTokenStore {
     .init(
+      keyringController: TestKeyringController(),
       tokenRegistry: TestTokenRegistry(),
       rpcController: TestEthJsonRpcController(),
       assetRatioController: TestAssetRatioController(),

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -78,7 +78,8 @@ extension SwapTokenStore {
       tokenRegistry: TestTokenRegistry(),
       rpcController: TestEthJsonRpcController(),
       assetRatioController: TestAssetRatioController(),
-      swapController: TestSwapController()
+      swapController: TestSwapController(),
+      transactionController: TestEthTxController()
     )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1163,19 +1163,26 @@ extension Strings {
       value: "Max Priority Fee",
       comment: "The title of the edit gas fee screen"
     )
-    public static let InsufficientBalance = NSLocalizedString(
+    public static let insufficientBalance = NSLocalizedString(
       "wallet.InsufficientBalance",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Insufficient balance",
       comment: "An error message when there is no insufficient balance for swapping. It will be displayed as the title of the disabled swap button at the bottom in the Swap Screen."
     )
-    public static let InsufficientFundsForGas = NSLocalizedString(
+    public static let insufficientFundsForGas = NSLocalizedString(
       "wallet.InsufficientFundsForGas",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Insufficient funds for gas",
       comment: "An error message when there is no insufficient funds for gas fee. It will be displayed as the title of the disabled swap button at the bottom in the Swap Screen."
+    )
+    public static let activateToken = NSLocalizedString(
+      "wallet.InsufficientFundsForGas",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Activate Token %@",
+      comment: "The title of the button at the bottom of Swap Screen, when the sell token is erc20 and it has not been activated its allowance. %@ will be replaced with the sell token's symbol such as 'DAI' or 'USDC'"
     )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1163,5 +1163,19 @@ extension Strings {
       value: "Max Priority Fee",
       comment: "The title of the edit gas fee screen"
     )
+    public static let InsufficientBalance = NSLocalizedString(
+      "wallet.InsufficientBalance",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Insufficient balance",
+      comment: "An error message when there is no insufficient balance for swapping. It will be displayed as the title of the disabled swap button at the bottom in the Swap Screen."
+    )
+    public static let InsufficientFundsForGas = NSLocalizedString(
+      "wallet.InsufficientFundsForGas",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Insufficient funds for gas",
+      comment: "An error message when there is no insufficient funds for gas fee. It will be displayed as the title of the disabled swap button at the bottom in the Swap Screen."
+    )
   }
 }

--- a/BraveWalletTests/WalletArrayExtensionTests.swift
+++ b/BraveWalletTests/WalletArrayExtensionTests.swift
@@ -1,0 +1,47 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import BraveWallet
+
+class WalletArrayExtensionTests: XCTestCase {
+    func testOddLengthInput() {
+        let inputHexData = "0xff573"
+        let bytes = [NSNumber](hexString: inputHexData)
+        let result: [NSNumber] = .init([15, 245, 115])
+        XCTAssertNotNil(bytes)
+        XCTAssertEqual(bytes, result)
+    }
+    
+    func testEvenLengthInput() {
+        let inputHexData = "0xff5733"
+        let bytes = [NSNumber](hexString: inputHexData)
+        let result: [NSNumber] = .init([255, 87, 51])
+        XCTAssertNotNil(bytes)
+        XCTAssertEqual(bytes, result)
+    }
+    
+    func testNoHexPrefixInput() {
+        let inputHexData = "ff5733"
+        let bytes = [NSNumber](hexString: inputHexData)
+        let result: [NSNumber] = .init([255, 87, 51])
+        XCTAssertNotNil(bytes)
+        XCTAssertEqual(bytes, result)
+    }
+    
+    func testInvalidHexInput() {
+        let inputHexData = "0x0csadgasg"
+        let bytes = [NSNumber](hexString: inputHexData)
+        XCTAssertNil(bytes)
+    }
+    
+    func testEmptyHexInput() {
+        let inputHexData = "0x"
+        let bytes = [NSNumber](hexString: inputHexData)
+        let result: [NSNumber] = .init()
+        XCTAssertNotNil(bytes)
+        XCTAssertEqual(bytes, result)
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -946,6 +946,8 @@
 		7D758919271A184D00B643C3 /* BuyTokenSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D758918271A184D00B643C3 /* BuyTokenSearchView.swift */; };
 		7D758921271F07B800B643C3 /* SendTokenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D758920271F07B800B643C3 /* SendTokenView.swift */; };
 		7DAC597B2726524E00E735A2 /* AddressQRCodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAC597A2726524E00E735A2 /* AddressQRCodeScannerView.swift */; };
+		7DC52B12273D99E70067E237 /* WalletArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */; };
+		7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */; };
 		A104E199210A384400D2323E /* ShieldsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A104E198210A384400D2323E /* ShieldsViewController.swift */; };
 		A134B88A20DA98BB00A581D0 /* ClientPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A134B88920DA98BB00A581D0 /* ClientPreferences.swift */; };
 		A13AC72520EC12360040D4BB /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13AC72420EC12360040D4BB /* Migration.swift */; };
@@ -2875,6 +2877,8 @@
 		7D758918271A184D00B643C3 /* BuyTokenSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyTokenSearchView.swift; sourceTree = "<group>"; };
 		7D758920271F07B800B643C3 /* SendTokenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendTokenView.swift; sourceTree = "<group>"; };
 		7DAC597A2726524E00E735A2 /* AddressQRCodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressQRCodeScannerView.swift; sourceTree = "<group>"; };
+		7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtension.swift; sourceTree = "<group>"; };
+		7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtensionTests.swift; sourceTree = "<group>"; };
 		A104E198210A384400D2323E /* ShieldsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsViewController.swift; sourceTree = "<group>"; };
 		A134B88920DA98BB00A581D0 /* ClientPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPreferences.swift; sourceTree = "<group>"; };
 		A13AC72420EC12360040D4BB /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
@@ -3756,6 +3760,7 @@
 				277309DD2721DDFB007643F6 /* WeiFormatter.swift */,
 				275C6FB32731D1A500AB2FC7 /* RpcControllerExtensions.swift */,
 				277430092733126000183725 /* WalletColors.swift */,
+				7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4121,6 +4126,7 @@
 				277309E72721DF6D007643F6 /* WeiFormatterTests.swift */,
 				27EA1B0D2729E6C8003C5CF9 /* AddressTests.swift */,
 				27180179272B053F0047EB15 /* PasswordValidationTests.swift */,
+				7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */,
 			);
 			path = BraveWalletTests;
 			sourceTree = "<group>";
@@ -7818,6 +7824,7 @@
 				27DDE88626FD2BC400A70C3A /* PortfolioStore.swift in Sources */,
 				271F68B126EBD27E00AA2A50 /* EnableBiometricsView.swift in Sources */,
 				271F68BF26EBD27E00AA2A50 /* DateRangeView.swift in Sources */,
+				7DC52B12273D99E70067E237 /* WalletArrayExtension.swift in Sources */,
 				7DAC597B2726524E00E735A2 /* AddressQRCodeScannerView.swift in Sources */,
 				271F68B226EBD27E00AA2A50 /* RestoreWalletView.swift in Sources */,
 				2774300A2733126000183725 /* WalletColors.swift in Sources */,
@@ -7884,6 +7891,7 @@
 			files = (
 				2718017A272B05400047EB15 /* PasswordValidationTests.swift in Sources */,
 				27EA1B0E2729E6C8003C5CF9 /* AddressTests.swift in Sources */,
+				7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */,
 				277309E82721DF6D007643F6 /* WeiFormatterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Summary of Changes
Integrated price quote in swap screen based on different user inputs that includes any changes among sell token selection, buy token selection, sell amount, buy amount, slippage percentage, account selection and network selection.
Some necessary checks are also implemented such as checking insufficient balance, insufficient funds for gas and allowance is not activated for erc20 sell tokens.  
Refresh button will trigger a refresh to get the correct market value and buy amount.

This pull request fixes #4271 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
