### PR TITLE
Fix #4582: Added widgets back to the project

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1059,6 +1059,7 @@
 		CA7C5CAD2731928F003366F7 /* WelcomeViewSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7C5CAC2731928F003366F7 /* WelcomeViewSearchView.swift */; };
 		CA7C5CAF2731D022003366F7 /* PrivacyEverywhereView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7C5CAE2731D022003366F7 /* PrivacyEverywhereView.swift */; };
 		CA84F896274F428B00B1388E /* SyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA84F895274F428B00B1388E /* SyncTests.swift */; };
+		CA8B4AF0276A8339002120F7 /* BraveWidgetsExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = CA0391B2271E1023000EB13C /* BraveWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		CA8D5C0E26D7CD8A009BF13D /* PlaylistDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8D5C0D26D7CD8A009BF13D /* PlaylistDetailViewController.swift */; };
 		CA8D5C1026D7CDAF009BF13D /* PlaylistListViewController+DragDropDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8D5C0F26D7CDAF009BF13D /* PlaylistListViewController+DragDropDelegate.swift */; };
 		CA8D5C1226D7CDCD009BF13D /* PlaylistListViewController+TableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8D5C1126D7CDCD009BF13D /* PlaylistListViewController+TableViewDataSource.swift */; };
@@ -1540,6 +1541,13 @@
 			remoteGlobalIDString = 5DE7688320B3456C00FF5533;
 			remoteInfo = BraveShared;
 		};
+		CA8B4AE3276A830F002120F7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CA0391B1271E1023000EB13C;
+			remoteInfo = BraveWidgetsExtension;
+		};
 		E63CD1B11B31B66400A63AFF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
@@ -1634,6 +1642,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
+				CA8B4AF0276A8339002120F7 /* BraveWidgetsExtension.appex in Embed App Extensions */,
 				27F4439F2135E11200296C58 /* ShareExtension.appex in Embed App Extensions */,
 				2F6931BB260CFB3700ECEB38 /* BrowserIntents.appex in Embed App Extensions */,
 			);
@@ -7184,6 +7193,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				CA8B4AE4276A830F002120F7 /* PBXTargetDependency */,
 				288A2D9C1AB8B3260023ABC3 /* PBXTargetDependency */,
 				2FCAE2301ABB51F800877008 /* PBXTargetDependency */,
 				5D1DC52720AC9AFB00905E5A /* PBXTargetDependency */,
@@ -9052,6 +9062,11 @@
 			isa = PBXTargetDependency;
 			target = 5DE7688320B3456C00FF5533 /* BraveShared */;
 			targetProxy = 5DE7689720B3456E00FF5533 /* PBXContainerItemProxy */;
+		};
+		CA8B4AE4276A830F002120F7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CA0391B1271E1023000EB13C /* BraveWidgetsExtension */;
+			targetProxy = CA8B4AE3276A830F002120F7 /* PBXContainerItemProxy */;
 		};
 		E6F965141B2F1CF20034B023 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -80,12 +80,7 @@ enum NavigationPath: Equatable {
         case .deepLink(let link): NavigationPath.handleDeepLink(link, with: bvc)
         case .url(let url, let isPrivate): NavigationPath.handleURL(url: url, isPrivate: isPrivate, with: bvc)
         case .text(let text): NavigationPath.handleText(text: text, with: bvc)
-        case .widgetShortcutURL(let path):
-            // MARK: Widgets Disabled due to Crash on iOS 14 Favourites - Brandon T.
-            // See: https://github.com/brave/brave-ios/issues/4582
-            // See: https://github.com/brave/brave-ios/pull/4692
-            print("WIDGETS DISABLED - DUE TO CRASH ON iOS 14!")
-            break //NavigationPath.handleWidgetShortcut(path, with: bvc)
+        case .widgetShortcutURL(let path): NavigationPath.handleWidgetShortcut(path, with: bvc)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -471,16 +471,13 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             }
         }
         
-        // MARK: Widgets Disabled due to Crash on iOS 14 Favourites - Brandon T.
-        // See: https://github.com/brave/brave-ios/issues/4582
-        // See: https://github.com/brave/brave-ios/pull/4692
         // Setup Widgets FRC
-//        widgetBookmarksFRC = Favorite.frc()
-//        widgetBookmarksFRC?.fetchRequest.fetchLimit = 16
-//        widgetBookmarksFRC?.delegate = self
-//        try? widgetBookmarksFRC?.performFetch()
-//
-//        updateWidgetFavoritesData()
+        widgetBookmarksFRC = Favorite.frc()
+        widgetBookmarksFRC?.fetchRequest.fetchLimit = 16
+        widgetBookmarksFRC?.delegate = self
+        try? widgetBookmarksFRC?.performFetch()
+
+        updateWidgetFavoritesData()
     }
     
     private func setupAdsNotificationHandler() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Widgets.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Widgets.swift
@@ -15,10 +15,16 @@ extension BrowserViewController: NSFetchedResultsControllerDelegate {
     func updateWidgetFavoritesData() {
         guard let frc = widgetBookmarksFRC else { return }
         try? frc.performFetch()
+        
         if let favs = frc.fetchedObjects {
             let group = DispatchGroup()
             var favData: [Int: WidgetFavorite] = [:]
-            for (index, fav) in favs.prefix(16).enumerated() {
+            
+            // MUST copy `favs` array.
+            // If we don't, operating on `favs` is undefined behaviour on iOS 14! - Brandon T.
+            // This causes a terribly difficult to find bug on iOS 14 (dangling pointer).
+            // See also: https://bugs.swift.org/browse/SR-12288
+            for (index, fav) in Array(favs).prefix(16).enumerated() {
                 if let url = fav.url?.asURL {
                     group.enter()
                     let fetcher = FaviconFetcher(siteURL: url, kind: .largeIcon, persistentCheckOverride: true)
@@ -29,7 +35,7 @@ extension BrowserViewController: NSFetchedResultsControllerDelegate {
                     }
                 }
             }
-            
+
             group.notify(queue: .main) { [self] in
                 widgetFaviconFetchers.removeAll()
                 // While we get favorites from the database in correct order,
@@ -39,7 +45,7 @@ extension BrowserViewController: NSFetchedResultsControllerDelegate {
                 let sortedData = favData
                     .sorted { $0.key < $1.key }
                     .map { $0.value }
-                
+
                 FavoritesWidgetData.updateWidgetData(sortedData)
             }
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Adding back Widgets feature to the project.
- Fixed Favourites Re-ordering crashing due to a bug in iOS itself.

iOS Bug:
```
MUST copy (Objective-C) `favs` array.
If we don't, operating on `favs` is undefined behaviour on iOS 14!
This causes a terribly difficult to find bug on iOS 14 (dangling pointer).
See also: https://bugs.swift.org/browse/SR-12288
```

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4582

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
