### PR TITLE
No Bug: Switch user script message handler to new promise API

### DIFF
--- a/Client/Extensions/PaymentRequestExtension.swift
+++ b/Client/Extensions/PaymentRequestExtension.swift
@@ -57,7 +57,9 @@ extension PaymentRequestExtension: TabContentScript {
         }
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
+        
         guard message.name == Self.name(), let body = message.body as? NSDictionary else { return }
         
         do {

--- a/Client/Frontend/Browser/BraveGetUA.swift
+++ b/Client/Frontend/Browser/BraveGetUA.swift
@@ -22,7 +22,7 @@ class BraveGetUA: TabContentScript {
         return BraveGetUA.name()
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
         // 🙀 😭 🏃‍♀️💨
     }
 

--- a/Client/Frontend/Browser/BraveSearchScriptHandler.swift
+++ b/Client/Frontend/Browser/BraveSearchScriptHandler.swift
@@ -48,7 +48,9 @@ class BraveSearchScriptHandler: TabContentScript {
     }
     
     func userContentController(_ userContentController: WKUserContentController,
-                               didReceiveScriptMessage message: WKScriptMessage) {
+                               didReceiveScriptMessage message: WKScriptMessage,
+                               replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         let allowedHosts = DomainUserScript.braveSearch.associatedDomains
         
         guard let requestHost = message.frameInfo.request.url?.host,

--- a/Client/Frontend/Browser/BraveTalkScriptHandler.swift
+++ b/Client/Frontend/Browser/BraveTalkScriptHandler.swift
@@ -29,7 +29,9 @@ class BraveTalkScriptHandler: TabContentScript {
     func scriptMessageHandlerName() -> String? { BraveTalkScriptHandler.name() }
     
     func userContentController(_ userContentController: WKUserContentController,
-                               didReceiveScriptMessage message: WKScriptMessage) {
+                               didReceiveScriptMessage message: WKScriptMessage,
+                               replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         let allowedHosts = DomainUserScript.braveTalk.associatedDomains
         
         guard let requestHost = message.frameInfo.request.url?.host,

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -173,7 +173,8 @@ extension ErrorPageHelper: TabContentScript {
         return "errorPageHelperMessageManager"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let errorURL = message.frameInfo.request.url,
             let internalUrl = InternalURL(errorURL),
             internalUrl.isErrorPage,

--- a/Client/Frontend/Browser/FindInPageHelper.swift
+++ b/Client/Frontend/Browser/FindInPageHelper.swift
@@ -29,7 +29,8 @@ class FindInPageHelper: TabContentScript {
         return "findInPageHandler"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let body = message.body as? [String: AnyObject] else {
             return
         }

--- a/Client/Frontend/Browser/FingerprintingProtection.swift
+++ b/Client/Frontend/Browser/FingerprintingProtection.swift
@@ -22,7 +22,8 @@ class FingerprintingProtection: TabContentScript {
         return "FingerprintingProtection\(UserScriptManager.messageHandlerTokenString)"
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         if let stats = self.tab?.contentBlocker.stats {
             self.tab?.contentBlocker.stats = stats.addingFingerprintingBlock()
             BraveGlobalShieldStats.shared.fpProtection += 1

--- a/Client/Frontend/Browser/FocusHelper.swift
+++ b/Client/Frontend/Browser/FocusHelper.swift
@@ -23,7 +23,9 @@ class FocusHelper: TabContentScript {
         return "focusHelper"
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
+        
         guard let body = message.body as? [String: AnyObject] else {
             return log.error("FocusHelper.js sent wrong type of message")
         }

--- a/Client/Frontend/Browser/FormPostHelper.swift
+++ b/Client/Frontend/Browser/FormPostHelper.swift
@@ -69,7 +69,8 @@ class FormPostHelper: TabContentScript {
         return "formPostHelper"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let formPostData = FormPostData(messageBody: message.body) else {
             print("Unable to parse FormPostData from script message body.")
             return

--- a/Client/Frontend/Browser/LocalRequestHelper.swift
+++ b/Client/Frontend/Browser/LocalRequestHelper.swift
@@ -13,7 +13,8 @@ class LocalRequestHelper: TabContentScript {
         return "localRequestHelper"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let requestUrl = message.frameInfo.request.url,
               let internalUrl = InternalURL(requestUrl),
               let params = message.body as? [String: String] else { return }

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -39,7 +39,8 @@ class LoginsHelper: TabContentScript {
         return "loginsManagerMessageHandler"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let body = message.body as? [String: AnyObject] else {
             return
         }

--- a/Client/Frontend/Browser/NoImageModeHelper.swift
+++ b/Client/Frontend/Browser/NoImageModeHelper.swift
@@ -22,7 +22,7 @@ class NoImageModeHelper: TabContentScript {
         return "NoImageMode"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
         // Do nothing.
     }
 

--- a/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
@@ -217,13 +217,12 @@ class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
     }
 }
 
-extension OnboardingWebViewController: WKScriptMessageHandler {
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        
+extension OnboardingWebViewController: WKScriptMessageHandlerWithReply {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
         for helper in helpers.values {
             if let scriptMessageHandlerName = helper.scriptMessageHandlerName(),
                 scriptMessageHandlerName == message.name {
-                return helper.userContentController(userContentController, didReceiveScriptMessage: message)
+                return helper.userContentController(userContentController, didReceiveScriptMessage: message, replyHandler: replyHandler)
             }
         }
     }
@@ -232,7 +231,7 @@ extension OnboardingWebViewController: WKScriptMessageHandler {
         helpers[name] = helper
         
         if let scriptMessageHandlerName = helper.scriptMessageHandlerName() {
-            webView.configuration.userContentController.add(self, name: scriptMessageHandlerName)
+            webView.configuration.userContentController.addScriptMessageHandler(self, contentWorld: .page, name: scriptMessageHandlerName)
         }
     }
 }

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -472,8 +472,8 @@ class PlaylistWebLoader: UIView {
             return "playlistCacheLoader_\(UserScriptManager.messageHandlerTokenString)"
         }
         
-        func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
-
+        func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+            defer { replyHandler(nil, nil) }
             if let info = PageInfo.from(message: message) {
                 isPageLoaded = info.pageLoad
                 

--- a/Client/Frontend/Browser/PlaylistHelper.swift
+++ b/Client/Frontend/Browser/PlaylistHelper.swift
@@ -71,8 +71,8 @@ class PlaylistHelper: NSObject, TabContentScript {
         return "playlistHelper_\(UserScriptManager.messageHandlerTokenString)"
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
-
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         PlaylistHelper.processPlaylistInfo(helper: self,
                                            item: PlaylistInfo.from(message: message))
     }

--- a/Client/Frontend/Browser/PrintHelper.swift
+++ b/Client/Frontend/Browser/PrintHelper.swift
@@ -29,7 +29,8 @@ class PrintHelper: TabContentScript {
         return "printHandler"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let body = message.body as? [String: AnyObject] else {
             return
         }

--- a/Client/Frontend/Browser/ResourceDownloadManager.swift
+++ b/Client/Frontend/Browser/ResourceDownloadManager.swift
@@ -47,7 +47,8 @@ class ResourceDownloadManager: TabContentScript {
         return "ResourceDownloadManager\(UserScriptManager.messageHandlerTokenString)"
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         
         do {
             let response = try DownloadedResourceResponse.from(message: message)

--- a/Client/Frontend/Browser/Search/CustomSearchHandler.swift
+++ b/Client/Frontend/Browser/Search/CustomSearchHandler.swift
@@ -16,7 +16,8 @@ class CustomSearchHelper: TabContentScript {
         return "customSearchHelper"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         // We don't listen to messages because the BVC calls the searchHelper script by itself.
     }
 

--- a/Client/Frontend/Browser/SessionRestoreHelper.swift
+++ b/Client/Frontend/Browser/SessionRestoreHelper.swift
@@ -24,7 +24,9 @@ class SessionRestoreHelper: TabContentScript {
         return "sessionRestoreHelper"
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
+        
         if let tab = tab, let params = message.body as? [String: AnyObject] {
             
             if UserScriptManager.isMessageHandlerTokenMissing(in: params) {

--- a/Client/Frontend/Browser/WindowRenderHelperScript.swift
+++ b/Client/Frontend/Browser/WindowRenderHelperScript.swift
@@ -21,7 +21,7 @@ class WindowRenderHelperScript: TabContentScript {
         return "WindowRenderHelper\(UserScriptManager.messageHandlerTokenString)"
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
         // Do nothing with the messages received.
         // For now.. It's useful for debugging though.
     }

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -260,7 +260,8 @@ class ReaderMode: TabContentScript {
         delegate?.readerMode(self, didParseReadabilityResult: readabilityResult, forTab: tab)
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let body = message.body as? [String: AnyObject] else {
             return
         }

--- a/Client/Rewards/AdsMediaReporting.swift
+++ b/Client/Rewards/AdsMediaReporting.swift
@@ -26,7 +26,8 @@ class AdsMediaReporting: TabContentScript {
         return "adsMediaReporting"
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let body = message.body as? [String: AnyObject] else {
             return
         }

--- a/Client/Rewards/RewardsReporting.swift
+++ b/Client/Rewards/RewardsReporting.swift
@@ -27,7 +27,8 @@ class RewardsReporting: TabContentScript {
         return "rewardsReporting"
     }
     
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         struct Content: Decodable {
             var method: String
             var url: String

--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper+TabContentScript.swift
@@ -23,7 +23,8 @@ extension ContentBlockerHelper: TabContentScript {
         blockedRequests.removeAll()
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+        defer { replyHandler(nil, nil) }
         guard let body = message.body as? [String: AnyObject] else {
             return
         }


### PR DESCRIPTION
## Summary of Changes

This switches the message script handler delegate from `WKScriptMessageHandler` to `WKScriptMessageHandlerWithReply` which allows us to handle async promises directly from Swift side.  Currently we do not use the reply handler for anything, but we could use it to handle promises in the Brave Search + Brave Talk helpers later

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

Theoretically this should have no affect to current JS as all handlers pass back nil, but we could sanity test some of the JS based features such as find in page/reader mode

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
