### PR TITLE
Fix #5034: Playlist-Folders crashing when deleting.

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -67,6 +67,11 @@ class PlaylistListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        PlaylistManager.shared.onFolderRemovedOrUpdated
+        .sink { [weak self] in
+            self?.tableView.reloadData()
+        }.store(in: &observers)
+        
         PlaylistManager.shared.contentWillChange
         .sink { [weak self] in
             self?.controllerWillChangeContent()

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -37,6 +37,7 @@ class PlaylistManager: NSObject {
                                                              displayName: String?,
                                                              error: Error?), Never>()
     private let onCurrentFolderChanged = PassthroughSubject<(), Never>()
+    private let onFolderDeleted = PassthroughSubject<(), Never>()
     
     private override init() {
         super.init()
@@ -65,6 +66,10 @@ class PlaylistManager: NSObject {
             
             onCurrentFolderChanged.send()
         }
+    }
+    
+    var onFolderRemovedOrUpdated: AnyPublisher<Void, Never> {
+        onFolderDeleted.eraseToAnyPublisher()
     }
     
     var contentWillChange: AnyPublisher<Void, Never> {
@@ -284,6 +289,7 @@ class PlaylistManager: NSObject {
             currentFolder = nil
         }
         
+        onFolderDeleted.send()
         reloadData()
         return success
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add observer to reload the table when a folder is deleted.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5034

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
