### PR TITLE
Fix #4987: Custom network name does not get validation after new input

### DIFF
--- a/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -58,7 +58,7 @@ class CustomNetworkModel: ObservableObject {
   @Published var networkName = NetworkInputItem(input: "") {
     didSet {
       if networkName.input != oldValue.input {
-        if networkId.input.isEmpty {
+        if networkName.input.isEmpty {
           networkName.error = Strings.Wallet.customNetworkEmptyErrMsg
         } else {
           networkName.error = nil


### PR DESCRIPTION

This pull request fixes #4987 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Go to Add network screen
2. Tap `Save` without any input
3. (all necessary error messages show up)
4. input network name
5. (network name error message should disappear when input is valid)


## Screenshots:

![simulator_screenshot_A93B37A9-107F-4BEB-89F7-258BE18A0805](https://user-images.githubusercontent.com/1187676/154328666-791f1eff-aa47-4e7b-b61f-f825a81462c6.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
