### PR TITLE
No bug: Use TxConfirmationStore to fetch unapproved txns

### DIFF
--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -24,7 +24,7 @@ struct CryptoPagesView: View {
       keyringStore: keyringStore,
       cryptoStore: cryptoStore,
       isShowingTransactions: $cryptoStore.isPresentingTransactionConfirmations,
-      isConfirmationsButtonVisible: !cryptoStore.unapprovedTransactions.isEmpty
+      isConfirmationsButtonVisible: cryptoStore.hasUnapprovedTransactions
     )
       .onAppear {
         // If a user chooses not to confirm/reject their transactions we shouldn't

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -136,9 +136,8 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
     .background(
       Color.clear
         .sheet(isPresented: $cryptoStore.isPresentingTransactionConfirmations) {
-          if !cryptoStore.unapprovedTransactions.isEmpty {
+          if cryptoStore.hasUnapprovedTransactions {
             TransactionConfirmationView(
-              transactions: cryptoStore.unapprovedTransactions,
               confirmationStore: cryptoStore.openConfirmationStore(),
               networkStore: cryptoStore.networkStore,
               keyringStore: keyringStore

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -26,7 +26,7 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
-  @Published var hasUnapprovedTransactions: Bool = false
+  @Published private(set) var hasUnapprovedTransactions: Bool = false
   
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -36,12 +36,6 @@ public class CryptoStore: ObservableObject {
   let blockchainRegistry: BraveWalletBlockchainRegistry
   private let txService: BraveWalletTxService
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
-  
-  private var unapprovedTransactions: [BraveWallet.TransactionInfo] = [] {
-    didSet {
-      hasUnapprovedTransactions = !unapprovedTransactions.isEmpty
-    }
-  }
   
   public init(
     keyringService: BraveWalletKeyringService,
@@ -215,7 +209,7 @@ public class CryptoStore: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
           // On iPad if we set these before the send or swap screens disappear for some reason it crashes
           // within the SwiftUI runtime. Delaying it to give time for the animation to complete fixes it.
-          self.unapprovedTransactions = pendingTransactions
+          self.hasUnapprovedTransactions = !pendingTransactions.isEmpty
           self.isPresentingTransactionConfirmations = !pendingTransactions.isEmpty
         }
       }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -26,7 +26,7 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
-  @Published private(set) var unapprovedTransactions: [BraveWallet.TransactionInfo] = []
+  @Published var hasUnapprovedTransactions: Bool = false
   
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -36,6 +36,12 @@ public class CryptoStore: ObservableObject {
   let blockchainRegistry: BraveWalletBlockchainRegistry
   private let txService: BraveWalletTxService
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
+  
+  private var unapprovedTransactions: [BraveWallet.TransactionInfo] = [] {
+    didSet {
+      hasUnapprovedTransactions = !unapprovedTransactions.isEmpty
+    }
+  }
   
   public init(
     keyringService: BraveWalletKeyringService,
@@ -177,7 +183,8 @@ public class CryptoStore: ObservableObject {
       txService: txService,
       blockchainRegistry: blockchainRegistry,
       walletService: walletService,
-      ethTxManagerProxy: ethTxManagerProxy
+      ethTxManagerProxy: ethTxManagerProxy,
+      keyringService: keyringService
     )
     confirmationStore = store
     return store

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -201,7 +201,7 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
   
-  func fetchGasEstimation1559() {
+  private func fetchGasEstimation1559() {
     ethTxManagerProxy.gasEstimation1559() { [weak self] gasEstimation in
       self?.gasEstimation1559 = gasEstimation
     }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -23,20 +23,17 @@ public class TransactionConfirmationStore: ObservableObject {
   @Published var isLoading: Bool = false
   @Published var gasEstimation1559: BraveWallet.GasEstimation1559?
   /// This is a list of all unpproved transactions iterated through all the accounts for the current keyring
-  @Published var transactions: [BraveWallet.TransactionInfo] = []
+  @Published private(set) var transactions: [BraveWallet.TransactionInfo] = []
   /// This is an id for the unppproved transaction that is currently displayed on screen
   @Published var activeTransactionId: BraveWallet.TransactionInfo.ID = "" {
     didSet {
       if let tx = transactions.first(where: { $0.id == activeTransactionId }) {
-        activeTransaction = tx
+        fetchDetails(for: tx)
       } else if let firstTx = transactions.first {
-        activeTransaction = firstTx
+        fetchDetails(for: firstTx)
       }
-      fetchDetails(for: activeTransaction)
     }
   }
-  /// This is a transaction object from `transactions` that its `id` is the value of `activeTransactionId`
-  @Published var activeTransaction: BraveWallet.TransactionInfo = .init()
   
   private var assetRatios: [String: Double] = [:]
   
@@ -108,7 +105,6 @@ public class TransactionConfirmationStore: ObservableObject {
   func fetchDetails(for transaction: BraveWallet.TransactionInfo) {
     state = .init() // Reset state
     isLoading = true
-    activeTransaction = transaction
     
     rpcService.chainId { [weak self] chainId in
       guard let self = self else { return }

--- a/BraveWallet/Preview Content/MockEthTxService.swift
+++ b/BraveWallet/Preview Content/MockEthTxService.swift
@@ -18,7 +18,15 @@ class MockTxService: BraveWalletTxService {
   }
   
   func allTransactionInfo(_ coinType: BraveWallet.CoinType, from: String, completion: @escaping ([BraveWallet.TransactionInfo]) -> Void) {
-    completion([])
+    completion([
+      BraveWallet.TransactionInfo.previewConfirmedERC20Approve,
+      .previewConfirmedSend,
+      .previewConfirmedSwap
+    ].map {
+      tx in
+      tx.txStatus = .unapproved
+      return tx
+    })
   }
   
   func add(_ observer: BraveWalletTxServiceObserver) {

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -147,7 +147,8 @@ extension TransactionConfirmationStore {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       walletService: MockBraveWalletService(),
-      ethTxManagerProxy: MockEthTxManagerProxy()
+      ethTxManagerProxy: MockEthTxManagerProxy(),
+      keyringService: MockKeyringService()
     )
   }
 }


### PR DESCRIPTION
## Summary of Changes
A list of un-approved transactions was fetched inside `CryptoStore` and passed to `TransactionConfirmationView` whenever the view will be presented.
This PR is to subtract the logic of fetching from `CryptoStore` and let `TransactionConfirmationStore` to take care of. So that `CryptoStore` will only determine when to show transaction confirmation panel. and the panel's store -- `TransactionConfirmationStore` to fetch the list of unapproved transactions.
This is beneficial when there will be more business logic going to be added in transaction confirmation flow, for example: transaction backlog issue.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
