### PR TITLE
Fix #4352: Implement Playlist Folders

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1491,6 +1491,12 @@ extension Strings {
                               value: "Open In Private Tab",
                               comment: "Button Title of the ActionSheet/Alert Button when sharing a playlist item from the Swipe-Action")
         
+        public static let sharePlaylistMoveActionMenuTitle =
+            NSLocalizedString("playlist.movePlaylistShareActionMenuTitle",
+                              bundle: .braveShared,
+                              value: "Move...",
+                              comment: "Button Title of the ActionSheet/Alert Button when moving a playlist item from the Swipe-Action to a new folder")
+        
         public static let sharePlaylistShareActionMenuTitle =
             NSLocalizedString("playlist.sharePlaylistShareActionMenuTitle",
                               bundle: .braveShared,
@@ -1706,6 +1712,188 @@ extension Strings {
                               bundle: .braveShared,
                               value: "Brave Playlist",
                               comment: "The title of the playlist when in Carplay mode")
+        
+        public static let playlistCarplaySettingsSectionTitle =
+            NSLocalizedString("playlist.carplaySettingsSectionTitle",
+                              bundle: .braveShared,
+                              value: "Settings",
+                              comment: "The title of the section containing settings/options in CarPlay")
+        
+        public static let playlistCarplayOptionsScreenTitle =
+            NSLocalizedString("playlist.carplayOptionsScreenTitle",
+                              bundle: .braveShared,
+                              value: "Playback Options",
+                              comment: "The title of the screen in CarPlay that contains all the audio/playback options")
+        
+        public static let playlistCarplayRestartPlaybackOptionTitle =
+            NSLocalizedString("playlist.carplayRestartPlaybackOptionTitle",
+                              bundle: .braveShared,
+                              value: "Restart Playback",
+                              comment: "The title of the checkbox that allows the user to restart audio/video playback")
+        
+        public static let playlistCarplayRestartPlaybackOptionDetailsTitle =
+            NSLocalizedString("playlist.carplayRestartPlaybackOptionDetailsTitle",
+                              bundle: .braveShared,
+                              value: "Decide whether or not selecting an already playing item will restart playback, or continue playing where last left off",
+                              comment: "The description of the checkbox that allows the user to restart audio/video playback")
+        
+        public static let playlistCarplayRestartPlaybackButtonStateEnabled =
+            NSLocalizedString("playlist.carplayRestartPlaybackButtonStateEnabled",
+                              bundle: .braveShared,
+                              value: "Enabled. Tap to disable playback restarting.",
+                              comment: "The already enabled button title with instructions telling the user they can tap it to disable playback.")
+        
+        public static let playlistCarplayRestartPlaybackButtonStateDisabled =
+            NSLocalizedString("playlist.carplayRestartPlaybackButtonStateDisabled",
+                              bundle: .braveShared,
+                              value: "Disabled. Tap to enable playback restarting.",
+                              comment: "The already disabled button title with instructions telling the user they can tap it to enable playback.")
+        
+        public static let playlistSaveForOfflineButtonTitle =
+            NSLocalizedString("playlist.saveForOfflineButtonTitle",
+                              bundle: .braveShared,
+                              value: "Save for Offline",
+                              comment: "The title of the button indicating that the user can save a video for offline playback. (playing without internet)")
+        
+        public static let playlistDeleteForOfflineButtonTitle =
+            NSLocalizedString("playlist.deleteForOfflineButtonTitle",
+                              bundle: .braveShared,
+                              value: "Delete Offline Cache",
+                              comment: "The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline)")
+    }
+    
+    public struct PlaylistFolders {
+        public static let playlistSavedFolderTitle =
+            NSLocalizedString("playlistFolders.savedFolderTitle",
+                              bundle: .braveShared,
+                              value: "Saved",
+                              comment: "The title of the default playlist folder")
+        
+        public static let playlistUntitledFolderTitle =
+            NSLocalizedString("playlistFolders.untitledFolderTitle",
+                              bundle: .braveShared,
+                              value: "Untitled Folder",
+                              comment: "The title of a folder when the user enters no name (untitled)")
+        
+        public static let playlistEditFolderScreenTitle =
+            NSLocalizedString("playlistFolders.editFolderScreenTitle",
+                              bundle: .braveShared,
+                              value: "Edit Folder",
+                              comment: "The title of the screen where the user edits folder names")
+        
+        public static let playlistNewFolderScreenTitle =
+            NSLocalizedString("playlistFolders.newFolderScreenTitle",
+                              bundle: .braveShared,
+                              value: "New Folder",
+                              comment: "The title of the screen to create a new folder")
+        
+        public static let playlistNewFolderButtonTitle =
+            NSLocalizedString("playlistFolders.newFolderButtonTitle",
+                              bundle: .braveShared,
+                              value: "New Folder",
+                              comment: "The title of the button to create a new folder")
+        
+        public static let playlistCreateNewFolderButtonTitle =
+            NSLocalizedString("playlistFolders.createNewFolderButtonTitle",
+                              bundle: .braveShared,
+                              value: "Create",
+                              comment: "The title of the button to create a new folder")
+        
+        public static let playlistFolderSubtitleItemSingleCount =
+            NSLocalizedString("playlistFolders.subtitleItemSingleCount",
+                              bundle: .braveShared,
+                              value: "1 Item",
+                              comment: "The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item.")
+        
+        public static let playlistFolderSubtitleItemCount =
+            NSLocalizedString("playlistFolders.subtitleItemCount",
+                              bundle: .braveShared,
+                              value: "%lld Items",
+                              comment: "The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items.")
+        
+        public static let playlistFolderErrorSavingMessage =
+            NSLocalizedString("playlistFolders.errorSavingMessage",
+                              bundle: .braveShared,
+                              value: "Sorry we were unable to save the changes you made to this folder",
+                              comment: "The error shown to the user when we cannot save their changes made on a folder")
+        
+        public static let playlistFolderEditMenuTitle =
+            NSLocalizedString("playlistFolders.editMenuTitle",
+                              bundle: .braveShared,
+                              value: "Edit Folder",
+                              comment: "The title of the menu option that allows the user to edit the name of a folder")
+        
+        public static let playlistFolderEditButtonTitle =
+            NSLocalizedString("playlistFolders.editButtonTitle",
+                              bundle: .braveShared,
+                              value: "Edit",
+                              comment: "The title of the button that allows the user to edit the name of a folder")
+        
+        public static let playlistFolderNewFolderSectionTitle =
+            NSLocalizedString("playlistFolders.newFolderSectionTitle",
+                              bundle: .braveShared,
+                              value: "Add videos to this folder",
+                              comment: "The title of the section where the user can select videos to add to the new folder being created")
+        
+        public static let playlistFolderNewFolderSectionSubtitle =
+            NSLocalizedString("playlistFolders.newFolderSectionSubtitle",
+                              bundle: .braveShared,
+                              value: "Tap to select videos",
+                              comment: "The sub-title of the section where the user can select videos to add to the new folder being created")
+        
+        public static let playlistFolderMoveFolderCurrentSectionTitle =
+            NSLocalizedString("playlistFolders.moveFolderCurrentSectionTitle",
+                              bundle: .braveShared,
+                              value: "Current Folder",
+                              comment: "The title of the section indicating the currently selected folder")
+        
+        public static let playlistFolderSelectAFolderTitle =
+            NSLocalizedString("playlistFolders.selectAFolderTitle",
+                              bundle: .braveShared,
+                              value: "Select a folder to move %lld items to",
+                              comment: "The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'")
+        
+        public static let playlistFolderSelectASingleFolderTitle =
+            NSLocalizedString("playlistFolders.selectAFolderTitle",
+                              bundle: .braveShared,
+                              value: "Select a folder to move 1 item to",
+                              comment: "The title of the section indicating that the user should select a folder to move 1 item to.")
+        
+        public static let playlistFolderMoveFolderScreenTitle =
+            NSLocalizedString("playlistFolders.moveFolderScreenTitle",
+                              bundle: .braveShared,
+                              value: "Move",
+                              comment: "The title of the screen where the user will move an item from one folder to another folder.")
+        
+        public static let playlistFolderMoveFolderButtonTitle =
+            NSLocalizedString("playlistFolders.moveFolderButtonTitle",
+                              bundle: .braveShared,
+                              value: "Move",
+                              comment: "The title of the button where the user will move an item from one folder to another folder.")
+        
+        public static let playlistFolderMoveItemDescription =
+            NSLocalizedString("playlistFolders.moveItemDescription",
+                              bundle: .braveShared,
+                              value: "%@ and 1 more item",
+                              comment: "%@ Should NOT be localized. It is a placeholder. Example: Brave Folder and 1 more item.")
+        
+        public static let playlistFolderMoveMultipleItemDescription =
+            NSLocalizedString("playlistFolders.moveMultipleItemDescription",
+                              bundle: .braveShared,
+                              value: "%@ and %lld more items",
+                              comment: "%@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items.")
+        
+        public static let playlistFolderMoveItemWithNoNameTitle =
+            NSLocalizedString("playlistFolders.moveItemWithNoNameTitle",
+                              bundle: .braveShared,
+                              value: "1 item",
+                              comment: "Sometimes an item can have no name. So this is a generic title to use")
+        
+        public static let playlistFolderMoveItemWithMultipleNoNameTitle =
+            NSLocalizedString("playlistFolders.moveItemWithMultipleNoNameTitle",
+                              bundle: .braveShared,
+                              value: "%lld items",
+                              comment: "%lld is a placeholder and should not be localized. Sometimes items can have no name. So this is a generic title to use")
     }
 }
 

--- a/BraveShared/Extensions/UIColorExtensions.swift
+++ b/BraveShared/Extensions/UIColorExtensions.swift
@@ -25,4 +25,22 @@ extension UIColor {
         getWhite(&white, alpha: nil)
         return white > 0.5
     }
+    
+    public var slightlyDesaturated: UIColor {
+        desaturated(0.5)
+    }
+    
+    public func desaturated(_ desaturation: CGFloat) -> UIColor {
+        var h: CGFloat = 0, s: CGFloat = 0
+        var b: CGFloat = 0, a: CGFloat = 0
+
+        guard self.getHue(&h, saturation: &s, brightness: &b, alpha: &a) else {
+            return self
+        }
+
+        return UIColor(hue: h,
+                       saturation: max(s - desaturation, 0.0),
+                       brightness: b,
+                       alpha: a)
+    }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 		CA439A9025E80EE400FE9150 /* VideoPlayerTrackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA439A8F25E80EE400FE9150 /* VideoPlayerTrackbar.swift */; };
 		CA4B1F7D274D6DA9009C5BBA /* BraveSyncQRCodeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4B1F7C274D6DA8009C5BBA /* BraveSyncQRCodeModel.swift */; };
 		CA550490269DED8F00C19917 /* MediaBackgrounding.js in Resources */ = {isa = PBXBuildFile; fileRef = CA55048F269DED8F00C19917 /* MediaBackgrounding.js */; };
+		CA57F9D927AA4AAF000C8242 /* PlaylistNewFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57F9D827AA4AAF000C8242 /* PlaylistNewFolderView.swift */; };
 		CA752EA526CEABF8009356EF /* PlaylistToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA752EA426CEABF8009356EF /* PlaylistToast.swift */; };
 		CA752EB126CEBE52009356EF /* FontScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9A22FF26A7370C00923D70 /* FontScaling.swift */; };
 		CA7C5CAD2731928F003366F7 /* WelcomeViewSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7C5CAC2731928F003366F7 /* WelcomeViewSearchView.swift */; };
@@ -1074,6 +1075,7 @@
 		CA8D5C2726D7D0A8009BF13D /* MPRemoteCommandCenter+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8D5C2626D7D0A8009BF13D /* MPRemoteCommandCenter+Combine.swift */; };
 		CA8D5C2926D7D0C6009BF13D /* MediaPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8D5C2826D7D0C6009BF13D /* MediaPlayer.swift */; };
 		CA8D5C2C26D7D0F7009BF13D /* VideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8D5C2B26D7D0F7009BF13D /* VideoPlayer.swift */; };
+		CA939F5A27BADC7E006A9BB2 /* PlaylistMoveFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA939F5927BADC7E006A9BB2 /* PlaylistMoveFolderView.swift */; };
 		CA9A22FE26A71ADA00923D70 /* PlaylistPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9A22FD26A71ADA00923D70 /* PlaylistPopoverView.swift */; };
 		CA9A233426B97B4300923D70 /* PlaylistMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9A233326B97B4300923D70 /* PlaylistMenuButton.swift */; };
 		CA9A234126B97B8400923D70 /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9A234026B97B8400923D70 /* MenuButton.swift */; };
@@ -1090,6 +1092,9 @@
 		CABFA8F62728651C00B73E97 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFA8F52728651C00B73E97 /* WelcomeViewController.swift */; };
 		CAC2CB402644488600BB8D36 /* RecentSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC2CB3F2644488600BB8D36 /* RecentSearchHeaderView.swift */; };
 		CAC2CB4D2644496400BB8D36 /* RecentSearchClipboardHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC2CB4C2644496400BB8D36 /* RecentSearchClipboardHeaderView.swift */; };
+		CAC5342327A83DE000013056 /* PlaylistFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC5342227A83DE000013056 /* PlaylistFolder.swift */; };
+		CAC5342927A9B87600013056 /* PlaylistFolderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC5342827A9B87600013056 /* PlaylistFolderController.swift */; };
+		CAD0D5D927C007CC001071AC /* PlaylistEditFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD0D5D827C007CC001071AC /* PlaylistEditFolderView.swift */; };
 		CE7F11941F3CEEC800ABFC0B /* RemoteDevices.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */; };
 		D018F93E1F44A71A0098F8CA /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D018F93D1F44A7190098F8CA /* Schema.swift */; };
 		D029A04920A62DB0001DB72F /* TemporaryDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D029A04820A62DB0001DB72F /* TemporaryDocument.swift */; };
@@ -2991,6 +2996,7 @@
 		CA439A8F25E80EE400FE9150 /* VideoPlayerTrackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerTrackbar.swift; sourceTree = "<group>"; };
 		CA4B1F7C274D6DA8009C5BBA /* BraveSyncQRCodeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveSyncQRCodeModel.swift; sourceTree = "<group>"; };
 		CA55048F269DED8F00C19917 /* MediaBackgrounding.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = MediaBackgrounding.js; sourceTree = "<group>"; };
+		CA57F9D827AA4AAF000C8242 /* PlaylistNewFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistNewFolderView.swift; sourceTree = "<group>"; };
 		CA752EA426CEABF8009356EF /* PlaylistToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistToast.swift; sourceTree = "<group>"; };
 		CA7C5CAC2731928F003366F7 /* WelcomeViewSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewSearchView.swift; sourceTree = "<group>"; };
 		CA7C5CAE2731D022003366F7 /* PrivacyEverywhereView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyEverywhereView.swift; sourceTree = "<group>"; };
@@ -3008,6 +3014,7 @@
 		CA8D5C2626D7D0A8009BF13D /* MPRemoteCommandCenter+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPRemoteCommandCenter+Combine.swift"; sourceTree = "<group>"; };
 		CA8D5C2826D7D0C6009BF13D /* MediaPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayer.swift; sourceTree = "<group>"; };
 		CA8D5C2B26D7D0F7009BF13D /* VideoPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayer.swift; sourceTree = "<group>"; };
+		CA939F5927BADC7E006A9BB2 /* PlaylistMoveFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistMoveFolderView.swift; sourceTree = "<group>"; };
 		CA9A22FD26A71ADA00923D70 /* PlaylistPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPopoverView.swift; sourceTree = "<group>"; };
 		CA9A22FF26A7370C00923D70 /* FontScaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontScaling.swift; sourceTree = "<group>"; };
 		CA9A233326B97B4300923D70 /* PlaylistMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistMenuButton.swift; sourceTree = "<group>"; };
@@ -3025,6 +3032,10 @@
 		CABFA8F52728651C00B73E97 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
 		CAC2CB3F2644488600BB8D36 /* RecentSearchHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchHeaderView.swift; sourceTree = "<group>"; };
 		CAC2CB4C2644496400BB8D36 /* RecentSearchClipboardHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchClipboardHeaderView.swift; sourceTree = "<group>"; };
+		CAC5341727A83A1B00013056 /* Model14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model14.xcdatamodel; sourceTree = "<group>"; };
+		CAC5342227A83DE000013056 /* PlaylistFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistFolder.swift; sourceTree = "<group>"; };
+		CAC5342827A9B87600013056 /* PlaylistFolderController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistFolderController.swift; sourceTree = "<group>"; };
+		CAD0D5D827C007CC001071AC /* PlaylistEditFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistEditFolderView.swift; sourceTree = "<group>"; };
 		CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteDevices.swift; sourceTree = "<group>"; };
 		D000661320472890009BA6F6 /* __firefox__.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = __firefox__.js; sourceTree = "<group>"; };
 		D018F93D1F44A7190098F8CA /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
@@ -5421,6 +5432,7 @@
 				0A53F3E621E6560A0086E80C /* InMemoryDataController.swift */,
 				0AD0B33125CC6106002EF4F4 /* LegacyBookmark.swift */,
 				5EC0028126051D14005DDE4A /* PlaylistItem.swift */,
+				CAC5342227A83DE000013056 /* PlaylistFolder.swift */,
 				5EC0029726052341005DDE4A /* PlaylistInfo.swift */,
 				CAB127622639F37C00BBFC75 /* RecentSearches.swift */,
 				2F9311D42665883400C6B74D /* DataSaved.swift */,
@@ -5885,6 +5897,10 @@
 				CA8D5C1726D7CE2E009BF13D /* PlaylistViewController+AVDelegates.swift */,
 				CA8D5C1926D7CE46009BF13D /* PlaylistViewController.swift */,
 				CAADEFE126E2857F0020DC4C /* PlaylistCarplayController.swift */,
+				CAC5342827A9B87600013056 /* PlaylistFolderController.swift */,
+				CA57F9D827AA4AAF000C8242 /* PlaylistNewFolderView.swift */,
+				CA939F5927BADC7E006A9BB2 /* PlaylistMoveFolderView.swift */,
+				CAD0D5D827C007CC001071AC /* PlaylistEditFolderView.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -8127,6 +8143,7 @@
 				44FA2F3021F8DB1000EFA86A /* DataPreferences.swift in Sources */,
 				27FD3FA625C8CE4B00696156 /* RSSFeedSource.swift in Sources */,
 				5D1DC55620AE004600905E5A /* DataController.swift in Sources */,
+				CAC5342327A83DE000013056 /* PlaylistFolder.swift in Sources */,
 				2F29FB8B267BE06100B0AD6A /* Model.xcdatamodeld in Sources */,
 				5D1DC55520AE004600905E5A /* TabMO.swift in Sources */,
 				0A53F3E721E6560A0086E80C /* InMemoryDataController.swift in Sources */,
@@ -8309,6 +8326,7 @@
 				0A6E20492608D7E200575798 /* DebugFlag.swift in Sources */,
 				2F098F8B255F2D730084FB37 /* BrowserViewController+ReaderMode.swift in Sources */,
 				4422D57421BFFB7F00BF1855 /* prog.cc in Sources */,
+				CA939F5A27BADC7E006A9BB2 /* PlaylistMoveFolderView.swift in Sources */,
 				4422D42F21BFCF8900BF1855 /* HttpsEverywhereObjC.mm in Sources */,
 				4422D56B21BFFB7F00BF1855 /* prefilter_tree.cc in Sources */,
 				2F13B801273311CB00253A4D /* BrowserViewController+Callout.swift in Sources */,
@@ -8468,6 +8486,7 @@
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				0AADC4D220D2A6A200FDE368 /* FavoritesHelper.swift in Sources */,
 				5E34781022D7A1D200B0D5F8 /* ResourceDownloadManager.swift in Sources */,
+				CA57F9D927AA4AAF000C8242 /* PlaylistNewFolderView.swift in Sources */,
 				C690C2142130121E00E6EEE9 /* WebImageCacheManager.swift in Sources */,
 				A104E199210A384400D2323E /* ShieldsViewController.swift in Sources */,
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,
@@ -8736,9 +8755,11 @@
 				CA8D5C2426D7D07E009BF13D /* PlaylistThumbnailUtility.swift in Sources */,
 				4422D42C21BFCF8900BF1855 /* HttpsEverywhere.cpp in Sources */,
 				4422D50021BFFB7600BF1855 /* db_iter.cc in Sources */,
+				CAD0D5D927C007CC001071AC /* PlaylistEditFolderView.swift in Sources */,
 				27B68E9425C8911D002D0826 /* BraveNewsAddSourceViewController.swift in Sources */,
 				D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */,
 				4422D54621BFFB7E00BF1855 /* rune.cc in Sources */,
+				CAC5342927A9B87600013056 /* PlaylistFolderController.swift in Sources */,
 				2F198EE82603FDD900945AB3 /* AddSearchEngineActivity.swift in Sources */,
 				EB11A1052044A90E0018F749 /* TrackingProtectionPageStats.swift in Sources */,
 				0A93F1802264C2D200A3571B /* FolderDetailsView.swift in Sources */,
@@ -15193,6 +15214,7 @@
 		2F29FB7E267BE06100B0AD6A /* Model.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				CAC5341727A83A1B00013056 /* Model14.xcdatamodel */,
 				2F84BCF8267BE0A100850801 /* Model13.xcdatamodel */,
 				2F29FB7F267BE06100B0AD6A /* Model7.xcdatamodel */,
 				2F29FB80267BE06100B0AD6A /* Model2.xcdatamodel */,
@@ -15207,7 +15229,7 @@
 				2F29FB89267BE06100B0AD6A /* Model.xcdatamodel */,
 				2F29FB8A267BE06100B0AD6A /* Model9.xcdatamodel */,
 			);
-			currentVersion = 2F84BCF8267BE0A100850801 /* Model13.xcdatamodel */;
+			currentVersion = CAC5341727A83A1B00013056 /* Model14.xcdatamodel */;
 			path = Model.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -144,10 +144,38 @@ class Migration {
         }
     }
     
+    private static func movePlaylistV2Items() {
+        // Migrate all items not belonging to a folder
+        func migrateItemsToSavedFolder(folderUUID: String) {
+            let items = PlaylistItem.getItems(parentFolder: nil)
+            if !items.isEmpty {
+                PlaylistItem.moveItems(items: items.map({ $0.objectID }), to: folderUUID)
+            }
+            
+            Preferences.Migration.playlistV2FoldersInitialMigrationCompleted.value = true
+        }
+        
+        if PlaylistFolder.getFolder(uuid: PlaylistFolder.savedFolderUUID) != nil {
+            migrateItemsToSavedFolder(folderUUID: PlaylistFolder.savedFolderUUID)
+        } else {
+            PlaylistFolder.addFolder(title: Strings.PlaylistFolders.playlistSavedFolderTitle, uuid: PlaylistFolder.savedFolderUUID) { uuid in
+                if PlaylistFolder.getFolder(uuid: uuid) != nil {
+                    migrateItemsToSavedFolder(folderUUID: uuid)
+                } else {
+                    log.error("Failed Moving Playlist items to Saved Folder - Unknown Error")
+                }
+            }
+        }
+    }
+    
     static func postCoreDataInitMigrations() {
         if !Preferences.Migration.removeLargeFaviconsMigrationCompleted.value {
             FaviconMO.clearTooLargeFavicons()
             Preferences.Migration.removeLargeFaviconsMigrationCompleted.value = true
+        }
+        
+        if !Preferences.Migration.playlistV2FoldersInitialMigrationCompleted.value {
+            movePlaylistV2Items()
         }
         
         if Preferences.Migration.coreDataCompleted.value { return }
@@ -178,6 +206,8 @@ fileprivate extension Preferences {
             Option<Bool>(key: "migration.documents-dir-completed", default: false)
         static let playlistV1FileSettingsLocationCompleted =
             Option<Bool>(key: "migration.playlistv1-file-settings-location-completed", default: false)
+        static let playlistV2FoldersInitialMigrationCompleted =
+            Option<Bool>(key: "migration.playlistv2-folders-initial-migration-completed", default: false)
         static let removeLargeFaviconsMigrationCompleted =
             Option<Bool>(key: "migration.remove-large-favicons", default: false)
         // This is new preference introduced in iOS 1.32.3, tracks whether we should perform database migration.

--- a/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
+++ b/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
@@ -105,7 +105,6 @@ class PlaylistCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         preservesSuperviewLayoutMargins = false
-        selectionStyle = .none
         
         contentView.addSubview(iconStackView)
         contentView.addSubview(infoStackView)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -10,6 +10,7 @@ import MediaPlayer
 import Data
 import BraveShared
 import Shared
+import CoreData
 
 private let log = Logger.browserLogger
 
@@ -17,11 +18,13 @@ class PlaylistCarplayController: NSObject {
     private let player: MediaPlayer
     private let mediaStreamer: PlaylistMediaStreamer
     private let interfaceController: CPInterfaceController
+    private var folderObserver: AnyCancellable?
     private var playerStateObservers = Set<AnyCancellable>()
     private var assetStateObservers = Set<AnyCancellable>()
     private var assetLoadingStateObservers = Set<AnyCancellable>()
     private var playlistObservers = Set<AnyCancellable>()
-    private var playlistItemIds = [String]()
+    private let savedFolder = PlaylistFolder.getFolder(uuid: PlaylistFolder.savedFolderUUID)
+    private let frc = PlaylistFolder.frc(savedFolderContentsOnly: false)
     
     // For now, I have absolutely ZERO idea why the API says:
     // CPAllowedTemplates = CPAlertTemplate, invalid object CPActionSheetTemplate
@@ -35,14 +38,14 @@ class PlaylistCarplayController: NSObject {
         self.mediaStreamer = mediaStreamer
         super.init()
         
+        frc.delegate = self
         interfaceController.delegate = self
         
+        observeFolderStates()
         observePlayerStates()
         observePlaylistStates()
         PlaylistManager.shared.reloadData()
-        
-        playlistItemIds = PlaylistManager.shared.allItems.map { $0.pageSrc }
-        self.doLayout()
+        doLayout()
         
         DispatchQueue.main.async {
             // Workaround to see carplay NowPlaying on the simulator
@@ -50,6 +53,41 @@ class PlaylistCarplayController: NSObject {
             UIApplication.shared.endReceivingRemoteControlEvents()
             UIApplication.shared.beginReceivingRemoteControlEvents()
             #endif
+        }
+    }
+    
+    func observeFolderStates() {
+        folderObserver = PlaylistManager.shared.onCurrentFolderDidChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self = self else { return }
+                
+                if self.interfaceController.rootTemplate == self.interfaceController.topTemplate {
+                    // Nothing to Pop
+                    // Push the Folder Template
+                    let listTemplate = self.generatePlaylistListTemplate()
+                    self.interfaceController.pushTemplate(listTemplate, animated: true) { [weak self] success, error in
+                        if !success, let error = error {
+                            self?.displayErrorAlert(error: error)
+                        }
+                    }
+                    return
+                }
+                
+                // Pop to Root Template
+                self.interfaceController.popToRootTemplate(animated: false) { success, error in
+                    if !success, let error = error {
+                        self.displayErrorAlert(error: error)
+                    } else {
+                        // Push the Folder Template
+                        let listTemplate = self.generatePlaylistListTemplate()
+                        self.interfaceController.pushTemplate(listTemplate, animated: true) { [weak self] success, error in
+                            if !success, let error = error {
+                                self?.displayErrorAlert(error: error)
+                            }
+                        }
+                    }
+                }
         }
     }
     
@@ -66,7 +104,7 @@ class PlaylistCarplayController: NSObject {
             }
             
             let playlistTabTemplate = tabTemplate.templates.compactMap({ $0 as? CPListTemplate }).first(where: {
-                ($0.userInfo as? [String: String])?["id"] == "Playlist.Tab"
+                ($0.userInfo as? [String: String])?["id"] == "Playlist.Folder.List.Tab"
             })
             
             if let playlistTabTemplate = playlistTabTemplate {
@@ -152,67 +190,31 @@ class PlaylistCarplayController: NSObject {
     }
     
     private func doLayout() {
-        playlistItemIds = PlaylistManager.shared.allItems.map { $0.pageSrc }
+        do {
+            try frc.performFetch()
+        } catch {
+            log.error(error)
+            displayErrorAlert(error: error)
+        }
         
-        // PLAYLIST TEMPLATE
-        let playlistTemplate = generatePlaylistListTemplate()
+        // FOLDERS TEMPLATE
+        let foldersTemplate = generatePlaylistFolderListTemplate()
         
         // SETTINGS TEMPLATE
         let settingsTemplate = generateSettingsTemplate()
         
         // ALL TEMPLATES
         let tabTemplates: [CPTemplate] = [
-            playlistTemplate,
+            foldersTemplate,
             settingsTemplate
         ]
         
         self.interfaceController.delegate = self
         self.interfaceController.setRootTemplate(CPTabBarTemplate(templates: tabTemplates),
                                                  animated: true,
-                                                 completion: { success, error in
+                                                 completion: { [weak self] success, error in
             if !success, let error = error {
-                // Some cars do NOT support CPActionSheetTemplate
-                // So we MUST use CPAlertTemplate
-                if PlaylistCarplayController.mustUseCPAlertTemplate {
-                    let alert = CPAlertTemplate(titleVariants: [error.localizedDescription], actions: [
-                        CPAlertAction(title: Strings.PlayList.okayButtonTitle, style: .default, handler: { [weak self] _ in
-                            self?.interfaceController.dismissTemplate(animated: true, completion: { success, error in
-                                if !success, let error = error {
-                                    log.error(error)
-                                }
-                            })
-                        })
-                    ])
-                    
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        self.interfaceController.presentTemplate(alert, animated: true, completion: { success, error in
-                            if !success, let error = error {
-                                log.error(error)
-                            }
-                        })
-                    }
-                } else {
-                    // Can also use CPAlertTemplate, but it doesn't have a "Message" parameter.
-                    let alert = CPActionSheetTemplate(title: Strings.PlayList.sorryAlertTitle,
-                                                      message: error.localizedDescription,
-                                                      actions: [
-                        CPAlertAction(title: Strings.PlayList.okayButtonTitle, style: .default, handler: { [weak self] _ in
-                            self?.interfaceController.dismissTemplate(animated: true, completion: { success, error in
-                                if !success, let error = error {
-                                    log.error(error)
-                                }
-                            })
-                        })
-                    ])
-                    
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        self.interfaceController.presentTemplate(alert, animated: true, completion: { success, error in
-                            if !success, let error = error {
-                                log.error(error)
-                            }
-                        })
-                    }
-                }
+                self?.displayErrorAlert(error: error)
             }
          })
     }
@@ -232,18 +234,21 @@ class PlaylistCarplayController: NSObject {
             PlaylistCarplayManager.shared.currentlyPlayingItemIndex = PlaylistManager.shared.index(of: pageSrc) ?? -1
         }
         
-        // Map all items to their IDs
-        playlistItemIds = PlaylistManager.shared.allItems.map { $0.pageSrc }
+        do {
+            try frc.performFetch()
+        } catch {
+            log.error(error)
+        }
         
-        // PLAYLIST TEMPLATE
-        let playlistTemplate = generatePlaylistListTemplate()
+        // FOLDERS TEMPLATE
+        let foldersTemplate = generatePlaylistFolderListTemplate()
         
         // SETTINGS TEMPLATE
         let settingsTemplate = generateSettingsTemplate()
         
         // ALL TEMPLATES
         let tabTemplates: [CPTemplate] = [
-            playlistTemplate,
+            foldersTemplate,
             settingsTemplate
         ]
         
@@ -258,7 +263,59 @@ class PlaylistCarplayController: NSObject {
         tabBarTemplate.updateTemplates(tabTemplates)
     }
     
+    private func generatePlaylistFolderListTemplate() -> CPTemplate {
+        // Fetch all Playlist Folders
+        let folders = frc.fetchedObjects ?? []
+
+        // Construct Folders UI
+        let savedFolder = CPListItem(text: savedFolder?.title ?? "",
+                                     detailText: "\(savedFolder?.playlistItems?.count ?? 0) Items",
+                                     image: nil,
+                                     accessoryImage: nil,
+                                     accessoryType: .disclosureIndicator).then {
+            $0.handler = { [unowned self] _, completion in
+                // Display items in this folder
+                PlaylistManager.shared.currentFolder = self.savedFolder
+                completion()
+            }
+            
+            $0.userInfo = ["uuid": self.savedFolder?.uuid]
+        }
+        
+        let otherFolders = folders.compactMap { folder -> CPListItem? in
+            CPListItem(text: folder.title ?? "",
+                                      detailText: "\(folder.playlistItems?.count ?? 0) Items",
+                                      image: nil,
+                                      accessoryImage: nil,
+                                      accessoryType: .disclosureIndicator).then {
+                $0.handler = { _, completion in
+                    // Display items in this folder
+                    PlaylistManager.shared.currentFolder = folder
+                    completion()
+                }
+                
+                $0.userInfo = ["uuid": folder.uuid]
+            }
+        }
+        
+        // Template
+        let foldersTemplate = CPListTemplate(
+            title: Strings.PlayList.playlistCarplayTitle,
+            sections: [CPListSection(items: [savedFolder]),
+                       CPListSection(items: otherFolders)]
+        ).then {
+            $0.tabImage = UIImage(systemName: "list.star")
+            $0.emptyViewTitleVariants = [Strings.PlayList.noItemLabelTitle]
+            $0.emptyViewSubtitleVariants = [Strings.PlayList.noItemLabelDetailLabel]
+            $0.userInfo = ["id": "Playlist.Folders.Tab"]
+        }
+        return foldersTemplate
+    }
+    
     private func generatePlaylistListTemplate() -> CPTemplate {
+        // Map all items to their IDs
+        let playlistItemIds = PlaylistManager.shared.allItems.map { $0.pageSrc }
+        
         // Fetch all Playlist Items
         var listItems = [CPListItem]()
         listItems = playlistItemIds.compactMap { itemId -> CPListItem? in
@@ -347,24 +404,24 @@ class PlaylistCarplayController: NSObject {
         
         // Template
         let playlistTemplate = CPListTemplate(
-            title: "Playlist",
+            title: PlaylistManager.shared.currentFolder?.title ?? "",
             sections: [CPListSection(items: listItems)]
         ).then {
             $0.tabImage = UIImage(systemName: "list.star")
             $0.emptyViewTitleVariants = [Strings.PlayList.noItemLabelTitle]
             $0.emptyViewSubtitleVariants = [Strings.PlayList.noItemLabelDetailLabel]
-            $0.userInfo = ["id": "Playlist.Tab"]
+            $0.userInfo = ["id": "Playlist.Folder.List.Tab"]
         }
         return playlistTemplate
     }
     
     private func generateSettingsTemplate() -> CPTemplate {
         // Playback Options
-        let restartPlaybackOption = CPListItem(text: "Restart Playback",
-                                   detailText: "Decide whether or not selecting an already playing item will restart playback, or continue playing where last left off").then {
+        let restartPlaybackOption = CPListItem(text: Strings.PlayList.playlistCarplayRestartPlaybackOptionTitle,
+                                               detailText: Strings.PlayList.playlistCarplayRestartPlaybackOptionDetailsTitle).then {
             $0.handler = { [unowned self] listItem, completion in
                 let enableGridView = Preferences.Playlist.enableCarPlayRestartPlayback.value
-                let title = enableGridView ? "Enabled. Tap to disable playback restarting." : "Disabled. Tap to enable playback restarting"
+                let title = enableGridView ? Strings.PlayList.playlistCarplayRestartPlaybackButtonStateEnabled : Strings.PlayList.playlistCarplayRestartPlaybackButtonStateDisabled
                 let icon = enableGridView ? #imageLiteral(resourceName: "checkbox_on") : #imageLiteral(resourceName: "loginUnselected")
                 let button = CPGridButton(titleVariants: [title], image: icon) { [unowned self] button in
                     Preferences.Playlist.enableCarPlayRestartPlayback.value = !enableGridView
@@ -376,7 +433,7 @@ class PlaylistCarplayController: NSObject {
                 }
                 
                 self.interfaceController.pushTemplate(
-                    CPGridTemplate(title: "Playback Options", gridButtons: [button]),
+                    CPGridTemplate(title: Strings.PlayList.playlistCarplayOptionsScreenTitle, gridButtons: [button]),
                     animated: true,
                     completion: { success, error in
                         if !success, let error = error {
@@ -391,11 +448,11 @@ class PlaylistCarplayController: NSObject {
         
         // Sections
         let playbackSection = CPListSection(items: [restartPlaybackOption],
-                                            header: "Playback Options",
-                                            sectionIndexTitle: "Playback Options")
+                                            header: Strings.PlayList.playlistCarplayOptionsScreenTitle,
+                                            sectionIndexTitle: Strings.PlayList.playlistCarplayOptionsScreenTitle)
         
         // Template
-        let settingsTemplate = CPListTemplate(title: "Settings",
+        let settingsTemplate = CPListTemplate(title: Strings.PlayList.playlistCarplaySettingsSectionTitle,
                                               sections: [playbackSection]).then {
             $0.tabImage = UIImage(systemName: "gear")
         }
@@ -418,6 +475,17 @@ extension PlaylistCarplayController: CPInterfaceControllerDelegate {
 
     func templateDidDisappear(_ aTemplate: CPTemplate, animated: Bool) {
         log.debug("Template \(aTemplate.classForCoder) did disappear.")
+    }
+}
+
+extension PlaylistCarplayController: NSFetchedResultsControllerDelegate {
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        
+        reloadData()
+    }
+    
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        reloadData()
     }
 }
 
@@ -911,6 +979,51 @@ extension PlaylistCarplayController {
                     log.error(error)
                 }
             })
+        }
+    }
+    
+    private func displayErrorAlert(error: Error) {
+        // Some cars do NOT support CPActionSheetTemplate
+        // So we MUST use CPAlertTemplate
+        if PlaylistCarplayController.mustUseCPAlertTemplate {
+            let alert = CPAlertTemplate(titleVariants: [error.localizedDescription], actions: [
+                CPAlertAction(title: Strings.PlayList.okayButtonTitle, style: .default, handler: { [weak self] _ in
+                    self?.interfaceController.dismissTemplate(animated: true, completion: { success, error in
+                        if !success, let error = error {
+                            log.error(error)
+                        }
+                    })
+                })
+            ])
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                self.interfaceController.presentTemplate(alert, animated: true, completion: { success, error in
+                    if !success, let error = error {
+                        log.error(error)
+                    }
+                })
+            }
+        } else {
+            // Can also use CPAlertTemplate, but it doesn't have a "Message" parameter.
+            let alert = CPActionSheetTemplate(title: Strings.PlayList.sorryAlertTitle,
+                                              message: error.localizedDescription,
+                                              actions: [
+                CPAlertAction(title: Strings.PlayList.okayButtonTitle, style: .default, handler: { [weak self] _ in
+                    self?.interfaceController.dismissTemplate(animated: true, completion: { success, error in
+                        if !success, let error = error {
+                            log.error(error)
+                        }
+                    })
+                })
+            ])
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                self.interfaceController.presentTemplate(alert, animated: true, completion: { success, error in
+                    if !success, let error = error {
+                        log.error(error)
+                    }
+                })
+            }
         }
     }
 }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -268,8 +268,9 @@ class PlaylistCarplayController: NSObject {
         let folders = frc.fetchedObjects ?? []
 
         // Construct Folders UI
-        let savedFolder = CPListItem(text: savedFolder?.title ?? "",
-                                     detailText: "\(savedFolder?.playlistItems?.count ?? 0) Items",
+        let itemCount = savedFolder?.playlistItems?.count ?? 0
+        let savedFolder = CPListItem(text: savedFolder?.title ?? Strings.PlaylistFolders.playlistUntitledFolderTitle,
+                                     detailText: "\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))",
                                      image: nil,
                                      accessoryImage: nil,
                                      accessoryType: .disclosureIndicator).then {
@@ -283,8 +284,9 @@ class PlaylistCarplayController: NSObject {
         }
         
         let otherFolders = folders.compactMap { folder -> CPListItem? in
-            CPListItem(text: folder.title ?? "",
-                                      detailText: "\(folder.playlistItems?.count ?? 0) Items",
+            let itemCount = folder.playlistItems?.count ?? 0
+            return CPListItem(text: folder.title ?? Strings.PlaylistFolders.playlistUntitledFolderTitle,
+                                      detailText: "\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))",
                                       image: nil,
                                       accessoryImage: nil,
                                       accessoryType: .disclosureIndicator).then {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistDetailViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistDetailViewController.swift
@@ -79,7 +79,7 @@ class PlaylistDetailViewController: UIViewController, UIGestureRecognizerDelegat
         navigationController?.setNavigationBarHidden(false, animated: true)
         
         if navigationController?.isNavigationBarHidden == true {
-            splitViewController?.preferredDisplayMode = .primaryOverlay
+            splitViewController?.preferredDisplayMode = .oneOverSecondary
         }
     }
         
@@ -102,7 +102,7 @@ class PlaylistDetailViewController: UIViewController, UIGestureRecognizerDelegat
     @objc
     private func onDisplayModeChange() {
         updateSplitViewDisplayMode(
-            to: splitViewController?.displayMode == .primaryOverlay ? .secondaryOnly : .primaryOverlay)
+            to: splitViewController?.displayMode == .oneOverSecondary ? .secondaryOnly : .oneOverSecondary)
     }
     
     public func setVideoPlayer(_ videoPlayer: VideoView?) {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
@@ -1,0 +1,65 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Data
+import CoreData
+import Shared
+import BraveShared
+
+struct PlaylistEditFolderView: View {
+    @State private var folderName: String
+    private var currentFolder: NSManagedObjectID
+    private let currentFolderTitle: String
+    private var isEditDisabled: Bool {
+        folderName.isEmpty || currentFolderTitle == folderName
+    }
+    
+    var onCancelButtonPressed: (() -> Void)?
+    var onEditFolder: ((_ folderTitle: String) -> Void)?
+    
+    init(currentFolder: NSManagedObjectID, currentFolderTitle: String) {
+        self.currentFolder = currentFolder
+        self.currentFolderTitle = currentFolderTitle
+        self.folderName = currentFolderTitle
+    }
+    
+    var body: some View {
+        NavigationView {
+            List {
+                Section {
+                    TextField(currentFolderTitle, text: $folderName)
+                        .disableAutocorrection(true)
+                }
+                .listRowBackground(Color(.secondaryBraveGroupedBackground))
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle(Strings.PlaylistFolders.playlistEditFolderScreenTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationViewStyle(.stack)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.cancelButtonTitle) { onCancelButtonPressed?() }
+                    .foregroundColor(.white)
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Strings.saveButtonTitle) { onEditFolder?(folderName) }
+                    .foregroundColor(isEditDisabled ? Color(.braveDisabled) : .white)
+                    .disabled(isEditDisabled)
+                }
+            }
+        }
+        .environment(\.colorScheme, .dark)
+    }
+}
+
+#if DEBUG
+struct PlaylistEditFolderView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlaylistEditFolderView()
+    }
+}
+#endif

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
@@ -47,7 +47,7 @@ struct PlaylistEditFolderView: View {
                 
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Strings.saveButtonTitle) { onEditFolder?(folderName) }
-                    .foregroundColor(isEditDisabled ? Color(.secondaryBraveLabel) : .white)
+                    .foregroundColor(isEditDisabled ? Color(.braveDisabled) : .white)
                     .disabled(isEditDisabled)
                 }
             }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
@@ -47,7 +47,7 @@ struct PlaylistEditFolderView: View {
                 
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Strings.saveButtonTitle) { onEditFolder?(folderName) }
-                    .foregroundColor(isEditDisabled ? Color(.braveDisabled) : .white)
+                    .foregroundColor(isEditDisabled ? Color(.secondaryBraveLabel) : .white)
                     .disabled(isEditDisabled)
                 }
             }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
@@ -1,0 +1,584 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import BraveUI
+import CoreData
+import Data
+import SwiftUI
+import Shared
+
+private let log = Logger.browserLogger
+
+private enum Section: Int, CaseIterable {
+    case savedItems
+    case folders
+}
+
+class PlaylistFolderController: UIViewController {
+    private let cellIdentifier = "PlaylistCell"
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    private let savedFolder = PlaylistFolder.getFolder(uuid: PlaylistFolder.savedFolderUUID)
+    private let othersFRC = PlaylistFolder.frc(savedFolderContentsOnly: false)
+    
+    var onFolderSelected: ((_ playlistFolder: PlaylistFolder?) -> Void)?
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        
+        title = Strings.PlayList.playListSectionTitle
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        overrideUserInterfaceStyle = .dark
+        
+        do {
+            try othersFRC.performFetch()
+        } catch {
+            log.error("Error: \(error)")
+        }
+        
+        toolbarItems = [
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(title: Strings.PlaylistFolders.playlistNewFolderButtonTitle, style: .plain, target: self, action: #selector(onNewFolder(_:)))
+        ]
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(onDonePressed(_:)))
+        
+        view.addSubview(tableView)
+        tableView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        tableView.do {
+            $0.dataSource = self
+            $0.delegate = self
+            $0.dragDelegate = self
+            $0.dropDelegate = self
+            $0.dragInteractionEnabled = true
+        }
+        
+        tableView.reloadData()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // Reload the table when visible
+        othersFRC.delegate = self
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        // Avoid reloading the table while in the background
+        othersFRC.delegate = nil
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        // Reload the table only when completely visible
+        tableView.reloadData()
+    }
+    
+    @objc
+    private func onDonePressed(_ button: UIBarButtonItem) {
+        self.dismiss(animated: true)
+    }
+}
+
+extension PlaylistFolderController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return Section.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let section = Section(rawValue: section) else {
+            return 0
+        }
+        
+        switch section {
+        case .savedItems: return 1
+        case .folders: return othersFRC.fetchedObjects?.count ?? 0
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier) else {
+            return UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
+        }
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        
+        guard let section = Section(rawValue: indexPath.section) else {
+            return
+        }
+        
+        let folderIcon = UIImage(systemName: "folder")?.template
+        
+        switch section {
+        case .savedItems:
+            let itemCount = savedFolder?.playlistItems?.count ?? 0
+            
+            cell.imageView?.image = folderIcon
+            cell.textLabel?.text = Strings.PlaylistFolders.playlistSavedFolderTitle
+            cell.detailTextLabel?.text = "\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))"
+            cell.detailTextLabel?.textColor = .secondaryBraveLabel
+            cell.accessoryType = .disclosureIndicator
+            cell.selectionStyle = .none
+        case .folders:
+            guard let folder = othersFRC.fetchedObjects?[safe: indexPath.row] else {
+                return
+            }
+            
+            let itemCount = folder.playlistItems?.count ?? 0
+            
+            cell.imageView?.image = folderIcon
+            cell.textLabel?.text = folder.title
+            cell.detailTextLabel?.text = "\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))"
+            cell.detailTextLabel?.textColor = .secondaryBraveLabel
+            cell.accessoryType = .disclosureIndicator
+            cell.selectionStyle = .none
+        }
+    }
+}
+
+extension PlaylistFolderController: UITableViewDelegate {
+    
+    private func deleteFolder(folder: PlaylistFolder) {
+        PlaylistManager.shared.delete(folder: folder)
+        
+        do {
+            try self.othersFRC.performFetch()
+        } catch {
+            log.error("Error: \(error)")
+        }
+        
+        tableView.reloadData()
+    }
+    
+    private func onEditFolder(folderUUID: String) {
+        guard let folder = self.othersFRC.fetchedObjects?.first(where: { $0.uuid == folderUUID }) else {
+            return
+        }
+        
+        let folderID = folder.objectID
+        
+        var editView = PlaylistEditFolderView(currentFolder: folderID, currentFolderTitle: folder.title ?? "")
+        
+        editView.onCancelButtonPressed = { [weak self] in
+            self?.presentedViewController?.dismiss(animated: true, completion: nil)
+        }
+        
+        editView.onEditFolder = { [weak self] folderTitle in
+            guard let self = self else { return }
+            
+            DataController.performOnMainContext { context in
+                do {
+                    let folder = try context.existingObject(with: folderID) as? PlaylistFolder
+                    folder?.title = folderTitle
+                    
+                    DispatchQueue.main.async {
+                        self.presentedViewController?.dismiss(animated: true, completion: nil)
+                    }
+                } catch {
+                    log.error("Error Saving Folder Title: \(error)")
+                    
+                    DispatchQueue.main.async {
+                        let alert = UIAlertController(title: Strings.genericErrorTitle, message: Strings.PlaylistFolders.playlistFolderErrorSavingMessage, preferredStyle: .alert)
+                        
+                        alert.addAction(UIAlertAction(title: Strings.OBErrorOkay, style: .default, handler: { _ in
+                            self.presentedViewController?.dismiss(animated: true, completion: nil)
+                        }))
+                        self.present(alert, animated: true, completion: nil)
+                    }
+                }
+            }
+        }
+        
+        let hostingController = UIHostingController(rootView: editView.environment(\.managedObjectContext, DataController.swiftUIContext)).then {
+            $0.modalPresentationStyle = .formSheet
+        }
+        
+        present(hostingController, animated: true, completion: nil)
+    }
+    
+    @objc
+    private func onNewFolder(_ button: UIBarButtonItem) {
+        var playlistFolder = PlaylistNewFolderView()
+        playlistFolder.onCancelButtonPressed = { [weak self] in
+            self?.presentedViewController?.dismiss(animated: true, completion: nil)
+        }
+        
+        playlistFolder.onCreateFolder = { [weak self] folderTitle, selectedItems in
+            guard let self = self else { return }
+            self.presentedViewController?.dismiss(animated: true, completion: nil)
+            
+            let folderTitle = folderTitle.isEmpty ? Strings.PlaylistFolders.playlistUntitledFolderTitle : folderTitle
+            
+            PlaylistFolder.addFolder(title: folderTitle) { uuid in
+                PlaylistItem.moveItems(items: selectedItems, to: uuid)
+                
+                DispatchQueue.main.async {
+                    do {
+                        try self.othersFRC.performFetch()
+                    } catch {
+                        log.error("Error Reloading Table: \(error)")
+                    }
+                    
+                    self.tableView.reloadData()
+                }
+            }
+        }
+
+        let hostingController = UIHostingController(rootView: playlistFolder.environment(\.managedObjectContext, DataController.swiftUIContext)).then {
+            $0.modalPresentationStyle = .formSheet
+            $0.modalTransitionStyle = UIDevice.isIpad ? .crossDissolve : .coverVertical
+        }
+        
+        present(hostingController, animated: true, completion: nil)
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let section = Section(rawValue: indexPath.section) else {
+            return
+        }
+        
+        switch section {
+        case .savedItems:
+            onFolderSelected?(savedFolder)
+        case .folders:
+            onFolderSelected?(othersFRC.fetchedObjects?[safe: indexPath.row])
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        
+        guard let section = Section(rawValue: indexPath.section) else {
+            return nil
+        }
+        
+        if section == .savedItems {
+            return nil
+        }
+        
+        let editAction = UIContextualAction(style: .normal, title: nil, handler: { [weak self] (action, view, completionHandler) in
+            guard let self = self else { return }
+            
+            switch section {
+            case .savedItems:
+                break
+                
+            case .folders:
+                guard let folder = self.othersFRC.fetchedObjects?[safe: indexPath.row],
+                      let folderUUID = folder.uuid else {
+                    completionHandler(false)
+                    return
+                }
+                self.onEditFolder(folderUUID: folderUUID)
+            }
+            
+            completionHandler(true)
+        })
+        
+        let deleteAction = UIContextualAction(style: .normal, title: nil, handler: { [weak self] (action, view, completionHandler) in
+            guard let self = self else { return }
+            
+            switch section {
+            case .savedItems:
+                break
+                
+            case .folders:
+                guard let folder = self.othersFRC.fetchedObjects?[safe: indexPath.row] else {
+                    completionHandler(false)
+                    return
+                }
+                self.deleteFolder(folder: folder)
+            }
+            
+            completionHandler(true)
+        })
+        
+        editAction.image = UIImage(systemName: "pencil")
+        editAction.backgroundColor = .braveBlurple
+        
+        deleteAction.image = #imageLiteral(resourceName: "playlist_delete_item")
+        deleteAction.backgroundColor = .braveErrorLabel
+        
+        return UISwipeActionsConfiguration(actions: [deleteAction, editAction])
+    }
+    
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        
+        guard let section = Section(rawValue: indexPath.section),
+              section == .folders else {
+            return nil
+        }
+        
+        guard let folder = othersFRC.fetchedObjects?[safe: indexPath.row],
+              let folderUUID = folder.uuid else {
+            return nil
+        }
+        
+        let actionProvider: UIContextMenuActionProvider = { [weak self] _ in
+            return UIMenu(children: [
+                UIAction(title: Strings.PlaylistFolders.playlistFolderEditMenuTitle, image: UIImage(systemName: "pencil"), handler: { _ in
+                    guard let self = self else {
+                        return
+                    }
+                    
+                    self.onEditFolder(folderUUID: folderUUID)
+                }),
+                
+                UIAction(title: Strings.delete, image: UIImage(systemName: "trash"), attributes: .destructive, handler: { _ in
+                    guard let self = self else { return }
+                    self.othersFRC.fetchedObjects?.first(where: { $0.uuid == folderUUID })?.do {
+                        self.deleteFolder(folder: $0)
+                    }
+                })
+            ])
+        }
+
+        let identifier = NSDictionary(dictionary: ["folderUUID": folderUUID,
+                                                   "row": indexPath.row])
+        return UIContextMenuConfiguration(identifier: identifier, previewProvider: nil, actionProvider: actionProvider)
+    }
+    
+    func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        guard let identifier = configuration.identifier as? NSDictionary else {
+            return nil
+        }
+        
+        guard let folderUUID = identifier["folderUUID"] as? String,
+              let row = identifier["row"] as? Int,
+              row < othersFRC.fetchedObjects?.count ?? -1 else {
+            return nil
+        }
+        
+        guard let folder = othersFRC.fetchedObjects?[safe: row],
+              folderUUID == folder.uuid,
+              let cell = tableView.cellForRow(at: IndexPath(row: row, section: Section.folders.rawValue)) else {
+            return nil
+        }
+
+        let parameters = UIPreviewParameters()
+        parameters.visiblePath = UIBezierPath(roundedRect: cell.contentView.frame.with {
+            $0.size.width = cell.bounds.width
+        }, cornerRadius: 12.0)
+        parameters.backgroundColor = .tertiaryBraveBackground
+        
+        return UITargetedPreview(view: cell, parameters: parameters)
+    }
+    
+    func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        self.tableView(tableView, previewForHighlightingContextMenuWithConfiguration: configuration)
+    }
+}
+
+extension PlaylistFolderController: NSFetchedResultsControllerDelegate {
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        
+        if parent != nil, tableView.hasActiveDrag || tableView.hasActiveDrop { return }
+        
+        var indexPath = indexPath
+        var newIndexPath = newIndexPath
+        
+        indexPath?.section = Section.folders.rawValue
+        newIndexPath?.section = Section.folders.rawValue
+        
+        switch type {
+            case .insert:
+                guard let newIndexPath = newIndexPath else { break }
+                tableView.insertRows(at: [newIndexPath], with: .fade)
+            case .delete:
+                guard let indexPath = indexPath else { break }
+                tableView.deleteRows(at: [indexPath], with: .fade)
+            case .update:
+                guard let indexPath = indexPath else { break }
+                tableView.reloadRows(at: [indexPath], with: .fade)
+            case .move:
+                guard let indexPath = indexPath,
+                      let newIndexPath = newIndexPath else { break }
+                tableView.deleteRows(at: [indexPath], with: .fade)
+                tableView.insertRows(at: [newIndexPath], with: .fade)
+            default:
+                break
+        }
+    }
+    
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        if parent != nil, tableView.hasActiveDrag || tableView.hasActiveDrop { return }
+        tableView.endUpdates()
+    }
+    
+    func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        if parent != nil, tableView.hasActiveDrag || tableView.hasActiveDrop { return }
+        tableView.beginUpdates()
+    }
+}
+
+// MARK: - Reordering of cells
+
+extension PlaylistFolderController: UITableViewDragDelegate, UITableViewDropDelegate {
+    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        guard let section = Section(rawValue: indexPath.section) else {
+            return false
+        }
+        return section == .folders
+    }
+    
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        .none
+    }
+    
+    func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        false
+    }
+    
+    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        
+        if sourceIndexPath.section != destinationIndexPath.section {
+            return
+        }
+        
+        var sourceIndexPath = sourceIndexPath
+        var destinationIndexPath = destinationIndexPath
+        sourceIndexPath.section = 0
+        destinationIndexPath.section = 0
+        
+        reorderItems(from: sourceIndexPath, to: destinationIndexPath) { [weak self] in
+            guard let self = self else { return }
+            
+            do {
+                try self.othersFRC.performFetch()
+            } catch {
+                log.error("Error Reloading Data: \(error)")
+            }
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        
+        if indexPath.section != Section.folders.rawValue {
+            return []
+        }
+        
+        let item = othersFRC.fetchedObjects?[safe: indexPath.row]
+        let dragItem = UIDragItem(itemProvider: NSItemProvider())
+        dragItem.localObject = item
+        return [dragItem]
+    }
+    
+    func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
+
+        var dropProposal = UITableViewDropProposal(operation: .cancel)
+        guard session.items.count == 1 else { return dropProposal }
+        
+        if destinationIndexPath?.section != Section.folders.rawValue {
+            return dropProposal
+        }
+        
+        if tableView.hasActiveDrag {
+            dropProposal = UITableViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+        }
+        return dropProposal
+    }
+        
+    func tableView(_ tableView: UITableView, performDropWith coordinator: UITableViewDropCoordinator) {
+        guard let sourceIndexPath = coordinator.items.first?.sourceIndexPath else {
+            return
+        }
+        
+        let destinationIndexPath: IndexPath
+        if let indexPath = coordinator.destinationIndexPath {
+            destinationIndexPath = indexPath
+        } else {
+            let section = tableView.numberOfSections - 1
+            let row = tableView.numberOfRows(inSection: section)
+            destinationIndexPath = IndexPath(row: row, section: section)
+        }
+        
+        guard let section = Section(rawValue: destinationIndexPath.section),
+              section == .folders else {
+            return
+        }
+        
+        if coordinator.proposal.operation == .move {
+            guard let item = coordinator.items.first else { return }
+            _ = coordinator.drop(item.dragItem, toRowAt: destinationIndexPath)
+            tableView.moveRow(at: sourceIndexPath, to: destinationIndexPath)
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, dragPreviewParametersForRowAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        guard let cell = tableView.cellForRow(at: indexPath) else { return nil }
+        
+        let preview = UIDragPreviewParameters()
+        preview.visiblePath = UIBezierPath(roundedRect: cell.contentView.frame.with {
+            $0.size.width = cell.bounds.width
+        }, cornerRadius: 12.0)
+        preview.backgroundColor = .tertiaryBraveBackground
+        return preview
+    }
+
+    func tableView(_ tableView: UITableView, dropPreviewParametersForRowAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        guard let cell = tableView.cellForRow(at: indexPath) else { return nil }
+        
+        let preview = UIDragPreviewParameters()
+        preview.visiblePath = UIBezierPath(roundedRect: cell.contentView.frame.with {
+            $0.size.width = cell.bounds.width
+        }, cornerRadius: 12.0)
+        preview.backgroundColor = .tertiaryBraveBackground
+        return preview
+    }
+    
+    func tableView(_ tableView: UITableView, dragSessionIsRestrictedToDraggingApplication session: UIDragSession) -> Bool {
+        true
+    }
+    
+    func reorderItems(from sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath, completion: (() -> Void)?) {
+        guard var objects = othersFRC.fetchedObjects else {
+            ensureMainThread {
+                completion?()
+            }
+            return
+        }
+
+        othersFRC.managedObjectContext.perform { [weak self] in
+            defer {
+                ensureMainThread {
+                    completion?()
+                }
+            }
+            
+            guard let self = self else { return }
+            
+            let src = self.othersFRC.object(at: sourceIndexPath)
+            objects.remove(at: sourceIndexPath.row)
+            objects.insert(src, at: destinationIndexPath.row)
+            
+            for (order, item) in objects.enumerated().reversed() {
+                item.order = Int32(order)
+            }
+            
+            do {
+                try self.othersFRC.managedObjectContext.save()
+            } catch {
+                log.error(error)
+            }
+        }
+    }
+}

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
@@ -24,7 +24,7 @@ class PlaylistFolderController: UIViewController {
     private let savedFolder = PlaylistFolder.getFolder(uuid: PlaylistFolder.savedFolderUUID)
     private let othersFRC = PlaylistFolder.frc(savedFolderContentsOnly: false)
     
-    var onFolderSelected: ((_ playlistFolder: PlaylistFolder?) -> Void)?
+    var onFolderSelected: ((_ playlistFolder: PlaylistFolder) -> Void)?
     
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -259,9 +259,13 @@ extension PlaylistFolderController: UITableViewDelegate {
         
         switch section {
         case .savedItems:
-            onFolderSelected?(savedFolder)
+            if let savedFolder = savedFolder {
+                onFolderSelected?(savedFolder)
+            }
         case .folders:
-            onFolderSelected?(othersFRC.fetchedObjects?[safe: indexPath.row])
+            if let folder = othersFRC.fetchedObjects?[safe: indexPath.row] {
+                onFolderSelected?(folder)
+            }
         }
     }
     

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+DragDropDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+DragDropDelegate.swift
@@ -5,22 +5,11 @@
 
 import Foundation
 import UIKit
+import BraveUI
 
 // MARK: - Reordering of cells
 
 extension PlaylistListViewController: UITableViewDragDelegate, UITableViewDropDelegate {
-    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        true
-    }
-    
-    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        .none
-    }
-    
-    func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
-        false
-    }
-    
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         PlaylistManager.shared.reorderItems(from: sourceIndexPath, to: destinationIndexPath) {
             PlaylistManager.shared.reloadData()
@@ -68,7 +57,7 @@ extension PlaylistListViewController: UITableViewDragDelegate, UITableViewDropDe
         
         let preview = UIDragPreviewParameters()
         preview.visiblePath = UIBezierPath(roundedRect: cell.contentView.frame, cornerRadius: 12.0)
-        preview.backgroundColor = slightlyLighterColour(color: UIColor.braveBackground)
+        preview.backgroundColor = .tertiaryBraveBackground
         return preview
     }
 
@@ -77,24 +66,11 @@ extension PlaylistListViewController: UITableViewDragDelegate, UITableViewDropDe
         
         let preview = UIDragPreviewParameters()
         preview.visiblePath = UIBezierPath(roundedRect: cell.contentView.frame, cornerRadius: 12.0)
-        preview.backgroundColor = slightlyLighterColour(color: UIColor.braveBackground)
+        preview.backgroundColor = .tertiaryBraveBackground
         return preview
     }
     
     func tableView(_ tableView: UITableView, dragSessionIsRestrictedToDraggingApplication session: UIDragSession) -> Bool {
         true
-    }
-    
-    private func slightlyLighterColour(color: UIColor) -> UIColor {
-        let desaturation: CGFloat = 0.5
-        var h: CGFloat = 0, s: CGFloat = 0
-        var b: CGFloat = 0, a: CGFloat = 0
-
-        guard color.getHue(&h, saturation: &s, brightness: &b, alpha: &a) else {return color}
-
-        return UIColor(hue: h,
-                       saturation: max(s - desaturation, 0.0),
-                       brightness: b,
-                       alpha: a)
     }
 }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
@@ -9,6 +9,7 @@ import AVKit
 import AVFoundation
 import Data
 import Shared
+import BraveUI
 
 private let log = Logger.browserLogger
 
@@ -41,6 +42,14 @@ extension PlaylistListViewController: UITableViewDataSource {
         }
     }
     
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        true
+    }
+    
+    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        !tableView.isEditing
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         PlaylistManager.shared.numberOfAssets
     }
@@ -71,13 +80,16 @@ extension PlaylistListViewController: UITableViewDataSource {
         let domain = URL(string: item.pageSrc)?.baseDomain ?? "0s"
         
         cell.do {
-            $0.selectionStyle = .none
+            $0.showsReorderControl = false
             $0.titleLabel.text = item.name
             $0.detailLabel.text = domain
             $0.contentView.backgroundColor = .clear
             $0.backgroundColor = .clear
             $0.thumbnailView.image = nil
             $0.thumbnailView.backgroundColor = .black
+            $0.selectedBackgroundView = UIView().then {
+                $0.backgroundColor = .tertiaryBraveBackground
+            }
         }
         
         let cacheState = PlaylistManager.shared.state(for: item.pageSrc)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -466,12 +466,6 @@ class PlaylistListViewController: UIViewController {
                     tableView.snp.remakeConstraints {
                         $0.edges.equalToSuperview()
                     }
-                    
-                    // On iPhone-8, 14.4, I need to scroll the tableView after setting its contentOffset and contentInset
-                    // Otherwise the layout is broken when exiting fullscreen in portrait mode.
-                    if PlaylistManager.shared.numberOfAssets > 0 {
-                        tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
-                    }
                 }
             } else {
                 playerView.snp.remakeConstraints {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -530,7 +530,12 @@ extension PlaylistListViewController {
         if PlaylistManager.shared.numberOfAssets > 0 {
             tableView.backgroundView = nil
             tableView.separatorStyle = .singleLine
-            navigationController?.setToolbarHidden(false, animated: true)
+            
+            if !playerView.isFullscreen, UIDevice.current.orientation.isLandscape && UIDevice.isPhone {
+                navigationController?.setToolbarHidden(true, animated: true)
+            } else {
+                navigationController?.setToolbarHidden(false, animated: true)
+            }
         } else {
             let messageLabel = UILabel(frame: view.bounds).then {
                 $0.text = Strings.PlayList.noItemLabelTitle

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -16,6 +16,7 @@ import SDWebImage
 import BraveShared
 import Shared
 import Data
+import SwiftUI
 
 private let log = Logger.browserLogger
 
@@ -36,8 +37,8 @@ class PlaylistListViewController: UIViewController {
     
     weak var delegate: PlaylistViewControllerDelegate?
     private let playerView: VideoView
-    private let contentManager = MPPlayableContentManager.shared()
     private var observers = Set<AnyCancellable>()
+    private var folderObserver: AnyCancellable?
     private(set) var autoPlayEnabled = Preferences.Playlist.firstLoadAutoPlay.value
     var playerController: AVPlayerViewController?
     
@@ -120,12 +121,56 @@ class PlaylistListViewController: UIViewController {
             $0.dragDelegate = self
             $0.dropDelegate = self
             $0.dragInteractionEnabled = true
+            $0.allowsMultipleSelectionDuringEditing = true
         }
-
+        
+        toolbarItems = [
+            UIBarButtonItem(title: Strings.PlaylistFolders.playlistFolderEditButtonTitle, style: .plain, target: self, action: #selector(onEditItems)),
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        ]
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        title = PlaylistManager.shared.currentFolder?.title
+        
         // Update
         DispatchQueue.main.async {
             self.fetchResults()
         }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        folderObserver = PlaylistManager.shared.onCurrentFolderDidChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self = self else { return }
+                self.title = PlaylistManager.shared.currentFolder?.title
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        onCancelEditingItems()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        folderObserver = nil
+        if isMovingFromParent || isBeingDismissed {
+            delegate?.stopPlaying()
+        }
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        updateTableBackgroundView()
     }
     
     // MARK: Internal
@@ -134,6 +179,11 @@ class PlaylistListViewController: UIViewController {
         updateTableBackgroundView()
         playerView.setControlsEnabled(false)
         
+        if let initialItem = initialItem,
+            let item = PlaylistItem.getItem(pageSrc: initialItem.pageSrc) {
+            PlaylistManager.shared.currentFolder = item.playlistFolder
+        }
+        
         let initialItem = self.initialItem
         let initialItemOffset = self.initialItemPlaybackOffset
         self.initialItem = nil
@@ -141,7 +191,6 @@ class PlaylistListViewController: UIViewController {
         
         PlaylistManager.shared.reloadData()
         tableView.reloadData()
-        contentManager.reloadData()
         
         // After reloading all data, update the background
         guard PlaylistManager.shared.numberOfAssets > 0 else {
@@ -172,6 +221,12 @@ class PlaylistListViewController: UIViewController {
             
             tableView.delegate?.tableView?(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
             autoPlayEnabled = true
+            return
+        }
+        
+        // If the current item is already playing, do nothing.
+        if let currentItemSrc = PlaylistCarplayManager.shared.currentPlaylistItem?.pageSrc,
+           PlaylistManager.shared.index(of: currentItemSrc) != nil {
             return
         }
         
@@ -248,9 +303,114 @@ class PlaylistListViewController: UIViewController {
     
     // MARK: Actions
     
+    func updateToolbar(editing: Bool) {
+        if editing {
+            if PlaylistFolder.getOtherFoldersCount() == 0 {
+                toolbarItems = [
+                    UIBarButtonItem(title: Strings.cancelButtonTitle, style: .plain, target: self, action: #selector(onCancelEditingItems)),
+                    UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                    UIBarButtonItem(title: Strings.delete, style: .plain, target: self, action: #selector(onDeleteEditingItems))
+                ]
+            } else {
+                toolbarItems = [
+                    UIBarButtonItem(title: Strings.cancelButtonTitle, style: .plain, target: self, action: #selector(onCancelEditingItems)),
+                    UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                    UIBarButtonItem(title: Strings.PlaylistFolders.playlistFolderMoveFolderButtonTitle, style: .plain, target: self, action: #selector(onMoveEditingItems)).then {
+                        $0.isEnabled = !(tableView.indexPathsForSelectedRows?.isEmpty ?? true)
+                    },
+                    UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                    UIBarButtonItem(title: Strings.delete, style: .plain, target: self, action: #selector(onDeleteEditingItems))
+                ]
+            }
+        } else {
+            toolbarItems = [
+                UIBarButtonItem(title: Strings.PlaylistFolders.playlistFolderEditButtonTitle, style: .plain, target: self, action: #selector(onEditItems)),
+                UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            ]
+        }
+    }
+    
+    func moveItems(indexPaths: [IndexPath]) {
+        delegate?.pausePlaying()
+        onCancelEditingItems()
+        
+        let selectedItems = indexPaths.compactMap({
+            PlaylistManager.shared.fetchedObjects[safe: $0.row]
+        })
+        
+        var moveController = PlaylistMoveFolderView(selectedItems: selectedItems)
+        moveController.onCancelButtonPressed = { [weak self] in
+            self?.presentedViewController?.dismiss(animated: true, completion: nil)
+        }
+        
+        moveController.onDoneButtonPressed = { [weak self] items, folder in
+            guard let self = self else { return }
+            self.presentedViewController?.dismiss(animated: true, completion: nil)
+            
+            // We moved an item that was playing
+            if items.firstIndex(where: { PlaylistInfo(item: $0).pageSrc == PlaylistCarplayManager.shared.currentPlaylistItem?.pageSrc }) != nil {
+                self.delegate?.stopPlaying()
+            }
+            
+            // We moved all items in this folder
+            if items.count == selectedItems.count {
+                self.navigationController?.popViewController(animated: true)
+            }
+            
+            PlaylistItem.moveItems(items: items.map({ $0.objectID }), to: folder?.uuid)
+        }
+        
+        let hostingController = UIHostingController(rootView: moveController.environment(\.managedObjectContext, DataController.swiftUIContext)).then {
+            $0.modalPresentationStyle = .formSheet
+        }
+        
+        present(hostingController, animated: true, completion: nil)
+    }
+    
     @objc
     private func onExit(_ button: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
+    }
+    
+    @objc
+    private func onEditItems() {
+        if tableView.isEditing {
+            // If already editing, such as when swiping on a cell,
+            // dismiss the trailing swipe and show the selections instead.
+            tableView.setEditing(false, animated: false)
+            tableView.setEditing(true, animated: false)
+        } else {
+            tableView.setEditing(true, animated: true)
+        }
+        
+        updateToolbar(editing: true)
+    }
+    
+    @objc
+    private func onCancelEditingItems() {
+        tableView.setEditing(false, animated: true)
+        updateToolbar(editing: false)
+    }
+    
+    @objc
+    private func onMoveEditingItems() {
+        moveItems(indexPaths: tableView.indexPathsForSelectedRows ?? [])
+    }
+    
+    @objc
+    private func onDeleteEditingItems() {
+        let selection = tableView.indexPathsForSelectedRows ?? []
+        onCancelEditingItems()
+        
+        let rows = selection.map({
+            (index: $0.row, item: PlaylistManager.shared.itemAtIndex($0.row))
+        })
+        
+        for row in rows {
+            if let item = row.item {
+                delegate?.deleteItem(item: item, at: row.index)
+            }
+        }
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -370,6 +530,7 @@ extension PlaylistListViewController {
         if PlaylistManager.shared.numberOfAssets > 0 {
             tableView.backgroundView = nil
             tableView.separatorStyle = .singleLine
+            navigationController?.setToolbarHidden(false, animated: true)
         } else {
             let messageLabel = UILabel(frame: view.bounds).then {
                 $0.text = Strings.PlayList.noItemLabelTitle
@@ -378,10 +539,17 @@ extension PlaylistListViewController {
                 $0.textAlignment = .center
                 $0.font = .systemFont(ofSize: 18.0, weight: .medium)
                 $0.sizeToFit()
+                
+                let offset = abs(tableView.contentOffset.y)
+                $0.frame.center.x = tableView.bounds.center.x
+                $0.frame.origin.y = offset + ((tableView.bounds.height - offset) / 2.0)
             }
             
-            tableView.backgroundView = messageLabel
+            tableView.backgroundView = UIView().then {
+                $0.addSubview(messageLabel)
+            }
             tableView.separatorStyle = .none
+            navigationController?.setToolbarHidden(true, animated: true)
         }
     }
     
@@ -505,7 +673,7 @@ extension PlaylistListViewController {
 
 // MARK: - PlaylistManagerDelegate
 
-extension PlaylistListViewController: PlaylistManagerDelegate {
+extension PlaylistListViewController {
     func updateCellDownloadStatus(indexPath: IndexPath, cell: PlaylistCell?, state: PlaylistDownloadManager.DownloadState, percentComplete: Double?) {
         
         guard let cell = cell ?? tableView.cellForRow(at: indexPath) as? PlaylistCell else {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
@@ -10,20 +10,16 @@ import CoreData
 import Shared
 import BraveShared
 
-private struct PlaylistFolderImage: View, Identifiable {
+private struct PlaylistFolderImage: View {
+    let item: PlaylistItem
+    
     static let cornerRadius = 5.0
     private static let favIconSize = 16.0
-    private let item: PlaylistItem
     @StateObject private var thumbnailLoader = PlaylistFolderImageLoader()
     @StateObject private var favIconLoader = PlaylistFolderImageLoader()
-    @State private var thumbnail = UIImage()
-    @State private var favIcon = UIImage()
-    
-    let id: String
     
     init(item: PlaylistItem) {
         self.item = item
-        id = item.id
     }
     
     var body: some View {
@@ -54,23 +50,26 @@ private struct PlaylistFolderView: View {
     @ScaledMetric private var imageSize = 28.0
     
     var body: some View {
-        HStack(spacing: 10.0) {
-            Image(systemName: "folder")
-                .foregroundColor(isSourceFolder ? Color(.secondaryBraveLabel) : Color(.braveOrange))
-                .frame(width: imageSize)
-            
-            VStack(alignment: .leading) {
-                if let folder = folder {
-                    let itemCount = folder.playlistItems?.count ?? 0
-                    
-                    Text(folder.title ?? "")
-                        .font(.body)
-                        .foregroundColor(isSourceFolder ? Color(.secondaryBraveLabel) : .white)
-                    Text("\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))")
-                        .font(.footnote)
-                        .foregroundColor(Color(.secondaryBraveLabel))
+        HStack {
+            HStack(spacing: 10.0) {
+                Image(systemName: "folder")
+                    .foregroundColor(isSourceFolder ? Color(.braveDisabled.resolvedColor(with: .init(userInterfaceStyle: .light))) : Color(.braveOrange))
+                    .frame(width: imageSize)
+                
+                VStack(alignment: .leading) {
+                    if let folder = folder {
+                        let itemCount = folder.playlistItems?.count ?? 0
+                        
+                        Text(folder.title ?? "")
+                            .font(.body)
+                            .foregroundColor(.white)
+                        Text("\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))")
+                            .font(.footnote)
+                            .foregroundColor(Color(.secondaryBraveLabel))
+                    }
                 }
             }
+            .opacity(isSourceFolder ? 0.5 : 1.0)
             
             Spacer()
             
@@ -79,7 +78,7 @@ private struct PlaylistFolderView: View {
                     .foregroundColor(.white)
             }
         }
-        .padding(.vertical, 7.0)
+        .padding(.vertical, 6.0)
     }
 }
 
@@ -194,15 +193,15 @@ struct PlaylistMoveFolderView: View {
                     }
                     
                     // Show all folders except the current one
-                    ForEach(folders) { folder in
-                        if folder.uuid != PlaylistManager.shared.currentFolder?.uuid {
-                            Button(action: {
-                                selectedFolder = folder
-                            }) {
-                                PlaylistFolderView(isSourceFolder: false,
-                                                   folder: folder,
-                                                   selectedFolder: $selectedFolder)
-                            }
+                    ForEach(
+                        folders.filter { $0.uuid != PlaylistManager.shared.currentFolder?.uuid }
+                    ) { folder in
+                        Button(action: {
+                            selectedFolder = folder
+                        }) {
+                            PlaylistFolderView(isSourceFolder: false,
+                                               folder: folder,
+                                               selectedFolder: $selectedFolder)
                         }
                     }
                 }
@@ -220,7 +219,7 @@ struct PlaylistMoveFolderView: View {
                 
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Strings.done) { onDoneButtonPressed?(selectedItems, selectedFolder) }
-                    .foregroundColor(isMoveDisabled ? Color(.secondaryBraveLabel) : .white)
+                    .foregroundColor(isMoveDisabled ? Color(.braveDisabled) : .white)
                     .disabled(isMoveDisabled)
                 }
             }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
@@ -51,11 +51,13 @@ private struct PlaylistFolderView: View {
     let isSourceFolder: Bool
     let folder: PlaylistFolder?
     @Binding var selectedFolder: PlaylistFolder?
+    @ScaledMetric private var imageSize = 28.0
     
     var body: some View {
-        HStack(spacing: 12.0) {
+        HStack(spacing: 10.0) {
             Image(systemName: "folder")
-                .foregroundColor(isSourceFolder ? Color(.braveDisabled) : Color(.braveOrange))
+                .foregroundColor(isSourceFolder ? Color(.secondaryBraveLabel) : Color(.braveOrange))
+                .frame(width: imageSize)
             
             VStack(alignment: .leading) {
                 if let folder = folder {
@@ -63,12 +65,10 @@ private struct PlaylistFolderView: View {
                     
                     Text(folder.title ?? "")
                         .font(.body)
-                        .foregroundColor(.white)
-                        .opacity(isSourceFolder ? 0.5 : 1.0)
+                        .foregroundColor(isSourceFolder ? Color(.secondaryBraveLabel) : .white)
                     Text("\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))")
                         .font(.footnote)
-                        .foregroundColor(.white)
-                        .opacity(0.5)
+                        .foregroundColor(Color(.secondaryBraveLabel))
                 }
             }
             
@@ -220,7 +220,7 @@ struct PlaylistMoveFolderView: View {
                 
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Strings.done) { onDoneButtonPressed?(selectedItems, selectedFolder) }
-                    .foregroundColor(isMoveDisabled ? Color(.braveDisabled) : .white)
+                    .foregroundColor(isMoveDisabled ? Color(.secondaryBraveLabel) : .white)
                     .disabled(isMoveDisabled)
                 }
             }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
@@ -1,0 +1,239 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Combine
+import Data
+import CoreData
+import Shared
+import BraveShared
+
+private struct PlaylistFolderImage: View, Identifiable {
+    static let cornerRadius = 5.0
+    private static let favIconSize = 16.0
+    private let item: PlaylistItem
+    @StateObject private var thumbnailLoader = PlaylistFolderImageLoader()
+    @StateObject private var favIconLoader = PlaylistFolderImageLoader()
+    @State private var thumbnail = UIImage()
+    @State private var favIcon = UIImage()
+    
+    let id: String
+    
+    init(item: PlaylistItem) {
+        self.item = item
+        id = item.id
+    }
+    
+    var body: some View {
+        Image(uiImage: thumbnailLoader.image ?? .init())
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 100.0, height: 60.0)
+            .background(Color.black)
+            .clipShape(RoundedRectangle(cornerRadius: PlaylistFolderImage.cornerRadius, style: .continuous))
+            .overlay(Image(uiImage: favIconLoader.image ?? .init())
+                        .resizable()
+                        .aspectRatio(1.0, contentMode: .fit)
+                        .frame(width: PlaylistFolderImage.favIconSize,
+                               height: PlaylistFolderImage.favIconSize)
+                        .clipShape(RoundedRectangle(cornerRadius: 3.0, style: .continuous))
+                        .padding(8.0), alignment: .topLeading)
+            .onAppear {
+                thumbnailLoader.load(thumbnail: item)
+                favIconLoader.load(favIcon: item)
+            }
+    }
+}
+
+private struct PlaylistFolderView: View {
+    let isSourceFolder: Bool
+    let folder: PlaylistFolder?
+    @Binding var selectedFolder: PlaylistFolder?
+    
+    var body: some View {
+        HStack(spacing: 12.0) {
+            Image(systemName: "folder")
+                .foregroundColor(isSourceFolder ? Color(.braveDisabled) : Color(.braveOrange))
+            
+            VStack(alignment: .leading) {
+                if let folder = folder {
+                    let itemCount = folder.playlistItems?.count ?? 0
+                    
+                    Text(folder.title ?? "")
+                        .font(.body)
+                        .foregroundColor(.white)
+                        .opacity(isSourceFolder ? 0.5 : 1.0)
+                    Text("\(itemCount == 1 ? Strings.PlaylistFolders.playlistFolderSubtitleItemSingleCount : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSubtitleItemCount, itemCount))")
+                        .font(.footnote)
+                        .foregroundColor(.white)
+                        .opacity(0.5)
+                }
+            }
+            
+            Spacer()
+            
+            if selectedFolder?.uuid == folder?.uuid {
+                Image(systemName: "checkmark")
+                    .foregroundColor(.white)
+            }
+        }
+        .padding(.vertical, 7.0)
+    }
+}
+
+struct PlaylistMoveFolderView: View {
+    @FetchRequest(
+        entity: PlaylistFolder.entity(),
+        sortDescriptors: [
+            NSSortDescriptor(keyPath: \PlaylistFolder.order, ascending: true),
+            NSSortDescriptor(keyPath: \PlaylistFolder.dateAdded, ascending: false)
+        ],
+        predicate: NSPredicate(format: "uuid != %@", PlaylistFolder.savedFolderUUID)
+    ) var folders: FetchedResults<PlaylistFolder>
+    
+    @FetchRequest(
+        entity: PlaylistFolder.entity(),
+        sortDescriptors: [],
+        predicate: NSPredicate(format: "uuid == %@", PlaylistFolder.savedFolderUUID)
+    ) var savedFolder: FetchedResults<PlaylistFolder>
+    
+    @State private var selectedFolder = PlaylistManager.shared.currentFolder
+    
+    private var isMoveDisabled: Bool {
+        return selectedFolder?.uuid == PlaylistManager.shared.currentFolder?.uuid
+    }
+    
+    private var itemDescription: String {
+        if selectedItems.count == 1 {
+            return selectedItems[0].name ?? Strings.PlaylistFolders.playlistFolderMoveItemWithMultipleNoNameTitle
+        }
+        
+        guard let title = selectedItems[0].name else {
+            return Strings.PlaylistFolders.playlistFolderMoveItemWithMultipleNoNameTitle
+        }
+        
+        if selectedItems.count == 2 {
+            return String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderMoveItemDescription, title)
+        }
+        
+        return String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderMoveMultipleItemDescription, title, selectedItems.count - 1)
+    }
+    
+    var selectedItems: [PlaylistItem]
+    var onCancelButtonPressed: (() -> Void)?
+    var onDoneButtonPressed: (([PlaylistItem], PlaylistFolder?) -> Void)?
+    
+    var body: some View {
+        NavigationView {
+            List {
+                Section(header: {
+                    HStack(spacing: 12.0) {
+                        if selectedItems.count > 1,
+                           let firstItem = selectedItems[safe: 0],
+                           let secondItem = selectedItems[safe: 1] {
+                            ZStack {
+                                PlaylistFolderImage(item: firstItem)
+                                    .rotationEffect(.degrees(5.0))
+                                PlaylistFolderImage(item: secondItem).rotationEffect(.degrees(-5.0))
+                            }
+                            
+                            Text(itemDescription)
+                                .lineLimit(2)
+                                .font(.body)
+                                .foregroundColor(.white)
+                                .textCase(.none)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } else if let item = selectedItems.first {
+                            PlaylistFolderImage(item: item)
+                            Text(item.name ?? Strings.PlaylistFolders.playlistFolderMoveItemWithNoNameTitle)
+                                .lineLimit(2)
+                                .font(.body)
+                                .foregroundColor(.white)
+                                .textCase(.none)
+                        }
+                    }
+                    .padding(.top)
+                }()) {}
+                .listRowInsets(.zero)
+                .listRowBackground(Color.clear)
+                
+                Section(header: Text(Strings.PlaylistFolders.playlistFolderMoveFolderCurrentSectionTitle)
+                            .font(.footnote)
+                            .textCase(.none)
+                            .foregroundColor(Color(.secondaryBraveLabel))
+                            .multilineTextAlignment(.leading)) {
+                    
+                    Button(action: {
+                        selectedFolder = PlaylistManager.shared.currentFolder
+                    }) {
+                        PlaylistFolderView(isSourceFolder: true,
+                                           folder: PlaylistManager.shared.currentFolder,
+                                           selectedFolder: $selectedFolder)
+                    }
+                }
+                .listRowBackground(Color(.secondaryBraveGroupedBackground))
+                
+                let sectionTitle = selectedItems.count == 1 ? Strings.PlaylistFolders.playlistFolderSelectASingleFolderTitle : String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderSelectAFolderTitle, selectedItems.count)
+                Section(header: Text(sectionTitle)
+                            .font(.footnote)
+                            .textCase(.none)
+                            .foregroundColor(Color(.secondaryBraveLabel))
+                            .multilineTextAlignment(.leading)) {
+                    
+                    // Show the "Saved" folder
+                    if PlaylistManager.shared.currentFolder?.uuid != savedFolder.first?.uuid {
+                        Button(action: {
+                            selectedFolder = savedFolder.first
+                        }) {
+                            PlaylistFolderView(isSourceFolder: false,
+                                               folder: savedFolder.first,
+                                               selectedFolder: $selectedFolder)
+                        }
+                    }
+                    
+                    // Show all folders except the current one
+                    ForEach(folders) { folder in
+                        if folder.uuid != PlaylistManager.shared.currentFolder?.uuid {
+                            Button(action: {
+                                selectedFolder = folder
+                            }) {
+                                PlaylistFolderView(isSourceFolder: false,
+                                                   folder: folder,
+                                                   selectedFolder: $selectedFolder)
+                            }
+                        }
+                    }
+                }
+                .listRowBackground(Color(.secondaryBraveGroupedBackground))
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle(Strings.PlaylistFolders.playlistFolderMoveFolderScreenTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationViewStyle(.stack)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.cancelButtonTitle) { onCancelButtonPressed?() }
+                    .foregroundColor(.white)
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Strings.done) { onDoneButtonPressed?(selectedItems, selectedFolder) }
+                    .foregroundColor(isMoveDisabled ? Color(.braveDisabled) : .white)
+                    .disabled(isMoveDisabled)
+                }
+            }
+        }
+        .environment(\.colorScheme, .dark)
+    }
+}
+
+#if DEBUG
+struct PlaylistMoveFolderView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlaylistMoveFolderView(selectedItems: [])
+            .environment(\.managedObjectContext, DataController.swiftUIContext)
+    }
+}
+#endif

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
@@ -44,23 +44,18 @@ class PlaylistFolderImageLoader: ObservableObject {
     }
 }
 
-private struct PlaylistFolderImage: View, Identifiable {
+private struct PlaylistFolderImage: View {
+    let item: PlaylistItem
+    
     static let cornerRadius = 10.0
     private static let favIconSize = 16.0
-    private let item: PlaylistItem
     private var title: String?
     
     @StateObject private var thumbnailLoader = PlaylistFolderImageLoader()
     @StateObject private var favIconLoader = PlaylistFolderImageLoader()
-    @State private var thumbnail = UIImage()
-    @State private var favIcon = UIImage()
-    
-    let id: String
     
     init(item: PlaylistItem) {
         self.item = item
-        id = item.id
-        title = item.name
     }
     
     var body: some View {
@@ -82,7 +77,7 @@ private struct PlaylistFolderImage: View, Identifiable {
                 
                 Spacer()
                 
-                if let title = title {
+                if let title = item.name {
                     Text(title)
                         .font(.footnote.weight(.semibold))
                         .lineLimit(2)
@@ -152,10 +147,12 @@ struct PlaylistNewFolderView: View {
                                       spacing: PlaylistNewFolderView.designGridSpacing) {
                                 ForEach(items) { item in
                                     Button(action: {
-                                        if let index = selected.firstIndex(of: item.objectID) {
-                                            selected.remove(at: index)
-                                        } else {
-                                            selected.append(item.objectID)
+                                        withAnimation(.linear(duration: 0.1)) {
+                                            if let index = selected.firstIndex(of: item.objectID) {
+                                                selected.remove(at: index)
+                                            } else {
+                                                selected.append(item.objectID)
+                                            }
                                         }
                                     }, label: {
                                         PlaylistFolderImage(item: item)
@@ -163,10 +160,13 @@ struct PlaylistNewFolderView: View {
                                     .frame(height: PlaylistNewFolderView.designGridItemHeight)
                                     .buttonStyle(.plain)
                                     .overlay(
-                                        RoundedRectangle(cornerRadius: PlaylistFolderImage.cornerRadius,
-                                                         style: .continuous)
-                                            .stroke(Color.blue,
-                                                    lineWidth: selected.contains(item.objectID) ? 2.0 : 0.0)
+                                        Group {
+                                            if selected.contains(item.objectID) {
+                                                RoundedRectangle(cornerRadius: PlaylistFolderImage.cornerRadius,
+                                                                 style: .continuous)
+                                                    .strokeBorder(Color.blue, lineWidth: 2)
+                                            }
+                                        }
                                     )
                                 }
                             }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
@@ -1,0 +1,206 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Combine
+import Data
+import CoreData
+import Shared
+import BraveShared
+
+class PlaylistFolderImageLoader: ObservableObject {
+    @Published var image: UIImage?
+    
+    private let renderer = PlaylistThumbnailRenderer()
+    
+    func load(thumbnail: PlaylistItem) {
+        guard let mediaSrc = thumbnail.mediaSrc,
+              let assetUrl = URL(string: mediaSrc) else {
+            image = nil
+            return
+        }
+        
+        loadImage(url: assetUrl, isFavIcon: false)
+    }
+    
+    func load(favIcon: PlaylistItem) {
+        guard let pageSrc = favIcon.pageSrc,
+              let favIconUrl = URL(string: pageSrc) else {
+            image = nil
+            return
+        }
+        
+        loadImage(url: favIconUrl, isFavIcon: true)
+    }
+    
+    private func loadImage(url: URL, isFavIcon: Bool) {
+        renderer.loadThumbnail(assetUrl: isFavIcon ? nil : url,
+                               favIconUrl: isFavIcon ? url : nil,
+                               completion: { [weak self] image in
+            self?.image = image
+        })
+    }
+}
+
+private struct PlaylistFolderImage: View, Identifiable {
+    static let cornerRadius = 10.0
+    private static let favIconSize = 16.0
+    private let item: PlaylistItem
+    private var title: String?
+    
+    @StateObject private var thumbnailLoader = PlaylistFolderImageLoader()
+    @StateObject private var favIconLoader = PlaylistFolderImageLoader()
+    @State private var thumbnail = UIImage()
+    @State private var favIcon = UIImage()
+    
+    let id: String
+    
+    init(item: PlaylistItem) {
+        self.item = item
+        id = item.id
+        title = item.name
+    }
+    
+    var body: some View {
+        Image(uiImage: thumbnailLoader.image ?? .init())
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.black)
+            .overlay(LinearGradient(colors: [.clear, .black],
+                                       startPoint: .top,
+                                       endPoint: .bottom))
+            .overlay(VStack(alignment: .leading) {
+                Image(uiImage: favIconLoader.image ?? .init())
+                    .resizable()
+                    .aspectRatio(1.0, contentMode: .fit)
+                    .frame(width: PlaylistFolderImage.favIconSize,
+                           height: PlaylistFolderImage.favIconSize)
+                    .clipShape(RoundedRectangle(cornerRadius: 3.0, style: .continuous))
+                
+                Spacer()
+                
+                if let title = title {
+                    Text(title)
+                        .font(.footnote.weight(.semibold))
+                        .lineLimit(2)
+                        .foregroundColor(.white)
+                }
+            }.padding(8.0), alignment: .topLeading)
+            .clipShape(RoundedRectangle(cornerRadius: PlaylistFolderImage.cornerRadius, style: .continuous))
+            .onAppear {
+                thumbnailLoader.load(thumbnail: item)
+                favIconLoader.load(favIcon: item)
+            }
+    }
+}
+
+struct PlaylistNewFolderView: View {
+    @FetchRequest(
+        entity: PlaylistItem.entity(),
+        sortDescriptors: [
+            NSSortDescriptor(keyPath: \PlaylistItem.order, ascending: true),
+            NSSortDescriptor(keyPath: \PlaylistItem.dateAdded, ascending: false)
+        ],
+        predicate: NSPredicate(format: "playlistFolder.uuid == %@", PlaylistFolder.savedFolderUUID)
+    ) var items: FetchedResults<PlaylistItem>
+    
+    private static let designGridSpacing = 12.0
+    private static let designGridItemWidth = 150.0
+    private static let designGridItemHeight = 100.0
+    private let gridItems = [GridItem(.adaptive(minimum: PlaylistNewFolderView.designGridItemWidth,
+                                                maximum: .infinity),
+                                      spacing: PlaylistNewFolderView.designGridSpacing)]
+    
+    @State private var folderName: String = ""
+    @State private var selected: [NSManagedObjectID] = []
+    
+    var onCancelButtonPressed: (() -> Void)?
+    var onCreateFolder: ((_ folderTitle: String, _ selectedItems: [NSManagedObjectID]) -> Void)?
+    
+    var body: some View {
+        NavigationView {
+            List {
+                Section {
+                    TextField(Strings.PlaylistFolders.playlistUntitledFolderTitle, text: $folderName)
+                        .disableAutocorrection(true)
+                        .padding()
+                }
+                .listRowBackground(Color(.secondaryBraveGroupedBackground))
+                .listRowInsets(.zero)
+                
+                if !items.isEmpty {
+                    Section {
+                        VStack(alignment: .leading) {
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(Strings.PlaylistFolders.playlistFolderNewFolderSectionTitle)
+                                        .font(.headline)
+                                        .foregroundColor(.white)
+                                        .multilineTextAlignment(.leading)
+                                    Text(Strings.PlaylistFolders.playlistFolderNewFolderSectionSubtitle)
+                                        .font(.footnote)
+                                        .foregroundColor(Color(.secondaryBraveLabel))
+                                        .multilineTextAlignment(.leading)
+                                }
+                            }
+                            
+                            LazyVGrid(columns: gridItems,
+                                      alignment: .leading,
+                                      spacing: PlaylistNewFolderView.designGridSpacing) {
+                                ForEach(items) { item in
+                                    Button(action: {
+                                        if let index = selected.firstIndex(of: item.objectID) {
+                                            selected.remove(at: index)
+                                        } else {
+                                            selected.append(item.objectID)
+                                        }
+                                    }, label: {
+                                        PlaylistFolderImage(item: item)
+                                    })
+                                    .frame(height: PlaylistNewFolderView.designGridItemHeight)
+                                    .buttonStyle(.plain)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: PlaylistFolderImage.cornerRadius,
+                                                         style: .continuous)
+                                            .stroke(Color.blue,
+                                                    lineWidth: selected.contains(item.objectID) ? 2.0 : 0.0)
+                                    )
+                                }
+                            }
+                        }
+                        .listRowBackground(Color(.braveGroupedBackground))
+                        .listRowInsets(.zero)
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle(Strings.PlaylistFolders.playlistNewFolderScreenTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationViewStyle(.stack)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.cancelButtonTitle) { onCancelButtonPressed?() }
+                    .foregroundColor(.white)
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Strings.PlaylistFolders.playlistCreateNewFolderButtonTitle) { onCreateFolder?(folderName, selected) }
+                    .foregroundColor(.white)
+                }
+            }
+        }
+        .environment(\.colorScheme, .dark)
+    }
+}
+
+#if DEBUG
+struct PlaylistNewFolderView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlaylistNewFolderView()
+            .environment(\.managedObjectContext, DataController.swiftUIContext)
+    }
+}
+#endif

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController+AVDelegates.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController+AVDelegates.swift
@@ -49,16 +49,28 @@ extension PlaylistViewController: AVPictureInPictureControllerDelegate {
         
         if let restorationController = PlaylistCarplayManager.shared.playlistController {
             restorationController.modalPresentationStyle = .fullScreen
-            let browserViewController = view.window == nil ? PlaylistCarplayManager.shared.browserController : self.currentScene?.browserViewController
+            guard let browserViewController = view.window == nil ? PlaylistCarplayManager.shared.browserController : self.currentScene?.browserViewController else {
+                
+                if UIDevice.isIpad {
+                    attachPlayerView()
+                }
+                
+                completionHandler(true)
+                return
+            }
             
             if UIDevice.isIpad {
                 attachPlayerView()
             }
             
-            browserViewController?.present(restorationController, animated: true)
-            PlaylistCarplayManager.shared.playlistController = nil
+            browserViewController.present(restorationController, animated: true) {
+                DispatchQueue.main.async {
+                    PlaylistCarplayManager.shared.playlistController = nil
+                    completionHandler(true)
+                }
+            }
+        } else {
+            completionHandler(true)
         }
-        
-        completionHandler(true)
     }
 }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -176,6 +176,42 @@ class PlaylistViewController: UIViewController {
         updateLayoutForOrientationChange()
         
         detailController.setVideoPlayer(playerView)
+        updateLayoutForOrientationMode()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        folderObserver = PlaylistManager.shared.onCurrentFolderDidChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self = self,
+                      self.listController.parent == nil,
+                      PlaylistManager.shared.currentFolder != nil
+                else { return }
+                
+                self.updateLayoutForOrientationMode()
+                self.folderController.navigationController?.pushViewController(self.listController, animated: true)
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        folderObserver = nil
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        updateLayoutForOrientationChange()
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+    
+    private func updateLayoutForOrientationMode() {
         detailController.navigationController?.setNavigationBarHidden(splitController.isCollapsed || traitCollection.horizontalSizeClass == .regular, animated: false)
         
         if UIDevice.isPhone {
@@ -195,37 +231,6 @@ class PlaylistViewController: UIViewController {
             listController.updateLayoutForMode(.pad)
             detailController.updateLayoutForMode(.pad)
         }
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        folderObserver = PlaylistManager.shared.onCurrentFolderDidChange
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                guard let self = self,
-                      self.listController.parent == nil,
-                      PlaylistManager.shared.currentFolder != nil
-                else { return }
-                
-                self.folderController.navigationController?.pushViewController(self.listController, animated: true)
-        }
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        folderObserver = nil
-    }
-    
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        
-        updateLayoutForOrientationChange()
-    }
-    
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
     }
     
     private func updateLayoutForOrientationChange() {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -27,6 +27,8 @@ protocol PlaylistViewControllerDelegate: AnyObject {
     func onFullscreen()
     func onExitFullscreen()
     func playItem(item: PlaylistInfo, completion: ((PlaylistMediaStreamer.PlaybackError) -> Void)?)
+    func pausePlaying()
+    func stopPlaying()
     func deleteItem(item: PlaylistInfo, at index: Int)
     func updateLastPlayedItem(item: PlaylistInfo)
     func displayLoadingResourceError()
@@ -49,9 +51,11 @@ class PlaylistViewController: UIViewController {
     private let mediaStreamer: PlaylistMediaStreamer
     
     private let splitController = UISplitViewController()
+    private let folderController = PlaylistFolderController()
     private lazy var listController = PlaylistListViewController(playerView: playerView)
     private let detailController = PlaylistDetailViewController()
     
+    private var folderObserver: AnyCancellable?
     private var playerStateObservers = Set<AnyCancellable>()
     private var assetStateObservers = Set<AnyCancellable>()
     private var assetLoadingStateObservers = Set<AnyCancellable>()
@@ -100,6 +104,10 @@ class PlaylistViewController: UIViewController {
             stop(playerView)
             PlaylistCarplayManager.shared.currentPlaylistItem = nil
             PlaylistCarplayManager.shared.currentlyPlayingItemIndex = -1
+            
+            // Destroy folder observers
+            folderObserver = nil
+            PlaylistManager.shared.currentFolder = nil
         }
         
         // Cancel all loading.
@@ -125,17 +133,32 @@ class PlaylistViewController: UIViewController {
         attachPlayerView()
         updatePlayerUI()
         observePlayerStates()
+        observeFolderStates()
         listController.delegate = self
         
         // Layout
         splitController.do {
-            $0.viewControllers = [SettingsNavigationController(rootViewController: listController),
+            $0.viewControllers = [SettingsNavigationController(rootViewController: folderController),
                                   SettingsNavigationController(rootViewController: detailController)]
             $0.delegate = self
             $0.primaryEdge = PlayListSide(rawValue: Preferences.Playlist.listViewSide.value) == .left ? .leading : .trailing
             $0.presentsWithGesture = false
             $0.maximumPrimaryColumnWidth = 400
             $0.minimumPrimaryColumnWidth = 400
+        }
+        
+        if let initialItem = listController.initialItem,
+           let item = PlaylistItem.getItem(pageSrc: initialItem.pageSrc) {
+            PlaylistManager.shared.currentFolder = item.playlistFolder
+        } else if let url = Preferences.Playlist.lastPlayedItemUrl.value,
+                  let item = PlaylistItem.getItem(pageSrc: url) {
+            PlaylistManager.shared.currentFolder = item.playlistFolder
+        } else {
+            PlaylistManager.shared.currentFolder = nil
+        }
+        
+        if PlaylistManager.shared.currentFolder != nil {
+            folderController.navigationController?.pushViewController(listController, animated: false)
         }
         
         addChild(splitController)
@@ -172,6 +195,27 @@ class PlaylistViewController: UIViewController {
             listController.updateLayoutForMode(.pad)
             detailController.updateLayoutForMode(.pad)
         }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        folderObserver = PlaylistManager.shared.onCurrentFolderDidChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self = self,
+                      self.listController.parent == nil,
+                      PlaylistManager.shared.currentFolder != nil
+                else { return }
+                
+                self.folderController.navigationController?.pushViewController(self.listController, animated: true)
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        folderObserver = nil
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -356,6 +400,12 @@ class PlaylistViewController: UIViewController {
                 event.mediaPlayer.pictureInPictureController?.isPictureInPicturePossible == true
         }.store(in: &playerStateObservers)
     }
+    
+    private func observeFolderStates() {
+        folderController.onFolderSelected = { folder in
+            PlaylistManager.shared.currentFolder = folder
+        }
+    }
 }
 
 // MARK: - UIAdaptivePresentationControllerDelegate
@@ -369,6 +419,7 @@ extension PlaylistViewController: UIAdaptivePresentationControllerDelegate {
 // MARK: - UISplitViewControllerDelegate
 
 extension PlaylistViewController: UISplitViewControllerDelegate {
+    
     func splitViewControllerSupportedInterfaceOrientations(_ splitViewController: UISplitViewController) -> UIInterfaceOrientationMask {
         return .allButUpsideDown
     }
@@ -417,7 +468,7 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
     }
     
     func onFullscreen() {
-        if !UIDevice.isIpad || splitViewController?.isCollapsed == true {
+        if !UIDevice.isIpad || splitController.isCollapsed {
             listController.onFullscreen()
         } else {
             detailController.onFullscreen()
@@ -425,22 +476,39 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
     }
     
     func onExitFullscreen() {
-        listController.onExitFullscreen()
+        if !UIDevice.isIpad || splitController.isCollapsed {
+            listController.onExitFullscreen()
+        } else {
+            if playerView.isFullscreen {
+                detailController.onExitFullscreen()
+            } else {
+                dismiss(animated: true, completion: nil)
+            }
+        }
+    }
+    
+    func pausePlaying() {
+        playerView.pause()
+    }
+    
+    func stopPlaying() {
+        PlaylistMediaStreamer.clearNowPlayingInfo()
+        
+        PlaylistCarplayManager.shared.currentlyPlayingItemIndex = -1
+        PlaylistCarplayManager.shared.currentPlaylistItem = nil
+        playerView.resetVideoInfo()
+        stop(playerView)
+        
+        // Cancel all loading.
+        assetLoadingStateObservers.removeAll()
+        assetStateObservers.removeAll()
     }
     
     func deleteItem(item: PlaylistInfo, at index: Int) {
         PlaylistManager.shared.delete(item: item)
         
         if PlaylistCarplayManager.shared.currentlyPlayingItemIndex == index || PlaylistManager.shared.numberOfAssets == 0 {
-            PlaylistMediaStreamer.clearNowPlayingInfo()
-            
-            PlaylistCarplayManager.shared.currentlyPlayingItemIndex = -1
-            playerView.resetVideoInfo()
-            stop(playerView)
-            
-            // Cancel all loading.
-            assetLoadingStateObservers.removeAll()
-            assetStateObservers.removeAll()
+            stopPlaying()
         }
     }
     

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -14,21 +14,12 @@ import BraveShared
 
 private let log = Logger.browserLogger
 
-protocol PlaylistManagerDelegate: AnyObject {
-    func onDownloadProgressUpdate(id: String, percentComplete: Double)
-    func onDownloadStateChanged(id: String, state: PlaylistDownloadManager.DownloadState, displayName: String?, error: Error?)
-    
-    func controllerDidChange(_ anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?)
-    func controllerDidChangeContent()
-    func controllerWillChangeContent()
-}
-
 class PlaylistManager: NSObject {
     static let shared = PlaylistManager()
     
     private var assetInformation = [PlaylistAssetFetcher]()
     private let downloadManager = PlaylistDownloadManager()
-    private let frc = PlaylistItem.frc()
+    private var frc = PlaylistItem.frc()
     private var didRestoreSession = false
     
     // Observers
@@ -45,6 +36,7 @@ class PlaylistManager: NSObject {
                                                              state: PlaylistDownloadManager.DownloadState,
                                                              displayName: String?,
                                                              error: Error?), Never>()
+    private let onCurrentFolderChanged = PassthroughSubject<(), Never>()
     
     private override init() {
         super.init()
@@ -54,6 +46,25 @@ class PlaylistManager: NSObject {
         
         // Delete system cache always on startup.
         deleteUserManagedAssets()
+    }
+    
+    var currentFolder: PlaylistFolder? {
+        didSet {
+            frc.delegate = nil
+            
+            if let currentFolder = currentFolder {
+                // Only return an FRC for the specified folder
+                frc = PlaylistItem.frc(parentFolder: currentFolder)
+            } else {
+                // Return every folder, including the "Saved" folder
+                frc = PlaylistItem.allFoldersFRC()
+            }
+            
+            frc.delegate = self
+            reloadData()
+            
+            onCurrentFolderChanged.send()
+        }
     }
     
     var contentWillChange: AnyPublisher<Void, Never> {
@@ -76,12 +87,20 @@ class PlaylistManager: NSObject {
         onDownloadStateChanged.eraseToAnyPublisher()
     }
     
+    var onCurrentFolderDidChange: AnyPublisher<(), Never> {
+        onCurrentFolderChanged.eraseToAnyPublisher()
+    }
+    
     var allItems: [PlaylistInfo] {
         frc.fetchedObjects?.map({ PlaylistInfo(item: $0) }) ?? []
     }
     
     var numberOfAssets: Int {
         frc.fetchedObjects?.count ?? 0
+    }
+    
+    var fetchedObjects: [PlaylistItem] {
+        frc.fetchedObjects ?? []
     }
     
     func itemAtIndex(_ index: Int) -> PlaylistInfo? {
@@ -222,6 +241,24 @@ class PlaylistManager: NSObject {
     
     func cancelDownload(item: PlaylistInfo) {
         downloadManager.cancelDownload(item: item)
+    }
+    
+    func delete(folder: PlaylistFolder) {
+        if currentFolder?.objectID == folder.objectID {
+            currentFolder = nil
+        }
+        
+        folder.playlistItems?.forEach({
+            self.delete(item: PlaylistInfo(item: $0))
+        })
+        
+        if folder.uuid != PlaylistFolder.savedFolderUUID {
+            PlaylistFolder.removeFolder(folder)
+        }
+        
+        if currentFolder?.isDeleted == true {
+            currentFolder = nil
+        }
     }
     
     @discardableResult

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -295,9 +295,12 @@ class VideoView: UIView, VideoTrackerBarDelegate {
     
     @objc
     private func onExitFullscreen(_ button: UIButton) {
-        isFullscreen = false
-        infoView.fullscreenButton.isHidden = false
-        infoView.exitButton.isHidden = true
+        if isFullscreen {
+            isFullscreen = false
+            infoView.fullscreenButton.isHidden = false
+            infoView.exitButton.isHidden = true
+        }
+        
         self.delegate?.onExitFullscreen(self)
     }
     

--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -258,7 +258,7 @@ extension PlaylistHelper {
         let token = UserScriptManager.securityTokenString
         let javascript = String(format: "window.__firefox__.stopMediaPlayback_%@()", token)
 
-        tab.webView?.evaluateSafeJavaScript(functionName: javascript, args: [], contentWorld: .page, completion: { value, error in
+        tab.webView?.evaluateSafeJavaScript(functionName: javascript, contentWorld: .page, completion: { value, error in
             if let error = error {
                 log.error("Error Retrieving Stopping Media Playback: \(error)")
             }

--- a/ClientTests/PlaylistTests.swift
+++ b/ClientTests/PlaylistTests.swift
@@ -4,8 +4,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import XCTest
-@testable import Client
 import CoreMedia
+@testable import Client
+@testable import Data
 
 class PlaylistTests: XCTestCase {
     func testVideoPlayerTrackBarTimeFormatter() throws {
@@ -24,5 +25,17 @@ class PlaylistTests: XCTestCase {
         XCTAssert(VideoTrackerBar.timeToString(CMTimeMakeWithSeconds(60.0, preferredTimescale: 1)) == "01:00") //mm:ss
         XCTAssert(VideoTrackerBar.timeToString(CMTimeMakeWithSeconds(60 * 60, preferredTimescale: 1)) == "01:00:00") //hh:mm:ss
         XCTAssert(VideoTrackerBar.timeToString(CMTimeMakeWithSeconds(60 * 60 * 24, preferredTimescale: 1)) == "01:00:00:00") //dd:hh:mm:ss
+    }
+    
+    func testSchemelessURLNormalization() throws {
+        let info = ["https://brave.com": "https://brave.com/test.mp4",
+                    "https://brave.com/": "https://brave.com/test.mp4",
+                    "http://brave.com": "http://brave.com/test.mp4",
+                    "http://brave.com/": "http://brave.com/test.mp4"]
+        
+        info.forEach {
+            XCTAssertEqual(PlaylistInfo.fixSchemelessURLs(src: "//brave.com/test.mp4", pageSrc: $0.key), $0.value)
+            XCTAssertEqual(PlaylistInfo.fixSchemelessURLs(src: "/test.mp4", pageSrc: $0.key), $0.value)
+        }
     }
 }

--- a/Data/models/DataController.swift
+++ b/Data/models/DataController.swift
@@ -239,6 +239,10 @@ public class DataController {
         self.perform(context: .existing(self.viewContext), save: save, task: task)
     }
     
+    public static var swiftUIContext: NSManagedObjectContext {
+        return DataController.shared.container.viewContext
+    }
+    
     // Context object also allows us access to all persistent container data if needed.
     static var viewContext: NSManagedObjectContext {
         return DataController.shared.container.viewContext

--- a/Data/models/Model.xcdatamodeld/.xccurrentversion
+++ b/Data/models/Model.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model13.xcdatamodel</string>
+	<string>Model14.xcdatamodel</string>
 </dict>
 </plist>

--- a/Data/models/Model.xcdatamodeld/Model14.xcdatamodel/contents
+++ b/Data/models/Model.xcdatamodeld/Model14.xcdatamodel/contents
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Bookmark" representedClassName=".Favorite" syncable="YES">
+        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customTitle" optional="YES" attributeType="String"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isFolder" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastVisited" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="syncDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="syncOrder" optional="YES" attributeType="String"/>
+        <attribute name="syncParentDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Bookmark" inverseName="parentFolder" inverseEntity="Bookmark"/>
+        <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="bookmarks" inverseEntity="Domain"/>
+        <relationship name="parentFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Bookmark" inverseName="children" inverseEntity="Bookmark"/>
+        <fetchIndex name="byLastVisitedIndex">
+            <fetchIndexElement property="lastVisited" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="DataSaved" representedClassName=".DataSaved" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="savedUrl" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="savedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Device" representedClassName=".Device" syncable="YES">
+        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="deviceDisplayId" optional="YES" attributeType="String"/>
+        <attribute name="isCurrentDevice" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSynced" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="syncDisplayUUID" optional="YES" attributeType="String"/>
+        <relationship name="tabs" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="TabMO" inverseName="device" inverseEntity="TabMO"/>
+    </entity>
+    <entity name="Domain" representedClassName=".Domain" syncable="YES">
+        <attribute name="blockedFromTopSites" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="shield_adblockAndTp" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_allOff" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_fpProtection" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_httpse" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_noScript" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_safeBrowsing" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="topsite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="bookmarks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Bookmark" inverseName="domain" inverseEntity="Bookmark"/>
+        <relationship name="favicon" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Favicon" inverseName="domain" inverseEntity="Favicon"/>
+        <relationship name="historyItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="History" inverseName="domain" inverseEntity="History"/>
+        <fetchIndex name="byBlockedFromTopSitesIndex">
+            <fetchIndexElement property="blockedFromTopSites" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Favicon" representedClassName=".FaviconMO" syncable="YES">
+        <attribute name="height" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="width" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="favicon" inverseEntity="Domain"/>
+    </entity>
+    <entity name="FeedSourceOverride" representedClassName=".FeedSourceOverride" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="publisherID" attributeType="String"/>
+        <fetchIndex name="byPublisherID">
+            <fetchIndexElement property="publisherID" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="publisherID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="History" representedClassName=".History" syncable="YES">
+        <attribute name="sectionIdentifier" optional="YES" transient="YES" attributeType="String"/>
+        <attribute name="syncUUID" optional="YES" attributeType="Transformable"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visitedOn" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="historyItems" inverseEntity="Domain"/>
+    </entity>
+    <entity name="PlaylistFolder" representedClassName=".PlaylistFolder" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="uuid" attributeType="String"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PlaylistItem" inverseName="playlistFolder" inverseEntity="PlaylistItem"/>
+    </entity>
+    <entity name="PlaylistItem" representedClassName=".PlaylistItem" syncable="YES">
+        <attribute name="cachedData" optional="YES" attributeType="Binary"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="mediaSrc" attributeType="String"/>
+        <attribute name="mimeType" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="pageSrc" attributeType="String"/>
+        <attribute name="pageTitle" optional="YES" attributeType="String"/>
+        <relationship name="playlistFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PlaylistFolder" inverseName="playlistItems" inverseEntity="PlaylistFolder"/>
+    </entity>
+    <entity name="RecentSearch" representedClassName="RecentSearch" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="searchType" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="websiteUrl" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="RSSFeedSource" representedClassName=".RSSFeedSource" syncable="YES">
+        <attribute name="feedUrl" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="feedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="TabMO" representedClassName=".TabMO" syncable="YES">
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastUpdate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="screenshot" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="screenshotUUID" optional="YES" attributeType="String"/>
+        <attribute name="syncUUID" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="urlHistoryCurrentIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="urlHistorySnapshot" optional="YES" attributeType="Transformable"/>
+        <relationship name="device" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Device" inverseName="tabs" inverseEntity="Device"/>
+    </entity>
+    <elements>
+        <element name="Bookmark" positionX="0" positionY="-450" width="155" height="285"/>
+        <element name="DataSaved" positionX="-378.8814697265625" positionY="-320.8398132324219" width="128" height="59"/>
+        <element name="Device" positionX="-314.8486938476562" positionY="-207" width="128" height="150"/>
+        <element name="Domain" positionX="225" positionY="-321" width="128" height="224"/>
+        <element name="Favicon" positionX="439" positionY="-414" width="128" height="104"/>
+        <element name="FeedSourceOverride" positionX="-530.2741088867188" positionY="-324.5160522460938" width="128" height="28"/>
+        <element name="History" positionX="493" positionY="-150" width="128" height="135"/>
+        <element name="PlaylistFolder" positionX="-207.20556640625" positionY="-430.9707641601562" width="128" height="104"/>
+        <element name="PlaylistItem" positionX="-146.2350463867188" positionY="-301.473388671875" width="128" height="179"/>
+        <element name="RecentSearch" positionX="-573.386474609375" positionY="-432.0953826904297" width="128" height="89"/>
+        <element name="RSSFeedSource" positionX="-413.9057006835938" positionY="-436.2492065429688" width="128" height="73"/>
+        <element name="TabMO" positionX="-488" positionY="-229" width="128" height="224"/>
+    </elements>
+</model>

--- a/Data/models/PlaylistFolder.swift
+++ b/Data/models/PlaylistFolder.swift
@@ -1,0 +1,124 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+import Shared
+
+private let log = Logger.browserLogger
+
+@objc(PlaylistFolder)
+final public class PlaylistFolder: NSManagedObject, CRUD, Identifiable {
+    @NSManaged public var uuid: String?
+    @NSManaged public var title: String?
+    @NSManaged public var order: Int32
+    @NSManaged public var dateAdded: Date?
+    @NSManaged public var playlistItems: Set<PlaylistItem>?
+    public static let savedFolderUUID = "7B6CC019-8946-4182-ACE8-42FE7B704C43"
+    
+    public var id: String {
+        uuid ?? UUID().uuidString
+    }
+    
+    public class func frc(savedFolderContentsOnly: Bool) -> NSFetchedResultsController<PlaylistFolder> {
+        let context = DataController.viewContext
+        let fetchRequest = NSFetchRequest<PlaylistFolder>()
+        fetchRequest.entity = PlaylistFolder.entity(context)
+        fetchRequest.fetchBatchSize = 20
+        
+        let orderSort = NSSortDescriptor(key: "order", ascending: true)
+        let createdSort = NSSortDescriptor(key: "dateAdded", ascending: false)
+        fetchRequest.sortDescriptors = [orderSort, createdSort]
+        
+        if savedFolderContentsOnly {
+            fetchRequest.predicate = NSPredicate(format: "uuid == %@", savedFolderUUID)
+        } else {
+            fetchRequest.predicate = NSPredicate(format: "uuid != %@", savedFolderUUID)
+        }
+        
+        return NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: context,
+                                          sectionNameKeyPath: nil, cacheName: nil)
+    }
+    
+    public static func addFolder(title: String, uuid: String? = nil, completion: ((_ uuid: String) -> Void)? = nil) {
+        DataController.perform(context: .new(inMemory: false), save: false) { context in
+            var folderId: String
+            if let uuid = uuid, !uuid.isEmpty {
+                folderId = uuid
+            } else {
+                folderId = UUID().uuidString
+            }
+            
+            let playlistFolder = PlaylistFolder(context: context)
+            playlistFolder.title = title
+            playlistFolder.dateAdded = Date()
+            playlistFolder.order = Int32.min
+            playlistFolder.uuid = folderId
+            
+            PlaylistFolder.reorderItems(context: context)
+            PlaylistFolder.saveContext(context)
+            
+            DispatchQueue.main.async {
+                completion?(folderId)
+            }
+        }
+    }
+    
+    public static func getOtherFoldersCount() -> Int {
+        PlaylistFolder.count(predicate: NSPredicate(format: "uuid != %@", PlaylistFolder.savedFolderUUID)) ?? 0
+    }
+    
+    public static func getFolder(uuid: String, context: NSManagedObjectContext? = nil) -> PlaylistFolder? {
+        PlaylistFolder.first(where: NSPredicate(format: "uuid == %@", uuid), context: context ?? DataController.viewContext)
+    }
+    
+    public static func removeFolder(_ uuid: String) {
+        PlaylistFolder.deleteAll(predicate: NSPredicate(format: "uuid == %@", uuid),
+                                 includesPropertyValues: false)
+    }
+    
+    public static func removeFolder(_ folder: PlaylistFolder) {
+        folder.delete()
+    }
+    
+    // MARK: - Internal
+    private static func reorderItems(context: NSManagedObjectContext) {
+        DataController.perform(context: .existing(context), save: true) { context in
+            let request = NSFetchRequest<PlaylistFolder>()
+            request.entity = PlaylistFolder.entity(context)
+            request.fetchBatchSize = 20
+            
+            let orderSort = NSSortDescriptor(key: "order", ascending: true)
+            let items = PlaylistFolder.all(sortDescriptors: [orderSort], context: context) ?? []
+            
+            for (order, item) in items.enumerated() {
+                item.order = Int32(order)
+            }
+        }
+    }
+    
+    @nonobjc
+    private class func fetchRequest() -> NSFetchRequest<PlaylistFolder> {
+        NSFetchRequest<PlaylistFolder>(entityName: "PlaylistFolder")
+    }
+    
+    private static func entity(_ context: NSManagedObjectContext) -> NSEntityDescription {
+        NSEntityDescription.entity(forEntityName: "PlaylistFolder", in: context)!
+    }
+    
+    private static func saveContext(_ context: NSManagedObjectContext) {
+        if context.concurrencyType == .mainQueueConcurrencyType {
+            log.warning("Writing to view context, this should be avoided.")
+        }
+        
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                assertionFailure("Error saving DB: \(error)")
+            }
+        }
+    }
+}

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -10,7 +10,7 @@ import Shared
 private let log = Logger.browserLogger
 
 @objc(PlaylistItem)
-final public class PlaylistItem: NSManagedObject, CRUD {
+final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
     @NSManaged public var cachedData: Data?
     @NSManaged public var dateAdded: Date?
     @NSManaged public var duration: TimeInterval
@@ -20,8 +20,47 @@ final public class PlaylistItem: NSManagedObject, CRUD {
     @NSManaged public var order: Int32
     @NSManaged public var pageSrc: String?
     @NSManaged public var pageTitle: String?
+    @NSManaged public var playlistFolder: PlaylistFolder?
+    
+    public var id: String {
+        objectID.uriRepresentation().absoluteString
+    }
     
     public class func frc() -> NSFetchedResultsController<PlaylistItem> {
+        let context = DataController.viewContext
+        let fetchRequest = NSFetchRequest<PlaylistItem>()
+        fetchRequest.entity = PlaylistItem.entity(context)
+        fetchRequest.fetchBatchSize = 20
+        
+        let orderSort = NSSortDescriptor(key: "order", ascending: true)
+        let createdSort = NSSortDescriptor(key: "dateAdded", ascending: false)
+        fetchRequest.sortDescriptors = [orderSort, createdSort]
+        
+        return NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: context,
+                                          sectionNameKeyPath: nil, cacheName: nil)
+    }
+    
+    public class func frc(parentFolder: PlaylistFolder?) -> NSFetchedResultsController<PlaylistItem> {
+        let context = DataController.viewContext
+        let fetchRequest = NSFetchRequest<PlaylistItem>()
+        fetchRequest.entity = PlaylistItem.entity(context)
+        fetchRequest.fetchBatchSize = 20
+        
+        if let parentFolder = parentFolder {
+            fetchRequest.predicate = NSPredicate(format: "playlistFolder.uuid == %@", parentFolder.uuid!)
+        } else {
+            fetchRequest.predicate = NSPredicate(format: "playlistFolder == nil")
+        }
+        
+        let orderSort = NSSortDescriptor(key: "order", ascending: true)
+        let createdSort = NSSortDescriptor(key: "dateAdded", ascending: false)
+        fetchRequest.sortDescriptors = [orderSort, createdSort]
+        
+        return NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: context,
+                                          sectionNameKeyPath: nil, cacheName: nil)
+    }
+    
+    public class func allFoldersFRC() -> NSFetchedResultsController<PlaylistItem> {
         let context = DataController.viewContext
         let fetchRequest = NSFetchRequest<PlaylistItem>()
         fetchRequest.entity = PlaylistItem.entity(context)
@@ -46,9 +85,9 @@ final public class PlaylistItem: NSManagedObject, CRUD {
             playlistItem.duration = item.duration
             playlistItem.mimeType = item.mimeType
             playlistItem.mediaSrc = item.src
-            playlistItem.order = -9999
+            playlistItem.order = Int32.min
+            playlistItem.playlistFolder = PlaylistFolder.getFolder(uuid: PlaylistFolder.savedFolderUUID, context: context)
             
-            PlaylistItem.saveContext(context)
             PlaylistItem.reorderItems(context: context)
             PlaylistItem.saveContext(context)
             
@@ -56,6 +95,21 @@ final public class PlaylistItem: NSManagedObject, CRUD {
                 completion?()
             }
         }
+    }
+    
+    public static func getItems(parentFolder: PlaylistFolder?) -> [PlaylistItem] {
+        let predicate: NSPredicate
+        if let parentFolder = parentFolder {
+            predicate = NSPredicate(format: "playlistFolder.uuid == %@", parentFolder.uuid!)
+        } else {
+            predicate = NSPredicate(format: "playlistFolder == nil")
+        }
+        
+        let orderSort = NSSortDescriptor(key: "order", ascending: true)
+        let createdSort = NSSortDescriptor(key: "dateAdded", ascending: false)
+        return PlaylistItem.all(where: predicate,
+                                     sortDescriptors: [orderSort, createdSort],
+                                     fetchLimit: 20) ?? []
     }
     
     public static func getItem(pageSrc: String) -> PlaylistItem? {
@@ -117,7 +171,22 @@ final public class PlaylistItem: NSManagedObject, CRUD {
     }
     
     public static func removeItem(_ item: PlaylistInfo) {
-        PlaylistItem.deleteAll(predicate: NSPredicate(format: "mediaSrc == %@", item.src), context: .new(inMemory: false), includesPropertyValues: false)
+        PlaylistItem.deleteAll(predicate: NSPredicate(format: "pageSrc == %@ OR mediaSrc == %@", item.pageSrc, item.src), context: .new(inMemory: false), includesPropertyValues: false)
+    }
+    
+    public static func moveItems(items: [NSManagedObjectID], to folderUUID: String?) {
+        DataController.perform { context in
+            var folder: PlaylistFolder?
+            if let folderUUID = folderUUID {
+                folder = PlaylistFolder.getFolder(uuid: folderUUID, context: context)
+            }
+            
+            let playlistItems = items.compactMap { try? context.existingObject(with: $0) as? PlaylistItem }
+            playlistItems.forEach {
+                $0.playlistFolder = folder
+                folder?.playlistItems?.insert($0)
+            }
+        }
     }
     
     // MARK: - Internal

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -174,6 +174,13 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
         PlaylistItem.deleteAll(predicate: NSPredicate(format: "pageSrc == %@ OR mediaSrc == %@", item.pageSrc, item.src), context: .new(inMemory: false), includesPropertyValues: false)
     }
     
+    public static func removeItems(_ items: [PlaylistInfo]) {
+        let pageSrcs = items.map({ $0.pageSrc })
+        let mediaSrcs = items.map({ $0.src })
+        
+        PlaylistItem.deleteAll(predicate: NSPredicate(format: "pageSrc IN %@ OR mediaSrc IN %@", pageSrcs, mediaSrcs), context: .new(inMemory: false), includesPropertyValues: false)
+    }
+    
     public static func moveItems(items: [NSManagedObjectID], to folderUUID: String?) {
         DataController.perform { context in
             var folder: PlaylistFolder?


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Implements Playlist Folders
- Adds Context Menus 
- Adds CarPlay Folders

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4352

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Verify migration:
- install 1.35, add bunch of videos to playlist
- Upgrade to 1.36, verify that videos are there in `Saved` folder

- Verify CarPlay folders works
- Verify Create, Edit (changing the folder name), Delete on folders work (Saved Folder is the only one that cannot do this).
- Verify re-arranging/re-ordering folders works
- Verify re-ordering items within a folder works
- Verify moving items from one folder to another works
- Verify empty folders show the empty state
- Verify Playlist thumbnails show
- Verify Long Press on a Folder to bring up context menu
- Verify Long Press on a Playlist Item brings up context menu
- Verify creating a folder with existing items, moves those items into the newly created folder
- Verify cannot move items when only one folder exists
- Verify cannot move item to the same folder that it's already in
- Verify all of the above on iPad
- Verify all of the above in Landscape
- Verify the above while plugged into the Car and that the CarPlay updates when deleted from iPhone.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
