### PR TITLE
Ref #4841: Fix animation hitches when presenting/dismissing tab tray

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayAnimation.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayAnimation.swift
@@ -55,95 +55,97 @@ extension TabTrayController: BasicAnimationControllerDelegate {
         tabSnapshot.contentMode = .scaleAspectFill
         tabSnapshot.frame = bvc.webViewContainer.frame
         
-        // BVC snapshot animates to the cell
-        let bvcSnapshot = UIImageView(image: bvc.view.snapshot)
-        bvcSnapshot.layer.cornerCurve = .continuous
-        bvcSnapshot.clipsToBounds = true
-        
-        // Just a small background view for animation sake between the tab tray and the bvc
-        let backgroundView = UIView()
-        backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
-        backgroundView.frame = finalFrame
-        
-        context.containerView.addSubview(destinationController.view)
-        context.containerView.addSubview(backgroundView)
-        context.containerView.addSubview(bvcSnapshot)
-        context.containerView.addSubview(tabSnapshot)
-        
-        destinationController.view.frame = finalFrame
-        destinationController.view.setNeedsLayout()
-        destinationController.view.layoutIfNeeded()
-        
-        let cv = tabTrayView.collectionView
-        cv.reloadData()
-        
-        var tabCell: TabCell?
-        var cellFrame: CGRect?
-        var cellTitleSnapshot: UIView?
-        if let indexPath = dataSource.indexPath(for: selectedTab) {
-            // This is needed for some reason otherwise the collection views content offest is
-            // incorrect.
-            cv.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
-            cv.layoutIfNeeded()
-            tabCell = cv.cellForItem(at: indexPath) as? TabCell
-            if let cell = tabCell {
-                // Hide the cell that is being animated too since we are making a copy of it to animate in
-                cellFrame = cv.convert(cell.frame, to: view)
-                
-                // For animations sake we are also making a copy of the title and animating it in closer to
-                // the animation finish
-                let titleSnapshot = UIImageView(image: cell.titleBackgroundView.snapshot)
-                titleSnapshot.contentMode = .scaleToFill
-                titleSnapshot.clipsToBounds = true
-                tabSnapshot.addSubview(titleSnapshot)
-                titleSnapshot.snp.makeConstraints {
-                    $0.top.leading.trailing.equalToSuperview()
+        // Allow the UI to render to make the snapshotting code more performant
+        DispatchQueue.main.async { [self] in
+            // BVC snapshot animates to the cell
+            let bvcSnapshot = UIImageView(image: bvc.view.snapshot)
+            bvcSnapshot.layer.cornerCurve = .continuous
+            bvcSnapshot.clipsToBounds = true
+            
+            // Just a small background view for animation sake between the tab tray and the bvc
+            let backgroundView = UIView()
+            backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
+            backgroundView.frame = finalFrame
+            
+            context.containerView.addSubview(destinationController.view)
+            context.containerView.addSubview(backgroundView)
+            context.containerView.addSubview(bvcSnapshot)
+            context.containerView.addSubview(tabSnapshot)
+            
+            destinationController.view.frame = finalFrame
+            destinationController.view.setNeedsLayout()
+            destinationController.view.layoutIfNeeded()
+            
+            let cv = tabTrayView.collectionView
+            cv.reloadData()
+            var tabCell: TabCell?
+            var cellFrame: CGRect?
+            var cellTitleSnapshot: UIView?
+            if let indexPath = dataSource.indexPath(for: selectedTab) {
+                // This is needed for some reason otherwise the collection views content offest is
+                // incorrect.
+                cv.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+                cv.layoutIfNeeded()
+                tabCell = cv.cellForItem(at: indexPath) as? TabCell
+                if let cell = tabCell {
+                    // Hide the cell that is being animated too since we are making a copy of it to animate in
+                    cellFrame = cv.convert(cell.frame, to: view)
+                    
+                    // For animations sake we are also making a copy of the title and animating it in closer to
+                    // the animation finish
+                    let titleSnapshot = UIImageView(image: cell.titleBackgroundView.snapshot)
+                    titleSnapshot.contentMode = .scaleToFill
+                    titleSnapshot.clipsToBounds = true
+                    tabSnapshot.addSubview(titleSnapshot)
+                    titleSnapshot.snp.makeConstraints {
+                        $0.top.leading.trailing.equalToSuperview()
+                    }
+                    titleSnapshot.alpha = 0.0
+                    cellTitleSnapshot = titleSnapshot
+                    
+                    tabSnapshot.setNeedsLayout()
+                    tabSnapshot.layoutIfNeeded()
+                    
+                    cell.isHidden = true
+                    cell.alpha = 0.0
                 }
-                titleSnapshot.alpha = 0.0
-                cellTitleSnapshot = titleSnapshot
-                
-                tabSnapshot.setNeedsLayout()
-                tabSnapshot.layoutIfNeeded()
-                
-                cell.isHidden = true
-                cell.alpha = 0.0
             }
-        }
-        
-        // Just for florish, scaling the collection view a bit
-        cv.transform = .init(scaleX: 1.2, y: 1.2)
-        cv.alpha = 0.5
-        let animator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.825) {
-            cv.transform = .identity
-            cv.alpha = 1
-            if let frame = cellFrame {
-                tabSnapshot.frame = frame
-                bvcSnapshot.frame = frame
-            } else {
-                tabSnapshot.alpha = 0.0
-                bvcSnapshot.alpha = 0.0
+            
+            // Just for florish, scaling the collection view a bit
+            cv.transform = .init(scaleX: 1.2, y: 1.2)
+            cv.alpha = 0.5
+            let animator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.825) {
+                cv.transform = .identity
+                cv.alpha = 1
+                if let frame = cellFrame {
+                    tabSnapshot.frame = frame
+                    bvcSnapshot.frame = frame
+                } else {
+                    tabSnapshot.alpha = 0.0
+                    bvcSnapshot.alpha = 0.0
+                }
+                tabSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+                bvcSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+                backgroundView.alpha = 0
             }
-            tabSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
-            bvcSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
-            backgroundView.alpha = 0
+            // Need delayed animation for these
+            animator.addAnimations({
+                cellTitleSnapshot?.alpha = 1.0
+            }, delayFactor: 0.5)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                tabCell?.isHidden = false
+                UIViewPropertyAnimator(duration: 0.1, curve: .linear) {
+                    tabCell?.alpha = 1
+                }.startAnimation()
+            }
+            animator.addCompletion { _ in
+                backgroundView.removeFromSuperview()
+                tabSnapshot.removeFromSuperview()
+                bvcSnapshot.removeFromSuperview()
+                context.completeTransition(true)
+            }
+            animator.startAnimation()
         }
-        // Need delayed animation for these
-        animator.addAnimations({
-            cellTitleSnapshot?.alpha = 1.0
-        }, delayFactor: 0.5)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            tabCell?.isHidden = false
-            UIViewPropertyAnimator(duration: 0.1, curve: .linear) {
-                tabCell?.alpha = 1
-            }.startAnimation()
-        }
-        animator.addCompletion { _ in
-            backgroundView.removeFromSuperview()
-            tabSnapshot.removeFromSuperview()
-            bvcSnapshot.removeFromSuperview()
-            context.completeTransition(true)
-        }
-        animator.startAnimation()
     }
     
     func animateDismissal(context: UIViewControllerContextTransitioning) {
@@ -177,93 +179,97 @@ extension TabTrayController: BasicAnimationControllerDelegate {
         tabSnapshot.clipsToBounds = true
         tabSnapshot.contentMode = .scaleAspectFill
         tabSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+        tabSnapshot.isHidden = true
         
         let finalFrame = context.finalFrame(for: toViewController)
         
         toView.frame = finalFrame
-        context.containerView.addSubview(toView)
-        toView.setNeedsLayout()
-        toView.layoutIfNeeded()
         
-        // BVC snapshot animates from the cell to its final resting spot
-        let toVCSnapshot: UIView = toView.snapshotView(afterScreenUpdates: true) ??
+        // Allow the UI to render to make the snapshotting code more performant
+        DispatchQueue.main.async { [self] in
+            // BVC snapshot animates from the cell to its final resting spot
+            let toVCSnapshot: UIView = toView.snapshotView(afterScreenUpdates: true) ??
             UIImageView(image: toView.snapshot)
-        toVCSnapshot.layer.cornerCurve = .continuous
-        toVCSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
-        toVCSnapshot.clipsToBounds = true
-        
-        // Just a small background view for animation sake between the tab tray and the bvc
-        let backgroundView = UIView()
-        backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
-        backgroundView.alpha = 0
-        backgroundView.frame = finalFrame
-        
-        context.containerView.addSubview(backgroundView)
-        context.containerView.addSubview(toVCSnapshot)
-        context.containerView.addSubview(tabSnapshot)
-        
-        // Hide the destination as we're animating a snapshot into place
-        toView.isHidden = true
-        
-        let cv = tabTrayView.collectionView
-        cv.reloadData()
-        
-        var tabCell: TabCell?
-        var cellTitleSnapshot: UIView?
-        if let tab = tabManager.selectedTab, let indexPath = dataSource.indexPath(for: tab) {
-            // This is needed for some reason otherwise the collection views content offest is
-            // incorrect.
-            cv.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
-            cv.layoutIfNeeded()
+            toVCSnapshot.layer.cornerCurve = .continuous
+            toVCSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+            toVCSnapshot.clipsToBounds = true
             
-            if let cell = cv.cellForItem(at: indexPath) as? TabCell {
-                tabCell = cell
+            // Just a small background view for animation sake between the tab tray and the bvc
+            let backgroundView = UIView()
+            backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
+            backgroundView.alpha = 0
+            backgroundView.frame = finalFrame
+            
+            context.containerView.addSubview(toView)
+            context.containerView.addSubview(backgroundView)
+            context.containerView.addSubview(toVCSnapshot)
+            context.containerView.addSubview(tabSnapshot)
+            
+            toView.setNeedsLayout()
+            toView.layoutIfNeeded()
+            // Hide the destination as we're animating a snapshot into place
+            toView.isHidden = true
+            
+            let cv = tabTrayView.collectionView
+            cv.reloadData()
+            
+            var tabCell: TabCell?
+            var cellTitleSnapshot: UIView?
+            if let tab = tabManager.selectedTab, let indexPath = dataSource.indexPath(for: tab) {
+                // This is needed for some reason otherwise the collection views content offest is
+                // incorrect.
+                cv.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+                cv.layoutIfNeeded()
                 
-                tabSnapshot.frame = cv.convert(cell.frame, to: view)
-                toVCSnapshot.frame = tabSnapshot.frame
-                
-                let titleSnapshot = UIImageView(image: cell.titleBackgroundView.snapshot)
-                titleSnapshot.contentMode = .scaleToFill
-                titleSnapshot.clipsToBounds = true
-                tabSnapshot.addSubview(titleSnapshot)
-                titleSnapshot.snp.makeConstraints {
-                    $0.top.leading.trailing.equalToSuperview()
+                if let cell = cv.cellForItem(at: indexPath) as? TabCell {
+                    tabCell = cell
+                    
+                    tabSnapshot.frame = cv.convert(cell.frame, to: view)
+                    toVCSnapshot.frame = tabSnapshot.frame
+                    
+                    let titleSnapshot = UIImageView(image: cell.titleBackgroundView.snapshot)
+                    titleSnapshot.contentMode = .scaleToFill
+                    titleSnapshot.clipsToBounds = true
+                    tabSnapshot.addSubview(titleSnapshot)
+                    titleSnapshot.snp.makeConstraints {
+                        $0.top.leading.trailing.equalToSuperview()
+                    }
+                    cellTitleSnapshot = titleSnapshot
+                    tabSnapshot.setNeedsLayout()
+                    tabSnapshot.layoutIfNeeded()
+                    
+                    cell.isHidden = true
                 }
-                cellTitleSnapshot = titleSnapshot
-                tabSnapshot.setNeedsLayout()
-                tabSnapshot.layoutIfNeeded()
+            }
+            tabSnapshot.isHidden = false
+            let animator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1.0) {
+                // For some flourish
+                cv.transform = .init(scaleX: 1.2, y: 1.2)
+                cv.alpha = 0.5
                 
-                cell.isHidden = true
+                tabSnapshot.frame = bvc.webViewContainer.frame
+                tabSnapshot.layer.cornerRadius = 0
+                toVCSnapshot.frame = finalFrame
+                toVCSnapshot.layer.cornerRadius = 0
+                backgroundView.alpha = 1
             }
-        }
-        
-        let animator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1.0) {
-            // For some flourish
-            cv.transform = .init(scaleX: 1.2, y: 1.2)
-            cv.alpha = 0.5
-            
-            tabSnapshot.frame = bvc.webViewContainer.frame
-            tabSnapshot.layer.cornerRadius = 0
-            toVCSnapshot.frame = finalFrame
-            toVCSnapshot.layer.cornerRadius = 0
-            backgroundView.alpha = 1
-        }
-        if let titleSnapshot = cellTitleSnapshot {
-            // Need a quicker animation for this one
-            UIViewPropertyAnimator(duration: 0.1, curve: .linear) {
-                titleSnapshot.alpha = 0
+            if let titleSnapshot = cellTitleSnapshot {
+                // Need a quicker animation for this one
+                UIViewPropertyAnimator(duration: 0.1, curve: .linear) {
+                    titleSnapshot.alpha = 0
+                }
+                .startAnimation()
             }
-            .startAnimation()
+            animator.addCompletion { _ in
+                tabCell?.isHidden = false
+                toView.isHidden = false
+                self.view.removeFromSuperview()
+                tabSnapshot.removeFromSuperview()
+                toVCSnapshot.removeFromSuperview()
+                backgroundView.removeFromSuperview()
+                context.completeTransition(true)
+            }
+            animator.startAnimation()
         }
-        animator.addCompletion { _ in
-            tabCell?.isHidden = false
-            toView.isHidden = false
-            self.view.removeFromSuperview()
-            tabSnapshot.removeFromSuperview()
-            toVCSnapshot.removeFromSuperview()
-            backgroundView.removeFromSuperview()
-            context.completeTransition(true)
-        }
-        animator.startAnimation()
     }
 }

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -150,8 +150,8 @@ class TabTrayController: LoadingViewController {
         var snapshot = Snapshot()
         snapshot.appendSections([.main])
         snapshot.appendItems(tabManager.tabsForCurrentMode(for: query))
-        dataSource.apply(snapshot, animatingDifferences: true) { [unowned self] in
-            self.updateEmptyPanelState()
+        dataSource.apply(snapshot, animatingDifferences: true) { [weak self] in
+            self?.updateEmptyPanelState()
         }
     }
     


### PR DESCRIPTION
Also fixes a potential crash if animation dismissal short-circuits

## Summary of Changes

This pull request fixes a regression caused by the tab tray being within a UINavigationController which causes snapshots to take longer if performed on the same runloop as the view being added to the hierarchy

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
