### PR TITLE
Fix # Display custom tokens in swap token list and move those with the selected network native token to the top of the list.

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -109,6 +109,7 @@ public class CryptoStore: ObservableObject {
       assetRatioService: assetRatioService,
       swapService: swapService,
       txService: txService,
+      walletService: walletService,
       prefilledToken: prefilledToken
     )
     swapTokenStore = store

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -106,6 +106,7 @@ extension SwapTokenStore {
       assetRatioService: MockAssetRatioService(),
       swapService: MockSwapService(),
       txService: MockEthTxService(),
+      walletService: MockBraveWalletService(),
       prefilledToken: nil
     )
   }

--- a/BraveWalletTests/SwapTokenStoreTests.swift
+++ b/BraveWalletTests/SwapTokenStoreTests.swift
@@ -17,6 +17,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: nil
         )
         let ex = expectation(description: "default-sell-buy-token-on-main")
@@ -42,6 +43,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: batToken
         )
         let ex = expectation(description: "default-sell-buy-token-on-main")
@@ -68,6 +70,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: nil
         )
         let ex = expectation(description: "default-sell-buy-token-on-ropsten")
@@ -98,6 +101,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: daiToken
         )
         let ex = expectation(description: "default-sell-buy-token-on-ropsten")
@@ -127,6 +131,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: nil
         )
         let ex = expectation(description: "fetch-price-quote")
@@ -149,6 +154,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: nil
         )
         let ex = expectation(description: "make-erc20-eip1559-swap-transaction")
@@ -174,6 +180,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: nil
         )
         let ex = expectation(description: "make-erc20-swap-transaction")
@@ -202,6 +209,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: nil
         )
         let ex = expectation(description: "make-eth-swap-eip1559-transaction")
@@ -227,6 +235,7 @@ class SendSwapStoreTests: XCTestCase {
             assetRatioService: MockAssetRatioService(),
             swapService: MockSwapService(),
             txService: MockEthTxService(),
+            walletService: MockBraveWalletService(),
             prefilledToken: nil
         )
         let ex = expectation(description: "make-eth-swap-eip1559-transaction")


### PR DESCRIPTION
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4981 #4980 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Add few custom tokens to a network that supports`swap`
2. Go to swap screen
3. click the `From` token field or `To` token field to go to the available token list 
(Native asset of the current selected network and custom tokens should be listed at the top)
Note: If the token has been selected in one of the `From` or `To` fields, this token becomes not available in the other field.

## Screenshots:

![simulator_screenshot_76C2CE48-C32B-4548-B0DE-65976CB67A1C](https://user-images.githubusercontent.com/1187676/155053288-cc62cf2a-ac78-4dea-9f46-fbfb1bd50727.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
