### PR TITLE
Fix #4667: Wait for send/swap to fully disappear before showing tx confirmations

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -187,8 +187,12 @@ public class CryptoStore: ObservableObject {
           // Dismiss any buy send swap open to show the unapproved transactions
           self.buySendSwapDestination = nil
         }
-        self.unapprovedTransactions = pendingTransactions
-        self.isPresentingTransactionConfirmations = !pendingTransactions.isEmpty
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+          // On iPad if we set these before the send or swap screens disappear for some reason it crashes
+          // within the SwiftUI runtime. Delaying it to give time for the animation to complete fixes it.
+          self.unapprovedTransactions = pendingTransactions
+          self.isPresentingTransactionConfirmations = !pendingTransactions.isEmpty
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4667 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
