### PR TITLE
Fix #4570, #3824: Change all JS related code to use WKContentWorld sandboxing Part #1

### DIFF
--- a/Client/Extensions/PaymentRequestExtension.swift
+++ b/Client/Extensions/PaymentRequestExtension.swift
@@ -49,7 +49,7 @@ extension PaymentRequestExtension: TabContentScript {
     
     private func sendPaymentRequestError(errorName: String, errorMessage: String) {
         ensureMainThread {
-            self.tab?.webView?.evaluateSafeJavaScript(functionName: "PaymentRequestCallback\(self.token).paymentreq_postCreate", args: ["", errorName, errorMessage]) { _, error in
+            self.tab?.webView?.evaluateSafeJavaScript(functionName: "PaymentRequestCallback\(self.token).paymentreq_postCreate", args: ["", errorName, errorMessage], contentWorld: .defaultClient) { _, error in
                     if error != nil {
                         log.error(error)
                     }
@@ -93,7 +93,7 @@ extension PaymentRequestExtension: TabContentScript {
                     }
                 case .completed(let orderId):
                     ensureMainThread {
-                        self.tab?.webView?.evaluateSafeJavaScript(functionName: "PaymentRequestCallback\(self.token).paymentreq_postCreate", args: [orderId, "", ""]) { _, error in
+                        self.tab?.webView?.evaluateSafeJavaScript(functionName: "PaymentRequestCallback\(self.token).paymentreq_postCreate", args: [orderId, "", ""], contentWorld: .defaultClient) { _, error in
                                 if error != nil {
                                     log.error(error)
                                 }

--- a/Client/Frontend/Browser/BraveSearchScriptHandler.swift
+++ b/Client/Frontend/Browser/BraveSearchScriptHandler.swift
@@ -116,6 +116,6 @@ class BraveSearchScriptHandler: TabContentScript {
         self.tab?.webView?.evaluateSafeJavaScript(
             functionName: functionName,
             args: args,
-            sandboxed: false)
+            contentWorld: .page)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1201,7 +1201,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             // IE: The user must explicitly tap a bookmark they have saved.
             // Block all other contexts such as redirects, downloads, embed, linked, etc..
             if visitType == .bookmark, let webView = tab.webView, let code = url.bookmarkletCodeComponent {
-                webView.evaluateSafeJavaScript(functionName: code, sandboxed: false, asFunction: false) { _, error in
+                webView.evaluateSafeJavaScript(functionName: code, contentWorld: .page, asFunction: false) { _, error in
                     if let error = error {
                         log.error(error)
                     }
@@ -1424,7 +1424,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             return
         }
         if NoImageModeHelper.isActivated {
-            webView.evaluateSafeJavaScript(functionName: "__firefox__.NoImageMode.setEnabled", args: ["true"])
+            webView.evaluateSafeJavaScript(functionName: "__firefox__.NoImageMode.setEnabled", args: ["true"], contentWorld: .defaultClient)
         }
     }
 
@@ -1768,7 +1768,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             findInPageBar.endEditing(true)
             let tab = tab ?? tabManager.selectedTab
             guard let webView = tab?.webView else { return }
-            webView.evaluateSafeJavaScript(functionName: "__firefox__.findDone")
+            webView.evaluateSafeJavaScript(functionName: "__firefox__.findDone", contentWorld: .defaultClient)
             findInPageBar.removeFromSuperview()
             self.findInPageBar = nil
             updateViewConstraints()
@@ -1792,7 +1792,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
                 // because that event wil not always fire due to unreliable page caching. This will either let us know that
                 // the currently loaded page can be turned into reading mode or if the page already is in reading mode. We
                 // ignore the result because we are being called back asynchronous when the readermode status changes.
-                webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).checkReadability", sandboxed: false)
+                webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).checkReadability", contentWorld: .page)
 
                 // Re-run additional scripts in webView to extract updated favicons and metadata.
                 runScriptsOnWebView(webView)
@@ -2483,7 +2483,7 @@ extension BrowserViewController: WKUIDelegate {
                     window.alert=window.confirm=window.prompt=function(n){},
                     [].slice.apply(document.querySelectorAll('iframe')).forEach(function(n){if(n.contentWindow != window){n.contentWindow.alert=n.contentWindow.confirm=n.contentWindow.prompt=function(n){}}})
                     """
-        webView.evaluateSafeJavaScript(functionName: script, sandboxed: false, asFunction: false)
+        webView.evaluateSafeJavaScript(functionName: script, contentWorld: .page, asFunction: false)
     }
     
     func handleAlert<T: JSAlertInfo>(webView: WKWebView, alert: inout T, completionHandler: @escaping () -> Void) {
@@ -2744,7 +2744,7 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
                 self.findInPageBar?.currentResult = index
             }
         } else {
-            webView.evaluateSafeJavaScript(functionName: "__firefox__.\(function)", args: [text], sandboxed: false)
+            webView.evaluateSafeJavaScript(functionName: "__firefox__.\(function)", args: [text], contentWorld: .page)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -296,14 +296,14 @@ extension Tab {
         let group = DispatchGroup()
         group.enter()
         
-        webView.evaluateSafeJavaScript(functionName: "document.documentElement.outerHTML.toString") { html, _ in
+        webView.evaluateSafeJavaScript(functionName: "document.documentElement.outerHTML.toString", contentWorld: .defaultClient) { html, _ in
             htmlBlob = html as? String
             group.leave()
         }
         
         if shouldClassifyLoadsForAds {
             group.enter()
-            webView.evaluateSafeJavaScript(functionName: "document.body.innerText", asFunction: false) { text, _ in
+            webView.evaluateSafeJavaScript(functionName: "document.body.innerText", contentWorld: .defaultClient, asFunction: false) { text, _ in
                 // Get the list of words in the page and join them together with a space
                 // to send to the classifier
                 classifierText = (text as? String)?.words.joined(separator: " ")

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -159,7 +159,7 @@ extension BrowserViewController {
             PlaylistHelper.updatePlaylistTab(tab: tab, item: playlistItem)
         } else {
             // Store the readability result in the cache and load it. This will later move to the ReadabilityHelper.
-            webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).readerize", sandboxed: false) { (object, error) -> Void in
+            webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).readerize", contentWorld: .page) { (object, error) -> Void in
                 if let readabilityResult = ReadabilityResult(object: object as AnyObject?) {
                     let playlistItem = tab.playlistItem
                     try? self.readerModeCache.put(currentURL, readabilityResult)

--- a/Client/Frontend/Browser/DomainUserScript.swift
+++ b/Client/Frontend/Browser/DomainUserScript.swift
@@ -98,9 +98,9 @@ enum DomainUserScript: CaseIterable {
             alteredSource = alteredSource.replacingOccurrences(of: "$<setJS>", with: "ABSSJ\(token)",
                                                                options: .literal)
             
-            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         case .archive:
-            return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         case .braveSearch:
             var alteredSource = source
             
@@ -111,7 +111,7 @@ enum DomainUserScript: CaseIterable {
                                       options: .literal)
                 .replacingOccurrences(of: "$<security_token>", with: securityToken)
                 
-            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         case .braveTalk:
             var alteredSource = source
             
@@ -122,7 +122,7 @@ enum DomainUserScript: CaseIterable {
                                       options: .literal)
                 .replacingOccurrences(of: "$<security_token>", with: securityToken)
                 
-            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         }
     }
     

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -217,7 +217,7 @@ class LoginsHelper: TabContentScript {
                 return
             }
             
-            self.tab?.webView?.evaluateSafeJavaScript(functionName: "window.__firefox__.logins.inject", args: [jsonString], sandboxed: false, escapeArgs: false) { (obj, err) -> Void in
+            self.tab?.webView?.evaluateSafeJavaScript(functionName: "window.__firefox__.logins.inject", args: [jsonString], contentWorld: .page, escapeArgs: false) { (obj, err) -> Void in
                 if err != nil {
                     log.debug(err)
                 }

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -33,7 +33,7 @@ class MetadataParserHelper: TabEventHandler {
                 return
         }
 
-        webView.evaluateSafeJavaScript(functionName: "__firefox__.metadata && __firefox__.metadata.getMetadata()", sandboxed: false, asFunction: false) { (result, error) in
+        webView.evaluateSafeJavaScript(functionName: "__firefox__.metadata && __firefox__.metadata.getMetadata()", contentWorld: .page, asFunction: false) { (result, error) in
             guard error == nil else {
                 // TabEvent.post(.pageMetadataNotAvailable, for: tab)
                 tab.pageMetadata = nil

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -378,7 +378,7 @@ class PlaylistWebLoader: UIView {
         replacements.forEach({
             alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
         })
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
     }()
     
     private weak var certStore: CertStore?

--- a/Client/Frontend/Browser/ResourceDownloadManager.swift
+++ b/Client/Frontend/Browser/ResourceDownloadManager.swift
@@ -60,7 +60,7 @@ class ResourceDownloadManager: TabContentScript {
     static func downloadResource(for tab: Tab, url: URL) {        
         let token = UserScriptManager.securityTokenString
 
-        tab.webView?.evaluateSafeJavaScript(functionName: "D\(token).download", args: [url.absoluteString], sandboxed: false) { _, error in
+        tab.webView?.evaluateSafeJavaScript(functionName: "D\(token).download", args: [url.absoluteString], contentWorld: .page) { _, error in
             if let error = error {
                 tab.temporaryDocument?.onDocumentDownloaded(document: nil, error: error)
             }

--- a/Client/Frontend/Browser/SessionRestoreHandler.swift
+++ b/Client/Frontend/Browser/SessionRestoreHandler.swift
@@ -13,9 +13,7 @@ extension WKWebView {
     // Use JS to redirect the page without adding a history entry
     func replaceLocation(with url: URL) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: apostropheEncoded)
-        evaluateSafeJavaScript(functionName: "location.replace", args: [safeUrl], sandboxed: true, escapeArgs: false, asFunction: true, completion: nil)
-        
-        evaluateJavaScript("location.replace('\(safeUrl)')", in: nil, in: .defaultClient, completionHandler: nil) //swiftlint:disable:this safe_javascript
+        evaluateSafeJavaScript(functionName: "location.replace", args: [safeUrl], contentWorld: .defaultClient, escapeArgs: false, asFunction: true, completion: nil)
     }
 }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -949,7 +949,7 @@ extension TabManager: WKNavigationDelegate {
         tab.noImageMode = isNoImageMode
         
         if !tab.contentBlocker.isEnabled {
-            webView.evaluateSafeJavaScript(functionName: "window.__firefox__.TrackingProtectionStats.setEnabled", args: [false, UserScriptManager.securityTokenString], sandboxed: false)
+            webView.evaluateSafeJavaScript(functionName: "window.__firefox__.TrackingProtectionStats.setEnabled", args: [false, UserScriptManager.securityTokenString], contentWorld: .page)
         }
     }
 

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -136,10 +136,16 @@ class UserScriptManager {
                 let wrappedSource = "(function() { const SECURITY_TOKEN = '\(UserScriptManager.messageHandlerTokenString)'; \(source) })()"
 
                 if sandboxed {
-                    return WKUserScript.createInDefaultContentWorld(source: wrappedSource, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
-                } else {
-                    return WKUserScript(source: wrappedSource, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly)
+                    return WKUserScript(source: wrappedSource,
+                                        injectionTime: injectionTime,
+                                        forMainFrameOnly: mainFrameOnly,
+                                        in: .defaultClient)
                 }
+                
+                return WKUserScript(source: wrappedSource,
+                                    injectionTime: injectionTime,
+                                    forMainFrameOnly: mainFrameOnly,
+                                    in: .page)
             }
             return nil
         }
@@ -152,7 +158,10 @@ class UserScriptManager {
         }
         var alteredSource = source
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "FingerprintingProtection\(messageHandlerTokenString)", options: .literal)
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        return WKUserScript(source: alteredSource,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     private let cookieControlUserScript: WKUserScript? = {
@@ -161,7 +170,10 @@ class UserScriptManager {
             return nil
         }
         
-        return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        return WKUserScript(source: source,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     // PaymentRequestUserScript is injected at document start to handle
@@ -180,7 +192,10 @@ class UserScriptManager {
         alteredSource = alteredSource.replacingOccurrences(of: "$<paymentreqcallback>", with: "PaymentRequestCallback\(securityTokenString)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "PaymentRequest\(messageHandlerTokenString)", options: .literal)
         
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        return WKUserScript(source: alteredSource,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     private let resourceDownloadManagerUserScript: WKUserScript? = {
@@ -193,7 +208,10 @@ class UserScriptManager {
         alteredSource = alteredSource.replacingOccurrences(of: "$<downloadManager>", with: "D\(securityTokenString)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "ResourceDownloadManager\(messageHandlerTokenString)", options: .literal)
         
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+        return WKUserScript(source: alteredSource,
+                            injectionTime: .atDocumentEnd,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     private let WindowRenderHelperScript: WKUserScript? = {
@@ -210,7 +228,10 @@ class UserScriptManager {
         alteredSource = alteredSource.replacingOccurrences(of: "$<windowRenderer>", with: "W\(securityTokenString)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "WindowRenderHelper\(messageHandlerTokenString)", options: .literal)
         
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        return WKUserScript(source: alteredSource,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     private let FullscreenHelperScript: WKUserScript? = {
@@ -218,7 +239,11 @@ class UserScriptManager {
             log.error("Failed to load FullscreenHelper.js")
             return nil
         }
-        return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        
+        return WKUserScript(source: source,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     private let PlaylistSwizzlerScript: WKUserScript? = {
@@ -227,7 +252,11 @@ class UserScriptManager {
             log.error("Failed to load PlaylistSwizzler.js")
             return nil
         }
-        return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        
+        return WKUserScript(source: source,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     private let PlaylistHelperScript: WKUserScript? = {
@@ -269,7 +298,10 @@ class UserScriptManager {
             alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
         })
         
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        return WKUserScript(source: alteredSource,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
     
     private let MediaBackgroundingScript: WKUserScript? = {
@@ -290,7 +322,10 @@ class UserScriptManager {
             alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
         })
         
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        return WKUserScript(source: alteredSource,
+                            injectionTime: .atDocumentStart,
+                            forMainFrameOnly: false,
+                            in: .page)
     }()
 
     private func reloadUserScripts() {

--- a/Client/Frontend/Browser/WindowRenderHelperScript.swift
+++ b/Client/Frontend/Browser/WindowRenderHelperScript.swift
@@ -28,6 +28,6 @@ class WindowRenderHelperScript: TabContentScript {
     
     static func executeScript(for tab: Tab) {
         let token = UserScriptManager.securityTokenString
-        tab.webView?.evaluateSafeJavaScript(functionName: "W\(token).resizeWindow", sandboxed: false)
+        tab.webView?.evaluateSafeJavaScript(functionName: "W\(token).resizeWindow", contentWorld: .page)
     }
 }

--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -91,7 +91,7 @@ extension ReadabilityOperation: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).checkReadability", sandboxed: false)
+        webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).checkReadability", contentWorld: .page)
     }
 }
 

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -293,7 +293,7 @@ class ReaderMode: TabContentScript {
     var style: ReaderModeStyle = DefaultReaderModeStyle {
         didSet {
             if state == ReaderModeState.active {
-                tab?.webView?.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).setStyle", args: [style.encode()], sandboxed: false, escapeArgs: false) { (object, error) -> Void in
+                tab?.webView?.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).setStyle", args: [style.encode()], contentWorld: .page, escapeArgs: false) { (object, error) -> Void in
                     return
                 }
             }

--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -144,7 +144,7 @@ class ContentBlockerHelper {
 
         // Async required here to ensure remove() call is processed.
         DispatchQueue.main.async() {
-            self.tab?.webView?.evaluateSafeJavaScript(functionName: "window.__firefox__.NoImageMode.setEnabled", args: [enabled])
+            self.tab?.webView?.evaluateSafeJavaScript(functionName: "window.__firefox__.NoImageMode.setEnabled", args: [enabled], contentWorld: .defaultClient)
         }
     }
 

--- a/ClientTests/TabSessionTests.swift
+++ b/ClientTests/TabSessionTests.swift
@@ -597,7 +597,7 @@ class TabSessionTests: XCTestCase {
                 XCTFail("WebView is not created yet")
                 return
             }
-            webView.evaluateSafeJavaScript(functionName: javascript, sandboxed: false,  asFunction: false) { result, error in
+            webView.evaluateSafeJavaScript(functionName: javascript, contentWorld: .page,  asFunction: false) { result, error in
                 guard let keys = result as? String else {
                     XCTFail("Javascript error while finding secret tokens")
                     expectation.fulfill()

--- a/ClientTests/UserAgentTests.swift
+++ b/ClientTests/UserAgentTests.swift
@@ -38,7 +38,7 @@ class UserAgentTests: XCTestCase {
         
         let webView = BraveWebView(frame: .zero, isPrivate: false)
         
-        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", sandboxed: false, asFunction: false) { result, error in
+        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", contentWorld: .page, asFunction: false) { result, error in
             let userAgent = result as! String
             if !self.mobileUARegex(userAgent) || self.desktopUARegex(userAgent) {
                 XCTFail("User agent did not match expected pattern! \(userAgent)")
@@ -57,14 +57,14 @@ class UserAgentTests: XCTestCase {
         let webView = BraveWebView(frame: .zero, isPrivate: false)
         let wkWebView = WKWebView()
         
-        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", args:[], sandboxed: false, asFunction: false) { result, error in
+        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", args:[], contentWorld: .page, asFunction: false) { result, error in
             
             guard let braveFirstPartOfUA = (result as? String)?.components(separatedBy: "Gecko") else {
                 XCTFail("Could not unwrap BraveWebView UA")
                 return
             }
             
-            wkWebView.evaluateSafeJavaScript(functionName: "navigator.userAgent", sandboxed: false, asFunction: false) { wkResult, wkError in
+            wkWebView.evaluateSafeJavaScript(functionName: "navigator.userAgent", contentWorld: .page, asFunction: false) { wkResult, wkError in
                 guard let wkWebViewFirstPartOfUA = (result as? String)?
                     .components(separatedBy: "Gecko") else {
                     XCTFail("Could not unwrap WKWebView UA")
@@ -94,7 +94,7 @@ class UserAgentTests: XCTestCase {
         let expectation = self.expectation(description: "Found Firefox user agent")
         let webView = BraveWebView(frame: .zero, isPrivate: false)
         
-        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", sandboxed: false, asFunction: false) { result, error in
+        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", contentWorld: .page, asFunction: false) { result, error in
            let userAgent = result as! String
             if self.mobileUARegex(userAgent) || !self.desktopUARegex(userAgent) {
                 XCTFail("User agent did not match expected pattern! \(userAgent)")
@@ -117,7 +117,7 @@ class UserAgentTests: XCTestCase {
         let expectation = self.expectation(description: "Found Firefox user agent")
         let webView = BraveWebView(frame: .zero, isPrivate: false)
         
-        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", sandboxed: false, asFunction: false) { result, error in
+        webView.evaluateSafeJavaScript(functionName: "navigator.userAgent", contentWorld: .page, asFunction: false) { result, error in
            let userAgent = result as! String
             if !self.mobileUARegex(userAgent) || self.desktopUARegex(userAgent) {
                 XCTFail("User agent did not match expected pattern! \(userAgent)")

--- a/ClientTests/WKWebViewExtensionsTest.swift
+++ b/ClientTests/WKWebViewExtensionsTest.swift
@@ -12,25 +12,25 @@ import WebKit
 class WKWebViewExtensionsTest: XCTestCase {
     func testGenerateJavascriptFunctionString() {
         let webView = BraveWebView(frame: .zero, isPrivate: false)
-        var js = webView.generateJavascriptFunctionString(functionName: "demo_function", args: [])
+        var js = webView.generateJSFunctionString(functionName: "demo_function", args: [])
         XCTAssertNil(js.error)
         XCTAssertEqual(js.javascript, "demo_function()")
         
-        js = webView.generateJavascriptFunctionString(functionName: "demo_function", args: ["a", "b", "c"])
+        js = webView.generateJSFunctionString(functionName: "demo_function", args: ["a", "b", "c"])
         XCTAssertNil(js.error)
         XCTAssertEqual(js.javascript, "demo_function('a', 'b', 'c')")
         
-        js = webView.generateJavascriptFunctionString(functionName: "demo_function", args: ["\"); (fn () {userPassword = 7})("])
+        js = webView.generateJSFunctionString(functionName: "demo_function", args: ["\"); (fn () {userPassword = 7})("])
         XCTAssertNotNil(js.error)
         
-        js = webView.generateJavascriptFunctionString(functionName: "demo_function", args: ["&", "'", "<", ">", "`"])
+        js = webView.generateJSFunctionString(functionName: "demo_function", args: ["&", "'", "<", ">", "`"])
         XCTAssertNotNil(js.error)
 
-        js = webView.generateJavascriptFunctionString(functionName: "demo_function", args: ["<script>alert(1);</script>"])
+        js = webView.generateJSFunctionString(functionName: "demo_function", args: ["<script>alert(1);</script>"])
         XCTAssertNil(js.error)
         XCTAssertEqual(js.javascript, "demo_function('&lt;script&gt;alert(1);&lt;/script&gt;')")
         
-        js = webView.generateJavascriptFunctionString(functionName: "demo_function", args: ["<script>alert(1);</script>"], escapeArgs: false)
+        js = webView.generateJSFunctionString(functionName: "demo_function", args: ["<script>alert(1);</script>"], escapeArgs: false)
         XCTAssertNil(js.error)
         XCTAssertEqual(js.javascript, "demo_function(<script>alert(1);</script>)")
     }

--- a/DataTests/CoreDataTestCase.swift
+++ b/DataTests/CoreDataTestCase.swift
@@ -5,6 +5,7 @@
 import XCTest
 import CoreData
 @testable import Data
+@testable import BraveShared
 
 class CoreDataTestCase: XCTestCase {
     
@@ -15,6 +16,7 @@ class CoreDataTestCase: XCTestCase {
                                                name: NSNotification.Name.NSManagedObjectContextDidSave,
                                                object: nil)
         
+        Preferences.Database.DocumentToSupportDirectoryMigration.completed.value = true
         DataController.shared = InMemoryDataController()
     }
     

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -11,16 +11,6 @@ enum JavascriptError: Error {
     case invalid
 }
 
-extension WKUserScript {
-    public class func createInDefaultContentWorld(source: String, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: Bool) -> WKUserScript {
-        if #available(iOS 14.0, *) {
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .defaultClient)
-        } else {
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly)
-        }
-    }
-}
-
 public extension WKWebView {
     func generateJSFunctionString(functionName: String, args: [Any?], escapeArgs: Bool = true) -> (javascript: String, error: Error?) {
         var sanitizedArgs = [String]()
@@ -54,7 +44,7 @@ public extension WKWebView {
         return ("\(functionName)(\(sanitizedArgs.joined(separator: ", ")))", nil)
     }
 
-    func evaluateSafeJavaScript(functionName: String, args: [Any] = [], escapeArgs: Bool = true, asFunction: Bool = true, completion: ((Any?, Error?) -> Void)? = nil) {
+    func evaluateSafeJavaScript(functionName: String, args: [Any] = [], contentWorld: WKContentWorld, escapeArgs: Bool = true, asFunction: Bool = true, completion: ((Any?, Error?) -> Void)? = nil) {
         var javascript = functionName
         
         if asFunction {
@@ -69,7 +59,7 @@ public extension WKWebView {
         }
         
         // swiftlint:disable:next safe_javascript
-        evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result  in
+        evaluateJavaScript(javascript, in: nil, in: contentWorld) { result  in
             switch result {
                 case .success(let value):
                     completion?(value, nil)

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -22,35 +22,43 @@ extension WKUserScript {
 }
 
 public extension WKWebView {
-    func generateJavascriptFunctionString(functionName: String, args: [Any], escapeArgs: Bool = true) -> (javascript: String, error: Error?) {
-        let context = JSContext()
-
-        var sanitizedArgs: [String] = []
-        var error: Error?
-
-        args.forEach {
-            if !escapeArgs {
-                sanitizedArgs.append("\($0)")
-                return
-            }
-            context?.exceptionHandler = { context, exception in
-                if exception != nil {
-                    error = JavascriptError.invalid
+    func generateJSFunctionString(functionName: String, args: [Any?], escapeArgs: Bool = true) -> (javascript: String, error: Error?) {
+        var sanitizedArgs = [String]()
+        for arg in args {
+            if let arg = arg {
+                do {
+                    if let arg = arg as? String {
+                        sanitizedArgs.append(escapeArgs ? "'\(arg.htmlEntityEncodedString)'" : "\(arg)")
+                    } else {
+                        let data = try JSONSerialization.data(withJSONObject: arg, options: [.fragmentsAllowed])
+                        
+                        if let str = String(data: data, encoding: .utf8) {
+                            sanitizedArgs.append(str)
+                        } else {
+                            throw JavascriptError.invalid
+                        }
+                    }
+                } catch {
+                    return ("", error)
                 }
+            } else {
+                sanitizedArgs.append("null")
             }
-            context?.evaluateScript("JSON.parse('\"\($0)\"')")
-            sanitizedArgs.append("'\(String(describing: $0).htmlEntityEncodedString)'")
-            return
         }
         
-        return ("\(functionName)(\(sanitizedArgs.joined(separator: ", ")))", error)
+        if args.count != sanitizedArgs.count {
+            assertionFailure("Javascript parsing failed.")
+            return ("", JavascriptError.invalid)
+        }
+        
+        return ("\(functionName)(\(sanitizedArgs.joined(separator: ", ")))", nil)
     }
 
     func evaluateSafeJavaScript(functionName: String, args: [Any] = [], sandboxed: Bool = true, escapeArgs: Bool = true, asFunction: Bool = true, completion: ((Any?, Error?) -> Void)? = nil) {
         var javascript = functionName
         
         if asFunction {
-            let js = generateJavascriptFunctionString(functionName: functionName, args: args, escapeArgs: escapeArgs)
+            let js = generateJSFunctionString(functionName: functionName, args: args, escapeArgs: escapeArgs)
             if js.error != nil {
                 if let completionHandler = completion {
                     completionHandler(nil, js.error)

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -54,7 +54,7 @@ public extension WKWebView {
         return ("\(functionName)(\(sanitizedArgs.joined(separator: ", ")))", nil)
     }
 
-    func evaluateSafeJavaScript(functionName: String, args: [Any] = [], sandboxed: Bool = true, escapeArgs: Bool = true, asFunction: Bool = true, completion: ((Any?, Error?) -> Void)? = nil) {
+    func evaluateSafeJavaScript(functionName: String, args: [Any] = [], escapeArgs: Bool = true, asFunction: Bool = true, completion: ((Any?, Error?) -> Void)? = nil) {
         var javascript = functionName
         
         if asFunction {
@@ -67,20 +67,14 @@ public extension WKWebView {
             }
             javascript = js.javascript
         }
-        if #available(iOS 14.0, *), sandboxed {
-            // swiftlint:disable:next safe_javascript
-            evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result  in
-                switch result {
-                    case .success(let value):
-                        completion?(value, nil)
-                    case .failure(let error):
-                        completion?(nil, error)
-                }
-            }
-        } else {
-            // swiftlint:disable:next safe_javascript
-            evaluateJavaScript(javascript) { data, error  in
-                completion?(data, error)
+        
+        // swiftlint:disable:next safe_javascript
+        evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result  in
+            switch result {
+                case .success(let value):
+                    completion?(value, nil)
+                case .failure(let error):
+                    completion?(nil, error)
             }
         }
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Security Review
- https://github.com/brave/security/issues/692

## Summary of Changes
- Change all JS related code to use WKContentWorld sandboxing Part #1
- Fixed JS function generation code which incorrectly handled arrays, dictionaries, and primitive types. The previous code would NOT generate a proper Javascript array or dictionary. It also would convert all primitive types to `String`, so booleans and other primitives like Int, Float, Double, etc.. would NOT work without this PR.
- In Part-2, we need to go through every single script and see what is the strictest level of sandboxing we can use WITHOUT breaking the scripts.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4570, #3824

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test readermode
- Test Playlists
- Test Youtube Fullscreen
- Test WebAuthN
- Test Brave Search
- Test Brave Ads
- Test Find-In-Page
- Test Downloading
- Test blocking cookies


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
