### PR TITLE
Fix colour for unapproved transactions and update localization comment

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -170,6 +170,7 @@ struct SendTokenView: View {
   }
 }
 
+#if DEBUG
 struct SendTokenView_Previews: PreviewProvider {
     static var previews: some View {
       SendTokenView(
@@ -180,3 +181,4 @@ struct SendTokenView_Previews: PreviewProvider {
         .previewColorSchemes()
     }
 }
+#endif

--- a/BraveWallet/Crypto/Transactions/TransactionView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionView.swift
@@ -105,6 +105,14 @@ struct TransactionView: View {
     Text("\(namedAddress(for: info.fromAddress)) \(Image(systemName: "arrow.right")) \(namedAddress(for: info.txData.baseData.to))")
   }
   
+  private var metadata: Text {
+    let date = Text(info.createdTime, formatter: timeFormatter)
+    if displayAccountCreator {
+      return date + Text(" · \(namedAddress(for: info.fromAddress))")
+    }
+    return date
+  }
+  
   var body: some View {
     HStack(spacing: 12) {
       BlockieGroup(
@@ -131,15 +139,8 @@ struct TransactionView: View {
         subtitle
           .foregroundColor(Color(.braveLabel))
         HStack {
-          HStack(spacing: 4) {
-            Text(info.createdTime, formatter: timeFormatter)
-            if displayAccountCreator {
-              Text("·")
-                .accessibilityHidden(true)
-              Text(namedAddress(for: info.fromAddress))
-            }
-          }
-          .foregroundColor(Color(.secondaryBraveLabel))
+          metadata
+            .foregroundColor(Color(.secondaryBraveLabel))
           Spacer()
           HStack(spacing: 4) {
             Image(systemName: "circle.fill")
@@ -184,16 +185,19 @@ extension BraveWallet.TransactionStatus {
     switch self {
     case .confirmed, .approved:
       return Color(.braveSuccessLabel)
-    case .rejected, .unapproved, .error:
+    case .rejected, .error:
       return Color(.braveErrorLabel)
     case .submitted:
       return Color(.braveWarningLabel)
+    case .unapproved:
+      return Color(.secondaryButtonTint)
     @unknown default:
       return Color.clear
     }
   }
 }
 
+#if DEBUG
 struct Transaction_Previews: PreviewProvider {
   static var previews: some View {
     Group {
@@ -226,3 +230,4 @@ struct Transaction_Previews: PreviewProvider {
     .previewLayout(.sizeThatFits)
   }
 }
+#endif

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1273,7 +1273,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Unapproved",
-      comment: "A status that explains that previous approval of the transaction has been revoked"
+      comment: "A status that explains that a transaction has not yet been approved"
     )
     public static let transactionStatusSubmitted = NSLocalizedString(
       "wallet.transactionStatusSubmitted",


### PR DESCRIPTION
Realized I had the wrong understanding of unapproved and matched colour with desktop

## Summary of Changes

Follow up to #4514 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
