### PR TITLE
Fix #3396: Add ability to search Open Tabs

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -380,6 +380,7 @@ extension Strings {
     public static let tabTrayAddTabAccessibilityLabel = NSLocalizedString("TabTrayAddTabAccessibilityLabel", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.")
     public static let `private` = NSLocalizedString("Private", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Private", comment: "Private button title")
     public static let privateBrowsing = NSLocalizedString("PrivateBrowsing", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Private Browsing", comment: "")
+    public static let tabTraySearchBarTitle = NSLocalizedString("TabTraySearchBarTitle", tableName: "BraveShared", bundle: .braveShared, value: "Search Tabs", comment: "Title displayed for placeholder inside Search Bar in Tab Tray")
 }
 
 // MARK:-  TabTrayButtonExtensions.swift

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -30,9 +30,15 @@ extension BrowserViewController: TopToolbarDelegate {
         
         isTabTrayActive = true
         
-        let vc = TabTrayController(tabManager: tabManager)
-        vc.delegate = self
-        present(vc, animated: true)
+        let tabTrayController = TabTrayController(tabManager: tabManager).then {
+            $0.delegate = self
+        }
+        
+        let navigationController = SettingsNavigationController(rootViewController: tabTrayController).then {
+            $0.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .phone ? .pageSheet : .formSheet
+        }
+
+        present(navigationController, animated: true)
     }
     
     func topToolbarDidPressReload(_ topToolbar: TopToolbarView) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -34,11 +34,7 @@ extension BrowserViewController: TopToolbarDelegate {
             $0.delegate = self
         }
         
-        let navigationController = SettingsNavigationController(rootViewController: tabTrayController).then {
-            $0.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .phone ? .pageSheet : .formSheet
-        }
-
-        present(navigationController, animated: true)
+        present(SettingsNavigationController(rootViewController: tabTrayController), animated: true)
     }
     
     func topToolbarDidPressReload(_ topToolbar: TopToolbarView) {

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -49,6 +49,8 @@ class TabTrayController: UIViewController {
         }
     }
     
+    private let searchController = UISearchController(searchResultsController: nil)
+
     init(tabManager: TabManager) {
         self.tabManager = tabManager
         super.init(nibName: nil, bundle: nil)
@@ -68,6 +70,24 @@ class TabTrayController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        definesPresentationContext = true
+
+        searchController.do {
+            $0.searchBar.autocapitalizationType = .none
+            //$0.searchResultsUpdater = self
+            $0.obscuresBackgroundDuringPresentation = false
+            $0.searchBar.placeholder = "Search"
+            //$0.delegate = self
+            // Don't hide the navigation bar because the search bar is in it.
+            $0.hidesNavigationBarDuringPresentation = false
+        }
+        
+        navigationItem.do {
+            // Place the search bar in the navigation item's title view.
+            $0.titleView = searchController.searchBar
+            $0.hidesSearchBarWhenScrolling = true
+        }
         
         tabManager.addDelegate(self)
         

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -186,12 +186,14 @@ class TabTrayController: LoadingViewController {
     // MARK: - Actions
     
     @objc func doneAction() {
+        tabTraySearchController.isActive = false
+
         dismiss(animated: true)
     }
     
     @objc func newTabAction() {
-        let isPrivateModeInfoShowing = tabTrayView.isPrivateModeInfoShowing
-        
+        tabTraySearchController.isActive = false
+                
         if privateMode {
             tabTrayView.hidePrivateModeInfo()
             navigationController?.setNavigationBarHidden(false, animated: false)
@@ -199,7 +201,7 @@ class TabTrayController: LoadingViewController {
         
         // If private mode info is showing it means we already added one tab.
         // So when user taps on the 'new tab' button we do nothing, only dismiss the view.
-        if isPrivateModeInfoShowing {
+        if tabTrayView.isPrivateModeInfoShowing {
             dismiss(animated: true)
         } else {
             tabManager.addTabAndSelect(isPrivate: privateMode)
@@ -207,6 +209,8 @@ class TabTrayController: LoadingViewController {
     }
     
     @objc func togglePrivateModeAction() {
+        tabTraySearchController.isActive = false
+
         tabManager.willSwitchTabMode(leavingPBM: privateMode)
         privateMode.toggle()
         // When we switch from Private => Regular make sure we reset _selectedIndex, fix for bug #888

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -54,7 +54,7 @@ class TabTrayController: LoadingViewController {
     private let tabTraySearchController = UISearchController(searchResultsController: nil)
     private var tabTraySearchQuery = ""
     
-    private lazy var emptyStateOverlayView: UIView = createNoSearchResultOverlayView()
+    private lazy var emptyStateOverlayView: UIView = EmptyStateOverlayView(description: Strings.noSearchResultsfound)
 
     init(tabManager: TabManager) {
         self.tabManager = tabManager
@@ -184,6 +184,7 @@ class TabTrayController: LoadingViewController {
         
         if privateMode {
             tabTrayView.hidePrivateModeInfo()
+            tabTraySearchController.searchBar.isHidden = true
         }
         
         // If private mode info is showing it means we already added one tab.
@@ -213,7 +214,7 @@ class TabTrayController: LoadingViewController {
         }
         
         // Disable Search when Private mode info is on 
-        tabTraySearchController.searchBar.isUserInteractionEnabled = !privateMode
+        tabTraySearchController.searchBar.isHidden = privateMode
     }
     
     private func remove(tab: Tab) {

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -211,6 +211,9 @@ class TabTrayController: LoadingViewController {
             // So when you dismiss the modal, correct tab and url is showed.
             tabManager.selectTab(tabManager.tabsForCurrentMode.first)
         }
+        
+        // Disable Search when Private mode info is on 
+        tabTraySearchController.searchBar.isUserInteractionEnabled = !privateMode
     }
     
     private func remove(tab: Tab) {

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -83,7 +83,7 @@ class TabTrayController: LoadingViewController {
             $0.searchBar.autocorrectionType = .no
             $0.searchResultsUpdater = self
             $0.obscuresBackgroundDuringPresentation = false
-            $0.searchBar.placeholder = "Search"
+            $0.searchBar.placeholder = Strings.tabTraySearchBarTitle
             $0.delegate = self
             // Don't hide the navigation bar because the search bar is in it.
             $0.hidesNavigationBarDuringPresentation = false
@@ -238,8 +238,8 @@ class TabTrayController: LoadingViewController {
         if emptyStateOverlayView.superview == nil {
             view.addSubview(emptyStateOverlayView)
             view.bringSubviewToFront(emptyStateOverlayView)
-            emptyStateOverlayView.snp.makeConstraints { make -> Void in
-                make.edges.equalTo(tabTrayView.collectionView)
+            emptyStateOverlayView.snp.makeConstraints {
+                $0.edges.equalTo(tabTrayView.collectionView)
             }
         }
     }

--- a/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
@@ -85,7 +85,7 @@ extension TabTrayController {
         override init(frame: CGRect) {
             super.init(frame: frame)
             
-            backgroundColor = .secondaryBraveBackground
+            backgroundColor = .braveBackground
             accessibilityLabel = Strings.tabTrayAccessibilityLabel
             
             let buttonsStackView = UIStackView().then {
@@ -106,7 +106,7 @@ extension TabTrayController {
                 $0.addStackViewItems(
                     .view(privateModeInfo),
                     .view(collectionView),
-                    .customSpace(4),
+                    .customSpace(10),
                     .view(buttonsStackView))
                 $0.isAccessibilityElement = false
             }
@@ -117,7 +117,8 @@ extension TabTrayController {
             
             addSubview(stackView)
             stackView.snp.makeConstraints {
-                $0.edges.equalTo(self.safeArea.edges).inset(8)
+                $0.top.left.right.equalToSuperview()//.offset(8)
+                $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
             }
             
             privateModeInfo.isHidden = true

--- a/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
@@ -14,6 +14,9 @@ extension TabTrayController {
         private struct UX {
             static let regularCellHeight = 192.0
             static let largeCellHeight = 256.0
+            static let itemInset = 6.0
+            static let buttonEdgeInset = 10.0
+            static let buttonStackLayoutMargin = 16.0
         }
         
         private func generateLayout(numberOfColumns: Int,
@@ -22,7 +25,7 @@ extension TabTrayController {
                 widthDimension: .fractionalWidth(1.0),
                 heightDimension: .fractionalHeight(1.0))
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            item.contentInsets = .init(top: 6, leading: 6, bottom: 6, trailing: 6)
+            item.contentInsets = .init(top: UX.itemInset, leading: UX.itemInset, bottom: UX.itemInset, trailing: UX.itemInset)
             
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
@@ -47,7 +50,7 @@ extension TabTrayController {
             $0.accessibilityLabel = Strings.tabTrayAddTabAccessibilityLabel
             $0.accessibilityIdentifier = "TabTrayController.addTabButton"
             $0.tintColor = .braveLabel
-            $0.contentEdgeInsets = .init(top: 0, left: 10, bottom: 0, right: 10)
+            $0.contentEdgeInsets = .init(top: 0, left: UX.buttonEdgeInset, bottom: 0, right: UX.buttonEdgeInset)
             $0.setContentCompressionResistancePriority(.required, for: .horizontal)
         }
         
@@ -96,7 +99,11 @@ extension TabTrayController {
                     .view(doneButton)
                 )
                 $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-                $0.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+                $0.layoutMargins = UIEdgeInsets(
+                    top: UX.buttonStackLayoutMargin,
+                    left: UX.buttonStackLayoutMargin,
+                    bottom: 0,
+                    right: UX.buttonStackLayoutMargin)
                 $0.isLayoutMarginsRelativeArrangement = true
             }
             
@@ -106,7 +113,6 @@ extension TabTrayController {
                 $0.addStackViewItems(
                     .view(privateModeInfo),
                     .view(collectionView),
-                    .customSpace(10),
                     .view(buttonsStackView))
                 $0.isAccessibilityElement = false
             }
@@ -117,7 +123,7 @@ extension TabTrayController {
             
             addSubview(stackView)
             stackView.snp.makeConstraints {
-                $0.top.left.right.equalToSuperview()//.offset(8)
+                $0.top.left.right.equalToSuperview()
                 $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
             }
             

--- a/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
@@ -70,7 +70,6 @@ extension TabTrayController {
         let privateModeButton = PrivateModeButton().then {
             $0.titleLabel?.font = .preferredFont(forTextStyle: .body)
             $0.titleLabel?.adjustsFontForContentSizeCategory = true
-            $0.titleLabel?.adjustsFontSizeToFitWidth = true
             $0.contentHorizontalAlignment = .left
             $0.setTitle(Strings.private, for: .normal)
             $0.tintColor = .braveLabel
@@ -93,30 +92,13 @@ extension TabTrayController {
             backgroundColor = .braveBackground
             accessibilityLabel = Strings.tabTrayAccessibilityLabel
             
-            let buttonsStackView = UIStackView().then {
-                $0.distribution = .equalSpacing
-                $0.addStackViewItems(
-                    .view(privateModeButton),
-                    .view(newTabButton),
-                    .view(doneButton)
-                )
-                $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-                $0.layoutMargins = UIEdgeInsets(equalInset: UX.buttonStackLayoutMargin)
-                $0.isLayoutMarginsRelativeArrangement = true
-            }
-            
             let stackView = UIStackView().then {
                 $0.axis = .vertical
                 $0.spacing = 0
                 $0.addStackViewItems(
                     .view(privateModeInfo),
-                    .view(collectionView),
-                    .view(buttonsStackView))
+                    .view(collectionView))
                 $0.isAccessibilityElement = false
-            }
-            
-            privateModeButton.snp.makeConstraints {
-                $0.width.equalTo(doneButton.snp.width)
             }
             
             addSubview(stackView)

--- a/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
@@ -15,6 +15,7 @@ extension TabTrayController {
             static let regularCellHeight = 192.0
             static let largeCellHeight = 256.0
             static let itemInset = 6.0
+            static let sectionInset = 4.0
             static let buttonEdgeInset = 10.0
             static let buttonStackLayoutMargin = 16.0
         }
@@ -36,6 +37,7 @@ extension TabTrayController {
                 count: numberOfColumns)
             
             let section = NSCollectionLayoutSection(group: group)
+            section.contentInsets = .init(top: UX.sectionInset, leading: UX.sectionInset, bottom: UX.sectionInset, trailing: UX.sectionInset)
             let layout = UICollectionViewCompositionalLayout(section: section)
             return layout
         }
@@ -99,11 +101,7 @@ extension TabTrayController {
                     .view(doneButton)
                 )
                 $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-                $0.layoutMargins = UIEdgeInsets(
-                    top: UX.buttonStackLayoutMargin,
-                    left: UX.buttonStackLayoutMargin,
-                    bottom: 0,
-                    right: UX.buttonStackLayoutMargin)
+                $0.layoutMargins = UIEdgeInsets(equalInset: UX.buttonStackLayoutMargin)
                 $0.isLayoutMarginsRelativeArrangement = true
             }
             

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -163,10 +163,27 @@ class TabManager: NSObject {
             return false
         }.count
     }
+    
+    func tabsForCurrentMode(for query: String? = nil) -> [Tab] {
+        if let query = query {
+            let tabType: TabType = PrivateBrowsingManager.shared.isPrivateBrowsing ? .private : .regular
+            return tabs(withType: tabType, query: query)
+        } else {
+            return tabsForCurrentMode
+        }
+    }
 
-    private func tabs(withType type: TabType) -> [Tab] {
+    private func tabs(withType type: TabType, query: String? = nil) -> [Tab] {
         assert(Thread.isMainThread)
-        return allTabs.filter { $0.type == type }
+        
+        let allTabs = allTabs.filter { $0.type == type }
+        
+        if let query = query {
+            return allTabs.filter { $0.type == type &&
+                (($0.lastTitle?.contains(query) != nil) || (($0.canonicalURL?.absoluteString.contains(query)) != nil)) }
+        } else {
+            return allTabs.filter { $0.type == type }
+        }
     }
     
     private class func getNewConfiguration() -> WKWebViewConfiguration {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -179,8 +179,8 @@ class TabManager: NSObject {
         let allTabs = allTabs.filter { $0.type == type }
         
         if let query = query, !query.isEmpty {
-            // Last title is the only data that will be present on every situation
-            return allTabs.filter { $0.lastTitle?.contains(query) ?? false }
+            // Display title is the only data that will be present on every situation
+            return allTabs.filter { $0.displayTitle.lowercased().contains(query) }
         } else {
             return allTabs
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -178,11 +178,11 @@ class TabManager: NSObject {
         
         let allTabs = allTabs.filter { $0.type == type }
         
-        if let query = query {
-            return allTabs.filter { $0.type == type &&
-                (($0.lastTitle?.contains(query) != nil) || (($0.canonicalURL?.absoluteString.contains(query)) != nil)) }
+        if let query = query, !query.isEmpty {
+            // Last title is the only data that will be present on every situation
+            return allTabs.filter { $0.lastTitle?.contains(query) ?? false }
         } else {
-            return allTabs.filter { $0.type == type }
+            return allTabs
         }
     }
     

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -180,7 +180,7 @@ class TabManager: NSObject {
         
         if let query = query, !query.isEmpty {
             // Display title is the only data that will be present on every situation
-            return allTabs.filter { $0.displayTitle.lowercased().contains(query) }
+            return allTabs.filter { $0.displayTitle.lowercased().contains(query) || ($0.url?.baseDomain?.contains(query) ?? false) }
         } else {
             return allTabs
         }

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -27,7 +27,7 @@ class PrivateModeButton: InsetButton {
         accessibilityLabel = Strings.tabPrivateModeToggleAccessibilityLabel
         accessibilityHint = Strings.tabPrivateModeToggleAccessibilityHint
         
-        titleEdgeInsets = UIEdgeInsets(top: -3, left: 6, bottom: -3, right: 6)
+        contentEdgeInsets = UIEdgeInsets(top: 3, left: 6, bottom: 3, right: 6)
         layer.cornerRadius = 4.0
         layer.cornerCurve = .continuous
         

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -39,15 +39,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         $0.target = self
         $0.action = #selector(importExportAction(_:))
     }
-    
-    private let spinner = UIActivityIndicatorView().then {
-        $0.snp.makeConstraints { make in
-            make.size.equalTo(24)
-        }
-        $0.hidesWhenStopped = true
-        $0.isHidden = true
-    }
-    
+
     private var leftToolbarItems: [UIBarButtonItem?] {
         var items: [UIBarButtonItem?] = [.fixedSpace(5)]
         if currentFolder == nil {
@@ -63,23 +55,6 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         }
         
         return items
-    }
-    
-    private var isLoading = false {
-        didSet {
-            if isLoading {
-                view.addSubview(spinner)
-                spinner.snp.makeConstraints {
-                    $0.center.equalTo(view.snp.center)
-                }
-                
-                spinner.startAnimating()
-                spinner.isHidden = false
-            } else {
-                spinner.stopAnimating()
-                spinner.removeFromSuperview()
-            }
-        }
     }
     
     private weak var addBookmarksFolderOkAction: UIAlertAction?

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -186,6 +186,8 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
             $0.register(BookmarkTableViewCell.self,
                            forCellReuseIdentifier: String(describing: BookmarkTableViewCell.self))
         }
+        
+        definesPresentationContext = true
     }
     
     override func accessibilityPerformEscape() -> Bool {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -14,7 +14,7 @@ class EmptyStateOverlayView: UIView {
     
     private let informationLabel = UILabel().then {
         $0.textAlignment = .center
-        $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
+        $0.font = .preferredFont(for: .title3, weight: .light)
         $0.textColor = .braveLabel
         $0.numberOfLines = 0
         $0.adjustsFontSizeToFitWidth = true
@@ -49,7 +49,7 @@ class EmptyStateOverlayView: UIView {
         informationLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalTo(logoImageView.snp.bottom).offset(15)
-            make.width.equalTo(170)
+            make.left.right.equalToSuperview().inset(15)
         }
     }
     

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -20,29 +20,6 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             : Strings.History.historyEmptyStateTitle,
         icon: #imageLiteral(resourceName: "emptyHistory"))
 
-    private let spinner = UIActivityIndicatorView().then {
-        $0.snp.makeConstraints { make in
-            make.size.equalTo(24)
-        }
-        $0.hidesWhenStopped = true
-        $0.isHidden = true
-    }
-    
-    private var isLoading: Bool = false {
-        didSet {
-            if isLoading {
-                self.view.addSubview(spinner)
-                self.spinner.snp.makeConstraints {
-                    $0.center.equalTo(view.snp.center)
-                }
-                self.spinner.startAnimating()
-            } else {
-                self.spinner.stopAnimating()
-                self.spinner.removeFromSuperview()
-            }
-        }
-    }
-
     private let historyAPI: BraveHistoryAPI
     
     var historyFRC: HistoryV2FetchResultsController?

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
+import Shared
 import Storage
 
 struct SiteTableViewControllerUX {
@@ -150,5 +151,33 @@ class LoadingViewController: UIViewController {
                 spinner.removeFromSuperview()
             }
         }
+    }
+    
+    func createNoSearchResultOverlayView() -> UIView {
+        let overlayView = UIView().then {
+            $0.backgroundColor = .secondaryBraveBackground
+        }
+        
+        let welcomeLabel = UILabel().then {
+            $0.text = Strings.noSearchResultsfound
+            $0.textAlignment = .center
+            $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
+            $0.textColor = .braveLabel
+            $0.numberOfLines = 0
+            $0.adjustsFontSizeToFitWidth = true
+        }
+        
+        overlayView.addSubview(welcomeLabel)
+        
+        welcomeLabel.snp.makeConstraints { make in
+            make.centerX.equalTo(overlayView)
+            // Sets proper top constraint for iPhone 6 in portait and for iPad.
+            make.centerY.equalTo(overlayView).offset(-180).priority(100)
+            // Sets proper top constraint for iPhone 4, 5 in portrait.
+            make.top.greaterThanOrEqualTo(overlayView).offset(50)
+            make.width.equalTo(170)
+        }
+        
+        return overlayView
     }
 }

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -47,7 +47,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView {
  * Provides base shared functionality for site rows and headers.
  */
 @objcMembers
-class SiteTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+class SiteTableViewController: LoadingViewController, UITableViewDelegate, UITableViewDataSource {
     fileprivate let CellIdentifier = "CellIdentifier"
     fileprivate let HeaderIdentifier = "HeaderIdentifier"
     var profile: Profile! {
@@ -124,5 +124,31 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
     
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         true
+    }
+}
+
+class LoadingViewController: UIViewController {
+    
+    let spinner = UIActivityIndicatorView().then {
+        $0.snp.makeConstraints { make in
+            make.size.equalTo(24)
+        }
+        $0.hidesWhenStopped = true
+        $0.isHidden = true
+    }
+    
+    var isLoading: Bool = false {
+        didSet {
+            if isLoading {
+                view.addSubview(spinner)
+                spinner.snp.makeConstraints {
+                    $0.center.equalTo(view.snp.center)
+                }
+                spinner.startAnimating()
+            } else {
+                spinner.stopAnimating()
+                spinner.removeFromSuperview()
+            }
+        }
     }
 }

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -152,32 +152,4 @@ class LoadingViewController: UIViewController {
             }
         }
     }
-    
-    func createNoSearchResultOverlayView() -> UIView {
-        let overlayView = UIView().then {
-            $0.backgroundColor = .secondaryBraveBackground
-        }
-        
-        let welcomeLabel = UILabel().then {
-            $0.text = Strings.noSearchResultsfound
-            $0.textAlignment = .center
-            $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
-            $0.textColor = .braveLabel
-            $0.numberOfLines = 0
-            $0.adjustsFontSizeToFitWidth = true
-        }
-        
-        overlayView.addSubview(welcomeLabel)
-        
-        welcomeLabel.snp.makeConstraints { make in
-            make.centerX.equalTo(overlayView)
-            // Sets proper top constraint for iPhone 6 in portait and for iPad.
-            make.centerY.equalTo(overlayView).offset(-180).priority(100)
-            // Sets proper top constraint for iPhone 4, 5 in portrait.
-            make.top.greaterThanOrEqualTo(overlayView).offset(50)
-            make.width.equalTo(170)
-        }
-        
-        return overlayView
-    }
 }


### PR DESCRIPTION
This pull request contains small alterations in Tab Tray UX and ability to search Open Tabs inside TabTray without changing other Tab Tray abilities.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3396

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open tab tray 
- Try searching different queries
- Switch to Private mode and check the bar is not presented when private mode information is presented
- Add some tabs in private mode
- Test Private mode is working as intended for search


## Screenshots:

https://user-images.githubusercontent.com/6643505/143916721-36695345-d8e9-4b43-b81d-cbae420bbfbf.MP4

A screenshot from iPhone 8 with light mode

![tasearchsmallosmall](https://user-images.githubusercontent.com/6643505/149013252-07319a6a-22c7-48d7-9a2d-e7ced1853898.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
