### PR TITLE
Fix #5019: Match add custom asset error message with desktop

### DIFF
--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1412,7 +1412,7 @@ extension Strings {
       "wallet.addCustomTokenErrorMessage",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Please verify the custom token information, check your internet connection, and try again.",
+      value: "Failed to add custom token, please try again.",
       comment: "The message of the error pop up when there is an error occurs during the process of adding a custom token."
     )
     public static let removeCustomTokenErrorTitle = NSLocalizedString(


### PR DESCRIPTION
This pull request fixes #5019 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:
![simulator_screenshot_3FD8787F-6B2A-440B-981B-D31F7976CFFA](https://user-images.githubusercontent.com/1187676/155568542-918e2acc-2b44-4c3b-b143-45bc7682b324.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
