### PR TITLE
Fix #4620: Disable action button and add a spinner on top while send/swap unapproved tx is under construction. 

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -25,7 +25,8 @@ struct SendTokenView: View {
   private var isSendDisabled: Bool {
     guard let sendAmount = BDouble(amountInput),
           let balance = sendTokenStore.selectedSendTokenBalance,
-          let token = sendTokenStore.selectedSendToken else {
+          let token = sendTokenStore.selectedSendToken,
+          !sendTokenStore.isMakingTx else {
       return true
     }
     
@@ -122,7 +123,7 @@ struct SendTokenView: View {
         Section(
           header:
             WalletLoadingButton(
-              isLoading: $sendTokenStore.isMakingTx,
+              isLoading: sendTokenStore.isMakingTx,
               action: {
                 sendTokenStore.sendToken(
                   from: keyringStore.selectedAccount,
@@ -132,12 +133,12 @@ struct SendTokenView: View {
                   isShowingError = !success
                 }
               },
-              title: {
+              label: {
                 Text(Strings.Wallet.sendCryptoSendButtonTitle)
               }
             )
             .buttonStyle(BraveFilledButtonStyle(size: .normal))
-            .disabled(isSendDisabled || sendTokenStore.isMakingTx)
+            .disabled(isSendDisabled)
             .frame(maxWidth: .infinity)
             .resetListHeaderStyle()
             .listRowBackground(Color(.clear))

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -121,19 +121,23 @@ struct SendTokenView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
           header:
-            Button(action: {
-              sendTokenStore.sendToken(
-                from: keyringStore.selectedAccount,
-                to: sendAddress,
-                amount: amountInput
-              ) { success in
-                isShowingError = !success
+            WalletLoadingButton(
+              isLoading: $sendTokenStore.isMakingTx,
+              action: {
+                sendTokenStore.sendToken(
+                  from: keyringStore.selectedAccount,
+                  to: sendAddress,
+                  amount: amountInput
+                ) { success in
+                  isShowingError = !success
+                }
+              },
+              title: {
+                Text(Strings.Wallet.sendCryptoSendButtonTitle)
               }
-            }) {
-              Text(Strings.Wallet.sendCryptoSendButtonTitle)
-            }
+            )
             .buttonStyle(BraveFilledButtonStyle(size: .normal))
-            .disabled(isSendDisabled)
+            .disabled(isSendDisabled || sendTokenStore.isMakingTx)
             .frame(maxWidth: .infinity)
             .resetListHeaderStyle()
             .listRowBackground(Color(.clear))

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -376,13 +376,17 @@ struct SwapCryptoView: View {
           )
             .foregroundColor(Color(.braveLabel))
             .font(.footnote)
-          Button(action: {
-            swapTokensStore.prepareSwap()
-          }) {
-            Text(swapButtonTitle)
-          }
-          .disabled(isSwapButtonDisabled)
-          .buttonStyle(BraveFilledButtonStyle(size: .normal))
+          WalletLoadingButton(
+            isLoading: $swapTokensStore.isMakingTx,
+            action: {
+              swapTokensStore.prepareSwap()
+            },
+            title: {
+              Text(swapButtonTitle)
+            }
+          )
+            .disabled(isSwapButtonDisabled || swapTokensStore.isMakingTx)
+            .buttonStyle(BraveFilledButtonStyle(size: .normal))
         }
         .frame(maxWidth: .infinity)
         .padding(.top, 16)

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -199,6 +199,9 @@ struct SwapCryptoView: View {
   }
   
   private var isSwapButtonDisabled: Bool {
+    guard !swapTokensStore.isMakingTx else {
+      return true
+    }
     switch swapTokensStore.state {
     case .error, .idle:
       return true
@@ -377,15 +380,15 @@ struct SwapCryptoView: View {
             .foregroundColor(Color(.braveLabel))
             .font(.footnote)
           WalletLoadingButton(
-            isLoading: $swapTokensStore.isMakingTx,
+            isLoading: swapTokensStore.isMakingTx,
             action: {
               swapTokensStore.prepareSwap()
             },
-            title: {
+            label: {
               Text(swapButtonTitle)
             }
           )
-            .disabled(isSwapButtonDisabled || swapTokensStore.isMakingTx)
+            .disabled(isSwapButtonDisabled)
             .buttonStyle(BraveFilledButtonStyle(size: .normal))
         }
         .frame(maxWidth: .infinity)

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -18,6 +18,8 @@ public class SendTokenStore: ObservableObject {
   }
   /// The current selected token balance. Default with nil value.
   @Published var selectedSendTokenBalance: Double?
+  /// A boolean indicates if this store is making an unapproved tx
+  @Published var isMakingTx = false
   
   private let keyringController: BraveWalletKeyringController
   private let rpcController: BraveWalletEthJsonRpcController
@@ -150,8 +152,14 @@ public class SendTokenStore: ObservableObject {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     guard let token = selectedSendToken, let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: 18) else { return }
     
+    isMakingTx = true
     rpcController.network { [weak self] network in
-      guard let self = self else { return }
+      guard let self = self else {
+        self?.isMakingTx = false
+        return
+      }
+      defer { self.isMakingTx = false }
+
       if token.isETH {
         let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: address, value: "0x\(weiHexString)", data: .init())
         if network.isEip1559 {

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -154,10 +154,7 @@ public class SendTokenStore: ObservableObject {
     
     isMakingTx = true
     rpcController.network { [weak self] network in
-      guard let self = self else {
-        self?.isMakingTx = false
-        return
-      }
+      guard let self = self else { return }
       defer { self.isMakingTx = false }
 
       if token.isETH {

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -215,7 +215,6 @@ public class SwapTokenStore: ObservableObject {
       guard let self = self else {
         self?.state = .error(Strings.Wallet.unknownError)
         self?.clearAllAmount()
-        self?.isMakingTx = false
         return
       }
       defer { self.isMakingTx = false }

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -86,6 +86,8 @@ public class SwapTokenStore: ObservableObject {
       }
     }
   }
+  /// A boolean indicates if this store is making an unapproved tx
+  @Published var isMakingTx = false
   
   private let keyringController: BraveWalletKeyringController
   private let tokenRegistry: BraveWalletERCTokenRegistry
@@ -208,12 +210,16 @@ public class SwapTokenStore: ObservableObject {
       let swapParams = swapParameters(for: .perSellAsset)
     else { return }
     
+    isMakingTx = true
     rpcController.network { [weak self] network in
       guard let self = self else {
         self?.state = .error(Strings.Wallet.unknownError)
         self?.clearAllAmount()
+        self?.isMakingTx = false
         return
       }
+      defer { self.isMakingTx = false }
+      
       self.addingUnapprovedTx = true
       self.swapController.transactionPayload(swapParams) { success, swapResponse, error in
         defer { self.addingUnapprovedTx = false }

--- a/BraveWallet/WalletLoadingButton.swift
+++ b/BraveWallet/WalletLoadingButton.swift
@@ -1,0 +1,63 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveUI
+
+struct WalletLoadingButton<Title: View>: View {
+  @Binding var isLoading: Bool
+  var action: () -> Void
+  var title: Title
+  
+  @ScaledMetric private var length: CGFloat = 20.0
+  
+  init(
+    isLoading: Binding<Bool>,
+    action: @escaping () -> Void,
+    @ViewBuilder title: () -> Title
+  ) {
+    self._isLoading = isLoading
+    self.action = action
+    self.title = title()
+  }
+  
+  var body: some View {
+    Button {
+      if !isLoading {
+        action()
+      }
+    } label: {
+      ZStack {
+        title
+        Circle()
+          .trim(from: 0, to: 0.7)
+          .stroke(.white, lineWidth: 2)
+          .frame(width: length, height: length)
+          .rotationEffect(.degrees(isLoading ? 360 : 0))
+          .animation(.linear(duration: 0.5).repeatForever(autoreverses: false), value: isLoading)
+          .opacity(isLoading ? 1 : 0)
+      }
+    }
+  }
+}
+
+#if DEBUG
+struct WalletLoadingButton_Previews: PreviewProvider {
+  static var previews: some View {
+    WalletLoadingButton(
+      isLoading: .constant(true),
+      action: {
+      // preview
+      },
+      title: {
+        Text("Preview")
+      }
+    )
+      .buttonStyle(BraveFilledButtonStyle(size: .normal))
+      .disabled(true)
+      .frame(maxWidth: .infinity)
+  }
+}
+#endif

--- a/BraveWallet/WalletLoadingButton.swift
+++ b/BraveWallet/WalletLoadingButton.swift
@@ -6,21 +6,19 @@
 import SwiftUI
 import BraveUI
 
-struct WalletLoadingButton<Title: View>: View {
-  @Binding var isLoading: Bool
+struct WalletLoadingButton<Label: View>: View {
+  var isLoading: Bool
   var action: () -> Void
-  var title: Title
-  
-  @ScaledMetric private var length: CGFloat = 20.0
+  var label: Label
   
   init(
-    isLoading: Binding<Bool>,
+    isLoading: Bool,
     action: @escaping () -> Void,
-    @ViewBuilder title: () -> Title
+    @ViewBuilder label: () -> Label
   ) {
-    self._isLoading = isLoading
+    self.isLoading = isLoading
     self.action = action
-    self.title = title()
+    self.label = label()
   }
   
   var body: some View {
@@ -30,13 +28,9 @@ struct WalletLoadingButton<Title: View>: View {
       }
     } label: {
       ZStack {
-        title
-        Circle()
-          .trim(from: 0, to: 0.7)
-          .stroke(.white, lineWidth: 2)
-          .frame(width: length, height: length)
-          .rotationEffect(.degrees(isLoading ? 360 : 0))
-          .animation(.linear(duration: 0.5).repeatForever(autoreverses: false), value: isLoading)
+        label
+          .opacity(isLoading ? 0 : 1)
+        ProgressView()
           .opacity(isLoading ? 1 : 0)
       }
     }
@@ -46,18 +40,32 @@ struct WalletLoadingButton<Title: View>: View {
 #if DEBUG
 struct WalletLoadingButton_Previews: PreviewProvider {
   static var previews: some View {
-    WalletLoadingButton(
-      isLoading: .constant(true),
-      action: {
-      // preview
-      },
-      title: {
-        Text("Preview")
-      }
-    )
-      .buttonStyle(BraveFilledButtonStyle(size: .normal))
-      .disabled(true)
-      .frame(maxWidth: .infinity)
+    Group {
+      WalletLoadingButton(
+        isLoading: true,
+        action: {
+        // preview
+        },
+        label: {
+          Text("Preview")
+        }
+      )
+        .buttonStyle(BraveFilledButtonStyle(size: .normal))
+        .disabled(true)
+        .frame(maxWidth: .infinity)
+      WalletLoadingButton(
+        isLoading: false,
+        action: {
+        // preview
+        },
+        label: {
+          Text("Preview")
+        }
+      )
+        .buttonStyle(BraveFilledButtonStyle(size: .normal))
+        .disabled(false)
+        .frame(maxWidth: .infinity)
+    }
   }
 }
 #endif

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -948,6 +948,7 @@
 		7DC52B12273D99E70067E237 /* WalletArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */; };
 		7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */; };
 		7DCA34D427555E96001B0555 /* CryptoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA34D327555E96001B0555 /* CryptoStore.swift */; };
+		7DF9113D275AC86100EF0D8B /* WalletLoadingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9113C275AC86100EF0D8B /* WalletLoadingButton.swift */; };
 		A104E199210A384400D2323E /* ShieldsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A104E198210A384400D2323E /* ShieldsViewController.swift */; };
 		A134B88A20DA98BB00A581D0 /* ClientPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A134B88920DA98BB00A581D0 /* ClientPreferences.swift */; };
 		A13AC72520EC12360040D4BB /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13AC72420EC12360040D4BB /* Migration.swift */; };
@@ -2882,6 +2883,7 @@
 		7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtension.swift; sourceTree = "<group>"; };
 		7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtensionTests.swift; sourceTree = "<group>"; };
 		7DCA34D327555E96001B0555 /* CryptoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoStore.swift; sourceTree = "<group>"; };
+		7DF9113C275AC86100EF0D8B /* WalletLoadingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLoadingButton.swift; sourceTree = "<group>"; };
 		A104E198210A384400D2323E /* ShieldsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsViewController.swift; sourceTree = "<group>"; };
 		A134B88920DA98BB00A581D0 /* ClientPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPreferences.swift; sourceTree = "<group>"; };
 		A13AC72420EC12360040D4BB /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
@@ -3801,6 +3803,7 @@
 				275034D626EF9E5D00CF4C8A /* Settings */,
 				270E5F2526F3E1A50024C70E /* Extensions */,
 				271F685026EBD27C00AA2A50 /* Preview Content */,
+				7DF9113C275AC86100EF0D8B /* WalletLoadingButton.swift */,
 				271F689026EBD27E00AA2A50 /* SwapButton.swift */,
 				271F688026EBD27D00AA2A50 /* TabbedPageViewController.swift */,
 				271F688E26EBD27D00AA2A50 /* WalletTableViewHeaderView.swift */,
@@ -7914,6 +7917,7 @@
 				2774303227332C2F00183725 /* TransactionConfirmationView.swift in Sources */,
 				271F689726EBD27E00AA2A50 /* CryptoPagesView.swift in Sources */,
 				7D758915271A17AF00B643C3 /* BuyTokenStore.swift in Sources */,
+				7DF9113D275AC86100EF0D8B /* WalletLoadingButton.swift in Sources */,
 				271F68B326EBD27E00AA2A50 /* RecoveryPhraseGrid.swift in Sources */,
 				2792CBC8275951B10055151E /* UIPasteboardExtensions.swift in Sources */,
 				271F689D26EBD27E00AA2A50 /* AssetSearchView.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes
Created a new button that will have a spinner spinning and disabled when its loading. 

This pull request fixes #4620 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
