### PR TITLE
Fix #4911: Update Swap button description copy

### DIFF
--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -411,7 +411,7 @@ extension Strings {
       "wallet.swapDescription",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Swap crypto assets with Brave DEX aggregator.",
+      value: "Swap tokens and assets.",
       comment: "The description of a swap button on the buy/send/swap modal"
     )
     public static let infoTitle = NSLocalizedString(


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4911


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Test Plan:
1. Unlock wallet
2. Tap swap button
3. Swap row should


## Screenshots:
![Simulator Screen Shot - iPhone 13 - 2022-03-08 at 09 30 36](https://user-images.githubusercontent.com/5314553/157258476-98649992-417b-4939-a2f9-6f5a246426ad.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
