### PR TITLE
Fix #4979 added the ability to quickly swap selected sell and buy tokens in swap screen

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -261,23 +261,18 @@ struct SwapCryptoView: View {
         Button(action: {
           swapTokensStore.swapSelectedTokens()
         }) {
-          HStack {
-            Spacer()
-            Image(systemName: "chevron.up.chevron.down")
-              .font(.body)
-              .foregroundColor(Color(.bravePrimary))
-              .padding(.horizontal, 20)
-              .padding(.vertical, 5)
-              .background(
-                Color(.secondaryButtonTint)
-                  .clipShape(Capsule().inset(by: 0.5).stroke())
-              )
-              .clipShape(Capsule())
-            Spacer()
-          }
+          Label(Strings.Wallet.swapSelectedTokens, systemImage: "chevron.up.chevron.down")
+            .labelStyle(.iconOnly)
+            .font(.body)
+            .foregroundColor(Color(.bravePrimary))
+            .padding(.horizontal, 20)
+            .padding(.vertical, 5)
+            .background(
+              Color(.secondaryButtonTint)
+                .clipShape(Capsule().inset(by: 0.5).stroke())
+            )
+            .clipShape(Capsule())
         }
-        .contentShape(Rectangle())
-        .accessibilityLabel(Strings.Wallet.swapSelectedTokens)
         .accessibility(addTraits: .isButton)
       }
         .listRowInsets(.zero)

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -273,7 +273,6 @@ struct SwapCryptoView: View {
             )
             .clipShape(Capsule())
         }
-        .accessibility(addTraits: .isButton)
       }
         .listRowInsets(.zero)
     ) {

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -253,12 +253,34 @@ struct SwapCryptoView: View {
           Strings.Wallet.swapCryptoAmountTitle,
           swapTokensStore.selectedFromToken?.symbol ?? ""))
       ),
-      footer: ShortcutAmountGrid(action: { amount in
-        swapTokensStore.sellAmount = ((swapTokensStore.selectedFromTokenBalance ?? 0) * amount.rawValue)
-          .decimalExpansion(precisionAfterDecimalPoint: Int(swapTokensStore.selectedFromToken?.decimals ?? 18))
-      })
-      .listRowInsets(.zero)
-      .padding(.bottom, 8)
+      footer: VStack(spacing: 20) {
+        ShortcutAmountGrid(action: { amount in
+          swapTokensStore.sellAmount = ((swapTokensStore.selectedFromTokenBalance ?? 0) * amount.rawValue)
+            .decimalExpansion(precisionAfterDecimalPoint: Int(swapTokensStore.selectedFromToken?.decimals ?? 18))
+        })
+        Button(action: {
+          swapTokensStore.swapSelectedTokens()
+        }) {
+          HStack {
+            Spacer()
+            Image(systemName: "chevron.up.chevron.down")
+              .font(.body)
+              .foregroundColor(Color(.bravePrimary))
+              .padding(.horizontal, 20)
+              .padding(.vertical, 5)
+              .background(
+                Color(.secondaryButtonTint)
+                  .clipShape(Capsule().inset(by: 0.5).stroke())
+              )
+              .clipShape(Capsule())
+            Spacer()
+          }
+        }
+        .contentShape(Rectangle())
+        .accessibilityLabel(Strings.Wallet.swapSelectedTokens)
+        .accessibility(addTraits: .isButton)
+      }
+        .listRowInsets(.zero)
     ) {
       TextField(
         String.localizedStringWithFormat(

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -510,6 +510,19 @@ public class SwapTokenStore: ObservableObject {
   
   // MARK: Public
   
+  func swapSelectedTokens() {
+    guard let oldFromToken = selectedFromToken,
+          let oldToToken = selectedToToken
+    else { return }
+    
+    selectedFromToken = oldToToken
+    selectedToToken = oldFromToken
+    
+    if !sellAmount.isEmpty {
+      fetchPriceQuote(base: .perSellAsset)
+    }
+  }
+  
   func prepareSwap() {
     switch state {
     case .error(_), .idle:

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1009,6 +1009,13 @@ extension Strings {
       value: "Refresh market price",
       comment: "A description for a refresh icon that when pressed receives a new snap quote for the currently swap assets"
     )
+    public static let swapSelectedTokens = NSLocalizedString(
+      "wallet.swapSelectedTokens",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Swap selected tokens",
+      comment: "An accessibility message for the swap button below from amount shortcut grids for users to swap the two selected tokens."
+    )
     public static let transactionCount = NSLocalizedString(
       "wallet.transactionCount",
       tableName: "BraveWallet",


### PR DESCRIPTION
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4979 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open wallet
2. go to Swap Screen
3. click the swap icon button below the percentage grids for sell amount
(a. Sell and buy tokens will be swapped. b. If there is any sell amount input previously, sell amount will stay the same but the reset amount fields will be re-calculated)

## Screenshots:

https://user-images.githubusercontent.com/1187676/155221474-94647941-a8ea-4e63-8a20-97d28e4aa460.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
