### PR TITLE
Fix #4841: Restore transformation-style tab tray animation

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 		27829E752549FF13007CF0B2 /* WalletTransferViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27829E742549FF13007CF0B2 /* WalletTransferViewController.swift */; };
 		27829E842549FF9D007CF0B2 /* WalletTransferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27829E832549FF9D007CF0B2 /* WalletTransferView.swift */; };
 		2784874524DC658C0004F03C /* BraveNewsEmptyFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2784874424DC658C0004F03C /* BraveNewsEmptyFeedView.swift */; };
+		2788E9CE2786421F0093FBE8 /* TabTrayAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2788E9CD2786421F0093FBE8 /* TabTrayAnimation.swift */; };
 		278C467823EDF0060083347F /* SimpleShieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C467723EDF0060083347F /* SimpleShieldsView.swift */; };
 		278C467B23EDF0940083347F /* ShieldsSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C467A23EDF0940083347F /* ShieldsSwitch.swift */; };
 		278C467C23EE2B450083347F /* UIStackViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271DECBA234CC7EF009DAC37 /* UIStackViewExtensions.swift */; };
@@ -2133,6 +2134,7 @@
 		27829E742549FF13007CF0B2 /* WalletTransferViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransferViewController.swift; sourceTree = "<group>"; };
 		27829E832549FF9D007CF0B2 /* WalletTransferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransferView.swift; sourceTree = "<group>"; };
 		2784874424DC658C0004F03C /* BraveNewsEmptyFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveNewsEmptyFeedView.swift; sourceTree = "<group>"; };
+		2788E9CD2786421F0093FBE8 /* TabTrayAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayAnimation.swift; sourceTree = "<group>"; };
 		278C467723EDF0060083347F /* SimpleShieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleShieldsView.swift; sourceTree = "<group>"; };
 		278C467A23EDF0940083347F /* ShieldsSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldsSwitch.swift; sourceTree = "<group>"; };
 		278C468623F1E6270083347F /* BraveUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BraveUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4684,6 +4686,7 @@
 				44514A5E269745FD004CBF73 /* TabTrayController.swift */,
 				44514A6B26974917004CBF73 /* TabTrayView.swift */,
 				44C2364426A05714005A573D /* TabTrayPrivateModeInfoView.swift */,
+				2788E9CD2786421F0093FBE8 /* TabTrayAnimation.swift */,
 			);
 			path = "Tab Tray";
 			sourceTree = "<group>";
@@ -8678,6 +8681,7 @@
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
 				CA8D5C1226D7CDCD009BF13D /* PlaylistListViewController+TableViewDataSource.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
+				2788E9CE2786421F0093FBE8 /* TabTrayAnimation.swift in Sources */,
 				5E6683A923D61CF7005B3A6C /* NTPDownloader.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
 				CA8D5C1026D7CDAF009BF13D /* PlaylistListViewController+DragDropDelegate.swift in Sources */,

--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -35,7 +35,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         Migration.postCoreDataInitMigrations()
         
         Preferences.General.themeNormalMode.objectWillChange
-            .merge(with: PrivateBrowsingManager.shared.objectWillChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateTheme()
+            }
+            .store(in: &cancellables)
+        
+        PrivateBrowsingManager.shared.$isPrivateBrowsing
+            .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.updateTheme()

--- a/Client/Frontend/Browser/Tab Tray/TabTrayAnimation.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayAnimation.swift
@@ -1,0 +1,268 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveUI
+import UIKit
+import Shared
+
+private let log = Logger.browserLogger
+
+extension TabTrayController: UIViewControllerTransitioningDelegate {
+    func animationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController,
+        source: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        return BasicAnimationController(delegate: self, direction: .presenting)
+    }
+    
+    func animationController(
+        forDismissed dismissed: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        return BasicAnimationController(delegate: self, direction: .dismissing)
+    }
+}
+
+extension TabTrayController: BasicAnimationControllerDelegate {
+    func animatePresentation(context: UIViewControllerContextTransitioning) {
+        guard let containerController = context.viewController(forKey: .from) as? UINavigationController,
+              let bvc = containerController.topViewController as? BrowserViewController
+        else {
+            log.error("""
+                Attempted to present the tab tray on something that is not a BrowserViewController which is
+                currently unsupported.
+            """)
+            context.completeTransition(true)
+            return
+        }
+        
+        guard let selectedTab = tabManager.selectedTab else {
+            log.error("Attempted to present the tab tray without having a selected tab")
+            context.completeTransition(true)
+            return
+        }
+        
+        let finalFrame = context.finalFrame(for: self)
+        
+        // Tab snapshot animates from web view container on BVC to the cell frame
+        let tabSnapshot = UIImageView(image: selectedTab.screenshot ?? .init())
+        tabSnapshot.layer.cornerCurve = .continuous
+        tabSnapshot.clipsToBounds = true
+        tabSnapshot.contentMode = .scaleAspectFill
+        tabSnapshot.frame = bvc.webViewContainer.frame
+        
+        // BVC snapshot animates to the cell
+        let bvcSnapshot = UIImageView(image: bvc.view.snapshot)
+        bvcSnapshot.layer.cornerCurve = .continuous
+        bvcSnapshot.clipsToBounds = true
+        
+        // Just a small background view for animation sake between the tab tray and the bvc
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
+        backgroundView.frame = finalFrame
+        
+        context.containerView.addSubview(view)
+        context.containerView.addSubview(backgroundView)
+        context.containerView.addSubview(bvcSnapshot)
+        context.containerView.addSubview(tabSnapshot)
+        
+        view.frame = finalFrame
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        
+        let cv = tabTrayView.collectionView
+        cv.reloadData()
+        
+        var tabCell: TabCell?
+        var cellFrame: CGRect?
+        var cellTitleSnapshot: UIView?
+        if let indexPath = dataSource.indexPath(for: selectedTab) {
+            // This is needed for some reason otherwise the collection views content offest is
+            // incorrect.
+            cv.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+            cv.layoutIfNeeded()
+            tabCell = cv.cellForItem(at: indexPath) as? TabCell
+            if let cell = tabCell {
+                // Hide the cell that is being animated too since we are making a copy of it to animate in
+                cellFrame = cv.convert(cell.frame, to: view)
+                
+                // For animations sake we are also making a copy of the title and animating it in closer to
+                // the animation finish
+                let titleSnapshot = UIImageView(image: cell.titleBackgroundView.snapshot)
+                titleSnapshot.contentMode = .scaleToFill
+                titleSnapshot.clipsToBounds = true
+                tabSnapshot.addSubview(titleSnapshot)
+                titleSnapshot.snp.makeConstraints {
+                    $0.top.leading.trailing.equalToSuperview()
+                }
+                titleSnapshot.alpha = 0.0
+                cellTitleSnapshot = titleSnapshot
+                
+                tabSnapshot.setNeedsLayout()
+                tabSnapshot.layoutIfNeeded()
+                
+                cell.isHidden = true
+                cell.alpha = 0.0
+            }
+        }
+        
+        // Just for florish, scaling the collection view a bit
+        cv.transform = .init(scaleX: 1.2, y: 1.2)
+        cv.alpha = 0.5
+        let animator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.825) {
+            cv.transform = .identity
+            cv.alpha = 1
+            if let frame = cellFrame {
+                tabSnapshot.frame = frame
+                bvcSnapshot.frame = frame
+            } else {
+                tabSnapshot.alpha = 0.0
+                bvcSnapshot.alpha = 0.0
+            }
+            tabSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+            bvcSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+            backgroundView.alpha = 0
+        }
+        // Need delayed animation for these
+        animator.addAnimations({
+            cellTitleSnapshot?.alpha = 1.0
+        }, delayFactor: 0.5)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            tabCell?.isHidden = false
+            UIViewPropertyAnimator(duration: 0.1, curve: .linear) {
+                tabCell?.alpha = 1
+            }.startAnimation()
+        }
+        animator.addCompletion { _ in
+            backgroundView.removeFromSuperview()
+            tabSnapshot.removeFromSuperview()
+            bvcSnapshot.removeFromSuperview()
+            context.completeTransition(true)
+        }
+        animator.startAnimation()
+    }
+    
+    func animateDismissal(context: UIViewControllerContextTransitioning) {
+        guard let toViewController = context.viewController(forKey: .to),
+              let toView = context.view(forKey: .to)
+        else {
+            log.error("""
+                Attempted to dismiss the tab tray without a view to dismiss from.
+            
+                Likely the `modalPresentationStyle` was changed away from `fullScreen` and should be changed
+                back if using this custom animation.
+            """)
+            context.completeTransition(true)
+            return
+        }
+        
+        guard let containerController = toViewController as? UINavigationController,
+              let bvc = containerController.topViewController as? BrowserViewController
+        else {
+            log.error("""
+                Attempted to dismiss the tab tray from something that is not a BrowserViewController which is
+                currently unsupported.
+            """)
+            context.completeTransition(true)
+            return
+        }
+        
+        // Tab screenshot will animate from the cell to the bvc web container
+        let tabSnapshot = UIImageView(image: tabManager.selectedTab?.screenshot ?? .init())
+        tabSnapshot.layer.cornerCurve = .continuous
+        tabSnapshot.clipsToBounds = true
+        tabSnapshot.contentMode = .scaleAspectFill
+        tabSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+        
+        let finalFrame = context.finalFrame(for: toViewController)
+        
+        toView.frame = finalFrame
+        context.containerView.addSubview(toView)
+        toView.setNeedsLayout()
+        toView.layoutIfNeeded()
+        
+        // BVC snapshot animates from the cell to its final resting spot
+        let toVCSnapshot: UIView = toView.snapshotView(afterScreenUpdates: true) ??
+            UIImageView(image: toView.snapshot)
+        toVCSnapshot.layer.cornerCurve = .continuous
+        toVCSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+        toVCSnapshot.clipsToBounds = true
+        
+        // Just a small background view for animation sake between the tab tray and the bvc
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
+        backgroundView.alpha = 0
+        backgroundView.frame = finalFrame
+        
+        context.containerView.addSubview(backgroundView)
+        context.containerView.addSubview(toVCSnapshot)
+        context.containerView.addSubview(tabSnapshot)
+        
+        // Hide the destination as we're animating a snapshot into place
+        toView.isHidden = true
+        
+        let cv = tabTrayView.collectionView
+        cv.reloadData()
+        
+        var tabCell: TabCell?
+        var cellTitleSnapshot: UIView?
+        if let tab = tabManager.selectedTab, let indexPath = dataSource.indexPath(for: tab) {
+            // This is needed for some reason otherwise the collection views content offest is
+            // incorrect.
+            cv.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+            cv.layoutIfNeeded()
+            
+            if let cell = cv.cellForItem(at: indexPath) as? TabCell {
+                tabCell = cell
+                
+                tabSnapshot.frame = cv.convert(cell.frame, to: view)
+                toVCSnapshot.frame = tabSnapshot.frame
+                
+                let titleSnapshot = UIImageView(image: cell.titleBackgroundView.snapshot)
+                titleSnapshot.contentMode = .scaleToFill
+                titleSnapshot.clipsToBounds = true
+                tabSnapshot.addSubview(titleSnapshot)
+                titleSnapshot.snp.makeConstraints {
+                    $0.top.leading.trailing.equalToSuperview()
+                }
+                cellTitleSnapshot = titleSnapshot
+                tabSnapshot.setNeedsLayout()
+                tabSnapshot.layoutIfNeeded()
+                
+                cell.isHidden = true
+            }
+        }
+        
+        let animator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1.0) {
+            // For some flourish
+            cv.transform = .init(scaleX: 1.2, y: 1.2)
+            cv.alpha = 0.5
+            
+            tabSnapshot.frame = bvc.webViewContainer.frame
+            tabSnapshot.layer.cornerRadius = 0
+            toVCSnapshot.frame = finalFrame
+            toVCSnapshot.layer.cornerRadius = 0
+            backgroundView.alpha = 1
+        }
+        if let titleSnapshot = cellTitleSnapshot {
+            // Need a quicker animation for this one
+            UIViewPropertyAnimator(duration: 0.1, curve: .linear) {
+                titleSnapshot.alpha = 0
+            }
+            .startAnimation()
+        }
+        animator.addCompletion { _ in
+            tabCell?.isHidden = false
+            toView.isHidden = false
+            self.view.removeFromSuperview()
+            tabSnapshot.removeFromSuperview()
+            toVCSnapshot.removeFromSuperview()
+            backgroundView.removeFromSuperview()
+            context.completeTransition(true)
+        }
+        animator.startAnimation()
+    }
+}

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -52,6 +52,11 @@ class TabTrayController: UIViewController {
     init(tabManager: TabManager) {
         self.tabManager = tabManager
         super.init(nibName: nil, bundle: nil)
+        
+        if !UIAccessibility.isReduceMotionEnabled {
+            transitioningDelegate = self
+            modalPresentationStyle = .fullScreen
+        }
     }
     
     @available(*, unavailable)

--- a/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayView.swift
@@ -16,7 +16,7 @@ extension TabTrayController {
             static let largeCellHeight = 256.0
         }
         
-        private func generateLayout(numberOfColumns: Int = 2,
+        private func generateLayout(numberOfColumns: Int,
                                     cellHeight: CGFloat = UX.regularCellHeight) -> UICollectionViewLayout {
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
@@ -37,7 +37,7 @@ extension TabTrayController {
             return layout
         }
         
-        lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout()).then {
+        lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout(numberOfColumns: numberOfColumns)).then {
             $0.setContentHuggingPriority(.defaultLow, for: .vertical)
             $0.backgroundColor = .secondaryBraveBackground
         }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4841

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Access the tab tray as usual from the browser
- Add new tabs until the number of tabs exceeds the on-screen space
- Verify that tabs transform correctly even when the tab would be off-screen initially (and vice-versa tapping on a partially off-screen tab, or tapping done while selected tab is off-screen)
- Verify private mode acts as normal
- Verify removing all tabs acts as normal

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
