### PR TITLE
Fix #4714:  No "Yes" link or button to tap on to enable Rewards in callout screen

### DIFF
--- a/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingRewardsAgreementViewController.swift
@@ -83,7 +83,7 @@ extension OnboardingRewardsAgreementViewController {
         var onTermsOfServicePressed: (() -> Void)?
         var onPrivacyPolicyPressed: (() -> Void)?
         
-        let turnOnButton = OnboardingCommon.Views.primaryButton(text: Strings.OBTurnOnButton).then {
+        let turnOnButton = OnboardingCommon.Views.primaryButton(text: Strings.yes).then {
             $0.accessibilityIdentifier = "OnboardingRewardsAgreementViewController.OBTurnOnButton"
             $0.backgroundColor = .braveBlurple
             $0.titleLabel?.minimumScaleFactor = 0.75


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4714

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
