### PR TITLE
Fix #4528: Revert changes to deleteAll logic.

### DIFF
--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -33,7 +33,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // We have to wait until pre1.12 migration is done until we proceed with database
         // initialization. This is because Database container may change. See bugs #3416, #3377.
         DataController.shared.initializeOnce()
-        Migration.postCoreDataInitMigrations()
         
         Preferences.General.themeNormalMode.objectWillChange
             .merge(with: PrivateBrowsingManager.shared.objectWillChange)

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -36,6 +36,11 @@ class Migration {
         if !Preferences.Migration.playlistV1FileSettingsLocationCompleted.value {
             movePlaylistV1Items()
         }
+        
+        if !Preferences.Migration.removeLargeFaviconsMigrationCompleted.value {
+            FaviconMO.clearTooLargeFavicons()
+            Preferences.Migration.removeLargeFaviconsMigrationCompleted.value = true
+        }
 
         // Adding Observer to enable sync types
         
@@ -138,28 +143,6 @@ class Migration {
             log.error("Moving Playlist Files for \(errorPath) failed: \(error)")
         }
     }
-    
-    static func postCoreDataInitMigrations() {
-        if !Preferences.Migration.removeLargeFaviconsMigrationCompleted.value {
-            FaviconMO.clearTooLargeFavicons()
-            Preferences.Migration.removeLargeFaviconsMigrationCompleted.value = true
-        }
-        
-        if Preferences.Migration.coreDataCompleted.value { return }
-        
-        // In 1.6.6 we included private tabs in CoreData (temporarely) until the user did one of the following:
-        //  - Cleared private data
-        //  - Exited Private Mode
-        //  - The app was terminated (bug)
-        // However due to a bug, some private tabs remain in the container. Since 1.7 removes `isPrivate` from TabMO,
-        // we must dismiss any records that are private tabs during migration from Model7
-        TabMO.deleteAllPrivateTabs()
-        
-        Domain.migrateShieldOverrides()
-        LegacyBookmarksHelper.migrateBookmarkOrders()
-        
-        Preferences.Migration.coreDataCompleted.value = true
-    }
 }
 
 fileprivate extension Preferences {
@@ -175,8 +158,6 @@ fileprivate extension Preferences {
             Option<Bool>(key: "migration.playlistv1-file-settings-location-completed", default: false)
         static let removeLargeFaviconsMigrationCompleted =
             Option<Bool>(key: "migration.remove-large-favicons", default: false)
-        
-        static let coreDataCompleted = Option<Bool>(key: "migration.cd-completed", default: false)
     }
     
     /// Migrate the users preferences from prior versions of the app (<2.0)
@@ -251,6 +232,19 @@ fileprivate extension Preferences {
         // On 1.6 lastLaunchInfo is used to check if it's first app launch or not.
         // This needs to be translated to our new preference.
         Preferences.General.isFirstLaunch.value = Preferences.DAU.lastLaunchInfo.value == nil
+        
+        // Core Data
+        
+        // In 1.6.6 we included private tabs in CoreData (temporarely) until the user did one of the following:
+        //  - Cleared private data
+        //  - Exited Private Mode
+        //  - The app was terminated (bug)
+        // However due to a bug, some private tabs remain in the container. Since 1.7 removes `isPrivate` from TabMO,
+        // we must dismiss any records that are private tabs during migration from Model7
+        TabMO.deleteAllPrivateTabs()
+        
+        Domain.migrateShieldOverrides()
+        LegacyBookmarksHelper.migrateBookmarkOrders()
         
         Preferences.Migration.completed.value = true
     }

--- a/Data/models/CRUDProtocols.swift
+++ b/Data/models/CRUDProtocols.swift
@@ -25,7 +25,7 @@ protocol Readable where Self: NSManagedObject {
 }
 
 // MARK: - Implementations
-extension Deletable {
+extension Deletable where Self: NSManagedObject {
     func delete(context: WriteContext = .new(inMemory: false)) {
         
         DataController.perform(context: context) { context in
@@ -63,10 +63,8 @@ extension Deletable {
 
                     // Batch delete writes directly to the persistent store.
                     // Therefore contexts and in-memory objects must be updated manually.
-                    
-                    guard let objectIDArray = try context.persistentStoreCoordinator?
-                        .execute(deleteRequest, with: context) as? [NSManagedObjectID] else { return }
-                    
+                    let result = try context.execute(deleteRequest) as? NSBatchDeleteResult
+                    guard let objectIDArray = result?.result as? [NSManagedObjectID] else { return }
                     let changes = [NSDeletedObjectsKey: objectIDArray]
 
                     // Merging changes to view context is important because fetch results controllers
@@ -82,7 +80,7 @@ extension Deletable {
     }
 }
 
-extension Readable {
+extension Readable where Self: NSManagedObject { 
     static func count(predicate: NSPredicate? = nil,
                       context: NSManagedObjectContext = DataController.viewContext) -> Int? {
         let request = getFetchRequest()

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -201,10 +201,6 @@ public class DataController {
     
     static func perform(context: WriteContext = .new(inMemory: false), save: Bool = true,
                         task: @escaping (NSManagedObjectContext) -> Void) {
-        if !DataController.shared.initializationCompleted && !AppConstants.isRunningTest {
-            assertionFailure("Performing on context before database initialized")
-            return
-        }
         
         switch context {
         case .existing(let existingContext):


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4528 
Refs https://github.com/brave/brave-ios/pull/4479

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
