### PR TITLE
Fix #4542, #4544: Dismiss popovers when tapping the pulse-highlight.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2825,8 +2825,9 @@ extension BrowserViewController: NewTabPageDelegate {
     
     func showNTPOnboarding() {
         if Preferences.General.isNewRetentionUser.value == true,
-            !topToolbar.inOverlayMode,
-            !Preferences.FullScreenCallout.ntpCalloutCompleted.value {
+           !topToolbar.inOverlayMode,
+           topToolbar.currentURL == nil,
+           !Preferences.FullScreenCallout.ntpCalloutCompleted.value {
             presentNTPStatsOnboarding()
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -57,7 +57,7 @@ extension BrowserViewController {
         }
         
         // Project the statsFrame to the current frame
-        let frame = view.convert(statsFrame, from: ntpController.view).insetBy(dx: 15.0, dy: 15.0).offsetBy(dx: 15.0, dy: 5.0)
+        let frame = view.convert(statsFrame, from: ntpController.view).insetBy(dx: 15.0, dy: 15.0)
         
         // Create a border view
         let borderView = UIView().then {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -157,6 +157,11 @@ extension BrowserViewController {
                                on: popover,
                                browser: self)
         
+        pulseAnimation.onTouchInside = { [weak self] in
+            self?.dismiss(animated: true)
+            pulseAnimation.removeFromSuperview()
+        }
+        
         popover.popoverDidDismiss = { _ in
             pulseAnimation.removeFromSuperview()
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -156,12 +156,6 @@ extension BrowserViewController {
                                from: topToolbar.locationView.shieldsButton,
                                on: popover,
                                browser: self)
-        
-        pulseAnimation.onTouchInside = { [weak self] in
-            self?.dismiss(animated: true)
-            pulseAnimation.removeFromSuperview()
-        }
-        
         popover.popoverDidDismiss = { _ in
             pulseAnimation.removeFromSuperview()
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -23,7 +23,8 @@ extension BrowserViewController {
         
         // 1. User is brand new
         // 2. User hasn't completed onboarding
-        if Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue {
+        if Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue,
+           Preferences.General.isNewRetentionUser.value == true {
             let onboardingController = WelcomeViewController(profile: profile,
                                                              rewards: rewards)
             onboardingController.modalPresentationStyle = .fullScreen

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
@@ -232,12 +232,6 @@ extension BrowserViewController {
                                from: topToolbar.locationView.shieldsButton,
                                on: popover,
                                browser: self)
-        
-        pulseAnimation.onTouchInside = { [weak self] in
-            self?.dismiss(animated: true)
-            pulseAnimation.removeFromSuperview()
-        }
-        
         popover.popoverDidDismiss = { _ in
             pulseAnimation.removeFromSuperview()
         }

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
@@ -233,6 +233,11 @@ extension BrowserViewController {
                                on: popover,
                                browser: self)
         
+        pulseAnimation.onTouchInside = { [weak self] in
+            self?.dismiss(animated: true)
+            pulseAnimation.removeFromSuperview()
+        }
+        
         popover.popoverDidDismiss = { _ in
             pulseAnimation.removeFromSuperview()
         }

--- a/Client/Frontend/Browser/Onboarding/Welcome/OnboardingPulseAnimationView.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/OnboardingPulseAnimationView.swift
@@ -7,6 +7,8 @@ import Foundation
 import BraveUI
 
 class RadialPulsingAnimation: UIView {
+    var onTouchInside: (() -> Void)?
+    
     private var pulseLayers = [CAShapeLayer]()
     
     init(ringCount: Int) {
@@ -25,6 +27,8 @@ class RadialPulsingAnimation: UIView {
             layer.lineCap = .round
             pulseLayers.append(layer)
         }
+        
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onTouchInside(_:))))
     }
     
     required init?(coder: NSCoder) {
@@ -108,5 +112,10 @@ class RadialPulsingAnimation: UIView {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.animate()
         }
+    }
+    
+    @objc
+    private func onTouchInside(_ recognizer: UITapGestureRecognizer) {
+        self.onTouchInside?()
     }
 }

--- a/Client/Frontend/Browser/Onboarding/Welcome/OnboardingPulseAnimationView.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/OnboardingPulseAnimationView.swift
@@ -7,12 +7,11 @@ import Foundation
 import BraveUI
 
 class RadialPulsingAnimation: UIView {
-    var onTouchInside: (() -> Void)?
-    
     private var pulseLayers = [CAShapeLayer]()
     
     init(ringCount: Int) {
         super.init(frame: .zero)
+        isUserInteractionEnabled = false
         
         // [1, 4] => {Y ∈ ℝ: 1 <= Y <= 4} where Y = Thicc, X = amount of rings
         let idealThicc = 1.5
@@ -27,8 +26,6 @@ class RadialPulsingAnimation: UIView {
             layer.lineCap = .round
             pulseLayers.append(layer)
         }
-        
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onTouchInside(_:))))
     }
     
     required init?(coder: NSCoder) {
@@ -97,6 +94,7 @@ class RadialPulsingAnimation: UIView {
             let imageView = UIImageView().then {
                 $0.image = icon
                 $0.contentMode = .scaleAspectFit
+                $0.isUserInteractionEnabled = false
             }
             
             addSubview(imageView)
@@ -112,10 +110,5 @@ class RadialPulsingAnimation: UIView {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.animate()
         }
-    }
-    
-    @objc
-    private func onTouchInside(_ recognizer: UITapGestureRecognizer) {
-        self.onTouchInside?()
     }
 }

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -263,6 +263,11 @@ extension BrowserViewController: PlaylistHelperDelegate {
                                            browser: self)
                     pulseAnimation.frame = pulseAnimation.frame.insetBy(dx: 10.0, dy: 12.0)
                     
+                    pulseAnimation.onTouchInside = { [weak self] in
+                        self?.dismiss(animated: true)
+                        pulseAnimation.removeFromSuperview()
+                    }
+                    
                     popover.popoverDidDismiss = { _ in
                         pulseAnimation.removeFromSuperview()
                     }

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -263,11 +263,6 @@ extension BrowserViewController: PlaylistHelperDelegate {
                                            browser: self)
                     pulseAnimation.frame = pulseAnimation.frame.insetBy(dx: 10.0, dy: 12.0)
                     
-                    pulseAnimation.onTouchInside = { [weak self] in
-                        self?.dismiss(animated: true)
-                        pulseAnimation.removeFromSuperview()
-                    }
-                    
                     popover.popoverDidDismiss = { _ in
                         pulseAnimation.removeFromSuperview()
                     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Dismisses the popover when you touch inside the pulse-animation
- Fix onboarding bug found by Anthony where the NTP animation shows on websites

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4542, #4544

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
