### PR TITLE
No Bug: Remove duplicated NSLocalizedString key.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -1855,7 +1855,7 @@ extension Strings {
                               comment: "The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'")
         
         public static let playlistFolderSelectASingleFolderTitle =
-            NSLocalizedString("playlistFolders.selectAFolderTitle",
+            NSLocalizedString("playlistFolders.selectASingleFolderTitle",
                               bundle: .braveShared,
                               value: "Select a folder to move 1 item to",
                               comment: "The title of the section indicating that the user should select a folder to move 1 item to.")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Translation for it will be updated in next release - 1.37

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
