### PR TITLE
No bug: Remove wallet option in browser settings once user reset wallet from there

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -348,7 +348,6 @@ public class KeyringStore: ObservableObject {
 extension KeyringStore: BraveWalletKeyringServiceObserver {
   public func keyringReset() {
     isOnboardingVisible = true
-    Self.resetKeychainStoredPassword()
   }
   
   public func autoLockMinutesChanged() {

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -31,11 +31,16 @@ public class SettingsStore: ObservableObject {
   
   func reset() {
     walletService.reset()
+    KeyringStore.resetKeychainStoredPassword()
   }
   
   public func isDefaultKeyringCreated(_ completion: @escaping (Bool) -> Void) {
     keyringService.defaultKeyringInfo { keyring in
       completion(keyring.isDefaultKeyringCreated)
     }
+  }
+  
+  public func addKeyringServiceObserver(_ observer: BraveWalletKeyringServiceObserver) {
+    keyringService.add(observer)
   }
 }

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -12,8 +12,6 @@ public struct WalletSettingsView: View {
   
   @State private var isShowingResetAlert = false
   
-  @Environment(\.presentationMode) @Binding private var presentationMode
-  
   public init(settingsStore: SettingsStore) {
     self.settingsStore = settingsStore
   }
@@ -63,7 +61,6 @@ public struct WalletSettingsView: View {
         message: Text(Strings.Wallet.settingsResetWalletAlertMessage),
         primaryButton: .destructive(Text(Strings.Wallet.settingsResetWalletAlertButtonTitle), action: {
           settingsStore.reset()
-          presentationMode.dismiss()
         }),
         secondaryButton: .cancel(Text(Strings.no))
       )

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -12,6 +12,8 @@ public struct WalletSettingsView: View {
   
   @State private var isShowingResetAlert = false
   
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
   public init(settingsStore: SettingsStore) {
     self.settingsStore = settingsStore
   }
@@ -61,6 +63,7 @@ public struct WalletSettingsView: View {
         message: Text(Strings.Wallet.settingsResetWalletAlertMessage),
         primaryButton: .destructive(Text(Strings.Wallet.settingsResetWalletAlertButtonTitle), action: {
           settingsStore.reset()
+          presentationMode.dismiss()
         }),
         secondaryButton: .cancel(Text(Strings.no))
       )

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -65,6 +65,7 @@ class SettingsViewController: TableViewController {
     private let windowProtection: WindowProtection?
     
     private let featureSectionUUID: UUID = .init()
+    private let walletRowUUID: UUID = .init()
 
     init(profile: Profile,
          tabManager: TabManager,
@@ -581,15 +582,27 @@ class SettingsViewController: TableViewController {
             settingsStore.isDefaultKeyringCreated { [weak self] created in
                 guard let self = self else { return }
                 var copyOfSections = self.sections
-                if created, let index = self.sections.firstIndex(where: {
+                if let featureSectionIndex = self.sections.firstIndex(where: {
                     $0.uuid == self.featureSectionUUID.uuidString
                 }) {
-                    copyOfSections[index].rows.append(
-                        Row(text: Strings.Wallet.braveWallet, selection: { [unowned self] in
-                            let vc = UIHostingController(rootView: WalletSettingsView(settingsStore: settingsStore))
-                            self.navigationController?.pushViewController(vc, animated: true)
-                        }, image: #imageLiteral(resourceName: "menu-crypto").template, accessory: .disclosureIndicator)
-                    )
+                    let walletRowIndex = copyOfSections[featureSectionIndex].rows.firstIndex(where: {
+                        $0.uuid == self.walletRowUUID.uuidString
+                    })
+                    if created, walletRowIndex == nil {
+                        settingsStore.addKeyringServiceObserver(self)
+                        copyOfSections[featureSectionIndex].rows.append(
+                            Row(text: Strings.Wallet.braveWallet,
+                                selection: { [unowned self] in
+                                    let vc = UIHostingController(rootView: WalletSettingsView(settingsStore: settingsStore))
+                                    self.navigationController?.pushViewController(vc, animated: true)
+                                },
+                                image: #imageLiteral(resourceName: "menu-crypto").template,
+                                accessory: .disclosureIndicator,
+                                uuid: self.walletRowUUID.uuidString)
+                        )
+                    } else if !created, let index = walletRowIndex {
+                        copyOfSections.remove(at: index)
+                    }
                 }
                 self.dataSource.sections = copyOfSections
             }
@@ -615,5 +628,20 @@ class SettingsViewController: TableViewController {
         if dataSource.sections.isEmpty { return }
         dataSource.sections[0] = Static.Section()
         Preferences.VPN.vpnSettingHeaderWasDismissed.value = true
+    }
+}
+
+extension SettingsViewController: BraveWalletKeyringServiceObserver {
+    func keyringCreated() {}
+    func keyringRestored() {}
+    func locked() {}
+    func unlocked() {}
+    func backedUp() {}
+    func accountsChanged() {}
+    func autoLockMinutesChanged() {}
+    func selectedAccountChanged() {}
+    
+    func keyringReset() {
+        setUpSections()
     }
 }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -643,5 +643,6 @@ extension SettingsViewController: BraveWalletKeyringServiceObserver {
     
     func keyringReset() {
         setUpSections()
+        navigationController?.popViewController(animated: true)
     }
 }


### PR DESCRIPTION
## Summary of Changes
Calling resetKeychain method from SettingsStore instead of KeyringStore in case KeyringStore has not been initialized.
Update browser settings feature section options when wallet has been reset.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
