### PR TITLE
Fix 4593: Crash in Onboarding when accessibility is extremely large

### DIFF
--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewCallout.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewCallout.swift
@@ -263,14 +263,17 @@ class WelcomeViewCallout: UIView {
             
             detailsLabel.do {
                 $0.text = details
-                $0.font = .preferredFont(forTextStyle: .body)
+                // Calling .preferredFont(forTextStyle: .body) will freeze the app, and crash!
+                // It creates an Out of Memory exception if the font is not .scaledFont!
+                // This is an OS bug. Fortunately our extension creates a scaled font properly.
+                $0.font = .preferredFont(for: .body, weight: .regular)
                 $0.alpha = 1.0
                 $0.isHidden = false
             }
             
             primaryButton.do {
                 $0.setTitle(buttonTitle, for: .normal)
-                $0.titleLabel?.font = .preferredFont(forTextStyle: .body)
+                $0.titleLabel?.font = .preferredFont(for: .body, weight: .regular)
                 $0.addAction(UIAction(identifier: .init(rawValue: "primary.action"), handler: { _ in
                     action()
                 }), for: .touchUpInside)
@@ -309,14 +312,14 @@ class WelcomeViewCallout: UIView {
             
             detailsLabel.do {
                 $0.text = info.details
-                $0.font = .preferredFont(forTextStyle: .body)
+                $0.font = .preferredFont(for: .body, weight: .regular)
                 $0.alpha = 1.0
                 $0.isHidden = false
             }
             
             primaryButton.do {
                 $0.setTitle(info.primaryButtonTitle, for: .normal)
-                $0.titleLabel?.font = .preferredFont(forTextStyle: .body)
+                $0.titleLabel?.font = .preferredFont(for: .body, weight: .regular)
                 $0.addAction(UIAction(identifier: .init(rawValue: "primary.action"), handler: { _ in
                     info.primaryAction()
                 }), for: .touchUpInside)
@@ -362,14 +365,14 @@ class WelcomeViewCallout: UIView {
             
             detailsLabel.do {
                 $0.text = info.details
-                $0.font = .preferredFont(forTextStyle: .body)
+                $0.font = .preferredFont(for: .body, weight: .regular)
                 $0.alpha = 1.0
                 $0.isHidden = false
             }
             
             primaryButton.do {
                 $0.setTitle(info.primaryButtonTitle, for: .normal)
-                $0.titleLabel?.font = .preferredFont(forTextStyle: .body)
+                $0.titleLabel?.font = .preferredFont(for: .body, weight: .regular)
                 $0.addAction(UIAction(identifier: .init(rawValue: "primary.action"), handler: { _ in
                     info.primaryAction()
                 }), for: .touchUpInside)
@@ -380,7 +383,7 @@ class WelcomeViewCallout: UIView {
             secondaryLabel.do {
                 $0.text = Strings.Callout.defaultBrowserCalloutSecondaryButtonDescription
                 $0.textAlignment = .right
-                $0.font = .preferredFont(forTextStyle: .body)
+                $0.font = .preferredFont(for: .body, weight: .regular)
                 $0.alpha = 1.0
                 $0.isHidden = false
                 $0.numberOfLines = 1
@@ -417,7 +420,7 @@ class WelcomeViewCallout: UIView {
             
             detailsLabel.do {
                 $0.text = "\(details)\n\(moreDetails)"
-                $0.font = .preferredFont(forTextStyle: .body)
+                $0.font = .preferredFont(for: .body, weight: .regular)
                 $0.alpha = 1.0
                 $0.isHidden = false
             }


### PR DESCRIPTION
Crash in Onboarding when accessibility is used and the fonts in Settings.app >= 3rd tick (roughly size 33pt).

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- On iPhone, when accessibility is on, and dynamic fonts are rendered, the system can run out of memory (this is an iOS bug where it cannot layout any content, NOT a Brave bug)
- This PR fixes it to use dynamically scaled fonts instead of iOS system dynamic fonts which has a massive memory leak and causes a crash.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4593

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test onboarding to make sure it doesn't crash


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
