### PR TITLE
Fix #4539: Rewards controller showing publisher on Internal URLs.

### DIFF
--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
@@ -89,7 +89,7 @@ class BraveRewardsViewController: UIViewController, PopoverContentComponent {
             self.rewardsView.statusView.setVisibleStatus(status: .rewardsOff, animated: false)
             self.rewardsView.publisherView.isHidden = true
         } else {
-            if let url = self.tab.url, !url.isLocal {
+            if let url = self.tab.url, !url.isLocal, !InternalURL.isValid(url: url) {
                 self.rewardsView.publisherView.isHidden = false
                 self.rewardsView.publisherView.hostLabel.text = url.baseDomain
                 ledger.fetchPublisherActivity(from: url, faviconURL: nil, publisherBlob: nil, tabId: UInt64(self.tab.rewardsId))


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Check against InternalURL so the panel doesn't show. NTP is no longer just `Local`, it is also `Internal`.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4539

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
In the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
