### PR TITLE
Fix #4635, #4638 - Fixed Onboarding popovers not showing due to conflicts

### DIFF
--- a/BraveUI/Popover/PopoverController.swift
+++ b/BraveUI/Popover/PopoverController.swift
@@ -286,7 +286,7 @@ public class PopoverController: UIViewController {
     ///
     /// - parameter view: The view to have the popover present from (scaling from the location of this view)
     /// - parameter viewController: The view controller to present this popover on
-    public func present(from view: UIView, on viewController: UIViewController, _ completion: (() -> Void)? = nil) {
+    public func present(from view: UIView, on viewController: UIViewController) {
         let convertedOriginViewCenter = viewController.view.convert(view.center, from: view.superview)
         
         switch arrowDirectionBehavior {
@@ -332,7 +332,7 @@ public class PopoverController: UIViewController {
             presentedSize: contentSize
         )
         
-        viewController.present(self, animated: true, completion: completion)
+        viewController.present(self, animated: true)
     }
     
     override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/BraveUI/Popover/PopoverController.swift
+++ b/BraveUI/Popover/PopoverController.swift
@@ -286,7 +286,7 @@ public class PopoverController: UIViewController {
     ///
     /// - parameter view: The view to have the popover present from (scaling from the location of this view)
     /// - parameter viewController: The view controller to present this popover on
-    public func present(from view: UIView, on viewController: UIViewController) {
+    public func present(from view: UIView, on viewController: UIViewController, _ completion: (() -> Void)? = nil) {
         let convertedOriginViewCenter = viewController.view.convert(view.center, from: view.superview)
         
         switch arrowDirectionBehavior {
@@ -332,7 +332,7 @@ public class PopoverController: UIViewController {
             presentedSize: contentSize
         )
         
-        viewController.present(self, animated: true)
+        viewController.present(self, animated: true, completion: completion)
     }
     
     override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -52,6 +52,12 @@ extension BrowserViewController {
     }
     
     func presentNTPStatsOnboarding() {
+        // If a controller is already presented (such as menu), do not show onboarding
+        guard presentedViewController == nil else {
+            return
+        }
+        
+        // We can only show this onboarding on the NTP
         guard let ntpController = tabManager.selectedTab?.newTabPageViewController,
             let statsFrame = ntpController.ntpStatsOnboardingFrame else {
             return

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -157,8 +157,15 @@ extension BrowserViewController {
                                from: topToolbar.locationView.shieldsButton,
                                on: popover,
                                browser: self)
-        popover.popoverDidDismiss = { _ in
+        popover.popoverDidDismiss = { [weak self] _ in
             pulseAnimation.removeFromSuperview()
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                guard let self = self else { return }
+                if self.shouldShowPlaylistOnboardingThisSession {
+                    self.showPlaylistOnboarding(tab: self.tabManager.selectedTab)
+                }
+            }
         }
     }
     

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -168,6 +168,7 @@ extension BrowserViewController {
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 guard let self = self else { return }
+                
                 if self.shouldShowPlaylistOnboardingThisSession {
                     self.showPlaylistOnboarding(tab: self.tabManager.selectedTab)
                 }

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
@@ -92,6 +92,8 @@ extension BrowserViewController {
                 
                 if !resources.isEmpty {
                     trackers[entity.key] = resources
+                } else {
+                    trackers[domain] = [domain]
                 }
             }
         }

--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeBraveBlockedAdsController.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeBraveBlockedAdsController.swift
@@ -13,6 +13,8 @@ import Shared
 class WelcomeBraveBlockedAdsController: UIViewController, PopoverContentComponent {
     private let label = UILabel().then {
         $0.numberOfLines = 0
+        $0.textColor = .braveLabel
+        $0.font = .preferredFont(forTextStyle: .body)
     }
     
     override func viewDidLoad() {
@@ -53,9 +55,25 @@ class WelcomeBraveBlockedAdsController: UIViewController, PopoverContentComponen
                 .font: UIFont.preferredFont(forTextStyle: .body)
             ]))
         } else {
-            let string = String(format: Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionTwo, trackerBlocked, domain)
+            let uuid = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+            let string = String(format: Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionTwo, "[\(uuid)]", domain)
+            let strings = string.separatedBy("[\(uuid)]")
+            guard strings.count == 2 else {
+                label.text = string
+                return
+            }
             
-            text.append(NSAttributedString(string: "\(string)\n\n\(Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionThree)", attributes: [
+            text.append(NSAttributedString(string: strings[0], attributes: [
+                .foregroundColor: UIColor.braveLabel,
+                .font: UIFont.preferredFont(forTextStyle: .body)
+            ]))
+            
+            text.append(NSAttributedString(string: " \(trackerBlocked) ", attributes: [
+                .foregroundColor: UIColor.braveLabel,
+                .font: UIFont.preferredFont(for: .body, weight: .bold)
+            ]))
+            
+            text.append(NSAttributedString(string: "\(strings[1])\n\n\(Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionThree)", attributes: [
                 .foregroundColor: UIColor.braveLabel,
                 .font: UIFont.preferredFont(forTextStyle: .body)
             ]))

--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeBraveBlockedAdsController.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeBraveBlockedAdsController.swift
@@ -27,57 +27,48 @@ class WelcomeBraveBlockedAdsController: UIViewController, PopoverContentComponen
     }
     
     func setData(domain: String, trackerBlocked: String, trackerCount: Int) {
-        let text = NSMutableAttributedString()
-        
+        var defaultText: String
+        let uuid = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+
         if trackerCount > 0 {
-            let uuid = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-            let string = trackerCount == 1 ?
-            String(format: Strings.Onboarding.blockedAdsOnboardingPopoverSingleTrackerDescription, "[\(uuid)]", trackerCount, domain) :
-            String(format: Strings.Onboarding.blockedAdsOnboardingPopoverMultipleTrackerDescription, "[\(uuid)]", trackerCount, domain)
-            let strings = string.separatedBy("[\(uuid)]")
-            guard strings.count == 2 else {
-                label.text = string
-                return
-            }
-            
-            text.append(NSAttributedString(string: strings[0], attributes: [
-                .foregroundColor: UIColor.braveLabel,
-                .font: UIFont.preferredFont(forTextStyle: .body)
-            ]))
-            
-            text.append(NSAttributedString(string: " \(trackerBlocked) ", attributes: [
-                .foregroundColor: UIColor.braveLabel,
-                .font: UIFont.preferredFont(for: .body, weight: .bold)
-            ]))
-            
-            text.append(NSAttributedString(string: "\(strings[1])\n\n\(Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionThree)", attributes: [
-                .foregroundColor: UIColor.braveLabel,
-                .font: UIFont.preferredFont(forTextStyle: .body)
-            ]))
+            defaultText = trackerCount == 1 ?
+                String(format: Strings.Onboarding.blockedAdsOnboardingPopoverSingleTrackerDescription, "[\(uuid)]", trackerCount, domain) :
+                String(format: Strings.Onboarding.blockedAdsOnboardingPopoverMultipleTrackerDescription, "[\(uuid)]", trackerCount, domain)
         } else {
-            let uuid = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-            let string = String(format: Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionTwo, "[\(uuid)]", domain)
-            let strings = string.separatedBy("[\(uuid)]")
-            guard strings.count == 2 else {
-                label.text = string
-                return
-            }
-            
-            text.append(NSAttributedString(string: strings[0], attributes: [
-                .foregroundColor: UIColor.braveLabel,
-                .font: UIFont.preferredFont(forTextStyle: .body)
-            ]))
-            
-            text.append(NSAttributedString(string: " \(trackerBlocked) ", attributes: [
-                .foregroundColor: UIColor.braveLabel,
-                .font: UIFont.preferredFont(for: .body, weight: .bold)
-            ]))
-            
-            text.append(NSAttributedString(string: "\(strings[1])\n\n\(Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionThree)", attributes: [
-                .foregroundColor: UIColor.braveLabel,
-                .font: UIFont.preferredFont(forTextStyle: .body)
-            ]))
+            defaultText = String(format: Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionTwo, "[\(uuid)]", domain)
         }
-        label.attributedText = text
+        
+        if let attributedText = createBlockedDescription(trackerBlocked: trackerBlocked, uuid: uuid, defaultText: defaultText) {
+            label.attributedText = attributedText
+        }
+    }
+    
+    private func createBlockedDescription(trackerBlocked: String, uuid: String, defaultText: String) -> NSAttributedString? {
+        let attributedText = NSMutableAttributedString()
+
+        let defaultTextChunks = defaultText.separatedBy("[\(uuid)]")
+        guard defaultTextChunks.count == 2 else {
+            label.text = defaultText
+            return nil
+        }
+        
+        attributedText.append(NSAttributedString(string: defaultTextChunks[0], attributes: [
+            .foregroundColor: UIColor.braveLabel,
+            .font: UIFont.preferredFont(forTextStyle: .body)
+        ]))
+        
+        attributedText.append(NSAttributedString(string: " \(trackerBlocked) ", attributes: [
+            .foregroundColor: UIColor.braveLabel,
+            .font: UIFont.preferredFont(for: .body, weight: .bold)
+        ]))
+        
+        attributedText.append(NSAttributedString(
+            string: "\(defaultTextChunks[1])\n\n\(Strings.Onboarding.blockedAdsOnboardingPopoverDescriptionThree)",
+            attributes: [
+                .foregroundColor: UIColor.braveLabel,
+                .font: UIFont.preferredFont(forTextStyle: .body)
+        ]))
+        
+        return attributedText
     }
 }

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -245,7 +245,8 @@ extension BrowserViewController: PlaylistHelperDelegate {
         let shouldShowOnboarding = tab?.url?.isPlaylistSupportedSiteURL == true
         
         if shouldShowOnboarding {
-            if Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value < 2 && shouldShowPlaylistOnboardingThisSession {
+            if Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value < 2 && shouldShowPlaylistOnboardingThisSession,
+                presentedViewController == nil {
                 Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value += 1
                 
                 topToolbar.layoutIfNeeded()
@@ -287,9 +288,9 @@ extension BrowserViewController: PlaylistHelperDelegate {
                         }
                     }
                 }
+                
+                shouldShowPlaylistOnboardingThisSession = false
             }
-            
-            shouldShowPlaylistOnboardingThisSession = false
         }
     }
     

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -245,7 +245,8 @@ extension BrowserViewController: PlaylistHelperDelegate {
         let shouldShowOnboarding = tab?.url?.isPlaylistSupportedSiteURL == true
         
         if shouldShowOnboarding {
-            if Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value < 2 && shouldShowPlaylistOnboardingThisSession,
+            if Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value < 2,
+                shouldShowPlaylistOnboardingThisSession,
                 presentedViewController == nil {
                 Preferences.Playlist.addToPlaylistURLBarOnboardingCount.value += 1
                 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixed Onboarding popovers not showing due to conflicts with other popovers and menus
- Fixed Onboarding popovers not showing adblock popover when no tracker name is matching the domain

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4635
This pull request fixes #4638

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
