### PR TITLE
Fix #4694: Ensure keyring is checked when the app is active

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -112,7 +112,7 @@ public class KeyringStore: ObservableObject {
       self.autoLockInterval = .init(value: minutes)
     }
     cancellable = NotificationCenter.default
-      .publisher(for: UIApplication.willEnterForegroundNotification, object: nil)
+      .publisher(for: UIApplication.didBecomeActiveNotification, object: nil)
       .sink { [weak self] _ in
         self?.updateKeyringInfo()
       }
@@ -120,6 +120,13 @@ public class KeyringStore: ObservableObject {
   
   private func updateKeyringInfo() {
     controller.defaultKeyringInfo { [self] keyringInfo in
+      if UIApplication.shared.applicationState != .active {
+        // Changes made in the backgroud due to timers going off at launch don't
+        // re-render things properly.
+        //
+        // This function is called again on `didBecomeActiveNotification` anyways.
+        return
+      }
       keyring = keyringInfo
       if !keyring.accountInfos.isEmpty {
         controller.selectedAccount { accountAddress in

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -52,9 +52,8 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
       .map(\.isLocked)
       .removeDuplicates()
       .sink { [weak self] isLocked in
-        guard let self = self else { return }
-        if isLocked, let controller = self.presentedViewController {
-          controller.dismiss(animated: true)
+        if let self = self, isLocked, self.presentedViewController != nil {
+          self.dismiss(animated: true)
         }
       }
   }


### PR DESCRIPTION
This also fixes a bug where multiple presented sheets such as Swap > Account Picker would not fully dismiss to root.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4694 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
