### PR TITLE
Fix #5021: Update brave-core to 1.36.105

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.36.87/brave-core-ios-1.36.87.tgz",
-      "integrity": "sha512-XkPVgsplWrT1Rz5VPailGHMVlxaY371tmYLwyYhbEyAGBD/IM7zlh9GkvG3kAw3bgz7nM+1v0l5TMro+P+Pzkg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.36.105/brave-core-ios-1.36.105.tgz",
+      "integrity": "sha512-9UCSF69fG5PKAF/e8a3OtjDzPR116pM9gZvF5YJAQ7XDcy0rXh7fsrBomT+Rzvuc/P1ffWkQZd+afnVOPmMHFA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.36.87/brave-core-ios-1.36.87.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.36.105/brave-core-ios-1.36.105.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5021 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Yoy can tap on app version in settings to make sure correct 1.36 build and chromium is showing there.

Test that sync, Rewards work.
This can be done during manual passes IMO.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
