### PR TITLE
Fix #4732: Long button text in Spanish is unreadable

### DIFF
--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewCallout.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewCallout.swift
@@ -72,6 +72,9 @@ class WelcomeViewCallout: UIView {
     private let primaryButton = RoundInterfaceButton(type: .custom).then {
         $0.setTitleColor(.white, for: .normal)
         $0.backgroundColor = .braveBlurple
+        $0.titleLabel?.numberOfLines = 0
+        $0.titleLabel?.minimumScaleFactor = 0.7
+        $0.titleLabel?.adjustsFontSizeToFitWidth = true
     }
     
     private let secondaryButtonContentView = UIStackView().then {
@@ -97,6 +100,9 @@ class WelcomeViewCallout: UIView {
         $0.backgroundColor = .clear
         $0.setContentHuggingPriority(.required, for: .horizontal)
         $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+        $0.titleLabel?.numberOfLines = 0
+        $0.titleLabel?.minimumScaleFactor = 0.7
+        $0.titleLabel?.adjustsFontSizeToFitWidth = true
     }
     
     // MARK: - State


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4732

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Install Brave
- Switch to a Spanish-speaking locale (language) in iOS
- Launch Brave
- Go through the onboarding tour until you see the translated Make Brave your default browser screen
- Look at the button strings for Set as default

## Screenshots:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-12-30 at 14 45 59](https://user-images.githubusercontent.com/6643505/147784301-ef894090-5948-4ce4-829d-ae0c9a5076dd.png)



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
