### PR TITLE
Fix #4676: Attempt to fix crash on iOS 14 when creating a wallet

### DIFF
--- a/BraveUI/SwiftUI/UIKitNavigationView.swift
+++ b/BraveUI/SwiftUI/UIKitNavigationView.swift
@@ -35,8 +35,6 @@ public struct UIKitNavigationView<Content: View>: View {
       )
     }
     func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
-      (uiViewController.viewControllers.first as? UIHostingController<Content>)?
-        .rootView = content
     }
   }
 }

--- a/BraveWallet/Chart/LineChartView.swift
+++ b/BraveWallet/Chart/LineChartView.swift
@@ -268,18 +268,26 @@ extension CGPoint {
 
 // MARK: - Accessibility
 
+private struct ChartAccessibilityViewModifier: ViewModifier {
+  var title: String
+  var dataPoints: [DataPoint]
+  
+  func body(content: Content) -> some View {
+    if #available(iOS 15.0, *) {
+      content
+        .accessibilityElement()
+        .accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
+        .accessibilityLabel(title)
+    } else {
+      content
+        .accessibilityLabel(title)
+    }
+  }
+}
+
 extension View {
   func chartAccessibility(title: String, dataPoints: [DataPoint]) -> some View {
-    Group {
-      if #available(iOS 15.0, *) {
-        self
-          .accessibilityElement()
-          .accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
-      } else {
-        self
-      }
-    }
-    .accessibilityLabel(title)
+    modifier(ChartAccessibilityViewModifier(title: title, dataPoints: dataPoints))
   }
 }
 


### PR DESCRIPTION
The crash logs point to a crash in the `Group` in `chartAccessibility` so switching that over to a ViewModifier in case that is the problem.
Another change made that had problems on 14 was changes in the `UIKitNavigationView`, so reverting those back to a previous version for the time being.

## Summary of Changes

This pull request fixes #4676 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
