### PR TITLE
No Bug: Fix incorrect modifier chain from `FB9812596` workaround

### DIFF
--- a/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -114,9 +114,10 @@ struct EditUserAssetsView: View {
                 EditTokenView(assetStore: store)
                   .osAvailabilityModifiers { content in
                     if #available(iOS 15.0, *) {
-                      modifier(SwipeActionsViewModifier_FB9812596 {
-                        removeCustomToken(store.token)
-                      })
+                      content
+                        .modifier(SwipeActionsViewModifier_FB9812596 {
+                          removeCustomToken(store.token)
+                        })
                     } else {
                       content
                         .contextMenu {


### PR DESCRIPTION
## Summary of Changes

Fixes a small typo in https://github.com/brave/brave-ios/pull/4910

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
