### PR TITLE
Fix #4528: Launch core data migration only when no migration was done.

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -175,8 +175,12 @@ fileprivate extension Preferences {
             Option<Bool>(key: "migration.playlistv1-file-settings-location-completed", default: false)
         static let removeLargeFaviconsMigrationCompleted =
             Option<Bool>(key: "migration.remove-large-favicons", default: false)
-        
-        static let coreDataCompleted = Option<Bool>(key: "migration.cd-completed", default: false)
+        // This is new preference introduced in iOS 1.32.3, tracks whether we should perform database migration.
+        // It should be called only for users who have not completed the migration beforehand.
+        // The reason for second migration flag is to first do file system migrations like moving database files,
+        // then do CRUD operations on the db if needed.
+        static let coreDataCompleted = Option<Bool>(key: "migration.cd-completed",
+                                                    default: Preferences.Migration.completed.value)
     }
     
     /// Migrate the users preferences from prior versions of the app (<2.0)

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -261,6 +261,9 @@ public class DataController {
     
     var storeURL: URL {
         let supportDirectory = Preferences.Database.DocumentToSupportDirectoryMigration.completed.value
+        if !supportDirectory {
+            assertionFailure("App wants to use very old document store, this can't be right.")
+        }
         return supportDirectory ? supportStoreURL : oldDocumentStoreURL
     }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4528 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
