### PR TITLE
Fix #4575: NTP crashing when closing default browser callout and brave news

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -493,7 +493,7 @@ class NewTabPageViewController: UIViewController {
             // However we saw it crashing in XCode logs, see #4202.
             let firstItemIndexPath = IndexPath(item: 0, section: 0)
             if let itemCount = collectionView.dataSource?.collectionView(collectionView, numberOfItemsInSection: 0),
-               itemCount > 0, // Cannot scroll to deleted item index.
+               itemCount > 0, // Only scroll if the section has items, otherwise it will crash.
                collectionView.dataSource?
                 .collectionView(collectionView, cellForItemAt: firstItemIndexPath) != nil {
                 collectionView.scrollToItem(at: firstItemIndexPath, at: .top, animated: true)

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -492,9 +492,17 @@ class NewTabPageViewController: UIViewController {
             // This should never happen since first item is our shields stats view.
             // However we saw it crashing in XCode logs, see #4202.
             let firstItemIndexPath = IndexPath(item: 0, section: 0)
-            if collectionView.dataSource?
+            if let itemCount = collectionView.dataSource?.collectionView(collectionView, numberOfItemsInSection: 0),
+               itemCount > 0, // Cannot scroll to deleted item index.
+               collectionView.dataSource?
                 .collectionView(collectionView, cellForItemAt: firstItemIndexPath) != nil {
                 collectionView.scrollToItem(at: firstItemIndexPath, at: .top, animated: true)
+            } else {
+                // Cannot scorll to deleted item index.
+                // Collection-View datasource never changes or updates
+                // Therefore we need to scroll to offset 0.
+                // See: #4575.
+                collectionView.setContentOffset(.zero, animated: true)
             }
             collectionView.verticalScrollIndicatorInsets = .zero
             UIView.animate(withDuration: 0.25) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix crash on NTP when closing Default Browser followed by closing Brave News.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4575

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Fresh Install
2. Close Default Browser callout (green callout with X button on NTP).
3. Close Brave News Opt-In card (still on NTP).
4. Observe No Crash after with this PR.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
