### PR TITLE
Fix #5089: Implemented playlist gestures for iOS.

### DIFF
--- a/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -229,20 +229,20 @@ class VideoView: UIView, VideoTrackerBarDelegate {
         // delegate?.togglePlayerGravity(self)
 
         // Advance or go back by 15 seconds
-        let tapLocation: CGPoint = gestureRecognizer.location(in: self)
+        let tapLocation = gestureRecognizer.location(in: self)
 
         // If we got a tap in 0width...0.4width (left part of the view).
-        if tapLocation.x > 0 && tapLocation.x < 0.4*self.bounds.size.width {
+        if tapLocation.x > 0 && tapLocation.x < 0.4 * bounds.size.width {
             // Retreat by 15 seconds.
             self.seekBackwards()
         // If we got a tap in 0.6width...1width (right part of the view).
-        } else if tapLocation.x > 0.6*self.bounds.size.width && tapLocation.x < self.bounds.size.width {
+        } else if tapLocation.x > 0.6 * bounds.size.width && tapLocation.x < bounds.size.width {
             // Advance video by 15 seconds.
             self.seekForwards()
         // If there's a click in the central area
-        } else if tapLocation.x > 0.4*self.bounds.size.width && 0.4*self.bounds.size.width < 0.6*self.bounds.size.width {
+        } else if tapLocation.x > 0.4 * bounds.size.width && 0.4 * bounds.size.width < 0.6 * bounds.size.width {
             // Pause/resume the video
-            if delegate?.isPlaying ?? false {
+            if delegate?.isPlaying == true {
                 self.pause()
             } else {
                 self.play()
@@ -252,7 +252,7 @@ class VideoView: UIView, VideoTrackerBarDelegate {
 
     // This is where we know when panning gesture started and finished.
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        if event?.type == UIEvent.EventType.touches {
+        if event?.type == .touches {
             dragStartedVolume = AVAudioSession.sharedInstance().outputVolume
 
             toggleOverlays(showOverlay: true)
@@ -316,40 +316,29 @@ class VideoView: UIView, VideoTrackerBarDelegate {
                 if currentDraggingDirection == .verticalDirection {
 
                     // Vertical dragging adjusts volume.
-                    let vDragRatio = 4*gestureRecognizer.translation(in: self).y/self.bounds.height // (-0.5 ... 0.5)*4
+                    let vDragRatio = 4 * gestureRecognizer.translation(in: self).y / bounds.height // (-0.5 ... 0.5) * 4
                     
                     if vDragRatio != 0 && self.dragStartedVolume >= 0 {
                         if let slider = volumeView.subviews.first(where: { $0 is UISlider }) as? UISlider {
-                            var finalVal: Float = 0
-                            finalVal = self.dragStartedVolume + Float(-vDragRatio)
+                            let finalVal = self.dragStartedVolume - Float(vDragRatio)
 
                             // Making sure finalVal is within 0..1 interval
-                            if finalVal < 0 {
-                                finalVal = 0
-                            } else if finalVal > 1 {
-                                finalVal = 1
-                            }
-                            slider.value = finalVal
+                            slider.value = min(max(0.0, finalVal), 1.0)
                         }
                     }
                     // End of vertical panning processing.
                 } else {
 
                     // Otherwise it's a horizontal pan.
-                    let dragRatio = gestureRecognizer.translation(in: self).x/self.bounds.width // (-0.5 ... 0.5)*1
+                    let dragRatio = gestureRecognizer.translation(in: self).x / bounds.width // (-0.5 ... 0.5)*1
                     var vidDurationSeconds = 0.0
                     if let currentItem = currentPlayer.currentItem {
                         vidDurationSeconds = CGFloat((currentItem.duration.value)) / CGFloat((currentItem.duration.timescale))
                     }
-                    var finalSeconds = dragStartedTimelinePos + dragRatio*vidDurationSeconds
+                    var finalSeconds = dragStartedTimelinePos + dragRatio * vidDurationSeconds
 
                     // Making sure we're not out of bounds
-                    if finalSeconds<0 {
-                        finalSeconds = 0
-                    }
-                    if finalSeconds > vidDurationSeconds {
-                        finalSeconds = vidDurationSeconds
-                    }
+                    finalSeconds = min(max(0.0, finalSeconds), vidDurationSeconds)
 
                     guard let delegate = delegate else { return }
 


### PR DESCRIPTION
Pan the playerLayer to advance the timeline (horizontally) and change the volume (vertically).
Double tap the playerLayer to toggle play/pause (central area) and advance (rightmost area)/retreat (leftmost area) by 15 seconds.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request implemented the feature, described at #5089

## Fix Notes

- Double tap on the video player's view (playerLayer) does not toggle player gravity (toggling between fitting full width or full height fitting of the video) anymore, as the double tapping gesture has been reassigned to other purposes.
I suggest adding the player gravity toggle as a separate UI button in player overlay.
- Occasionally (rarely), for some reason rewinding the video triggers the particle effect (fireworks). Is it a regression or was it happening before?
- The official iOS Youtube app allows rewinding the video by panning the videoplayer's view only after the user holds his finger on the screen for some fraction of a second, thus preventing unwanted timeline movements. I found that this hold is not necessary for me, but may be worth considering adding for the others.
- It may be worth adding some visual cues for the user so he knows these gestures are now available. Perhaps some semi-transparent overlay when the player area is being touched?
- The feature currently works for all iOS devices (not only iPads).


## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Open a video in a playlist
- Drag (pan) the video player view in horizontal / vertical direction, make sure it rewinds the video (when panned horizontally) and changes the volume (when panned vertically) accordingly.
- Double tap on the left, middle, right area of the player. Make sure it goes back 15 seconds, toggles play/pause, goes forward 15 seconds accordingly.
- Regression testing.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![screenshot](https://github.com/yuriymacdev/FeatureProposal/raw/main/BravePlayerProposal.gif)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
