### PR TITLE
Fix #4904: MediaSource issue for Playlist on iPad.

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -252,7 +252,7 @@ class UserScriptManager {
         return WKUserScript(source: source,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
-                            in: .defaultClient)
+                            in: .page)
     }()
     
     private let PlaylistHelperScript: WKUserScript? = {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixed MediaSource not accessible by page on iPad

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4904

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Go to Youtube.com
2. Tap on a video.
3. Expected: Playlist URL Bar button should show if the `MediaSource` playlist setting is turned on. If the setting is off, button will not show.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
