### PR TITLE
Ref #4400: Add more iPad keyboard shortcuts (Text Fix for Paste action)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -568,7 +568,7 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
             })
             
             let pasteAction = UIAction(
-                title: Strings.pasteAndGoTitle,
+                title: Strings.pasteTitle,
                 image: UIImage(systemName: "doc.on.clipboard"),
                 handler: UIAction.deferredActionHandler { _ in
                 if let pasteboardContents = UIPasteboard.general.string {


### PR DESCRIPTION
Fixing url bar actions where Paste action text is written as duplicate of Paste and Go

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4400

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
