### PR TITLE
Fix #4716: Crash on NTP Stats Onboarding

### DIFF
--- a/BraveUI/Popover/PopoverController.swift
+++ b/BraveUI/Popover/PopoverController.swift
@@ -286,7 +286,7 @@ public class PopoverController: UIViewController {
     ///
     /// - parameter view: The view to have the popover present from (scaling from the location of this view)
     /// - parameter viewController: The view controller to present this popover on
-    public func present(from view: UIView, on viewController: UIViewController) {
+    public func present(from view: UIView, on viewController: UIViewController, completion: (() -> Void)? = nil) {
         let convertedOriginViewCenter = viewController.view.convert(view.center, from: view.superview)
         
         switch arrowDirectionBehavior {
@@ -332,7 +332,7 @@ public class PopoverController: UIViewController {
             presentedSize: contentSize
         )
         
-        viewController.present(self, animated: true)
+        viewController.present(self, animated: true, completion: completion)
     }
     
     override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes a crash on NTP stats onboarding

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4716

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
