### PR TITLE
Fix #4745: Auto fill-in token info once user inputs a valid token contract address

### DIFF
--- a/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -33,11 +33,13 @@ struct AddCustomAssetView: View {
         ) {
           TextField(Strings.Wallet.enterContractAddress, text: $addressInput)
             .onChange(of: addressInput) { newValue in
-              userAssetStore.tokenInfo(by: newValue) { token in
-                if let token = token, !token.isErc721 {
-                  nameInput = token.name
-                  symbolInput = token.symbol
-                  decimalsInput = "\(token.decimals)"
+              if !newValue.isEmpty {
+                userAssetStore.tokenInfo(by: newValue) { token in
+                  if let token = token, !token.isErc721 {
+                    nameInput = token.name
+                    symbolInput = token.symbol
+                    decimalsInput = "\(token.decimals)"
+                  }
                 }
               }
             }

--- a/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -32,6 +32,15 @@ struct AddCustomAssetView: View {
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenContractAddress))
         ) {
           TextField(Strings.Wallet.enterContractAddress, text: $addressInput)
+            .onChange(of: addressInput) { newValue in
+              userAssetStore.tokenInfo(by: newValue) { token in
+                if let token = token, !token.isErc721 {
+                  nameInput = token.name
+                  symbolInput = token.symbol
+                  decimalsInput = "\(token.decimals)"
+                }
+              }
+            }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
@@ -109,7 +118,8 @@ struct AddCustomAssetView_Previews: PreviewProvider {
     static var previews: some View {
       AddCustomAssetView(userAssetStore: UserAssetsStore(walletService: MockBraveWalletService(),
                                                          blockchainRegistry: MockBlockchainRegistry(),
-                                                         rpcService: MockJsonRpcService()))
+                                                         rpcService: MockJsonRpcService(),
+                                                         assetRatioService: MockAssetRatioService()))
     }
 }
 #endif

--- a/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -23,8 +23,13 @@ struct AddCustomAssetView: View {
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenName))
         ) {
-          TextField(Strings.Wallet.enterTokenName, text: $nameInput)
-            .disabled(userAssetStore.isSearchingToken)
+          HStack {
+            TextField(Strings.Wallet.enterTokenName, text: $nameInput)
+              .disabled(userAssetStore.isSearchingToken)
+            if userAssetStore.isSearchingToken && nameInput.isEmpty {
+              ProgressView()
+            }
+          }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
@@ -54,21 +59,26 @@ struct AddCustomAssetView: View {
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenSymbol))
         ) {
-          TextField(Strings.Wallet.enterTokenSymbol, text: $symbolInput)
-            .disabled(userAssetStore.isSearchingToken)
+          HStack {
+            TextField(Strings.Wallet.enterTokenSymbol, text: $symbolInput)
+              .disabled(userAssetStore.isSearchingToken)
+            if userAssetStore.isSearchingToken && symbolInput.isEmpty {
+              ProgressView()
+            }
+          }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
-          header: WalletListHeaderView(title: Text(Strings.Wallet.decimalsPrecision)),
-          footer: Group {
-            ProgressView()
-              .frame(maxWidth: .infinity)
-              .opacity(userAssetStore.isSearchingToken ? 1 : 0)
-          }
+          header: WalletListHeaderView(title: Text(Strings.Wallet.decimalsPrecision))
         ) {
-          TextField(NumberFormatter().string(from: NSNumber(value: 0)) ?? "0", text: $decimalsInput)
-            .keyboardType(.numberPad)
-            .disabled(userAssetStore.isSearchingToken)
+          HStack {
+            TextField(NumberFormatter().string(from: NSNumber(value: 0)) ?? "0", text: $decimalsInput)
+              .keyboardType(.numberPad)
+              .disabled(userAssetStore.isSearchingToken)
+            if userAssetStore.isSearchingToken && decimalsInput.isEmpty {
+              ProgressView()
+            }
+          }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -49,7 +49,8 @@ public class PortfolioStore: ObservableObject {
   public private(set) lazy var userAssetsStore: UserAssetsStore = .init(
     walletService: self.walletService,
     blockchainRegistry: self.blockchainRegistry,
-    rpcService: self.rpcService
+    rpcService: self.rpcService,
+    assetRatioService: self.assetRatioService
   )
   
   private let keyringService: BraveWalletKeyringService

--- a/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -126,9 +126,9 @@ public class UserAssetsStore: ObservableObject {
   func tokenInfo(by contractAddress: String, completion: @escaping (BraveWallet.BlockchainToken?) -> Void) {
     timer?.invalidate()
     timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false, block: { [weak self] _ in
-      if let assetStore = self?.assetStores.first(where: { $0.token.contractAddress == contractAddress }) { // First check user's visible assets
+      if let assetStore = self?.assetStores.first(where: { $0.token.contractAddress.lowercased() == contractAddress.lowercased() }) { // First check user's visible assets
         completion(assetStore.token)
-      } else if let token = self?.allTokens.first(where: { $0.contractAddress == contractAddress }) { // Then check full tokens list
+      } else if let token = self?.allTokens.first(where: { $0.contractAddress.lowercased() == contractAddress.lowercased() }) { // Then check full tokens list
         completion(token)
       } else { // Last network call to get token info by its contractAddress only if the network is Mainnet
         self?.rpcService.network { network in

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -110,7 +110,8 @@ extension UserAssetsStore {
     .init(
       walletService: MockBraveWalletService(),
       blockchainRegistry: MockBlockchainRegistry(),
-      rpcService: MockJsonRpcService()
+      rpcService: MockJsonRpcService(),
+      assetRatioService: MockAssetRatioService()
     )
   }
 }


### PR DESCRIPTION
## Summary of Changes
While the users are inputing token contract address, if we can find the token in the order of 1. user visible assets, 2. all tokens 3. search on mainnet, we will prefill the reset token information for the users. 

This pull request fixes #4745 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Disclaimer: We respect the users' input on other fields. Means if the users have input some custom values other than contract address, then pasting a contract address, we will look for a token using that contract address but we will not override the prior values that the users have already input. However, if the field is empty, we will fill in the token info once we find a token. 

Scenario 1:
1. Stay on the mainnet
2. click `Edit Visible Assets` in the portfolio screen
3. click `Add custom asset`
4. paste a valid token contract address in the token contract address field. 
expect result: The reset of the token info will be filled in.

Scenario 2:
1. Select other network other than the mainnet
2. click `Edit Visible Assets` in the portfolio screen
3. click `Add custom asset`
4. paste a valid token contract address (make sure this token is neither in user's visible assets list nor in the all token lists) in the token contract address field. 
expect result: Nothing will happen
Follow up:
1. Continue to add that custom token in step 4 above
2. click `Add custom asset` again
3. paste the same token contact address
expect result: The reset of the token info will be filled in. (But this time adding will fail)

Scenario 3:
1. Select any network
2. click `Edit Visible Assets` in the portfolio screen
3. click `Add custom asset`
4. paste a valid token contract address (choose a token that you can find in the full token list) in the token contract address field. 
expect result: The reset of the token info will be filled in

## Screenshots:

https://user-images.githubusercontent.com/1187676/153327847-a9cf1608-7ac0-48c9-ae79-ff15eb49ceb1.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
