### PR TITLE
No Bug: Adding Visual Onboarding Repeater in Settings for Testing

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -83,7 +83,6 @@ extension BrowserViewController {
             
             parentController.present(onboardingController, animated: false)
             isOnboardingOrFullScreenCalloutPresented = true
-//            shouldShowNTPEducation = true
         }
     }
     

--- a/Client/Frontend/Settings/RetentionPreferencesDebugMenuViewController.swift
+++ b/Client/Frontend/Settings/RetentionPreferencesDebugMenuViewController.swift
@@ -10,13 +10,10 @@ import BraveShared
 
 private let log = Logger.browserLogger
 
-class RetentionPreferencesDebugMenuViewController: TableViewController {    
-    private var browserViewController: BrowserViewController?
-
+class RetentionPreferencesDebugMenuViewController: TableViewController {
+    
     init() {
         super.init(style: .insetGrouped)
-        
-        browserViewController = self.currentScene?.browserViewController
     }
     
     @available(*, unavailable)
@@ -30,10 +27,9 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
         title = "Retention Preferences"
         
         dataSource.sections = [
+            startOnboardingSection,
             debugFlags,
-            retentionPreferenceFlags,
-            browserLocalFlags
-        ]
+            retentionPreferenceFlags        ]
     }
     
     private func presentDebugFlagAlert() {
@@ -47,6 +43,28 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
     }
     
     // MARK: - Sections
+    
+    private lazy var startOnboardingSection: Static.Section = {
+        var section = Static.Section(
+            rows: [
+                .init(text: "Start Onboarding", selection: { [unowned self] in
+                    let onboardingController = WelcomeViewController(profile: nil,
+                                                                     rewards: nil)
+                    onboardingController.modalPresentationStyle = .fullScreen
+                    onboardingController.onAdsWebsiteSelected = { [weak self] url in
+                        self?.dismiss(animated: true)
+                    }
+                    onboardingController.onSkipSelected = { [weak self] in
+                        self?.dismiss(animated: true)
+                    }
+                    
+                    present(onboardingController, animated: false)
+                }, cellClass: MultilineButtonCell.self)
+            ]
+        )
+        
+        return section
+    }()
     
     private lazy var debugFlags: Section = {
         var shields = Section(
@@ -154,32 +172,6 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
                     cellReuseId: "DefaultBrowserCalloutCell")
                 ],
                 footer: .title("These are the preferences that stored in preferences for determining the If certain elements are shown to user.")
-        )
-        return shields
-    }()
-        
-    private lazy var browserLocalFlags: Section = {
-        var shields = Section(
-            header: .title("Local Browser Flags"),
-            rows: [
-                .boolRow(
-                    title: "Benchmark Notification Presented",
-                    detailText: "Flag tracking If a product notification is presented in the actual launch session. This flag is used in order to not to try to present another one over existing popover.",
-                    toggleValue: browserViewController?.benchmarkNotificationPresented ?? false,
-                    valueChange: { [unowned self] status in
-                        self.browserViewController?.benchmarkNotificationPresented = status
-                    },
-                    cellReuseId: "BenchmarkNotificationCell"),
-                .boolRow(
-                    title: "Onboarding or Callout Presented",
-                    detailText: "Flag tracking If a full screen callout or onboarding is presented in order to not to try to present another callout  over existing one",
-                    toggleValue: browserViewController?.isOnboardingOrFullScreenCalloutPresented ?? false,
-                    valueChange: { [unowned self] status in
-                        self.browserViewController?.isOnboardingOrFullScreenCalloutPresented = status
-                    },
-                    cellReuseId: "OnboardingCalloutPresentedCell"),
-            ],
-            footer: .title("These are flags locally stored in browser controller determines certain situations where an onboarding element, a callout or an education pop-up will appear.")
         )
         return shields
     }()


### PR DESCRIPTION
No Bug: Adding a Start Onboarding functionin custom settings  just to display onboarding visuals repeatily

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #NA

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

https://user-images.githubusercontent.com/6643505/146068708-815d8852-0841-43f5-af5a-f87a044a9db7.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
