### PR TITLE
Fix #4643: Don't capture private data while screen recording

### DIFF
--- a/BraveUI/SwiftUI/AlertOnScreenshotViewModifier.swift
+++ b/BraveUI/SwiftUI/AlertOnScreenshotViewModifier.swift
@@ -1,0 +1,31 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SwiftUI
+
+private struct AlertOnScreenshotViewModifier: ViewModifier {
+  var alert: () -> Alert
+  @State private var isPresentingAlert: Bool = false
+  
+  func body(content: Content) -> some View {
+    content
+      .alert(isPresented: $isPresentingAlert, content: alert)
+      .onReceive(
+        NotificationCenter.default.publisher(
+          for: UIApplication.userDidTakeScreenshotNotification, object: nil
+        )
+      ) { _ in
+        isPresentingAlert = true
+      }
+  }
+}
+
+extension View {
+  /// Displays an alert on the current view if the user takes a screenshot of their device
+  public func alertOnScreenshot(_ alert: @escaping () -> Alert) -> some View {
+    modifier(AlertOnScreenshotViewModifier(alert: alert))
+  }
+}

--- a/BraveUI/SwiftUI/NoCaptureViewModifier.swift
+++ b/BraveUI/SwiftUI/NoCaptureViewModifier.swift
@@ -1,0 +1,32 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SwiftUI
+
+private struct NoCaptureViewModifier: ViewModifier {
+  @State private var isCaptured: Bool = false
+  
+  func body(content: Content) -> some View {
+    content
+      .opacity(isCaptured ? 0 : 1)
+      .onAppear {
+        isCaptured = UIScreen.main.isCaptured
+      }
+      .onReceive(
+        NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification, object: nil)
+      ) { notification in
+        isCaptured = (notification.object as? UIScreen)?.isCaptured ?? UIScreen.main.isCaptured
+      }
+  }
+}
+
+extension View {
+  /// Redacts the given view if the system is actively recording, mirroring, or using AirPlay to stream the
+  /// contents of the screen.
+  public func noCapture() -> some View {
+    modifier(NoCaptureViewModifier())
+  }
+}

--- a/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
@@ -38,6 +38,7 @@ struct AccountPrivateKeyView: View {
             .font(.system(.body, design: .monospaced))
             .blur(radius: isKeyVisible ? 0 : 5)
             .accessibilityHidden(!isKeyVisible)
+            .noCapture()
           Button(action: {
             UIPasteboard.general.setSecureString(key)
           }) {
@@ -75,6 +76,13 @@ struct AccountPrivateKeyView: View {
     .navigationBarTitleDisplayMode(.inline)
     .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
       isKeyVisible = false
+    }
+    .alertOnScreenshot {
+      Alert(
+        title: Text(Strings.Wallet.screenshotDetectedTitle),
+        message: Text(Strings.Wallet.privateKeyScreenshotDetectedMessage),
+        dismissButton: .cancel(Text(Strings.OKString))
+      )
     }
   }
 }

--- a/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -59,6 +59,7 @@ struct BackupRecoveryPhraseView: View {
           .padding(.vertical)
         RecoveryPhraseGrid(data: recoveryWords, id: \.self) { word in
           Text(verbatim: "\(word.index + 1). \(word.value)")
+            .noCapture()
             .font(.footnote.bold())
             .padding(8)
             .frame(maxWidth: .infinity)
@@ -109,6 +110,13 @@ struct BackupRecoveryPhraseView: View {
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
+    .alertOnScreenshot {
+      Alert(
+        title: Text(Strings.Wallet.screenshotDetectedTitle),
+        message: Text(Strings.Wallet.recoveryPhraseScreenshotDetectedMessage),
+        dismissButton: .cancel(Text(Strings.OKString))
+      )
+    }
   }
   
   struct ToolbarModifier: ViewModifier {

--- a/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
@@ -56,6 +56,7 @@ struct VerifyRecoveryPhraseView: View {
             tappedWord(word)
           }) {
             Text(verbatim: word.value)
+              .noCapture()
               .font(.footnote.bold())
               .foregroundColor(.primary)
               .fixedSize(horizontal: false, vertical: true)
@@ -107,6 +108,13 @@ struct VerifyRecoveryPhraseView: View {
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
     .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
+    .alertOnScreenshot {
+      Alert(
+        title: Text(Strings.Wallet.screenshotDetectedTitle),
+        message: Text(Strings.Wallet.recoveryPhraseScreenshotDetectedMessage),
+        dismissButton: .cancel(Text(Strings.OKString))
+      )
+    }
   }
 }
 
@@ -167,6 +175,7 @@ private struct SelectedWordsBox: View {
       case .word(let word, let index, let isCorrect):
         Button(action: { tappedWord(atIndex: index) }) {
           Text(verbatim: "\(index + 1). \(word)")
+            .noCapture()
             .padding(8)
             .frame(maxWidth: .infinity)
             .fixedSize(horizontal: false, vertical: true)

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1513,5 +1513,26 @@ extension Strings {
       value: "Quote includes a %@ Brave fee.",
       comment: "A disclaimer that appears at the bottom of an swap screen which discloses the fixed Brave fee included in the swap quotes. '%@' will be replaced by a percentage. For example: 'Quote includes a 0.875% Brave fee'"
     )
+    public static let screenshotDetectedTitle = NSLocalizedString(
+      "wallet.screenshotDetectedTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Screenshot detected",
+      comment: "A title of an alert when the user takes a screenshot of their device"
+    )
+    public static let recoveryPhraseScreenshotDetectedMessage = NSLocalizedString(
+      "wallet.recoveryPhraseScreenshotDetectedMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Warning: A screenshot of your recovery phrase may get backed up to a cloud file service, and be readable by any application with photos access. Brave recommends that you not save this screenshot, and delete it as soon as possible.",
+      comment: "The message displayed when the user takes a screenshot of their recovery phrase"
+    )
+    public static let privateKeyScreenshotDetectedMessage = NSLocalizedString(
+      "wallet.privateKeyScreenshotDetectedMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Warning: A screenshot of your private key may get backed up to a cloud file service, and be readable by any application with photos access. Brave recommends that you not save this screenshot, and delete it as soon as possible.",
+      comment: "The message displayed when the user takes a screenshot of their private key"
+    )
   }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -445,6 +445,8 @@
 		27AD20C426851C5400889AA7 /* BraveCore.xcframework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		27AD20CC26851DD100889AA7 /* BraveRewards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AD20CB26851DD100889AA7 /* BraveRewards.swift */; };
 		27AE360D25E55AA200E795E5 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AE360C25E55AA200E795E5 /* MenuViewController.swift */; };
+		27B1041B275ECE7600728421 /* NoCaptureViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B1041A275ECE7600728421 /* NoCaptureViewModifier.swift */; };
+		27B10428275ED44900728421 /* AlertOnScreenshotViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B10427275ED44900728421 /* AlertOnScreenshotViewModifier.swift */; };
 		27B16C5924E1D72600E0CF2C /* NewTabPageFeedOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B16C5824E1D72600E0CF2C /* NewTabPageFeedOverlayView.swift */; };
 		27B33D5826556E7300F3D274 /* BraveButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B33D5726556E7300F3D274 /* BraveButtonStyle.swift */; };
 		27B3DDD024AE83710006A7ED /* FeedSourceOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B3DDCF24AE83710006A7ED /* FeedSourceOverride.swift */; };
@@ -2186,6 +2188,8 @@
 		27AD20C226851C5400889AA7 /* BraveCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BraveCore.xcframework; path = "node_modules/brave-core-ios/BraveCore.xcframework"; sourceTree = "<group>"; };
 		27AD20CB26851DD100889AA7 /* BraveRewards.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = BraveRewards.swift; sourceTree = "<group>"; };
 		27AE360C25E55AA200E795E5 /* MenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
+		27B1041A275ECE7600728421 /* NoCaptureViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoCaptureViewModifier.swift; sourceTree = "<group>"; };
+		27B10427275ED44900728421 /* AlertOnScreenshotViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertOnScreenshotViewModifier.swift; sourceTree = "<group>"; };
 		27B16C5824E1D72600E0CF2C /* NewTabPageFeedOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageFeedOverlayView.swift; sourceTree = "<group>"; };
 		27B33D5726556E7300F3D274 /* BraveButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BraveButtonStyle.swift; sourceTree = "<group>"; };
 		27B3DDCF24AE83710006A7ED /* FeedSourceOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSourceOverride.swift; sourceTree = "<group>"; };
@@ -4579,6 +4583,8 @@
 				2766847B270B76D900DF45C5 /* FilterableViewModifier.swift */,
 				276AADB9272850850034A0C2 /* Shimmer.swift */,
 				271F685426EBD27C00AA2A50 /* PreviewModifiers.swift */,
+				27B1041A275ECE7600728421 /* NoCaptureViewModifier.swift */,
+				27B10427275ED44900728421 /* AlertOnScreenshotViewModifier.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -7989,6 +7995,7 @@
 				271F68C926EBD29500AA2A50 /* DocumentOpenerView.swift in Sources */,
 				27733E792697867D0086799A /* AccessibilityEmbedInScrollViewViewModifier.swift in Sources */,
 				271F68C726EBD29500AA2A50 /* UIKitController.swift in Sources */,
+				27B10428275ED44900728421 /* AlertOnScreenshotViewModifier.swift in Sources */,
 				27EF6B8124BF6095005E034F /* UITableViewExtensions.swift in Sources */,
 				44A58CC82693A309005C0879 /* ActivityView.swift in Sources */,
 				2FBE200926F8E97300B7098B /* UIFontExtenions.swift in Sources */,
@@ -7999,6 +8006,7 @@
 				2766847C270B76D900DF45C5 /* FilterableViewModifier.swift in Sources */,
 				27E17B932744134000F3C282 /* PreviewModifiers.swift in Sources */,
 				271F68C426EBD29500AA2A50 /* EdgeInsetsExtensions.swift in Sources */,
+				27B1041B275ECE7600728421 /* NoCaptureViewModifier.swift in Sources */,
 				276A790C244660B500AC9446 /* UICollectionViewExtensions.swift in Sources */,
 				278C469523F1E8620083347F /* LoaderView.swift in Sources */,
 				278C469723F1E8620083347F /* BraveButton.swift in Sources */,


### PR DESCRIPTION
Also displays an alert when you screenshot on screens displaying private data

## Summary of Changes

This pull request fixes #4643

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
