### PR TITLE
Fix #4761: Bump BraveCore to Release build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.34.68/brave-core-ios-1.34.68.tgz",
-      "integrity": "sha512-2BhUNFKdJ3oxBAWye5mTpDhWWpljmszmaS7lftoyJkFayZQ/uc4ExDKRgl8SFMrDZDTLIFfErYIwW9mb2jrgYA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.34.79/brave-core-ios-1.34.79.tgz",
+      "integrity": "sha512-K0jBgXC7A2mmcKRDTMyT8CHM6f7YewAAKPqlrSW5q765L8lMSlVeF2lBdXk8Mq7htnuTKEicz+tQw8SOOrnJXg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.34.68/brave-core-ios-1.34.68.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.34.79/brave-core-ios-1.34.79.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4761

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
