### PR TITLE
Fix #4651: Added Drag drop for Favourites, and Disabled Widgets

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -80,7 +80,12 @@ enum NavigationPath: Equatable {
         case .deepLink(let link): NavigationPath.handleDeepLink(link, with: bvc)
         case .url(let url, let isPrivate): NavigationPath.handleURL(url: url, isPrivate: isPrivate, with: bvc)
         case .text(let text): NavigationPath.handleText(text: text, with: bvc)
-        case .widgetShortcutURL(let path): NavigationPath.handleWidgetShortcut(path, with: bvc)
+        case .widgetShortcutURL(let path):
+            // MARK: Widgets Disabled due to Crash on iOS 14 Favourites - Brandon T.
+            // See: https://github.com/brave/brave-ios/issues/4582
+            // See: https://github.com/brave/brave-ios/pull/4692
+            print("WIDGETS DISABLED - DUE TO CRASH ON iOS 14!")
+            break //NavigationPath.handleWidgetShortcut(path, with: bvc)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1608,10 +1608,8 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
                 let addToFavoritesActivity = AddToFavoritesActivity() { [weak tab] in
                     FavoritesHelper.add(url: url, title: tab?.displayTitle)
                 }
-                // TODO: Issue #4651 - Drag and drop Favourites crashing on iOS-14
-                if #available(iOS 15.0, *) {
-                    activities.append(addToFavoritesActivity)
-                }
+                
+                activities.append(addToFavoritesActivity)
             }
             activities.append(requestDesktopSiteActivity)
             

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -471,13 +471,16 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             }
         }
         
+        // MARK: Widgets Disabled due to Crash on iOS 14 Favourites - Brandon T.
+        // See: https://github.com/brave/brave-ios/issues/4582
+        // See: https://github.com/brave/brave-ios/pull/4692
         // Setup Widgets FRC
-        widgetBookmarksFRC = Favorite.frc()
-        widgetBookmarksFRC?.fetchRequest.fetchLimit = 16
-        widgetBookmarksFRC?.delegate = self
-        try? widgetBookmarksFRC?.performFetch()
-        
-        updateWidgetFavoritesData()
+//        widgetBookmarksFRC = Favorite.frc()
+//        widgetBookmarksFRC?.fetchRequest.fetchLimit = 16
+//        widgetBookmarksFRC?.delegate = self
+//        try? widgetBookmarksFRC?.performFetch()
+//
+//        updateWidgetFavoritesData()
     }
     
     private func setupAdsNotificationHandler() {

--- a/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Client/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -144,11 +144,9 @@ class FavoritesViewController: UIViewController {
         collectionView.delegate = self
         collectionView.dragDelegate = self
         collectionView.dropDelegate = self
-        // TODO: Issue #4651 - Drag and drop Favourites crashing on iOS-14
-        if #available(iOS 15.0, *) {
-            // Drag should be enabled to rearrange favourite
-            collectionView.dragInteractionEnabled = true
-        }
+        
+        // Drag should be enabled to rearrange favourite
+        collectionView.dragInteractionEnabled = true
         collectionView.keyboardDismissMode = .interactive
         
         dataSource.supplementaryViewProvider = { [weak self] collectionView, kind, indexPath in

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -1026,11 +1026,9 @@ extension NewTabPageViewController {
             showsVerticalScrollIndicator = false
             // Even on light mode we use a darker background now
             indicatorStyle = .white
-            // TODO: Issue #4651 - Drag and drop Favourites crashing on iOS-14
-            if #available(iOS 15.0, *) {
-                // Drag should be enabled to rearrange favourite
-                dragInteractionEnabled = true
-            }
+            
+            // Drag should be enabled to rearrange favourite
+            dragInteractionEnabled = true
         }
         @available(*, unavailable)
         required init(coder: NSCoder) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- This happens only on **iOS 14** right now.
- Widgets are `observing` the `Favourite` changes and causing a crash when dragging-and-dropping favourites on NTP.
- Widgets are `observing` the `Favourite` changes and causing a crash when editing, removing, or adding favourites to NTP.
- Widgets have been disabled entirely by this PR. The widgets code is retaining something in memory + the observer, and so a crash happens. Removing widgets fixes everything including all the random weird crashes.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4651

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
