### PR TITLE
Fix #4871: Make sure HTML properties keep their configurability from WebKit

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/MediaBackgrounding.js
+++ b/Client/Frontend/UserContent/UserScripts/MediaBackgrounding.js
@@ -6,11 +6,12 @@
 // The below is needed because the script may not be web-packed into a bundle so it may be missing the run-once code
 
 window.__firefox__.includeOnce("MediaBackgrounding", function() {
-    var visibilityState_Get = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState").get;
-    var visibilityState_Set = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState").set;
+    var descriptor = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
+    var visibilityState_Get = descriptor.get;
+    var visibilityState_Set = descriptor.set;
     Object.defineProperty(Document.prototype, 'visibilityState', {
-        enumerable: true,
-        configurable: true,
+        enumerable: descriptor.enumerable,
+        configurable: descriptor.configurable,
         get: function() {
             var result = visibilityState_Get.call(this);
             if (result != "visible") {

--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -323,9 +323,10 @@ window.__firefox__.includeOnce("Playlist", function() {
                 value: null
             });
             
+            var descriptor = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'src');
             Object.defineProperty(HTMLMediaElement.prototype, 'src', {
-                enumerable: true,
-                configurable: false,
+                enumerable: descriptor.enumerable,
+                configurable: descriptor.configurable,
                 get: function(){
                     return this.getAttribute('src')
                 },
@@ -334,20 +335,6 @@ window.__firefox__.includeOnce("Playlist", function() {
                     // But since the property represents an attribute, this is okay.
                     this.setAttribute('src', value);
                     //$<notifyNode>(this); // Handled by `setVideoAttribute`
-                }
-            });
-            
-            Object.defineProperty(HTMLAudioElement.prototype, 'src', {
-                enumerable: true,
-                configurable: false,
-                get: function(){
-                    return this.getAttribute('src')
-                },
-                set: function(value) {
-                    // Typically we'd call the original setter.
-                    // But since the property represents an attribute, this is okay.
-                    this.setAttribute('src', value);
-                    //$<notifyNode>(this); // Handled by `setAudioAttribute`
                 }
             });
             

--- a/Client/Frontend/UserContent/UserScripts/PlaylistDetector.js
+++ b/Client/Frontend/UserContent/UserScripts/PlaylistDetector.js
@@ -204,6 +204,10 @@ window.__firefox__.includeOnce("PlaylistDetector", function() {
                 }
                 return original.call(node, tag);
             };
+            
+            node.createElement.toString = function() {
+                return "function () { [native code] }";
+            };
         }
 
         function $<getAllVideoElements>() {


### PR DESCRIPTION
## Summary of Changes
- Make sure properties keep their original configurability for that specific OS and device.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4871

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- In the ticket.


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
