### PR TITLE
Fix #4789: Bookmarks page not remembered when using the toolbar icon

### DIFF
--- a/Client/Frontend/Browser/BrowserNavigationHelper.swift
+++ b/Client/Frontend/Browser/BrowserNavigationHelper.swift
@@ -43,7 +43,10 @@ class BrowserNavigationHelper {
     
     func openBookmarks() {
         guard let bvc = bvc else { return }
-        let vc = BookmarksViewController(folder: nil, bookmarkManager: bvc.bookmarkManager, isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        let vc = BookmarksViewController(
+            folder: bvc.bookmarkManager.lastVisitedFolder(),
+            bookmarkManager: bvc.bookmarkManager,
+            isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
         vc.toolbarUrlActionsDelegate = bvc
         
         open(vc, doneButton: DoneButton(style: .done, position: .right))

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -108,7 +108,10 @@ extension BrowserViewController {
     func destinationMenuSection(_ menuController: MenuViewController, isShownOnWebPage: Bool) -> some View {
         VStack(spacing: 0) {
             MenuItemButton(icon: #imageLiteral(resourceName: "menu_bookmarks").template, title: Strings.bookmarksMenuItem) { [unowned self, unowned menuController] in
-                let vc = BookmarksViewController(folder: self.bookmarkManager.lastVisitedFolder(), bookmarkManager: self.bookmarkManager, isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
+                let vc = BookmarksViewController(
+                    folder: bookmarkManager.lastVisitedFolder(),
+                    bookmarkManager: bookmarkManager,
+                    isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
                 vc.toolbarUrlActionsDelegate = self
                 menuController.presentInnerMenu(vc)
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -449,17 +449,6 @@ extension BrowserViewController: TopToolbarDelegate {
         })
     }
     
-    private func showBookmarkController() {
-        let bookmarkViewController = BookmarksViewController(
-            folder: bookmarkManager.lastVisitedFolder(),
-            bookmarkManager: bookmarkManager,
-            isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        
-        bookmarkViewController.toolbarUrlActionsDelegate = self
-        
-        presentSettingsNavigation(with: bookmarkViewController)
-    }
-    
     func openAddBookmark() {
         guard let selectedTab = tabManager.selectedTab,
               let selectedUrl = selectedTab.url,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4789

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open Brave and tap bookmarks icon
- Drill into your bookmarks — this user went to Mobile bookmarks --> Imported bookmarks
- Tap on any bookmark to navigate to the site
- Tap the bookmarks icon again

## Screenshots:


https://user-images.githubusercontent.com/6643505/148109533-cc9d6937-c9c6-4ddd-a570-9491ede2a876.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
