### PR TITLE
No Bug: Onboarding And Menu Tweaks

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -542,31 +542,55 @@ extension Strings {
 // MARK: - OptionsMenu
 
 extension Strings {
-    public struct PrivacyFeature {
+    public struct OptionsMenu {
         public static let menuSectionTitle = NSLocalizedString(
             "optionsMenu.menuSectionTitle",
             tableName: "BraveShared",
             bundle: .braveShared,
-            value: "Privacy Features",
+            value: "Brave Features",
             comment: "Privacy Features Section title")
+        public static let braveVPNItemTitle = NSLocalizedString(
+            "optionsMenu.braveVPNItemTitle",
+            tableName: "BraveShared",
+            bundle: .braveShared,
+            value: "VPN",
+            comment: "Brave VPN Item Menu title")
         public static let braveVPNItemDescription = NSLocalizedString(
             "optionsMenu.braveVPNItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
             value: "Get around censorship and increase your privacy protection.",
             comment: "The subtitle description of menu item Brave VPN")
+        public static let braveTalkItemTitle = NSLocalizedString(
+            "optionsMenu.braveTalkItemTitle",
+            tableName: "BraveShared",
+            bundle: .braveShared,
+            value: "Talk",
+            comment: "Brave Talk Item Menu title")
         public static let braveTalkItemDescription = NSLocalizedString(
             "optionsMenu.braveTalkItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
             value: "Unlimited private video calls with your friends and colleagues.",
             comment: "The subtitle description of menu item Brave Talk")
+        public static let braveNewsItemTitle = NSLocalizedString(
+            "optionsMenu.braveNewsItemTitle",
+            tableName: "BraveShared",
+            bundle: .braveShared,
+            value: "News",
+            comment: "Brave News Item Menu title")
         public static let braveNewsItemDescription = NSLocalizedString(
             "optionsMenu.braveNewsItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
             value: "Today’s top stories in a completely private feed, just for you.",
             comment: "The subtitle description of menu item Brave News")
+        public static let bravePlaylistItemTitle = NSLocalizedString(
+            "optionsMenu.bravePlaylistItemTitle",
+            tableName: "BraveShared",
+            bundle: .braveShared,
+            value: "Playlist",
+            comment: "Brave News Item Menu title")
         public static let bravePlaylistItemDescription = NSLocalizedString(
             "optionsMenu.bravePlaylistItemDescription",
             tableName: "BraveShared",

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -559,7 +559,7 @@ extension Strings {
             "optionsMenu.braveVPNItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
-            value: "Get around censorship and increase your privacy protection.",
+            value: "Protect your entire device online",
             comment: "The subtitle description of menu item Brave VPN")
         public static let braveTalkItemTitle = NSLocalizedString(
             "optionsMenu.braveTalkItemTitle",
@@ -571,7 +571,7 @@ extension Strings {
             "optionsMenu.braveTalkItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
-            value: "Unlimited private video calls with your friends and colleagues.",
+            value: "Private video calls, right in your browser",
             comment: "The subtitle description of menu item Brave Talk")
         public static let braveNewsItemTitle = NSLocalizedString(
             "optionsMenu.braveNewsItemTitle",
@@ -583,7 +583,7 @@ extension Strings {
             "optionsMenu.braveNewsItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
-            value: "Today’s top stories in a completely private feed, just for you.",
+            value: "Today's top stories in a private news feed",
             comment: "The subtitle description of menu item Brave News")
         public static let bravePlaylistItemTitle = NSLocalizedString(
             "optionsMenu.bravePlaylistItemTitle",
@@ -595,7 +595,7 @@ extension Strings {
             "optionsMenu.bravePlaylistItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
-            value: "Create a playlist of your favorite audio and video streams, straight in your browser. ",
+            value: "Make an offline playlist of the content you love",
             comment: "The subtitle description of menu item Brave Playlist")
     }
 }

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -208,12 +208,12 @@ extension Strings {
         public static let playlistOnboardingViewTitle =
             NSLocalizedString("callout.playlistOnboardingViewTitle",
                               tableName: "BraveShared", bundle: .braveShared,
-                              value: "Ad block is just the beginning",
+                              value: "Add video to Playlist…",
                               comment: "Title for Playlist Onboarding View")
         public static let playlistOnboardingViewDescription =
             NSLocalizedString("callout.playlistOnboardingViewDescription",
                               tableName: "BraveShared", bundle: .braveShared,
-                              value: "With Brave Playlist, you can play videos in the background, picture-in-picture, or even offline. And, of course, ad-free.",
+                              value: "…play anywhere, anytime. In the background, picture-in-picture, or even offline. And, of course, ad-free.",
                               comment: "Description for Playlist Onboarding View")
         public static let playlistOnboardingViewButtonTitle =
             NSLocalizedString("callout.playlistOnboardingViewButtonTitle",

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -595,7 +595,7 @@ extension Strings {
             "optionsMenu.bravePlaylistItemDescription",
             tableName: "BraveShared",
             bundle: .braveShared,
-            value: "Make an offline playlist of the content you love",
+            value: "Keep an offline playlist of any video/stream",
             comment: "The subtitle description of menu item Brave Playlist")
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2829,7 +2829,7 @@ extension BrowserViewController: NewTabPageDelegate {
     
     func showNTPOnboarding() {
         if Preferences.General.isNewRetentionUser.value == true,
-            Preferences.DebugFlag.skipNTPCallouts == false,
+            Preferences.DebugFlag.skipNTPCallouts != true,
             !topToolbar.inOverlayMode,
             !Preferences.FullScreenCallout.ntpCalloutCompleted.value {
             presentNTPStatsOnboarding()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -32,7 +32,7 @@ extension BrowserViewController {
     
     func privacyFeaturesMenuSection(_ menuController: MenuViewController) -> some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text(Strings.PrivacyFeature.menuSectionTitle.uppercased())
+            Text(Strings.OptionsMenu.menuSectionTitle.capitalized)
                 .font(.callout.weight(.semibold))
                 .foregroundColor(Color(.braveLabel))
                 .padding(.horizontal, 14)
@@ -40,7 +40,7 @@ extension BrowserViewController {
                         
             VPNMenuButton(
                 vpnProductInfo: self.vpnProductInfo,
-                description: Strings.PrivacyFeature.braveVPNItemDescription,
+                description: Strings.OptionsMenu.braveVPNItemDescription,
                 displayVPNDestination: { [unowned self] vc in
                     (self.presentedViewController as? MenuViewController)?
                         .pushInnerMenu(vc)
@@ -53,24 +53,23 @@ extension BrowserViewController {
                 }
             )
             
+            MenuItemButton(
+                icon: #imageLiteral(resourceName: "playlist_menu").template,
+                title: Strings.OptionsMenu.bravePlaylistItemTitle,
+                subtitle: Strings.OptionsMenu.bravePlaylistItemDescription) { [weak self] in
+                guard let self = self else { return }
+
+                self.presentPlaylistController()
+            }
+            
             // Add Brave Talk and News options only in normal browsing
             if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-                MenuItemButton(
-                    icon: #imageLiteral(resourceName: "menu-brave-talk").template,
-                    title: Strings.BraveTalk.braveTalkTitle,
-                    subtitle: Strings.PrivacyFeature.braveTalkItemDescription) { [weak self] in
-                    guard let self = self, let url = URL(string: "https://talk.brave.com/") else { return }
-                    
-                    self.popToBVC()
-                    self.finishEditingAndSubmit(url, visitType: .typed)
-                }
-                
                 // Show Brave News if it is first launch and after first launch If the new is enabled
                 if Preferences.General.isFirstLaunch.value || (!Preferences.General.isFirstLaunch.value && Preferences.BraveNews.isEnabled.value) {
                     MenuItemButton(
                         icon: #imageLiteral(resourceName: "menu_brave_news").template,
-                        title: Strings.BraveNews.braveNews,
-                        subtitle: Strings.PrivacyFeature.braveNewsItemDescription) { [weak self] in
+                        title: Strings.OptionsMenu.braveNewsItemTitle,
+                        subtitle: Strings.OptionsMenu.braveNewsItemDescription) { [weak self] in
                         guard let self = self, let newTabPageController = self.tabManager.selectedTab?.newTabPageViewController  else {
                             return
                         }
@@ -79,15 +78,16 @@ extension BrowserViewController {
                         newTabPageController.scrollToBraveNews()
                     }
                 }
-            }
-            
-            MenuItemButton(
-                icon: #imageLiteral(resourceName: "playlist_menu").template,
-                title: Strings.PlayList.playlistCarplayTitle,
-                subtitle: Strings.PrivacyFeature.bravePlaylistItemDescription) { [weak self] in
-                guard let self = self else { return }
-
-                self.presentPlaylistController()
+                
+                MenuItemButton(
+                    icon: #imageLiteral(resourceName: "menu-brave-talk").template,
+                    title: Strings.OptionsMenu.braveTalkItemTitle,
+                    subtitle: Strings.OptionsMenu.braveTalkItemDescription) { [weak self] in
+                    guard let self = self, let url = URL(string: "https://talk.brave.com/") else { return }
+                    
+                    self.popToBVC()
+                    self.finishEditingAndSubmit(url, visitType: .typed)
+                }
             }
         }
         .fixedSize(horizontal: false, vertical: true)

--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
@@ -521,8 +521,8 @@ class WelcomeViewController: UIViewController {
             // Japan
         case "JP":
             siteList = [
-                WebsiteRegion(icon: #imageLiteral(resourceName: "welcome-view-search-view-yahoo"), title: "Yahoo", domain: "https://m.yahoo.co.jp/"),
-                WebsiteRegion(icon: #imageLiteral(resourceName: "welcome-view-search-view-wired"), title: "Wired", domain: "https://wired.jp/"),
+                WebsiteRegion(icon: #imageLiteral(resourceName: "faviconYahoo"), title: "Yahoo! JAPAN", domain: "https://m.yahoo.co.jp/"),
+                WebsiteRegion(icon: #imageLiteral(resourceName: "welcome-view-search-view-wired"), title: "Wired(日本版)", domain: "https://wired.jp/"),
                 WebsiteRegion(icon: #imageLiteral(resourceName: "welcome-view-search-view-number-bunshin"), title: "Number Web", domain: "https://number.bunshun.jp/")
             ]
             

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
@@ -73,7 +73,7 @@ struct VPNMenuButton: View {
         HStack {
             MenuItemHeaderView(
                 icon: #imageLiteral(resourceName: "vpn_menu_icon").template,
-                title: "Brave VPN",
+                title: description == nil ? "Brave VPN" : Strings.OptionsMenu.braveVPNItemTitle,
                 subtitle: description)
             Spacer()
             if isVPNStatusChanging {


### PR DESCRIPTION
The title of Wired and Yahoo, the favicon of Yahoo is changed for JP.

## Summary of Changes

This pull request fixes #NA

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
