### PR TITLE
Fix #5051: Added one more option in wallet settings to reset local transactions.

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -183,8 +183,11 @@ public class CryptoStore: ObservableObject {
     return store
   }
   
-  private(set) lazy var settingsStore = SettingsStore(keyringService: keyringService,
-                                                      walletService: walletService)
+  private(set) lazy var settingsStore = SettingsStore(
+    keyringService: keyringService,
+    walletService: walletService,
+    txService: txService
+  )
   
   func fetchUnapprovedTransactions() {
     keyringService.defaultKeyringInfo { [self] keyring in

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -16,13 +16,16 @@ public class SettingsStore: ObservableObject {
   
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
+  private let txService: BraveWalletTxService
   
   public init(
     keyringService: BraveWalletKeyringService,
-    walletService: BraveWalletBraveWalletService
+    walletService: BraveWalletBraveWalletService,
+    txService: BraveWalletTxService
   ) {
     self.keyringService = keyringService
     self.walletService = walletService
+    self.txService = txService
     
     self.keyringService.autoLockMinutes { minutes in
       self.autoLockInterval = .init(value: minutes)
@@ -32,6 +35,10 @@ public class SettingsStore: ObservableObject {
   func reset() {
     walletService.reset()
     KeyringStore.resetKeychainStoredPassword()
+  }
+  
+  func resetTransaction() {
+    txService.reset()
   }
   
   public func isDefaultKeyringCreated(_ completion: @escaping (Bool) -> Void) {

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -156,7 +156,8 @@ extension SettingsStore {
   static var previewStore: SettingsStore {
     .init(
       keyringService: MockKeyringService(),
-      walletService: MockBraveWalletService()
+      walletService: MockBraveWalletService(),
+      txService: MockTxService()
     )
   }
 }

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -67,7 +67,7 @@ public struct WalletSettingsView: View {
       ) {
         Button(action: { isShowingResetTransactionAlert = true }) {
           Text(Strings.Wallet.settingsResetTransactionTitle)
-            .foregroundColor(Color(.braveLabel))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -92,7 +92,7 @@ public struct WalletSettingsView: View {
             primaryButton: .destructive(Text(Strings.Wallet.settingsResetTransactionAlertButtonTitle), action: {
               settingsStore.resetTransaction()
             }),
-            secondaryButton: .cancel(Text(Strings.no))
+            secondaryButton: .cancel(Text(Strings.cancelButtonTitle))
           )
         }
     )

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -11,7 +11,8 @@ public struct WalletSettingsView: View {
   @ObservedObject var settingsStore: SettingsStore
   @ObservedObject var networkStore: NetworkStore
   
-  @State private var isShowingResetAlert = false
+  @State private var isShowingResetWalletAlert = false
+  @State private var isShowingResetTransactionAlert = false
   
   public init(
     settingsStore: SettingsStore,
@@ -60,8 +61,18 @@ public struct WalletSettingsView: View {
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      Section(
+        footer: Text(Strings.Wallet.settingsResetTransactionFooter)
+          .foregroundColor(Color(.secondaryBraveLabel))
+      ) {
+        Button(action: { isShowingResetTransactionAlert = true }) {
+          Text(Strings.Wallet.settingsResetTransactionTitle)
+            .foregroundColor(Color(.braveLabel))
+        }
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section {
-        Button(action: { isShowingResetAlert = true }) {
+        Button(action: { isShowingResetWalletAlert = true }) {
           Text(Strings.Wallet.settingsResetButtonTitle)
             .foregroundColor(.red)
         }
@@ -72,16 +83,32 @@ public struct WalletSettingsView: View {
     .listStyle(InsetGroupedListStyle())
     .navigationTitle(Strings.Wallet.braveWallet)
     .navigationBarTitleDisplayMode(.inline)
-    .alert(isPresented: $isShowingResetAlert) {
-      Alert(
-        title: Text(Strings.Wallet.settingsResetWalletAlertTitle),
-        message: Text(Strings.Wallet.settingsResetWalletAlertMessage),
-        primaryButton: .destructive(Text(Strings.Wallet.settingsResetWalletAlertButtonTitle), action: {
-          settingsStore.reset()
-        }),
-        secondaryButton: .cancel(Text(Strings.no))
-      )
-    }
+    .background(
+      Color.clear
+        .alert(isPresented: $isShowingResetTransactionAlert) {
+          Alert(
+            title: Text(Strings.Wallet.settingsResetWalletAlertTitle),
+            message: Text(Strings.Wallet.settingsResetTransactionAlertMessage),
+            primaryButton: .destructive(Text(Strings.Wallet.settingsResetTransactionAlertButtonTitle), action: {
+              settingsStore.resetTransaction()
+            }),
+            secondaryButton: .cancel(Text(Strings.no))
+          )
+        }
+    )
+    .background(
+      Color.clear
+        .alert(isPresented: $isShowingResetWalletAlert) {
+          Alert(
+            title: Text(Strings.Wallet.settingsResetWalletAlertTitle),
+            message: Text(Strings.Wallet.settingsResetWalletAlertMessage),
+            primaryButton: .destructive(Text(Strings.Wallet.settingsResetWalletAlertButtonTitle), action: {
+              settingsStore.reset()
+            }),
+            secondaryButton: .cancel(Text(Strings.no))
+          )
+        }
+    )
   }
 }
 

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -87,7 +87,7 @@ public struct WalletSettingsView: View {
       Color.clear
         .alert(isPresented: $isShowingResetTransactionAlert) {
           Alert(
-            title: Text(Strings.Wallet.settingsResetWalletAlertTitle),
+            title: Text(Strings.Wallet.settingsResetTransactionAlertTitle),
             message: Text(Strings.Wallet.settingsResetTransactionAlertMessage),
             primaryButton: .destructive(Text(Strings.Wallet.settingsResetTransactionAlertButtonTitle), action: {
               settingsStore.resetTransaction()

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1818,7 +1818,7 @@ extension Strings {
       "wallet.settingsResetTransactionTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Clear wallet transaction and nonce information",
+      value: "Clear transaction & nonce info",
       comment: "The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0"
     )
     public static let settingsResetTransactionFooter = NSLocalizedString(

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1814,5 +1814,40 @@ extension Strings {
       value: "For now, no additional action is required. Just wait for the unconfirmed transactions to clear.",
       comment: "Additional information, when users have previously clear and replace the incomplete transaction(s)"
     )
+    public static let settingsResetTransactionTitle = NSLocalizedString(
+      "wallet.settingsResetTransactionTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Clear wallet transaction and nonce information",
+      comment: "The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0"
+    )
+    public static let settingsResetTransactionFooter = NSLocalizedString(
+      "wallet.settingsResetTransactionFooter",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Clearing transactions may be useful for developers or when clearing state on a local server",
+      comment: "The footer message below the button to reset transaction"
+    )
+    public static let settingsResetTransactionAlertTitle = NSLocalizedString(
+      "wallet.settingsResetTransactionAlertTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Are you sure you want to reset transacton and nonce information?",
+      comment: "The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0"
+    )
+    public static let settingsResetTransactionAlertMessage = NSLocalizedString(
+      "wallet.settingsResetTransactionAlertMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "This option is mostly used by developers running a local test server",
+      comment: "The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0"
+    )
+    public static let settingsResetTransactionAlertButtonTitle = NSLocalizedString(
+      "wallet.settingsResetTransactionAlertButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Reset",
+      comment: "The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0"
+    )
   }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -143,9 +143,13 @@ extension BrowserViewController {
             MenuItemButton(icon: #imageLiteral(resourceName: "menu-settings").template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
                 var settingsStore: SettingsStore?
                 if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-                   let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
-                    settingsStore = SettingsStore(keyringService: keyringService,
-                                                  walletService: walletService)
+                   let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+                   let txService = BraveWallet.TxServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
+                    settingsStore = SettingsStore(
+                        keyringService: keyringService,
+                        walletService: walletService,
+                        txService: txService
+                    )
                 }
                 let networkStore = BraveWallet.JsonRpcServiceFactory
                     .get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)


### PR DESCRIPTION
This pull request fixes #5051 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. make some transactions so they show up under account activity screen
2. go to wallet settings and click rest transaction row
3. (a pop up will show up to ask users to confirm)
4. click reset in the pop up
5. go back to account activity screen, the list of transactions should be gone. 

## Screenshots:
![simulator_screenshot_C1468836-375D-4599-A4DA-AFBCFE2B54CC](https://user-images.githubusercontent.com/1187676/157090104-72ca7a55-f22f-4bf3-ae3f-43e8d5d19c37.png)

![simulator_screenshot_2FE29391-5FFF-45BA-93A1-EFCE33D26229](https://user-images.githubusercontent.com/1187676/157090119-427b8676-51d7-4da0-9e0a-d2f27056a78c.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
