### PR TITLE
Fix #4562: Show new accounts when they're added within asset detail

### DIFF
--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -177,8 +177,13 @@ class AssetDetailStore: ObservableObject {
 
 extension AssetDetailStore: BraveWalletKeyringControllerObserver {
   func accountsChanged() {
-    fetchAccountBalances()
-    fetchTransactions()
+    keyringController.defaultKeyringInfo { [self] keyring in
+      accounts = keyring.accountInfos.map {
+        .init(account: $0, decimalBalance: 0.0, balance: "", fiatBalance: "")
+      }
+      fetchAccountBalances()
+      fetchTransactions()
+    }
   }
   
   func keyringCreated() {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4562

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit asset detail from portfolio or asset search
- Add an account via the "Add Account" button
- Verify it is added and visible within the accounts list

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
