### PR TITLE
Fix #4953: Add BraveCore version information to settings version action

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -482,19 +482,20 @@ class SettingsViewController: TableViewController {
         let version = String(format: Strings.versionTemplate,
                              Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "",
                              Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "")
+        let coreVersion = "BraveCore \(BraveCoreVersionInfo.braveCoreVersion) (\(BraveCoreVersionInfo.chromiumVersion))"
         return Static.Section(
             header: .title(Strings.about),
             rows: [
                 Row(text: version, selection: { [unowned self] in
                     let device = UIDevice.current
-                    let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+                    let actionSheet = UIAlertController(title: version, message: coreVersion, preferredStyle: .actionSheet)
                     actionSheet.popoverPresentationController?.sourceView = self.view
                     actionSheet.popoverPresentationController?.sourceRect = self.view.bounds
                     let iOSVersion = "\(device.systemName) \(UIDevice.current.systemVersion)"
                     
                     let deviceModel = String(format: Strings.deviceTemplate, device.modelName, iOSVersion)
                     let copyDebugInfoAction = UIAlertAction(title: Strings.copyAppInfoToClipboard, style: .default) { _ in
-                        UIPasteboard.general.strings = [version, deviceModel]
+                        UIPasteboard.general.strings = [version, coreVersion, deviceModel]
                     }
                     
                     actionSheet.addAction(copyDebugInfoAction)

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.36.80/brave-core-ios-1.36.80.tgz",
-      "integrity": "sha512-ZwmGg/DrSvhbg3vzlhDzQD8HqCcmgcp0NFVTdtlOd4QfTxKnK1KjH95ViInEebkMPkxBSHQGxTbO1/zhGFDDkQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.36.87/brave-core-ios-1.36.87.tgz",
+      "integrity": "sha512-XkPVgsplWrT1Rz5VPailGHMVlxaY371tmYLwyYhbEyAGBD/IM7zlh9GkvG3kAw3bgz7nM+1v0l5TMro+P+Pzkg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.36.80/brave-core-ios-1.36.80.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.36.87/brave-core-ios-1.36.87.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
Also bumps BraveCore to 1.36.87 beta build

## Summary of Changes

This pull request fixes #4953 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![Simulator Screen Shot - iPhone 13 Pro - 2022-02-09 at 12 21 29](https://user-images.githubusercontent.com/529104/153255170-06e4c3f0-7aae-4232-be08-aec1fdba8cbf.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
