### PR TITLE
Fix #4676: Remove accessibility chart descriptor

### DIFF
--- a/BraveWallet/Chart/LineChartView.swift
+++ b/BraveWallet/Chart/LineChartView.swift
@@ -273,15 +273,24 @@ private struct ChartAccessibilityViewModifier: ViewModifier {
   var dataPoints: [DataPoint]
   
   func body(content: Content) -> some View {
-    if #available(iOS 15.0, *) {
-      content
-        .accessibilityElement()
-        .accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
-        .accessibilityLabel(title)
-    } else {
-      content
-        .accessibilityLabel(title)
-    }
+    // This crashes on iOS 14 with optimized builds due to some sort of Swift runtime bug where it cannot
+    // resolve a manged symbol.
+    //
+    // Last checked: Xcode 13.2 (13C90)
+    //
+    //    if #available(iOS 15.0, *) {
+    //      content
+    //        .accessibilityElement()
+    //        .accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
+    //        .accessibilityLabel(title)
+    //    } else {
+    //      content
+    //        .accessibilityLabel(title)
+    //    }
+    //
+    // For now we will just apply the title as the accessibility label
+    content
+      .accessibilityLabel(title)
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4676

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
