### PR TITLE
Fix #4504: Destroy store when associated view is gone.

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -29,9 +29,9 @@ struct AccountsView: View {
     // the navigation is a UINavigationController and this view is inside of a UIPageViewController
     let view = AccountView(address: account.address, name: account.name)
     let destination = AccountActivityView(
+      cryptoStore: cryptoStore,
       keyringStore: keyringStore,
-      activityStore: cryptoStore.accountActivityStore(for: account),
-      networkStore: cryptoStore.networkStore
+      account: account
     )
     if #available(iOS 15.0, *) {
       ZStack {

--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -29,10 +29,13 @@ struct AccountsView: View {
     // the navigation is a UINavigationController and this view is inside of a UIPageViewController
     let view = AccountView(address: account.address, name: account.name)
     let destination = AccountActivityView(
-      cryptoStore: cryptoStore,
       keyringStore: keyringStore,
-      account: account
+      activityStore: cryptoStore.accountActivityStore(for: account),
+      networkStore: cryptoStore.networkStore
     )
+      .onDisappear {
+        cryptoStore.closeAccountActivityStore(for: account)
+      }
     if #available(iOS 15.0, *) {
       ZStack {
         view

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -10,8 +10,6 @@ import BraveUI
 import struct Shared.Strings
 
 struct AccountActivityView: View {
-  private let cryptoStore: CryptoStore
-  
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var activityStore: AccountActivityStore
   @ObservedObject var networkStore: NetworkStore
@@ -20,17 +18,6 @@ struct AccountActivityView: View {
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
-  
-  init(
-    cryptoStore: CryptoStore,
-    keyringStore: KeyringStore,
-    account: BraveWallet.AccountInfo
-  ) {
-    self.cryptoStore = cryptoStore
-    self.keyringStore = keyringStore
-    self.activityStore = cryptoStore.accountActivityStore(for: account)
-    self.networkStore = cryptoStore.networkStore
-  }
   
   private struct DetailsPresentation: Identifiable {
     var inEditMode: Bool
@@ -142,9 +129,6 @@ struct AccountActivityView: View {
     .onAppear {
       activityStore.update()
     }
-    .onDisappear {
-      cryptoStore.closeAccountActivityStore(for: activityStore.account)
-    }
   }
 }
 
@@ -192,9 +176,9 @@ private struct AccountActivityHeaderView: View {
 struct AccountActivityView_Previews: PreviewProvider {
   static var previews: some View {
     AccountActivityView(
-      cryptoStore: .previewStore,
-      keyringStore: .previewStoreWithWalletCreated,
-      account: .previewAccount
+      keyringStore: .previewStore,
+      activityStore: .previewStore,
+      networkStore: .previewStore
     )
     .previewColorSchemes()
   }

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -10,13 +10,27 @@ import BraveUI
 import struct Shared.Strings
 
 struct AccountActivityView: View {
+  private let cryptoStore: CryptoStore
+  
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var activityStore: AccountActivityStore
   @ObservedObject var networkStore: NetworkStore
   
   @State private var detailsPresentation: DetailsPresentation?
+  
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
+  
+  init(
+    cryptoStore: CryptoStore,
+    keyringStore: KeyringStore,
+    account: BraveWallet.AccountInfo
+  ) {
+    self.cryptoStore = cryptoStore
+    self.keyringStore = keyringStore
+    self.activityStore = cryptoStore.accountActivityStore(for: account)
+    self.networkStore = cryptoStore.networkStore
+  }
   
   private struct DetailsPresentation: Identifiable {
     var inEditMode: Bool
@@ -128,6 +142,9 @@ struct AccountActivityView: View {
     .onAppear {
       activityStore.update()
     }
+    .onDisappear {
+      cryptoStore.closeAccountActivityStore(for: activityStore.account)
+    }
   }
 }
 
@@ -175,9 +192,9 @@ private struct AccountActivityHeaderView: View {
 struct AccountActivityView_Previews: PreviewProvider {
   static var previews: some View {
     AccountActivityView(
+      cryptoStore: .previewStore,
       keyringStore: .previewStoreWithWalletCreated,
-      activityStore: .previewStore,
-      networkStore: .previewStore
+      account: .previewAccount
     )
     .previewColorSchemes()
   }

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -11,11 +11,9 @@ import BraveUI
 import struct Shared.Strings
 
 struct AssetDetailView: View {
-  private let cryptoStore: CryptoStore
-  
-  @ObservedObject private var assetDetailStore: AssetDetailStore
-  @ObservedObject private var keyringStore: KeyringStore
-  @ObservedObject private var networkStore: NetworkStore
+  @ObservedObject var assetDetailStore: AssetDetailStore
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var networkStore: NetworkStore
   
   @State private var tableInset: CGFloat = -16.0
   @State private var isShowingAddAccount: Bool = false
@@ -24,17 +22,6 @@ struct AssetDetailView: View {
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
   
   @Environment(\.openWalletURLAction) private var openWalletURL
-  
-  init(
-    cryptoStore: CryptoStore,
-    keyringStore: KeyringStore,
-    token: BraveWallet.ERCToken
-  ) {
-    self.cryptoStore = cryptoStore
-    self.keyringStore = keyringStore
-    self.networkStore = cryptoStore.networkStore
-    self.assetDetailStore = cryptoStore.assetDetailStore(for: token)
-  }
 
   var body: some View {
     List {
@@ -145,9 +132,6 @@ struct AssetDetailView: View {
       }
       .navigationViewStyle(StackNavigationViewStyle())
     }
-    .onDisappear {
-      cryptoStore.closeAssetDetailStore(for: assetDetailStore.token)
-    }
   }
 }
 
@@ -156,9 +140,9 @@ struct CurrencyDetailView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
       AssetDetailView(
-        cryptoStore: .previewStore,
+        assetDetailStore: .previewStore,
         keyringStore: .previewStore,
-        token: TestTokenRegistry.testTokens.first!
+        networkStore: .previewStore
       )
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -11,9 +11,11 @@ import BraveUI
 import struct Shared.Strings
 
 struct AssetDetailView: View {
-  @ObservedObject var assetDetailStore: AssetDetailStore
-  @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var networkStore: NetworkStore
+  private let cryptoStore: CryptoStore
+  
+  @ObservedObject private var assetDetailStore: AssetDetailStore
+  @ObservedObject private var keyringStore: KeyringStore
+  @ObservedObject private var networkStore: NetworkStore
   
   @State private var tableInset: CGFloat = -16.0
   @State private var isShowingAddAccount: Bool = false
@@ -22,6 +24,17 @@ struct AssetDetailView: View {
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
   
   @Environment(\.openWalletURLAction) private var openWalletURL
+  
+  init(
+    cryptoStore: CryptoStore,
+    keyringStore: KeyringStore,
+    token: BraveWallet.ERCToken
+  ) {
+    self.cryptoStore = cryptoStore
+    self.keyringStore = keyringStore
+    self.networkStore = cryptoStore.networkStore
+    self.assetDetailStore = cryptoStore.assetDetailStore(for: token)
+  }
 
   var body: some View {
     List {
@@ -132,6 +145,9 @@ struct AssetDetailView: View {
       }
       .navigationViewStyle(StackNavigationViewStyle())
     }
+    .onDisappear {
+      cryptoStore.closeAssetDetailStore(for: assetDetailStore.token)
+    }
   }
 }
 
@@ -140,9 +156,9 @@ struct CurrencyDetailView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
       AssetDetailView(
-        assetDetailStore: .previewStore,
+        cryptoStore: .previewStore,
         keyringStore: .previewStore,
-        networkStore: .previewStore
+        token: TestTokenRegistry.testTokens.first!
       )
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -9,26 +9,14 @@ import BraveCore
 import Shared
 
 struct BuyTokenView: View {
-  private var cryptoStore: CryptoStore
-  
-  @ObservedObject private var keyringStore: KeyringStore
-  @ObservedObject private var networkStore: NetworkStore
-  @ObservedObject private var buyTokenStore: BuyTokenStore
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var networkStore: NetworkStore
+  @ObservedObject var buyTokenStore: BuyTokenStore
   
   @State private var amountInput = ""
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
-  
-  init(
-    cryptoStore: CryptoStore,
-    keyringStore: KeyringStore
-  ) {
-    self.cryptoStore = cryptoStore
-    self.keyringStore = keyringStore
-    self.networkStore = cryptoStore.networkStore
-    self.buyTokenStore = cryptoStore.openBuyTokenStore()
-  }
   
   var body: some View {
     NavigationView {
@@ -138,9 +126,6 @@ struct BuyTokenView: View {
       .onAppear {
         buyTokenStore.fetchBuyTokens()
       }
-      .onDisappear {
-        cryptoStore.closeBuyTokenStore()
-      }
     }
   }
 }
@@ -149,8 +134,9 @@ struct BuyTokenView: View {
 struct BuyTokenView_Previews: PreviewProvider {
     static var previews: some View {
       BuyTokenView(
-        cryptoStore: .previewStore,
-        keyringStore: .previewStoreWithWalletCreated
+        keyringStore: .previewStore,
+        networkStore: .previewStore,
+        buyTokenStore: .previewStore
       )
         .previewColorSchemes()
     }

--- a/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -9,13 +9,26 @@ import BraveCore
 import Shared
 
 struct BuyTokenView: View {
-  @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var networkStore: NetworkStore
-  @ObservedObject var buyTokenStore: BuyTokenStore
+  private var cryptoStore: CryptoStore
+  
+  @ObservedObject private var keyringStore: KeyringStore
+  @ObservedObject private var networkStore: NetworkStore
+  @ObservedObject private var buyTokenStore: BuyTokenStore
+  
   @State private var amountInput = ""
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
+  
+  init(
+    cryptoStore: CryptoStore,
+    keyringStore: KeyringStore
+  ) {
+    self.cryptoStore = cryptoStore
+    self.keyringStore = keyringStore
+    self.networkStore = cryptoStore.networkStore
+    self.buyTokenStore = cryptoStore.openBuyTokenStore()
+  }
   
   var body: some View {
     NavigationView {
@@ -125,6 +138,9 @@ struct BuyTokenView: View {
       .onAppear {
         buyTokenStore.fetchBuyTokens()
       }
+      .onDisappear {
+        cryptoStore.closeBuyTokenStore()
+      }
     }
   }
 }
@@ -133,9 +149,8 @@ struct BuyTokenView: View {
 struct BuyTokenView_Previews: PreviewProvider {
     static var previews: some View {
       BuyTokenView(
-        keyringStore: .previewStoreWithWalletCreated,
-        networkStore: .previewStore,
-        buyTokenStore: .previewStore
+        cryptoStore: .previewStore,
+        keyringStore: .previewStoreWithWalletCreated
       )
         .previewColorSchemes()
     }

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -7,11 +7,14 @@ import SwiftUI
 import struct Shared.Strings
 import BraveUI
 import BigNumber
+import MapKit
 
 struct SendTokenView: View {
-  @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var networkStore: NetworkStore
-  @ObservedObject var sendTokenStore: SendTokenStore
+  private var cryptoStore: CryptoStore
+  
+  @ObservedObject private var keyringStore: KeyringStore
+  @ObservedObject private var networkStore: NetworkStore
+  @ObservedObject private var sendTokenStore: SendTokenStore
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   
@@ -21,6 +24,16 @@ struct SendTokenView: View {
   @State private var isShowingError = false
   
   @ScaledMetric private var length: CGFloat = 16.0
+  
+  init(
+    cryptoStore: CryptoStore,
+    keyringStore: KeyringStore
+  ) {
+    self.cryptoStore = cryptoStore
+    self.keyringStore = keyringStore
+    self.networkStore = cryptoStore.networkStore
+    self.sendTokenStore = cryptoStore.openSendTokenStore()
+  }
   
   private var isSendDisabled: Bool {
     guard let sendAmount = BDouble(amountInput),
@@ -167,6 +180,9 @@ struct SendTokenView: View {
     .onAppear {
       sendTokenStore.fetchAssets()
     }
+    .onDisappear {
+      cryptoStore.closeSendTokenStore()
+    }
   }
 }
 
@@ -174,9 +190,8 @@ struct SendTokenView: View {
 struct SendTokenView_Previews: PreviewProvider {
     static var previews: some View {
       SendTokenView(
-        keyringStore: .previewStoreWithWalletCreated,
-        networkStore: .previewStore,
-        sendTokenStore: .previewStore
+        cryptoStore: .previewStore,
+        keyringStore: .previewStore
       )
         .previewColorSchemes()
     }

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -7,14 +7,11 @@ import SwiftUI
 import struct Shared.Strings
 import BraveUI
 import BigNumber
-import MapKit
 
 struct SendTokenView: View {
-  private var cryptoStore: CryptoStore
-  
-  @ObservedObject private var keyringStore: KeyringStore
-  @ObservedObject private var networkStore: NetworkStore
-  @ObservedObject private var sendTokenStore: SendTokenStore
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var networkStore: NetworkStore
+  @ObservedObject var sendTokenStore: SendTokenStore
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   
@@ -24,16 +21,6 @@ struct SendTokenView: View {
   @State private var isShowingError = false
   
   @ScaledMetric private var length: CGFloat = 16.0
-  
-  init(
-    cryptoStore: CryptoStore,
-    keyringStore: KeyringStore
-  ) {
-    self.cryptoStore = cryptoStore
-    self.keyringStore = keyringStore
-    self.networkStore = cryptoStore.networkStore
-    self.sendTokenStore = cryptoStore.openSendTokenStore()
-  }
   
   private var isSendDisabled: Bool {
     guard let sendAmount = BDouble(amountInput),
@@ -180,9 +167,6 @@ struct SendTokenView: View {
     .onAppear {
       sendTokenStore.fetchAssets()
     }
-    .onDisappear {
-      cryptoStore.closeSendTokenStore()
-    }
   }
 }
 
@@ -190,8 +174,9 @@ struct SendTokenView: View {
 struct SendTokenView_Previews: PreviewProvider {
     static var previews: some View {
       SendTokenView(
-        cryptoStore: .previewStore,
-        keyringStore: .previewStore
+        keyringStore: .previewStore,
+        networkStore: .previewStore,
+        sendTokenStore: .previewStore
       )
         .previewColorSchemes()
     }

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -162,11 +162,9 @@ struct MarketPriceView: View {
 }
 
 struct SwapCryptoView: View {
-  private var cryptoStore: CryptoStore
-  
-  @ObservedObject private var keyringStore: KeyringStore
-  @ObservedObject private var ethNetworkStore: NetworkStore
-  @ObservedObject private var swapTokensStore: SwapTokenStore
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var ethNetworkStore: NetworkStore
+  @ObservedObject var swapTokensStore: SwapTokenStore
   
   @State private var orderType: OrderType = .market
   @State var hideSlippage = true
@@ -174,16 +172,6 @@ struct SwapCryptoView: View {
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
-  
-  init(
-    cryptoStore: CryptoStore,
-    keyringStore: KeyringStore
-  ) {
-    self.cryptoStore = cryptoStore
-    self.keyringStore = keyringStore
-    self.ethNetworkStore = cryptoStore.networkStore
-    self.swapTokensStore = cryptoStore.openSwapTokenStore()
-  }
   
   @ViewBuilder var unsupportedSwapChainSection: some View {
     Section {
@@ -471,9 +459,6 @@ struct SwapCryptoView: View {
       .onAppear {
         swapTokensStore.prepare(with: keyringStore.selectedAccount)
       }
-      .onDisappear {
-        cryptoStore.closeSwapTokenStore()
-      }
     }
   }
 }
@@ -482,8 +467,9 @@ struct SwapCryptoView: View {
 struct SwapCryptoView_Previews: PreviewProvider {
   static var previews: some View {
     SwapCryptoView(
-      cryptoStore: .previewStore,
-      keyringStore: .previewStoreWithWalletCreated
+      keyringStore: .previewStore,
+      ethNetworkStore: .previewStore,
+      swapTokensStore: .previewStore
     )
 //      .previewSizeCategories([.large, .accessibilityLarge])
   }

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -162,9 +162,11 @@ struct MarketPriceView: View {
 }
 
 struct SwapCryptoView: View {
-  @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var ethNetworkStore: NetworkStore
-  @ObservedObject var swapTokensStore: SwapTokenStore
+  private var cryptoStore: CryptoStore
+  
+  @ObservedObject private var keyringStore: KeyringStore
+  @ObservedObject private var ethNetworkStore: NetworkStore
+  @ObservedObject private var swapTokensStore: SwapTokenStore
   
   @State private var orderType: OrderType = .market
   @State var hideSlippage = true
@@ -172,6 +174,16 @@ struct SwapCryptoView: View {
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
+  
+  init(
+    cryptoStore: CryptoStore,
+    keyringStore: KeyringStore
+  ) {
+    self.cryptoStore = cryptoStore
+    self.keyringStore = keyringStore
+    self.ethNetworkStore = cryptoStore.networkStore
+    self.swapTokensStore = cryptoStore.openSwapTokenStore()
+  }
   
   @ViewBuilder var unsupportedSwapChainSection: some View {
     Section {
@@ -459,6 +471,9 @@ struct SwapCryptoView: View {
       .onAppear {
         swapTokensStore.prepare(with: keyringStore.selectedAccount)
       }
+      .onDisappear {
+        cryptoStore.closeSwapTokenStore()
+      }
     }
   }
 }
@@ -467,9 +482,8 @@ struct SwapCryptoView: View {
 struct SwapCryptoView_Previews: PreviewProvider {
   static var previews: some View {
     SwapCryptoView(
-      keyringStore: .previewStoreWithWalletCreated,
-      ethNetworkStore: .previewStore,
-      swapTokensStore: .previewStore
+      cryptoStore: .previewStore,
+      keyringStore: .previewStoreWithWalletCreated
     )
 //      .previewSizeCategories([.large, .accessibilityLarge])
   }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -114,21 +114,18 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
           switch action {
           case .buy:
             BuyTokenView(
-              keyringStore: keyringStore,
-              networkStore: cryptoStore.networkStore,
-              buyTokenStore: cryptoStore.buyTokenStore
+              cryptoStore: cryptoStore,
+              keyringStore: keyringStore
             )
           case .send:
             SendTokenView(
-              keyringStore: keyringStore,
-              networkStore: cryptoStore.networkStore,
-              sendTokenStore: cryptoStore.sendTokenStore
+              cryptoStore: cryptoStore,
+              keyringStore: keyringStore
             )
           case .swap:
             SwapCryptoView(
-              keyringStore: keyringStore,
-              ethNetworkStore: cryptoStore.networkStore,
-              swapTokensStore: cryptoStore.swapTokenStore
+              cryptoStore: cryptoStore,
+              keyringStore: keyringStore
             )
           }
         }
@@ -138,9 +135,7 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
         .sheet(isPresented: $cryptoStore.isPresentingTransactionConfirmations) {
           if !cryptoStore.unapprovedTransactions.isEmpty {
             TransactionConfirmationView(
-              transactions: cryptoStore.unapprovedTransactions,
-              confirmationStore: cryptoStore.confirmationStore,
-              networkStore: cryptoStore.networkStore,
+              cryptoStore: cryptoStore,
               keyringStore: keyringStore
             )
           }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -114,18 +114,21 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
           switch action {
           case .buy:
             BuyTokenView(
-              cryptoStore: cryptoStore,
-              keyringStore: keyringStore
+              keyringStore: keyringStore,
+              networkStore: cryptoStore.networkStore,
+              buyTokenStore: cryptoStore.openBuyTokenStore()
             )
           case .send:
             SendTokenView(
-              cryptoStore: cryptoStore,
-              keyringStore: keyringStore
+              keyringStore: keyringStore,
+              networkStore: cryptoStore.networkStore,
+              sendTokenStore: cryptoStore.openSendTokenStore()
             )
           case .swap:
             SwapCryptoView(
-              cryptoStore: cryptoStore,
-              keyringStore: keyringStore
+              keyringStore: keyringStore,
+              ethNetworkStore: cryptoStore.networkStore,
+              swapTokensStore: cryptoStore.openSwapTokenStore()
             )
           }
         }
@@ -135,7 +138,9 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
         .sheet(isPresented: $cryptoStore.isPresentingTransactionConfirmations) {
           if !cryptoStore.unapprovedTransactions.isEmpty {
             TransactionConfirmationView(
-              cryptoStore: cryptoStore,
+              transactions: cryptoStore.unapprovedTransactions,
+              confirmationStore: cryptoStore.openConfirmationStore(),
+              networkStore: cryptoStore.networkStore,
               keyringStore: keyringStore
             )
           }

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -107,9 +107,9 @@ struct PortfolioView: View {
       ), destination: {
         if let token = selectedToken {
           AssetDetailView(
-            assetDetailStore: cryptoStore.assetDetailStore(for: token),
+            cryptoStore: cryptoStore,
             keyringStore: keyringStore,
-            networkStore: networkStore
+            token: token
           )
         }
       }, label: {

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -107,10 +107,13 @@ struct PortfolioView: View {
       ), destination: {
         if let token = selectedToken {
           AssetDetailView(
-            cryptoStore: cryptoStore,
+            assetDetailStore: cryptoStore.assetDetailStore(for: token),
             keyringStore: keyringStore,
-            token: token
+            networkStore: cryptoStore.networkStore
           )
+            .onDisappear {
+              cryptoStore.closeAssetDetailStore(for: token)
+            }
         }
       }, label: {
         EmptyView()

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -21,9 +21,9 @@ struct AssetSearchView: View {
       TokenList(tokens: allTokens.filter({ $0.isErc20 || $0.isETH })) { token in
         NavigationLink(
           destination: AssetDetailView(
-            assetDetailStore: cryptoStore.assetDetailStore(for: token),
+            cryptoStore: cryptoStore,
             keyringStore: keyringStore,
-            networkStore: cryptoStore.networkStore
+            token: token
           )
         ) {
           TokenView(token: token)

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -21,10 +21,13 @@ struct AssetSearchView: View {
       TokenList(tokens: allTokens.filter({ $0.isErc20 || $0.isETH })) { token in
         NavigationLink(
           destination: AssetDetailView(
-            cryptoStore: cryptoStore,
+            assetDetailStore: cryptoStore.assetDetailStore(for: token),
             keyringStore: keyringStore,
-            token: token
+            networkStore: cryptoStore.networkStore
           )
+            .onDisappear {
+              cryptoStore.closeAssetDetailStore(for: token)
+            }
         ) {
           TokenView(token: token)
         }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -9,8 +9,35 @@ public class CryptoStore: ObservableObject {
   public let networkStore: NetworkStore
   public let portfolioStore: PortfolioStore
   
-  @Published var buySendSwapDestination: BuySendSwapDestination?
-  @Published var isPresentingTransactionConfirmations: Bool = false
+  @Published var buySendSwapDestination: BuySendSwapDestination? {
+    didSet {
+      if buySendSwapDestination == nil {
+        switch oldValue {
+        case .buy:
+          if buyTokenStore != nil {
+            buyTokenStore = nil
+          }
+        case .send:
+          if sendTokenStore != nil {
+            sendTokenStore = nil
+          }
+        case .swap:
+          if swapTokenStore != nil {
+            sendTokenStore = nil
+          }
+        case .none:
+          break
+        }
+      }
+    }
+  }
+  @Published var isPresentingTransactionConfirmations: Bool = false {
+    didSet {
+      if !isPresentingTransactionConfirmations, confirmationStore != nil {
+        confirmationStore = nil
+      }
+    }
+  }
   @Published private(set) var unapprovedTransactions: [BraveWallet.TransactionInfo] = []
   
   private let keyringController: BraveWalletKeyringController
@@ -64,12 +91,6 @@ public class CryptoStore: ObservableObject {
     return store
   }
   
-  func closeBuyTokenStore() {
-    if buySendSwapDestination == nil, buyTokenStore != nil {
-      buyTokenStore = nil
-    }
-  }
-  
   private var sendTokenStore: SendTokenStore?
   func openSendTokenStore() -> SendTokenStore {
     if let store = sendTokenStore {
@@ -83,12 +104,6 @@ public class CryptoStore: ObservableObject {
     )
     sendTokenStore = store
     return store
-  }
-  
-  func closeSendTokenStore() {
-    if buySendSwapDestination == nil, sendTokenStore != nil {
-      sendTokenStore = nil
-    }
   }
   
   private var swapTokenStore: SwapTokenStore?
@@ -106,12 +121,6 @@ public class CryptoStore: ObservableObject {
     )
     swapTokenStore = store
     return store
-  }
-  
-  func closeSwapTokenStore() {
-    if buySendSwapDestination == nil, swapTokenStore != nil {
-      swapTokenStore = nil
-    }
   }
   
   private var assetDetailStore: AssetDetailStore?
@@ -171,12 +180,6 @@ public class CryptoStore: ObservableObject {
     )
     confirmationStore = store
     return store
-  }
-  
-  func closeConfirmationStore() {
-    if !isPresentingTransactionConfirmations, confirmationStore != nil {
-      confirmationStore = nil
-    }
   }
   
   func fetchUnapprovedTransactions() {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -12,28 +12,15 @@ public class CryptoStore: ObservableObject {
   @Published var buySendSwapDestination: BuySendSwapDestination? {
     didSet {
       if buySendSwapDestination == nil {
-        switch oldValue {
-        case .buy:
-          if buyTokenStore != nil {
-            buyTokenStore = nil
-          }
-        case .send:
-          if sendTokenStore != nil {
-            sendTokenStore = nil
-          }
-        case .swap:
-          if swapTokenStore != nil {
-            sendTokenStore = nil
-          }
-        case .none:
-          break
-        }
+        buyTokenStore = nil
+        sendTokenStore = nil
+        swapTokenStore = nil
       }
     }
   }
   @Published var isPresentingTransactionConfirmations: Bool = false {
     didSet {
-      if !isPresentingTransactionConfirmations, confirmationStore != nil {
+      if !isPresentingTransactionConfirmations {
         confirmationStore = nil
       }
     }

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -10,8 +10,7 @@ import struct Shared.Strings
 import BigNumber
 
 struct TransactionConfirmationView: View {
-  private let cryptoStore: CryptoStore
-  private var transactions: [BraveWallet.TransactionInfo]
+  var transactions: [BraveWallet.TransactionInfo]
   
   @ObservedObject var confirmationStore: TransactionConfirmationStore
   @ObservedObject var networkStore: NetworkStore
@@ -30,17 +29,6 @@ struct TransactionConfirmationView: View {
     didSet {
       confirmationStore.fetchDetails(for: activeTransaction)
     }
-  }
-  
-  init(
-    cryptoStore: CryptoStore,
-    keyringStore: KeyringStore
-  ) {
-    self.cryptoStore = cryptoStore
-    self.keyringStore = keyringStore
-    self.confirmationStore = cryptoStore.openConfirmationStore()
-    self.networkStore = cryptoStore.networkStore
-    self.transactions = cryptoStore.unapprovedTransactions
   }
   
   private func next() {
@@ -317,9 +305,6 @@ struct TransactionConfirmationView: View {
       activeTransactionId = transactions[0].id
       confirmationStore.fetchDetails(for: activeTransaction)
     }
-    .onDisappear {
-      cryptoStore.closeConfirmationStore()
-    }
   }
   
   @ViewBuilder private var rejectConfirmContainer: some View {
@@ -380,7 +365,17 @@ private struct DetailsTextView: UIViewRepresentable {
 struct TransactionConfirmationView_Previews: PreviewProvider {
   static var previews: some View {
     TransactionConfirmationView(
-      cryptoStore: .previewStore,
+      transactions: [
+        BraveWallet.TransactionInfo.previewConfirmedERC20Approve,
+        .previewConfirmedSend,
+        .previewConfirmedSwap
+      ].map {
+        tx in
+        tx.txStatus = .unapproved
+        return tx
+      },
+      confirmationStore: .previewStore,
+      networkStore: .previewStore,
       keyringStore: .previewStoreWithWalletCreated
     )
       .previewLayout(.sizeThatFits)


### PR DESCRIPTION
## Summary of Changes
Destroy store when associated view is out of the view hierarchy. 

This pull request fixes #4504 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
