### PR TITLE
Fix 5047: Fix Crash in PIP presentation

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController+AVDelegates.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController+AVDelegates.swift
@@ -63,6 +63,19 @@ extension PlaylistViewController: AVPictureInPictureControllerDelegate {
                 attachPlayerView()
             }
             
+            // There is a case when the user can manually present the PlaylistController through 3-dot menu
+            // or URL bar. In that case, attempting to present the same controller WILL crash the application
+            // So we need to guard against it.
+            if restorationController.presentingViewController != nil ||
+                restorationController.isMovingToParent ||
+                restorationController.isBeingPresented {
+                DispatchQueue.main.async {
+                    PlaylistCarplayManager.shared.playlistController = nil
+                    completionHandler(true)
+                }
+                return
+            }
+            
             browserViewController.present(restorationController, animated: true) {
                 DispatchQueue.main.async {
                     PlaylistCarplayManager.shared.playlistController = nil


### PR DESCRIPTION
## Summary of Changes
- Fixes crash when presenting playlist controller via PIP that is already being presented

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5047

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
