### PR TITLE
Fix #3959, #3190, #4860: Fixes related with missing Quick search engine bar - Wrong Top Section Header Paddings

### DIFF
--- a/Client/Frontend/Settings/SearchQuickEnginesViewController.swift
+++ b/Client/Frontend/Settings/SearchQuickEnginesViewController.swift
@@ -52,6 +52,11 @@ class SearchQuickEnginesViewController: UITableViewController {
             $0.isEditing = true
             $0.registerHeaderFooter(SettingsTableSectionHeaderFooterView.self)
             $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickSearchEngineRowIdentifier)
+            #if swift(>=5.5)
+            if #available(iOS 15.0, *) {
+                $0.sectionHeaderTopPadding = 5
+            }
+            #endif
         }
 
         let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: UX.headerHeight))

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -112,6 +112,11 @@ class SearchSettingsTableViewController: UITableViewController {
             $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.showRecentSearchesRowIdentifier)
             $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickSearchEngineRowIdentifier)
             $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.customSearchEngineRowIdentifier)
+            #if swift(>=5.5)
+            if #available(iOS 15.0, *) {
+                $0.sectionHeaderTopPadding = 5
+            }
+            #endif
         }
 
         // Insert Done button if being presented outside of the Settings Nav stack

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -69,16 +69,23 @@ class SiteTableViewController: LoadingViewController, UITableViewDelegate, UITab
             return
         }
 
-        tableView.delegate = self
-        tableView.dataSource = self
-        tableView.register(SiteTableViewCell.self, forCellReuseIdentifier: CellIdentifier)
-        tableView.register(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: HeaderIdentifier)
-        tableView.layoutMargins = .zero
-        tableView.keyboardDismissMode = .onDrag
-        tableView.backgroundColor = .secondaryBraveBackground
-        tableView.separatorColor = .braveSeparator
-        tableView.accessibilityIdentifier = "SiteTable"
-        tableView.cellLayoutMarginsFollowReadableWidth = false
+        tableView.do {
+            $0.delegate = self
+            $0.dataSource = self
+            $0.register(SiteTableViewCell.self, forCellReuseIdentifier: CellIdentifier)
+            $0.register(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: HeaderIdentifier)
+            $0.layoutMargins = .zero
+            $0.keyboardDismissMode = .onDrag
+            $0.backgroundColor = .secondaryBraveBackground
+            $0.separatorColor = .braveSeparator
+            $0.accessibilityIdentifier = "SiteTable"
+            $0.cellLayoutMarginsFollowReadableWidth = false
+            #if swift(>=5.5)
+            if #available(iOS 15.0, *) {
+                $0.sectionHeaderTopPadding = 5
+            }
+            #endif
+        }
 
         // Set an empty footer to prevent empty cells from appearing in the list.
         tableView.tableFooterView = UIView()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3959 , #3190, #4860


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Check specific Testing conditions for the issues inside the tickets

## Screenshots:

#3959 Quick search engine bar is missing


![search-done-2](https://user-images.githubusercontent.com/6643505/149818950-36aa3410-ab0c-4ae9-bb18-a321697e0952.png)


#3190 Quick search engines do not appear

![IMG_0001](https://user-images.githubusercontent.com/6643505/149819469-fd6387bb-e109-49ef-bc55-6aa799da0380.png)

#4860 Wrong Top Section Header Padding in various Screens

![search-done-1](https://user-images.githubusercontent.com/6643505/149819787-6e61d876-d50a-442d-af1e-0a52556ea9ca.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
