### PR TITLE
Fix #4906: Reduce right padding on navigation bar buttons for symmetry

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -201,7 +201,9 @@ class TabLocationView: UIView {
     }()
     
     lazy var separatorLine: UIView = CustomSeparatorView(lineSize: .init(width: 1, height: 26), cornerRadius: 2).then {
+        $0.isUserInteractionEnabled = false
         $0.backgroundColor = .braveSeparator
+        $0.layoutMargins = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: 2)
     }
     
     lazy var tabOptionsStackView = UIStackView()
@@ -222,19 +224,13 @@ class TabLocationView: UIView {
         addGestureRecognizer(longPressRecognizer)
         addGestureRecognizer(tapRecognizer)
         
-        var optionSubviews = [readerModeButton, playlistButton, reloadButton, separatorLine, shieldsButton]
-        separatorLine.isUserInteractionEnabled = false
-        
-        optionSubviews.append(rewardsButton)
-        
-        let buttonContentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+        let optionSubviews = [readerModeButton, playlistButton, reloadButton, separatorLine, shieldsButton, rewardsButton]
         optionSubviews.forEach {
-            ($0 as? CustomSeparatorView)?.layoutMargins = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: 2)
-            ($0 as? UIButton)?.contentEdgeInsets = buttonContentEdgeInsets
+            ($0 as? UIButton)?.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
             $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
             $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+            tabOptionsStackView.addArrangedSubview($0)
         }
-        optionSubviews.forEach(tabOptionsStackView.addArrangedSubview)
         
         urlTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
         

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -244,7 +244,7 @@ class TabLocationView: UIView {
         contentView.spacing = 10
         contentView.setCustomSpacing(5, after: urlTextField)
         
-        tabOptionsStackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 6)
+        tabOptionsStackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 3)
         tabOptionsStackView.isLayoutMarginsRelativeArrangement = true
         addSubview(contentView)
         


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

* Adjusted the right margin by reducing it by 3px to make margins look more symmetrical. Fixes https://github.com/brave/brave-ios/issues/4906
* Did some minor code cleanup to reduce code lines.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

* STR included in ticket. 
* Test the icons for positioning and functionality


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
<img width="356" alt="Screen Shot 2022-03-02 at 9 11 38 AM" src="https://user-images.githubusercontent.com/909331/156377898-934e7ca7-1f86-42cb-bd99-72dfb7870275.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
