### PR TITLE
Fix #4764: Sync Crash on 1.34.x due to resetting sync chain

### DIFF
--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -363,8 +363,11 @@ extension SyncSettingsTableViewController {
                     // `Preferences.Chromium.syncEnabled.value = false`
                     // But I don't have a TRUE way to tell if the current device
                     // was removed from the sync chain because `OnSelfDeviceInfoDeleted` has no callback.
-                    // So instead, we call `reset_sync` which won't hurt.
-                    syncAPI.leaveSyncGroup()
+                    // So instead, we call `removeAllObservers` which won't hurt.
+                    // Calling `syncAPI.leaveSyncGroup() aka reset_sync` as of 1.34.x will crash the application.
+                    
+                    syncAPI.removeAllObservers()
+                    Preferences.Chromium.syncEnabled.value = false
                     self.navigationController?.popToRootViewController(animated: true)
                 } else {
                     self.tableView.reloadData()


### PR DESCRIPTION
## Summary of Changes
- As of 1.34.x, we cannot call `reset_sync` to reset the sync chain when the current device is deleted from the sync chain

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4764

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test deleting the sync chain device remotely

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
