### PR TITLE
Fix #4001: Brave-Search script has the wrong name

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -13,6 +13,8 @@ import BraveCore
 extension BrowserViewController {
     
     func presentOnboardingIntro() {
+        if Preferences.DebugFlag.skipOnboardingIntro == true { return }
+        
         if Preferences.URP.referralCode.value == nil &&
             UIPasteboard.general.hasStrings &&
             (Preferences.General.basicOnboardingCompleted.value != OnboardingState.completed.rawValue &&

--- a/Client/Frontend/Browser/DomainUserScript.swift
+++ b/Client/Frontend/Browser/DomainUserScript.swift
@@ -75,7 +75,7 @@ enum DomainUserScript: CaseIterable {
         case .archive:
             return "ArchiveIsCompat"
         case .braveSearch:
-            return "BraveServicesHelper"
+            return "BraveSearchHelper"
         case .braveTalk:
             return "BraveTalkHelper"
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- BraveSearch script has the wrong name
- Modified debug flags for simulator & debug builds so clipboard doesn't harass the devs

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4001

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Same as #4001 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
