### PR TITLE
Fix #4610: Add stats to show onboarding only when there is some Stats

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2828,10 +2828,17 @@ extension BrowserViewController: NewTabPageDelegate {
     }
     
     func showNTPOnboarding() {
+        let stats = BraveGlobalShieldStats.shared
+        let hasStats = (stats.adblock +
+                        stats.httpse +
+                        stats.trackingProtection +
+                        stats.images) > 0
+        
         if Preferences.General.isNewRetentionUser.value == true,
             Preferences.DebugFlag.skipNTPCallouts != true,
             !topToolbar.inOverlayMode,
-            !Preferences.FullScreenCallout.ntpCalloutCompleted.value {
+            !Preferences.FullScreenCallout.ntpCalloutCompleted.value,
+             hasStats {
             presentNTPStatsOnboarding()
         }
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add stats to show onboarding only when there is some Stats

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes: #4610

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
