### PR TITLE
Fix #4554: Filter out erc721 tokens in token selection inside asset search, send and swap 

### DIFF
--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -17,7 +17,7 @@ struct AssetSearchView: View {
   
   var body: some View {
     NavigationView {
-      TokenList(tokens: allTokens.filter({ !$0.isErc721 })) { token in
+      TokenList(tokens: allTokens.filter({ $0.isErc20 || $0.isETH })) { token in
         NavigationLink(
           destination: AssetDetailView(
             assetDetailStore: walletStore.assetDetailStore(for: token),

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -17,7 +17,7 @@ struct AssetSearchView: View {
   
   var body: some View {
     NavigationView {
-      TokenList(tokens: allTokens) { token in
+      TokenList(tokens: allTokens.filter({ !$0.isErc721 })) { token in
         NavigationLink(
           destination: AssetDetailView(
             assetDetailStore: walletStore.assetDetailStore(for: token),

--- a/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -13,7 +13,7 @@ struct SendTokenSearchView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   
   var body: some View {
-    TokenList(tokens: sendTokenStore.userAssets) { token in
+    TokenList(tokens: sendTokenStore.userAssets.filter({ !$0.isErc721 })) { token in
       Button(action: {
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()

--- a/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -13,7 +13,7 @@ struct SendTokenSearchView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   
   var body: some View {
-    TokenList(tokens: sendTokenStore.userAssets.filter({ !$0.isErc721 })) { token in
+    TokenList(tokens: sendTokenStore.userAssets.filter({ $0.isErc20 || $0.isETH })) { token in
       Button(action: {
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()

--- a/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
@@ -21,7 +21,7 @@ struct SwapTokenSearchView: View {
   
   var body: some View {
     let excludedToken = searchType == .fromToken ? swapTokenStore.selectedToToken : swapTokenStore.selectedFromToken
-    TokenList(tokens: swapTokenStore.allTokens.filter { $0.symbol != excludedToken?.symbol }) { token in
+    TokenList(tokens: swapTokenStore.allTokens.filter { ($0.symbol != excludedToken?.symbol) && !$0.isErc721 }) { token in
       Button(action: {
         if searchType == .fromToken {
           swapTokenStore.selectedFromToken = token

--- a/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
@@ -21,7 +21,7 @@ struct SwapTokenSearchView: View {
   
   var body: some View {
     let excludedToken = searchType == .fromToken ? swapTokenStore.selectedToToken : swapTokenStore.selectedFromToken
-    TokenList(tokens: swapTokenStore.allTokens.filter { ($0.symbol != excludedToken?.symbol) && !$0.isErc721 }) { token in
+    TokenList(tokens: swapTokenStore.allTokens.filter { ($0.symbol != excludedToken?.symbol) && ($0.isErc20 || $0.isETH) }) { token in
       Button(action: {
         if searchType == .fromToken {
           swapTokenStore.selectedFromToken = token


### PR DESCRIPTION
## Summary of Changes
Filtered out ERC721 tokens in asset selection before we fully support ERC721 tx.
Started using new api in rpcController to get current selected network.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4554 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
