### PR TITLE
Add support for making EIP-1559 send & swap transactions on supported chains

### DIFF
--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -165,7 +165,7 @@ public class SendTokenStore: ObservableObject {
             }
           }
         } else {
-          self.transactionController.makeErc20TransferData(account.address, amount: "0x\(weiHexString)") { [self] success, data in
+          self.transactionController.makeErc20TransferData(account.address, amount: "0x\(weiHexString)") { success, data in
             guard success else {
               completion(false)
               return

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -129,6 +129,18 @@ public class SendTokenStore: ObservableObject {
     }
   }
   
+  private func makeEIP1559Tx(
+    chainId: String,
+    baseData: BraveWallet.TxData,
+    from account: BraveWallet.AccountInfo,
+    completion: @escaping (_ success: Bool) -> Void
+  ) {
+    let eip1559Data = BraveWallet.TxData1559(baseData: baseData, chainId: chainId, maxPriorityFeePerGas: "", maxFeePerGas: "", gasEstimation: nil)
+    self.transactionController.addUnapproved1559Transaction(eip1559Data, from: account.address) { success, txMetaId, errorMessage in
+      completion(success)
+    }
+  }
+  
   func sendToken(
     from account: BraveWallet.AccountInfo,
     to address: String,
@@ -138,21 +150,34 @@ public class SendTokenStore: ObservableObject {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     guard let token = selectedSendToken, let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: 18) else { return }
     
-    if token.isETH {
-      let data = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: address, value: "0x\(weiHexString)", data: .init())
-      transactionController.addUnapprovedTransaction(data, from: account.address) { success, txMetaId, errorMessage in
-        completion(success)
-      }
-    } else {
-      transactionController.makeErc20TransferData(account.address, amount: "0x\(weiHexString)") { [self] success, data in
-        guard success else {
-          completion(false)
-          return
-        }
-        rpcController.chainId { [self] chainId in
-          let txData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
-          transactionController.addUnapprovedTransaction(txData, from: account.address) { success, txMetaId, errorMessage in
-            completion(success)
+    rpcController.chainId { [weak self] chainId in
+      guard let self = self else { return }
+      self.rpcController.allNetworks { networks in
+        guard let currentNetwork = networks.first(where: { $0.id == chainId }) else { return }
+        
+        if token.isETH {
+          let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: address, value: "0x\(weiHexString)", data: .init())
+          if currentNetwork.isEip1559 {
+            self.makeEIP1559Tx(chainId: chainId, baseData: baseData, from: account, completion: completion)
+          } else {
+            self.transactionController.addUnapprovedTransaction(baseData, from: account.address) { success, txMetaId, errorMessage in
+              completion(success)
+            }
+          }
+        } else {
+          self.transactionController.makeErc20TransferData(account.address, amount: "0x\(weiHexString)") { [self] success, data in
+            guard success else {
+              completion(false)
+              return
+            }
+            let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
+            if currentNetwork.isEip1559 {
+              self.makeEIP1559Tx(chainId: chainId, baseData: baseData, from: account, completion: completion)
+            } else {
+              self.transactionController.addUnapprovedTransaction(baseData, from: account.address) { success, txMetaId, errorMessage in
+                completion(success)
+              }
+            }
           }
         }
       }

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -206,32 +206,65 @@ public class SwapTokenStore: ObservableObject {
       let accountInfo = accountInfo,
       let swapParams = swapParameters(for: .perSellAsset)
     else { return }
-    swapController.transactionPayload(swapParams) { [weak self] success, swapResponse, error in
-      guard success, let self = self else {
+    self.rpcController.allNetworks { [weak self] networks in
+      guard
+        let self = self,
+        let currentNetwork = networks.first(where: { $0.id == self.chainId })
+      else {
         self?.state = .error(Strings.Wallet.unknownError)
         self?.clearAllAmount()
         return
       }
-      guard let response = swapResponse else { return }
-      let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
-      let gasPrice = "0x\(weiFormatter.weiString(from: response.gasPrice, radix: .hex, decimals: 18) ?? "0")"
-      let gasLimit = "0x\(weiFormatter.weiString(from: response.estimatedGas, radix: .hex, decimals: 18) ?? "0")"
-      let value = "0x\(weiFormatter.weiString(from: response.value, radix: .hex, decimals: 18) ?? "0")"
-      let data: [NSNumber] = .init(hexString: response.data) ?? .init()
-      let txData: BraveWallet.TxData = .init(
-        nonce: "",
-        gasPrice: gasPrice,
-        gasLimit: gasLimit,
-        to: response.to,
-        value: value,
-        data: data
-      )
-      self.transactionController.addUnapprovedTransaction(txData, from: accountInfo.address) { [weak self] success, txMetaId, error in
-        // should be observed
+      
+      self.swapController.transactionPayload(swapParams) { success, swapResponse, error in
         guard success else {
-          self?.state = .error(Strings.Wallet.unknownError)
-          self?.clearAllAmount()
+          self.state = .error(Strings.Wallet.unknownError)
+          self.clearAllAmount()
           return
+        }
+        guard let response = swapResponse else { return }
+        let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+        let gasPrice = "0x\(weiFormatter.weiString(from: response.gasPrice, radix: .hex, decimals: 0) ?? "0")" // already in wei
+        let gasLimit = "0x\(weiFormatter.weiString(from: response.estimatedGas, radix: .hex, decimals: 0) ?? "0")" // already in wei
+        let value = "0x\(weiFormatter.weiString(from: response.value, radix: .hex, decimals: 0) ?? "0")" // already in wei
+        let data: [NSNumber] = .init(hexString: response.data) ?? .init()
+        
+        if currentNetwork.isEip1559 {
+          let baseData: BraveWallet.TxData = .init(
+            nonce: "",
+            gasPrice: "", // no gas price in eip1559
+            gasLimit: gasLimit,
+            to: response.to,
+            value: value,
+            data: data
+          )
+          self.makeEIP1559Tx(chainId: self.chainId,
+                             baseData: baseData,
+                             from: accountInfo) { success in
+            // should be observed
+            guard success else {
+              self.state = .error(Strings.Wallet.unknownError)
+              self.clearAllAmount()
+              return
+            }
+          }
+        } else {
+          let baseData: BraveWallet.TxData = .init(
+            nonce: "",
+            gasPrice: gasPrice,
+            gasLimit: gasLimit,
+            to: response.to,
+            value: value,
+            data: data
+          )
+          self.transactionController.addUnapprovedTransaction(baseData, from: accountInfo.address) { success, txMetaId, error in
+            // should be observed
+            guard success else {
+              self.state = .error(Strings.Wallet.unknownError)
+              self.clearAllAmount()
+              return
+            }
+          }
         }
       }
     }
@@ -305,12 +338,17 @@ public class SwapTokenStore: ObservableObject {
         decimals: Int(fromToken.decimals)
       )
     else { return }
-    transactionController.makeErc20ApproveData(
-      spenderAddress,
-      amount: balanceInWeiHex
-    ) { [weak self] success, data in
+    rpcController.allNetworks { [weak self] networks in
+      guard
+        let self = self,
+        let currentNetwork = networks.first(where: { $0.id == self.chainId })
+      else { return }
+      self.transactionController.makeErc20ApproveData(
+        spenderAddress,
+        amount: balanceInWeiHex
+      ) { success, data in
         guard success else { return }
-        let txData = BraveWallet.TxData(
+        let baseData = BraveWallet.TxData(
           nonce: "",
           gasPrice: "",
           gasLimit: "",
@@ -318,19 +356,66 @@ public class SwapTokenStore: ObservableObject {
           value: "0x0",
           data: data
         )
-      self?.transactionController.addUnapprovedTransaction(
-          txData,
-          from: accountInfo.address,
-          completion: { success, txMetaId, error in
-            // should be observed
+        if currentNetwork.isEip1559 {
+          self.makeEIP1559Tx(chainId: self.chainId,
+                             baseData: baseData,
+                             from: accountInfo) { success in
             guard success else {
-              self?.state = .error(Strings.Wallet.unknownError)
-              self?.clearAllAmount()
+              self.state = .error(Strings.Wallet.unknownError)
+              self.clearAllAmount()
               return
             }
           }
-      )
+        } else {
+          self.transactionController.addUnapprovedTransaction(
+              baseData,
+              from: accountInfo.address,
+              completion: { success, txMetaId, error in
+                // should be observed
+                guard success else {
+                  self.state = .error(Strings.Wallet.unknownError)
+                  self.clearAllAmount()
+                  return
+                }
+              }
+          )
+        }
+      }
     }
+  }
+  
+  private func makeEIP1559Tx(
+    chainId: String,
+    baseData: BraveWallet.TxData,
+    from account: BraveWallet.AccountInfo,
+    completion: @escaping (_ success: Bool) -> Void
+  ) {
+    var maxPriorityFeePerGas = ""
+    var maxFeePerGas = ""
+    assetRatioController.gasOracle { [weak self] gasEstimation in
+      guard let self = self else { return }
+      if let gasEstimation = gasEstimation {
+        // Bump fast priority fee and max fee by 1 GWei if same as average fees.
+        if gasEstimation.fastMaxPriorityFeePerGas == gasEstimation.avgMaxPriorityFeePerGas {
+          maxPriorityFeePerGas = "0x\(self.feeInGWeiHex(with: gasEstimation.fastMaxPriorityFeePerGas, by: 9) ?? "0")"
+          maxFeePerGas = "0x\(self.feeInGWeiHex(with: gasEstimation.fastMaxFeePerGas, by: 9) ?? "0")"
+        } else {
+          // Always suggest fast gas fees as default
+          maxPriorityFeePerGas = gasEstimation.fastMaxPriorityFeePerGas
+          maxFeePerGas = gasEstimation.fastMaxFeePerGas
+        }
+      }
+      let eip1559Data = BraveWallet.TxData1559(baseData: baseData, chainId: chainId, maxPriorityFeePerGas: maxPriorityFeePerGas, maxFeePerGas: maxFeePerGas, gasEstimation: gasEstimation)
+      self.transactionController.addUnapproved1559Transaction(eip1559Data, from: account.address) { success, txMetaId, errorMessage in
+        completion(success)
+      }
+    }
+  }
+  
+  private func feeInGWeiHex(with value: String, by decimals: Int) -> String? {
+    guard let bv = BDouble(value) else { return nil }
+    let bumpValue = bv * (BDouble(10) ** decimals)
+    return bumpValue.rounded().asString(radix: 16)
   }
   
   private func checkBalanceShowError(swapResponse: BraveWallet.SwapResponse) {

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -397,8 +397,8 @@ public class SwapTokenStore: ObservableObject {
       if let gasEstimation = gasEstimation {
         // Bump fast priority fee and max fee by 1 GWei if same as average fees.
         if gasEstimation.fastMaxPriorityFeePerGas == gasEstimation.avgMaxPriorityFeePerGas {
-          maxPriorityFeePerGas = "0x\(self.feeInGWeiHex(with: gasEstimation.fastMaxPriorityFeePerGas, by: 9) ?? "0")"
-          maxFeePerGas = "0x\(self.feeInGWeiHex(with: gasEstimation.fastMaxFeePerGas, by: 9) ?? "0")"
+          maxPriorityFeePerGas = "0x\(self.bumpFeeByOneGWei(with: gasEstimation.fastMaxPriorityFeePerGas) ?? "0")"
+          maxFeePerGas = "0x\(self.bumpFeeByOneGWei(with: gasEstimation.fastMaxFeePerGas) ?? "0")"
         } else {
           // Always suggest fast gas fees as default
           maxPriorityFeePerGas = gasEstimation.fastMaxPriorityFeePerGas
@@ -412,10 +412,10 @@ public class SwapTokenStore: ObservableObject {
     }
   }
   
-  private func feeInGWeiHex(with value: String, by decimals: Int) -> String? {
+  private func bumpFeeByOneGWei(with value: String) -> String? {
     guard let bv = BDouble(value) else { return nil }
-    let bumpValue = bv * (BDouble(10) ** decimals)
-    return bumpValue.rounded().asString(radix: 16)
+    let bumpedValue = bv + (BDouble(10) ** 9)
+    return bumpedValue.rounded().asString(radix: 16)
   }
   
   private func checkBalanceShowError(swapResponse: BraveWallet.SwapResponse) {


### PR DESCRIPTION
## Summary of Changes
Support adding EIP1559 unapproved tx in sending and swapping for all the network that supports EIP1559 tx.
Fallback with legacy tx handling. 

This pull request fixes #4537 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
