### PR TITLE
Fix #4589: Convert everything in QR-Code v2 to Strings.

### DIFF
--- a/Client/Frontend/Sync/BraveCore/BraveSyncQRCodeModel.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveSyncQRCodeModel.swift
@@ -54,6 +54,20 @@ struct BraveSyncQRCodeModel: Codable {
         self.notValidAfter = Int64(notValidAfter)
     }
     
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try Int(container.decode(String.self, forKey: .version)) ?? 0
+        syncHexCode = try container.decode(String.self, forKey: .syncHexCode)
+        notValidAfter = try Int64(container.decode(String.self, forKey: .notValidAfter)) ?? 0
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(String(version), forKey: .version)
+        try container.encode(syncHexCode, forKey: .syncHexCode)
+        try container.encode(String(notValidAfter), forKey: .notValidAfter)
+    }
+    
     private enum CodingKeys: String, CodingKey {
         case version
         case syncHexCode = "sync_code_hex"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Encode and Decode everything in the QR-Code as Strings. This is what Android and Desktop is doing.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4589

## Submitter Checklist:

- [X] *Unit Tests* are updated to cover new or changed functionality
- [X] User-facing strings use `NSLocalizableString()`

## Test Plan:
Test Sync with iOS, Android and Desktop.

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
