### PR TITLE
Fix #5093: Fixes Now playing info on lock screen + Fixed background audio on iOS 15+.

### DIFF
--- a/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -182,7 +182,9 @@ class PlaylistMediaStreamer {
     
     static func setNowPlayingMediaArtwork(artwork: MPMediaItemArtwork?) {
         if let artwork = artwork {
-            MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyArtwork] = artwork
+            var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            nowPlayingInfo[MPMediaItemPropertyArtwork] = artwork
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
         }
     }
     

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -440,8 +440,10 @@ extension MediaPlayer {
 extension MediaPlayer {
     // Registers basic notifications
     private func registerNotifications() {
-        NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
-        .receive(on: RunLoop.main)
+        Publishers.Zip(
+            NotificationCenter.default.publisher(for: UIScene.didEnterBackgroundNotification),
+            NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
+        )
         .sink { [weak self] _ in
             guard let self = self else { return }
             
@@ -453,8 +455,10 @@ extension MediaPlayer {
             self.detachLayer()
         }.store(in: &notificationObservers)
         
-        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-        .receive(on: RunLoop.main)
+        Publishers.Zip(
+            NotificationCenter.default.publisher(for: UIScene.didActivateNotification),
+            NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+        )
         .sink { [weak self] _ in
             guard let self = self else { return }
             
@@ -467,7 +471,6 @@ extension MediaPlayer {
         }.store(in: &notificationObservers)
         
         NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification, object: AVAudioSession.sharedInstance())
-        .receive(on: RunLoop.main)
         .sink { [weak self] notification in
             
             guard let self = self,
@@ -504,7 +507,6 @@ extension MediaPlayer {
         }.store(in: &notificationObservers)
         
         NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)
-        .receive(on: RunLoop.main)
         .sink { [weak self] _ in
             guard let self = self else { return }
             


### PR DESCRIPTION
## Summary of Changes
- On iOS 15 only, the audio pauses when you enter the lock-screen.
- This PR fixes that by listening for the notification `earlier` by first removing the `receive(on: .main)` which is `async`.
- This PR also fixes that by listening for the `scene` notification which comes way earlier than the `application` notification on iOS 15 only. It doesn't hurt to listen for both here, so it's fine.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5093

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
