### PR TITLE
Fix #4120, #3818: FavIcons not rendering correct icon.

### DIFF
--- a/Client/Frontend/Browser/Favicons/LargeFaviconView.swift
+++ b/Client/Frontend/Browser/Favicons/LargeFaviconView.swift
@@ -32,7 +32,7 @@ class LargeFaviconView: UIView {
     
     func cancelLoading() {
         fetcher = nil
-        imageView.image = UIImage()
+        imageView.image = nil
         imageView.contentMode = .scaleAspectFit
         backgroundColor = .clear
         layoutMargins = .zero

--- a/Client/Frontend/Browser/Favicons/LargeFaviconView.swift
+++ b/Client/Frontend/Browser/Favicons/LargeFaviconView.swift
@@ -30,6 +30,15 @@ class LargeFaviconView: UIView {
         }
     }
     
+    func cancelLoading() {
+        fetcher = nil
+        imageView.image = UIImage()
+        imageView.contentMode = .scaleAspectFit
+        backgroundColor = .clear
+        layoutMargins = .zero
+        backgroundView.isHidden = false
+    }
+    
     private var fetcher: FaviconFetcher?
     
     private let imageView = UIImageView().then {

--- a/Client/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
@@ -87,11 +87,22 @@ class FavoritesSectionProvider: NSObject, NTPObservableSectionProvider {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        // swiftlint:disable:next force_cast
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FavoriteCell.identifier, for: indexPath) as! FavoriteCell
+        return collectionView.dequeueReusableCell(withReuseIdentifier: FavoriteCell.identifier, for: indexPath)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        
+        guard let cell = cell as? FavoriteCell else {
+            return
+        }
+        
         let fav = frc.object(at: IndexPath(item: indexPath.item, section: 0))
         cell.textLabel.textColor = .white
         cell.textLabel.text = fav.displayTitle ?? fav.url
+        
+        // Reset Fav-icon loading and image-view to default
+        cell.imageView.cancelLoading()
+        
         if let url = fav.url?.asURL {
             // All favorites should have domain's, but it was noticed at one
             // point that this wasn't the case, so for future bug-tracking
@@ -104,7 +115,6 @@ class FavoritesSectionProvider: NSObject, NTPObservableSectionProvider {
             cell.imageView.loadFavicon(siteURL: url, domain: domain, monogramFallbackCharacter: fav.title?.first)
         }
         cell.accessibilityLabel = cell.textLabel.text
-        return cell
     }
     
     private func itemSize(collectionView: UICollectionView, section: Int) -> CGSize {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes FavIcons rendering the wrong websites

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4120, #3818

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Reinstall many times OR re-launch the app many times. Eventually the fav-icons will mix up and render incorrectly.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
