### PR TITLE
Fix #4777:  Update reset wallet to call BraveWalletService.reset

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -5,7 +5,6 @@
 
 import SwiftUI
 import struct Shared.Strings
-import BraveCore
 
 struct AccountsHeaderView: View {
   @ObservedObject var keyringStore: KeyringStore

--- a/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -49,8 +49,7 @@ struct AccountsHeaderView: View {
               .navigationViewStyle(StackNavigationViewStyle())
             }
         )
-        NavigationLink(destination: WalletSettingsView(keyringStore: keyringStore,
-                                                       cryptoStore: cryptoStore)
+        NavigationLink(destination: WalletSettingsView(settingsStore: cryptoStore.openSettingsStore())
         ) {
           Label(Strings.Wallet.settings, image: "brave.gear")
             .labelStyle(.iconOnly)

--- a/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -5,9 +5,11 @@
 
 import SwiftUI
 import struct Shared.Strings
+import BraveCore
 
 struct AccountsHeaderView: View {
   @ObservedObject var keyringStore: KeyringStore
+  var cryptoStore: CryptoStore
   
   @State private var isPresentingBackup: Bool = false
   @State private var isPresentingAddAccount: Bool = false
@@ -48,7 +50,9 @@ struct AccountsHeaderView: View {
               .navigationViewStyle(StackNavigationViewStyle())
             }
         )
-        NavigationLink(destination: WalletSettingsView(keyringStore: keyringStore)) {
+        NavigationLink(destination: WalletSettingsView(keyringStore: keyringStore,
+                                                       cryptoStore: cryptoStore)
+        ) {
           Label(Strings.Wallet.settings, image: "brave.gear")
             .labelStyle(.iconOnly)
         }
@@ -62,7 +66,10 @@ struct AccountsHeaderView: View {
 #if DEBUG
 struct AccountsHeaderView_Previews: PreviewProvider {
   static var previews: some View {
-    AccountsHeaderView(keyringStore: .previewStore)
+    AccountsHeaderView(
+      keyringStore: .previewStore,
+      cryptoStore: .previewStore
+    )
       .previewLayout(.sizeThatFits)
       .previewColorSchemes()
   }

--- a/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -8,7 +8,7 @@ import struct Shared.Strings
 
 struct AccountsHeaderView: View {
   @ObservedObject var keyringStore: KeyringStore
-  var cryptoStore: CryptoStore
+  var settingsStore: SettingsStore
   
   @State private var isPresentingBackup: Bool = false
   @State private var isPresentingAddAccount: Bool = false
@@ -49,7 +49,7 @@ struct AccountsHeaderView: View {
               .navigationViewStyle(StackNavigationViewStyle())
             }
         )
-        NavigationLink(destination: WalletSettingsView(settingsStore: cryptoStore.openSettingsStore())
+        NavigationLink(destination: WalletSettingsView(settingsStore: settingsStore)
         ) {
           Label(Strings.Wallet.settings, image: "brave.gear")
             .labelStyle(.iconOnly)
@@ -66,7 +66,7 @@ struct AccountsHeaderView_Previews: PreviewProvider {
   static var previews: some View {
     AccountsHeaderView(
       keyringStore: .previewStore,
-      cryptoStore: .previewStore
+      settingsStore: .previewStore
     )
       .previewLayout(.sizeThatFits)
       .previewColorSchemes()

--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -35,7 +35,8 @@ struct AccountsView: View {
   var body: some View {
     List {
       Section(
-        header: AccountsHeaderView(keyringStore: keyringStore)
+        header: AccountsHeaderView(keyringStore: keyringStore,
+                                   cryptoStore: cryptoStore)
           .resetListHeaderStyle()
       ) {
       }

--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -36,7 +36,7 @@ struct AccountsView: View {
     List {
       Section(
         header: AccountsHeaderView(keyringStore: keyringStore,
-                                   cryptoStore: cryptoStore)
+                                   settingsStore: cryptoStore.settingsStore)
           .resetListHeaderStyle()
       ) {
       }

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -58,7 +58,7 @@ struct CryptoPagesView: View {
       })
       .background(
         NavigationLink(
-          destination: WalletSettingsView(settingsStore: cryptoStore.openSettingsStore()),
+          destination: WalletSettingsView(settingsStore: cryptoStore.settingsStore),
           isActive: $isShowingSettings
         ) {
           Text(Strings.Wallet.settings)

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -58,8 +58,7 @@ struct CryptoPagesView: View {
       })
       .background(
         NavigationLink(
-          destination: WalletSettingsView(keyringStore: keyringStore,
-                                          cryptoStore: cryptoStore),
+          destination: WalletSettingsView(settingsStore: cryptoStore.openSettingsStore()),
           isActive: $isShowingSettings
         ) {
           Text(Strings.Wallet.settings)

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -58,7 +58,8 @@ struct CryptoPagesView: View {
       })
       .background(
         NavigationLink(
-          destination: WalletSettingsView(keyringStore: keyringStore),
+          destination: WalletSettingsView(keyringStore: keyringStore,
+                                          cryptoStore: cryptoStore),
           isActive: $isShowingSettings
         ) {
           Text(Strings.Wallet.settings)

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -201,6 +201,10 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
+  
+  func reset() {
+    walletService.reset()
+  }
 }
 
 extension CryptoStore: BraveWalletEthTxServiceObserver {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -176,6 +176,19 @@ public class CryptoStore: ObservableObject {
     return store
   }
   
+  private var settingsStore: SettingsStore?
+  func openSettingsStore() -> SettingsStore {
+    if let store = settingsStore {
+      return store
+    }
+    let store = SettingsStore(
+      keyringService: keyringService,
+      walletService: walletService
+    )
+    settingsStore = store
+    return store
+  }
+  
   func fetchUnapprovedTransactions() {
     keyringService.defaultKeyringInfo { [self] keyring in
       var pendingTransactions: [BraveWallet.TransactionInfo] = []

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -176,18 +176,8 @@ public class CryptoStore: ObservableObject {
     return store
   }
   
-  private var settingsStore: SettingsStore?
-  func openSettingsStore() -> SettingsStore {
-    if let store = settingsStore {
-      return store
-    }
-    let store = SettingsStore(
-      keyringService: keyringService,
-      walletService: walletService
-    )
-    settingsStore = store
-    return store
-  }
+  private(set) lazy var settingsStore = SettingsStore(keyringService: keyringService,
+                                                      walletService: walletService)
   
   func fetchUnapprovedTransactions() {
     keyringService.defaultKeyringInfo { [self] keyring in
@@ -213,10 +203,6 @@ public class CryptoStore: ObservableObject {
         }
       }
     }
-  }
-  
-  func reset() {
-    walletService.reset()
   }
 }
 

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -96,10 +96,15 @@ public class KeyringStore: ObservableObject {
   }
   
   private let keyringService: BraveWalletKeyringService
+  private let walletService: BraveWalletBraveWalletService // for wallet reset
   private var cancellable: AnyCancellable?
   
-  public init(keyringService: BraveWalletKeyringService) {
+  public init(
+    keyringService: BraveWalletKeyringService,
+    walletService: BraveWalletBraveWalletService
+  ) {
     self.keyringService = keyringService
+    self.walletService = walletService
     self.keyringService.add(self)
     updateKeyringInfo()
     self.keyringService.defaultKeyringInfo { [self] keyringInfo in
@@ -255,6 +260,7 @@ public class KeyringStore: ObservableObject {
   }
   
   func reset() {
+    walletService.reset()
     isOnboardingVisible = true
     Self.resetKeychainStoredPassword()
   }

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -96,15 +96,10 @@ public class KeyringStore: ObservableObject {
   }
   
   private let keyringService: BraveWalletKeyringService
-  private let walletService: BraveWalletBraveWalletService // for wallet reset
   private var cancellable: AnyCancellable?
   
-  public init(
-    keyringService: BraveWalletKeyringService,
-    walletService: BraveWalletBraveWalletService
-  ) {
+  public init(keyringService: BraveWalletKeyringService) {
     self.keyringService = keyringService
-    self.walletService = walletService
     self.keyringService.add(self)
     updateKeyringInfo()
     self.keyringService.defaultKeyringInfo { [self] keyringInfo in
@@ -259,12 +254,6 @@ public class KeyringStore: ObservableObject {
     }
   }
   
-  func reset() {
-    walletService.reset()
-    isOnboardingVisible = true
-    Self.resetKeychainStoredPassword()
-  }
-  
   func privateKey(for account: BraveWallet.AccountInfo, completion: @escaping (String?) -> Void) {
     if account.isPrimary {
       keyringService.privateKey(forDefaultKeyringAccount: account.address) { success, key in
@@ -371,6 +360,8 @@ public class KeyringStore: ObservableObject {
 
 extension KeyringStore: BraveWalletKeyringServiceObserver {
   public func keyringReset() {
+    isOnboardingVisible = true
+    Self.resetKeychainStoredPassword()
   }
   
   public func autoLockMinutesChanged() {

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -78,21 +78,11 @@ public class KeyringStore: ObservableObject {
   /// and dismisses the `UnlockWalletView`. We need to keep the unlock view/biometrics prompt up until
   /// the user dismisess it or enables it.
   @Published var isRestoreFromUnlockBiometricsPromptVisible: Bool = false
-  /// The number of minutes to wait until the Brave Wallet is automatically locked
-  @Published var autoLockInterval: AutoLockInterval = .minute {
-    didSet {
-      keyringService.setAutoLockMinutes(autoLockInterval.value) { _ in }
-    }
-  }
   /// The users selected account when buying/sending/swapping currencies
   @Published var selectedAccount: BraveWallet.AccountInfo = .init() {
     didSet {
       keyringService.setSelectedAccount(selectedAccount.address) { _ in }
     }
-  }
-  /// For showing wallet in the main Settings only when default keyring is created
-  public var isDefaultKeyringCreated: Bool {
-    return keyring.isDefaultKeyringCreated
   }
   
   private let keyringService: BraveWalletKeyringService
@@ -111,9 +101,6 @@ public class KeyringStore: ObservableObject {
         // and should be removed.
         Self.resetKeychainStoredPassword()
       }
-    }
-    self.keyringService.autoLockMinutes { minutes in
-      self.autoLockInterval = .init(value: minutes)
     }
     cancellable = NotificationCenter.default
       .publisher(for: UIApplication.didBecomeActiveNotification, object: nil)

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -1,0 +1,41 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+
+public class SettingsStore: ObservableObject {
+  /// The number of minutes to wait until the Brave Wallet is automatically locked
+  @Published var autoLockInterval: AutoLockInterval = .minute {
+    didSet {
+      keyringService.setAutoLockMinutes(autoLockInterval.value) { _ in }
+    }
+  }
+  
+  private let keyringService: BraveWalletKeyringService
+  private let walletService: BraveWalletBraveWalletService
+  
+  public init(
+    keyringService: BraveWalletKeyringService,
+    walletService: BraveWalletBraveWalletService
+  ) {
+    self.keyringService = keyringService
+    self.walletService = walletService
+    
+    self.keyringService.autoLockMinutes { minutes in
+      self.autoLockInterval = .init(value: minutes)
+    }
+  }
+  
+  func reset() {
+    walletService.reset()
+  }
+  
+  public func isDefaultKeyringCreated(_ completion: @escaping (Bool) -> Void) {
+    keyringService.defaultKeyringInfo { keyring in
+      completion(keyring.isDefaultKeyringCreated)
+    }
+  }
+}

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -26,7 +26,8 @@ public class WalletStore {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     txService: BraveWalletEthTxService
   ) {
-    self.keyringStore = .init(keyringService: keyringService)
+    self.keyringStore = .init(keyringService: keyringService,
+                              walletService: walletService)
     self.setUp(
       keyringService: keyringService,
       rpcService: rpcService,

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -26,8 +26,7 @@ public class WalletStore {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     txService: BraveWalletEthTxService
   ) {
-    self.keyringStore = .init(keyringService: keyringService,
-                              walletService: walletService)
+    self.keyringStore = .init(keyringService: keyringService)
     self.setUp(
       keyringService: keyringService,
       rpcService: rpcService,

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -46,14 +46,10 @@ extension NetworkStore {
 
 extension KeyringStore {
   static var previewStore: KeyringStore {
-    .init(
-      keyringService: MockKeyringService(),
-      walletService: MockBraveWalletService()
-    )
+    .init(keyringService: MockKeyringService())
   }
   static var previewStoreWithWalletCreated: KeyringStore {
-    let store = KeyringStore(keyringService: MockKeyringService(),
-                             walletService: MockBraveWalletService())
+    let store = KeyringStore(keyringService: MockKeyringService())
     store.createWallet(password: "password")
     return store
   }

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -46,10 +46,14 @@ extension NetworkStore {
 
 extension KeyringStore {
   static var previewStore: KeyringStore {
-    .init(keyringService: MockKeyringService())
+    .init(
+      keyringService: MockKeyringService(),
+      walletService: MockBraveWalletService()
+    )
   }
   static var previewStoreWithWalletCreated: KeyringStore {
-    let store = KeyringStore(keyringService: MockKeyringService())
+    let store = KeyringStore(keyringService: MockKeyringService(),
+                             walletService: MockBraveWalletService())
     store.createWallet(password: "password")
     return store
   }

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -139,4 +139,13 @@ extension TransactionConfirmationStore {
   }
 }
 
+extension SettingsStore {
+  static var previewStore: SettingsStore {
+    .init(
+      keyringService: MockKeyringService(),
+      walletService: MockBraveWalletService()
+    )
+  }
+}
+
 #endif

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -9,11 +9,16 @@ import BraveUI
 
 public struct WalletSettingsView: View {
   @ObservedObject var keyringStore: KeyringStore
+  var cryptoStore: CryptoStore
   
   @State private var isShowingResetAlert = false
   
-  public init(keyringStore: KeyringStore) {
+  public init(
+    keyringStore: KeyringStore,
+    cryptoStore: CryptoStore
+  ) {
     self.keyringStore = keyringStore
+    self.cryptoStore = cryptoStore
   }
   
   private var autoLockIntervals: [AutoLockInterval] {
@@ -60,7 +65,7 @@ public struct WalletSettingsView: View {
         title: Text(Strings.Wallet.settingsResetWalletAlertTitle),
         message: Text(Strings.Wallet.settingsResetWalletAlertMessage),
         primaryButton: .destructive(Text(Strings.Wallet.settingsResetWalletAlertButtonTitle), action: {
-          keyringStore.reset()
+          cryptoStore.reset()
         }),
         secondaryButton: .cancel(Text(Strings.no))
       )
@@ -72,7 +77,10 @@ public struct WalletSettingsView: View {
 struct WalletSettingsView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      WalletSettingsView(keyringStore: .previewStore)
+      WalletSettingsView(
+        keyringStore: .previewStore,
+        cryptoStore: .previewStore
+      )
     }
   }
 }

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -8,25 +8,20 @@ import struct Shared.Strings
 import BraveUI
 
 public struct WalletSettingsView: View {
-  @ObservedObject var keyringStore: KeyringStore
-  var cryptoStore: CryptoStore
+  @ObservedObject var settingsStore: SettingsStore
   
   @State private var isShowingResetAlert = false
   
-  public init(
-    keyringStore: KeyringStore,
-    cryptoStore: CryptoStore
-  ) {
-    self.keyringStore = keyringStore
-    self.cryptoStore = cryptoStore
+  public init(settingsStore: SettingsStore) {
+    self.settingsStore = settingsStore
   }
-  
+
   private var autoLockIntervals: [AutoLockInterval] {
     var all = AutoLockInterval.allOptions
-    if !all.contains(keyringStore.autoLockInterval) {
+    if !all.contains(settingsStore.autoLockInterval) {
       // Ensure that the users selected interval always appears as an option even if
       // we remove it from `allOptions`
-      all.append(keyringStore.autoLockInterval)
+      all.append(settingsStore.autoLockInterval)
     }
     return all.sorted(by: { $0.value < $1.value })
   }
@@ -37,7 +32,7 @@ public struct WalletSettingsView: View {
         footer: Text(Strings.Wallet.autoLockFooter)
           .foregroundColor(Color(.secondaryBraveLabel))
       ) {
-        Picker(selection: $keyringStore.autoLockInterval) {
+        Picker(selection: $settingsStore.autoLockInterval) {
           ForEach(autoLockIntervals) { interval in
             Text(interval.label)
               .tag(interval)
@@ -65,7 +60,7 @@ public struct WalletSettingsView: View {
         title: Text(Strings.Wallet.settingsResetWalletAlertTitle),
         message: Text(Strings.Wallet.settingsResetWalletAlertMessage),
         primaryButton: .destructive(Text(Strings.Wallet.settingsResetWalletAlertButtonTitle), action: {
-          cryptoStore.reset()
+          settingsStore.reset()
         }),
         secondaryButton: .cancel(Text(Strings.no))
       )
@@ -77,10 +72,7 @@ public struct WalletSettingsView: View {
 struct WalletSettingsView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      WalletSettingsView(
-        keyringStore: .previewStore,
-        cryptoStore: .previewStore
-      )
+      WalletSettingsView(settingsStore: .previewStore)
     }
   }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -940,6 +940,7 @@
 		7D758921271F07B800B643C3 /* SendTokenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D758920271F07B800B643C3 /* SendTokenView.swift */; };
 		7DAC597B2726524E00E735A2 /* AddressQRCodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAC597A2726524E00E735A2 /* AddressQRCodeScannerView.swift */; };
 		7DC054C227A9CCA400BBA042 /* KeyringServiceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC054C127A9CCA400BBA042 /* KeyringServiceExtensions.swift */; };
+		7DC054DA27AB30E700BBA042 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC054D927AB30E700BBA042 /* SettingsStore.swift */; };
 		7DC52B12273D99E70067E237 /* WalletArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */; };
 		7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */; };
 		7DCA34D427555E96001B0555 /* CryptoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA34D327555E96001B0555 /* CryptoStore.swift */; };
@@ -2883,6 +2884,7 @@
 		7D758920271F07B800B643C3 /* SendTokenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendTokenView.swift; sourceTree = "<group>"; };
 		7DAC597A2726524E00E735A2 /* AddressQRCodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressQRCodeScannerView.swift; sourceTree = "<group>"; };
 		7DC054C127A9CCA400BBA042 /* KeyringServiceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyringServiceExtensions.swift; sourceTree = "<group>"; };
+		7DC054D927AB30E700BBA042 /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		7DC52B11273D99E70067E237 /* WalletArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtension.swift; sourceTree = "<group>"; };
 		7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletArrayExtensionTests.swift; sourceTree = "<group>"; };
 		7DCA34D327555E96001B0555 /* CryptoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoStore.swift; sourceTree = "<group>"; };
@@ -3878,6 +3880,7 @@
 				7D2D6EDC2731B7FF000650EA /* SwapTokenStore.swift */,
 				27E17B802744067A00F3C282 /* AccountActivityStore.swift */,
 				27AAE240274FFBA900288E90 /* TransactionConfirmationStore.swift */,
+				7DC054D927AB30E700BBA042 /* SettingsStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -7822,6 +7825,7 @@
 				271F689326EBD27E00AA2A50 /* MockContent.swift in Sources */,
 				275034E326EF9E6A00CF4C8A /* WalletSettingsView.swift in Sources */,
 				271F689B26EBD27E00AA2A50 /* CryptoView.swift in Sources */,
+				7DC054DA27AB30E700BBA042 /* SettingsStore.swift in Sources */,
 				2701B14C2735B65300BE6FC6 /* EditPriorityFeeView.swift in Sources */,
 				27180150273ABD3A00F683E3 /* BiometricsPromptView.swift in Sources */,
 				271F689826EBD27E00AA2A50 /* NetworkStore.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -148,32 +148,17 @@ extension BrowserViewController {
                                                   walletService: walletService)
                 }
                 
-                settingsStore?.isDefaultKeyringCreated { created in
-                    if created {
-                        let vc = SettingsViewController(profile: self.profile,
-                                                        tabManager: self.tabManager,
-                                                        feedDataSource: self.feedDataSource,
-                                                        rewards: self.rewards,
-                                                        legacyWallet: self.legacyWallet,
-                                                        windowProtection: self.windowProtection,
-                                                        historyAPI: self.historyAPI,
-                                                        syncAPI: self.syncAPI,
-                                                        walletSettingsStore: settingsStore)
-                        vc.settingsDelegate = self
-                        menuController.pushInnerMenu(vc)
-                    } else {
-                        let vc = SettingsViewController(profile: self.profile,
-                                                        tabManager: self.tabManager,
-                                                        feedDataSource: self.feedDataSource,
-                                                        rewards: self.rewards,
-                                                        legacyWallet: self.legacyWallet,
-                                                        windowProtection: self.windowProtection,
-                                                        historyAPI: self.historyAPI,
-                                                        syncAPI: self.syncAPI)
-                        vc.settingsDelegate = self
-                        menuController.pushInnerMenu(vc)
-                    }
-                }
+                let vc = SettingsViewController(profile: self.profile,
+                                                tabManager: self.tabManager,
+                                                feedDataSource: self.feedDataSource,
+                                                rewards: self.rewards,
+                                                legacyWallet: self.legacyWallet,
+                                                windowProtection: self.windowProtection,
+                                                historyAPI: self.historyAPI,
+                                                syncAPI: self.syncAPI,
+                                                walletSettingsStore: settingsStore)
+                vc.settingsDelegate = self
+                menuController.pushInnerMenu(vc)
             }
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -141,9 +141,12 @@ extension BrowserViewController {
                 }
             }
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
-                let keyringStore = BraveWallet.KeyringServiceFactory
-                    .get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
-                    .map { KeyringStore(keyringService: $0) }
+                var keyringStore: KeyringStore?
+                if let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+                   let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
+                        keyringStore = KeyringStore(keyringService: keyringService,
+                                                    walletService: walletService)
+                }
                 
                 let vc = SettingsViewController(profile: self.profile,
                                                 tabManager: self.tabManager,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -142,10 +142,21 @@ extension BrowserViewController {
             }
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
                 var keyringStore: KeyringStore?
-                if let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-                   let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
-                        keyringStore = KeyringStore(keyringService: keyringService,
-                                                    walletService: walletService)
+                var cryptoStore: CryptoStore?
+                if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+                   let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+                   let assetRatioService = BraveWallet.AssetRatioServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+                   let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+                   let swapService = BraveWallet.SwapServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+                   let txService = BraveWallet.EthTxServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
+                    keyringStore = KeyringStore(keyringService: keyringService)
+                    cryptoStore = CryptoStore(keyringService: keyringService,
+                                              rpcService: rpcService,
+                                              walletService: walletService,
+                                              assetRatioService: assetRatioService,
+                                              swapService: swapService,
+                                              blockchainRegistry: BraveCoreMain.blockchainRegistry,
+                                              txService: txService)
                 }
                 
                 let vc = SettingsViewController(profile: self.profile,
@@ -156,7 +167,8 @@ extension BrowserViewController {
                                                 windowProtection: self.windowProtection,
                                                 historyAPI: self.historyAPI,
                                                 syncAPI: self.syncAPI,
-                                                walletKeyringStore: keyringStore)
+                                                walletKeyringStore: keyringStore,
+                                                cryptoStore: cryptoStore)
                 vc.settingsDelegate = self
                 menuController.pushInnerMenu(vc)
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -141,36 +141,39 @@ extension BrowserViewController {
                 }
             }
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
-                var keyringStore: KeyringStore?
-                var cryptoStore: CryptoStore?
+                var settingsStore: SettingsStore?
                 if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-                   let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-                   let assetRatioService = BraveWallet.AssetRatioServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-                   let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-                   let swapService = BraveWallet.SwapServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-                   let txService = BraveWallet.EthTxServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
-                    keyringStore = KeyringStore(keyringService: keyringService)
-                    cryptoStore = CryptoStore(keyringService: keyringService,
-                                              rpcService: rpcService,
-                                              walletService: walletService,
-                                              assetRatioService: assetRatioService,
-                                              swapService: swapService,
-                                              blockchainRegistry: BraveCoreMain.blockchainRegistry,
-                                              txService: txService)
+                   let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
+                    settingsStore = SettingsStore(keyringService: keyringService,
+                                                  walletService: walletService)
                 }
                 
-                let vc = SettingsViewController(profile: self.profile,
-                                                tabManager: self.tabManager,
-                                                feedDataSource: self.feedDataSource,
-                                                rewards: self.rewards,
-                                                legacyWallet: self.legacyWallet,
-                                                windowProtection: self.windowProtection,
-                                                historyAPI: self.historyAPI,
-                                                syncAPI: self.syncAPI,
-                                                walletKeyringStore: keyringStore,
-                                                cryptoStore: cryptoStore)
-                vc.settingsDelegate = self
-                menuController.pushInnerMenu(vc)
+                settingsStore?.isDefaultKeyringCreated { created in
+                    if created {
+                        let vc = SettingsViewController(profile: self.profile,
+                                                        tabManager: self.tabManager,
+                                                        feedDataSource: self.feedDataSource,
+                                                        rewards: self.rewards,
+                                                        legacyWallet: self.legacyWallet,
+                                                        windowProtection: self.windowProtection,
+                                                        historyAPI: self.historyAPI,
+                                                        syncAPI: self.syncAPI,
+                                                        walletSettingsStore: settingsStore)
+                        vc.settingsDelegate = self
+                        menuController.pushInnerMenu(vc)
+                    } else {
+                        let vc = SettingsViewController(profile: self.profile,
+                                                        tabManager: self.tabManager,
+                                                        feedDataSource: self.feedDataSource,
+                                                        rewards: self.rewards,
+                                                        legacyWallet: self.legacyWallet,
+                                                        windowProtection: self.windowProtection,
+                                                        historyAPI: self.historyAPI,
+                                                        syncAPI: self.syncAPI)
+                        vc.settingsDelegate = self
+                        menuController.pushInnerMenu(vc)
+                    }
+                }
             }
         }
     }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -577,7 +577,7 @@ class SettingsViewController: TableViewController {
     }()
     
     private func setUpSections() {
-        if #available(iOS 14.0, *), let settingsStore = walletSettingsStore {
+        if let settingsStore = walletSettingsStore {
             settingsStore.isDefaultKeyringCreated { [weak self] created in
                 guard let self = self else { return }
                 var copyOfSections = self.sections
@@ -590,10 +590,8 @@ class SettingsViewController: TableViewController {
                             self.navigationController?.pushViewController(vc, animated: true)
                         }, image: #imageLiteral(resourceName: "menu-crypto").template, accessory: .disclosureIndicator)
                     )
-                    self.dataSource.sections = copyOfSections
-                } else {
-                    self.dataSource.sections = self.sections
                 }
+                self.dataSource.sections = copyOfSections
             }
         }
     }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -61,8 +61,7 @@ class SettingsViewController: TableViewController {
     private let feedDataSource: FeedDataSource
     private let historyAPI: BraveHistoryAPI
     private let syncAPI: BraveSyncAPI
-    private let walletKeyringStore: KeyringStore?
-    private let cryptoStore: CryptoStore?
+    private let walletSettingsStore: SettingsStore?
     private let windowProtection: WindowProtection?
 
     init(profile: Profile,
@@ -73,8 +72,7 @@ class SettingsViewController: TableViewController {
          windowProtection: WindowProtection?,
          historyAPI: BraveHistoryAPI,
          syncAPI: BraveSyncAPI,
-         walletKeyringStore: KeyringStore? = nil,
-         cryptoStore: CryptoStore? = nil
+         walletSettingsStore: SettingsStore? = nil
     ) {
         self.profile = profile
         self.tabManager = tabManager
@@ -84,8 +82,7 @@ class SettingsViewController: TableViewController {
         self.windowProtection = windowProtection
         self.historyAPI = historyAPI
         self.syncAPI = syncAPI
-        self.walletKeyringStore = walletKeyringStore
-        self.cryptoStore = cryptoStore
+        self.walletSettingsStore = walletSettingsStore
         
         super.init(style: .insetGrouped)
     }
@@ -252,10 +249,10 @@ class SettingsViewController: TableViewController {
             }, image: #imageLiteral(resourceName: "settings-playlist").template, accessory: .disclosureIndicator)
         )
         
-        if #available(iOS 14.0, *), let keyringStore = walletKeyringStore, keyringStore.isDefaultKeyringCreated, let cryptoStore = cryptoStore {
+        if #available(iOS 14.0, *), let settingsStore = walletSettingsStore {
             section.rows.append(
                 Row(text: Strings.Wallet.braveWallet, selection: { [unowned self] in
-                    let vc = UIHostingController(rootView: WalletSettingsView(keyringStore: keyringStore, cryptoStore: cryptoStore))
+                    let vc = UIHostingController(rootView: WalletSettingsView(settingsStore: settingsStore))
                     self.navigationController?.pushViewController(vc, animated: true)
                 }, image: #imageLiteral(resourceName: "menu-crypto").template, accessory: .disclosureIndicator)
             )

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -62,6 +62,7 @@ class SettingsViewController: TableViewController {
     private let historyAPI: BraveHistoryAPI
     private let syncAPI: BraveSyncAPI
     private let walletKeyringStore: KeyringStore?
+    private let cryptoStore: CryptoStore?
     private let windowProtection: WindowProtection?
 
     init(profile: Profile,
@@ -72,7 +73,8 @@ class SettingsViewController: TableViewController {
          windowProtection: WindowProtection?,
          historyAPI: BraveHistoryAPI,
          syncAPI: BraveSyncAPI,
-         walletKeyringStore: KeyringStore? = nil
+         walletKeyringStore: KeyringStore? = nil,
+         cryptoStore: CryptoStore? = nil
     ) {
         self.profile = profile
         self.tabManager = tabManager
@@ -83,6 +85,7 @@ class SettingsViewController: TableViewController {
         self.historyAPI = historyAPI
         self.syncAPI = syncAPI
         self.walletKeyringStore = walletKeyringStore
+        self.cryptoStore = cryptoStore
         
         super.init(style: .insetGrouped)
     }
@@ -249,10 +252,10 @@ class SettingsViewController: TableViewController {
             }, image: #imageLiteral(resourceName: "settings-playlist").template, accessory: .disclosureIndicator)
         )
         
-        if #available(iOS 14.0, *), let keyringStore = walletKeyringStore, keyringStore.isDefaultKeyringCreated {
+        if #available(iOS 14.0, *), let keyringStore = walletKeyringStore, keyringStore.isDefaultKeyringCreated, let cryptoStore = cryptoStore {
             section.rows.append(
                 Row(text: Strings.Wallet.braveWallet, selection: { [unowned self] in
-                    let vc = UIHostingController(rootView: WalletSettingsView(keyringStore: keyringStore))
+                    let vc = UIHostingController(rootView: WalletSettingsView(keyringStore: keyringStore, cryptoStore: cryptoStore))
                     self.navigationController?.pushViewController(vc, animated: true)
                 }, image: #imageLiteral(resourceName: "menu-crypto").template, accessory: .disclosureIndicator)
             )


### PR DESCRIPTION
## Summary of Changes
Core had an update to solve resetting `KeyringService` is not resetting `RpcService`.
Hence iOS side needs to update to call the correct reset.
According to bbondy, `BraveWalletService.reset` is the only one we need. ref: https://github.com/brave/brave-ios/issues/4777#issuecomment-1006113518 

This pull request fixes #4777 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
