### PR TITLE
Fix #4613: Make private key and recovery phrase copy to clipboard secure

### DIFF
--- a/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
@@ -39,7 +39,7 @@ struct AccountPrivateKeyView: View {
             .blur(radius: isKeyVisible ? 0 : 5)
             .accessibilityHidden(!isKeyVisible)
           Button(action: {
-            UIPasteboard.general.string = key
+            UIPasteboard.general.setSecureString(key)
           }) {
             Text("\(Strings.Wallet.copyToPasteboard) \(Image("brave.clipboard"))")
               .font(.subheadline)

--- a/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -39,7 +39,9 @@ struct BackupRecoveryPhraseView: View {
   }
   
   private func copyRecoveryPhrase() {
-    UIPasteboard.general.string = recoveryWords.map(\.value).joined(separator: " ")
+    UIPasteboard.general.setSecureString(
+      recoveryWords.map(\.value).joined(separator: " ")
+    )
   }
   
   var body: some View {

--- a/BraveWallet/Extensions/UIPasteboardExtensions.swift
+++ b/BraveWallet/Extensions/UIPasteboardExtensions.swift
@@ -1,0 +1,26 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import CoreServices
+
+extension UIPasteboard {
+  /// Copies a string into the pasteboard that is excluded from Handoff and expires at a certain date
+  ///
+  /// Defaults to expiring a secure string after 60s
+  func setSecureString(
+    _ string: String,
+    expirationDate: Date = Date().addingTimeInterval(60)
+  ) {
+    setItems(
+      [[kUTTypeUTF8PlainText as String: string]],
+      options: [
+        .localOnly: true,
+        .expirationDate: expirationDate
+      ]
+    )
+  }
+}

--- a/BraveWalletTests/PasteboardTests.swift
+++ b/BraveWalletTests/PasteboardTests.swift
@@ -1,0 +1,25 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import BraveWallet
+
+class PasteboardTests: XCTestCase {
+    func testExpiringSecureString() {
+        let expectation = expectation(description: "pasteboard-expiration")
+        let pasteboard = UIPasteboard.withUniqueName()
+        let data = "test"
+        pasteboard.setSecureString(data, expirationDate: Date().addingTimeInterval(0.5))
+        XCTAssertEqual(pasteboard.string, data)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            defer { expectation.fulfill() }
+            // After expiration the string should be nil
+            XCTAssertNil(pasteboard.string)
+        }
+        waitForExpectations(timeout: 3) { error in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -416,6 +416,8 @@
 		278C6FFF24F6EA3700A246C8 /* ReportBrokenSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C6FFE24F6EA3700A246C8 /* ReportBrokenSiteView.swift */; };
 		278C700224F6F33E00A246C8 /* SiteReportedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C700124F6F33D00A246C8 /* SiteReportedView.swift */; };
 		278C700A24F96D7000A246C8 /* BraveShieldsAndPrivacySettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C700924F96D7000A246C8 /* BraveShieldsAndPrivacySettingsController.swift */; };
+		2792CBC8275951B10055151E /* UIPasteboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2792CBC7275951B10055151E /* UIPasteboardExtensions.swift */; };
+		2792CBD5275952C40055151E /* PasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2792CBD4275952C40055151E /* PasteboardTests.swift */; };
 		2795274A21A890EB00921AA1 /* FingerprintingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */; };
 		27953F7423F5B04500B4B595 /* ViewLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27953F7323F5B04500B4B595 /* ViewLabel.swift */; };
 		27953F7723F5DF5D00B4B595 /* AboutShieldsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27953F7623F5DF5D00B4B595 /* AboutShieldsViewController.swift */; };
@@ -2153,6 +2155,8 @@
 		278C6FFE24F6EA3700A246C8 /* ReportBrokenSiteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportBrokenSiteView.swift; sourceTree = "<group>"; };
 		278C700124F6F33D00A246C8 /* SiteReportedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteReportedView.swift; sourceTree = "<group>"; };
 		278C700924F96D7000A246C8 /* BraveShieldsAndPrivacySettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveShieldsAndPrivacySettingsController.swift; sourceTree = "<group>"; };
+		2792CBC7275951B10055151E /* UIPasteboardExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPasteboardExtensions.swift; sourceTree = "<group>"; };
+		2792CBD4275952C40055151E /* PasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardTests.swift; sourceTree = "<group>"; };
 		2795274921A890EB00921AA1 /* FingerprintingProtectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintingProtectionTests.swift; sourceTree = "<group>"; };
 		27953F7323F5B04500B4B595 /* ViewLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLabel.swift; sourceTree = "<group>"; };
 		27953F7623F5DF5D00B4B595 /* AboutShieldsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutShieldsViewController.swift; sourceTree = "<group>"; };
@@ -3764,6 +3768,7 @@
 				275C6FB32731D1A500AB2FC7 /* RpcControllerExtensions.swift */,
 				277430092733126000183725 /* WalletColors.swift */,
 				7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */,
+				2792CBC7275951B10055151E /* UIPasteboardExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4144,6 +4149,7 @@
 				277309E72721DF6D007643F6 /* WeiFormatterTests.swift */,
 				27EA1B0D2729E6C8003C5CF9 /* AddressTests.swift */,
 				7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */,
+				2792CBD4275952C40055151E /* PasteboardTests.swift */,
 			);
 			path = BraveWalletTests;
 			sourceTree = "<group>";
@@ -7909,6 +7915,7 @@
 				271F689726EBD27E00AA2A50 /* CryptoPagesView.swift in Sources */,
 				7D758915271A17AF00B643C3 /* BuyTokenStore.swift in Sources */,
 				271F68B326EBD27E00AA2A50 /* RecoveryPhraseGrid.swift in Sources */,
+				2792CBC8275951B10055151E /* UIPasteboardExtensions.swift in Sources */,
 				271F689D26EBD27E00AA2A50 /* AssetSearchView.swift in Sources */,
 				277309DE2721DDFB007643F6 /* WeiFormatter.swift in Sources */,
 				271F689926EBD27E00AA2A50 /* Address.swift in Sources */,
@@ -7935,6 +7942,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2792CBD5275952C40055151E /* PasteboardTests.swift in Sources */,
 				27EA1B0E2729E6C8003C5CF9 /* AddressTests.swift in Sources */,
 				7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */,
 				277309E82721DF6D007643F6 /* WeiFormatterTests.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4613

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
