### PR TITLE
Fix #5027: Slow portfolio balance calls can show balance incorrectly

### DIFF
--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -87,96 +87,108 @@ public class PortfolioStore: ObservableObject {
     $0.currencyCode = "USD"
   }
   
-  /// Fills the `userVisibleAssets` models with balances in decimal format
-  func fetchBalances(accounts: [BraveWallet.AccountInfo], completion: @escaping () -> Void) {
+  /// Fetches the balances for a given list of tokens for each of the given accounts, giving a dictionary with a balance for each token symbol.
+  private func fetchBalances(for tokens: [BraveWallet.BlockchainToken], accounts: [BraveWallet.AccountInfo], completion: @escaping ([String: Double]) -> Void) {
+    var balances: [String: Double] = [:]
     let group = DispatchGroup()
     for account in accounts {
-      for asset in userVisibleAssets {
-        let token = asset.token
+      for token in tokens {
         group.enter()
-        rpcService.balance(for: token, in: account) { [weak self] balance in
+        rpcService.balance(for: token, in: account) { balance in
           defer { group.leave() }
-          guard let self = self,
-                let balance = balance,
-                let index = self.userVisibleAssets.firstIndex(where: { $0.token.symbol == token.symbol }) else {
-                  return
-                }
-          self.userVisibleAssets[index].decimalBalance += balance
+          guard let balance = balance else {
+            return
+          }
+          let symbol = token.symbol.lowercased()
+          if let oldBalance = balances[token.symbol] {
+            balances[symbol] = oldBalance + balance
+          } else {
+            balances[symbol] = balance
+          }
         }
       }
     }
-    group.notify(queue: .main, execute: completion)
+    group.notify(queue: .main, execute: {
+      completion(balances)
+    })
   }
   
-  func fetchPrices(_ completion: @escaping () -> Void) {
+  /// Fetches the prices for a given list of symbols, giving a dictionary with the price for each symbol
+  private func fetchPrices(for symbols: [String], completion: @escaping ([String: String]) -> Void) {
     assetRatioService.price(
-      userVisibleAssets.map { $0.token.symbol.lowercased() },
+      symbols.map { $0.lowercased() },
       toAssets: ["usd"],
       timeframe: timeframe
-    ) { [weak self] success, assetPrices in
+    ) { success, assetPrices in
       // `success` only refers to finding _all_ prices and if even 1 of N prices
       // fail to fetch it will be false
-      guard let self = self else { return }
-      for assetPrice in assetPrices {
-        if let index = self.userVisibleAssets.firstIndex(where: {
-          $0.token.symbol.caseInsensitiveCompare(assetPrice.fromAsset) == .orderedSame
-        }) {
-          self.userVisibleAssets[index].price = assetPrice.price
-        }
-      }
-      completion()
+      let prices = Dictionary(uniqueKeysWithValues: assetPrices.map { ($0.fromAsset, $0.price) })
+      completion(prices)
     }
   }
   
-  func fetchHistoryForNonZeroBalances(_ completion: @escaping () -> Void) {
-    let assets = userVisibleAssets.filter { $0.decimalBalance > 0 }
-    if assets.isEmpty {
-      completion()
-      return
-    }
+  /// Fetches the price history for the given symbols, giving a dictionary with the price history for each symbol
+  private func fetchPriceHistory(for symbols: [String], completion: @escaping ([String: [BraveWallet.AssetTimePrice]]) -> Void) {
+    var priceHistories: [String: [BraveWallet.AssetTimePrice]] = [:]
     let group = DispatchGroup()
-    // Fill prices for each asset
-    for asset in assets {
+    for symbol in symbols {
+      let symbol = symbol.lowercased()
       group.enter()
       assetRatioService.priceHistory(
-        asset.token.symbol,
+        symbol,
         vsAsset: "usd",
         timeframe: timeframe
-      ) { [weak self] success, history in
+      ) { success, history in
         defer { group.leave() }
-        guard let self = self, success else { return }
-        if let index = self.userVisibleAssets.firstIndex(where: {
-          $0.token.symbol.caseInsensitiveCompare(asset.token.symbol) == .orderedSame
-        }) {
-          self.userVisibleAssets[index].history = history.sorted(by: { $0.date < $1.date })
-        }
+        guard success else { return }
+        priceHistories[symbol] = history.sorted(by: { $0.date < $1.date })
       }
     }
-    group.notify(queue: .main, execute: completion)
+    group.notify(queue: .main, execute: {
+      completion(priceHistories)
+    })
   }
-  
+
   func update() {
-    isLoadingBalances = true
-    rpcService.chainId { [self] chainId in
+    self.isLoadingBalances = true
+    self.rpcService.chainId { [self] chainId in
       // Get user assets for the selected chain
-      walletService.userAssets(chainId) { [self] tokens in
-        userVisibleAssets = tokens.filter(\.visible).map {
-          .init(token: $0, decimalBalance: 0, price: "", history: [])
-        }
-        let group = DispatchGroup()
-        group.enter()
-        keyringService.defaultKeyringInfo { keyring in
-          fetchBalances(accounts: keyring.accountInfos) {
-            fetchHistoryForNonZeroBalances {
-              group.leave()
+      self.walletService.userAssets(chainId) { [self] tokens in
+        let visibleTokens = tokens.filter(\.visible)
+        let dispatchGroup = DispatchGroup()
+        // fetch user balances, then fetch price history for tokens with non-zero balance
+        var balances: [String: Double] = [:]
+        var priceHistories: [String: [BraveWallet.AssetTimePrice]] = [:]
+        dispatchGroup.enter()
+        self.keyringService.defaultKeyringInfo { keyring in
+          self.fetchBalances(for: visibleTokens, accounts: keyring.accountInfos) { fetchedBalances in
+            balances = fetchedBalances
+            let nonZeroBalanceTokens = balances.filter { $1 > 0 }.map { $0.key }
+            self.fetchPriceHistory(for: nonZeroBalanceTokens) { fetchedPriceHistories in
+              defer { dispatchGroup.leave() }
+              priceHistories = fetchedPriceHistories
             }
           }
         }
-        group.enter()
-        fetchPrices {
-          group.leave()
+        // fetch prices
+        let visibleTokenSymbols = visibleTokens.map { $0.symbol.lowercased() }
+        var prices: [String: String] = [:]
+        dispatchGroup.enter()
+        self.fetchPrices(for: visibleTokenSymbols) { fetchedPrices in
+          defer { dispatchGroup.leave() }
+          prices = fetchedPrices
         }
-        group.notify(queue: .main) {
+        dispatchGroup.notify(queue: .main) {
+          // build our userVisibleAssets
+          self.userVisibleAssets = visibleTokens.map { token in
+            let symbol = token.symbol.lowercased()
+            return AssetViewModel(
+              token: token,
+              decimalBalance: balances[symbol] ?? 0.0,
+              price: prices[symbol] ?? "",
+              history: priceHistories[symbol] ?? []
+            )
+          }
           // Compute balance based on current prices
           let currentBalance = userVisibleAssets
             .compactMap {
@@ -186,21 +198,21 @@ public class PortfolioStore: ObservableObject {
               return nil
             }
             .reduce(0.0, +)
-          balance = numberFormatter.string(from: NSNumber(value: currentBalance)) ?? "–"
+          self.balance = self.numberFormatter.string(from: NSNumber(value: currentBalance)) ?? "–"
           // Compute historical balances based on historical prices and current balances
           let assets = userVisibleAssets.filter { !$0.history.isEmpty } // [[AssetTimePrice]]
           let minCount = assets.map(\.history.count).min() ?? 0 // Shortest array count
-          historicalBalances = (0..<minCount).map { index in
+          self.historicalBalances = (0..<minCount).map { index in
             let value = assets.reduce(0.0, {
               $0 + ((Double($1.history[index].price) ?? 0.0) * $1.decimalBalance)
             })
             return .init(
               date: assets.map { $0.history[index].date }.max() ?? .init(),
               price: value,
-              formattedPrice: numberFormatter.string(from: NSNumber(value: value)) ?? "0.00"
+              formattedPrice: self.numberFormatter.string(from: NSNumber(value: value)) ?? "0.00"
             )
           }
-          isLoadingBalances = false
+          self.isLoadingBalances = false
         }
       }
     }

--- a/BraveWalletTests/PortfolioStoreTests.swift
+++ b/BraveWalletTests/PortfolioStoreTests.swift
@@ -1,0 +1,110 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Combine
+import XCTest
+import BraveCore
+@testable import BraveWallet
+
+class PortfolioStoreTests: XCTestCase {
+    
+    private var cancellables: Set<AnyCancellable> = .init()
+    
+    func testUpdate() {
+        // config test
+        let mockAccountInfos: [BraveWallet.AccountInfo] = [.previewAccount]
+        let chainId = BraveWallet.MainnetChainId
+        let network: BraveWallet.EthereumChain = .mainnet
+        let mockUserAssets: [BraveWallet.BlockchainToken] = [.previewToken.then { $0.visible = true }]
+        let mockDecimalBalance: Double = 0.0896
+        let numDecimals = Int(mockUserAssets[0].decimals)
+        let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: numDecimals))
+        let mockBalanceWei = formatter.weiString(from: 0.0896, radix: .hex, decimals: numDecimals) ?? ""
+        let mockEthAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23")
+        let mockEthPriceHistory: [BraveWallet.AssetTimePrice] = [.init(date: Date(timeIntervalSinceNow: -1000), price: "$3000.00"), .init(date: Date(), price: "3059.99")]
+        let totalEthBalanceValue: Double = (Double(mockEthAssetPrice.price) ?? 0) * mockDecimalBalance
+        let currencyFormatter = NumberFormatter().then { $0.numberStyle = .currency }
+        let totalEthBalance = currencyFormatter.string(from: NSNumber(value: totalEthBalanceValue)) ?? ""
+        
+        // setup test services
+        let keyringService = BraveWallet.TestKeyringService()
+        keyringService._keyringInfo = { _, completion in
+            let keyring: BraveWallet.KeyringInfo = .init(
+                id: BraveWallet.DefaultKeyringId,
+                isKeyringCreated: true,
+                isLocked: false,
+                isBackedUp: true,
+                accountInfos: mockAccountInfos)
+            completion(keyring)
+        }
+        keyringService._addObserver = { _ in }
+        keyringService._isLocked = { $0(false) }
+        let rpcService = BraveWallet.TestJsonRpcService()
+        rpcService._addObserver = { _ in }
+        rpcService._chainId = { $0(chainId) }
+        rpcService._network = { $0(network) }
+        rpcService._balance = { _, _, completion in
+            completion(mockBalanceWei, .success, "")
+        }
+        let walletService = BraveWallet.TestBraveWalletService()
+        walletService._userAssets = { _, completion in
+            completion(mockUserAssets)
+        }
+        let assetRatioService = BraveWallet.TestAssetRatioService()
+        assetRatioService._price = { _, _, _, completion in
+            completion(true, [mockEthAssetPrice])
+        }
+        assetRatioService._priceHistory = { _, _, _, completion in
+            completion(true, mockEthPriceHistory)
+        }
+        // setup store
+        let store = PortfolioStore(
+            keyringService: keyringService,
+            rpcService: rpcService,
+            walletService: walletService,
+            assetRatioService: assetRatioService,
+            blockchainRegistry: BraveWallet.TestBlockchainRegistry()
+        )
+        // test that `update()` will assign new value to `userVisibleAssets` publisher
+        let userVisibleAssetsException = expectation(description: "update-userVisibleAssets")
+        XCTAssertTrue(store.userVisibleAssets.isEmpty) // Initial state
+        store.$userVisibleAssets
+            .dropFirst()
+            .first()
+            .sink { userVisibleAssets in
+                defer { userVisibleAssetsException.fulfill() }
+                XCTAssertEqual(userVisibleAssets.count, 1)
+                XCTAssertEqual(userVisibleAssets[0].decimalBalance, mockDecimalBalance)
+                XCTAssertEqual(userVisibleAssets[0].price, mockEthAssetPrice.price)
+                XCTAssertEqual(userVisibleAssets[0].history, mockEthPriceHistory)
+        }.store(in: &cancellables)
+        // test that `update()` will assign new value to `balance` publisher
+        let balanceException = expectation(description: "update-balance")
+        store.$balance
+            .dropFirst()
+            .first()
+            .sink { balance in
+                defer { balanceException.fulfill() }
+                XCTAssertEqual(balance, totalEthBalance)
+            }
+            .store(in: &cancellables)
+        // test that `update()` will update `isLoadingBalances` publisher
+        let isLoadingBalancesException = expectation(description: "update-isLoadingBalances")
+        store.$isLoadingBalances
+            .dropFirst()
+            .collect(2)
+            .first()
+            .sink { isLoadingUpdates in
+                defer { isLoadingBalancesException.fulfill() }
+                XCTAssertTrue(isLoadingUpdates[0])
+                XCTAssertFalse(isLoadingUpdates[1])
+            }
+            .store(in: &cancellables)
+        store.update()
+        waitForExpectations(timeout: 1) { error in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1141,6 +1141,7 @@
 		D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */; };
 		D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
+		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
 		D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */; };
 		D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */; };
 		D8D33A7D1FBD080300A20A28 /* SnapKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */; };
@@ -3100,6 +3101,7 @@
 		D3FA777A1A43B2990010CD32 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
+		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
 		D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensions.swift; sourceTree = "<group>"; };
 		D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientProgressBar.swift; sourceTree = "<group>"; };
 		D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapKitExtensions.swift; sourceTree = "<group>"; };
@@ -4172,6 +4174,7 @@
 				7DF911DE27726E5E00EF0D8B /* BuyTokenStoreTest.swift */,
 				279115362755597200033843 /* SendTokenStoreTests.swift */,
 				7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */,
+				D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */,
 				277309E72721DF6D007643F6 /* WeiFormatterTests.swift */,
 				27EA1B0D2729E6C8003C5CF9 /* AddressTests.swift */,
 				7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */,
@@ -7970,6 +7973,7 @@
 			files = (
 				2792CBD5275952C40055151E /* PasteboardTests.swift in Sources */,
 				279115422755597200033843 /* SendTokenStoreTests.swift in Sources */,
+				D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */,
 				27EA1B0E2729E6C8003C5CF9 /* AddressTests.swift in Sources */,
 				7DF911DF27726E5E00EF0D8B /* BuyTokenStoreTest.swift in Sources */,
 				7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes
- There was a race condition as `update()` would reset `userVisibleAssets` and call `fetchBalances` and `fetchPrices` which both directly modifier `userVisibleAssets`, but if `update()` is called >1 times prior to fetch calls responding we could double up balances.
- Added `PortfolioStoreTests` to test against `update()`

This pull request fixes #5027

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Best to reproduce this off development first as race conditions are somewhat tricky.
1. Open and unlock wallet
2. Turn on network link conditioner to simulate slow network; I used 100kb/s down & up, 10ms delay and 25% packet drop for a slow network.
3. Rapidly change networks while loading
4. Observe balance exceed actual balance


## Screenshots:
Broken against `development`:
https://user-images.githubusercontent.com/5314553/157954951-c233204e-dbb5-4ac1-99d0-9c32f2125232.mov

Fixed against this `bugfix/5027-update-race-condition` branch:
https://user-images.githubusercontent.com/5314553/157961890-8db7a11b-473a-49f0-9061-db7017b9e3d6.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
