### PR TITLE
Fix #5072, #5071, #5068, #5065, #5069: CarPlay folders not updating correctly when phone is used at the same time.

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -15,9 +15,9 @@ import CoreData
 private let log = Logger.browserLogger
 
 private enum PlaylistCarPlayTemplateID: String {
-    case Folders
-    case ItemsList
-    case Settings
+    case folders
+    case itemsList
+    case settings
 }
 
 class PlaylistCarplayController: NSObject {
@@ -114,16 +114,16 @@ class PlaylistCarplayController: NSObject {
 
             // If the folder's items isn't showing, then we're either on the folder view or settings view
             // Therefore we need to push the folder view onto the stack
-            if currentTemplate == nil || (currentTemplate?.userInfo as? [String: String])?["id"] != PlaylistCarPlayTemplateID.ItemsList.rawValue {
+            if currentTemplate == nil || (currentTemplate?.userInfo as? [String: String])?["id"] != PlaylistCarPlayTemplateID.itemsList.rawValue {
                 
                 // Fetch the root playlistTabTemplate
                 currentTemplate = tabTemplate.templates.compactMap({ $0 as? CPListTemplate }).first(where: {
-                    ($0.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.ItemsList.rawValue
+                    ($0.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.itemsList.rawValue
                 })
             }
             
             // We need to ensure the template that is showing is the list of playlist items
-            guard (currentTemplate?.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.ItemsList.rawValue else {
+            guard (currentTemplate?.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.itemsList.rawValue else {
                 return
             }
             
@@ -329,7 +329,7 @@ class PlaylistCarplayController: NSObject {
             $0.tabImage = UIImage(systemName: "list.star")
             $0.emptyViewTitleVariants = [Strings.PlayList.noItemLabelTitle]
             $0.emptyViewSubtitleVariants = [Strings.PlayList.noItemLabelDetailLabel]
-            $0.userInfo = ["id": PlaylistCarPlayTemplateID.Folders.rawValue]
+            $0.userInfo = ["id": PlaylistCarPlayTemplateID.folders.rawValue]
         }
         return foldersTemplate
     }
@@ -432,7 +432,7 @@ class PlaylistCarplayController: NSObject {
             $0.tabImage = UIImage(systemName: "list.star")
             $0.emptyViewTitleVariants = [Strings.PlayList.noItemLabelTitle]
             $0.emptyViewSubtitleVariants = [Strings.PlayList.noItemLabelDetailLabel]
-            $0.userInfo = ["id": PlaylistCarPlayTemplateID.ItemsList.rawValue]
+            $0.userInfo = ["id": PlaylistCarPlayTemplateID.itemsList.rawValue]
         }
         return playlistTemplate
     }
@@ -477,7 +477,7 @@ class PlaylistCarplayController: NSObject {
         let settingsTemplate = CPListTemplate(title: Strings.PlayList.playlistCarplaySettingsSectionTitle,
                                               sections: [playbackSection]).then {
             $0.tabImage = UIImage(systemName: "gear")
-            $0.userInfo = ["id": PlaylistCarPlayTemplateID.Settings.rawValue]
+            $0.userInfo = ["id": PlaylistCarPlayTemplateID.settings.rawValue]
         }
         return settingsTemplate
     }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -14,6 +14,12 @@ import CoreData
 
 private let log = Logger.browserLogger
 
+private enum PlaylistCarPlayTemplateID: String {
+    case Folders
+    case ItemsList
+    case Settings
+}
+
 class PlaylistCarplayController: NSObject {
     private let player: MediaPlayer
     private let mediaStreamer: PlaylistMediaStreamer
@@ -103,11 +109,25 @@ class PlaylistCarplayController: NSObject {
                 return
             }
             
-            let playlistTabTemplate = tabTemplate.templates.compactMap({ $0 as? CPListTemplate }).first(where: {
-                ($0.userInfo as? [String: String])?["id"] == "Playlist.Folder.List.Tab"
-            })
+            // The folder is already showing all its items
+            var currentTemplate = self.interfaceController.topTemplate as? CPListTemplate
+
+            // If the folder's items isn't showing, then we're either on the folder view or settings view
+            // Therefore we need to push the folder view onto the stack
+            if currentTemplate == nil || (currentTemplate?.userInfo as? [String: String])?["id"] != PlaylistCarPlayTemplateID.ItemsList.rawValue {
+                
+                // Fetch the root playlistTabTemplate
+                currentTemplate = tabTemplate.templates.compactMap({ $0 as? CPListTemplate }).first(where: {
+                    ($0.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.ItemsList.rawValue
+                })
+            }
             
-            if let playlistTabTemplate = playlistTabTemplate {
+            // We need to ensure the template that is showing is the list of playlist items
+            guard (currentTemplate?.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.ItemsList.rawValue else {
+                return
+            }
+            
+            if let playlistTabTemplate = currentTemplate {
                 let items = playlistTabTemplate.sections.flatMap({ $0.items }).compactMap({ $0 as? CPListItem })
                 
                 items.forEach({
@@ -309,7 +329,7 @@ class PlaylistCarplayController: NSObject {
             $0.tabImage = UIImage(systemName: "list.star")
             $0.emptyViewTitleVariants = [Strings.PlayList.noItemLabelTitle]
             $0.emptyViewSubtitleVariants = [Strings.PlayList.noItemLabelDetailLabel]
-            $0.userInfo = ["id": "Playlist.Folders.Tab"]
+            $0.userInfo = ["id": PlaylistCarPlayTemplateID.Folders.rawValue]
         }
         return foldersTemplate
     }
@@ -347,7 +367,7 @@ class PlaylistCarplayController: NSObject {
                     for item in listItems.enumerated() {
                         let userInfo = item.element.userInfo as? [String: Any] ?? [:]
                         item.element.isPlaying = isPlaying &&
-                            (PlaylistCarplayManager.shared.currentlyPlayingItemIndex == item.offset || PlaylistCarplayManager.shared.currentPlaylistItem?.src == userInfo["id"] as? String)
+                            (PlaylistCarplayManager.shared.currentPlaylistItem?.src == userInfo["id"] as? String)
                     }
                     
                     let userInfo = listItem.userInfo as? [String: Any]
@@ -369,7 +389,7 @@ class PlaylistCarplayController: NSObject {
             
             // Update the current playing status
             listItem.isPlaying = player.isPlaying &&
-                (PlaylistCarplayManager.shared.currentlyPlayingItemIndex == itemIndex || PlaylistCarplayManager.shared.currentPlaylistItem?.src == item.src)
+                (PlaylistCarplayManager.shared.currentPlaylistItem?.src == item.src)
             
             listItem.accessoryType = PlaylistManager.shared.state(for: itemId) != .downloaded ? .cloud : .none
             listItem.setImage(FaviconFetcher.defaultFaviconImage)
@@ -412,7 +432,7 @@ class PlaylistCarplayController: NSObject {
             $0.tabImage = UIImage(systemName: "list.star")
             $0.emptyViewTitleVariants = [Strings.PlayList.noItemLabelTitle]
             $0.emptyViewSubtitleVariants = [Strings.PlayList.noItemLabelDetailLabel]
-            $0.userInfo = ["id": "Playlist.Folder.List.Tab"]
+            $0.userInfo = ["id": PlaylistCarPlayTemplateID.ItemsList.rawValue]
         }
         return playlistTemplate
     }
@@ -457,6 +477,7 @@ class PlaylistCarplayController: NSObject {
         let settingsTemplate = CPListTemplate(title: Strings.PlayList.playlistCarplaySettingsSectionTitle,
                                               sections: [playbackSection]).then {
             $0.tabImage = UIImage(systemName: "gear")
+            $0.userInfo = ["id": PlaylistCarPlayTemplateID.Settings.rawValue]
         }
         return settingsTemplate
     }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
@@ -186,8 +186,9 @@ extension PlaylistFolderController: UITableViewDelegate {
         
         editView.onEditFolder = { [weak self] folderTitle in
             guard let self = self else { return }
-            PlaylistFolder.updateFolder(folderID: folderID) { folder, error in
-                if let error = error {
+            PlaylistFolder.updateFolder(folderID: folderID) { result in
+                switch result {
+                case .failure(let error):
                     log.error("Error Saving Folder Title: \(error)")
                     
                     DispatchQueue.main.async {
@@ -198,8 +199,9 @@ extension PlaylistFolderController: UITableViewDelegate {
                         }))
                         self.present(alert, animated: true, completion: nil)
                     }
-                } else {
-                    folder?.title = folderTitle
+                    
+                case .success(let folder):
+                    folder.title = folderTitle
                     
                     DispatchQueue.main.async {
                         self.presentedViewController?.dismiss(animated: true, completion: nil)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
@@ -186,16 +186,8 @@ extension PlaylistFolderController: UITableViewDelegate {
         
         editView.onEditFolder = { [weak self] folderTitle in
             guard let self = self else { return }
-            
-            DataController.performOnMainContext { context in
-                do {
-                    let folder = try context.existingObject(with: folderID) as? PlaylistFolder
-                    folder?.title = folderTitle
-                    
-                    DispatchQueue.main.async {
-                        self.presentedViewController?.dismiss(animated: true, completion: nil)
-                    }
-                } catch {
+            PlaylistFolder.updateFolder(folderID: folderID) { folder, error in
+                if let error = error {
                     log.error("Error Saving Folder Title: \(error)")
                     
                     DispatchQueue.main.async {
@@ -205,6 +197,12 @@ extension PlaylistFolderController: UITableViewDelegate {
                             self.presentedViewController?.dismiss(animated: true, completion: nil)
                         }))
                         self.present(alert, animated: true, completion: nil)
+                    }
+                } else {
+                    folder?.title = folderTitle
+                    
+                    DispatchQueue.main.async {
+                        self.presentedViewController?.dismiss(animated: true, completion: nil)
                     }
                 }
             }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -154,6 +154,7 @@ class PlaylistListViewController: UIViewController {
             .sink { [weak self] in
                 guard let self = self else { return }
                 self.title = PlaylistManager.shared.currentFolder?.title
+                self.tableView.reloadData()
         }
     }
     
@@ -342,6 +343,10 @@ class PlaylistListViewController: UIViewController {
         let selectedItems = indexPaths.compactMap({
             PlaylistManager.shared.fetchedObjects[safe: $0.row]
         })
+        
+        if selectedItems.contains(where: { $0.pageSrc == PlaylistCarplayManager.shared.currentPlaylistItem?.pageSrc }) {
+            delegate?.stopPlaying()
+        }
         
         var moveController = PlaylistMoveFolderView(selectedItems: selectedItems)
         moveController.onCancelButtonPressed = { [weak self] in

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -898,13 +898,13 @@ extension PlaylistViewController: VideoViewDelegate {
                         return
                     }
                     
-                    PlaylistMediaStreamer.clearNowPlayingInfo()
                     self.playerView.setVideoInfo(videoDomain: item.pageSrc,
                                                  videoTitle: item.pageTitle)
                     PlaylistMediaStreamer.setNowPlayingInfo(item, withPlayer: self.player)
                     completion?(.none)
                 }).store(in: &assetLoadingStateObservers)
             } else {
+                PlaylistMediaStreamer.clearNowPlayingInfo()
                 completion?(.expired)
             }
             return

--- a/Data/models/PlaylistFolder.swift
+++ b/Data/models/PlaylistFolder.swift
@@ -83,6 +83,21 @@ final public class PlaylistFolder: NSManagedObject, CRUD, Identifiable {
         folder.delete()
     }
     
+    public static func updateFolder(folderID: NSManagedObjectID, _ update: @escaping (PlaylistFolder?, Error?) -> Void) {
+        DataController.perform(context: .new(inMemory: false), save: true) { context in
+            do {
+                guard let folder = try context.existingObject(with: folderID) as? PlaylistFolder else {
+                    update(nil, "Invalid Folder")
+                    return
+                }
+                
+                update(folder, nil)
+            } catch {
+                update(nil, error)
+            }
+        }
+    }
+    
     // MARK: - Internal
     private static func reorderItems(context: NSManagedObjectContext) {
         DataController.perform(context: .existing(context), save: true) { context in

--- a/Data/models/PlaylistFolder.swift
+++ b/Data/models/PlaylistFolder.swift
@@ -83,17 +83,17 @@ final public class PlaylistFolder: NSManagedObject, CRUD, Identifiable {
         folder.delete()
     }
     
-    public static func updateFolder(folderID: NSManagedObjectID, _ update: @escaping (PlaylistFolder?, Error?) -> Void) {
+    public static func updateFolder(folderID: NSManagedObjectID, _ update: @escaping (Result<PlaylistFolder, Error>) -> Void) {
         DataController.perform(context: .new(inMemory: false), save: true) { context in
             do {
                 guard let folder = try context.existingObject(with: folderID) as? PlaylistFolder else {
-                    update(nil, "Invalid Folder")
+                    update(.failure("No Existing Object in CoreData"))
                     return
                 }
                 
-                update(folder, nil)
+                update(.success(folder))
             } catch {
-                update(nil, error)
+                update(.failure(error))
             }
         }
     }


### PR DESCRIPTION
## Summary of Changes
- Fix album art bugs on lockscreen and when changing between folders
- Fix folder name not saving properly when changing the name and killing the app
- Fixed playing indicator in CarPlay not updating correctly when playing from the phone
- Fixed folders on the phone not refreshing properly when playing an item in carplay

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5072, #5071, #5068, #5065, #5069

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
