### PR TITLE
Fix #5052: Add ability to customize unapproved transaction's nonce value.

### DIFF
--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -203,7 +203,7 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
   
-  private func fetchTransactions(completion: (() -> Void)?) {
+  private func fetchTransactions(completion: @escaping (() -> Void)) {
     keyringService.defaultKeyringInfo { [weak self] keyring in
       guard let self = self else { return }
       var pendingTransactions: [BraveWallet.TransactionInfo] = []
@@ -217,7 +217,7 @@ public class TransactionConfirmationStore: ObservableObject {
       }
       group.notify(queue: .main) {
         self.transactions = pendingTransactions
-        completion?()
+        completion()
       }
     }
   }
@@ -281,13 +281,13 @@ public class TransactionConfirmationStore: ObservableObject {
   func editNonce(
     for transaction: BraveWallet.TransactionInfo,
     nonce: String,
-    completion: ((Bool) -> Void)? = nil
+    completion: @escaping ((Bool) -> Void)
   ) {
     ethTxManagerProxy.setNonceForUnapprovedTransaction(transaction.id, nonce: nonce) { success in
       // not going to refresh unapproved transactions since the tx observer will be
       // notified `onTransactionStatusChanged` and `ononUnapprovedTxUpdated`
       // `transactions` list will be refreshed there.
-      completion?(success)
+      completion(success)
     }
   }
 }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -203,6 +203,25 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
   
+  private func fetchTransactions(completion: (() -> Void)? = nil) {
+    keyringService.defaultKeyringInfo { [weak self] keyring in
+      guard let self = self else { return }
+      var pendingTransactions: [BraveWallet.TransactionInfo] = []
+      let group = DispatchGroup()
+      for info in keyring.accountInfos {
+        group.enter()
+        self.txService.allTransactionInfo(.eth, from: info.address) { tx in
+          defer { group.leave() }
+          pendingTransactions.append(contentsOf: tx.filter { $0.txStatus == .unapproved })
+        }
+      }
+      group.notify(queue: .main) {
+        self.transactions = pendingTransactions
+        completion?()
+      }
+    }
+  }
+  
   func confirm(transaction: BraveWallet.TransactionInfo) {
     txService.approveTransaction(.eth, txMetaId: transaction.id) { success, error, message  in
     }
@@ -249,25 +268,26 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
   
-  func fetchTransactions() {
-    keyringService.defaultKeyringInfo { [weak self] keyring in
-      guard let self = self else { return }
-      var pendingTransactions: [BraveWallet.TransactionInfo] = []
-      let group = DispatchGroup()
-      for info in keyring.accountInfos {
-        group.enter()
-        self.txService.allTransactionInfo(.eth, from: info.address) { tx in
-          defer { group.leave() }
-          pendingTransactions.append(contentsOf: tx.filter { $0.txStatus == .unapproved })
-        }
-      }
-      group.notify(queue: .main) {
-        self.transactions = pendingTransactions
-        if let firstTx = self.transactions.first { // only do additional set up if we have some unapproved tx
-          self.activeTransactionId = firstTx.id
-          self.fetchGasEstimation1559()
-        }
-      }
+  func prepare() {
+    fetchTransactions { [weak self] in
+      guard let self = self,
+            let firstTx = self.transactions.first
+      else { return }
+      self.activeTransactionId = firstTx.id
+      self.fetchGasEstimation1559()
+    }
+  }
+  
+  func editNonce(
+    for transaction: BraveWallet.TransactionInfo,
+    nonce: String,
+    completion: ((Bool) -> Void)? = nil
+  ) {
+    ethTxManagerProxy.setNonceForUnapprovedTransaction(transaction.id, nonce: nonce) { success in
+      // not going to refresh unapproved transactions since the tx observer will be
+      // notified `onTransactionStatusChanged` and `ononUnapprovedTxUpdated`
+      // `transactions` list will be refreshed there.
+      completion?(success)
     }
   }
 }
@@ -277,10 +297,19 @@ extension TransactionConfirmationStore: BraveWalletTxServiceObserver {
     // won't have any new unapproved tx being added if you on tx confirmation panel
   }
   public func onTransactionStatusChanged(_ txInfo: BraveWallet.TransactionInfo) {
-    fetchTransactions()
+    refreshTransactions(txInfo)
   }
   public func onUnapprovedTxUpdated(_ txInfo: BraveWallet.TransactionInfo) {
     // refresh the unapproved transaction list, as well as tx details UI
-    fetchTransactions()
+    refreshTransactions(txInfo)
+  }
+  
+  private func refreshTransactions(_ txInfo: BraveWallet.TransactionInfo) {
+    fetchTransactions { [weak self] in
+      guard let self = self else { return }
+      if self.activeTransactionId == txInfo.id {
+        self.fetchDetails(for: txInfo)
+      }
+    }
   }
 }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -203,7 +203,7 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
   
-  private func fetchTransactions(completion: (() -> Void)? = nil) {
+  private func fetchTransactions(completion: (() -> Void)?) {
     keyringService.defaultKeyringInfo { [weak self] keyring in
       guard let self = self else { return }
       var pendingTransactions: [BraveWallet.TransactionInfo] = []

--- a/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
@@ -95,7 +95,7 @@ struct EditGasFeeView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section {
         Button(action: save) {
-          Text(Strings.Wallet.saveGasFee)
+          Text(Strings.Wallet.saveButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .large))
         .frame(maxWidth: .infinity)

--- a/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -40,7 +40,7 @@ struct EditNonceView: View {
               }
           }
         }) {
-          Text(Strings.Wallet.saveCustomNonce)
+          Text(Strings.Wallet.saveButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .large))
         .disabled(nonce.isEmpty)
@@ -54,19 +54,14 @@ struct EditNonceView: View {
     .navigationTitle(Strings.Wallet.advancedSettingsTransaction)
     .onAppear {
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        // Most likely a SwiftUI bug. Need add a delay here to render text properly
         setup()
       }
     }
   }
   
   private func setup() {
-    let nonceDecimal: String
-    if let intValue = Int(transaction.ethTxNonce.removingHexPrefix, radix: 16) { // BaseData.nonce should always in hex
-      nonceDecimal = "\(intValue)"
-    } else {
-      nonceDecimal = transaction.ethTxNonce
-    }
-    nonce = nonceDecimal
+    nonce = Int(transaction.ethTxNonce.removingHexPrefix, radix: 16).map(String.init) ?? transaction.ethTxNonce
   }
 }
 

--- a/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -5,45 +5,44 @@
 
 import SwiftUI
 import BraveUI
+import BraveCore
+import struct Shared.Strings
 
 struct EditNonceView: View {
-  @Environment(\.sizeCategory) private var sizeCategory
-  @State private var nonce = ""
+  var confirmationStore: TransactionConfirmationStore
+  var transaction: BraveWallet.TransactionInfo
   
-  @ViewBuilder private var editNonceButtons: some View {
-    Button(action: {}) {
-      Text("Cancel")
-    }
-    .buttonStyle(BraveOutlineButtonStyle(size: .large))
-    Button(action: {}) {
-      Text("Save")
-    }
-    .buttonStyle(BraveFilledButtonStyle(size: .large))
-  }
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  @State private var nonce = ""
   
   var body: some View {
     List {
-      Section {
-        TextField("Enter custom nonce value", text: $nonce)
+      Section(
+        header: Text(Strings.Wallet.editNonceHeader)
+          .textCase(.none),
+        footer: Text(Strings.Wallet.editNonceFooter)
+      ) {
+        TextField(Strings.Wallet.editNoncePlaceholder, text: $nonce)
           .keyboardType(.numberPad)
-      } header: {
-        Text("Nonce")
-          .textCase(.none)
-      } footer: {
-        Text("Transaction may not be propagated in the network.")
       }
       Section {
-        Group {
-          if sizeCategory.isAccessibilityCategory {
-            VStack {
-              editNonceButtons
-            }
-          } else {
-            HStack {
-              editNonceButtons
-            }
+        Button(action: {
+          if let value = Int(nonce) {
+            let nonceHex = "0x\(String(format: "%02x", value))"
+            confirmationStore.editNonce(
+              for: transaction,
+              nonce: nonceHex) { success in
+                if success {
+                  presentationMode.dismiss()
+                } else {
+                  // Show error?
+               }
+              }
           }
+        }) {
+          Text(Strings.Wallet.saveCustomNonce)
         }
+        .buttonStyle(BraveFilledButtonStyle(size: .large))
         .frame(maxWidth: .infinity)
         .listRowInsets(.zero)
         .listRowBackground(Color(.braveGroupedBackground))
@@ -51,7 +50,24 @@ struct EditNonceView: View {
     }
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
-    .navigationTitle("Advanced settings")
+    .navigationTitle(Strings.Wallet.advancedSettingsTransaction)
+    .onAppear {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        setup()
+      }
+    }
+  }
+  
+  private func setup() {
+    if let txNonce = transaction.txDataUnion.ethTxData1559?.baseData.nonce {
+      let nonceDecimal: String
+      if let intValue = Int(txNonce.removingHexPrefix, radix: 16) { // BaseData.nonce should always in hex
+        nonceDecimal = "\(intValue)"
+      } else {
+        nonceDecimal = txNonce
+      }
+      nonce = nonceDecimal
+    }
   }
 }
 
@@ -59,7 +75,10 @@ struct EditNonceView: View {
 struct EditNonceView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      EditNonceView()
+      EditNonceView(
+        confirmationStore: .previewStore,
+        transaction: .previewConfirmedSend
+      )
     }
   }
 }

--- a/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -43,6 +43,7 @@ struct EditNonceView: View {
           Text(Strings.Wallet.saveCustomNonce)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .large))
+        .disabled(nonce.isEmpty)
         .frame(maxWidth: .infinity)
         .listRowInsets(.zero)
         .listRowBackground(Color(.braveGroupedBackground))
@@ -59,15 +60,13 @@ struct EditNonceView: View {
   }
   
   private func setup() {
-    if let txNonce = transaction.txDataUnion.ethTxData1559?.baseData.nonce {
-      let nonceDecimal: String
-      if let intValue = Int(txNonce.removingHexPrefix, radix: 16) { // BaseData.nonce should always in hex
-        nonceDecimal = "\(intValue)"
-      } else {
-        nonceDecimal = txNonce
-      }
-      nonce = nonceDecimal
+    let nonceDecimal: String
+    if let intValue = Int(transaction.ethTxNonce.removingHexPrefix, radix: 16) { // BaseData.nonce should always in hex
+      nonceDecimal = "\(intValue)"
+    } else {
+      nonceDecimal = transaction.ethTxNonce
     }
+    nonce = nonceDecimal
   }
 }
 

--- a/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -1,0 +1,66 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveUI
+
+struct EditNonceView: View {
+  @Environment(\.sizeCategory) private var sizeCategory
+  @State private var nonce = ""
+  
+  @ViewBuilder private var editNonceButtons: some View {
+    Button(action: {}) {
+      Text("Cancel")
+    }
+    .buttonStyle(BraveOutlineButtonStyle(size: .large))
+    Button(action: {}) {
+      Text("Save")
+    }
+    .buttonStyle(BraveFilledButtonStyle(size: .large))
+  }
+  
+  var body: some View {
+    List {
+      Section {
+        TextField("Enter custom nonce value", text: $nonce)
+          .keyboardType(.numberPad)
+      } header: {
+        Text("Nonce")
+          .textCase(.none)
+      } footer: {
+        Text("Transaction may not be propagated in the network.")
+      }
+      Section {
+        Group {
+          if sizeCategory.isAccessibilityCategory {
+            VStack {
+              editNonceButtons
+            }
+          } else {
+            HStack {
+              editNonceButtons
+            }
+          }
+        }
+        .frame(maxWidth: .infinity)
+        .listRowInsets(.zero)
+        .listRowBackground(Color(.braveGroupedBackground))
+      }
+    }
+    .listStyle(InsetGroupedListStyle())
+    .navigationBarTitleDisplayMode(.inline)
+    .navigationTitle("Advanced settings")
+  }
+}
+
+#if DEBUG
+struct EditNonceView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      EditNonceView()
+    }
+  }
+}
+#endif

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -242,7 +242,7 @@ struct EditPriorityFeeView: View {
       }
       Section {
         Button(action: save) {
-          Text(Strings.Wallet.saveGasFee)
+          Text(Strings.Wallet.saveButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .large))
         .frame(maxWidth: .infinity)

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -235,6 +235,21 @@ struct TransactionConfirmationView: View {
                   }
                   .padding()
                   .accessibilityElement(children: .contain)
+                  Divider()
+                    .padding(.leading)
+                  NavigationLink(destination: EditNonceView()) {
+                    HStack {
+                      Image("brave.gear")
+                        .foregroundColor(Color(.braveBlurpleTint))
+                      Text("Advanced Settings")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .foregroundColor(Color(.braveBlurpleTint))
+                      Spacer()
+                      Image(systemName: "chevron.right")
+                    }
+                    .padding()
+                    .font(.footnote.weight(.semibold))
+                  }
                 }
               case .details:
                 VStack(alignment: .leading) {

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -237,11 +237,14 @@ struct TransactionConfirmationView: View {
                   .accessibilityElement(children: .contain)
                   Divider()
                     .padding(.leading)
-                  NavigationLink(destination: EditNonceView()) {
+                  NavigationLink(destination: EditNonceView(
+                    confirmationStore: confirmationStore,
+                    transaction: activeTransaction
+                  )) {
                     HStack {
                       Image("brave.gear")
                         .foregroundColor(Color(.braveBlurpleTint))
-                      Text("Advanced Settings")
+                      Text(Strings.Wallet.advancedSettingsTransaction)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .foregroundColor(Color(.braveBlurpleTint))
                       Spacer()
@@ -321,7 +324,7 @@ struct TransactionConfirmationView: View {
     }
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
-      confirmationStore.fetchTransactions()
+      confirmationStore.prepare()
     }
   }
   

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -81,6 +81,17 @@ extension BraveWallet.TransactionInfo {
     }*/
     txDataUnion.ethTxData1559?.baseData.data ?? .init()
   }
+  
+  var ethTxNonce: String {
+    // Eth transaction are all coming as `ethTxData1559`
+    // Comment below out for future proper eth transaction separation (EIP1559 and non-EIP1559)
+    /*if isEIP1559Transaction {
+      return txDataUnion.ethTxData1559?.baseData.nonce ?? .init()
+    } else {
+      return txDataUnion.ethTxData?.nonce ?? .init()
+    }*/
+    txDataUnion.ethTxData1559?.baseData.nonce ?? ""
+  }
 }
 
 extension BraveWallet.EthereumChain: Identifiable {

--- a/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -351,7 +351,7 @@ struct CustomNetworkDetailsView: View {
           Button(action: {
             addCustomNetwork()
           }) {
-            Text(Strings.Wallet.saveCustomNetworkButtonTitle)
+            Text(Strings.Wallet.saveButtonTitle)
               .foregroundColor(Color(.braveOrange))
           }
         }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1198,12 +1198,12 @@ extension Strings {
       value: "Maximum fee",
       comment: "The highest the user will pay in a gas fee based on the entered gas fee details or predefined option. It is displayed above the amount"
     )
-    public static let saveGasFee = NSLocalizedString(
-      "wallet.saveGasFee",
+    public static let saveButtonTitle = NSLocalizedString(
+      "wallet.saveButtonTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Save",
-      comment: "A button title for saving the users selected gas fee options"
+      comment: "A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network"
     )
     public static let maxPriorityFeeTitle = NSLocalizedString(
       "wallet.maxPriorityFeeTitle",
@@ -1758,13 +1758,6 @@ extension Strings {
       value: "Add Network",
       comment: "The title of bar item for users to add custom network screen"
     )
-    public static let saveCustomNetworkButtonTitle = NSLocalizedString(
-      "wallet.saveCustomNetworkButtonTitle",
-      tableName: "BraveWallet",
-      bundle: .braveWallet,
-      value: "Save",
-      comment: "The title of the button on top right navigation bar for the users to click to save a new custom network."
-    )
     public static let addCustomNetworkDropdownButtonTitle = NSLocalizedString(
       "wallet.addCustomNetworkDropdownButtonTitle",
       tableName: "BraveWallet",
@@ -1876,13 +1869,6 @@ extension Strings {
       bundle: .braveWallet,
       value: "Enter custom nonce value",
       comment: "The placeholder for custom nonce textfield."
-    )
-    public static let saveCustomNonce = NSLocalizedString(
-      "wallet.saveCustomNonce",
-      tableName: "BraveWallet",
-      bundle: .braveWallet,
-      value: "Save",
-      comment: "The title of the button for users to save custom nonce"
     )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1849,5 +1849,40 @@ extension Strings {
       value: "Reset",
       comment: "The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0"
     )
+    public static let advancedSettingsTransaction = NSLocalizedString(
+      "wallet.advancedSettingsTransaction",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Advanced settings",
+      comment: "The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen."
+    )
+    public static let editNonceHeader = NSLocalizedString(
+      "wallet.editNonceHeader",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Nonce",
+      comment: "The header title for edit nonce section in advanced settings screen."
+    )
+    public static let editNonceFooter = NSLocalizedString(
+      "wallet.editNonceFooter",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Transaction may not be propagated to the network if custom nonce value is non-sequential or has other errors",
+      comment: "The footer title for edit nonce section in advanced settings screen."
+    )
+    public static let editNoncePlaceholder = NSLocalizedString(
+      "wallet.editNoncePlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter custom nonce value",
+      comment: "The placeholder for custom nonce textfield."
+    )
+    public static let saveCustomNonce = NSLocalizedString(
+      "wallet.saveCustomNonce",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Save",
+      comment: "The title of the button for users to save custom nonce"
+    )
   }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -947,6 +947,7 @@
 		7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */; };
 		7DCA34D427555E96001B0555 /* CryptoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA34D327555E96001B0555 /* CryptoStore.swift */; };
 		7DE5B6E427BEBA86000DA8E4 /* MockEthTxManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE5B6E327BEBA86000DA8E4 /* MockEthTxManagerProxy.swift */; };
+		7DE5B78C27D4188E000DA8E4 /* EditNonceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE5B78B27D4188E000DA8E4 /* EditNonceView.swift */; };
 		7DF9113D275AC86100EF0D8B /* WalletLoadingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9113C275AC86100EF0D8B /* WalletLoadingButton.swift */; };
 		7DF911C0276A8D1600EF0D8B /* SwapTokenStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */; };
 		7DF911DF27726E5E00EF0D8B /* BuyTokenStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF911DE27726E5E00EF0D8B /* BuyTokenStoreTest.swift */; };
@@ -2900,6 +2901,7 @@
 		7DCA34D327555E96001B0555 /* CryptoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoStore.swift; sourceTree = "<group>"; };
 		7DE5B6E327BEBA86000DA8E4 /* MockEthTxManagerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEthTxManagerProxy.swift; sourceTree = "<group>"; };
 		7DE5B73227C994B7000DA8E4 /* Model15.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model15.xcdatamodel; sourceTree = "<group>"; };
+		7DE5B78B27D4188E000DA8E4 /* EditNonceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditNonceView.swift; sourceTree = "<group>"; };
 		7DF9113C275AC86100EF0D8B /* WalletLoadingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLoadingButton.swift; sourceTree = "<group>"; };
 		7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapTokenStoreTests.swift; sourceTree = "<group>"; };
 		7DF911DE27726E5E00EF0D8B /* BuyTokenStoreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyTokenStoreTest.swift; sourceTree = "<group>"; };
@@ -4180,6 +4182,7 @@
 				2774303127332C2F00183725 /* TransactionConfirmationView.swift */,
 				2701B14B2735B65300BE6FC6 /* EditPriorityFeeView.swift */,
 				27D91E70274D55F0009B1FA3 /* EditGasFeeView.swift */,
+				7DE5B78B27D4188E000DA8E4 /* EditNonceView.swift */,
 			);
 			path = "Transaction Confirmations";
 			sourceTree = "<group>";
@@ -7876,6 +7879,7 @@
 				7DC52B12273D99E70067E237 /* WalletArrayExtension.swift in Sources */,
 				7DAC597B2726524E00E735A2 /* AddressQRCodeScannerView.swift in Sources */,
 				271F68B226EBD27E00AA2A50 /* RestoreWalletView.swift in Sources */,
+				7DE5B78C27D4188E000DA8E4 /* EditNonceView.swift in Sources */,
 				2774300A2733126000183725 /* WalletColors.swift in Sources */,
 				27DDE88A26FE1A7700A70C3A /* MockBraveWalletService.swift in Sources */,
 				271F68F826EBE92900AA2A50 /* WalletHostingViewController.swift in Sources */,


### PR DESCRIPTION
This pull request fixes #5052 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. open an un-approved transaction
2. figure out the next available nonce value is going to be by checking the the biggest nonce value from scanner. The next available one will be that number increased by 1.
3. go back to wallet and the transaction confirmation screen.
4. click on `Advanced settings` to go to the edit screen
5. input the next available nonce and click `Save`
6. (it will pop back to the previous screen)
7. click on `Advanced settings` to go to the edit screen again
8. (the previous input value should be still there)
9. lock and unlock the wallet and repeat step 7 and 8
10. close the app and relaunch again. repeat step 7 and 8


## Screenshots:

![simulator_screenshot_E73280D5-7523-466E-B081-98CAD625D86D](https://user-images.githubusercontent.com/1187676/157473014-cb3ee7ff-f6af-48de-9a1f-c0f391bf10da.png)
![simulator_screenshot_94276EC9-1ED3-4449-89EA-0B07D7349434](https://user-images.githubusercontent.com/1187676/157473044-ba36d7c3-c05e-429a-a734-1ceefd1c2b2e.png)
![simulator_screenshot_383EF2DF-61DC-4F56-854D-E6EB1DD9746E](https://user-images.githubusercontent.com/1187676/157473108-7d2f8963-86e4-4713-a991-e49b61016a7a.png)


## Reviewer Checklist:
- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
