### PR TITLE
Fix #4641: Add send address validation in send screen.

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -95,32 +95,8 @@ struct SendTokenView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
-          header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoToTitle))
-        ) {
-          VStack(alignment: .leading) {
-            HStack(spacing: 14.0) {
-              TextField(Strings.Wallet.sendCryptoAddressPlaceholder, text: $sendTokenStore.sendAddress)
-              Button(action: {
-                if let string = UIPasteboard.general.string {
-                  sendTokenStore.sendAddress = string
-                }
-              }) {
-                Label(Strings.Wallet.pasteFromPasteboard, image: "brave.clipboard")
-                  .labelStyle(.iconOnly)
-                  .foregroundColor(Color(.primaryButtonTint))
-                  .font(.body)
-              }
-              .buttonStyle(PlainButtonStyle())
-              Button(action: {
-                isShowingScanner = true
-              }) {
-                Label(Strings.Wallet.scanQRCodeAccessibilityLabel, image: "brave.qr-code")
-                  .labelStyle(.iconOnly)
-                  .foregroundColor(Color(.primaryButtonTint))
-                  .font(.body)
-              }
-              .buttonStyle(PlainButtonStyle())
-            }
+          header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoToTitle)),
+          footer: Group {
             if let error = sendTokenStore.addressError {
               HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Image(systemName: "exclamationmark.circle.fill")
@@ -137,6 +113,30 @@ struct SendTokenView: View {
               .font(.footnote)
               .foregroundColor(Color(.braveErrorLabel))
             }
+          }
+        ) {
+          HStack(spacing: 14.0) {
+            TextField(Strings.Wallet.sendCryptoAddressPlaceholder, text: $sendTokenStore.sendAddress)
+            Button(action: {
+              if let string = UIPasteboard.general.string {
+                sendTokenStore.sendAddress = string
+              }
+            }) {
+              Label(Strings.Wallet.pasteFromPasteboard, image: "brave.clipboard")
+                .labelStyle(.iconOnly)
+                .foregroundColor(Color(.primaryButtonTint))
+                .font(.body)
+            }
+            .buttonStyle(PlainButtonStyle())
+            Button(action: {
+              isShowingScanner = true
+            }) {
+              Label(Strings.Wallet.scanQRCodeAccessibilityLabel, image: "brave.qr-code")
+                .labelStyle(.iconOnly)
+                .foregroundColor(Color(.primaryButtonTint))
+                .font(.body)
+            }
+            .buttonStyle(PlainButtonStyle())
           }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -112,6 +112,7 @@ struct SendTokenView: View {
               )
               .font(.footnote)
               .foregroundColor(Color(.braveErrorLabel))
+              .padding(.bottom)
             }
           }
         ) {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -87,7 +87,8 @@ public class CryptoStore: ObservableObject {
       keyringController: keyringController,
       rpcController: rpcController,
       walletService: walletService,
-      transactionController: transactionController
+      transactionController: transactionController,
+      tokenRegistery: tokenRegistry
     )
     sendTokenStore = store
     return store

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import BraveCore
+import Shared
 
 /// A store contains data for sending tokens
 public class SendTokenStore: ObservableObject {
@@ -20,42 +21,86 @@ public class SendTokenStore: ObservableObject {
   @Published var selectedSendTokenBalance: Double?
   /// A boolean indicates if this store is making an unapproved tx
   @Published var isMakingTx = false
+  /// The destination account address
+  @Published var sendAddress = "" {
+    didSet {
+      timer?.invalidate()
+      timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false, block: { [weak self] _ in
+        self?.validateSendAddress()
+      })
+    }
+  }
+  /// An error for input send address. Nil for no error.
+  @Published var addressError: AddressError?
+  
+  enum AddressError: LocalizedError {
+    case sameAsFromAddress
+    case contractAddress
+    case notEthAddress
+    
+    var errorDescription: String? {
+      switch self {
+      case .sameAsFromAddress:
+        return Strings.Wallet.sendAddressWarning1
+      case .contractAddress:
+        return Strings.Wallet.sendAddressWarning2
+      case .notEthAddress:
+        return Strings.Wallet.sendAddressWarning3
+      }
+    }
+  }
   
   private let keyringController: BraveWalletKeyringController
   private let rpcController: BraveWalletEthJsonRpcController
   private let walletService: BraveWalletBraveWalletService
   private let transactionController: BraveWalletEthTxController
+  private let tokenRegistery: BraveWalletERCTokenRegistry
+  private var allTokens: [BraveWallet.ERCToken] = []
+  private var currentAccountAddress: String?
+  private var timer: Timer?
   
   public init(
     keyringController: BraveWalletKeyringController,
     rpcController: BraveWalletEthJsonRpcController,
     walletService: BraveWalletBraveWalletService,
-    transactionController: BraveWalletEthTxController
+    transactionController: BraveWalletEthTxController,
+    tokenRegistery: BraveWalletERCTokenRegistry
   ) {
     self.keyringController = keyringController
     self.rpcController = rpcController
     self.walletService = walletService
     self.transactionController = transactionController
+    self.tokenRegistery = tokenRegistery
     
     self.keyringController.add(self)
     self.rpcController.add(self)
+    
+    self.keyringController.selectedAccount { address in
+      self.currentAccountAddress = address
+    }
   }
   
   func fetchAssets() {
-    rpcController.chainId { [self] chainId in
-      walletService.userAssets(chainId) { tokens in
-        userAssets = tokens
+    rpcController.chainId { [weak self] chainId in
+      guard let self = self else { return }
+      self.walletService.userAssets(chainId) { tokens in
+        self.userAssets = tokens
         
-        if let selectedToken = selectedSendToken {
+        if let selectedToken = self.selectedSendToken {
           if tokens.isEmpty {
-            selectedSendToken = nil
+            self.selectedSendToken = nil
           } else if let token = tokens.first(where: { $0.id == selectedToken.id }) {
-            selectedSendToken = token
+            self.selectedSendToken = token
           }
         } else {
-          selectedSendToken = tokens.first
+          self.selectedSendToken = tokens.first
         }
       }
+    }
+    
+    // store tokens in `allTokens` for address validation
+    tokenRegistery.allTokens { [weak self] tokens in
+      self?.allTokens = tokens + [.eth]
     }
   }
   
@@ -134,23 +179,43 @@ public class SendTokenStore: ObservableObject {
   private func makeEIP1559Tx(
     chainId: String,
     baseData: BraveWallet.TxData,
-    from account: BraveWallet.AccountInfo,
+    from address: String,
     completion: @escaping (_ success: Bool) -> Void
   ) {
     let eip1559Data = BraveWallet.TxData1559(baseData: baseData, chainId: chainId, maxPriorityFeePerGas: "", maxFeePerGas: "", gasEstimation: nil)
-    self.transactionController.addUnapproved1559Transaction(eip1559Data, from: account.address) { success, txMetaId, errorMessage in
+    self.transactionController.addUnapproved1559Transaction(eip1559Data, from: address) { success, txMetaId, errorMessage in
       completion(success)
     }
   }
   
+  private func validateSendAddress() {
+    guard !sendAddress.isEmpty else {
+      addressError = nil
+      return
+    }
+    let normalizedSendAddress = sendAddress.lowercased()
+    if !sendAddress.isETHAddress {
+      addressError = .notEthAddress
+    } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
+      addressError = .sameAsFromAddress
+    } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil)
+                || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil) {
+      addressError = .contractAddress
+    } else {
+      addressError = nil
+    }
+  }
+  
   func sendToken(
-    from account: BraveWallet.AccountInfo,
-    to address: String,
     amount: String,
     completion: @escaping (_ success: Bool) -> Void
   ) {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
-    guard let token = selectedSendToken, let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: 18) else { return }
+    guard
+      let token = selectedSendToken,
+      let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: 18),
+      let fromAddress = currentAccountAddress
+    else { return }
     
     isMakingTx = true
     rpcController.network { [weak self] network in
@@ -158,25 +223,25 @@ public class SendTokenStore: ObservableObject {
       defer { self.isMakingTx = false }
 
       if token.isETH {
-        let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: address, value: "0x\(weiHexString)", data: .init())
+        let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: self.sendAddress, value: "0x\(weiHexString)", data: .init())
         if network.isEip1559 {
-          self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: account, completion: completion)
+          self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress, completion: completion)
         } else {
-          self.transactionController.addUnapprovedTransaction(baseData, from: account.address) { success, txMetaId, errorMessage in
+          self.transactionController.addUnapprovedTransaction(baseData, from: fromAddress) { success, txMetaId, errorMessage in
             completion(success)
           }
         }
       } else {
-        self.transactionController.makeErc20TransferData(account.address, amount: "0x\(weiHexString)") { success, data in
+        self.transactionController.makeErc20TransferData(self.sendAddress, amount: "0x\(weiHexString)") { success, data in
           guard success else {
             completion(false)
             return
           }
           let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
           if network.isEip1559 {
-            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: account, completion: completion)
+            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress, completion: completion)
           } else {
-            self.transactionController.addUnapprovedTransaction(baseData, from: account.address) { success, txMetaId, errorMessage in
+            self.transactionController.addUnapprovedTransaction(baseData, from: fromAddress) { success, txMetaId, errorMessage in
               completion(success)
             }
           }
@@ -210,6 +275,10 @@ extension SendTokenStore: BraveWalletKeyringControllerObserver {
   
   public func selectedAccountChanged() {
     fetchAssetBalance()
+    keyringController.selectedAccount { [weak self] address in
+      self?.currentAccountAddress = address
+      self?.validateSendAddress()
+    }
   }
 }
 

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -213,7 +213,7 @@ public class SendTokenStore: ObservableObject {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     guard
       let token = selectedSendToken,
-      let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: 18),
+      let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: Int(token.decimals)),
       let fromAddress = currentAccountAddress
     else { return }
     

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -41,11 +41,11 @@ public class SendTokenStore: ObservableObject {
     var errorDescription: String? {
       switch self {
       case .sameAsFromAddress:
-        return Strings.Wallet.sendAddressWarning1
+        return Strings.Wallet.sendWarningAddressIsOwn
       case .contractAddress:
-        return Strings.Wallet.sendAddressWarning2
+        return Strings.Wallet.sendWarningAddressIsContract
       case .notEthAddress:
-        return Strings.Wallet.sendAddressWarning3
+        return Strings.Wallet.sendWarningAddressNotValid
       }
     }
   }

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -70,7 +70,8 @@ extension SendTokenStore {
       keyringController: TestKeyringController(),
       rpcController: TestEthJsonRpcController(),
       walletService: TestBraveWalletService(),
-      transactionController: TestEthTxController()
+      transactionController: TestEthTxController(),
+      tokenRegistery: TestTokenRegistry()
     )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1534,5 +1534,26 @@ extension Strings {
       value: "Warning: A screenshot of your private key may get backed up to a cloud file service, and be readable by any application with photos access. Brave recommends that you not save this screenshot, and delete it as soon as possible.",
       comment: "The message displayed when the user takes a screenshot of their private key"
     )
+    public static let sendAddressWarning1 = NSLocalizedString(
+      "wallet.sendAddressWarning1",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "The receiving address is your own address",
+      comment: "A warning that appears below the send crypto address text field, when the input `To` address is the same as the current selected account's address."
+    )
+    public static let sendAddressWarning2 = NSLocalizedString(
+      "wallet.sendAddressWarning2",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "The receiving address is a token's contract address",
+      comment: "A warning that appears below the send crypto address text field, when the input `To` address is a token contract address."
+    )
+    public static let sendAddressWarning3 = NSLocalizedString(
+      "wallet.sendAddressWarning3",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Not a valid ETH address",
+      comment: "A warning that appears below the send crypto address text field, when the input `To` address is not a valid ETH address."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1534,22 +1534,22 @@ extension Strings {
       value: "Warning: A screenshot of your private key may get backed up to a cloud file service, and be readable by any application with photos access. Brave recommends that you not save this screenshot, and delete it as soon as possible.",
       comment: "The message displayed when the user takes a screenshot of their private key"
     )
-    public static let sendAddressWarning1 = NSLocalizedString(
-      "wallet.sendAddressWarning1",
+    public static let sendWarningAddressIsOwn = NSLocalizedString(
+      "wallet.sendWarningAddressIsOwn",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "The receiving address is your own address",
       comment: "A warning that appears below the send crypto address text field, when the input `To` address is the same as the current selected account's address."
     )
-    public static let sendAddressWarning2 = NSLocalizedString(
-      "wallet.sendAddressWarning2",
+    public static let sendWarningAddressIsContract = NSLocalizedString(
+      "wallet.sendWarningAddressIsContract",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "The receiving address is a token's contract address",
       comment: "A warning that appears below the send crypto address text field, when the input `To` address is a token contract address."
     )
-    public static let sendAddressWarning3 = NSLocalizedString(
-      "wallet.sendAddressWarning3",
+    public static let sendWarningAddressNotValid = NSLocalizedString(
+      "wallet.sendWarningAddressNotValid",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Not a valid ETH address",


### PR DESCRIPTION
## Summary of Changes
Added send address validation in send screen. If user inputs the address is one of the following:
1. not an eth address (starts with `0x`, and rest of the chars are hex digits, total length after `0x` is 40)
2. is the same as the current selected account address (from address)
3. is a contract address (custom tokens  or non-custom tokens)
Will be a warning message displayed below the send address text field. 
Warning message will disappear if address becomes valid again or empty. 

This pull request fixes #4641 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:
![IMG_8393](https://user-images.githubusercontent.com/1187676/145057678-d6372ef5-4828-4076-9ea9-85f990ef058c.PNG)
![IMG_8399](https://user-images.githubusercontent.com/1187676/145086358-3ab9352b-8df8-45f7-a743-4f8c17906849.PNG)
![IMG_8398](https://user-images.githubusercontent.com/1187676/145086360-51336038-eefe-4fbf-bcee-e6aa0f90d71f.PNG)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
