### PR TITLE
Fix #4625: Sometimes CoreData crashes [Threading issue suspected]

### DIFF
--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -168,14 +168,20 @@ extension PlaylistCarplayManager: CPSessionConfigurationDelegate {
         carplaySessionConfiguration = CPSessionConfiguration(delegate: self)
         
         isCarPlayAvailable = true
-        attemptInterfaceConnection(isCarPlayAvailable: true)
+        
+        DispatchQueue.main.async {
+            self.attemptInterfaceConnection(isCarPlayAvailable: true)
+        }
     }
     
     func disconnect(interfaceController: CPInterfaceController) {
         isCarPlayAvailable = false
         carplayInterface = nil
         carplayInterface?.delegate = nil
-        attemptInterfaceConnection(isCarPlayAvailable: false)
+        
+        DispatchQueue.main.async {
+            self.attemptInterfaceConnection(isCarPlayAvailable: false)
+        }
     }
     
     func sessionConfiguration(_ sessionConfiguration: CPSessionConfiguration,


### PR DESCRIPTION
## Summary of Changes
- No idea if this fixes it, but it seems very very likely that CoreData is crashing if initialized from a different thread.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4625

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
