### PR TITLE
Fix CryptoPagesView sheet presentation on iOS 14.0-14.4

### DIFF
--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -48,12 +48,18 @@ struct CryptoPagesView: View {
         }
         .hidden()
       )
-      .sheet(isPresented: $isShowingSearch) {
-        AssetSearchView(walletStore: walletStore)
-      }
-      .sheet(isPresented: $isShowingTransactions) {
-        TransactionConfirmationView(transactions: [], networkStore: walletStore.networkStore)
-      }
+      .background(
+        Color.clear
+          .sheet(isPresented: $isShowingSearch) {
+            AssetSearchView(walletStore: walletStore)
+          }
+      )
+      .background(
+        Color.clear
+          .sheet(isPresented: $isShowingTransactions) {
+            TransactionConfirmationView(transactions: [], networkStore: walletStore.networkStore)
+          }
+      )
       .toolbar {
         ToolbarItemGroup(placement: .navigationBarTrailing) {
           Button(action: {


### PR DESCRIPTION
iOS 14.0 to 14.4 do not support stacking `sheet` modifiers on the same level.

## Summary of Changes

Refs #4461 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
