### PR TITLE
Fix # 5081: Add error handling in edit gas fee, priority fee and nonce

### DIFF
--- a/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
@@ -23,6 +23,7 @@ struct EditGasFeeView: View {
   
   @State private var perGasPrice: String = ""
   @State private var gasLimit: String = ""
+  @State private var showError: Bool = false
   
   private func setup() {
     perGasPrice = WeiFormatter.weiToDecimalGwei(transaction.ethTxGasPrice.removingHexPrefix, radix: .hex) ?? "0"
@@ -55,7 +56,7 @@ struct EditGasFeeView: View {
       if success {
         presentationMode.dismiss()
       } else {
-         // Show error?
+        showError = true
       }
     }
   }
@@ -107,6 +108,13 @@ struct EditGasFeeView: View {
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.editGasTitle)
+    .alert(isPresented: $showError) {
+      Alert(
+        title: Text(Strings.Wallet.unknownError),
+        message: Text(Strings.Wallet.editTransactionError),
+        dismissButton: .default(Text(Strings.Wallet.editTransactionErrorCTA))
+      )
+    }
     .onAppear {
       // For some reason we need to delay this for SwiftUI to render the text properly…
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
@@ -23,7 +23,7 @@ struct EditGasFeeView: View {
   
   @State private var perGasPrice: String = ""
   @State private var gasLimit: String = ""
-  @State private var showError: Bool = false
+  @State private var isShowingAlert: Bool = false
   
   private func setup() {
     perGasPrice = WeiFormatter.weiToDecimalGwei(transaction.ethTxGasPrice.removingHexPrefix, radix: .hex) ?? "0"
@@ -56,7 +56,7 @@ struct EditGasFeeView: View {
       if success {
         presentationMode.dismiss()
       } else {
-        showError = true
+        isShowingAlert = true
       }
     }
   }
@@ -108,7 +108,7 @@ struct EditGasFeeView: View {
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.editGasTitle)
-    .alert(isPresented: $showError) {
+    .alert(isPresented: $isShowingAlert) {
       Alert(
         title: Text(Strings.Wallet.unknownError),
         message: Text(Strings.Wallet.editTransactionError),

--- a/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -14,6 +14,7 @@ struct EditNonceView: View {
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @State private var nonce = ""
+  @State private var showError = false
   
   var body: some View {
     List {
@@ -35,7 +36,7 @@ struct EditNonceView: View {
                 if success {
                   presentationMode.dismiss()
                 } else {
-                  // Show error?
+                  showError = true
                }
               }
           }
@@ -43,7 +44,7 @@ struct EditNonceView: View {
           Text(Strings.Wallet.saveButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .large))
-        .disabled(nonce.isEmpty)
+        .disabled(Int(nonce) == nil)
         .frame(maxWidth: .infinity)
         .listRowInsets(.zero)
         .listRowBackground(Color(.braveGroupedBackground))
@@ -52,6 +53,13 @@ struct EditNonceView: View {
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.advancedSettingsTransaction)
+    .alert(isPresented: $showError) {
+      Alert(
+        title: Text(Strings.Wallet.unknownError),
+        message: Text(Strings.Wallet.editTransactionError),
+        dismissButton: .default(Text(Strings.Wallet.editTransactionErrorCTA))
+      )
+    }
     .onAppear {
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
         // Most likely a SwiftUI bug. Need add a delay here to render text properly

--- a/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -14,7 +14,7 @@ struct EditNonceView: View {
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @State private var nonce = ""
-  @State private var showError = false
+  @State private var isShowingAlert = false
   
   var body: some View {
     List {
@@ -36,7 +36,7 @@ struct EditNonceView: View {
                 if success {
                   presentationMode.dismiss()
                 } else {
-                  showError = true
+                  isShowingAlert = true
                }
               }
           }
@@ -53,7 +53,7 @@ struct EditNonceView: View {
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.advancedSettingsTransaction)
-    .alert(isPresented: $showError) {
+    .alert(isPresented: $isShowingAlert) {
       Alert(
         title: Text(Strings.Wallet.unknownError),
         message: Text(Strings.Wallet.editTransactionError),

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -35,6 +35,7 @@ struct EditPriorityFeeView: View {
   @State private var maximumGasPrice: String = ""
   @State private var maximumTipPrice: String = ""
   @State private var baseInGwei: String = ""
+  @State private var showError: Bool = false
   
   private func setup() {
     let selectedMaxPrice = transaction.txDataUnion.ethTxData1559?.maxFeePerGas ?? ""
@@ -106,7 +107,7 @@ struct EditPriorityFeeView: View {
       if success {
         presentationMode.dismiss()
       } else {
-        // Show error?
+        showError = true
       }
     }
   }
@@ -254,6 +255,13 @@ struct EditPriorityFeeView: View {
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.maxPriorityFeeTitle)
+    .alert(isPresented: $showError) {
+      Alert(
+        title: Text(Strings.Wallet.unknownError),
+        message: Text(Strings.Wallet.editTransactionError),
+        dismissButton: .default(Text(Strings.Wallet.editTransactionErrorCTA))
+      )
+    }
     .onAppear(perform: setup)
   }
 }

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -35,7 +35,7 @@ struct EditPriorityFeeView: View {
   @State private var maximumGasPrice: String = ""
   @State private var maximumTipPrice: String = ""
   @State private var baseInGwei: String = ""
-  @State private var showError: Bool = false
+  @State private var isShowingAlert: Bool = false
   
   private func setup() {
     let selectedMaxPrice = transaction.txDataUnion.ethTxData1559?.maxFeePerGas ?? ""
@@ -107,7 +107,7 @@ struct EditPriorityFeeView: View {
       if success {
         presentationMode.dismiss()
       } else {
-        showError = true
+        isShowingAlert = true
       }
     }
   }
@@ -255,7 +255,7 @@ struct EditPriorityFeeView: View {
     .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.maxPriorityFeeTitle)
-    .alert(isPresented: $showError) {
+    .alert(isPresented: $isShowingAlert) {
       Alert(
         title: Text(Strings.Wallet.unknownError),
         message: Text(Strings.Wallet.editTransactionError),

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1870,5 +1870,19 @@ extension Strings {
       value: "Enter custom nonce value",
       comment: "The placeholder for custom nonce textfield."
     )
+    public static let editTransactionError = NSLocalizedString(
+      "wallet.editTransactionError",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Please check your inputs and try again.",
+      comment: "The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value."
+    )
+    public static let editTransactionErrorCTA = NSLocalizedString(
+      "wallet.editTransactionErrorCTA",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Go back",
+      comment: "The transaction edit error alert button which will dismiss the alert."
+    )
   }
 }


### PR DESCRIPTION
This pull request fixes #5081 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
