### PR TITLE
Fix #4619: NTP onboarding showing when it shouldn't (on websites).

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2831,6 +2831,7 @@ extension BrowserViewController: NewTabPageDelegate {
         if Preferences.General.isNewRetentionUser.value == true,
             Preferences.DebugFlag.skipNTPCallouts != true,
             !topToolbar.inOverlayMode,
+            topToolbar.currentURL == nil,
             !Preferences.FullScreenCallout.ntpCalloutCompleted.value {
             presentNTPStatsOnboarding()
         }

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
@@ -86,6 +86,7 @@ extension BrowserViewController {
               !Preferences.General.onboardingAdblockPopoverShown.value,
               !benchmarkNotificationPresented,
               !Preferences.AppState.backgroundedCleanly.value,
+              Preferences.General.isNewRetentionUser.value == true,
               !topToolbar.inOverlayMode,
               !isTabTrayActive,
               selectedTab.webView?.scrollView.isDragging == false,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- NTP onboarding showing when it shouldn't (on websites).
- Re-added the fix from: https://github.com/brave/brave-ios/pull/4543/files
- This was a regression possibly in a rebase or something

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4619

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
