### PR TITLE
Fix #3965: Add consistent capitalization to siri shortcut descriptions

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -2060,7 +2060,7 @@ extension Strings {
         public static let shortcutSettingsClearBrowserHistoryDescription =
             NSLocalizedString("shortcuts.shortcutSettingsClearBrowserHistoryDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to Open a New Tab & Clear Browser History via Siri - Voice Assistant",
+                              value: "Use Shortcuts to open a new tab & clear browser history via Siri - Voice Assistant",
                               comment: "Description of Clear Browser History Siri Shortcut in Settings Screen")
         
         public static let shortcutSettingsEnableVPNTitle =
@@ -2084,7 +2084,7 @@ extension Strings {
         public static let shortcutSettingsOpenBraveNewsDescription =
             NSLocalizedString("shortcuts.shortcutSettingsOpenBraveNewsDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to Open a New Tab & Show Brave News Feed via Siri - Voice Assistant",
+                              value: "Use Shortcuts to open a new tab & show Brave News Feed via Siri - Voice Assistant",
                               comment: "Description of Open Brave News Siri Shortcut in Settings Screen")
         
         public static let shortcutSettingsOpenPlaylistTitle =
@@ -2096,7 +2096,7 @@ extension Strings {
         public static let shortcutSettingsOpenPlaylistDescription =
             NSLocalizedString("shortcuts.shortcutSettingsOpenPlaylistDescription",
                               bundle: .braveShared,
-                              value: "Use Shortcuts to Open Playlist via Siri - Voice Assistant",
+                              value: "Use Shortcuts to open Playlist via Siri - Voice Assistant",
                               comment: "Description of Open Playlist Siri Shortcut in Settings Screen")
         
         public static let shortcutOpenApplicationSettingsTitle =


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fix english text to have consistent capitalization on Siri Shortcut descriptions. Fixes https://github.com/brave/brave-ios/issues/3965

Note: Since the ticket was created a few new inconsistencies were added. I attempted to fix those as well however they are slightly out of the scope of the original ticket. More than happy to pull those changes out.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR included in ticket. Additional text changes outside of the STR include:
"Use Shortcuts to open playlist via Siri - Voice Assistant"
"Use Shortcuts to open a new tab & clear browser history via Siri - Voice Assistant"


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-01 at 11 50 54](https://user-images.githubusercontent.com/909331/156212356-128f8100-71d4-47bf-8d25-230705e4faa3.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
