### PR TITLE
Fix #4586 Tab bar selection indicator with wrong width on iPad at wallet launch

### DIFF
--- a/BraveWallet/TabbedPageViewController.swift
+++ b/BraveWallet/TabbedPageViewController.swift
@@ -87,6 +87,9 @@ class TabbedPageViewController: UIViewController {
     tabsBar.selectedTabAtIndexPath = { [unowned self] indexPath in
       moveToPage(at: indexPath)
     }
+    tabsBar.boundsWidthChanged = { [unowned self] in
+      updateTabsBarSelectionIndicator(pageIndex: currentIndex ?? 0)
+    }
     
     tabsBar.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview()
@@ -343,12 +346,20 @@ private class TabsBarView: UIView, UICollectionViewDelegate {
       // When we add back more items to the pages list, switch this back to estimated and remove
       // item size setting within `layoutSubviews`
       flowLayout.itemSize = CGSize(width: 44, height: tabBarHeight)
-//      flowLayout.estimatedItemSize = CGSize(width: 44, height: tabBarHeight)
       return flowLayout
     }()
   )
   
   var selectedTabAtIndexPath: ((IndexPath) -> Void)?
+  var boundsWidthChanged: (() -> Void)?
+  
+  override var bounds: CGRect {
+    didSet {
+      if oldValue.width != bounds.width {
+        boundsWidthChanged?()
+      }
+    }
+  }
   
   override func layoutSubviews() {
     super.layoutSubviews()


### PR DESCRIPTION
## Summary of Changes
The tab bounds.width changes on iPad somehow. The fix is to update the indicator'frame once the tab bounds.width is changed. 

This pull request fixes #4586

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

https://user-images.githubusercontent.com/1187676/146597674-580f99c7-b5e7-4017-8940-06476696f55c.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
