### PR TITLE
No Bug: Changes to Hide Features option

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -431,8 +431,9 @@ class SettingsViewController: TableViewController {
         return Section(
             header: .title(Strings.security),
             rows: [
-                .boolRow(title: Strings.browserLock, detailText: Strings.browserLockDescription, option: Preferences.Privacy.lockWithPasscode, image: #imageLiteral(resourceName: "settings-passcode").template)
+                .boolRow(title: Strings.browserLock, detailText: Strings.browserLockDescription, option: Preferences.Privacy.lockWithPasscode, image: #imageLiteral(resourceName: "settings-passcode").template),
                 // TODO: Uncomment once we restore saved logins, see #4583
+                // Also delete the preference toggle for saved logins
                 /*,
                 Row(text: Strings.Login.loginListNavigationTitle, selection: { [unowned self] in
                     let loginsPasswordsViewController = LoginListViewController(
@@ -442,6 +443,7 @@ class SettingsViewController: TableViewController {
                     self.navigationController?.pushViewController(loginsPasswordsViewController, animated: true)
                 }, image: #imageLiteral(resourceName: "settings-save-logins").template, accessory: .disclosureIndicator)
                 */
+                .boolRow(title: Strings.saveLogins, option: Preferences.General.saveLogins, image: #imageLiteral(resourceName: "settings-save-logins").template)
             ]
         )
     }()


### PR DESCRIPTION
Saved Logins toggle should be added back when Logins & Password is gone

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
