### PR TITLE
Fix #4214: Remove asymmetrical padding on top toolbar

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -259,8 +259,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
     private let mainStackView = UIStackView().then {
         $0.alignment = .center
         $0.spacing = 8
-        $0.isLayoutMarginsRelativeArrangement = true
-        $0.layoutMargins = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 10.0)
         $0.translatesAutoresizingMaskIntoConstraints = false
     }
     


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4214 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 13 Pro - 2022-01-06 at 15 15 15](https://user-images.githubusercontent.com/529104/148445638-cdf5015e-f58e-48c0-9f94-13820db48600.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-01-06 at 15 14 50](https://user-images.githubusercontent.com/529104/148445642-0e69cc28-80b2-4b84-a98a-6afda8e5b56b.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-01-06 at 15 14 47](https://user-images.githubusercontent.com/529104/148445643-e7cb2628-fb8d-481c-bda5-39af003075c4.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-01-06 at 15 14 44](https://user-images.githubusercontent.com/529104/148445644-5a9f690c-7895-4f7b-80e2-b1f12a033842.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).


cc @Brandon-T I'm not 100% sure why this 10px padding was added but everything I've tested around it seems fine without it