### PR TITLE
No Bug: Add SwiftUI Previews `#if DEBUG` Swiftlint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -95,5 +95,13 @@ custom_rules:
     capture_group: 0
     message: "Using `evaluateJavaScript` directly is not allowed. Use `evaluateSafeJavaScript` instead."
     severity: error
+  swiftui_previews_guard:
+    included: ".*\\.swift"
+    excluded: ".*Test\\.swift"
+    name: "SwiftUI Previews Guard"
+    regex: "(?<!#if DEBUG\n)(^struct [^\n:]+: PreviewProvider)"
+    capture_group: 1
+    message: "SwiftUI Previews should be enclosed within an #if DEBUG…#endif guard"
+    severity: error
 
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)

--- a/BraveUI/Design System/Views/BraveButtonStyle.swift
+++ b/BraveUI/Design System/Views/BraveButtonStyle.swift
@@ -89,6 +89,7 @@ public struct BraveOutlineButtonStyle: ButtonStyle {
   }
 }
 
+#if DEBUG
 struct BraveButtonStyle_Previews: PreviewProvider {
   static let defaultSizes: [BraveButtonSize] = [
     .small, .normal, .large
@@ -128,3 +129,4 @@ struct BraveButtonStyle_Previews: PreviewProvider {
     .previewLayout(.sizeThatFits)
   }
 }
+#endif

--- a/BraveUI/SwiftUI/PopupView.swift
+++ b/BraveUI/SwiftUI/PopupView.swift
@@ -99,6 +99,7 @@ public struct PopupView<Content: View>: View {
   }
 }
 
+#if DEBUG
 struct PopupPreviews: PreviewProvider {
   static var previews: some View {
     Group {
@@ -123,3 +124,4 @@ struct PopupPreviews: PreviewProvider {
     }
   }
 }
+#endif

--- a/BraveWallet/Blockies/BlockieGroup.swift
+++ b/BraveWallet/Blockies/BlockieGroup.swift
@@ -48,6 +48,7 @@ struct BlockieGroup: View {
   }
 }
 
+#if DEBUG
 struct BlockieGroup_Previews: PreviewProvider {
   static var previews: some View {
     ZStack {
@@ -76,3 +77,4 @@ struct BlockieGroup_Previews: PreviewProvider {
       .previewSizeCategories()
   }
 }
+#endif

--- a/BraveWallet/Blockies/Blockies.swift
+++ b/BraveWallet/Blockies/Blockies.swift
@@ -112,6 +112,7 @@ struct Blockie: View {
   }
 }
 
+#if DEBUG
 struct BlockiesPreview: PreviewProvider {
   static var previews: some View {
     ZStack {
@@ -128,3 +129,4 @@ struct BlockiesPreview: PreviewProvider {
     .previewLayout(.sizeThatFits)
   }
 }
+#endif

--- a/BraveWallet/Crypto/AssetIconView.swift
+++ b/BraveWallet/Crypto/AssetIconView.swift
@@ -63,6 +63,7 @@ struct AssetIconView: View {
   }
 }
 
+#if DEBUG
 struct AssetIconView_Previews: PreviewProvider {
   static var previews: some View {
     AssetIconView(token: .previewToken)
@@ -85,3 +86,4 @@ struct AssetIconView_Previews: PreviewProvider {
       .previewSizeCategories()
   }
 }
+#endif

--- a/BraveWallet/Crypto/Onboarding/BiometricsPromptView.swift
+++ b/BraveWallet/Crypto/Onboarding/BiometricsPromptView.swift
@@ -35,8 +35,10 @@ struct BiometricsPromptView: UIViewControllerRepresentable {
   }
 }
 
+#if DEBUG
 struct BiometricsPromptView_Previews: PreviewProvider {
   static var previews: some View {
     BiometricsPromptView(isPresented: .constant(true), action: { _, _ in false })
   }
 }
+#endif

--- a/BraveWallet/Crypto/Onboarding/RecoveryPhraseGrid.swift
+++ b/BraveWallet/Crypto/Onboarding/RecoveryPhraseGrid.swift
@@ -46,6 +46,7 @@ struct RecoveryPhraseGrid<Word: Hashable, ID: Hashable, Content: View>: View {
   }
 }
 
+#if DEBUG
 struct RecoveryPhraseGrid_Previews: PreviewProvider {
   static let data: [String] = [
     "Tomato", "Green", "Velvet", "Span",
@@ -71,3 +72,4 @@ struct RecoveryPhraseGrid_Previews: PreviewProvider {
     .previewLayout(.sizeThatFits)
   }
 }
+#endif

--- a/BraveWidgets/FavoritesWidget.swift
+++ b/BraveWidgets/FavoritesWidget.swift
@@ -176,6 +176,7 @@ private struct FavoritesGridView: View {
 
 // MARK: - Preview
 
+#if DEBUG
 struct FavoritesView_Previews: PreviewProvider {
     static var previews: some View {
         FavoritesView(entry: .init(date: Date(), favorites: []))
@@ -188,3 +189,4 @@ struct FavoritesView_Previews: PreviewProvider {
             .previewContext(WidgetPreviewContext(family: .systemLarge))
     }
 }
+#endif

--- a/BraveWidgets/ShortcutsWidget.swift
+++ b/BraveWidgets/ShortcutsWidget.swift
@@ -201,6 +201,7 @@ private struct ShortcutsView: View {
 
 // MARK: - Previews
 
+#if DEBUG
 struct ShortcutsWidget_Previews: PreviewProvider {
     static var previews: some View {
         ShortcutsView(slots: [.newTab, .newPrivateTab, .bookmarks])
@@ -211,3 +212,4 @@ struct ShortcutsWidget_Previews: PreviewProvider {
             .previewContext(WidgetPreviewContext(family: .systemMedium))
     }
 }
+#endif

--- a/BraveWidgets/SingleStatWidget.swift
+++ b/BraveWidgets/SingleStatWidget.swift
@@ -79,6 +79,7 @@ private struct StatView: View {
 
 // MARK: - Previews
 
+#if DEBUG
 struct SingleStatWidget_Previews: PreviewProvider {
     static var previews: some View {
         StatView(entry: StatEntry(date: Date(), statData: .init(name: "Ads & Trackers Blocked", value: "100k", color: UIColor.braveOrange)))
@@ -88,3 +89,4 @@ struct SingleStatWidget_Previews: PreviewProvider {
             .previewContext(WidgetPreviewContext(family: .systemSmall))
     }
 }
+#endif

--- a/BraveWidgets/StatsWidget.swift
+++ b/BraveWidgets/StatsWidget.swift
@@ -105,6 +105,8 @@ private struct StatsView: View {
 }
 
 // MARK: - Previews
+
+#if DEBUG
 struct StatsWidget_Previews: PreviewProvider {
     static var stats: [StatData] {
         let kinds: [StatKind] = [.adsBlocked, .dataSaved, .timeSaved]
@@ -119,3 +121,4 @@ struct StatsWidget_Previews: PreviewProvider {
             .previewContext(WidgetPreviewContext(family: .systemMedium))
     }
 }
+#endif

--- a/Client/Frontend/Browser/Onboarding/Welcome/PlaylistOnboardingView.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/PlaylistOnboardingView.swift
@@ -44,6 +44,7 @@ struct PlaylistOnboardingView: View {
     }
 }
 
+#if DEBUG
 struct PlaylistOnboardingView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
@@ -56,6 +57,7 @@ struct PlaylistOnboardingView_Previews: PreviewProvider {
         }
     }
 }
+#endif
 
 class PlaylistOnboardingViewController: UIHostingController<PlaylistOnboardingView> & PopoverContentComponent {
     

--- a/Client/Frontend/Browser/Onboarding/Welcome/PrivacyEverywhereView.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/PrivacyEverywhereView.swift
@@ -52,6 +52,7 @@ struct PrivacyEverywhereView: View {
     }
 }
 
+#if DEBUG
 struct PrivacyEverywhereView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
@@ -67,3 +68,4 @@ struct PrivacyEverywhereView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Client/Frontend/Browser/Playlist/PlaylistPopoverView.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistPopoverView.swift
@@ -136,6 +136,7 @@ struct PlaylistPopoverView: View {
     }
 }
 
+#if DEBUG
 struct PlaylistPopoverView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
@@ -146,6 +147,7 @@ struct PlaylistPopoverView_Previews: PreviewProvider {
         }
     }
 }
+#endif
 
 class PlaylistPopoverViewController: UIHostingController<PlaylistPopoverView> & PopoverContentComponent {
     

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/PlaylistMenuButton.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/PlaylistMenuButton.swift
@@ -79,6 +79,7 @@ struct PlaylistMenuButton: View {
     }
 }
 
+#if DEBUG
 struct PlaylistMenuButton_Previews: PreviewProvider {
     struct InteractivePreview: View {
         @State var isAdded: Bool = false
@@ -103,3 +104,4 @@ struct PlaylistMenuButton_Previews: PreviewProvider {
         .previewLayout(.sizeThatFits)
     }
 }
+#endif

--- a/Client/Frontend/Passcode/PasscodeMigrationView.swift
+++ b/Client/Frontend/Passcode/PasscodeMigrationView.swift
@@ -107,6 +107,7 @@ private struct PasscodeMigrationView: View {
     }
 }
 
+#if DEBUG
 struct PasscodeMigrationView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
@@ -129,3 +130,4 @@ struct PasscodeMigrationView_Previews: PreviewProvider {
         }
     }
 }
+#endif


### PR DESCRIPTION
This requires that all SwiftUI PreviewProvider be wrapped directly inside a `#if DEBUG` guard such as:

```swift
#if DEBUG
struct Foo: PreviewProvider {
 ...
}
#endif
```

Otherwise linting will fail.

Unfortunately due to regex limitations the macro must be 1-line above the SwiftUI Preview

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
