### PR TITLE
Fix #4655, #4652, #4653: Onboarding upgrade on iPad for Referral code check.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1094,6 +1094,10 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
                 if finished {
                     self.webViewContainer.accessibilityElementsHidden = true
                     UIAccessibility.post(notification: .screenChanged, argument: nil)
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        self.showNTPOnboarding()
+                    }
                 }
             })
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1605,7 +1605,10 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
                 let addToFavoritesActivity = AddToFavoritesActivity() { [weak tab] in
                     FavoritesHelper.add(url: url, title: tab?.displayTitle)
                 }
-                activities.append(addToFavoritesActivity)
+                // TODO: Issue #4651 - Drag and drop Favourites crashing on iOS-14
+                if #available(iOS 15.0, *) {
+                    activities.append(addToFavoritesActivity)
+                }
             }
             activities.append(requestDesktopSiteActivity)
             

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -25,6 +25,11 @@ extension BrowserViewController {
             
             controller.onPrivacyConsentCompleted = { [weak self, unowned controller] in
                 guard let self = self else { return }
+                
+                if Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue {
+                    controller.dismiss(animated: true, completion: nil)
+                    return
+                }
                 self.presentOnboardingWelcomeScreen(on: controller)
             }
             

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -15,8 +15,8 @@ extension BrowserViewController {
     func presentOnboardingIntro() {
         if Preferences.URP.referralCode.value == nil &&
             UIPasteboard.general.hasStrings &&
-            Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue,
-            Preferences.General.basicOnboardingProgress.value == OnboardingProgress.none.rawValue {
+            (Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue &&
+             Preferences.General.basicOnboardingCompleted.value != OnboardingState.skipped.rawValue) {
             let controller = OnboardingPrivacyConsentViewController()
             
             controller.handleReferralLookup = { [weak self] urp, consentGranted in
@@ -25,12 +25,10 @@ extension BrowserViewController {
             
             controller.onPrivacyConsentCompleted = { [weak self, unowned controller] in
                 guard let self = self else { return }
-                
-                if Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue {
+                if Preferences.General.basicOnboardingCompleted.value == OnboardingState.completed.rawValue || Preferences.General.basicOnboardingCompleted.value == OnboardingState.skipped.rawValue {
                     controller.dismiss(animated: true, completion: nil)
                     return
                 }
-                self.presentOnboardingWelcomeScreen(on: controller)
             }
             
             present(controller, animated: false)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -15,7 +15,8 @@ extension BrowserViewController {
     func presentOnboardingIntro() {
         if Preferences.URP.referralCode.value == nil &&
             UIPasteboard.general.hasStrings &&
-            Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue {
+            Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue,
+            Preferences.General.basicOnboardingProgress.value == OnboardingProgress.none.rawValue {
             let controller = OnboardingPrivacyConsentViewController()
             
             controller.handleReferralLookup = { [weak self] urp, consentGranted in
@@ -23,7 +24,8 @@ extension BrowserViewController {
             }
             
             controller.onPrivacyConsentCompleted = { [weak self, unowned controller] in
-                self?.presentOnboardingWelcomeScreen(on: controller)
+                guard let self = self else { return }
+                self.presentOnboardingWelcomeScreen(on: controller)
             }
             
             present(controller, animated: false)

--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -144,7 +144,11 @@ class FavoritesViewController: UIViewController {
         collectionView.delegate = self
         collectionView.dragDelegate = self
         collectionView.dropDelegate = self
-        collectionView.dragInteractionEnabled = true
+        // TODO: Issue #4651 - Drag and drop Favourites crashing on iOS-14
+        if #available(iOS 15.0, *) {
+            // Drag should be enabled to rearrange favourite
+            collectionView.dragInteractionEnabled = true
+        }
         collectionView.keyboardDismissMode = .interactive
         
         dataSource.supplementaryViewProvider = { [weak self] collectionView, kind, indexPath in

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -1026,8 +1026,11 @@ extension NewTabPageViewController {
             showsVerticalScrollIndicator = false
             // Even on light mode we use a darker background now
             indicatorStyle = .white
-            // Drag should be enabled to rearrange favourite
-            dragInteractionEnabled = true
+            // TODO: Issue #4651 - Drag and drop Favourites crashing on iOS-14
+            if #available(iOS 15.0, *) {
+                // Drag should be enabled to rearrange favourite
+                dragInteractionEnabled = true
+            }
         }
         @available(*, unavailable)
         required init(coder: NSCoder) {

--- a/Client/Frontend/Browser/Onboarding/OnboardingPrivacyConsentViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingPrivacyConsentViewController.swift
@@ -11,29 +11,50 @@ private let log = Logger.browserLogger
 
 class OnboardingPrivacyConsentViewController: UIViewController {
     
+    private struct UX {
+        /// The onboarding screens are showing as a modal on iPads.
+        static let preferredModalSize = CGSize(width: 375, height: 667)
+    }
+    
     var handleReferralLookup: ((_ urp: UserReferralProgram, _ checkClipboard: Bool) -> Void)?
     var onPrivacyConsentCompleted: (() -> Void)?
+
+    private let contentView = View().then {
+        $0.layer.cornerCurve = .continuous
+        $0.layer.cornerRadius = 10.0
+        $0.layer.masksToBounds = true
+    }
     
     init() {
         super.init(nibName: nil, bundle: nil)
-        
-        modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .phone ? .fullScreen : .formSheet
+        modalPresentationStyle = .fullScreen
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private var contentView: View {
-        return view as! View // swiftlint:disable:this force_cast
-    }
-    
-    override func loadView() {
-        view = View()
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        view.backgroundColor = #colorLiteral(red: 0.1176470588, green: 0.1254901961, blue: 0.1607843137, alpha: 1)
+        view.addSubview(contentView)
+        
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            contentView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+        } else {
+            contentView.snp.makeConstraints {
+                $0.leading.greaterThanOrEqualToSuperview()
+                $0.trailing.lessThanOrEqualToSuperview()
+                $0.top.greaterThanOrEqualToSuperview()
+                $0.bottom.lessThanOrEqualToSuperview()
+                $0.center.equalToSuperview()
+                $0.width.equalTo(UX.preferredModalSize.width)
+                $0.height.equalTo(UX.preferredModalSize.height)
+            }
+        }
         
         contentView.yesConsentButton.addTarget(self, action: #selector(yesConsentTapped), for: .touchUpInside)
         contentView.noConsentButton.addTarget(self, action: #selector(noConsentTaapped), for: .touchUpInside)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix onboarding NTP not shown when pressing new tab button directly
- Fix onboarding referral code check upgrade guard
- Fix onboarding stats not showing right after referral check (ticket is duplicate of first case)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes: #4655
This pull request fixes: #4652
This pull request fixes: #4653

Disabling Favourites for re- ordering for iOS 14 - Temporary change for Issue #4651

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
