### PR TITLE
Fix #4400: Add more iPad keyboard shortcuts

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -64,7 +64,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     fileprivate var homePanelIsInline = false
     var searchLoader: SearchLoader?
     let alertStackView = UIStackView() // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
-    fileprivate var findInPageBar: FindInPageBar?
+    var findInPageBar: FindInPageBar?
     
     // Single data source used for all favorites vcs
     let backgroundDataSource = NTPDataSource()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -154,50 +154,50 @@ extension BrowserViewController {
 
     override var keyCommands: [UIKeyCommand]? {
         let navigationCommands = [
+            // Web Page Key Commands
             UIKeyCommand(title: Strings.reloadPageTitle, action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command),
             UIKeyCommand(title: Strings.backTitle, action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command),
             UIKeyCommand(title: Strings.forwardTitle, action: #selector(goForwardKeyCommand), input: "]", modifierFlags: .command),
-            
-            UIKeyCommand(title: "Select URL Bar", action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command), // TODO: title filter
-            
+            // URL Bar - Tab Key Commands
+            UIKeyCommand(title: Strings.selectLocationBarTitle, action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command),
             UIKeyCommand(title: Strings.newTabTitle, action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command),
             UIKeyCommand(title: Strings.newPrivateTabTitle, action: #selector(newPrivateTabKeyCommand), input: "p", modifierFlags: [.command, .shift]),
             UIKeyCommand(title: Strings.closeTabTitle, action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command),
             UIKeyCommand(title: Strings.showNextTabTitle, action: #selector(nextTabKeyCommand), input: "\t", modifierFlags: .control),
             UIKeyCommand(title: Strings.showPreviousTabTitle, action: #selector(previousTabKeyCommand), input: "\t", modifierFlags: [.control, .shift]),
-
             UIKeyCommand(title: Strings.showTabTrayFromTabKeyCodeTitle, action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate]),
             UIKeyCommand(title: String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count),
-                         action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .shift]), // TODO: new 1
-            
-            UIKeyCommand(title: "Show History", action: #selector(showHistoryKeyCommand), input: "y", modifierFlags: [.command]), // TODO: new 1
-            UIKeyCommand(title: "Show Downloads", action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command), // TODO: new 1
-
+                         action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .shift]),
+            // Page Navigation Key Commands
+            UIKeyCommand(title: Strings.showHistoryTitle, action: #selector(showHistoryKeyCommand), input: "y", modifierFlags: [.command]),
+            UIKeyCommand(title: Strings.showDownloadsTitle, action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command),
             // Switch tab to match Safari on iOS.
             UIKeyCommand(input: "]", modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
             UIKeyCommand(input: "[", modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
             UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(showTabTrayKeyCommand)), // Safari on macOS
         ]
         
+        // Tab Navigation Key Commands Show tab # 1-9 - Command + 1-9
         var tabNavigationCommands: [UIKeyCommand] = []
-        
         for index in 1..<10 {
-            tabNavigationCommands.append(UIKeyCommand(input: String(index), modifierFlags: [.command], action: #selector(showTabKeyCommand(sender:)))) // TODO: new 1
+            tabNavigationCommands.append(UIKeyCommand(input: String(index), modifierFlags: [.command], action: #selector(showTabKeyCommand(sender:))))
         }
         
+        // Bookmarks Key Commands
         let bookmarkEditingCommands = [
-            UIKeyCommand(title: "Show Bookmarks", action: #selector(showBookmarksKeyCommand), input: "o", modifierFlags: [.shift, .command]), // TODO: new 1
-            UIKeyCommand(title: "Add Bookmark", action: #selector(addBookmarkCommand), input: "d", modifierFlags: [.command]), // TODO: title added
-            UIKeyCommand(title: "Add to Favourites", action: #selector(addToFavouritesCommand), input: "d", modifierFlags: [.command, .shift]) //TODO:  new 1
+            UIKeyCommand(title: Strings.showBookmarksTitle, action: #selector(showBookmarksKeyCommand), input: "o", modifierFlags: [.shift, .command]),
+            UIKeyCommand(title: Strings.addBookmarkTitle, action: #selector(addBookmarkCommand), input: "d", modifierFlags: [.command]),
+            UIKeyCommand(title: Strings.addFavouritesTitle, action: #selector(addToFavouritesCommand), input: "d", modifierFlags: [.command, .shift])
         ]
         
+        // Find in Page Key Commands
         var findTextCommands = [
-            UIKeyCommand(title: "Find in Page", action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command),
+            UIKeyCommand(title: Strings.findInPageTitle, action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command),
         ]
         
         let findTextUtilitiesCommands = [
-            UIKeyCommand(title: "Find Next", action: #selector(findNextCommand), input: "g", modifierFlags: [.command]), // TODO: new condition to show them
-            UIKeyCommand(title: "Find Previous", action: #selector(findPreviousCommand), input: "g", modifierFlags: [.command, .shift])
+            UIKeyCommand(title: Strings.findNextTitle, action: #selector(findNextCommand), input: "g", modifierFlags: [.command]),
+            UIKeyCommand(title: Strings.findPreviousTitle, action: #selector(findPreviousCommand), input: "g", modifierFlags: [.command, .shift])
         ]
         
         let isFindingText = !(findInPageBar?.text?.isEmpty ?? true)
@@ -206,14 +206,14 @@ extension BrowserViewController {
             findTextCommands.append(contentsOf: findTextUtilitiesCommands)
         }
         
+        // Share With Key Command
         let shareCommands = [
-            UIKeyCommand(title: "Share With...", action: #selector(shareWithKeyCommand), input: "s", modifierFlags: .command) // TODO: new 1
+            UIKeyCommand(title: Strings.shareWithTitle, action: #selector(shareWithKeyCommand), input: "s", modifierFlags: .command)
         ]
         
         var keyCommandList = navigationCommands + tabNavigationCommands + bookmarkEditingCommands + shareCommands + findTextCommands
         
         // URL completion and Override Key commands
-        
         let searchLocationCommands = [
             UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -85,6 +85,18 @@ extension BrowserViewController {
             tabManager.selectTab(lastTab)
         }
     }
+    
+    @objc private func showTabKeyCommand(sender: UIKeyCommand) {
+        guard let input = sender.input, let index = Int(input) else {
+            return
+        }
+
+        let tabs = tabManager.tabsForCurrentMode
+
+        if tabs.count > index - 1 {
+            tabManager.selectTab(tabs[index - 1])
+        }
+    }
 
     @objc private func showTabTrayKeyCommand() {
         showTabTray()
@@ -112,13 +124,16 @@ extension BrowserViewController {
         navigationHelper.openShareSheet()
     }
     
-    @objc private func showHistoryCommand() {
+    @objc private func showHistoryKeyCommand() {
         navigationHelper.openHistory()
-
     }
     
-    @objc private func showBookmarksCommand() {
+    @objc private func showBookmarksKeyCommand() {
         navigationHelper.openBookmarks()
+    }
+    
+    @objc private func showDownloadsKeyCommand() {
+        navigationHelper.openDownloads()
     }
     
     @objc private func findNextCommand() {
@@ -138,7 +153,7 @@ extension BrowserViewController {
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        let tabNavigationCommands = [
+        let navigationCommands = [
             UIKeyCommand(title: Strings.reloadPageTitle, action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command),
             UIKeyCommand(title: Strings.backTitle, action: #selector(goBackKeyCommand), input: "[", modifierFlags: .command),
             UIKeyCommand(title: Strings.forwardTitle, action: #selector(goForwardKeyCommand), input: "]", modifierFlags: .command),
@@ -155,16 +170,23 @@ extension BrowserViewController {
             UIKeyCommand(title: String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count),
                          action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .shift]), // TODO: new 1
             
-            UIKeyCommand(title: "Show History", action: #selector(showHistoryCommand), input: "y", modifierFlags: [.command]), // TODO: new 1
-            
+            UIKeyCommand(title: "Show History", action: #selector(showHistoryKeyCommand), input: "y", modifierFlags: [.command]), // TODO: new 1
+            UIKeyCommand(title: "Show Downloads", action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command), // TODO: new 1
+
             // Switch tab to match Safari on iOS.
             UIKeyCommand(input: "]", modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
             UIKeyCommand(input: "[", modifierFlags: [.command, .shift], action: #selector(previousTabKeyCommand)),
-            UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(showTabTrayKeyCommand)) // Safari on macOS
+            UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(showTabTrayKeyCommand)), // Safari on macOS
         ]
         
+        var tabNavigationCommands: [UIKeyCommand] = []
+        
+        for index in 1..<10 {
+            tabNavigationCommands.append(UIKeyCommand(input: String(index), modifierFlags: [.command], action: #selector(showTabKeyCommand(sender:)))) // TODO: new 1
+        }
+        
         let bookmarkEditingCommands = [
-            UIKeyCommand(title: "Show Bookmarks", action: #selector(showBookmarksCommand), input: "o", modifierFlags: [.shift, .command]), // TODO: new 1
+            UIKeyCommand(title: "Show Bookmarks", action: #selector(showBookmarksKeyCommand), input: "o", modifierFlags: [.shift, .command]), // TODO: new 1
             UIKeyCommand(title: "Add Bookmark", action: #selector(addBookmarkCommand), input: "d", modifierFlags: [.command]), // TODO: title added
             UIKeyCommand(title: "Add to Favourites", action: #selector(addToFavouritesCommand), input: "d", modifierFlags: [.command, .shift]) //TODO:  new 1
         ]
@@ -188,7 +210,7 @@ extension BrowserViewController {
             UIKeyCommand(title: "Share With...", action: #selector(shareWithKeyCommand), input: "s", modifierFlags: .command) // TODO: new 1
         ]
         
-        var keyCommandList = tabNavigationCommands + bookmarkEditingCommands + shareCommands + findTextCommands
+        var keyCommandList = navigationCommands + tabNavigationCommands + bookmarkEditingCommands + shareCommands + findTextCommands
         
         // URL completion and Override Key commands
         

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -61,6 +61,15 @@ extension Strings {
     public static let closeTabTitle = NSLocalizedString("CloseTabTitle", bundle: Bundle.shared, value: "Close Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
     public static let showNextTabTitle = NSLocalizedString("ShowNextTabTitle", bundle: Bundle.shared, value: "Show Next Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
     public static let showPreviousTabTitle = NSLocalizedString("ShowPreviousTabTitle", bundle: Bundle.shared, value: "Show Previous Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showHistoryTitle = NSLocalizedString("showHistoryTitle", bundle: Bundle.braveShared, value: "Show History", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showDownloadsTitle = NSLocalizedString("showDownloadsTitle", bundle: Bundle.braveShared, value: "Show Downloads", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showBookmarksTitle = NSLocalizedString("showBookmarksTitle", bundle: Bundle.shared, value: "Show Bookmarks", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let addBookmarkTitle = NSLocalizedString("addBookmarkTitle", bundle: Bundle.braveShared, value: "Add Bookmark", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let addFavouritesTitle = NSLocalizedString("addFavouritesTitle", bundle: Bundle.braveShared, value: "Add to Favourites", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let findInPageTitle = NSLocalizedString("findInPageTitle", bundle: Bundle.braveShared, value: "Find in Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let findNextTitle = NSLocalizedString("findNextTitle", bundle: Bundle.braveShared, value: "Find Next", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let findPreviousTitle = NSLocalizedString("findPreviousTitle", bundle: Bundle.braveShared, value: "Find Previous", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let shareWithTitle = NSLocalizedString("shareWithTitle", bundle: Bundle.braveShared, value: "Share with...", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
 }
 
 // Home page.


### PR DESCRIPTION
This PR is adding some new items and organization to keyboard shortcuts.

New Shortcuts added are:
- Close All Tabs
- Show History
- Show Downloads
- Show Bookmarks
- Add to Favourites
- Share With
(1 st video)

In addition "Find in Page" key commands are organized and "Find Next" and "Find Previous" is shown only when there is a text in search bar. 
(2 nd Video)

Also Tab Navigation Key Commands are added to Show tab # 1-9 - Command + 1-9. These shortcuts are not marked with title but they exist like in other browsers. (3 rd video)

## Summary of Changes

This pull request fixes #4400 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
(shown in 1st video)
- Open the App on iPad
- Hold CMD key to check keyboard shortcut list
- Try all the new shortcuts  (Close All Tabs, Show History, Show Downloads, Show Bookmarks, Add to Favourites, Share With)

(shown in 2nd video)
- Open the App on iPad
- Hold CMD key to check keyboard shortcut list and check only "Find in Page" exists from Find shorcuts
- Activate find in page and type a search keyword
- Use find next and find previous shortcuts

(shown in 3rd video)
- Open the App on iPad
- Open various numbers of tabs
- Navigate using Command + 1-9 in tabs that are opened

## Screenshots:

Video_1 Regular View to iPad Key commands


https://user-images.githubusercontent.com/6643505/147774730-988df1b7-af2f-4b06-ae47-4d185082a02f.mp4

Video_2 Find In Page Key Commands


https://user-images.githubusercontent.com/6643505/147775055-5ff2e4ff-2322-48bc-8ad9-42d5726fdec5.mp4

Video_3 Tab Navigation Key Commands Show tab # 1-9 - Command + 1-9


https://user-images.githubusercontent.com/6643505/147775083-983ac946-b214-4d60-9ed1-d2818536112a.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
