### PR TITLE
Fix #4693: BAT/rewards icon appears greyed out when dismissing on-boarding via skip

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -46,8 +46,9 @@ extension BrowserViewController {
             
             Preferences.FullScreenCallout.rewardsCalloutCompleted.value = true
             present(controller, animated: true)
-            topToolbar.locationView.rewardsButton.iconState =
-                (rewards.isEnabled || rewards.isCreatingWallet) ? .enabled : .disabled
+            topToolbar.locationView.rewardsButton.iconState = Preferences.Rewards.rewardsToggledOnce.value ?
+                (rewards.isEnabled || rewards.isCreatingWallet ? .enabled : .disabled) :
+                .initial
             return
         }
         


### PR DESCRIPTION
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4693

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Download/install
- Skip the initial on-boarding during first launch and dismiss the on-boarding modals via NTP
- Load a random website
- Tap on the rewards panel and tap on Skip
- You'll notice the BAT icon is not greyed out.

## Screenshots:



https://user-images.githubusercontent.com/6643505/147782688-bda9066c-6863-42b0-b45c-473fe91f45b9.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
