### PR TITLE
Fix #4597: Fix crash when editing a custom gas fee

### DIFF
--- a/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -52,21 +52,19 @@ struct EditPriorityFeeView: View {
     maximumTipPrice = WeiFormatter.weiToDecimalGwei(selectedMaxTip.removingHexPrefix, radix: .hex) ?? "0"
     maximumGasPrice = WeiFormatter.weiToDecimalGwei(selectedMaxPrice.removingHexPrefix, radix: .hex) ?? "0"
     baseInGwei = WeiFormatter.weiToDecimalGwei(gasEstimation.baseFeePerGas.removingHexPrefix, radix: .hex) ?? "0"
-
-    withAnimation(nil) {
-      // Comparing from high to low as sometimes avg/slow fees are the same
-      if selectedMaxPrice == gasEstimation.fastMaxFeePerGas &&
-          selectedMaxTip == gasEstimation.fastMaxPriorityFeePerGas {
-        gasFeeKind = .high
-      } else if selectedMaxPrice == gasEstimation.avgMaxFeePerGas &&
-                  selectedMaxTip == gasEstimation.avgMaxPriorityFeePerGas {
-        gasFeeKind = .optimal
-      } else if selectedMaxPrice == gasEstimation.slowMaxFeePerGas &&
-                  selectedMaxTip == gasEstimation.slowMaxPriorityFeePerGas {
-        gasFeeKind = .low
-      } else {
-        gasFeeKind = .custom
-      }
+    
+    // Comparing from high to low as sometimes avg/slow fees are the same
+    if selectedMaxPrice == gasEstimation.fastMaxFeePerGas &&
+        selectedMaxTip == gasEstimation.fastMaxPriorityFeePerGas {
+      gasFeeKind = .high
+    } else if selectedMaxPrice == gasEstimation.avgMaxFeePerGas &&
+                selectedMaxTip == gasEstimation.avgMaxPriorityFeePerGas {
+      gasFeeKind = .optimal
+    } else if selectedMaxPrice == gasEstimation.slowMaxFeePerGas &&
+                selectedMaxTip == gasEstimation.slowMaxPriorityFeePerGas {
+      gasFeeKind = .low
+    } else {
+      gasFeeKind = .custom
     }
   }
   
@@ -170,7 +168,7 @@ struct EditPriorityFeeView: View {
           .resetListHeaderStyle()
           .padding(.vertical)
       ) {
-        Picker(selection: $gasFeeKind) {
+        Picker(selection: $gasFeeKind.animation(.default)) {
           Text(Strings.Wallet.gasFeePredefinedLimitLow).tag(GasFeeKind.low)
           Text(Strings.Wallet.gasFeePredefinedLimitOptimal).tag(GasFeeKind.optimal)
           Text(Strings.Wallet.gasFeePredefinedLimitHigh).tag(GasFeeKind.high)
@@ -252,7 +250,6 @@ struct EditPriorityFeeView: View {
         .listRowBackground(Color(.braveGroupedBackground))
       }
     }
-    .animation(.default, value: gasFeeKind)
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.maxPriorityFeeTitle)


### PR DESCRIPTION
This is caused by an iOS 14 bug where an animation on the list is causing a deferred addition of the "custom" section which is getting set on `onAppear`. By switching to use an animation on the `Binding` of `gasFeeKind` we only animate explicitly on changing `gasFeeKind` via the `Picker`

## Summary of Changes

This pull request fixes #4597

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
