### PR TITLE
Fix #4958: With sandboxing, arguments must be escaped. Also page needs to access handlers

### DIFF
--- a/Client/Assets/Interstitial Pages/Pages/CertificateError.html
+++ b/Client/Assets/Interstitial Pages/Pages/CertificateError.html
@@ -61,7 +61,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/.
         <p id="details" class="moreDetails" style="display:none;">
             %error_more_details_description%
             <br /><br />
-            <a id="proceedAnyway" class="moreDetails" href="#" onclick='return proceedUnsafe()'>%visit_unsafe%</a>.
+            <a id="proceedAnyway" class="moreDetails" href="#">%visit_unsafe%</a>.
         </p>
         
         <script type="text/javascript">

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1961,7 +1961,7 @@ extension BrowserViewController: TabDelegate {
         }
 
         let errorHelper = ErrorPageHelper(certStore: profile.certStore)
-        tab.addContentScript(errorHelper, name: ErrorPageHelper.name(), contentWorld: .defaultClient)
+        tab.addContentScript(errorHelper, name: ErrorPageHelper.name(), contentWorld: .page)
 
         let sessionRestoreHelper = SessionRestoreHelper(tab: tab)
         sessionRestoreHelper.delegate = self
@@ -1984,7 +1984,7 @@ extension BrowserViewController: TabDelegate {
         // let spotlightHelper = SpotlightHelper(tab: tab)
         // tab.addHelper(spotlightHelper, name: SpotlightHelper.name())
 
-        tab.addContentScript(LocalRequestHelper(), name: LocalRequestHelper.name(), contentWorld: .defaultClient)
+        tab.addContentScript(LocalRequestHelper(), name: LocalRequestHelper.name(), contentWorld: .page)
 
         tab.contentBlocker.setupTabTrackingProtection()
         tab.addContentScript(tab.contentBlocker, name: ContentBlockerHelper.name(), contentWorld: .page)

--- a/Client/Frontend/Browser/SessionRestoreHandler.swift
+++ b/Client/Frontend/Browser/SessionRestoreHandler.swift
@@ -13,7 +13,7 @@ extension WKWebView {
     // Use JS to redirect the page without adding a history entry
     func replaceLocation(with url: URL) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: apostropheEncoded)
-        evaluateSafeJavaScript(functionName: "location.replace", args: [safeUrl], contentWorld: .defaultClient, escapeArgs: false, asFunction: true, completion: nil)
+        evaluateSafeJavaScript(functionName: "location.replace", args: [safeUrl], contentWorld: .defaultClient, asFunction: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
## Summary of Changes
- Fix page not accessing handlers properly when skipping errors.
- Fix `escapeArgs: false` when not actually supposed to. Args should be escaped.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4958

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test Certificate error page `proceed to...`
- Test Session Restore on weird websites like: (https://rocketnews24.com/category/%e3%82%b0%e3%83%ab%e3%83%a1/)


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
