### PR TITLE
Fix #4686: unable to pull balance for DAI and USDC on Ropsten in Swap and failure in low allowance token swapping tx

### DIFF
--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -35,7 +35,7 @@ extension BraveWallet.ERCToken: Identifiable {
     contractAddress.isEmpty && symbol.lowercased() == "eth"
   }
   
-  public func swapAddress(in chainId: String) -> String {
+  public func contractAddress(in chainId: String) -> String {
     if chainId == BraveWallet.RopstenChainId {
       switch symbol.uppercased() {
       case "ETH": return BraveWallet.ethSwapAddress
@@ -54,9 +54,11 @@ extension BraveWallet {
   public static let ethSwapAddress: String = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   
   ///  The address that is expected when you are swapping DAI via SwapController APIs
+  ///  Also the contract address to fetch DAI balance on Ropsten
   public static let daiSwapAddress: String = "0xad6d458402f60fd3bd25163575031acdce07538d"
   
   ///  The address that is expected when you are swapping USDC via SwapController APIs
+  ///  Also the contract address to fetch USDC balance on Ropsten
   public static let usdcSwapAddress: String = "0x07865c6e87b9f70255377e024ace6630c1eaa37f"
   
   /// A list of supported assets' symbols for swapping in `Ropsten` network

--- a/BraveWallet/Extensions/RpcControllerExtensions.swift
+++ b/BraveWallet/Extensions/RpcControllerExtensions.swift
@@ -37,7 +37,13 @@ extension BraveWalletEthJsonRpcController {
     if token.isETH {
       balance(account.address, completion: convert)
     } else if token.isErc20 {
-      erc20TokenBalance(token.contractAddress, address: account.address, completion: convert)
+      chainId { [self] chainId in
+        erc20TokenBalance(
+          token.contractAddress(in: chainId),
+          address: account.address,
+          completion: convert
+        )
+      }
     } else if token.isErc721 {
       erc721TokenBalance(token.contractAddress, tokenId: token.tokenId, accountAddress: account.address,
                          completion: convert)


### PR DESCRIPTION
## Summary of Changes
Pulling with correct token contract address for DAI and USDC's balance on Ropsten.
Fixed allowance check and erc20 swap tx.

This PR fixes: #4686 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
