### PR TITLE
Fix #4521, #4525: Register SafeBrowsing page as an error url & Fix Licenses pages

### DIFF
--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -87,7 +87,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
         // Ugly hack to ensure we wait until we're finished restoring the session on the first tab
         // before checking if we should display the clipboard bar.
         guard sessionRestored,
-            !url.absoluteString.hasPrefix("\(WebServer.sharedInstance.base)/about/sessionrestore?history=") else {
+            !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?history=") else {
             return
         }
 

--- a/Client/Frontend/Browser/LinkPreviewViewController.swift
+++ b/Client/Frontend/Browser/LinkPreviewViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 import WebKit
 import Data
+import Shared
 
 class LinkPreviewViewController: UIViewController {
     
@@ -19,7 +20,11 @@ class LinkPreviewViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) { fatalError() }
     
     override func viewDidLoad() {
-        let wk = WKWebView(frame: view.frame)
+        let configuration = WKWebViewConfiguration().then {
+            $0.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
+        }
+        
+        let wk = WKWebView(frame: view.frame, configuration: configuration)
         
         let domain = Domain.getOrCreate(forUrl: url, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
         

--- a/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -65,7 +65,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
         } else {
             self.timer = nil
         }
-        self.webView.load(URLRequest(url: url))
+        self.webView.load(PrivilegedRequest(url: url) as URLRequest)
         self.interstitialSpinnerView.startAnimating()
     }
 
@@ -107,7 +107,10 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
 
     func makeWebView() -> BraveWebView {
         let frame = CGRect(width: 1, height: 1)
-        let webView = BraveWebView(frame: frame)
+        let configuration = WKWebViewConfiguration().then {
+            $0.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
+        }
+        let webView = BraveWebView(frame: frame, configuration: configuration)
         webView.allowsLinkPreview = false
         webView.navigationDelegate = self
         return webView

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -503,10 +503,8 @@ class SettingsViewController: TableViewController {
                     },
                     accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: Strings.settingsLicenses, selection: { [unowned self] in
-                    guard let url = URL(string: WebServer.sharedInstance.base) else { return }
-                    
                     let licenses = SettingsContentViewController().then {
-                        $0.url = url.appendingPathComponent("about").appendingPathComponent("license")
+                        $0.url = URL(string: "\(InternalURL.baseUrl)/\(AboutLicenseHandler.path)")
                     }
                     self.navigationController?.pushViewController(licenses, animated: true)
                     }, accessory: .disclosureIndicator)

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -7,8 +7,6 @@ import Shared
 import BraveShared
 
 public struct UIConstants {
-    static let aboutHomePage = URL(string: "\(WebServer.sharedInstance.base)/about/home/")!
-
     static let defaultPadding: CGFloat = 10
     static let snackbarButtonHeight: CGFloat = 48
     static let topToolbarHeight: CGFloat = 44

--- a/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
+++ b/Client/WebFilters/SafeBrowsing/SafeBrowsing.swift
@@ -37,7 +37,7 @@ class SafeBrowsing {
     }
     
     func showMalwareWarningPage(forUrl url: URL, inWebView webView: WKWebView) {
-        var components = URLComponents(string: WebServer.sharedInstance.base + "/errors/SafeBrowsingError.html")!
+        var components = URLComponents(string: WebServer.sharedInstance.base + "/\(InternalURL.Path.errorpage)/SafeBrowsingError.html")!
         
         // This parameter help us to know what url caused the malware protection to show so we can
         // update url with it(instead of showing localhost error page url).

--- a/Client/WebFilters/SafeBrowsing/SafeBrowsingHandler.swift
+++ b/Client/WebFilters/SafeBrowsing/SafeBrowsingHandler.swift
@@ -4,9 +4,10 @@
 
 import Foundation
 import GCDWebServers
+import Shared
 
 struct SafeBrowsingHandler {
     static func register(_ webServer: WebServer) {
-        webServer.registerMainBundleResource("SafeBrowsingError.html", module: "errors")
+        webServer.registerMainBundleResource("SafeBrowsingError.html", module: "\(InternalURL.Path.errorpage)")
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Register safe browsing page as an InternalURL.
- Register license page as an InternalURL.
- Remove unused constants and changed some to use InternalURL (no difference to the code as the results are the same).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes ##4521, #4525

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
