### PR TITLE
Hide private key when backgrounding and embed screen in ScrollView

### DIFF
--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -156,7 +156,7 @@ public class SwapTokenStore: ObservableObject {
     }
     
     rpcController.balance(for: token, in: account) { balance in
-      completion(BDouble(balance ?? 0))
+      completion(balance.map { BDouble($0) })
     }
   }
   

--- a/BraveWallet/Preview Content/TestContent.swift
+++ b/BraveWallet/Preview Content/TestContent.swift
@@ -12,7 +12,7 @@ extension BraveWallet.AccountInfo {
   static var previewAccount: BraveWallet.AccountInfo {
     let account = BraveWallet.AccountInfo()
     account.name = "Account 1"
-    account.address = "0x879240B2D6179E9EC40BC2AFFF"
+    account.address = "0x879240B2D6179E9EC40BC2AFFF9E9EC40BC2AFFF"
     return account
   }
 }


### PR DESCRIPTION
Also fixes the preview account address to match the test keyring controller address and small change to swap code

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
