### PR TITLE
Fix #4601 / #4645: Japan NTP Tutorial Page - Incorrect tooltip

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -183,9 +183,6 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     /// Boolean tracking  if Tab Tray is active on the screen
     /// Used to determine If pop-over should be presented
     var isTabTrayActive = false
-        
-    /// Boolean Tracking NTP Education should be loaded after onboarding of user
-    var shouldShowNTPEducation = false
 
     /// Data Source object used to determine blocking stats
     var benchmarkBlockingDataSource: BlockingSummaryDataSource?
@@ -2824,16 +2821,6 @@ extension BrowserViewController: NewTabPageDelegate {
             
             self.presentActivityViewController(url, sourceView: self.view, sourceRect: viewRect,
                                                arrowDirection: .any)
-        }
-    }
-    
-    func showNTPOnboarding() {
-        if Preferences.General.isNewRetentionUser.value == true,
-            Preferences.DebugFlag.skipNTPCallouts != true,
-            !topToolbar.inOverlayMode,
-            topToolbar.currentURL == nil,
-            !Preferences.FullScreenCallout.ntpCalloutCompleted.value {
-            presentNTPStatsOnboarding()
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -41,7 +41,7 @@ extension BrowserViewController {
             
             let controller = OnboardingRewardsAgreementViewController(profile: profile, rewards: rewards)
             controller.onOnboardingStateChanged = { [weak self] controller, state in
-                self?.dismissOnboarding(controller, state: state)
+                self?.completeOnboarding(controller)
             }
             
             Preferences.FullScreenCallout.rewardsCalloutCompleted.value = true

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -105,7 +105,7 @@ extension BrowserViewController {
         if BraveRewards.isAvailable, !Preferences.Rewards.rewardsToggledOnce.value {
             let controller = OnboardingRewardsAgreementViewController(profile: profile, rewards: rewards)
             controller.onOnboardingStateChanged = { [weak self] controller, state in
-                self?.dismissOnboarding(controller, state: state)
+                self?.completeOnboarding(controller)
             }
             present(controller, animated: true)
             isOnboardingOrFullScreenCalloutPresented = true

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/BrowserViewController+ProductNotification.swift
@@ -144,10 +144,12 @@ extension BrowserViewController {
                 Preferences.ProductNotificationBenchmarks.trackerTierCount.value < $0.value}
             
             if !existingTierList.isEmpty {
-                guard let firstExistingTier = existingTierList.first else { return }
-                
                 Preferences.ProductNotificationBenchmarks.trackerTierCount.value = numOfTrackerAds
                 
+                guard let firstExistingTier = existingTierList.filter({ numOfTrackerAds > $0.value }).first else {
+                    return
+                }
+
                 if numOfTrackerAds > firstExistingTier.value {
                     notifyTrackerAdsCount(firstExistingTier.value,
                                           description: Strings.ShieldEducation.benchmarkAnyTierTitle)

--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
@@ -28,7 +28,8 @@ class WelcomeViewController: UIViewController {
     private var state: WelcomeViewCalloutState?
     
     var onAdsWebsiteSelected: ((URL?) -> Void)?
-    
+    var onSkipSelected: (() -> Void)?
+
     convenience init(profile: Profile?, rewards: BraveRewards?) {
         self.init(profile: profile,
                   rewards: rewards,
@@ -356,6 +357,7 @@ class WelcomeViewController: UIViewController {
                                                    rewards: rewards,
                                                    state: nil)
         nextController.onAdsWebsiteSelected = onAdsWebsiteSelected
+        nextController.onSkipSelected = onSkipSelected
         let state = WelcomeViewCalloutState.privacy(
             title: Strings.Onboarding.privacyScreenTitle,
             details: Strings.Onboarding.privacyScreenDescription,
@@ -373,6 +375,7 @@ class WelcomeViewController: UIViewController {
                                                    rewards: rewards,
                                                    state: nil)
         nextController.onAdsWebsiteSelected = onAdsWebsiteSelected
+        nextController.onSkipSelected = onSkipSelected
         let state = WelcomeViewCalloutState.defaultBrowser(
             info: WelcomeViewCalloutState.WelcomeViewDefaultBrowserDetails(
                 title: Strings.Callout.defaultBrowserCalloutTitle,
@@ -395,6 +398,7 @@ class WelcomeViewController: UIViewController {
                                                    rewards: rewards,
                                                    state: nil)
         nextController.onAdsWebsiteSelected = onAdsWebsiteSelected
+        nextController.onSkipSelected = onSkipSelected
         let state = WelcomeViewCalloutState.ready(
             title: Strings.Onboarding.readyScreenTitle,
             details: Strings.Onboarding.readyScreenDescription,
@@ -406,18 +410,19 @@ class WelcomeViewController: UIViewController {
     @objc
     private func onSkipButtonPressed(_ button: UIButton) {
         close()
+        onSkipSelected?()
     }
     
     private func onWebsiteSelected(_ item: WebsiteRegion) {
         close()
         if let url = URL(string: item.domain) {
-            self.onAdsWebsiteSelected?(url)
+            onAdsWebsiteSelected?(url)
         }
     }
     
     private func onEnterCustomWebsite() {
         close()
-        self.onAdsWebsiteSelected?(nil)
+        onAdsWebsiteSelected?(nil)
     }
     
     private func onSetDefaultBrowser() {

--- a/Client/Frontend/Settings/RetentionPreferencesDebugMenuViewController.swift
+++ b/Client/Frontend/Settings/RetentionPreferencesDebugMenuViewController.swift
@@ -98,6 +98,17 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
                     },
                     cellReuseId: "RetentionUserCell"),
                 .boolRow(
+                    title: "NTP Education Shown",
+                    detailText: "Flag tracking NTP Education should be loaded after onboarding of user.",
+                    toggleValue: Preferences.FullScreenCallout.ntpCalloutCompleted.value,
+                    valueChange: {
+                        if $0 {
+                            let status = $0
+                            Preferences.FullScreenCallout.ntpCalloutCompleted.value = status
+                        }
+                    },
+                    cellReuseId: "NTPEducationCell"),
+                .boolRow(
                     title: "VPN Callout Shown",
                     detailText: "Flag determining if VPN callout is shown to user.",
                     toggleValue: Preferences.FullScreenCallout.vpnCalloutCompleted.value,
@@ -159,14 +170,6 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
                         self.browserViewController?.benchmarkNotificationPresented = status
                     },
                     cellReuseId: "BenchmarkNotificationCell"),
-                .boolRow(
-                    title: "Should Show NTP Education",
-                    detailText: "Flag tracking NTP Education should be loaded after onboarding of user.",
-                    toggleValue: browserViewController?.shouldShowNTPEducation ?? false,
-                    valueChange: { [unowned self] status in
-                        self.browserViewController?.shouldShowNTPEducation = status
-                    },
-                    cellReuseId: "ShouldShowNTPEducationCell"),
                 .boolRow(
                     title: "Onboarding or Callout Presented",
                     detailText: "Flag tracking If a full screen callout or onboarding is presented in order to not to try to present another callout  over existing one",


### PR DESCRIPTION

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4601

This pull request fixes #4645

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
