### PR TITLE
Fix #4775: Message Token Leak Fix

### DIFF
--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -224,6 +224,11 @@ extension PlaylistHelper: UIGestureRecognizerDelegate {
 
 extension PlaylistHelper {
     static func getCurrentTime(webView: WKWebView, nodeTag: String, completion: @escaping (Double) -> Void) {
+        guard let nodeTag = nodeTag.javaScriptEscapedString else {
+            log.error("Unsanitized NodeTag.")
+            return
+        }
+        
         let token = UserScriptManager.securityTokenString
         let javascript = String(format: "window.__firefox__.mediaCurrentTimeFromTag_%@('%@')", token, nodeTag)
 

--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -224,7 +224,7 @@ extension PlaylistHelper: UIGestureRecognizerDelegate {
 
 extension PlaylistHelper {
     static func getCurrentTime(webView: WKWebView, nodeTag: String, completion: @escaping (Double) -> Void) {
-        guard let nodeTag = nodeTag.javaScriptEscapedString else {
+        guard UUID(uuidString: nodeTag) != nil else {
             log.error("Unsanitized NodeTag.")
             return
         }

--- a/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/RewardsReporting.js
+++ b/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/RewardsReporting.js
@@ -4,92 +4,94 @@
 
 "use strict";
 
-const mediaPublisherOrigins = [
-    'https://www.twitch.tv', 'https://m.twitch.tv', 'https://player.twitch.tv',
-    'https://www.youtube.com', 'https://m.youtube.com',
-    'https://vimeo.com',
-]
+(function(){
+    const mediaPublisherOrigins = [
+        'https://www.twitch.tv', 'https://m.twitch.tv', 'https://player.twitch.tv',
+        'https://www.youtube.com', 'https://m.youtube.com',
+        'https://vimeo.com',
+    ]
 
-if (mediaPublisherOrigins.includes(document.location.origin) && webkit.messageHandlers.rewardsReporting) {
-    install();
-}
-
-function install() {
-    function sendMessage(method, url, data, referrerUrl) {
-        webkit.messageHandlers.rewardsReporting.postMessage({"securitytoken": SECURITY_TOKEN, "data": {
-            method: method === undefined ? "GET" : method,
-            url: url,
-            data: (data === undefined || data instanceof Blob) ? null : data,
-            referrerUrl: referrerUrl === undefined ? null : referrerUrl,
-        }});
+    if (mediaPublisherOrigins.includes(document.location.origin) && webkit.messageHandlers.rewardsReporting) {
+        install();
     }
     
-    let originalOpen = XMLHttpRequest.prototype.open;
-    let originalSend = XMLHttpRequest.prototype.send;
-    let originalFetch = window.fetch;
-    let originalSendBeacon = navigator.sendBeacon;
-    let originalImageSrc = Object.getOwnPropertyDescriptor(Image.prototype, "src");
-    
-    XMLHttpRequest.prototype.open = function(method, url) {
-        const listener = function() {
-            sendMessage(this._method, this.responseURL === null ? this._url : this.responseURL, this._data, this._ref);
-        };
-        this._method = method;
-        this._url = url;
-        this.addEventListener('load', listener, true);
-        this.addEventListener('error', listener, true);
-        return originalOpen.apply(this, arguments);
-    };
-    
-    XMLHttpRequest.prototype.send = function(body) {
-        this._ref = null;
-        this._data = body;
-        if (body instanceof Document) {
-            this._ref = body.referrer;
-            this._data = null;
+    function install() {
+        function sendMessage(method, url, data, referrerUrl) {
+            webkit.messageHandlers.rewardsReporting.postMessage({"securitytoken": SECURITY_TOKEN, "data": {
+                method: method === undefined ? "GET" : method,
+                url: url,
+                data: (data === undefined || data instanceof Blob) ? null : data,
+                referrerUrl: referrerUrl === undefined ? null : referrerUrl,
+            }});
         }
-        return originalSend.apply(this, arguments);
-    };
-
-    window.fetch = function(resource, options) {
-        const args = arguments
-        const url = resource instanceof Request ? resource.url : resource
-        const method = options != null ? options.method : 'GET'
-        const body = options != null ? options.body : null
-        const referrer = options != null ? options.referrer : null
-
-        return new Promise(function(resolve, reject) {
-            originalFetch.apply(this, args)
-            .then(function(response) {
-                sendMessage(method, url, body, referrer);
-                resolve(response);
-            })
-            .catch(function(error) {
-                sendMessage(method, url, body, referrer);
-                reject(error);
-            })
-        });
-    };
-
-    navigator.sendBeacon = function(url, data) {
-        sendMessage("POST", url, data);
-        return originalSendBeacon.apply(this, arguments);
-    };
-    
-    delete Image.prototype.src;
-    Object.defineProperty(Image.prototype, "src", {
-      get: function() {
-        return originalImageSrc.get.call(this);
-      },
-      set: function(value) {
-        const listener = function() {
-            sendMessage("GET", this.src);
+        
+        let originalOpen = XMLHttpRequest.prototype.open;
+        let originalSend = XMLHttpRequest.prototype.send;
+        let originalFetch = window.fetch;
+        let originalSendBeacon = navigator.sendBeacon;
+        let originalImageSrc = Object.getOwnPropertyDescriptor(Image.prototype, "src");
+        
+        XMLHttpRequest.prototype.open = function(method, url) {
+            const listener = function() {
+                sendMessage(this._method, this.responseURL === null ? this._url : this.responseURL, this._data, this._ref);
+            };
+            this._method = method;
+            this._url = url;
+            this.addEventListener('load', listener, true);
+            this.addEventListener('error', listener, true);
+            return originalOpen.apply(this, arguments);
         };
-        this.addEventListener('load', listener, true);
-        this.addEventListener('error', listener, true);
-        originalImageSrc.set.call(this, value);
-      },
-      enumerable: true,
-      configurable: true
-    });
-}
+        
+        XMLHttpRequest.prototype.send = function(body) {
+            this._ref = null;
+            this._data = body;
+            if (body instanceof Document) {
+                this._ref = body.referrer;
+                this._data = null;
+            }
+            return originalSend.apply(this, arguments);
+        };
+
+        window.fetch = function(resource, options) {
+            const args = arguments
+            const url = resource instanceof Request ? resource.url : resource
+            const method = options != null ? options.method : 'GET'
+            const body = options != null ? options.body : null
+            const referrer = options != null ? options.referrer : null
+
+            return new Promise(function(resolve, reject) {
+                originalFetch.apply(this, args)
+                .then(function(response) {
+                    sendMessage(method, url, body, referrer);
+                    resolve(response);
+                })
+                .catch(function(error) {
+                    sendMessage(method, url, body, referrer);
+                    reject(error);
+                })
+            });
+        };
+
+        navigator.sendBeacon = function(url, data) {
+            sendMessage("POST", url, data);
+            return originalSendBeacon.apply(this, arguments);
+        };
+        
+        delete Image.prototype.src;
+        Object.defineProperty(Image.prototype, "src", {
+          get: function() {
+            return originalImageSrc.get.call(this);
+          },
+          set: function(value) {
+            const listener = function() {
+                sendMessage("GET", this.src);
+            };
+            this.addEventListener('load', listener, true);
+            this.addEventListener('error', listener, true);
+            originalImageSrc.set.call(this, value);
+          },
+          enumerable: true,
+          configurable: true
+        });
+    }
+})();

--- a/Client/Frontend/UserContent/UserScripts/FullscreenHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/FullscreenHelper.js
@@ -41,6 +41,10 @@ if (!isFullscreenSupportedNatively && videosSupportFullscreen && !/mobile/i.test
         return false;
     };
     
+    HTMLElement.prototype.requestFullscreen.toString = function() {
+        return "function () { [native code]; }";
+    };
+    
     Object.defineProperty(document, 'fullscreenEnabled', {
         get: function() {
             return true;

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -352,7 +352,11 @@ window.__firefox__.includeOnce("Playlist", function() {
                 if (key.toLowerCase() == 'src') {
                     $<notifyNode>(this);
                 }
-            }
+            };
+            
+            HTMLVideoElement.prototype.setAttribute.toString = function() {
+                return "function () { [native code] }";
+            };
             
             var setAudioAttribute = HTMLAudioElement.prototype.setAttribute;
             HTMLAudioElement.prototype.setAttribute = function(key, value) {
@@ -360,7 +364,11 @@ window.__firefox__.includeOnce("Playlist", function() {
                 if (key.toLowerCase() == 'src') {
                     $<notifyNode>(this);
                 }
-            }
+            };
+            
+            HTMLAudioElement.prototype.setAttribute.toString = function() {
+                return "function () { [native code] }";
+            };
             
             // When the page is idle
             // Fetch static video and audio elements

--- a/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/AdsReporting.js
+++ b/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/AdsReporting.js
@@ -4,46 +4,48 @@
 
 "use strict";
 
-if (webkit.messageHandlers.adsMediaReporting) {
-    install();
-}
-
-function install() {
-  function sendMessage(playing) {
-    webkit.messageHandlers.adsMediaReporting.postMessage({"securitytoken": SECURITY_TOKEN, "data": {playing}});
-  }
-
-  function checkVideoNode(node) {
-    if (node.constructor.name == "HTMLVideoElement") {
-      hookVideoFunctions();
+(function(){
+    if (webkit.messageHandlers.adsMediaReporting) {
+        install();
     }
-  }
 
-  function mediaPaused() {
-    sendMessage(false)
-  }
+    function install() {
+      function sendMessage(playing) {
+        webkit.messageHandlers.adsMediaReporting.postMessage({"securitytoken": SECURITY_TOKEN, "data": {playing}});
+      }
 
-  function mediaPlaying() {
-    sendMessage(true)
-  }
+      function checkVideoNode(node) {
+        if (node.constructor.name == "HTMLVideoElement") {
+          hookVideoFunctions();
+        }
+      }
 
-  function getVideoElements() {
-    return document.querySelectorAll('video')
-  }
+      function mediaPaused() {
+        sendMessage(false)
+      }
 
-  function hookVideoFunctions() {
-    getVideoElements().forEach(function (item) {
-      item.addEventListener('pause', mediaPaused, false);
-      item.addEventListener('playing', mediaPlaying, false);
-    });
-  }
+      function mediaPlaying() {
+        sendMessage(true)
+      }
 
-  var observer = new MutationObserver(function (mutations) {
-    mutations.forEach(function (mutation) {
-      mutation.addedNodes.forEach(function (node) {
-        checkVideoNode(node);
+      function getVideoElements() {
+        return document.querySelectorAll('video')
+      }
+
+      function hookVideoFunctions() {
+        getVideoElements().forEach(function (item) {
+          item.addEventListener('pause', mediaPaused, false);
+          item.addEventListener('playing', mediaPlaying, false);
+        });
+      }
+
+      var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+          mutation.addedNodes.forEach(function (node) {
+            checkVideoNode(node);
+          });
+        });
       });
-    });
-  });
-  observer.observe(document, {subtree: true, childList: true });
-}
+      observer.observe(document, {subtree: true, childList: true });
+    }
+})()


### PR DESCRIPTION
## Summary of Changes

- First Sanitize the `nodeTag` when passed from JS to Swift.
- Override `toString` so our `prototype`s cannot be parsed.
- Enclose all other `global` functions that aren't called natively into an anonymous function to prevent the page from calling them manually.
- TODO: `WKContentWorld` Sandboxing Part-2! for future release (maybe even the next one).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4775

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in hackerone ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
