### PR TITLE
Fix #4579: Add note about using 0x to swap UI

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -163,8 +163,10 @@ struct SwapCryptoView: View {
   
   @State private var orderType: OrderType = .market
   @State var hideSlippage = true
+  @State private var isSwapDisclaimerVisible: Bool = false
   
   @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.openWalletURLAction) private var openWalletURL
   
   @ViewBuilder var unsupportedSwapChainSection: some View {
     Section {
@@ -363,6 +365,34 @@ struct SwapCryptoView: View {
         .resetListHeaderStyle()
         .padding(.top, 20)
     ) {
+      Button(action: {
+        isSwapDisclaimerVisible = true
+      }) {
+        HStack {
+          Text(Strings.Wallet.swapDexAggrigatorNote)
+            .multilineTextAlignment(.center)
+            .foregroundColor(Color(.braveLabel))
+          Image(systemName: "info.circle")
+            .foregroundColor(Color(.braveBlurpleTint))
+            .accessibilityHidden(true)
+        }
+      }
+      .buttonStyle(.plain)
+      .padding(.vertical, 4)
+      .alert(isPresented: $isSwapDisclaimerVisible) {
+        Alert(
+          title: Text(Strings.Wallet.swapDexAggrigatorNote),
+          message: Text(Strings.Wallet.swapDexAggrigatorDisclaimer),
+          primaryButton: Alert.Button.default(Text(Strings.learnMore), action: {
+            guard let url = URL(string: "https://0x.org/") else { return }
+            openWalletURL?(url)
+          }),
+          secondaryButton: Alert.Button.cancel(Text(Strings.OKString))
+        )
+      }
+      .frame(maxWidth: .infinity)
+      .font(.footnote)
+      .listRowBackground(Color(.braveGroupedBackground))
     }
   }
   

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -166,7 +166,7 @@ extension Strings {
       "wallet.accountPrivateKeyDisplayWarning",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Warning: Never share your recovery phrase. Anyone with this phrase can take your assets forever.",
+      value: "Warning: Never share your private key. Anyone with this key can take your assets forever.",
       comment: "A warning message displayed at the top of the Private Key screen"
     )
     public static let copyToPasteboard = NSLocalizedString(
@@ -1442,6 +1442,20 @@ extension Strings {
       bundle: .braveWallet,
       value: "Settings",
       comment: "The title of the settings option inside the menu when user clicks the three dots button beside assets search button."
+    )
+    public static let swapDexAggrigatorNote = NSLocalizedString(
+      "wallet.swapDexAggrigatorNote",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Brave uses 0x as a DEX aggregator.",
+      comment: "A disclaimer note shown on the Swap screen. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange)"
+    )
+    public static let swapDexAggrigatorDisclaimer = NSLocalizedString(
+      "wallet.swapDexAggrigatorDisclaimer",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "0x will process the Ethereum address and IP address to fulfill a transaction (including getting quotes). 0x will ONLY use this data for the purposes of processing transactions.",
+      comment: "A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage."
     )
   }
 }


### PR DESCRIPTION
Also updates Private Key warning copy

## Summary of Changes

This pull request fixes #4579 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 13 Pro - 2021-11-30 at 12 35 17](https://user-images.githubusercontent.com/529104/144098549-6dbecfe4-57c8-40f8-96a9-8c94937dc82e.png)

![Simulator Screen Shot - iPhone 13 Pro - 2021-11-30 at 12 35 19](https://user-images.githubusercontent.com/529104/144098558-752f48b7-d531-41ed-8f5e-3792a82d3155.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
