### PR TITLE
Fix #3430: Preserve tab screenshots whenever the page has finished loading.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1846,6 +1846,10 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             // VoiceOver will sometimes be stuck on the element, not allowing user to move
             // forward/backward. Strange, but LayoutChanged fixes that.
             UIAccessibility.post(notification: .layoutChanged, argument: nil)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+                self.screenshotHelper.takeScreenshot(tab)
+            }
         } else if let webView = tab.webView {
             // Ref #2016: Keyboard auto hides while typing
             // For some reason the web view will steal first responder as soon

--- a/Client/Frontend/Browser/Tab Tray/TabTrayCell.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayCell.swift
@@ -37,10 +37,14 @@ class TabCell: UICollectionViewCell {
     var margin = 0.0
     
     var closedTab: ((Tab) -> Void)?
-    var tab: Tab?
+    weak var tab: Tab?
     
     func configure(with tab: Tab) {
         self.tab = tab
+        tab.onScreenshotUpdated = { [weak self, weak tab] in
+            self?.screenshotView.image = tab?.screenshot
+        }
+        
         titleLabel.text = tab.displayTitle
         favicon.image = #imageLiteral(resourceName: "defaultFavicon")
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -48,6 +48,7 @@ class Tab: NSObject {
     
     let rewardsId: UInt32
     
+    var onScreenshotUpdated: (() -> Void)?
     var rewardsEnabledCallback: ((Bool) -> Void)?
     
     var alertShownCount: Int = 0
@@ -568,6 +569,8 @@ class Tab: NSObject {
         if revUUID {
             self.screenshotUUID = UUID()
         }
+        
+        onScreenshotUpdated?()
     }
 
     /// Switches user agent Desktop -> Mobile or Mobile -> Desktop.

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -967,6 +967,7 @@ extension TabManager: WKNavigationDelegate {
 
             // Saving Tab Private Mode - not supported yet.
             if let tab = tabForWebView(webView), !tab.isPrivate {
+                preserveScreenshots()
                 saveTab(tab)
             }
         }


### PR DESCRIPTION
## Summary of Changes
- Preserve tab screenshots whenever the page has finished loading.
- This fixes the blank screenshots constantly showing up. Ideally we should be checking the page load status though.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3430

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test session restore
- Test opening pages in new tabs
- Test private browsing tab tray
- Test performance (open many tabs and restore session or open many tabs and then tab tray).


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
