### PR TITLE
No Bug: Support releasing with Xcode 13.2 and up (including 13.3 beta)

### DIFF
--- a/BraveUI/SwiftUI/FilterableViewModifier.swift
+++ b/BraveUI/SwiftUI/FilterableViewModifier.swift
@@ -53,6 +53,25 @@ private class SearchDelegate: NSObject, UISearchBarDelegate, ObservableObject {
   }
 }
 
+// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
+@available(iOS 15.0, *)
+private struct SearchableViewModifier_FB9812596: ViewModifier {
+  var text: Binding<String>
+  var prompt: String?
+  var onSubmit: (() -> Void)?
+  
+  func body(content: Content) -> some View {
+    content.searchable(
+      text: text,
+      placement: .navigationBarDrawer(displayMode: .always),
+      prompt: prompt.map(Text.init)
+    )
+    .onSubmit(of: .search) {
+      onSubmit?()
+    }
+  }
+}
+
 extension View {
   /// Adds a search bar to the parent navigation controller to simply filter the contents of the View
   ///
@@ -63,14 +82,7 @@ extension View {
     onSubmit: (() -> Void)? = nil
   ) -> some View {
     if #available(iOS 15.0, *) {
-      searchable(
-        text: text,
-        placement: .navigationBarDrawer(displayMode: .always),
-        prompt: prompt.map(Text.init)
-      )
-      .onSubmit(of: .search) {
-        onSubmit?()
-      }
+      modifier(SearchableViewModifier_FB9812596(text: text, prompt: prompt, onSubmit: onSubmit))
     } else {
       modifier(FilterableViewModifier(query: text, prompt: prompt, onSubmit: onSubmit))
     }

--- a/BraveWallet/Chart/LineChartView.swift
+++ b/BraveWallet/Chart/LineChartView.swift
@@ -268,26 +268,27 @@ extension CGPoint {
 
 // MARK: - Accessibility
 
-private struct ChartAccessibilityViewModifier: ViewModifier {
+// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
+@available(iOS 15.0, *)
+private struct ChartAccessibilityModifier_FB9812596: ViewModifier {
   var title: String
   var dataPoints: [DataPoint]
   
   func body(content: Content) -> some View {
-    if #available(iOS 15.0, *) {
-      content
-        .accessibilityElement()
-        .accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
-        .accessibilityLabel(title)
-    } else {
-      content
-        .accessibilityLabel(title)
-    }
+    content.accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
   }
 }
 
 extension View {
-  func chartAccessibility(title: String, dataPoints: [DataPoint]) -> some View {
-    modifier(ChartAccessibilityViewModifier(title: title, dataPoints: dataPoints))
+  @ViewBuilder func chartAccessibility(title: String, dataPoints: [DataPoint]) -> some View {
+    Group {
+      if #available(iOS 15.0, *) {
+        self.modifier(ChartAccessibilityModifier_FB9812596(title: title, dataPoints: dataPoints))
+      } else {
+        self
+      }
+    }
+    .accessibilityLabel(title)
   }
 }
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -6925,9 +6925,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 288A2D9F1AB8B3260023ABC3 /* Build configuration list for PBXNativeTarget "Shared" */;
 			buildPhases = (
+				288A2D831AB8B3260023ABC3 /* Headers */,
 				288A2D811AB8B3260023ABC3 /* Sources */,
 				288A2D821AB8B3260023ABC3 /* Frameworks */,
-				288A2D831AB8B3260023ABC3 /* Headers */,
 				288A2D841AB8B3260023ABC3 /* Resources */,
 			);
 			buildRules = (
@@ -6960,9 +6960,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2FCAE2331ABB51F900877008 /* Build configuration list for PBXNativeTarget "Storage" */;
 			buildPhases = (
+				2FCAE2171ABB51F800877008 /* Headers */,
 				2FCAE2151ABB51F800877008 /* Sources */,
 				2FCAE2161ABB51F800877008 /* Frameworks */,
-				2FCAE2171ABB51F800877008 /* Headers */,
 				2FCAE2181ABB51F800877008 /* Resources */,
 			);
 			buildRules = (
@@ -7000,9 +7000,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5D1DC53A20AC9AFB00905E5A /* Build configuration list for PBXNativeTarget "Data" */;
 			buildPhases = (
+				5D1DC51020AC9AF900905E5A /* Headers */,
 				5D1DC50E20AC9AF900905E5A /* Sources */,
 				5D1DC50F20AC9AF900905E5A /* Frameworks */,
-				5D1DC51020AC9AF900905E5A /* Headers */,
 				5D1DC51120AC9AF900905E5A /* Resources */,
 			);
 			buildRules = (
@@ -7039,9 +7039,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5DE7689B20B3456E00FF5533 /* Build configuration list for PBXNativeTarget "BraveShared" */;
 			buildPhases = (
+				5DE7688120B3456C00FF5533 /* Headers */,
 				5DE7687F20B3456C00FF5533 /* Sources */,
 				5DE7688020B3456C00FF5533 /* Frameworks */,
-				5DE7688120B3456C00FF5533 /* Headers */,
 				5DE7688220B3456C00FF5533 /* Resources */,
 			);
 			buildRules = (
@@ -7120,8 +7120,8 @@
 			buildPhases = (
 				F979BE0F25BCC098009B6ACF /* Build packaged javascript files */,
 				2779B7052159297D0044A102 /* Run SwiftLint */,
-				F84B21BA1A090F8100AAB793 /* Sources */,
 				0A43293F21B1CB810041625B /* Headers */,
+				F84B21BA1A090F8100AAB793 /* Sources */,
 				F84B21BC1A090F8100AAB793 /* Resources */,
 				28CE83DE1A1D1E7C00576538 /* Frameworks */,
 				F84B22531A0920C600AAB793 /* Embed App Extensions */,

--- a/ThirdParty/Static/Static.xcodeproj/project.pbxproj
+++ b/ThirdParty/Static/Static.xcodeproj/project.pbxproj
@@ -216,9 +216,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 21826ABE1B3F51A100AA9641 /* Build configuration list for PBXNativeTarget "Static-iOS" */;
 			buildPhases = (
+				21826AA71B3F51A100AA9641 /* Headers */,
 				21826AA51B3F51A100AA9641 /* Sources */,
 				21826AA61B3F51A100AA9641 /* Frameworks */,
-				21826AA71B3F51A100AA9641 /* Headers */,
 				21826AA81B3F51A100AA9641 /* Resources */,
 			);
 			buildRules = (


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This adds a workaround for `FB9812596` which crashes on iOS 14 release builds when using iOS 15 APIs within an 15.0 availability runtime check.

We will unfortunately from here on out enforce by code review the usage of iOS 15+ APIs from within isolated `ViewModifier` structs such as this to avoid future iOS 14 crashes

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Test that visiting wallet portfolio screen, edit assets screen and asset search screens on iOS 14 do not crash
- Repeat on iOS 15

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
