### PR TITLE
Fix #4947: Update URL bar + tab bar to improve active tab visibility

### DIFF
--- a/BraveUI/Design System/Colors/Colors.swift
+++ b/BraveUI/Design System/Colors/Colors.swift
@@ -167,6 +167,25 @@ extension UIColor {
   }
 }
 
+extension UIColor {
+  public static var urlBarBackground: UIColor {
+    .init { traitCollection in
+      if traitCollection.userInterfaceStyle == .dark {
+        return .tertiaryBraveBackground
+      }
+      return .secondaryBraveBackground
+    }
+  }
+  public static var urlBarSeparator: UIColor {
+    .init { traitCollection in
+      if traitCollection.userInterfaceStyle == .dark {
+        return UIColor(white: 1.0, alpha: 0.1)
+      }
+      return .braveSeparator
+    }
+  }
+}
+
 // MARK: - Static Colors
 
 extension UIColor {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -661,7 +661,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
 
         // Temporary work around for covering the non-clipped web view content
         statusBarOverlay = UIView()
-        statusBarOverlay.backgroundColor = .secondaryBraveBackground
+        statusBarOverlay.backgroundColor = .urlBarBackground
         view.addSubview(statusBarOverlay)
 
         topTouchArea = UIButton()
@@ -751,7 +751,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
                 if isPrivateBrowsing {
                     self?.statusBarOverlay.backgroundColor = .privateModeBackground
                 } else {
-                    self?.statusBarOverlay.backgroundColor = .secondaryBraveBackground
+                    self?.statusBarOverlay.backgroundColor = .urlBarBackground
                 }
             })
     }
@@ -1148,6 +1148,10 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     }
     
     func updateTabsBarVisibility() {
+        defer {
+            topToolbar.line.isHidden = !tabsBar.view.isHidden
+        }
+        
         if tabManager.selectedTab == nil {
             tabsBar.view.isHidden = true
             return

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -117,7 +117,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     }
 
     let line = UIView().then {
-        $0.backgroundColor = .braveSeparator
+        $0.backgroundColor = .urlBarSeparator
     }
     
     let tabsButton = TabsButton()
@@ -197,14 +197,14 @@ class TopToolbarView: UIView, ToolbarProtocol {
         if isPrivateBrowsing {
             backgroundColor = .privateModeBackground
         } else {
-            backgroundColor = .secondaryBraveBackground
+            backgroundColor = .urlBarBackground
         }
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        backgroundColor = .secondaryBraveBackground
+        backgroundColor = .urlBarBackground
         
         locationContainer.addSubview(locationView)
         


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #4947 

- light mode: unselected tab 5% → 10% dark overlay
- dark mode: url bar + tab bar background: secondary → tertiary background 
- selected tab text color: text02 → text01
- unselected tab: title label alpha 60% → 80%
- added private mode tints to tab bar
- removed line between url bar and tab bar

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
