### PR TITLE
[No Bug]: NTP CalloutSkip condition should be checked separately 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -29,7 +29,7 @@ extension BrowserViewController {
     }
     
     func presentVPNAlertCallout() {
-        if Preferences.DebugFlag.skipNTPCallouts == true, isOnboardingOrFullScreenCalloutPresented { return }
+        if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
 
         if !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .vpn) {
             return
@@ -61,7 +61,7 @@ extension BrowserViewController {
     }
     
     func presentDefaultBrowserScreenCallout() {
-        if Preferences.DebugFlag.skipNTPCallouts == true, isOnboardingOrFullScreenCalloutPresented { return }
+        if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
 
         if !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .defaultBrowser) {
             return
@@ -96,7 +96,7 @@ extension BrowserViewController {
     }
     
     func presentBraveRewardsScreenCallout() {
-        if Preferences.DebugFlag.skipNTPCallouts == true, isOnboardingOrFullScreenCalloutPresented { return }
+        if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
 
         if !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .rewards) {
             return
@@ -114,7 +114,7 @@ extension BrowserViewController {
     }
     
     func presentSyncAlertCallout() {
-        if Preferences.DebugFlag.skipNTPCallouts == true, isOnboardingOrFullScreenCalloutPresented { return }
+        if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
 
         if !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .sync) {
             return


### PR DESCRIPTION
Skip condition should be checked with OR operator

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #NA

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Load the Fresh installed application using Debug mode

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
