### PR TITLE
Fix #4954: Tab search bar still active after completing search which requires two taps to select found tab

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -266,6 +266,8 @@ extension TabTrayController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let tab = dataSource.itemIdentifier(for: indexPath) else { return }
         tabManager.selectTab(tab)
+        
+        tabTraySearchController.isActive = false
         dismiss(animated: true)
     }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4954

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Launch Brave (use the dev build from TF so you can load the QA links and generate a bunch of tabs)
- Once you have several tabs opened, initiate a search
- Notice that you do not need to tap twice to select the tabs that were found

## Screenshots:

https://user-images.githubusercontent.com/6643505/153045729-102552a3-88e3-465c-bc3c-cd84021c05f2.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
