### PR TITLE
Fix #4704 Only show wallet in the main settings when a wallet account has been set up

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -90,6 +90,10 @@ public class KeyringStore: ObservableObject {
       controller.setSelectedAccount(selectedAccount.address) { _ in }
     }
   }
+  /// For showing wallet in the main Settings only when default keyring is created
+  public var isDefaultKeyringCreated: Bool {
+    return keyring.isDefaultKeyringCreated
+  }
   
   private let controller: BraveWalletKeyringController
   private var cancellable: AnyCancellable?

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -249,7 +249,7 @@ class SettingsViewController: TableViewController {
             }, image: #imageLiteral(resourceName: "settings-playlist").template, accessory: .disclosureIndicator)
         )
         
-        if #available(iOS 14.0, *), let keyringStore = walletKeyringStore {
+        if #available(iOS 14.0, *), let keyringStore = walletKeyringStore, keyringStore.isDefaultKeyringCreated {
             section.rows.append(
                 Row(text: Strings.Wallet.braveWallet, selection: { [unowned self] in
                     let vc = UIHostingController(rootView: WalletSettingsView(keyringStore: keyringStore))


### PR DESCRIPTION

This pull request fixes #4704 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
