### PR TITLE
No Bug: Restore wallet accessibility chart descriptor on iOS 15

### DIFF
--- a/BraveWallet/Chart/LineChartView.swift
+++ b/BraveWallet/Chart/LineChartView.swift
@@ -273,24 +273,15 @@ private struct ChartAccessibilityViewModifier: ViewModifier {
   var dataPoints: [DataPoint]
   
   func body(content: Content) -> some View {
-    // This crashes on iOS 14 with optimized builds due to some sort of Swift runtime bug where it cannot
-    // resolve a manged symbol.
-    //
-    // Last checked: Xcode 13.2 (13C90)
-    //
-    //    if #available(iOS 15.0, *) {
-    //      content
-    //        .accessibilityElement()
-    //        .accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
-    //        .accessibilityLabel(title)
-    //    } else {
-    //      content
-    //        .accessibilityLabel(title)
-    //    }
-    //
-    // For now we will just apply the title as the accessibility label
-    content
-      .accessibilityLabel(title)
+    if #available(iOS 15.0, *) {
+      content
+        .accessibilityElement()
+        .accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
+        .accessibilityLabel(title)
+    } else {
+      content
+        .accessibilityLabel(title)
+    }
   }
 }
 


### PR DESCRIPTION
Turns out Xcode 13.2 RC crashes on `#available` checks when the branch for that runtime availability actually includes symbols for that version (like using iOS 15 APIs in iOS 15 check) so this can be restored for now and we can blacklist using Xcode 13.2 for the time being.

## Summary of Changes

Refs #4676

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
