### PR TITLE
Fix #4591: Show wallet button in menu while private browsing

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -114,39 +114,37 @@ extension BrowserViewController {
                 let vc = DownloadsPanel(profile: self.profile)
                 menuController.pushInnerMenu(vc)
             }
-            if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                MenuItemButton(
-                    icon: #imageLiteral(resourceName: "menu-crypto").template,
-                    title: Strings.Wallet.wallet
-                ) { [unowned self] in
-                    let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-                    guard
-                        let keyringController = BraveWallet.KeyringControllerFactory.get(privateMode: privateMode),
-                        let rpcController = BraveWallet.EthJsonRpcControllerFactory.get(privateMode: privateMode),
-                        let assetRatioController = BraveWallet.AssetRatioControllerFactory.get(privateMode: privateMode),
-                        let walletService = BraveWallet.ServiceFactory.get(privateMode: privateMode),
-                        let swapController = BraveWallet.SwapControllerFactory.get(privateMode: privateMode),
-                        let txController = BraveWallet.EthTxControllerFactory.get(privateMode: privateMode)
-                    else {
-                        log.error("Failed to load wallet. One or more services were unavailable")
-                        return
-                    }
-                    
-                    let walletStore = WalletStore(
-                        keyringController: keyringController,
-                        rpcController: rpcController,
-                        walletService: walletService,
-                        assetRatioController: assetRatioController,
-                        swapController: swapController,
-                        tokenRegistry: BraveCoreMain.ercTokenRegistry,
-                        transactionController: txController
-                    )
-                    
-                    let vc = WalletHostingViewController(walletStore: walletStore)
-                    vc.delegate = self
-                    self.dismiss(animated: true) {
-                        self.present(vc, animated: true)
-                    }
+            MenuItemButton(
+                icon: #imageLiteral(resourceName: "menu-crypto").template,
+                title: Strings.Wallet.wallet
+            ) { [unowned self] in
+                let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
+                guard
+                    let keyringController = BraveWallet.KeyringControllerFactory.get(privateMode: privateMode),
+                    let rpcController = BraveWallet.EthJsonRpcControllerFactory.get(privateMode: privateMode),
+                    let assetRatioController = BraveWallet.AssetRatioControllerFactory.get(privateMode: privateMode),
+                    let walletService = BraveWallet.ServiceFactory.get(privateMode: privateMode),
+                    let swapController = BraveWallet.SwapControllerFactory.get(privateMode: privateMode),
+                    let txController = BraveWallet.EthTxControllerFactory.get(privateMode: privateMode)
+                else {
+                    log.error("Failed to load wallet. One or more services were unavailable")
+                    return
+                }
+                
+                let walletStore = WalletStore(
+                    keyringController: keyringController,
+                    rpcController: rpcController,
+                    walletService: walletService,
+                    assetRatioController: assetRatioController,
+                    swapController: swapController,
+                    tokenRegistry: BraveCoreMain.ercTokenRegistry,
+                    transactionController: txController
+                )
+                
+                let vc = WalletHostingViewController(walletStore: walletStore)
+                vc.delegate = self
+                self.dismiss(animated: true) {
+                    self.present(vc, animated: true)
                 }
             }
             if isShownOnWebPage {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4591

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enter private mode (or enable always private browsing mode)
- Verify wallet button is visible

## Screenshots:

<img width="387" alt="image" src="https://user-images.githubusercontent.com/529104/144261766-46e5b14b-7545-4204-be93-a123f331c06d.png">

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
