### PR TITLE
Fix #4988: Refresh selectedToken in Send Screen when chain has been changed.

### DIFF
--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -305,6 +305,8 @@ extension SendTokenStore: BraveWalletKeyringServiceObserver {
 
 extension SendTokenStore: BraveWalletJsonRpcServiceObserver {
   public func chainChangedEvent(_ chainId: String) {
+    // nil `selectedSendToken` to force refresh `selectedSendToken` in `fetchAssets()`
+    selectedSendToken = nil
     fetchAssets()
   }
   


### PR DESCRIPTION

This pull request fixes #4988 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open wallet
2. Select a non-custom network
3. Go to send
4. (selected token should be ETH)
5. select a custom network in the send screen using the network dropdown menu
6. (selected token will become the first token of user asset list)


## Screenshots:
https://user-images.githubusercontent.com/1187676/154297710-e7b45d3e-a71b-40c4-a487-c3a81be38c96.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
