### PR TITLE
Fix #4627: Update copy for X shields blocked popup.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1181,7 +1181,7 @@ extension Strings {
         public static let trackerCountShareTitle =
             NSLocalizedString("shieldEducation.trackerCountShareTitle",
                               bundle: .braveShared,
-                              value: "%ld trackers & ads blocked",
+                              value: "%ld trackers & ads blocked!",
                               comment: "Title for Shield Education Tracker Count Share. The parameter substituted for \"%ld\" is the count of the trackers and ads blocked in total until present. E.g.: 5000 trackers & ads blocked")
         
         public static let videoAdBlockTitle =
@@ -1213,6 +1213,12 @@ extension Strings {
                               bundle: .braveShared,
                               value: "Share the news",
                               comment: "Action title for actionable Share warnings")
+        
+        public static let benchmarkAnyTierTitle =
+            NSLocalizedString("shieldEducation.benchmarkAnyTierTitle",
+                              bundle: .braveShared,
+                              value: "Congrats on reaching this privacy milestone.",
+                              comment: "Subtitle for tracker benchmark Share")
         
         public static let benchmarkSpecialTierTitle =
             NSLocalizedString("shieldEducation.benchmarkSpecialTierTitle",

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
@@ -27,23 +27,6 @@ extension BrowserViewController {
         case grandTier = 500_000
         case legendaryTier = 1_000_000
 
-        var title: String {
-            switch self {
-                case .specialTier:
-                    return Strings.ShieldEducation.benchmarkSpecialTierTitle
-                case .newbieExclusiveTier, .casualExclusiveTier, .regularExclusiveTier, .expertExclusiveTier:
-                    return Strings.ShieldEducation.benchmarkExclusiveTierTitle
-                case .professionalTier:
-                    return Strings.ShieldEducation.benchmarkProfessionalTierTitle
-                case .primeTier:
-                    return Strings.ShieldEducation.benchmarkPrimeTierTitle
-                case .grandTier:
-                    return Strings.ShieldEducation.benchmarkGrandTierTitle
-                case .legendaryTier:
-                    return Strings.ShieldEducation.benchmarkLegendaryTierTitle
-            }
-        }
-
         var nextTier: BenchmarkTrackerCountTier? {
             guard let indexOfSelf = Self.allCases.firstIndex(where: { self == $0 }) else {
                 return nil
@@ -164,7 +147,8 @@ extension BrowserViewController {
                 Preferences.ProductNotificationBenchmarks.trackerTierCount.value = numOfTrackerAds
                 
                 if numOfTrackerAds > firstExistingTier.value {
-                    notifyTrackerAdsCount(firstExistingTier.value, description: firstExistingTier.title)
+                    notifyTrackerAdsCount(firstExistingTier.value,
+                                          description: Strings.ShieldEducation.benchmarkAnyTierTitle)
                 }
             }
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4627 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
<img width="331" alt="Zrzut ekranu 2021-12-3 o 20 02 15" src="https://user-images.githubusercontent.com/6950387/144658443-e96fda58-a8d2-46bc-98a6-dbfa2fa0f7e1.png">




## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
