### PR TITLE
Fix #4608: Fix layout of Onboarding callouts on NTP

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -58,7 +58,7 @@ extension BrowserViewController {
         }
         
         // Project the statsFrame to the current frame
-        let frame = view.convert(statsFrame, from: ntpController.view).insetBy(dx: 15.0, dy: 15.0)
+        let frame = view.convert(statsFrame, from: ntpController.view).insetBy(dx: -5.0, dy: 15.0)
         
         // Create a border view
         let borderView = UIView().then {

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -90,7 +90,7 @@ class NewTabPageViewController: UIViewController {
         }
         
         if let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: section)) as? NewTabCollectionViewCell<BraveShieldStatsView> {
-            return collectionView.convert(cell.contentView.frame, to: view)
+            return cell.contentView.convert(cell.contentView.frame, to: view)
         }
         return nil
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

- Fix layout of Onboarding callouts on NTP
- Fix frame insets to match updated layout position

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4608

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Go through Onboarding to NTP, with and without default browser callout.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
