### PR TITLE
Fix #4848: Printer abuse

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1972,7 +1972,7 @@ extension BrowserViewController: TabDelegate {
         let noImageModeHelper = NoImageModeHelper(tab: tab)
         tab.addContentScript(noImageModeHelper, name: NoImageModeHelper.name())
         
-        let printHelper = PrintHelper(tab: tab)
+        let printHelper = PrintHelper(browserController: self, tab: tab)
         tab.addContentScript(printHelper, name: PrintHelper.name(), sandboxed: false)
 
         let customSearchHelper = CustomSearchHelper(tab: tab)

--- a/Client/Frontend/Browser/PrintHelper.swift
+++ b/Client/Frontend/Browser/PrintHelper.swift
@@ -40,7 +40,8 @@ class PrintHelper: TabContentScript {
         }
         
         if let tab = tab, let webView = tab.webView, let url = webView.url {
-            if let domain = url.baseDomain, domain != currentDomain {
+            // If the main-frame's URL has changed
+            if let domain = url.baseDomain, domain != currentDomain, message.frameInfo.isMainFrame {
                 isBlocking = false
                 printCounter = 0
             }

--- a/Client/Frontend/Browser/PrintHelper.swift
+++ b/Client/Frontend/Browser/PrintHelper.swift
@@ -9,13 +9,19 @@ import WebKit
 private let log = Logger.browserLogger
 
 class PrintHelper: TabContentScript {
-    fileprivate weak var tab: Tab?
+    private weak var browserController: BrowserViewController?
+    private weak var tab: Tab?
+    private var isPresentingController = false
+    private var printCounter = 0
+    private var isBlocking = false
+    private var currentDomain: String?
 
     class func name() -> String {
         return "PrintHelper"
     }
 
-    required init(tab: Tab) {
+    required init(browserController: BrowserViewController, tab: Tab) {
+        self.browserController = browserController
         self.tab = tab
     }
 
@@ -33,10 +39,50 @@ class PrintHelper: TabContentScript {
             return
         }
         
-        if let tab = tab, let webView = tab.webView {
-            let printController = UIPrintInteractionController.shared
-            printController.printFormatter = webView.viewPrintFormatter()
-            printController.present(animated: true, completionHandler: nil)
+        if let tab = tab, let webView = tab.webView, let url = webView.url {
+            if let domain = url.baseDomain, domain != currentDomain {
+                isBlocking = false
+                printCounter = 0
+            }
+            
+            currentDomain = url.baseDomain
+            
+            if isPresentingController || isBlocking {
+                return
+            }
+            
+            let showPrintSheet = { [weak self] in
+                self?.isPresentingController = true
+                
+                let printController = UIPrintInteractionController.shared
+                printController.printFormatter = webView.viewPrintFormatter()
+                printController.present(animated: true, completionHandler: { _, _, _ in
+                    self?.isPresentingController = false
+                })
+            }
+            
+            printCounter += 1
+            
+            if printCounter > 1 {
+                // Show confirm alert here.
+                let suppressSheet = UIAlertController(title: nil, message: Strings.suppressAlertsActionMessage, preferredStyle: .actionSheet)
+                suppressSheet.addAction(UIAlertAction(title: Strings.suppressAlertsActionTitle, style: .destructive, handler: { [weak self] _ in
+                    self?.isBlocking = true
+                }))
+                
+                suppressSheet.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: { _ in
+                    showPrintSheet()
+                }))
+                if UIDevice.current.userInterfaceIdiom == .pad, let popoverController = suppressSheet.popoverPresentationController {
+                    popoverController.sourceView = webView
+                    popoverController.sourceRect = CGRect(x: webView.bounds.midX, y: webView.bounds.midY, width: 0, height: 0)
+                    popoverController.permittedArrowDirections = []
+                }
+
+                browserController?.present(suppressSheet, animated: true)
+            } else {
+                showPrintSheet()
+            }
         }
     }
 }


### PR DESCRIPTION
## Security
- Security Review: https://github.com/brave/security/issues/713

## Summary of Changes
- Fixes an issue where a malicious website can do abuse printing and will DOS the user as well as sometimes crash the browser if fast enough due to Out of Memory.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4848

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test that printing a page still works (at least the dialog should show up).
- Test that it will show the user an alert that lets them `suppress` future annoying alerts for that domain.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
