### PR TITLE
Fix #4490: Fixes app crash popup showing unnecessarily.

### DIFF
--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -344,7 +344,6 @@ extension SceneDelegate {
         // Don't track crashes if we're building the development environment due to the fact that terminating/stopping
         // the simulator via Xcode will count as a "crash" and lead to restore popups in the subsequent launch
         let crashedLastSession = !Preferences.AppState.backgroundedCleanly.value && AppConstants.buildChannel != .debug
-        Preferences.AppState.backgroundedCleanly.value = false
         
         // Create a browser instance
         let browserViewController = BrowserViewController(


### PR DESCRIPTION
## Summary of Changes
- Do not set the flag when the browser is created. This is because the scene isn't active yet. The flag should only be set when the scene is active, resigns, and terminates. Creating a browser instance called from `willConnect` doesn't change the active state, and modifying the flag during the transition to active, can cause the crash popup to show incorrectly.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4490

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
