### PR TITLE
Fix #5091: Apply iOS 14 crash workaround Xcode 13.2 using iOS 15 APIs

### DIFF
--- a/Client/Frontend/Settings/ManageWebsiteDataView.swift
+++ b/Client/Frontend/Settings/ManageWebsiteDataView.swift
@@ -118,13 +118,9 @@ struct ManageWebsiteDataView: View {
                                 if #available(iOS 15.0, *) {
                                     // Better swipe gestures
                                     content
-                                        .swipeActions(edge: .trailing) {
-                                            Button(role: .destructive) {
-                                                removeRecords([record])
-                                            } label: {
-                                                Label(Strings.removeDataRecord, systemImage: "trash")
-                                            }
-                                        }
+                                        .modifier(SwipeActionsViewModifier_FB9812596 {
+                                            removeRecords([record])
+                                        })
                                 } else {
                                     content
                                 }
@@ -212,5 +208,20 @@ private func localizedStringForDataRecordType(_ type: String) -> String? {
 extension WKWebsiteDataRecord: Identifiable {
     public var id: String {
         displayName
+    }
+}
+
+// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
+@available(iOS 15.0, *)
+private struct SwipeActionsViewModifier_FB9812596: ViewModifier {
+    var action: () -> Void
+    
+    func body(content: Content) -> some View {
+        content
+            .swipeActions(edge: .trailing) {
+                Button(role: .destructive, action: action) {
+                    Label(Strings.removeDataRecord, systemImage: "trash")
+                }
+            }
     }
 }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5091

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
