### PR TITLE
Fix #4973: Certificate page not restoring properly.

### DIFF
--- a/Client/Frontend/Browser/SessionRestoreHandler.swift
+++ b/Client/Frontend/Browser/SessionRestoreHandler.swift
@@ -13,7 +13,7 @@ extension WKWebView {
     // Use JS to redirect the page without adding a history entry
     func replaceLocation(with url: URL) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: apostropheEncoded)
-        evaluateSafeJavaScript(functionName: "location.replace", args: [safeUrl], contentWorld: .defaultClient, asFunction: true, completion: nil)
+        evaluateSafeJavaScript(functionName: "location.replace", args: ["'\(safeUrl)'"], contentWorld: .defaultClient, escapeArgs: false, asFunction: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Revert the code to use `'url'` (quoted) as shown here: https://github.com/brave/brave-ios/blob/22d9f0bf4e3e1f5651e571352a7b72c3e7ab44b5/Client/Frontend/Browser/SessionRestoreHandler.swift#L18

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4973

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test session restore on `badssl.com`
- Test regular session restore


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
