### PR TITLE
Fix #4568: Hide Brave Wallet access in private mode, and fix menu copy

### DIFF
--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -15,6 +15,13 @@ extension Strings {
       value: "Brave Wallet",
       comment: "The title shown on the wallet settings page."
     )
+    public static let wallet = NSLocalizedString(
+      "wallet.wallet",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Wallet",
+      comment: "The title shown on the menu to access Brave Wallet"
+    )
     public static let portfolioPageTitle = NSLocalizedString(
       "wallet.portfolioPageTitle",
       tableName: "BraveWallet",

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -114,10 +114,10 @@ extension BrowserViewController {
                 let vc = DownloadsPanel(profile: self.profile)
                 menuController.pushInnerMenu(vc)
             }
-            if #available(iOS 14.0, *) {
+            if !PrivateBrowsingManager.shared.isPrivateBrowsing {
                 MenuItemButton(
                     icon: #imageLiteral(resourceName: "menu-crypto").template,
-                    title: Strings.Wallet.braveWallet
+                    title: Strings.Wallet.wallet
                 ) { [unowned self] in
                     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
                     guard


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4568

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
