### PR TITLE
Fixes for sending custom assets and ERC20 transfers

### DIFF
--- a/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -90,7 +90,7 @@ struct AddCustomAssetView: View {
                                      isErc20: true,
                                      isErc721: false,
                                      symbol: symbolInput,
-                                     decimals: Int32(symbolInput) ?? 18,
+                                     decimals: Int32(decimalsInput) ?? 18,
                                      visible: true,
                                      tokenId: "")
     userAssetStore.addUserAsset(token: token) { [self] success in

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -164,7 +164,8 @@ public class CryptoStore: ObservableObject {
       assetRatioController: assetRatioController,
       rpcController: rpcController,
       txController: transactionController,
-      tokenRegistry: tokenRegistry
+      tokenRegistry: tokenRegistry,
+      walletService: walletService
     )
     confirmationStore = store
     return store

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -69,15 +69,23 @@ struct TransactionConfirmationView: View {
   }
   
   private var transactionDetails: String {
-    let data = activeTransaction.txData.baseData.data
-      .map { byte in
-        String(format: "%02X", byte.uint8Value)
+    if activeTransaction.txArgs.isEmpty {
+      let data = activeTransaction.txData.baseData.data
+        .map { byte in
+          String(format: "%02X", byte.uint8Value)
+        }
+        .joined()
+      if data.isEmpty {
+        return Strings.Wallet.inputDataPlaceholder
       }
-      .joined()
-    if data.isEmpty {
-      return Strings.Wallet.inputDataPlaceholder
+      return "0x\(data)"
+    } else {
+      return zip(activeTransaction.txParams, activeTransaction.txArgs)
+        .map { (param, arg) in
+          "\(param): \(arg)"
+        }
+        .joined(separator: "\n\n")
     }
-    return "0x\(data)"
   }
   
   @ViewBuilder private var editGasFeeButton: some View {

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -129,7 +129,8 @@ extension TransactionConfirmationStore {
       assetRatioController: TestAssetRatioController(),
       rpcController: TestEthJsonRpcController(),
       txController: TestEthTxController(),
-      tokenRegistry: TestTokenRegistry()
+      tokenRegistry: TestTokenRegistry(),
+      walletService: TestBraveWalletService()
     )
   }
 }


### PR DESCRIPTION
## Summary of Changes

- Fix adding custom assets with different decimals
- Fix sending custom assets and showing wrong value for ERC20 transactions
- Fix transaction details for ERC20 transfers

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
