### PR TITLE
Fix #4802: No search history result isn't showing up the correct message

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		2F29FB8B267BE06100B0AD6A /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 2F29FB7E267BE06100B0AD6A /* Model.xcdatamodeld */; };
 		2F2C3549261D10AE00631310 /* CustomIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F693223260D218900ECEB38 /* CustomIntentHandler.swift */; };
 		2F2C35A6261DF41100631310 /* CustomIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F693223260D218900ECEB38 /* CustomIntentHandler.swift */; };
+		2F41064527860EE200732FFF /* EmptyStateOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F41064427860EE200732FFF /* EmptyStateOverlayView.swift */; };
 		2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */; };
 		2F44FB2D1A9D5D8500FD20CC /* FiraSans-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B7421A793CF20022C5E0 /* FiraSans-BoldItalic.ttf */; };
 		2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */; };
@@ -2292,6 +2293,7 @@
 		2F29FB88267BE06100B0AD6A /* Model5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model5.xcdatamodel; sourceTree = "<group>"; };
 		2F29FB89267BE06100B0AD6A /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		2F29FB8A267BE06100B0AD6A /* Model9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model9.xcdatamodel; sourceTree = "<group>"; };
+		2F41064427860EE200732FFF /* EmptyStateOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateOverlayView.swift; sourceTree = "<group>"; };
 		2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHashExtensions.swift; sourceTree = "<group>"; };
 		2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
 		2F44FCC41A9E85E900FD20CC /* SettingsTableSectionHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableSectionHeaderFooterView.swift; sourceTree = "<group>"; };
@@ -5716,6 +5718,7 @@
 				27AE360C25E55AA200E795E5 /* MenuViewController.swift */,
 				277E94F125F834240001926E /* VPNMenuButton.swift */,
 				CA9A233326B97B4300923D70 /* PlaylistMenuButton.swift */,
+				2F41064427860EE200732FFF /* EmptyStateOverlayView.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -8845,6 +8848,7 @@
 				27953F7723F5DF5D00B4B595 /* AboutShieldsViewController.swift in Sources */,
 				0A1E84442190A57F0042F782 /* SyncCameraView.swift in Sources */,
 				A1CA29C420E1746A00CB9126 /* OptionSelectionViewController.swift in Sources */,
+				2F41064527860EE200732FFF /* EmptyStateOverlayView.swift in Sources */,
 				5EC594ED232C2C8F00922111 /* OnboardingWebViewController.swift in Sources */,
 				0A4B012420D0321A004D4011 /* UX.swift in Sources */,
 				2FD1C60B2638823D00E3C25F /* HistoryFetchers.swift in Sources */,

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -102,7 +102,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     private var isBookmarksBeingSearched = false
     private let bookmarksSearchController = UISearchController(searchResultsController: nil)
     private var bookmarksSearchQuery = ""
-    private lazy var noSearchResultOverlayView = createNoSearchResultOverlayView()
+    private lazy var noSearchResultOverlayView = EmptyStateOverlayView(description: Strings.noSearchResultsfound)
 
     // MARK: Lifecycle
     
@@ -232,35 +232,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     private func updateLastVisitedFolder(_ folder: Bookmarkv2?) {
         Preferences.Chromium.lastBookmarksFolderNodeId.value = folder?.objectID ?? -1
     }
-    
-    private func createNoSearchResultOverlayView() -> UIView {
-        let overlayView = UIView().then {
-            $0.backgroundColor = .secondaryBraveBackground
-        }
-        
-        let welcomeLabel = UILabel().then {
-            $0.text = Strings.noSearchResultsfound
-            $0.textAlignment = .center
-            $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
-            $0.textColor = .braveLabel
-            $0.numberOfLines = 0
-            $0.adjustsFontSizeToFitWidth = true
-        }
-        
-        overlayView.addSubview(welcomeLabel)
-        
-        welcomeLabel.snp.makeConstraints { make in
-            make.centerX.equalTo(overlayView)
-            // Sets proper top constraint for iPhone 6 in portait and for iPad.
-            make.centerY.equalTo(overlayView).offset(-180).priority(100)
-            // Sets proper top constraint for iPhone 4, 5 in portrait.
-            make.top.greaterThanOrEqualTo(overlayView).offset(50)
-            make.width.equalTo(170)
-        }
-        
-        return overlayView
-    }
-    
+
     private func updateEmptyPanelState() {
         if isBookmarksBeingSearched, bookmarkManager.fetchedSearchObjectsCount == 0 {
             showEmptyPanelState()

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -1,0 +1,64 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+
+class EmptyStateOverlayView: UIView {
+    
+    private let logoImageView = UIImageView().then {
+        $0.tintColor = .braveLabel
+    }
+    
+    private let informationLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
+        $0.textColor = .braveLabel
+        $0.numberOfLines = 0
+        $0.adjustsFontSizeToFitWidth = true
+    }
+    
+    required init(description: String? = nil, icon: UIImage? = nil) {
+        super.init(frame: .zero)
+        
+        backgroundColor = .secondaryBraveBackground
+        
+        if let icon = icon {
+            logoImageView.image = icon.template
+        }
+        
+        addSubview(logoImageView)
+
+        logoImageView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.size.equalTo(60)
+            // Sets proper top constraint for iPhone 6 in portrait and for iPad.
+            make.centerY.equalToSuperview().offset(-180).priority(100)
+            // Sets proper top constraint for iPhone 4, 5 in portrait.
+            make.top.greaterThanOrEqualToSuperview().offset(50)
+        }
+
+        if let description = description {
+            informationLabel.text = description
+        }
+        
+        addSubview(informationLabel)
+        
+        informationLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(logoImageView.snp.bottom).offset(15)
+            make.width.equalTo(170)
+        }
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+    
+    func updateInfoLabel(with text: String) {
+        informationLabel.text = text
+    }
+}

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -14,7 +14,11 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     
     weak var toolbarUrlActionsDelegate: ToolbarUrlActionsDelegate?
 
-    private lazy var emptyStateOverlayView = HistoryStateOverlayView()
+    private lazy var emptyStateOverlayView = EmptyStateOverlayView(
+        description: Preferences.Privacy.privateBrowsingOnly.value
+            ? Strings.History.historyPrivateModeOnlyStateTitle
+            : Strings.History.historyEmptyStateTitle,
+        icon: #imageLiteral(resourceName: "emptyHistory"))
 
     private let spinner = UIActivityIndicatorView().then {
         $0.snp.makeConstraints { make in
@@ -415,57 +419,5 @@ extension HistoryViewController: UISearchControllerDelegate {
         
         isHistoryBeingSearched = false
         tableView.reloadData()
-    }
-}
-
-class HistoryStateOverlayView: UIView {
-    
-    private let logoImageView = UIImageView(image: #imageLiteral(resourceName: "emptyHistory").template).then {
-        $0.tintColor = .braveLabel
-    }
-    
-    private let informationLabel = UILabel().then {
-        $0.text = Preferences.Privacy.privateBrowsingOnly.value
-            ? Strings.History.historyPrivateModeOnlyStateTitle
-            : Strings.History.historyEmptyStateTitle
-        $0.textAlignment = .center
-        $0.font = DynamicFontHelper.defaultHelper.DeviceFontLight
-        $0.textColor = .braveLabel
-        $0.numberOfLines = 0
-        $0.adjustsFontSizeToFitWidth = true
-    }
-    
-    required init() {
-        super.init(frame: .zero)
-        
-        backgroundColor = .secondaryBraveBackground
-
-        addSubview(logoImageView)
-        
-        logoImageView.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.size.equalTo(60)
-            // Sets proper top constraint for iPhone 6 in portait and for iPad.
-            make.centerY.equalToSuperview().offset(-180).priority(100)
-            // Sets proper top constraint for iPhone 4, 5 in portrait.
-            make.top.greaterThanOrEqualToSuperview().offset(50)
-        }
-        
-        addSubview(informationLabel)
-        
-        informationLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(logoImageView.snp.bottom).offset(15)
-            make.width.equalTo(170)
-        }
-    }
-    
-    @available(*, unavailable)
-    required init(coder: NSCoder) {
-        fatalError()
-    }
-    
-    func updateInfoLabel(with text: String) {
-        informationLabel.text = text
     }
 }


### PR DESCRIPTION
This PR is adding A new overlay view which is used in history and bookmarks. This overlay view can be constructed with a title and icon optional and has update ability to the description.

This allows us to eliminate the duplicate code in history and bookmark list

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4802

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open 4 websites and confirm history is stored in History
- Open Search history bar and enter any website which is not listed in the search history list
- No search results found message should be shown

## Screenshots:


https://user-images.githubusercontent.com/6643505/148285917-41340b11-2b68-47a5-9298-f211639ce193.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
