### PR TITLE
Fix #4413: Reset all the stores except KeyringStore after user resets wallet

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -11,7 +11,7 @@ import BraveUI
 import struct Shared.Strings
 
 struct AccountsView: View {
-  var walletStore: WalletStore
+  var cryptoStore: CryptoStore
   @ObservedObject var keyringStore: KeyringStore
   @State private var navigationController: UINavigationController?
   
@@ -30,8 +30,8 @@ struct AccountsView: View {
     let view = AccountView(address: account.address, name: account.name)
     let destination = AccountActivityView(
       keyringStore: keyringStore,
-      activityStore: walletStore.accountActivityStore(for: account),
-      networkStore: walletStore.networkStore
+      activityStore: cryptoStore.accountActivityStore(for: account),
+      networkStore: cryptoStore.networkStore
     )
     if #available(iOS 15.0, *) {
       ZStack {
@@ -109,7 +109,10 @@ struct AccountsView: View {
 struct AccountsViewController_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      AccountsView(walletStore: .previewStore, keyringStore: .previewStoreWithWalletCreated)
+      AccountsView(
+        cryptoStore: .previewStore,
+        keyringStore: .previewStoreWithWalletCreated
+      )
     }
     .previewLayout(.sizeThatFits)
     .previewColorSchemes()

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -12,7 +12,6 @@ import BraveUI
 import struct Shared.Strings
 
 struct CryptoPagesView: View {
-  var walletStore: WalletStore
   @ObservedObject var cryptoStore: CryptoStore
   @ObservedObject var keyringStore: KeyringStore
   
@@ -22,7 +21,7 @@ struct CryptoPagesView: View {
   
   var body: some View {
     _CryptoPagesView(
-      walletStore: walletStore,
+      keyringStore: keyringStore,
       cryptoStore: cryptoStore,
       isShowingTransactions: $cryptoStore.isPresentingTransactionConfirmations,
       isConfirmationsButtonVisible: !cryptoStore.unapprovedTransactions.isEmpty
@@ -70,7 +69,7 @@ struct CryptoPagesView: View {
         Color.clear
           .sheet(isPresented: $isShowingSearch) {
             AssetSearchView(
-              walletStore: walletStore,
+              keyringStore: keyringStore,
               cryptoStore: cryptoStore
             )
           }
@@ -86,7 +85,7 @@ struct CryptoPagesView: View {
           }
           Menu {
             Button(action: {
-              walletStore.keyringStore.lock()
+              keyringStore.lock()
             }) {
               Label(Strings.Wallet.lock, image: "brave.lock")
                 .imageScale(.medium) // Menu inside nav bar implicitly gets large
@@ -116,14 +115,14 @@ struct CryptoPagesView: View {
   }
   
   private struct _CryptoPagesView: UIViewControllerRepresentable {
-    var walletStore: WalletStore
+    var keyringStore: KeyringStore
     var cryptoStore: CryptoStore
     var isShowingTransactions: Binding<Bool>
     var isConfirmationsButtonVisible: Bool
     
     func makeUIViewController(context: Context) -> CryptoPagesViewController {
       CryptoPagesViewController(
-        walletStore: walletStore,
+        keyringStore: keyringStore,
         cryptoStore: cryptoStore,
         buySendSwapDestination: context.environment.buySendSwapDestination,
         isShowingTransactions: isShowingTransactions
@@ -136,7 +135,7 @@ struct CryptoPagesView: View {
 }
 
 private class CryptoPagesViewController: TabbedPageViewController {
-  private let walletStore: WalletStore
+  private let keyringStore: KeyringStore
   private let cryptoStore: CryptoStore
   private let swapButton = SwapButton()
   let confirmationsButton = ConfirmationsButton()
@@ -145,12 +144,12 @@ private class CryptoPagesViewController: TabbedPageViewController {
   @Binding private var isShowingTransactions: Bool
   
   init(
-    walletStore: WalletStore,
+    keyringStore: KeyringStore,
     cryptoStore: CryptoStore,
     buySendSwapDestination: Binding<BuySendSwapDestination?>,
     isShowingTransactions: Binding<Bool>
   ) {
-    self.walletStore = walletStore
+    self.keyringStore = keyringStore
     self.cryptoStore = cryptoStore
     self._buySendSwapDestination = buySendSwapDestination
     self._isShowingTransactions = isShowingTransactions
@@ -172,7 +171,7 @@ private class CryptoPagesViewController: TabbedPageViewController {
     pages = [
       UIHostingController(rootView: PortfolioView(
         cryptoStore: cryptoStore,
-        keyringStore: walletStore.keyringStore,
+        keyringStore: keyringStore,
         networkStore: cryptoStore.networkStore,
         portfolioStore: cryptoStore.portfolioStore
       )).then {
@@ -180,7 +179,7 @@ private class CryptoPagesViewController: TabbedPageViewController {
       },
       UIHostingController(rootView: AccountsView(
         cryptoStore: cryptoStore,
-        keyringStore: walletStore.keyringStore
+        keyringStore: keyringStore
       )).then {
         $0.title = Strings.Wallet.accountsPageTitle
       }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -61,8 +61,12 @@ public struct CryptoView: View {
       switch visibleScreen {
       case .crypto:
         if let store = walletStore.cryptoStore {
-          CryptoContainerView(walletStore: walletStore, cryptoStore: store, toolbarDismissContent: dismissButtonToolbarContents)
-            .transition(.asymmetric(insertion: .identity, removal: .opacity))
+          CryptoContainerView(
+            keyringStore: keyringStore,
+            cryptoStore: store,
+            toolbarDismissContent: dismissButtonToolbarContents
+          )
+          .transition(.asymmetric(insertion: .identity, removal: .opacity))
         }
       case .unlock:
         UIKitNavigationView {
@@ -93,13 +97,13 @@ public struct CryptoView: View {
 }
 
 private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
-  var walletStore: WalletStore
+  var keyringStore: KeyringStore
   @ObservedObject var cryptoStore: CryptoStore
   var toolbarDismissContent: DismissContent
   
   var body: some View {
     UIKitNavigationView {
-      CryptoPagesView(walletStore: walletStore, cryptoStore: cryptoStore, keyringStore: walletStore.keyringStore)
+      CryptoPagesView(cryptoStore: cryptoStore, keyringStore: keyringStore)
         .toolbar {
           toolbarDismissContent
         }
@@ -110,19 +114,19 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
           switch action {
           case .buy:
             BuyTokenView(
-              keyringStore: walletStore.keyringStore,
+              keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
               buyTokenStore: cryptoStore.buyTokenStore
             )
           case .send:
             SendTokenView(
-              keyringStore: walletStore.keyringStore,
+              keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
               sendTokenStore: cryptoStore.sendTokenStore
             )
           case .swap:
             SwapCryptoView(
-              keyringStore: walletStore.keyringStore,
+              keyringStore: keyringStore,
               ethNetworkStore: cryptoStore.networkStore,
               swapTokensStore: cryptoStore.swapTokenStore
             )
@@ -137,7 +141,7 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
               transactions: cryptoStore.unapprovedTransactions,
               confirmationStore: cryptoStore.confirmationStore,
               networkStore: cryptoStore.networkStore,
-              keyringStore: walletStore.keyringStore
+              keyringStore: keyringStore
             )
           }
         }

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -11,7 +11,7 @@ import Introspect
 import struct Shared.Strings
 
 struct PortfolioView: View {
-  var walletStore: WalletStore
+  var cryptoStore: CryptoStore
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var portfolioStore: PortfolioStore
@@ -73,7 +73,7 @@ struct PortfolioView: View {
         ForEach(portfolioStore.userVisibleAssets) { asset in
           NavigationLink(
             destination: AssetDetailView(
-              assetDetailStore: walletStore.assetDetailStore(for: asset.token),
+              assetDetailStore: cryptoStore.assetDetailStore(for: asset.token),
               keyringStore: keyringStore,
               networkStore: networkStore
             )
@@ -200,10 +200,10 @@ struct PortfolioViewController_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
       PortfolioView(
-        walletStore: .previewStore,
-        keyringStore: WalletStore.previewStore.keyringStore,
-        networkStore: WalletStore.previewStore.networkStore,
-        portfolioStore: WalletStore.previewStore.portfolioStore
+        cryptoStore: .previewStore,
+        keyringStore: .previewStore,
+        networkStore: .previewStore,
+        portfolioStore: CryptoStore.previewStore.portfolioStore
       )
       .navigationBarTitleDisplayMode(.inline)
     }

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -9,7 +9,7 @@ import BraveCore
 import struct Shared.Strings
 
 struct AssetSearchView: View {
-  var walletStore: WalletStore
+  var keyringStore: KeyringStore
   var cryptoStore: CryptoStore
   
   @Environment(\.presentationMode) @Binding private var presentationMode
@@ -22,7 +22,7 @@ struct AssetSearchView: View {
         NavigationLink(
           destination: AssetDetailView(
             assetDetailStore: cryptoStore.assetDetailStore(for: token),
-            keyringStore: walletStore.keyringStore,
+            keyringStore: keyringStore,
             networkStore: cryptoStore.networkStore
           )
         ) {

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -10,6 +10,7 @@ import struct Shared.Strings
 
 struct AssetSearchView: View {
   var walletStore: WalletStore
+  var cryptoStore: CryptoStore
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   
@@ -20,9 +21,9 @@ struct AssetSearchView: View {
       TokenList(tokens: allTokens.filter({ $0.isErc20 || $0.isETH })) { token in
         NavigationLink(
           destination: AssetDetailView(
-            assetDetailStore: walletStore.assetDetailStore(for: token),
+            assetDetailStore: cryptoStore.assetDetailStore(for: token),
             keyringStore: walletStore.keyringStore,
-            networkStore: walletStore.networkStore
+            networkStore: cryptoStore.networkStore
           )
         ) {
           TokenView(token: token)
@@ -43,7 +44,7 @@ struct AssetSearchView: View {
     }
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
-      walletStore.tokenRegistry.allTokens { tokens in
+      cryptoStore.tokenRegistry.allTokens { tokens in
         self.allTokens = tokens.sorted(by: { $0.symbol < $1.symbol })
       }
     }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -1,0 +1,167 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+
+public class CryptoStore: ObservableObject {
+  public let networkStore: NetworkStore
+  public let portfolioStore: PortfolioStore
+  public let buyTokenStore: BuyTokenStore
+  public let sendTokenStore: SendTokenStore
+  public let swapTokenStore: SwapTokenStore
+  public let confirmationStore: TransactionConfirmationStore
+  
+  @Published var buySendSwapDestination: BuySendSwapDestination?
+  @Published var isPresentingTransactionConfirmations: Bool = false
+  @Published private(set) var unapprovedTransactions: [BraveWallet.TransactionInfo] = []
+  
+  private let keyringController: BraveWalletKeyringController
+  private let rpcController: BraveWalletEthJsonRpcController
+  private let walletService: BraveWalletBraveWalletService
+  private let assetRatioController: BraveWalletAssetRatioController
+  private let swapController: BraveWalletSwapController
+  let tokenRegistry: BraveWalletERCTokenRegistry
+  private let transactionController: BraveWalletEthTxController
+  
+  public init(
+    keyringController: BraveWalletKeyringController,
+    rpcController: BraveWalletEthJsonRpcController,
+    walletService: BraveWalletBraveWalletService,
+    assetRatioController: BraveWalletAssetRatioController,
+    swapController: BraveWalletSwapController,
+    tokenRegistry: BraveWalletERCTokenRegistry,
+    transactionController: BraveWalletEthTxController
+  ) {
+    self.keyringController = keyringController
+    self.rpcController = rpcController
+    self.walletService = walletService
+    self.assetRatioController = assetRatioController
+    self.swapController = swapController
+    self.tokenRegistry = tokenRegistry
+    self.transactionController = transactionController
+    
+    self.networkStore = .init(rpcController: rpcController)
+    self.portfolioStore = .init(
+      keyringController: keyringController,
+      rpcController: rpcController,
+      walletService: walletService,
+      assetRatioController: assetRatioController,
+      tokenRegistry: tokenRegistry
+    )
+    self.buyTokenStore = .init(
+      tokenRegistry: tokenRegistry,
+      rpcController: rpcController
+    )
+    self.sendTokenStore = .init(
+      keyringController: keyringController,
+      rpcController: rpcController,
+      walletService: walletService,
+      transactionController: transactionController
+    )
+    self.swapTokenStore = .init(
+      keyringController: keyringController,
+      tokenRegistry: tokenRegistry,
+      rpcController: rpcController,
+      assetRatioController: assetRatioController,
+      swapController: swapController,
+      transactionController: transactionController
+    )
+    self.confirmationStore = .init(
+      assetRatioController: assetRatioController,
+      rpcController: rpcController,
+      txController: transactionController,
+      tokenRegistry: tokenRegistry
+    )
+    
+    self.keyringController.add(self)
+    self.transactionController.add(self)
+  }
+  
+  private var assetDetailStore: AssetDetailStore?
+  func assetDetailStore(for token: BraveWallet.ERCToken) -> AssetDetailStore {
+    if let store = assetDetailStore, store.token.id == token.id {
+      return store
+    }
+    let store = AssetDetailStore(
+      assetRatioController: assetRatioController,
+      keyringController: keyringController,
+      rpcController: rpcController,
+      txController: transactionController,
+      token: token
+    )
+    assetDetailStore = store
+    return store
+  }
+  
+  private var accountActivityStore: AccountActivityStore?
+  func accountActivityStore(for account: BraveWallet.AccountInfo) -> AccountActivityStore {
+    if let store = accountActivityStore, store.account.address == account.address {
+      return store
+    }
+    let store = AccountActivityStore(
+      account: account,
+      walletService: walletService,
+      rpcController: rpcController,
+      assetRatioController: assetRatioController,
+      txController: transactionController
+    )
+    accountActivityStore = store
+    return store
+  }
+  
+  func fetchUnapprovedTransactions() {
+    keyringController.defaultKeyringInfo { [self] keyring in
+      var pendingTransactions: [BraveWallet.TransactionInfo] = []
+      let group = DispatchGroup()
+      for info in keyring.accountInfos {
+        group.enter()
+        transactionController.allTransactionInfo(info.address) { tx in
+          defer { group.leave() }
+          pendingTransactions.append(contentsOf: tx.filter { $0.txStatus == .unapproved })
+        }
+      }
+      group.notify(queue: .main) {
+        if !pendingTransactions.isEmpty && buySendSwapDestination != nil {
+          // Dismiss any buy send swap open to show the unapproved transactions
+          self.buySendSwapDestination = nil
+        }
+        self.unapprovedTransactions = pendingTransactions
+        self.isPresentingTransactionConfirmations = !pendingTransactions.isEmpty
+      }
+    }
+  }
+}
+
+extension CryptoStore: BraveWalletEthTxControllerObserver {
+  public func onNewUnapprovedTx(_ txInfo: BraveWallet.TransactionInfo) {
+    fetchUnapprovedTransactions()
+  }
+  public func onUnapprovedTxUpdated(_ txInfo: BraveWallet.TransactionInfo) {
+    fetchUnapprovedTransactions()
+  }
+  public func onTransactionStatusChanged(_ txInfo: BraveWallet.TransactionInfo) {
+    fetchUnapprovedTransactions()
+  }
+}
+
+extension CryptoStore: BraveWalletKeyringControllerObserver {
+  public func keyringCreated() {
+  }
+  public func keyringRestored() {
+  }
+  public func locked() {
+    isPresentingTransactionConfirmations = false
+  }
+  public func unlocked() {
+  }
+  public func backedUp() {
+  }
+  public func accountsChanged() {
+  }
+  public func autoLockMinutesChanged() {
+  }
+  public func selectedAccountChanged() {
+  }
+}

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -5,31 +5,18 @@
 
 import Foundation
 import BraveCore
+import SwiftUI
+import Combine
 
 /// The main wallet store
-public class WalletStore: ObservableObject {
+public class WalletStore {
   
   public let keyringStore: KeyringStore
-  public let networkStore: NetworkStore
-  public let portfolioStore: PortfolioStore
-  public let buyTokenStore: BuyTokenStore
-  public let sendTokenStore: SendTokenStore
-  public let swapTokenStore: SwapTokenStore
-  public let confirmationStore: TransactionConfirmationStore
-  
-  @Published var buySendSwapDestination: BuySendSwapDestination?
-  @Published var isPresentingTransactionConfirmations: Bool = false
-  @Published private(set) var unapprovedTransactions: [BraveWallet.TransactionInfo] = []
+  public var cryptoStore: CryptoStore?
   
   // MARK: -
   
-  private let keyringController: BraveWalletKeyringController
-  private let rpcController: BraveWalletEthJsonRpcController
-  private let walletService: BraveWalletBraveWalletService
-  private let assetRatioController: BraveWalletAssetRatioController
-  private let swapController: BraveWalletSwapController
-  let tokenRegistry: BraveWalletERCTokenRegistry
-  private let transactionController: BraveWalletEthTxController
+  private var cancellable: AnyCancellable?
   
   public init(
     keyringController: BraveWalletKeyringController,
@@ -40,134 +27,42 @@ public class WalletStore: ObservableObject {
     tokenRegistry: BraveWalletERCTokenRegistry,
     transactionController: BraveWalletEthTxController
   ) {
-    self.keyringController = keyringController
-    self.rpcController = rpcController
-    self.walletService = walletService
-    self.assetRatioController = assetRatioController
-    self.swapController = swapController
-    self.tokenRegistry = tokenRegistry
-    self.transactionController = transactionController
-    
     self.keyringStore = .init(keyringController: keyringController)
-    self.networkStore = .init(rpcController: rpcController)
-    self.portfolioStore = .init(
+    self.setUp(
       keyringController: keyringController,
       rpcController: rpcController,
       walletService: walletService,
-      assetRatioController: assetRatioController,
-      tokenRegistry: tokenRegistry
-    )
-    self.buyTokenStore = .init(
-      tokenRegistry: tokenRegistry,
-      rpcController: rpcController
-    )
-    self.sendTokenStore = .init(
-      keyringController: keyringController,
-      rpcController: rpcController,
-      walletService: walletService,
-      transactionController: transactionController
-    )
-    self.swapTokenStore = .init(
-      keyringController: keyringController,
-      tokenRegistry: tokenRegistry,
-      rpcController: rpcController,
       assetRatioController: assetRatioController,
       swapController: swapController,
+      tokenRegistry: tokenRegistry,
       transactionController: transactionController
     )
-    self.confirmationStore = .init(
-      assetRatioController: assetRatioController,
-      rpcController: rpcController,
-      txController: transactionController,
-      tokenRegistry: tokenRegistry
-    )
-    self.keyringController.add(self)
-    self.transactionController.add(self)
   }
   
-  func fetchUnapprovedTransactions() {
-    keyringController.defaultKeyringInfo { [self] keyring in
-      var pendingTransactions: [BraveWallet.TransactionInfo] = []
-      let group = DispatchGroup()
-      for info in keyring.accountInfos {
-        group.enter()
-        transactionController.allTransactionInfo(info.address) { tx in
-          defer { group.leave() }
-          pendingTransactions.append(contentsOf: tx.filter { $0.txStatus == .unapproved })
-        }
-      }
-      group.notify(queue: .main) {
-        if !pendingTransactions.isEmpty && buySendSwapDestination != nil {
-          // Dismiss any buy send swap open to show the unapproved transactions
-          self.buySendSwapDestination = nil
-        }
-        self.unapprovedTransactions = pendingTransactions
-        self.isPresentingTransactionConfirmations = !pendingTransactions.isEmpty
+  private func setUp(
+    keyringController: BraveWalletKeyringController,
+    rpcController: BraveWalletEthJsonRpcController,
+    walletService: BraveWalletBraveWalletService,
+    assetRatioController: BraveWalletAssetRatioController,
+    swapController: BraveWalletSwapController,
+    tokenRegistry: BraveWalletERCTokenRegistry,
+    transactionController: BraveWalletEthTxController
+  ) {
+    self.cancellable = self.keyringStore.$keyring
+      .sink { keyring in
+      if !keyring.isDefaultKeyringCreated, self.cryptoStore != nil {
+        self.cryptoStore = nil
+      } else if keyring.isDefaultKeyringCreated, self.cryptoStore == nil {
+        self.cryptoStore = CryptoStore(
+          keyringController: keyringController,
+          rpcController: rpcController,
+          walletService: walletService,
+          assetRatioController: assetRatioController,
+          swapController: swapController,
+          tokenRegistry: tokenRegistry,
+          transactionController: transactionController
+        )
       }
     }
-  }
-  
-  private var assetDetailStore: AssetDetailStore?
-  func assetDetailStore(for token: BraveWallet.ERCToken) -> AssetDetailStore {
-    if let store = assetDetailStore, store.token.id == token.id {
-      return store
-    }
-    let store = AssetDetailStore(
-      assetRatioController: assetRatioController,
-      keyringController: keyringController,
-      rpcController: rpcController,
-      txController: transactionController,
-      token: token
-    )
-    assetDetailStore = store
-    return store
-  }
-  
-  private var accountActivityStore: AccountActivityStore?
-  func accountActivityStore(for account: BraveWallet.AccountInfo) -> AccountActivityStore {
-    if let store = accountActivityStore, store.account.address == account.address {
-      return store
-    }
-    let store = AccountActivityStore(
-      account: account,
-      walletService: walletService,
-      rpcController: rpcController,
-      assetRatioController: assetRatioController,
-      txController: transactionController
-    )
-    accountActivityStore = store
-    return store
-  }
-}
-
-extension WalletStore: BraveWalletEthTxControllerObserver {
-  public func onNewUnapprovedTx(_ txInfo: BraveWallet.TransactionInfo) {
-    fetchUnapprovedTransactions()
-  }
-  public func onUnapprovedTxUpdated(_ txInfo: BraveWallet.TransactionInfo) {
-    fetchUnapprovedTransactions()
-  }
-  public func onTransactionStatusChanged(_ txInfo: BraveWallet.TransactionInfo) {
-    fetchUnapprovedTransactions()
-  }
-}
-
-extension WalletStore: BraveWalletKeyringControllerObserver {
-  public func keyringCreated() {
-  }
-  public func keyringRestored() {
-  }
-  public func locked() {
-    isPresentingTransactionConfirmations = false
-  }
-  public func unlocked() {
-  }
-  public func backedUp() {
-  }
-  public func accountsChanged() {
-  }
-  public func autoLockMinutesChanged() {
-  }
-  public func selectedAccountChanged() {
   }
 }

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -49,20 +49,22 @@ public class WalletStore {
     transactionController: BraveWalletEthTxController
   ) {
     self.cancellable = self.keyringStore.$keyring
-      .sink { keyring in
-      if !keyring.isDefaultKeyringCreated, self.cryptoStore != nil {
-        self.cryptoStore = nil
-      } else if keyring.isDefaultKeyringCreated, self.cryptoStore == nil {
-        self.cryptoStore = CryptoStore(
-          keyringController: keyringController,
-          rpcController: rpcController,
-          walletService: walletService,
-          assetRatioController: assetRatioController,
-          swapController: swapController,
-          tokenRegistry: tokenRegistry,
-          transactionController: transactionController
-        )
-      }
+      .map(\.isDefaultKeyringCreated)
+      .removeDuplicates()
+      .sink { isDefaultKeyringCreated in
+        if !isDefaultKeyringCreated, self.cryptoStore != nil {
+          self.cryptoStore = nil
+        } else if isDefaultKeyringCreated, self.cryptoStore == nil {
+          self.cryptoStore = CryptoStore(
+            keyringController: keyringController,
+            rpcController: rpcController,
+            walletService: walletService,
+            assetRatioController: assetRatioController,
+            swapController: swapController,
+            tokenRegistry: tokenRegistry,
+            transactionController: transactionController
+          )
+        }
     }
   }
 }

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -51,7 +51,8 @@ public class WalletStore {
     self.cancellable = self.keyringStore.$keyring
       .map(\.isDefaultKeyringCreated)
       .removeDuplicates()
-      .sink { isDefaultKeyringCreated in
+      .sink { [weak self] isDefaultKeyringCreated in
+        guard let self = self else { return }
         if !isDefaultKeyringCreated, self.cryptoStore != nil {
           self.cryptoStore = nil
         } else if isDefaultKeyringCreated, self.cryptoStore == nil {

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -5,7 +5,6 @@
 
 import Foundation
 import BraveCore
-import SwiftUI
 import Combine
 
 /// The main wallet store

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -22,6 +22,20 @@ extension WalletStore {
   }
 }
 
+extension CryptoStore {
+  static var previewStore: CryptoStore {
+    .init(
+      keyringController: TestKeyringController(),
+      rpcController: TestEthJsonRpcController(),
+      walletService: TestBraveWalletService(),
+      assetRatioController: TestAssetRatioController(),
+      swapController: TestSwapController(),
+      tokenRegistry: TestTokenRegistry(),
+      transactionController: TestEthTxController()
+    )
+  }
+}
+
 extension NetworkStore {
   static var previewStore: NetworkStore {
     .init(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -945,6 +945,7 @@
 		7DAC597B2726524E00E735A2 /* AddressQRCodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAC597A2726524E00E735A2 /* AddressQRCodeScannerView.swift */; };
 		7DC52B12273D99E70067E237 /* WalletArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */; };
 		7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */; };
+		7DCA34D427555E96001B0555 /* CryptoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA34D327555E96001B0555 /* CryptoStore.swift */; };
 		A104E199210A384400D2323E /* ShieldsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A104E198210A384400D2323E /* ShieldsViewController.swift */; };
 		A134B88A20DA98BB00A581D0 /* ClientPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A134B88920DA98BB00A581D0 /* ClientPreferences.swift */; };
 		A13AC72520EC12360040D4BB /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13AC72420EC12360040D4BB /* Migration.swift */; };
@@ -2883,6 +2884,7 @@
 		7DAC597A2726524E00E735A2 /* AddressQRCodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressQRCodeScannerView.swift; sourceTree = "<group>"; };
 		7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtension.swift; sourceTree = "<group>"; };
 		7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtensionTests.swift; sourceTree = "<group>"; };
+		7DCA34D327555E96001B0555 /* CryptoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoStore.swift; sourceTree = "<group>"; };
 		A104E198210A384400D2323E /* ShieldsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsViewController.swift; sourceTree = "<group>"; };
 		A134B88920DA98BB00A581D0 /* ClientPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPreferences.swift; sourceTree = "<group>"; };
 		A13AC72420EC12360040D4BB /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
@@ -3870,6 +3872,7 @@
 			children = (
 				271F685C26EBD27D00AA2A50 /* Address.swift */,
 				27DDE88726FD2D8B00A70C3A /* WalletStore.swift */,
+				7DCA34D327555E96001B0555 /* CryptoStore.swift */,
 				271F685B26EBD27D00AA2A50 /* NetworkStore.swift */,
 				271F685D26EBD27D00AA2A50 /* KeyringStore.swift */,
 				27DDE88526FD2BC400A70C3A /* PortfolioStore.swift */,
@@ -7897,6 +7900,7 @@
 				271F689A26EBD27E00AA2A50 /* KeyringStore.swift in Sources */,
 				27E17B902744129B00F3C282 /* TestSwapController.swift in Sources */,
 				271F68A026EBD27E00AA2A50 /* AccountDetailsView.swift in Sources */,
+				7DCA34D427555E96001B0555 /* CryptoStore.swift in Sources */,
 				271F68B026EBD27E00AA2A50 /* BackupRecoveryPhraseView.swift in Sources */,
 				271F68A926EBD27E00AA2A50 /* BuySendSwapView.swift in Sources */,
 				7D758917271A182800B643C3 /* TokenList.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes
Created a new nullable `CryptoStore` that takes all the observable properties from the `WalletStore` other than `KeyringStore`.
This new store will be created if a new wallet is created or a wallet gets restored. and will be nil out when user reset their wallet.

This pull request fixes #4413 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
