### PR TITLE
Fix #4982: Revert 4903. Fixed unlock screen layout broken from landscape to portrait mode with biometric popup.

### DIFF
--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -93,6 +93,12 @@ public struct CryptoView: View {
     .environment(\.openWalletURLAction, .init(action: { url in
       openWalletURLAction?(url)
     }))
+    .onAppear {
+      if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
+        UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
+        UINavigationController.attemptRotationToDeviceOrientation()
+      }
+    }
   }
 }
 

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -72,7 +72,6 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     view.window?.addGestureRecognizer(gesture)
-    UIDevice.current.forcePortraitIfIphone(for: UIApplication.shared)
   }
   
   // MARK: -
@@ -82,7 +81,7 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
   }
   
   public override var shouldAutorotate: Bool {
-    true
+    false
   }
 }
 


### PR DESCRIPTION

This pull request fixes brave/brave-browser#36884 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open browser
2. Rotate to landscape
3. open wallet 
(after pass biometric popup, wallet should rotate to portrait)


## Screenshots:
https://user-images.githubusercontent.com/1187676/154757632-a02b03cf-5d25-46d4-a745-9cdf43ce0587.MP4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
