### PR TITLE
Fix #5101: Adding Default Engines in Quick Search Toolbar

### DIFF
--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -152,7 +152,7 @@ class SearchEngines {
 
     var quickSearchEngines: [OpenSearchEngine]! {
         get {
-            return self.orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
+            return self.orderedEngines.filter({ (engine) in self.isEngineEnabled(engine) })
         }
     }
 

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -109,17 +109,8 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     }
 
     private var quickSearchEngines: [OpenSearchEngine] {
-        guard let engines = searchEngines else { return [] }
-        var quickEngines = engines.quickSearchEngines
-
-        // If we're not showing search suggestions, the default search engine won't be visible
-        // at the top of the table. Show it with the others in the bottom search bar.
-        if tabType.isPrivate || !engines.shouldShowSearchSuggestions {
-            quickEngines?.insert(engines.defaultEngine(), at: 0)
-        }
-
-        guard let seachEngine = quickEngines else { return [] }
-        return seachEngine
+        guard let searchEngines = searchEngines?.quickSearchEngines else { return [] }
+        return searchEngines
     }
 
     // If the user only has a single quick search engine, it is also their default one.

--- a/ClientTests/SearchEnginesTests.swift
+++ b/ClientTests/SearchEnginesTests.swift
@@ -139,8 +139,8 @@ class SearchEnginesTests: XCTestCase {
         engines.disableEngine((engineSet?[1])!)
         XCTAssertTrue(engines.isEngineEnabled((engineSet?[1])!))
 
-        // The default engine is not included in the quick search engines.
-        XCTAssertEqual(0, engines.quickSearchEngines.filter { engine in engine.shortName == engineSet?[1].shortName }.count)
+        // The default engine is included in the quick search engines.
+        XCTAssertEqual(1, engines.quickSearchEngines.filter { engine in engine.shortName == engineSet?[0].shortName }.count)
 
         // Enable and disable work.
         engines.enableEngine((engineSet?[0])!)


### PR DESCRIPTION
Default Selected Engine should be in Quick Search Engine list when it is used in Search Controller Screen search Toolbar.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5101

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
  1. Fresh Install Brave Browser
  2. Start typing in Omnibox and accept Search suggestions
  3. Check default Search Engine (Brave Search) is not included in quick search engine bar
  
## Screenshots:

https://user-images.githubusercontent.com/6643505/158449136-ebe2cea3-40fc-45ec-a801-195d5773af49.MP4


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
