### PR TITLE
Fix #5010: Remove deprecated long press toolbar gestures.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -519,11 +519,6 @@ extension BrowserViewController: ToolbarDelegate {
         self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
     }
     
-    func tabToolbarDidLongPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        // The actions are carried to menu actions for Tab-Tray Button
-        UIImpactFeedbackGenerator(style: .heavy).bzzt()
-    }
-    
     func tabToolbarDidLongPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {
         UIImpactFeedbackGenerator(style: .heavy).bzzt()
         showBackForwardList()
@@ -531,11 +526,6 @@ extension BrowserViewController: ToolbarDelegate {
     
     func tabToolbarDidPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton) {
         showTabTray()
-    }
-    
-    func tabToolbarDidLongPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-        // The actions are carried to menu actions for Tab-Tray Button
-        UIImpactFeedbackGenerator(style: .heavy).bzzt()
     }
     
     func showBackForwardList() {

--- a/Client/Frontend/Browser/Toolbars/ToolbarButton.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarButton.swift
@@ -49,4 +49,7 @@ class ToolbarButton: UIButton {
         }
     }
     
+    override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        UIImpactFeedbackGenerator(style: .medium).bzzt()
+    }
 }

--- a/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -19,10 +19,6 @@ class ToolbarHelper: NSObject {
         toolbar.backButton.addGestureRecognizer(longPressGestureBackButton)
         toolbar.backButton.addTarget(self, action: #selector(didClickBack), for: .touchUpInside)
         
-        toolbar.tabsButton.addTarget(self, action: #selector(didClickTabs), for: .touchUpInside)
-        let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTabs))
-        toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
-        
         toolbar.shareButton.setImage(#imageLiteral(resourceName: "nav-share").template, for: .normal)
         toolbar.shareButton.accessibilityLabel = Strings.tabToolbarShareButtonAccessibilityLabel
         toolbar.shareButton.addTarget(self, action: #selector(didClickShare), for: UIControl.Event.touchUpInside)
@@ -30,13 +26,10 @@ class ToolbarHelper: NSObject {
         toolbar.addTabButton.setImage(#imageLiteral(resourceName: "add_tab").template, for: .normal)
         toolbar.addTabButton.accessibilityLabel = Strings.tabToolbarAddTabButtonAccessibilityLabel
         toolbar.addTabButton.addTarget(self, action: #selector(didClickAddTab), for: UIControl.Event.touchUpInside)
-        toolbar.addTabButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressAddTab(_:))))
         
         toolbar.searchButton.setImage(#imageLiteral(resourceName: "ntp-search").template, for: .normal)
         // Accessibility label not needed, since overriden in the bottom tool bar class.
         toolbar.searchButton.addTarget(self, action: #selector(didClickSearch), for: UIControl.Event.touchUpInside)
-        // Same long press gesture allows creating tab on NTP, esp private tab easily
-        toolbar.searchButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressAddTab(_:))))
 
         toolbar.menuButton.setImage(#imageLiteral(resourceName: "menu_more").template, for: .normal)
         toolbar.menuButton.accessibilityLabel = Strings.tabToolbarMenuButtonAccessibilityLabel
@@ -67,10 +60,6 @@ class ToolbarHelper: NSObject {
         toolbar.tabToolbarDelegate?.tabToolbarDidPressTabs(toolbar, button: toolbar.tabsButton)
     }
     
-    func didLongPressTabs(_ recognizer: UILongPressGestureRecognizer) {
-        toolbar.tabToolbarDelegate?.tabToolbarDidLongPressTabs(toolbar, button: toolbar.tabsButton)
-    }
-    
     func didClickForward() {
         toolbar.tabToolbarDelegate?.tabToolbarDidPressForward(toolbar, button: toolbar.forwardButton)
     }
@@ -91,11 +80,5 @@ class ToolbarHelper: NSObject {
     
     func didClickSearch() {
         toolbar.tabToolbarDelegate?.tabToolbarDidPressSearch(toolbar, button: toolbar.searchButton)
-    }
-    
-    func didLongPressAddTab(_ longPress: UILongPressGestureRecognizer) {
-        if longPress.state == .began {
-            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressAddTab(toolbar, button: toolbar.shareButton)
-        }
     }
 }

--- a/Client/Frontend/Browser/Toolbars/ToolbarProtocols.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarProtocols.swift
@@ -50,10 +50,8 @@ protocol ToolbarDelegate: AnyObject {
     func tabToolbarDidLongPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidPressMenu(_ tabToolbar: ToolbarProtocol)
-    func tabToolbarDidLongPressTabs(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidPressShare()
     func tabToolbarDidPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidPressSearch(_ tabToolbar: ToolbarProtocol, button: UIButton)
-    func tabToolbarDidLongPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton)
     func tabToolbarDidSwipeToChangeTabs(_ tabToolbar: ToolbarProtocol, direction: UISwipeGestureRecognizer.Direction)
 }


### PR DESCRIPTION
Currently we use the new iOS 14 UIMenu on buttons.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5010 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
