### PR TITLE
Fix #4995: Don't show Brave News inline ads when there are no feed items

### DIFF
--- a/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
+++ b/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
@@ -756,6 +756,15 @@ class FeedDataSource {
                     generatedCards.append(contentsOf: elementCards)
                 }
             }
+            if generatedCards.count < 10, generatedCards.allSatisfy({
+                if case .ad = $0 {
+                    return true
+                }
+                return false
+            }) {
+                // If there are less than 10 cards and they all are ads, show nothing
+                generatedCards.removeAll()
+            }
             DispatchQueue.main.async {
                 completion(generatedCards)
             }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4995

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Test regular feed, ensure ads and feed items are visible
- Install fresh (required to reset ads cap), disable all sources, verify that no inline ads appear
- Add a source that results in more than 10 feed items and verify ads and feed items are visible

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
