### PR TITLE
Fix #4985: EVM form gets wiped if update/add fails.

### DIFF
--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -66,7 +66,7 @@ struct NetworkPicker: View {
     .accessibilityValue(selectedNetwork.shortChainName)
     .sheet(isPresented: $isPresentingAddNetwork) {
       NavigationView {
-        CustomNetworkDetailsView(networkStore: networkStore, network: nil)
+        CustomNetworkDetailsView(networkStore: networkStore, model: .init())
       }
     }
   }

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -6,6 +6,7 @@
 import Foundation
 import BraveCore
 import SwiftUI
+import Shared
 
 /// An interface that helps you interact with a json-rpc service
 ///
@@ -54,14 +55,14 @@ public class NetworkStore: ObservableObject {
   @Published var isAddingNewNetwork: Bool = false
   
   public func addCustomNetwork(_ network: BraveWallet.EthereumChain,
-                               completion: @escaping (_ accepted: Bool) -> Void) {
-    func add(network: BraveWallet.EthereumChain, completion: @escaping (_ accepted: Bool) -> Void) {
+                               completion: @escaping (_ accepted: Bool, _ errMsg: String) -> Void) {
+    func add(network: BraveWallet.EthereumChain, completion: @escaping (_ accepted: Bool, _ errMsg: String) -> Void) {
       rpcService.add(network) { [self] chainId, status, message in
         if status == .success {
           // Update `ethereumChains` by api calling
           updateChainList()
           isAddingNewNetwork = false
-          completion(true)
+          completion(true, "")
         } else {
           // meaning add custom network failed for some reason.
           // Also add the the old network back on rpc service
@@ -70,11 +71,11 @@ public class NetworkStore: ObservableObject {
               // Update `ethereumChains` by api calling
               self.updateChainList()
               self.isAddingNewNetwork = false
-              completion(false)
+              completion(false, message)
             }
           } else {
             isAddingNewNetwork = false
-            completion(false)
+            completion(false, message)
           }
         }
       }
@@ -85,7 +86,7 @@ public class NetworkStore: ObservableObject {
       removeNetworkForNewAddition(network) { [self] success in
         guard success else {
           isAddingNewNetwork = false
-          completion(false)
+          completion(false, Strings.Wallet.failedToRemoveCustomNetworkErrorMessage)
           return
         }
         add(network: network, completion: completion)

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -45,7 +45,7 @@ extension NetworkStore {
   
   static var previewStoreWithCustomNetworkAdded: NetworkStore {
     let store = NetworkStore.previewStore
-    store.addCustomNetwork(.init(chainId: "0x100", chainName: "MockChain", blockExplorerUrls: ["https://mockchainscan.com"], iconUrls: [], rpcUrls: ["https://rpc.mockchain.com"], symbol: "MOCK", symbolName: "MOCK", decimals: 18, isEip1559: false)) { _ in }
+    store.addCustomNetwork(.init(chainId: "0x100", chainName: "MockChain", blockExplorerUrls: ["https://mockchainscan.com"], iconUrls: [], rpcUrls: ["https://rpc.mockchain.com"], symbol: "MOCK", symbolName: "MOCK", decimals: 18, isEip1559: false)) { _, _ in }
     return store
   }
 }

--- a/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/BraveWallet/Settings/CustomNetworkListView.swift
@@ -24,7 +24,7 @@ private struct SwipeActionsViewModifier_FB9812596: ViewModifier {
 
 struct CustomNetworkListView: View {
   @ObservedObject var networkStore: NetworkStore
-  @State private var isPresentingNetworkDetails: CustomNetworkDetails?
+  @State private var isPresentingNetworkDetails: CustomNetworkModel?
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.sizeCategory) private var sizeCategory
   
@@ -46,7 +46,8 @@ struct CustomNetworkListView: View {
         let customNetworks = networkStore.ethereumChains.filter({ $0.isCustom })
         ForEach(customNetworks) { network in
           Button(action: {
-            isPresentingNetworkDetails = .init(isEditMode: true, network: network)
+            isPresentingNetworkDetails = .init()
+            isPresentingNetworkDetails?.populateDetails(from: network)
           }) {
             HStack {
               VStack(alignment: .leading, spacing: 2) {
@@ -116,18 +117,18 @@ struct CustomNetworkListView: View {
     .toolbar {
       ToolbarItemGroup(placement: .confirmationAction) {
         Button(action: {
-          isPresentingNetworkDetails = .init(isEditMode: false)
+          isPresentingNetworkDetails = .init()
         }) {
           Label(Strings.Wallet.addCustomNetworkBarItemTitle, systemImage: "plus")
             .foregroundColor(Color(.braveOrange))
         }
       }
     }
-    .sheet(item: $isPresentingNetworkDetails) { details in
+    .sheet(item: $isPresentingNetworkDetails) { detailsModel in
       NavigationView {
         CustomNetworkDetailsView(
           networkStore: networkStore,
-          network: details.network
+          model: detailsModel
         )
       }
       .navigationViewStyle(StackNavigationViewStyle())

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1730,12 +1730,12 @@ extension Strings {
       value: "Failed to add this network.",
       comment: "The title of an alert when the custom network the user attempted to add fails for some reason"
     )
-    public static let failedToAddCustomNetworkErrorMessage = NSLocalizedString(
-      "wallet.failedToAddCustomNetworkErrorMessage",
+    public static let failedToRemoveCustomNetworkErrorMessage = NSLocalizedString(
+      "wallet.failedToRemoveCustomNetworkErrorMessage",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Please try again.",
-      comment: "The message of an alert when the custom network the user attempted to add fails for some reason"
+      value: "Failed to remove network.\nPlease try again.",
+      comment: "The message of an alert when the user attempted to remove custom network and it fails for some reason"
     )
     public static let customNetworksTitle = NSLocalizedString(
       "wallet.customNetworksTitle",


### PR DESCRIPTION

This pull request fixes #4985 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Either update or add a new custom network 
2. make sure to input at least one valid value but will be rejected by the rpcService (chain id, rpc url)
3. (you will get an error pop up with an error message from the server. and the form stays unchanged)


## Screenshots:

https://user-images.githubusercontent.com/1187676/154402428-0910fb89-c6d7-487f-b3d5-606acc24c102.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
