### PR TITLE
Ref #4841: Restore tab tray animation after search feature was added

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -33,8 +33,12 @@ extension BrowserViewController: TopToolbarDelegate {
         let tabTrayController = TabTrayController(tabManager: tabManager).then {
             $0.delegate = self
         }
-        
-        present(SettingsNavigationController(rootViewController: tabTrayController), animated: true)
+        let container = SettingsNavigationController(rootViewController: tabTrayController)
+        if !UIAccessibility.isReduceMotionEnabled {
+            container.transitioningDelegate = tabTrayController
+            container.modalPresentationStyle = .fullScreen
+        }
+        present(container, animated: true)
     }
     
     func topToolbarDidPressReload(_ topToolbar: TopToolbarView) {

--- a/Client/Frontend/Browser/Tab Tray/TabTrayAnimation.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayAnimation.swift
@@ -29,7 +29,8 @@ extension TabTrayController: UIViewControllerTransitioningDelegate {
 extension TabTrayController: BasicAnimationControllerDelegate {
     func animatePresentation(context: UIViewControllerContextTransitioning) {
         guard let containerController = context.viewController(forKey: .from) as? UINavigationController,
-              let bvc = containerController.topViewController as? BrowserViewController
+              let bvc = containerController.topViewController as? BrowserViewController,
+              let destinationController = context.viewController(forKey: .to)
         else {
             log.error("""
                 Attempted to present the tab tray on something that is not a BrowserViewController which is
@@ -45,7 +46,7 @@ extension TabTrayController: BasicAnimationControllerDelegate {
             return
         }
         
-        let finalFrame = context.finalFrame(for: self)
+        let finalFrame = context.finalFrame(for: destinationController)
         
         // Tab snapshot animates from web view container on BVC to the cell frame
         let tabSnapshot = UIImageView(image: selectedTab.screenshot ?? .init())
@@ -64,14 +65,14 @@ extension TabTrayController: BasicAnimationControllerDelegate {
         backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
         backgroundView.frame = finalFrame
         
-        context.containerView.addSubview(view)
+        context.containerView.addSubview(destinationController.view)
         context.containerView.addSubview(backgroundView)
         context.containerView.addSubview(bvcSnapshot)
         context.containerView.addSubview(tabSnapshot)
         
-        view.frame = finalFrame
-        view.setNeedsLayout()
-        view.layoutIfNeeded()
+        destinationController.view.frame = finalFrame
+        destinationController.view.setNeedsLayout()
+        destinationController.view.layoutIfNeeded()
         
         let cv = tabTrayView.collectionView
         cv.reloadData()

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -461,6 +461,6 @@ class TabTraySearchBar: UIView {
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         // This is done to adjust the frame of a UISearchBar inside of UISearchController
         // Adjusting the bar frame directly doesnt work so had to create a custom view with UISearchBar
-        .init(width: size.width - 20, height: size.height)
+        .init(width: size.width + 16, height: size.height)
     }
 }


### PR DESCRIPTION
Small regression fix for tab tray animation

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- re-verify #4841 tests with search feature added

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
