### PR TITLE
Fix #4783: When Brave is closed, selecting "New private window" from context menu opens standard window

### DIFF
--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -103,6 +103,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if !connectionOptions.urlContexts.isEmpty {
             self.scene(windowScene, openURLContexts: connectionOptions.urlContexts)
         }
+        
+        if let shortcutItem = connectionOptions.shortcutItem {
+            QuickActions.sharedInstance.launchedShortcutItem = shortcutItem
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
The shortcut item which be handled while app is closed should be included in quick actions shared instance so it can be activated in sceneDidBecomeActive. the handling shortcut in sceneDidBecomeActive is already in the code.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4783

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Test All the Shortcut items and check they are working when app is closed.

## Screenshots:


https://user-images.githubusercontent.com/6643505/149414048-08a1288a-d703-40b0-956c-9bcce940fbd8.mov



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
