### PR TITLE
Fix #4487: Fetch portfolio details if wallet is already unlocked

### DIFF
--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -73,6 +73,12 @@ public class PortfolioStore: ObservableObject {
     
     self.rpcController.add(self)
     self.keyringController.add(self)
+    
+    keyringController.isLocked { [self] isLocked in
+      if !isLocked {
+        update()
+      }
+    }
   }
   
   private let numberFormatter = NumberFormatter().then {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4487

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
