### PR TITLE
Fix #5006: Tab button menu UX improvements.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -113,6 +113,12 @@ extension Strings {
     public static let openPhoneSettingsActionTitle = NSLocalizedString("OpenPhoneSettingsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Open Settings", comment: "See http://mzl.la/1G7uHo7")
     public static let copyImageActionTitle = NSLocalizedString("CopyImageActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Copy Image", comment: "Context menu item for copying an image to the clipboard")
     public static let closeAllTabsTitle = NSLocalizedString("CloseAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Close All %i Tabs", comment: "")
+    public static let closeAllTabsPrompt =
+        NSLocalizedString("closeAllTabsPrompt",
+                          tableName: "BraveShared",
+                          bundle: .braveShared,
+                          value: "Are you sure you want to close all open tabs?",
+                          comment: "We ask users this prompt before attempting to close multiple tabs via context menu")
     public static let savedTabsFolderTitle = NSLocalizedString("SavedTabsFolderTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Saved Tabs", comment: "The title for the folder created when all bookmarks are being ")
     public static let bookmarkAllTabsTitle = NSLocalizedString("BookmarkAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Bookmark All Tabs", comment: "Action item title of long press for Adding Bookmark for All Tabs in Tab List")
     public static let suppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "Title of alert that seeks permission from user to suppress future JS alerts")

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2381,18 +2381,6 @@ extension BrowserViewController: TabManagerDelegate {
         
         var closeTabMenuChildren: [UIAction] = []
         
-        if tabManager.tabsForCurrentMode.count > 1 {
-            let closeAllTabs = UIAction(
-                title: String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count),
-                image: UIImage(systemName: "xmark"),
-                attributes: .destructive,
-                handler: UIAction.deferredActionHandler { _ in
-                tabManager.removeAll()
-            })
-            
-            closeTabMenuChildren.append(closeAllTabs)
-        }
-        
         let closeActiveTab = UIAction(
             title: String(format: Strings.closeTabTitle),
             image: UIImage(systemName: "xmark"),
@@ -2405,6 +2393,35 @@ extension BrowserViewController: TabManagerDelegate {
         
         closeTabMenuChildren.append(closeActiveTab)
         
+        if tabManager.tabsForCurrentMode.count > 1 {
+            let closeAllTabs = UIAction(
+                title: String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count),
+                image: UIImage(systemName: "xmark"),
+                attributes: .destructive,
+                handler: UIAction.deferredActionHandler { [unowned self] _ in
+                    
+                    let alert = UIAlertController(title: nil, message: Strings.closeAllTabsPrompt, preferredStyle: .actionSheet)
+                    let cancelAction = UIAlertAction(title: Strings.CancelString, style: .cancel)
+                    let closedTabsTitle = String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count)
+                    let closeAllAction = UIAlertAction(title: closedTabsTitle, style: .destructive) { _ in
+                        tabManager.removeAll()
+                    }
+                    alert.addAction(closeAllAction)
+                    alert.addAction(cancelAction)
+                    
+                    if let popoverPresentation = alert.popoverPresentationController {
+                        let tabsButton = toolbar?.tabsButton ?? topToolbar.tabsButton
+                        popoverPresentation.sourceView = tabsButton
+                        popoverPresentation.sourceRect =
+                            .init(x: tabsButton.frame.width / 2, y: tabsButton.frame.height, width: 1, height: 1)
+                    }
+                    
+                    self.present(alert, animated: true)
+            })
+            
+            closeTabMenuChildren.append(closeAllTabs)
+        }
+        
         let newTabMenu = UIMenu(title: "", options: .displayInline, children: newTabMenuChildren)
         let addTabMenu = UIMenu(title: "", options: .displayInline, children: addTabMenuChildren)
         let bookmarkMenu = UIMenu(title: "", options: .displayInline, children: bookmarkMenuChildren)
@@ -2413,7 +2430,7 @@ extension BrowserViewController: TabManagerDelegate {
         toolbar?.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, bookmarkMenu, newTabMenu])
         topToolbar.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, bookmarkMenu, newTabMenu])
         
-        //Update Actions for Add-Tab Button
+        // Update Actions for Add-Tab Button
         toolbar?.addTabButton.menu = UIMenu(title: "", identifier: nil, children: [addTabMenu])
     }
 }

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -80,4 +80,8 @@ class TabsButton: UIButton {
         self.countLabel.text = countToBe
         self.accessibilityValue = countToBe
     }
+    
+    override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        UIImpactFeedbackGenerator(style: .medium).bzzt()
+    }
 }


### PR DESCRIPTION
When we moved to the new iOS 14 menus(see ticket #4440), few features were not ported over.
This commits adds back haptic feedback on long press gesture,
adds a confirmation prompt before removing multiple tabs and puts
close-all menu item above close single tab to avoid hitting it too easily.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5006 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
All tests are done by long pressing on tab's button, either on the one on bottom toolbar
or in case of iPads and landscape iPhones tapping on the top toolbar's tabs button.

- Verify that long pressing on a tab's button generates haptic feedback, small vigration
- When on iPhone in landscape, verify that 'Close all tabs' button is shown above close-single-tab button. Please note than on iPad the order of button is reversed, this is Apple controlled.
- Add few tabs, long press and try to close them all, verify that there is a confirmation prompt before trying to remove all tabs. Verify that tabs were closing after tapping on the prompt. Please notice that there is no `Cancel` button on iPads prompt, this is also what Apple sets by default

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

| ![IMG_0036](https://user-images.githubusercontent.com/6950387/154980373-288af7b5-c462-4813-89ff-2f2ad2e03d0f.PNG)  |  ![IMG_0037](https://user-images.githubusercontent.com/6950387/154980348-1336e56b-94d4-412b-a157-9cfebbef9d5a.PNG) |
|---|---|
| <img width="272" alt="Zrzut ekranu 2022-02-21 o 15 39 46" src="https://user-images.githubusercontent.com/6950387/154980638-a30e201c-2646-443c-9e3f-dbb18d06ce41.png">  |  <img width="264" alt="Zrzut ekranu 2022-02-21 o 15 49 16" src="https://user-images.githubusercontent.com/6950387/154980630-c7ab259a-dff9-40a2-a8cb-b9ce467e320e.png"> |

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
