### PR TITLE
Fix #4944: Swap value reset to 0

### DIFF
--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -557,7 +557,6 @@ public class SwapTokenStore: ObservableObject {
         if success, let response = response {
           self.handlePriceQuoteResponse(response, base: base)
         } else {
-          self.clearAllAmount()
           
           // check balance first because error can cause by insufficient balance
           if let sellTokenBalance = self.selectedFromTokenBalance,
@@ -572,6 +571,7 @@ public class SwapTokenStore: ObservableObject {
             return
           }
           self.state = .error(Strings.Wallet.unknownError)
+          self.clearAllAmount()
         }
       }
     }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4944

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open swap view
2. Enter a long decimal value
3. Value should no longer reset


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
