### PR TITLE
Guard iOS 14.3 and up to be sandboxed. iOS 14.2 and below has a WebKit Crash

### DIFF
--- a/Client/Frontend/Browser/DomainUserScript.swift
+++ b/Client/Frontend/Browser/DomainUserScript.swift
@@ -98,9 +98,9 @@ enum DomainUserScript: CaseIterable {
             alteredSource = alteredSource.replacingOccurrences(of: "$<setJS>", with: "ABSSJ\(token)",
                                                                options: .literal)
             
-            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
+            return WKUserScript.create(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         case .archive:
-            return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
+            return WKUserScript.create(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         case .braveSearch:
             var alteredSource = source
             
@@ -111,7 +111,7 @@ enum DomainUserScript: CaseIterable {
                                       options: .literal)
                 .replacingOccurrences(of: "$<security_token>", with: securityToken)
                 
-            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
+            return WKUserScript.create(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         case .braveTalk:
             var alteredSource = source
             
@@ -122,7 +122,7 @@ enum DomainUserScript: CaseIterable {
                                       options: .literal)
                 .replacingOccurrences(of: "$<security_token>", with: securityToken)
                 
-            return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
+            return WKUserScript.create(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
         }
     }
     

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -32,7 +32,7 @@ class MetadataParserHelper: TabEventHandler {
                 tab.pageMetadata = nil
                 return
         }
-
+        
         webView.evaluateSafeJavaScript(functionName: "__firefox__.metadata && __firefox__.metadata.getMetadata()", contentWorld: .defaultClient, asFunction: false) { (result, error) in
             guard error == nil else {
                 // TabEvent.post(.pageMetadataNotAvailable, for: tab)

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -378,7 +378,7 @@ class PlaylistWebLoader: UIView {
         replacements.forEach({
             alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
         })
-        return WKUserScript(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
+        return WKUserScript.create(source: alteredSource, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .page)
     }()
     
     private weak var certStore: CertStore?

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -633,7 +633,7 @@ class Tab: NSObject {
         }
         if let path = Bundle.main.path(forResource: fileName, ofType: type),
             let source = try? String(contentsOfFile: path) {
-            let userScript = WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly, in: contentWorld)
+            let userScript = WKUserScript.create(source: source, injectionTime: injectionTime, forMainFrameOnly: mainFrameOnly, in: contentWorld)
             webView.configuration.userContentController.addUserScript(userScript)
         }
     }
@@ -691,7 +691,11 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
         // If this helper handles script messages, then get the handler name and register it. The Tab
         // receives all messages and then dispatches them to the right TabHelper.
         if let scriptMessageHandlerName = helper.scriptMessageHandlerName() {
-            tab.webView?.configuration.userContentController.add(self, contentWorld: contentWorld, name: scriptMessageHandlerName)
+            if #available(iOS 14.3, *) {
+                tab.webView?.configuration.userContentController.add(self, contentWorld: contentWorld, name: scriptMessageHandlerName)
+            } else {
+                tab.webView?.configuration.userContentController.add(self, name: scriptMessageHandlerName)
+            }
         }
     }
 

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -138,7 +138,7 @@ class UserScriptManager {
                 let source = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String {
                 let wrappedSource = "(function() { const SECURITY_TOKEN = '\(UserScriptManager.messageHandlerTokenString)'; \(source) })()"
                 
-                return WKUserScript(source: wrappedSource,
+                return WKUserScript.create(source: wrappedSource,
                                     injectionTime: injectionTime,
                                     forMainFrameOnly: mainFrameOnly,
                                     in: sandboxed ? .defaultClient : .page)
@@ -154,7 +154,7 @@ class UserScriptManager {
         }
         var alteredSource = source
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "FingerprintingProtection\(messageHandlerTokenString)", options: .literal)
-        return WKUserScript(source: alteredSource,
+        return WKUserScript.create(source: alteredSource,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .page)
@@ -166,7 +166,7 @@ class UserScriptManager {
             return nil
         }
         
-        return WKUserScript(source: source,
+        return WKUserScript.create(source: source,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .page)
@@ -188,7 +188,7 @@ class UserScriptManager {
         alteredSource = alteredSource.replacingOccurrences(of: "$<paymentreqcallback>", with: "PaymentRequestCallback\(securityTokenString)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "PaymentRequest\(messageHandlerTokenString)", options: .literal)
         
-        return WKUserScript(source: alteredSource,
+        return WKUserScript.create(source: alteredSource,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .page)
@@ -204,7 +204,7 @@ class UserScriptManager {
         alteredSource = alteredSource.replacingOccurrences(of: "$<downloadManager>", with: "D\(securityTokenString)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "ResourceDownloadManager\(messageHandlerTokenString)", options: .literal)
         
-        return WKUserScript(source: alteredSource,
+        return WKUserScript.create(source: alteredSource,
                             injectionTime: .atDocumentEnd,
                             forMainFrameOnly: false,
                             in: .defaultClient)
@@ -224,7 +224,7 @@ class UserScriptManager {
         alteredSource = alteredSource.replacingOccurrences(of: "$<windowRenderer>", with: "W\(securityTokenString)", options: .literal)
         alteredSource = alteredSource.replacingOccurrences(of: "$<handler>", with: "WindowRenderHelper\(messageHandlerTokenString)", options: .literal)
         
-        return WKUserScript(source: alteredSource,
+        return WKUserScript.create(source: alteredSource,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .defaultClient)
@@ -236,7 +236,7 @@ class UserScriptManager {
             return nil
         }
         
-        return WKUserScript(source: source,
+        return WKUserScript.create(source: source,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .page)
@@ -249,7 +249,7 @@ class UserScriptManager {
             return nil
         }
         
-        return WKUserScript(source: source,
+        return WKUserScript.create(source: source,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .page)
@@ -294,7 +294,7 @@ class UserScriptManager {
             alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
         })
         
-        return WKUserScript(source: alteredSource,
+        return WKUserScript.create(source: alteredSource,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .page)
@@ -318,7 +318,7 @@ class UserScriptManager {
             alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
         })
         
-        return WKUserScript(source: alteredSource,
+        return WKUserScript.create(source: alteredSource,
                             injectionTime: .atDocumentStart,
                             forMainFrameOnly: false,
                             in: .page)


### PR DESCRIPTION
## Summary of Changes
- Guard iOS 14.3 and up to be sandboxed. 
- iOS 14.2 and below has a crash: `"Fatal error: Bug in WebKit: Received neither result or failure.: file WebKit/WebKitSwiftOverlay.swift, line 66"`

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4967

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
It can be tested as a part of manual passes:

- Test session restore
- Test reader-mode
- Test playlist
- Test a bookmarklet like: `javascript:alert("hello");`

This exact crash we are fixing happens on iOS 14.2 or lower devices. QA most likely does not have such device,
we tested it on our own locally with simulator builds.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
