### PR TITLE
Fix #4595: Ensure we update keyring state when app foregrounds

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -9,6 +9,7 @@ import BraveCore
 import Security
 import struct Shared.Strings
 import LocalAuthentication
+import Combine
 
 struct AutoLockInterval: Identifiable, Hashable {
   var value: Int32
@@ -91,6 +92,7 @@ public class KeyringStore: ObservableObject {
   }
   
   private let controller: BraveWalletKeyringController
+  private var cancellable: AnyCancellable?
   
   public init(keyringController: BraveWalletKeyringController) {
     controller = keyringController
@@ -102,6 +104,11 @@ public class KeyringStore: ObservableObject {
     controller.autoLockMinutes { minutes in
       self.autoLockInterval = .init(value: minutes)
     }
+    cancellable = NotificationCenter.default
+      .publisher(for: UIApplication.willEnterForegroundNotification, object: nil)
+      .sink { [weak self] _ in
+        self?.updateKeyringInfo()
+      }
   }
   
   private func updateKeyringInfo() {

--- a/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/BraveWallet/Crypto/UnlockWalletView.swift
@@ -122,7 +122,8 @@ struct UnlockWalletView: View {
     }
     .onAppear {
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [self] in
-        if !keyringStore.lockedManually && !attemptedBiometricsUnlock && keyringStore.keyring.isLocked {
+        if !keyringStore.lockedManually && !attemptedBiometricsUnlock && keyringStore.keyring.isLocked &&
+            UIApplication.shared.isProtectedDataAvailable {
           attemptedBiometricsUnlock = true
           fillPasswordFromKeychain()
         }


### PR DESCRIPTION
Also harden logic around requesting keychain data on unlock screen

## Summary of Changes

This pull request fixes #4595

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
