### PR TITLE
Fixes #4896: Force to portrait mode 

### DIFF
--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -72,6 +72,7 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     view.window?.addGestureRecognizer(gesture)
+    UIDevice.current.forcePortraitIfIphone(for: UIApplication.shared)
   }
   
   // MARK: -

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -82,7 +82,7 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
   }
   
   public override var shouldAutorotate: Bool {
-    false
+    true
   }
 }
 


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->
Thank you for letting me contribute to the brave-iOS code base.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4896 

This PR add force to brave wallet to open in portrait mode if the device is iPhone and in landscape mode 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

Before the changes, brave wallet in landscape mode
<img src = "https://user-images.githubusercontent.com/16591961/151267085-3db4f7cf-1aac-45e7-8914-e1f00bcfdd10.png" width="70%">
After the changes, brave wallet in landscape mode
<img src = "https://user-images.githubusercontent.com/16591961/151267091-a6d64a7d-fdf8-4df8-9c29-9fdea332e69b.png" width="70%">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
