### PR TITLE
Fix #4712: Multiple send/swap tx are added if user presses button multiple times quickly

### DIFF
--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -220,14 +220,17 @@ public class SendTokenStore: ObservableObject {
     isMakingTx = true
     rpcController.network { [weak self] network in
       guard let self = self else { return }
-      defer { self.isMakingTx = false }
 
       if token.isETH {
         let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: self.sendAddress, value: "0x\(weiHexString)", data: .init())
         if network.isEip1559 {
-          self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress, completion: completion)
+          self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success in
+            self.isMakingTx = false
+            completion(success)
+          }
         } else {
           self.transactionController.addUnapprovedTransaction(baseData, from: fromAddress) { success, txMetaId, errorMessage in
+            self.isMakingTx = false
             completion(success)
           }
         }
@@ -239,9 +242,13 @@ public class SendTokenStore: ObservableObject {
           }
           let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
           if network.isEip1559 {
-            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress, completion: completion)
+            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success in
+              self.isMakingTx = false
+              completion(success)
+            }
           } else {
             self.transactionController.addUnapprovedTransaction(baseData, from: fromAddress) { success, txMetaId, errorMessage in
+              self.isMakingTx = false 
               completion(success)
             }
           }

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -39,7 +39,13 @@ public class SwapTokenStore: ObservableObject {
   /// The current market price for selected token to swap from.
   @Published var selectedFromTokenPrice = "0"
   /// The state of swap screen
-  @Published var state: SwapState = .idle
+  @Published var state: SwapState = .idle {
+    didSet {
+      if case .error = state {
+        isMakingTx = false
+      }
+    }
+  }
   /// The sell amount in this swap
   @Published var sellAmount = "" {
     didSet {
@@ -47,7 +53,7 @@ public class SwapTokenStore: ObservableObject {
         state = .idle
         return
       }
-      if oldValue != sellAmount && !updatingPriceQuote && !addingUnapprovedTx {
+      if oldValue != sellAmount && !updatingPriceQuote && !isMakingTx {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false, block: { [weak self] _ in
           self?.fetchPriceQuote(base: .perSellAsset)
@@ -62,7 +68,7 @@ public class SwapTokenStore: ObservableObject {
         state = .idle
         return
       }
-      if oldValue != buyAmount && !updatingPriceQuote && !addingUnapprovedTx {
+      if oldValue != buyAmount && !updatingPriceQuote && !isMakingTx {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false, block: { [weak self] _ in
           self?.fetchPriceQuote(base: .perBuyAsset)
@@ -106,7 +112,6 @@ public class SwapTokenStore: ObservableObject {
     }
   }
   private var updatingPriceQuote = false
-  private var addingUnapprovedTx = false
   private var timer: Timer?
   
   enum SwapParamsBase {
@@ -217,8 +222,6 @@ public class SwapTokenStore: ObservableObject {
         self?.clearAllAmount()
         return
       }
-      
-      self.addingUnapprovedTx = true
       self.swapController.transactionPayload(swapParams) { success, swapResponse, error in
         guard success else {
           self.state = .error(Strings.Wallet.unknownError)
@@ -249,13 +252,12 @@ public class SwapTokenStore: ObservableObject {
           self.makeEIP1559Tx(chainId: network.chainId,
                              baseData: baseData,
                              from: accountInfo) { success in
-            self.addingUnapprovedTx = false
-            self.isMakingTx = false
             guard success else {
               self.state = .error(Strings.Wallet.unknownError)
               self.clearAllAmount()
               return
             }
+            self.isMakingTx = false
           }
         } else {
           let baseData: BraveWallet.TxData = .init(
@@ -267,13 +269,12 @@ public class SwapTokenStore: ObservableObject {
             data: data
           )
           self.transactionController.addUnapprovedTransaction(baseData, from: accountInfo.address) { success, txMetaId, error in
-            self.addingUnapprovedTx = false
-            self.isMakingTx = false
             guard success else {
               self.state = .error(Strings.Wallet.unknownError)
               self.clearAllAmount()
               return
             }
+            self.isMakingTx = false
           }
         }
       }
@@ -350,7 +351,6 @@ public class SwapTokenStore: ObservableObject {
     isMakingTx = true
     rpcController.network { [weak self] network in
       guard let self = self else { return }
-      self.addingUnapprovedTx = true
       self.transactionController.makeErc20ApproveData(
         spenderAddress,
         amount: "0x\(balanceInWeiHex)"
@@ -368,26 +368,24 @@ public class SwapTokenStore: ObservableObject {
           self.makeEIP1559Tx(chainId: network.chainId,
                              baseData: baseData,
                              from: accountInfo) { success in
-            self.addingUnapprovedTx = false
-            self.isMakingTx = false
             guard success else {
               self.state = .error(Strings.Wallet.unknownError)
               self.clearAllAmount()
               return
             }
+            self.isMakingTx = false
           }
         } else {
           self.transactionController.addUnapprovedTransaction(
               baseData,
               from: accountInfo.address,
               completion: { success, txMetaId, error in
-                self.addingUnapprovedTx = false
-                self.isMakingTx = false
                 guard success else {
                   self.state = .error(Strings.Wallet.unknownError)
                   self.clearAllAmount()
                   return
                 }
+                self.isMakingTx = false
               }
           )
         }


### PR DESCRIPTION
A refix to this bug by make sure loading state is set properly at the right place.
The mistake is `defer` executes after the current scope, not necessarily after completion block

This pull request fixes https://github.com/brave/brave-ios/issues/4712

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
