### PR TITLE
No Bug: Hiding Search Options from History and Bookmarks

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -98,11 +98,14 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     private let importExportUtility = BraveCoreImportExportUtility()
     private var documentInteractionController: UIDocumentInteractionController?
     
+    // TODO: Uncomment once we restore search bar, see #4599
+    /*
     private var searchBookmarksTimer: Timer?
     private var isBookmarksBeingSearched = false
     private let bookmarksSearchController = UISearchController(searchResultsController: nil)
     private var bookmarksSearchQuery = ""
     private lazy var noSearchResultOverlayView = createNoSearchResultOverlayView()
+    */
 
     // MARK: Lifecycle
     
@@ -164,6 +167,8 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     // MARK: Layout - Theme
     
     private func applyTheme() {
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         bookmarksSearchController.do {
             $0.searchBar.autocapitalizationType = .none
             $0.searchResultsUpdater = self
@@ -172,10 +177,14 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
             $0.delegate = self
             $0.hidesNavigationBarDuringPresentation = true
         }
+        */
         
         navigationItem.do {
+            // TODO: Uncomment once we restore search bar, see #4599
+            /*
             $0.searchController = bookmarksSearchController
             $0.hidesSearchBarWhenScrolling = false
+            */
             $0.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(tappedDone))
         }
         
@@ -261,6 +270,8 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         return overlayView
     }
     
+    // TODO: Uncomment once we restore search bar, see #4599
+    /*
     private func updateEmptyPanelState() {
         if isBookmarksBeingSearched, bookmarkManager.fetchedSearchObjectsCount == 0 {
             showEmptyPanelState()
@@ -278,6 +289,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
             }
         }
     }
+    */
     
     // MARK: Actions
     
@@ -362,9 +374,12 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     }
     
     private func performBookmarkFetch() {
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         if isBookmarksBeingSearched {
             return
         }
+        */
         
         do {
             // Recreate the frc if it was previously removed
@@ -379,6 +394,8 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         }
     }
     
+    // TODO: Uncomment once we restore search bar, see #4599
+    /*
     private func refreshBookmarkSearchResult(with query: String = "") {
         guard isBookmarksBeingSearched else {
             return
@@ -401,13 +418,17 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
             completion()
         }
     }
+    */
     
     private func fetchBookmarkItem(at indexPath: IndexPath) -> Bookmarkv2? {
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         if isBookmarksBeingSearched {
             return bookmarkManager.searchObject(at: indexPath)
         } else {
+        */
             return bookmarksFRC?.object(at: indexPath)
-        }
+        //}
     }
     
     //MARK: Internal
@@ -449,9 +470,12 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     fileprivate func configureCell(_ cell: BookmarkTableViewCell, atIndexPath indexPath: IndexPath) {
         var fetchedBookmarkItem: Bookmarkv2?
         
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         if isBookmarksBeingSearched {
             fetchedBookmarkItem = bookmarkManager.searchObject(at: indexPath)
         } else {
+        */
             // Make sure Bookmark at index path exists,
             // `frc.object(at:)` crashes otherwise, doesn't fail safely with nil
             if let objectsCount = bookmarksFRC?.fetchedObjectsCount, indexPath.row >= objectsCount {
@@ -460,7 +484,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
             }
             
             fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath)
-        }
+        //}
         
         guard let item = fetchedBookmarkItem else { return }
         cell.tag = item.objectID
@@ -612,7 +636,12 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         isBookmarksBeingSearched ? bookmarkManager.fetchedSearchObjectsCount : bookmarksFRC?.fetchedObjectsCount ?? 0
+        */
+        
+        bookmarksFRC?.fetchedObjectsCount ?? 0
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -628,13 +657,16 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         var fetchedBookmarkItem: Bookmarkv2?
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         if isBookmarksBeingSearched {
             return true
         } else {
+        */
             fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath)
             return fetchedBookmarkItem?.canBeDeleted ?? false
 
-        }
+        //}
     }
 }
 
@@ -693,7 +725,12 @@ extension BookmarksViewController {
     }
     
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         !isBookmarksBeingSearched
+        */
+        
+        true
     }
     
     private func showEditBookmarkController(bookmark: Bookmarkv2) {
@@ -763,10 +800,13 @@ extension BookmarksViewController: BookmarksV2FetchResultsDelegate {
     }
     
     func controllerDidReloadContents(_ controller: BookmarksV2FetchResultsController) {
+        // TODO: Uncomment once we restore search bar, see #4599
+        /*
         if isBookmarksBeingSearched {
             refreshBookmarkSearchResult(with: bookmarksSearchQuery)
             return
         }
+        */
         
         // We're in some sort of invalid state in sync..
         // Somehow this folder was deleted but the user is currently viewing it..
@@ -869,6 +909,8 @@ extension BookmarksViewController {
 
 }
 
+// TODO: Uncomment once we restore search bar, see #4599
+/*
 // MARK: UISearchResultUpdating
 
 extension BookmarksViewController: UISearchResultsUpdating {
@@ -919,3 +961,4 @@ extension BookmarksViewController: UISearchControllerDelegate {
         navigationController?.setToolbarHidden(false, animated: true)
     }
 }
+*/

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -48,7 +48,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     
     var isHistoryRefreshing = false
     
-    // TODO: Uncomment once we restore saved logins, see #4599
+    // TODO: Uncomment once we restore search bar, see #4599
     /*
     private var searchHistoryTimer: Timer?
     private var isHistoryBeingSearched = false
@@ -85,7 +85,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             
         navigationItem.do {
             if !Preferences.Privacy.privateBrowsingOnly.value {
-                // TODO: Uncomment once we restore saved logins, see #4599
+                // TODO: Uncomment once we restore search bar, see #4599
                 /*
                 $0.searchController = searchController
                 $0.hidesSearchBarWhenScrolling = false
@@ -107,7 +107,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     private func applyTheme() {
         title = Strings.historyScreenTitle
 
-        // TODO: Uncomment once we restore saved logins, see #4599
+        // TODO: Uncomment once we restore search bar, see #4599
         /*
         searchController.do {
             $0.searchBar.autocapitalizationType = .none
@@ -231,7 +231,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
         }
     }
     
-    // TODO: Uncomment once we restore saved logins, see #4599
+    // TODO: Uncomment once we restore search bar, see #4599
     /*
     private func invalidateSearchTimer() {
         if searchHistoryTimer != nil {
@@ -314,7 +314,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let historyItem = historyFRC?.object(at: indexPath) else { return }
         
-        // TODO: Uncomment once we restore saved logins, see #4599
+        // TODO: Uncomment once we restore search bar, see #4599
         /*
         if isHistoryBeingSearched {
             searchController.isActive = false
@@ -358,7 +358,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             case .delete:
                 guard let historyItem = historyFRC?.object(at: indexPath) else { return }
                 historyAPI.removeHistory(historyItem)
-                // TODO: Uncomment once we restore saved logins, see #4599
+                // TODO: Uncomment once we restore search bar, see #4599
                 /*
                 if isHistoryBeingSearched {
                     reloadDataAndShowLoading(with: searchQuery)
@@ -429,7 +429,7 @@ extension HistoryViewController: HistoryV2FetchResultsDelegate {
     }
 }
 
-// TODO: Uncomment once we restore saved logins, see #4599
+// TODO: Uncomment once we restore search bar, see #4599
 /*
 // MARK: UISearchResultUpdating
 

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -48,10 +48,13 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     
     var isHistoryRefreshing = false
     
+    // TODO: Uncomment once we restore saved logins, see #4599
+    /*
     private var searchHistoryTimer: Timer?
     private var isHistoryBeingSearched = false
     private let searchController = UISearchController(searchResultsController: nil)
     private var searchQuery = ""
+    */
     
     init(isPrivateBrowsing: Bool, historyAPI: BraveHistoryAPI) {
         self.isPrivateBrowsing = isPrivateBrowsing
@@ -82,8 +85,11 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             
         navigationItem.do {
             if !Preferences.Privacy.privateBrowsingOnly.value {
+                // TODO: Uncomment once we restore saved logins, see #4599
+                /*
                 $0.searchController = searchController
                 $0.hidesSearchBarWhenScrolling = false
+                */
                 $0.rightBarButtonItem =
                     UIBarButtonItem(image: #imageLiteral(resourceName: "playlist_delete_item").template, style: .done, target: self, action: #selector(performDeleteAll))
             }
@@ -101,6 +107,8 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     private func applyTheme() {
         title = Strings.historyScreenTitle
 
+        // TODO: Uncomment once we restore saved logins, see #4599
+        /*
         searchController.do {
             $0.searchBar.autocapitalizationType = .none
             $0.searchResultsUpdater = self
@@ -109,13 +117,17 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             $0.delegate = self
             $0.hidesNavigationBarDuringPresentation = true
         }
+        */
     }
     
     private func refreshHistory() {
+        // TODO: Uncomment once we restore saved logins, see #4599
+        /*
         if isHistoryBeingSearched {
             return
         }
-        
+        */
+         
         if Preferences.Privacy.privateBrowsingOnly.value {
             showEmptyPanelState()
         } else {
@@ -219,12 +231,15 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
         }
     }
     
+    // TODO: Uncomment once we restore saved logins, see #4599
+    /*
     private func invalidateSearchTimer() {
         if searchHistoryTimer != nil {
             searchHistoryTimer?.invalidate()
             searchHistoryTimer = nil
         }
     }
+    */
     
     @objc private func performDeleteAll() {
         let style: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
@@ -299,10 +314,13 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let historyItem = historyFRC?.object(at: indexPath) else { return }
         
+        // TODO: Uncomment once we restore saved logins, see #4599
+        /*
         if isHistoryBeingSearched {
             searchController.isActive = false
         }
-            
+        */
+         
         if let url = URL(string: historyItem.url.absoluteString) {
             dismiss(animated: true) {
                 self.toolbarUrlActionsDelegate?.select(url: url, visitType: .typed)
@@ -340,12 +358,14 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             case .delete:
                 guard let historyItem = historyFRC?.object(at: indexPath) else { return }
                 historyAPI.removeHistory(historyItem)
-                
+                // TODO: Uncomment once we restore saved logins, see #4599
+                /*
                 if isHistoryBeingSearched {
                     reloadDataAndShowLoading(with: searchQuery)
                 } else {
+                */
                     refreshHistory()
-                }
+                //}
             default:
                 break
         }
@@ -409,6 +429,8 @@ extension HistoryViewController: HistoryV2FetchResultsDelegate {
     }
 }
 
+// TODO: Uncomment once we restore saved logins, see #4599
+/*
 // MARK: UISearchResultUpdating
 
 extension HistoryViewController: UISearchResultsUpdating {
@@ -451,3 +473,4 @@ extension HistoryViewController: UISearchControllerDelegate {
         tableView.reloadData()
     }
 }
+*/


### PR DESCRIPTION
This pull request is hiding the search options for history and bookmarks for 1.33 release.

We have to uncomment and enable features in 1.34
Ticket: https://github.com/brave/brave-ios/issues/4599

The Release milestones is changd for search tickets
https://github.com/brave/brave-ios/issues/3397
https://github.com/brave/brave-ios/issues/3398



## Summary of Changes

This pull request fixes #NA

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
