### PR TITLE
Fix #4583: Restore saved logins screen

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -446,9 +446,6 @@ class SettingsViewController: TableViewController {
             header: .title(Strings.security),
             rows: [
                 .boolRow(title: Strings.browserLock, detailText: Strings.browserLockDescription, option: Preferences.Privacy.lockWithPasscode, image: #imageLiteral(resourceName: "settings-passcode").template),
-                // TODO: Uncomment once we restore saved logins, see #4583
-                // Also delete the preference toggle for saved logins
-                /*,
                 Row(text: Strings.Login.loginListNavigationTitle, selection: { [unowned self] in
                     let loginsPasswordsViewController = LoginListViewController(
                         profile: self.profile,
@@ -456,8 +453,6 @@ class SettingsViewController: TableViewController {
                     loginsPasswordsViewController.settingsDelegate = self.settingsDelegate
                     self.navigationController?.pushViewController(loginsPasswordsViewController, animated: true)
                 }, image: #imageLiteral(resourceName: "settings-save-logins").template, accessory: .disclosureIndicator)
-                */
-                .boolRow(title: Strings.saveLogins, option: Preferences.General.saveLogins, image: #imageLiteral(resourceName: "settings-save-logins").template)
             ]
         )
     }()


### PR DESCRIPTION
Restoring Password And Logins Entry into Settings Screen

## Summary of Changes

This pull request fixes #4583

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
