### PR TITLE
Fix #5054: Fix position of the share sheet when long pressing link/image

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2622,8 +2622,7 @@ extension BrowserViewController: WKUIDelegate {
                     let shareAction = UIAction(title: Strings.shareLinkActionTitle,
                                                image: UIImage(systemName: "square.and.arrow.up")) { _ in
                         let touchPoint = braveWebView.lastHitPoint
-                        let touchSize = CGSize(width: 0, height: 16)
-                        let touchRect = CGRect(origin: touchPoint, size: touchSize)
+                        let touchRect = CGRect(origin: touchPoint, size: .zero)
 
                         // TODO: Find a way to add fixes #3323 and #2961 here:
                         // Normally we use `tab.temporaryDocument` for the downloaded file on the tab.
@@ -2636,7 +2635,7 @@ extension BrowserViewController: WKUIDelegate {
                         // Some possibile fixes include:
                         // - Detect the file type and download it if necessary and don't rely on the `tab.temporaryDocument`.
                         // - Add custom "Save to file" functionality (needs investigation).
-                        self.presentActivityViewController(url, sourceView: self.view,
+                        self.presentActivityViewController(url, sourceView: braveWebView,
                                                            sourceRect: touchRect,
                                                            arrowDirection: .any)
                     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5054 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR In ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
<img width="347" alt="Screen Shot 2022-03-04 at 10 34 26 AM" src="https://user-images.githubusercontent.com/909331/156792926-f8859e2d-14a4-47d8-9ef4-aabff943093b.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
