### PR TITLE
Fix #4759, #4747: Bump Brave-Core to 1.34.68 (Beta)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.33.106/brave-core-ios-1.33.106.tgz",
-      "integrity": "sha512-dnJ1VxtVYnQVtotYsibMMmQGYacKOE/VP49dxOAOULfp2tiYoL9tFKktaoZD5Z5kOaGsKFA19hbUNNztRrByvw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.34.68/brave-core-ios-1.34.68.tgz",
+      "integrity": "sha512-2BhUNFKdJ3oxBAWye5mTpDhWWpljmszmaS7lftoyJkFayZQ/uc4ExDKRgl8SFMrDZDTLIFfErYIwW9mb2jrgYA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.33.106/brave-core-ios-1.33.106.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.34.68/brave-core-ios-1.34.68.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Bump Brave-Core version to 1.34.68 (beta) for QA to Test Desktop
- QA will also test that Sync works on iOS properly and that devices can be deleted from the sync chain without being automatically re-added.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4759, #4747

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test that devices can be deleted from the sync chain
- Test that sync still works as it should


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
