### PR TITLE
Fix #4561: Add address copying long-press actions to accounts rows

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -24,6 +24,14 @@ struct AccountsView: View {
     keyringStore.keyring.accountInfos.filter(\.isImported)
   }
   
+  private func copyAccountAddressButton(_ address: String) -> some View {
+    Button(action: {
+      UIPasteboard.general.string = address
+    }) {
+      Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+    }
+  }
+  
   var body: some View {
     List {
       Section(
@@ -41,6 +49,9 @@ struct AccountsView: View {
             selectedAccount = account
           } label: {
             AccountView(address: account.address, name: account.name)
+          }
+          .contextMenu {
+            copyAccountAddressButton(account.address)
           }
         }
       }
@@ -64,6 +75,9 @@ struct AccountsView: View {
               selectedAccount = account
             } label: {
               AccountView(address: account.address, name: account.name)
+            }
+            .contextMenu {
+              copyAccountAddressButton(account.address)
             }
           }
         }

--- a/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -150,15 +150,16 @@ private struct AccountDetailsHeaderView: View {
             }
           }
         )
-      HStack {
-        Text(address.truncatedAddress)
-          .foregroundColor(Color(.secondaryBraveLabel))
-        Button(action: { UIPasteboard.general.string = address }) {
+      Button(action: { UIPasteboard.general.string = address }) {
+        HStack {
+          Text(address.truncatedAddress)
+            .foregroundColor(Color(.secondaryBraveLabel))
           Label(Strings.Wallet.copyToPasteboard, image: "brave.clipboard")
             .labelStyle(.iconOnly)
             .foregroundColor(Color(.braveLabel))
         }
       }
+      .buttonStyle(.plain)
       .font(.title3.weight(.semibold))
     }
     .padding(.horizontal)

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -123,6 +123,13 @@ struct AccountPicker: View {
             }) {
               AccountView(address: account.address, name: account.name)
             }
+            .contextMenu {
+              Button(action: {
+                UIPasteboard.general.string = account.address
+              }) {
+                Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+              }
+            }
           }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))


### PR DESCRIPTION
Also increases the tap area for the copy address in account details

## Summary of Changes

This pull request fixes #4561 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Long press primary or secondary accounts in Accounts list screen and verify copy address works
- Repeat above on Accounts Picker screen (from Buy/Send/Swap)
- Verify that you can now tap on the truncated address to copy the address within the Account Details screen

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
