### PR TITLE
Fix #5077, #5070: Fixes syncing between CarPlay and iPhone for Playlist Folders actions

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -217,8 +217,11 @@ class PlaylistListViewController: UIViewController {
         updateTableBackgroundView()
         playerView.setControlsEnabled(true)
         
-        // If car play is active or media is already playing, do nothing
-        if PlaylistCarplayManager.shared.isCarPlayAvailable && (delegate?.currentPlaylistAsset != nil || delegate?.isPlaying ?? false) {
+        // If car play is active OR media is already playing, do nothing
+        // We do nothing when CarPlay is active because the user shouldn't be using the phone anyway
+        // But also because if the driver is controlling the audio, there will be a conflict
+        // if both the driver is selecting an item, and auto-play happens.
+        if PlaylistCarplayManager.shared.isCarPlayAvailable || (delegate?.currentPlaylistAsset != nil || delegate?.isPlaying ?? false) {
             autoPlayEnabled = true
             return
         }
@@ -345,7 +348,6 @@ class PlaylistListViewController: UIViewController {
     }
     
     func moveItems(indexPaths: [IndexPath]) {
-        delegate?.pausePlaying()
         onCancelEditingItems()
         
         let selectedItems = indexPaths.compactMap({
@@ -354,6 +356,8 @@ class PlaylistListViewController: UIViewController {
         
         if selectedItems.contains(where: { $0.pageSrc == PlaylistCarplayManager.shared.currentPlaylistItem?.pageSrc }) {
             delegate?.stopPlaying()
+        } else {
+            delegate?.pausePlaying()
         }
         
         var moveController = PlaylistMoveFolderView(selectedItems: selectedItems)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -103,6 +103,13 @@ class PlaylistListViewController: UIViewController {
                                          displayName: $0.displayName,
                                          error: $0.error)
         }.store(in: &observers)
+        
+        PlaylistCarplayManager.shared.onCarplayUIChangedToRoot.eraseToAnyPublisher()
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] in
+            guard let self = self else { return }
+            self.navigationController?.popToRootViewController(animated: true)
+        }.store(in: &observers)
     
         // Theme
         title = Strings.PlayList.playListSectionTitle
@@ -170,6 +177,7 @@ class PlaylistListViewController: UIViewController {
         folderObserver = nil
         if isMovingFromParent || isBeingDismissed {
             delegate?.stopPlaying()
+            PlaylistCarplayManager.shared.onCarplayUIChangedToRoot.send()
         }
     }
     

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -309,6 +309,14 @@ class PlaylistViewController: UIViewController {
             guard let self = self else { return }
             self.playerView.controlsView.playPauseButton.setImage(#imageLiteral(resourceName: "playlist_play"), for: .normal)
             self.playerView.resetVideoInfo()
+            PlaylistMediaStreamer.clearNowPlayingInfo()
+            
+            PlaylistCarplayManager.shared.currentlyPlayingItemIndex = -1
+            PlaylistCarplayManager.shared.currentPlaylistItem = nil
+            
+            // Cancel all loading.
+            self.assetLoadingStateObservers.removeAll()
+            self.assetStateObservers.removeAll()
         }.store(in: &playerStateObservers)
         
         player.publisher(for: .changePlaybackRate).sink { [weak self] event in
@@ -507,6 +515,11 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
         // Cancel all loading.
         assetLoadingStateObservers.removeAll()
         assetStateObservers.removeAll()
+        
+        // Delay CarPlay updating its UI
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            PlaylistCarplayManager.shared.popToRootViewController()
+        }
     }
     
     func deleteItem(item: PlaylistInfo, at index: Int) {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -515,11 +515,6 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
         // Cancel all loading.
         assetLoadingStateObservers.removeAll()
         assetStateObservers.removeAll()
-        
-        // Delay CarPlay updating its UI
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            PlaylistCarplayManager.shared.popToRootViewController()
-        }
     }
     
     func deleteItem(item: PlaylistInfo, at index: Int) {

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -23,6 +23,7 @@ class PlaylistCarplayManager: NSObject {
     private var carPlayController: PlaylistCarplayController?
     private var carplayInterface: CPInterfaceController?
     private var carplaySessionConfiguration: CPSessionConfiguration?
+    let onCarplayUIChangedToRoot = PassthroughSubject<Void, Never>()
     
     var browserController: BrowserViewController?
     
@@ -50,6 +51,10 @@ class PlaylistCarplayManager: NSObject {
     // Because there can only be a single AudioSession and MediaPlayer
     // in use at any given moment
     static let shared = PlaylistCarplayManager()
+    
+    func popToRootViewController() {
+        carPlayController?.popToRootViewController()
+    }
     
     func getCarPlayController() -> PlaylistCarplayController? {
         // On iOS 14, we use CPTemplate (Custom UI)

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -52,10 +52,6 @@ class PlaylistCarplayManager: NSObject {
     // in use at any given moment
     static let shared = PlaylistCarplayManager()
     
-    func popToRootViewController() {
-        carPlayController?.popToRootViewController()
-    }
-    
     func getCarPlayController() -> PlaylistCarplayController? {
         // On iOS 14, we use CPTemplate (Custom UI)
         // We control what gets displayed


### PR DESCRIPTION
## Summary of Changes
- Fixes syncing between CarPlay UI and the Phone's UI.
- When dismissing a folder on the phone, it will dismiss on CarPlay and vice-versa.
- When entering a folder on the phone, it will enter on CarPlay and vice-versa.
- This is extremely difficult as there isn't such a thing as a `button` or `back button` on CarPlay so observers + delegates have to be abused :(. CarPlay doesn't have the concept of going back and forth, and UI really isn't supposed to sync either.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5077, fixes #5070

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
