### PR TITLE
Fix #4976: Ensure CTAs on Brave News display ads are always visible

### DIFF
--- a/Client/Frontend/Brave Today/FeedItemView.swift
+++ b/Client/Frontend/Brave Today/FeedItemView.swift
@@ -53,6 +53,7 @@ class FeedItemView: UIView {
     }
     lazy var callToActionButton = CallToActionButton().then {
         $0.setContentHuggingPriority(.required, for: .horizontal)
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
     
     /// Generates the view hierarchy given a layout component


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #4976 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- See issue

## Screenshots:

![image](https://user-images.githubusercontent.com/529104/153506946-3ca5f38a-5e9e-4e55-a2e9-589c81b1c49f.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
