### PR TITLE
Ref #4974: Added unit test coverage for unquotedIfNecessary

### DIFF
--- a/Client/Frontend/Reader/ReaderModeUtils.swift
+++ b/Client/Frontend/Reader/ReaderModeUtils.swift
@@ -33,7 +33,7 @@ struct ReaderModeUtils {
     }
 }
 
-private extension String {
+extension String {
     var unquotedIfNecessary: String {
         var str = self
         if str.first == "\"" || str.first == "'" {

--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -85,4 +85,10 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("https://https://test".withSecureUrlScheme, "https://test")
         XCTAssertEqual("https://http://test".withSecureUrlScheme, "https://test")
     }
+    
+    func testUnquotedIfNecessary() {
+        XCTAssertEqual("\"test\"".unquotedIfNecessary, "test")
+        XCTAssertEqual("'test'".unquotedIfNecessary, "test")
+        XCTAssertEqual("test".unquotedIfNecessary, "test")
+    }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

First of all, thank you so much for providing us the opportunity to contribute to this great repository. This is my very first PR in the world of contribution to the open source.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #[4974](https://github.com/brave/brave-ios/issues/4794)

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Goal of the PR is to add unit test coverage for `unquotedIfNecessary` which is inside the scope of `String` extension. To be able to access it in unit tests, I had to mark the extension non-private. I have added test coverage to verify the variable removes `"` and `'` from the String and returns the content inside the quotes as is.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
none

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
