### PR TITLE
Fix #4631: Don't use stack view layout margins inside popovers

### DIFF
--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
@@ -14,8 +14,6 @@ extension BraveRewardsViewController {
         private let stackView = UIStackView().then {
             $0.axis = .vertical
             $0.spacing = 20
-            $0.isLayoutMarginsRelativeArrangement = true
-            $0.layoutMargins = UIEdgeInsets(top: 20, left: 16, bottom: 20, right: 16)
         }
         let rewardsToggle = UISwitch().then {
             $0.setContentHuggingPriority(.required, for: .horizontal)
@@ -50,7 +48,7 @@ extension BraveRewardsViewController {
             
             addSubview(stackView)
             stackView.snp.makeConstraints {
-                $0.edges.equalToSuperview()
+                $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 20, left: 16, bottom: 20, right: 16))
             }
             stackView.addStackViewItems(
                 .view(UIStackView().then {

--- a/Client/Frontend/Browser/BrowserViewController/ProductNotifications/ShareTrackersController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/ProductNotifications/ShareTrackersController.swift
@@ -132,8 +132,6 @@ private class ShareTrackersView: UIView {
     private let stackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 20
-        $0.isLayoutMarginsRelativeArrangement = true
-        $0.layoutMargins = UX.contentMargins
     }
     
     private lazy var titleLabel = UILabel().then {
@@ -189,7 +187,7 @@ private class ShareTrackersView: UIView {
         addSubview(stackView)
         
         stackView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.edges.equalToSuperview().inset(UX.contentMargins)
         }
 
         stackView.addStackViewItems(


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4631

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
