### PR TITLE
Add error code when failing to setup biometrics in a non-public build

### DIFF
--- a/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import LocalAuthentication
 import BraveUI
 import struct Shared.Strings
+import struct Shared.AppConstants
 
 struct CreateWalletContainerView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -130,10 +131,12 @@ private struct CreateWalletView: View {
       .padding(.vertical)
       .background(BiometricsPromptView(isPresented: $isShowingBiometricsPrompt) { enabled, navController in
         // Store password in keychain
-        if enabled, !KeyringStore.storePasswordInKeychain(password) {
+        if enabled, case let status = KeyringStore.storePasswordInKeychain(password),
+           status != errSecSuccess {
+          let isPublic = AppConstants.buildChannel.isPublic
           let alert = UIAlertController(
             title: Strings.Wallet.biometricsSetupErrorTitle,
-            message: Strings.Wallet.biometricsSetupErrorMessage,
+            message: Strings.Wallet.biometricsSetupErrorMessage + (isPublic ? "" : " (\(status))"),
             preferredStyle: .alert
           )
           alert.addAction(.init(title: Strings.OKString, style: .default, handler: nil))

--- a/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import BraveUI
 import struct Shared.Strings
+import struct Shared.AppConstants
 import LocalAuthentication
 
 struct RestoreWalletContainerView: View {
@@ -214,10 +215,12 @@ private struct RestoreWalletView: View {
         keyringStore.markOnboardingCompleted()
       }
       // Store password in keychain
-      if enabled, !KeyringStore.storePasswordInKeychain(password) {
+      if enabled, case let status = KeyringStore.storePasswordInKeychain(password),
+         status != errSecSuccess {
+        let isPublic = AppConstants.buildChannel.isPublic
         let alert = UIAlertController(
           title: Strings.Wallet.biometricsSetupErrorTitle,
-          message: Strings.Wallet.biometricsSetupErrorMessage,
+          message: Strings.Wallet.biometricsSetupErrorMessage + (isPublic ? "" : " (\(status))"),
           preferredStyle: .alert
         )
         alert.addAction(.init(title: Strings.OKString, style: .default, handler: nil))

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -267,8 +267,8 @@ public class KeyringStore: ObservableObject {
   private static let passwordKeychainKey = "brave-wallet-password"
   
   /// Stores the users wallet password in the keychain so that they may unlock using biometrics/passcode
-  static func storePasswordInKeychain(_ password: String) -> Bool {
-    guard let passwordData = password.data(using: .utf8) else { return false }
+  static func storePasswordInKeychain(_ password: String) -> OSStatus {
+    guard let passwordData = password.data(using: .utf8) else { return errSecInvalidData }
     #if targetEnvironment(simulator)
     // There is a bug with iOS 15 simulators when attempting to add a keychain item with
     // `kSecAttrAccessControl` set. This of course means that on simulator we will not ask for biometrics
@@ -295,8 +295,7 @@ public class KeyringStore: ObservableObject {
       kSecValueData as String: passwordData
     ]
     #endif
-    let status = SecItemAdd(query as CFDictionary, nil)
-    return status == errSecSuccess
+    return SecItemAdd(query as CFDictionary, nil)
   }
   
   @discardableResult


### PR DESCRIPTION
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).

cc @srirambv 