### PR TITLE
Fix #4677: Prefill default buy/send/swap token if user comes from token details screen

### DIFF
--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -143,13 +143,34 @@ struct AssetDetailHeaderView: View {
       Divider()
         .padding(.bottom)
       HStack {
-        Button(action: { buySendSwapDestination = .buy(assetDetailStore.token) }) {
+        Button(
+          action: {
+            buySendSwapDestination = BuySendSwapDestination(
+              kind: .buy,
+              initialToken: assetDetailStore.token
+            )
+          }
+        ) {
           Text(Strings.Wallet.buy)
         }
-        Button(action: { buySendSwapDestination = .send(assetDetailStore.token) }) {
+        Button(
+          action: {
+            buySendSwapDestination = BuySendSwapDestination(
+              kind: .send,
+              initialToken: assetDetailStore.token
+            )
+          }
+        ) {
           Text(Strings.Wallet.send)
         }
-        Button(action: { buySendSwapDestination = .swap(assetDetailStore.token) }) {
+        Button(
+          action: {
+            buySendSwapDestination = BuySendSwapDestination(
+              kind: .swap,
+              initialToken: assetDetailStore.token
+            )
+          }
+        ) {
           Text(Strings.Wallet.swap)
         }
       }

--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -143,13 +143,13 @@ struct AssetDetailHeaderView: View {
       Divider()
         .padding(.bottom)
       HStack {
-        Button(action: { buySendSwapDestination = .buy }) {
+        Button(action: { buySendSwapDestination = .buy(assetDetailStore.token) }) {
           Text(Strings.Wallet.buy)
         }
-        Button(action: { buySendSwapDestination = .send }) {
+        Button(action: { buySendSwapDestination = .send(assetDetailStore.token) }) {
           Text(Strings.Wallet.send)
         }
-        Button(action: { buySendSwapDestination = .swap }) {
+        Button(action: { buySendSwapDestination = .swap(assetDetailStore.token) }) {
           Text(Strings.Wallet.swap)
         }
       }

--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -143,15 +143,17 @@ struct AssetDetailHeaderView: View {
       Divider()
         .padding(.bottom)
       HStack {
-        Button(
-          action: {
-            buySendSwapDestination = BuySendSwapDestination(
-              kind: .buy,
-              initialToken: assetDetailStore.token
-            )
+        if assetDetailStore.isBuySupported {
+          Button(
+            action: {
+              buySendSwapDestination = BuySendSwapDestination(
+                kind: .buy,
+                initialToken: assetDetailStore.token
+              )
+            }
+          ) {
+            Text(Strings.Wallet.buy)
           }
-        ) {
-          Text(Strings.Wallet.buy)
         }
         Button(
           action: {

--- a/BraveWallet/Crypto/BuySendSwap/BuySendSwapDestination.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuySendSwapDestination.swift
@@ -9,46 +9,40 @@ import SwiftUI
 import BraveCore
 
 /// Used to determine where a user is navigated to when they tap on a buy, send or swap button
-enum BuySendSwapDestination: Identifiable, CaseIterable, Equatable, Hashable {
-  
-  static var allCases: [BuySendSwapDestination] = [.buy(), .send(), .swap()]
-  
-  case buy(BraveWallet.ERCToken? = nil)
-  case send(BraveWallet.ERCToken? = nil)
-  case swap(BraveWallet.ERCToken? = nil)
-  
-  var id: String {
-    switch self {
-    case .buy:
-      return "buy"
-    case .send:
-      return "send"
-    case .swap:
-      return "swap"
+struct BuySendSwapDestination: Identifiable, Equatable, Hashable {
+  enum Kind: String, Identifiable, CaseIterable {
+    case buy, send, swap
+    
+    var id: String {
+      rawValue
+    }
+    
+    var localizedTitle: String {
+      switch self {
+      case .buy:
+        return Strings.Wallet.buy
+      case .send:
+        return Strings.Wallet.send
+      case .swap:
+        return Strings.Wallet.swap
+      }
+    }
+    
+    var localizedDescription: String {
+      switch self {
+      case .buy:
+        return Strings.Wallet.buyDescription
+      case .send:
+        return Strings.Wallet.sendDescription
+      case .swap:
+        return Strings.Wallet.swapDescription
+      }
     }
   }
   
-  var localizedTitle: String {
-    switch self {
-    case .buy:
-      return Strings.Wallet.buy
-    case .send:
-      return Strings.Wallet.send
-    case .swap:
-      return Strings.Wallet.swap
-    }
-  }
-  
-  var localizedDescription: String {
-    switch self {
-    case .buy:
-      return Strings.Wallet.buyDescription
-    case .send:
-      return Strings.Wallet.sendDescription
-    case .swap:
-      return Strings.Wallet.swapDescription
-    }
-  }
+  var kind: Kind
+  var initialToken: BraveWallet.ERCToken?
+  var id: String { kind.id }
 }
 
 private struct BuySendSwapDestinationKey: EnvironmentKey {

--- a/BraveWallet/Crypto/BuySendSwap/BuySendSwapDestination.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuySendSwapDestination.swift
@@ -6,15 +6,26 @@
 import Foundation
 import struct Shared.Strings
 import SwiftUI
+import BraveCore
 
 /// Used to determine where a user is navigated to when they tap on a buy, send or swap button
-enum BuySendSwapDestination: String, Identifiable, CaseIterable {
-  case buy
-  case send
-  case swap
+enum BuySendSwapDestination: Identifiable, CaseIterable, Equatable, Hashable {
+  
+  static var allCases: [BuySendSwapDestination] = [.buy(), .send(), .swap()]
+  
+  case buy(BraveWallet.ERCToken? = nil)
+  case send(BraveWallet.ERCToken? = nil)
+  case swap(BraveWallet.ERCToken? = nil)
   
   var id: String {
-    rawValue
+    switch self {
+    case .buy:
+      return "buy"
+    case .send:
+      return "send"
+    case .swap:
+      return "swap"
+    }
   }
   
   var localizedTitle: String {

--- a/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
@@ -8,17 +8,19 @@ import struct Shared.Strings
 
 struct BuySendSwapView: View {
   var action: (BuySendSwapDestination) -> Void
-  
+  var destinations = [BuySendSwapDestination(kind: .buy),
+                      BuySendSwapDestination(kind: .send),
+                      BuySendSwapDestination(kind: .swap)]
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
-      ForEach(BuySendSwapDestination.allCases, id: \.self) { action in
-        Button(action: { self.action(action) }) {
+      ForEach(destinations, id: \.self) { destination in
+        Button(action: { self.action(destination) }) {
           VStack(alignment: .leading, spacing: 3) {
-            Text(action.localizedTitle)
+            Text(destination.kind.localizedTitle)
               .foregroundColor(Color(.bravePrimary))
               .font(.headline)
               .multilineTextAlignment(.leading)
-            Text(action.localizedDescription)
+            Text(destination.kind.localizedDescription)
               .foregroundColor(Color(.braveLabel))
               .font(.footnote)
               .multilineTextAlignment(.leading)
@@ -26,7 +28,7 @@ struct BuySendSwapView: View {
           .frame(maxWidth: .infinity, alignment: .leading)
           .padding([.leading, .trailing], 20)
         }
-        if action != BuySendSwapDestination.allCases.last {
+        if destination != destinations.last {
           Divider()
             .padding(.leading, 20)
         }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -111,24 +111,24 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
     .background(
       Color.clear
         .sheet(item: $cryptoStore.buySendSwapDestination) { action in
-          switch action {
-          case .buy(let prefilledToken):
+          switch action.kind {
+          case .buy:
             BuyTokenView(
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
-              buyTokenStore: cryptoStore.openBuyTokenStore(prefilledToken)
+              buyTokenStore: cryptoStore.openBuyTokenStore(action.initialToken)
             )
-          case .send(let prefilledToken):
+          case .send:
             SendTokenView(
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
-              sendTokenStore: cryptoStore.openSendTokenStore(prefilledToken)
+              sendTokenStore: cryptoStore.openSendTokenStore(action.initialToken)
             )
-          case .swap(let prefilledToken):
+          case .swap:
             SwapCryptoView(
               keyringStore: keyringStore,
               ethNetworkStore: cryptoStore.networkStore,
-              swapTokensStore: cryptoStore.openSwapTokenStore(prefilledToken)
+              swapTokensStore: cryptoStore.openSwapTokenStore(action.initialToken)
             )
           }
         }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -112,23 +112,23 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
       Color.clear
         .sheet(item: $cryptoStore.buySendSwapDestination) { action in
           switch action {
-          case .buy:
+          case .buy(let prefilledToken):
             BuyTokenView(
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
-              buyTokenStore: cryptoStore.openBuyTokenStore()
+              buyTokenStore: cryptoStore.openBuyTokenStore(prefilledToken)
             )
-          case .send:
+          case .send(let prefilledToken):
             SendTokenView(
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
-              sendTokenStore: cryptoStore.openSendTokenStore()
+              sendTokenStore: cryptoStore.openSendTokenStore(prefilledToken)
             )
-          case .swap:
+          case .swap(let prefilledToken):
             SwapCryptoView(
               keyringStore: keyringStore,
               ethNetworkStore: cryptoStore.networkStore,
-              swapTokensStore: cryptoStore.openSwapTokenStore()
+              swapTokensStore: cryptoStore.openSwapTokenStore(prefilledToken)
             )
           }
         }

--- a/BraveWallet/Crypto/Stores/BuyTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/BuyTokenStore.swift
@@ -23,10 +23,12 @@ public class BuyTokenStore: ObservableObject {
   
   public init(
     tokenRegistry: BraveWalletERCTokenRegistry,
-    rpcController: BraveWalletEthJsonRpcController
+    rpcController: BraveWalletEthJsonRpcController,
+    prefilledToken: BraveWallet.ERCToken?
   ) {
     self.tokenRegistry = tokenRegistry
     self.rpcController = rpcController
+    self.selectedBuyToken = prefilledToken
   }
   
   func fetchBuyUrl(account: BraveWallet.AccountInfo, amount: String, completion: @escaping (_ url: String?) -> Void) {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -66,20 +66,21 @@ public class CryptoStore: ObservableObject {
   }
   
   private var buyTokenStore: BuyTokenStore?
-  func openBuyTokenStore() -> BuyTokenStore {
+  func openBuyTokenStore(_ prefilledToken: BraveWallet.ERCToken?) -> BuyTokenStore {
     if let store = buyTokenStore {
       return store
     }
     let store = BuyTokenStore(
       tokenRegistry: tokenRegistry,
-      rpcController: rpcController
+      rpcController: rpcController,
+      prefilledToken: prefilledToken
     )
     buyTokenStore = store
     return store
   }
   
   private var sendTokenStore: SendTokenStore?
-  func openSendTokenStore() -> SendTokenStore {
+  func openSendTokenStore(_ prefilledToken: BraveWallet.ERCToken?) -> SendTokenStore {
     if let store = sendTokenStore {
       return store
     }
@@ -88,14 +89,15 @@ public class CryptoStore: ObservableObject {
       rpcController: rpcController,
       walletService: walletService,
       transactionController: transactionController,
-      tokenRegistery: tokenRegistry
+      tokenRegistery: tokenRegistry,
+      prefilledToken: prefilledToken
     )
     sendTokenStore = store
     return store
   }
   
   private var swapTokenStore: SwapTokenStore?
-  func openSwapTokenStore() -> SwapTokenStore {
+  func openSwapTokenStore(_ prefilledToken: BraveWallet.ERCToken?) -> SwapTokenStore {
     if let store = swapTokenStore {
       return store
     }
@@ -105,7 +107,8 @@ public class CryptoStore: ObservableObject {
       rpcController: rpcController,
       assetRatioController: assetRatioController,
       swapController: swapController,
-      transactionController: transactionController
+      transactionController: transactionController,
+      prefilledToken: prefilledToken
     )
     swapTokenStore = store
     return store

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -124,6 +124,7 @@ public class CryptoStore: ObservableObject {
       keyringController: keyringController,
       rpcController: rpcController,
       txController: transactionController,
+      tokenRegistry: tokenRegistry,
       token: token
     )
     assetDetailStore = store

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -64,13 +64,15 @@ public class SendTokenStore: ObservableObject {
     rpcController: BraveWalletEthJsonRpcController,
     walletService: BraveWalletBraveWalletService,
     transactionController: BraveWalletEthTxController,
-    tokenRegistery: BraveWalletERCTokenRegistry
+    tokenRegistery: BraveWalletERCTokenRegistry,
+    prefilledToken: BraveWallet.ERCToken?
   ) {
     self.keyringController = keyringController
     self.rpcController = rpcController
     self.walletService = walletService
     self.transactionController = transactionController
     self.tokenRegistery = tokenRegistery
+    self.selectedSendToken = prefilledToken
     
     self.keyringController.add(self)
     self.rpcController.add(self)

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -140,7 +140,8 @@ public class SwapTokenStore: ObservableObject {
     rpcController: BraveWalletEthJsonRpcController,
     assetRatioController: BraveWalletAssetRatioController,
     swapController: BraveWalletSwapController,
-    transactionController: BraveWalletEthTxController
+    transactionController: BraveWalletEthTxController,
+    prefilledToken: BraveWallet.ERCToken?
   ) {
     self.keyringController = keyringController
     self.tokenRegistry = tokenRegistry
@@ -148,6 +149,7 @@ public class SwapTokenStore: ObservableObject {
     self.assetRatioController = assetRatioController
     self.swapController = swapController
     self.transactionController = transactionController
+    self.selectedFromToken = prefilledToken
     
     self.keyringController.add(self)
     self.rpcController.add(self)

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -563,9 +563,17 @@ public class SwapTokenStore: ObservableObject {
         }
       } else {
         if chainId == BraveWallet.MainnetChainId {
-          selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == "BAT" })
+          if let fromToken = selectedFromToken, fromToken.symbol.uppercased() == "BAT" {
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() != "BAT" })
+          } else {
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == "BAT" })
+          }
         } else if chainId == BraveWallet.RopstenChainId {
-          selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == "DAI" })
+          if let fromToken = selectedFromToken, fromToken.symbol.uppercased() == "DAI" {
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() != "DAI" })
+          } else {
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == "DAI" })
+          }
         }
         completion?()
       }

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -113,6 +113,8 @@ public class SwapTokenStore: ObservableObject {
   }
   private var updatingPriceQuote = false
   private var timer: Timer?
+  private let batSymbol = "BAT"
+  private let daiSymbol = "DAI"
   
   enum SwapParamsBase {
     // calculating based on sell asset amount
@@ -563,16 +565,16 @@ public class SwapTokenStore: ObservableObject {
         }
       } else {
         if chainId == BraveWallet.MainnetChainId {
-          if let fromToken = selectedFromToken, fromToken.symbol.uppercased() == "BAT" {
-            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() != "BAT" })
+          if let fromToken = selectedFromToken, fromToken.symbol.uppercased() == batSymbol.uppercased() {
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() != batSymbol.uppercased() })
           } else {
-            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == "BAT" })
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == batSymbol.uppercased() })
           }
         } else if chainId == BraveWallet.RopstenChainId {
-          if let fromToken = selectedFromToken, fromToken.symbol.uppercased() == "DAI" {
-            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() != "DAI" })
+          if let fromToken = selectedFromToken, fromToken.symbol.uppercased() == daiSymbol.uppercased() {
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() != daiSymbol.uppercased() })
           } else {
-            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == "DAI" })
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == daiSymbol.uppercased() })
           }
         }
         completion?()

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -59,7 +59,8 @@ extension BuyTokenStore {
   static var previewStore: BuyTokenStore {
     .init(
       tokenRegistry: TestTokenRegistry(),
-      rpcController: TestEthJsonRpcController()
+      rpcController: TestEthJsonRpcController(),
+      prefilledToken: .eth
     )
   }
 }
@@ -71,7 +72,8 @@ extension SendTokenStore {
       rpcController: TestEthJsonRpcController(),
       walletService: TestBraveWalletService(),
       transactionController: TestEthTxController(),
-      tokenRegistery: TestTokenRegistry()
+      tokenRegistery: TestTokenRegistry(),
+      prefilledToken: .eth
     )
   }
 }
@@ -96,7 +98,8 @@ extension SwapTokenStore {
       rpcController: TestEthJsonRpcController(),
       assetRatioController: TestAssetRatioController(),
       swapController: TestSwapController(),
-      transactionController: TestEthTxController()
+      transactionController: TestEthTxController(),
+      prefilledToken: nil
     )
   }
 }

--- a/BraveWallet/Preview Content/TestStores.swift
+++ b/BraveWallet/Preview Content/TestStores.swift
@@ -85,6 +85,7 @@ extension AssetDetailStore {
       keyringController: TestKeyringController(),
       rpcController: TestEthJsonRpcController(),
       txController: TestEthTxController(),
+      tokenRegistry: TestTokenRegistry(),
       token: .eth
     )
   }

--- a/BraveWalletTests/BuyTokenStoreTest.swift
+++ b/BraveWalletTests/BuyTokenStoreTest.swift
@@ -1,0 +1,30 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+import XCTest
+import Combine
+import BraveCore
+@testable import BraveWallet
+
+class BuyTokenStoreTests: XCTestCase {
+    func testPrefilledToken() {
+        var store = BuyTokenStore(
+            tokenRegistry: TestTokenRegistry(),
+            rpcController: TestEthJsonRpcController(),
+            prefilledToken: nil
+        )
+        XCTAssertNil(store.selectedBuyToken)
+        
+        store = BuyTokenStore(
+            tokenRegistry: TestTokenRegistry(),
+            rpcController: TestEthJsonRpcController(),
+            prefilledToken: .eth
+        )
+        XCTAssertEqual(store.selectedBuyToken?.symbol.lowercased(), BraveWallet.ERCToken.eth.symbol.lowercased())
+    }
+    
+}

--- a/BraveWalletTests/SendTokenStoreTests.swift
+++ b/BraveWalletTests/SendTokenStoreTests.swift
@@ -11,6 +11,28 @@ import BraveCore
 class SendTokenStoreTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
     
+    func testPrefilledToken() {
+        var store = SendTokenStore(
+            keyringController: TestKeyringController(),
+            rpcController: TestEthJsonRpcController(),
+            walletService: TestBraveWalletService(),
+            transactionController: TestEthTxController(),
+            tokenRegistery: TestTokenRegistry(),
+            prefilledToken: nil
+        )
+        XCTAssertNil(store.selectedSendToken)
+        
+        store = SendTokenStore(
+            keyringController: TestKeyringController(),
+            rpcController: TestEthJsonRpcController(),
+            walletService: TestBraveWalletService(),
+            transactionController: TestEthTxController(),
+            tokenRegistery: TestTokenRegistry(),
+            prefilledToken: .eth
+        )
+        XCTAssertEqual(store.selectedSendToken?.symbol.lowercased(), BraveWallet.ERCToken.eth.symbol.lowercased())
+    }
+    
     func testFetchAssets() {
         let store = SendTokenStore(
             keyringController: TestKeyringController(),

--- a/BraveWalletTests/SendTokenStoreTests.swift
+++ b/BraveWalletTests/SendTokenStoreTests.swift
@@ -17,7 +17,8 @@ class SendTokenStoreTests: XCTestCase {
             rpcController: TestEthJsonRpcController(),
             walletService: TestBraveWalletService(),
             transactionController: TestEthTxController(),
-            tokenRegistery: TestTokenRegistry()
+            tokenRegistery: TestTokenRegistry(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "fetch-assets")
         XCTAssertNil(store.selectedSendToken) // Initial state
@@ -41,9 +42,9 @@ class SendTokenStoreTests: XCTestCase {
             rpcController: TestEthJsonRpcController(),
             walletService: TestBraveWalletService(),
             transactionController: TestEthTxController(),
-            tokenRegistery: TestTokenRegistry()
+            tokenRegistery: TestTokenRegistry(),
+            prefilledToken: .eth
         )
-        store.selectedSendToken = .eth
         store.setUpTest()
         let ex = expectation(description: "send-eth-eip1559-transaction")
         store.sendToken(amount: "0.01") { success in
@@ -62,9 +63,9 @@ class SendTokenStoreTests: XCTestCase {
             rpcController: rpcController,
             walletService: TestBraveWalletService(),
             transactionController: TestEthTxController(),
-            tokenRegistery: TestTokenRegistry()
+            tokenRegistery: TestTokenRegistry(),
+            prefilledToken: .eth
         )
-        store.selectedSendToken = .eth
         store.setUpTest()
         
         let ex = expectation(description: "send-eth-transaction")
@@ -86,7 +87,8 @@ class SendTokenStoreTests: XCTestCase {
             rpcController: TestEthJsonRpcController(),
             walletService: TestBraveWalletService(),
             transactionController: TestEthTxController(),
-            tokenRegistery: TestTokenRegistry()
+            tokenRegistery: TestTokenRegistry(),
+            prefilledToken: nil
         )
         let token: BraveWallet.ERCToken = .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, symbol: "BAT", decimals: 18, visible: true, tokenId: "")
         store.selectedSendToken = token
@@ -109,9 +111,9 @@ class SendTokenStoreTests: XCTestCase {
             rpcController: rpcController,
             walletService: TestBraveWalletService(),
             transactionController: TestEthTxController(),
-            tokenRegistery: TestTokenRegistry()
+            tokenRegistery: TestTokenRegistry(),
+            prefilledToken: .eth
         )
-        store.selectedSendToken = .eth
         store.setUpTest()
         
         let ex = expectation(description: "send-bat-transaction")

--- a/BraveWalletTests/SendTokenStoreTests.swift
+++ b/BraveWalletTests/SendTokenStoreTests.swift
@@ -10,6 +10,7 @@ import BraveCore
 
 class SendTokenStoreTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
+    private let batSymbol = "BAT"
     
     func testPrefilledToken() {
         var store = SendTokenStore(
@@ -112,7 +113,7 @@ class SendTokenStoreTests: XCTestCase {
             tokenRegistery: TestTokenRegistry(),
             prefilledToken: nil
         )
-        let token: BraveWallet.ERCToken = .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, symbol: "BAT", decimals: 18, visible: true, tokenId: "")
+        let token: BraveWallet.ERCToken = .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, symbol: batSymbol, decimals: 18, visible: true, tokenId: "")
         store.selectedSendToken = token
         store.setUpTest()
         

--- a/BraveWalletTests/SwapTokenStoreTests.swift
+++ b/BraveWalletTests/SwapTokenStoreTests.swift
@@ -16,7 +16,8 @@ class SendSwapStoreTests: XCTestCase {
             rpcController: TestEthJsonRpcController(),
             assetRatioController: TestAssetRatioController(),
             swapController: TestSwapController(),
-            transactionController: TestEthTxController()
+            transactionController: TestEthTxController(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "default-sell-buy-token-on-main")
         XCTAssertNil(store.selectedFromToken)
@@ -40,7 +41,8 @@ class SendSwapStoreTests: XCTestCase {
             rpcController: rpcController,
             assetRatioController: TestAssetRatioController(),
             swapController: TestSwapController(),
-            transactionController: TestEthTxController()
+            transactionController: TestEthTxController(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "default-sell-buy-token-on-ropsten")
         XCTAssertNil(store.selectedFromToken)
@@ -67,7 +69,8 @@ class SendSwapStoreTests: XCTestCase {
             rpcController: TestEthJsonRpcController(),
             assetRatioController: TestAssetRatioController(),
             swapController: TestSwapController(),
-            transactionController: TestEthTxController()
+            transactionController: TestEthTxController(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "fetch-price-quote")
         store.setUpTest()
@@ -88,7 +91,8 @@ class SendSwapStoreTests: XCTestCase {
             rpcController: TestEthJsonRpcController(),
             assetRatioController: TestAssetRatioController(),
             swapController: TestSwapController(),
-            transactionController: TestEthTxController()
+            transactionController: TestEthTxController(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "make-erc20-eip1559-swap-transaction")
         store.setUpTest()
@@ -112,7 +116,8 @@ class SendSwapStoreTests: XCTestCase {
             rpcController: rpcController,
             assetRatioController: TestAssetRatioController(),
             swapController: TestSwapController(),
-            transactionController: TestEthTxController()
+            transactionController: TestEthTxController(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "make-erc20-swap-transaction")
         store.setUpTest()
@@ -139,7 +144,8 @@ class SendSwapStoreTests: XCTestCase {
             rpcController: TestEthJsonRpcController(),
             assetRatioController: TestAssetRatioController(),
             swapController: TestSwapController(),
-            transactionController: TestEthTxController()
+            transactionController: TestEthTxController(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "make-eth-swap-eip1559-transaction")
         store.setUpTest()
@@ -163,7 +169,8 @@ class SendSwapStoreTests: XCTestCase {
             rpcController: rpcController,
             assetRatioController: TestAssetRatioController(),
             swapController: TestSwapController(),
-            transactionController: TestEthTxController()
+            transactionController: TestEthTxController(),
+            prefilledToken: nil
         )
         let ex = expectation(description: "make-eth-swap-eip1559-transaction")
         store.setUpTest()

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -954,6 +954,7 @@
 		7DCA34D427555E96001B0555 /* CryptoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA34D327555E96001B0555 /* CryptoStore.swift */; };
 		7DF9113D275AC86100EF0D8B /* WalletLoadingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9113C275AC86100EF0D8B /* WalletLoadingButton.swift */; };
 		7DF911C0276A8D1600EF0D8B /* SwapTokenStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */; };
+		7DF911DF27726E5E00EF0D8B /* BuyTokenStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF911DE27726E5E00EF0D8B /* BuyTokenStoreTest.swift */; };
 		A104E199210A384400D2323E /* ShieldsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A104E198210A384400D2323E /* ShieldsViewController.swift */; };
 		A134B88A20DA98BB00A581D0 /* ClientPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A134B88920DA98BB00A581D0 /* ClientPreferences.swift */; };
 		A13AC72520EC12360040D4BB /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13AC72420EC12360040D4BB /* Migration.swift */; };
@@ -2922,6 +2923,7 @@
 		7DCA34D327555E96001B0555 /* CryptoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoStore.swift; sourceTree = "<group>"; };
 		7DF9113C275AC86100EF0D8B /* WalletLoadingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLoadingButton.swift; sourceTree = "<group>"; };
 		7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapTokenStoreTests.swift; sourceTree = "<group>"; };
+		7DF911DE27726E5E00EF0D8B /* BuyTokenStoreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyTokenStoreTest.swift; sourceTree = "<group>"; };
 		A104E198210A384400D2323E /* ShieldsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsViewController.swift; sourceTree = "<group>"; };
 		A134B88920DA98BB00A581D0 /* ClientPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientPreferences.swift; sourceTree = "<group>"; };
 		A13AC72420EC12360040D4BB /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
@@ -4192,6 +4194,7 @@
 		277309E62721DF6D007643F6 /* BraveWalletTests */ = {
 			isa = PBXGroup;
 			children = (
+				7DF911DE27726E5E00EF0D8B /* BuyTokenStoreTest.swift */,
 				279115362755597200033843 /* SendTokenStoreTests.swift */,
 				7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */,
 				277309E72721DF6D007643F6 /* WeiFormatterTests.swift */,
@@ -7998,6 +8001,7 @@
 				2792CBD5275952C40055151E /* PasteboardTests.swift in Sources */,
 				279115422755597200033843 /* SendTokenStoreTests.swift in Sources */,
 				27EA1B0E2729E6C8003C5CF9 /* AddressTests.swift in Sources */,
+				7DF911DF27726E5E00EF0D8B /* BuyTokenStoreTest.swift in Sources */,
 				7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */,
 				7DF911C0276A8D1600EF0D8B /* SwapTokenStoreTests.swift in Sources */,
 				277309E82721DF6D007643F6 /* WeiFormatterTests.swift in Sources */,


### PR DESCRIPTION
This pull request fixes #4677 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Case 1:
1. Go to buy/send/swap screen from Asset Detail Screen
2. Make sure the prefilled buy token, or send from token, or swap from token is the same as the token from the asset details screen (swap to token should not be the same as the swap from token)

Case 2:
1. Make sure the selected network is NOT Ropsten
2. Go to buy/send/swap screen from anywhere but NOT Asset Detail Screen
3. Make sure prefilled buy token is BAT, prefilled send from token is ETH, prefilled swap from token is ETH, the prefilled swap to token is BAT

Case 3:
1. Make sure the selected network is Ropsten
2. Go to send/swap screen from anywhere but NOT Asset Detail Screen
3. prefilled send from token is ETH, prefilled swap from token is ETH, prefilled swap to token is DAI

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
