### PR TITLE
Fix #4548: Bump Brave-Core to v1.33.106 - Fixes Rewards not working due to Missing Host

### DIFF
--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -109,6 +109,7 @@ class AssetDetailStore: ObservableObject {
         }
       assetRatioController.priceHistory(
         token.symbol,
+        vsAsset: "usd",
         timeframe: timeframe
       ) { [weak self] success, history in
         guard let self = self else { return }

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -132,6 +132,7 @@ public class PortfolioStore: ObservableObject {
       group.enter()
       assetRatioController.priceHistory(
         asset.token.symbol,
+        vsAsset: "usd",
         timeframe: timeframe
       ) { [weak self] success, history in
         defer { group.leave() }

--- a/BraveWallet/Preview Content/TestAssetRatioController.swift
+++ b/BraveWallet/Preview Content/TestAssetRatioController.swift
@@ -19,7 +19,7 @@ class TestAssetRatioController: BraveWalletAssetRatioController {
     }
     completion(!prices.isEmpty, Array(prices.values))
   }
-  func priceHistory(_ asset: String, timeframe: BraveWallet.AssetPriceTimeframe, completion: @escaping (Bool, [BraveWallet.AssetTimePrice]) -> Void) {
+  func priceHistory(_ asset: String, vsAsset: String, timeframe: BraveWallet.AssetPriceTimeframe, completion: @escaping (Bool, [BraveWallet.AssetTimePrice]) -> Void) {
     //    completion(true, assets)
   }
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.33.96/brave-core-ios-1.33.96.tgz",
-      "integrity": "sha512-zXFdPCum3fFVESNrm0V8I4MgMpiYrjeL2K9y9AeJxdveeMcmI+kI+8pCFV1bZLce9CNCs/l4u+AwOiSnRrERsQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.33.106/brave-core-ios-1.33.106.tgz",
+      "integrity": "sha512-dnJ1VxtVYnQVtotYsibMMmQGYacKOE/VP49dxOAOULfp2tiYoL9tFKktaoZD5Z5kOaGsKFA19hbUNNztRrByvw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.33.96/brave-core-ios-1.33.96.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.33.106/brave-core-ios-1.33.106.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Bump Brave-Core to v1.33.106 to fix Rewards issue where the host is missing in the `v1/promotions` requests and a few others.
- Update wallet code to use v1.33.106

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4548

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Verify that REWARDS is still working
- Verify that Wallet is working


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
