### PR TITLE
Fix #4682: Vpn callout is not happening after 4 days

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -944,11 +944,13 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
         
         // Full Screen Callout Presentation
         // Priority: VPN - Default Browser - Rewards - Sync
-        presentVPNAlertCallout()
-        presentDefaultBrowserScreenCallout()
-        presentBraveRewardsScreenCallout()
-        presentSyncAlertCallout()
-                
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            presentVPNAlertCallout()
+            presentDefaultBrowserScreenCallout()
+            presentBraveRewardsScreenCallout()
+            presentSyncAlertCallout()
+        }
+        
         screenshotHelper.viewIsVisible = true
         screenshotHelper.takePendingScreenshots(tabManager.allTabs)
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -944,11 +944,12 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
         
         // Full Screen Callout Presentation
         // Priority: VPN - Default Browser - Rewards - Sync
+        // TODO: Remove the dispatch after with a proper fix and fix calling present functions before super.viewDidAppear
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            presentVPNAlertCallout()
-            presentDefaultBrowserScreenCallout()
-            presentBraveRewardsScreenCallout()
-            presentSyncAlertCallout()
+            self.presentVPNAlertCallout()
+            self.presentDefaultBrowserScreenCallout()
+            self.presentBraveRewardsScreenCallout()
+            self.presentSyncAlertCallout()
         }
         
         screenshotHelper.viewIsVisible = true


### PR DESCRIPTION
Fixing callout presentation to handle VPN Product Load

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4682

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
