### PR TITLE
No Bug: Add ability to pass in supported BraveCore switches at launch

### DIFF
--- a/BraveShared/Preferences.swift
+++ b/BraveShared/Preferences.swift
@@ -159,6 +159,17 @@ extension Preferences {
         /// Whether or not the user successfully enrolled before
         public static let didEnrollDeviceCheck = Option<Bool>(key: "rewards.devicecheck.did.enroll", default: false)
     }
+    
+    public final class BraveCore {
+        /// Switches that are passed into BraveCoreMain during launch.
+        ///
+        /// This preference stores a list of `BraveCoreSwitch` raw values
+        public static let activeSwitches = Option<[String]>(key: "brave-core.active-switches", default: [])
+        /// The values for switches that may be passed into BraveCoreMain if they're active
+        ///
+        /// Each key is a `BraveCoreSwitch`
+        public static let switchValues = Option<[String: String]>(key: "brave-core.switches.values", default: [:])
+    }
 }
 
 extension Preferences {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		2777273722EB43A100F0214C /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777273622EB43A100F0214C /* StringExtensions.swift */; };
 		2777274022EB44B300F0214C /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777273F22EB44B300F0214C /* StringExtensionTests.swift */; };
 		2777275A22EB4C7700F0214C /* BraveShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DE7688420B3456C00FF5533 /* BraveShared.framework */; };
+		2777954927E126AB00536D0C /* BraveCoreDebugSwitchesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777954827E126AB00536D0C /* BraveCoreDebugSwitchesView.swift */; };
 		277C0A9A273DC0890059AB0A /* NamedAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277C0A99273DC0890059AB0A /* NamedAddresses.swift */; };
 		277C5B21254CAD790032DEF2 /* BraveRewardsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277C5B16254CAD2A0032DEF2 /* BraveRewardsExtensions.swift */; };
 		277E94F225F834240001926E /* VPNMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277E94F125F834240001926E /* VPNMenuButton.swift */; };
@@ -2118,6 +2119,7 @@
 		27756E9825AF6F5F00C129AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2777273622EB43A100F0214C /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		2777273F22EB44B300F0214C /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
+		2777954827E126AB00536D0C /* BraveCoreDebugSwitchesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveCoreDebugSwitchesView.swift; sourceTree = "<group>"; };
 		277C0A99273DC0890059AB0A /* NamedAddresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedAddresses.swift; sourceTree = "<group>"; };
 		277C5B16254CAD2A0032DEF2 /* BraveRewardsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveRewardsExtensions.swift; sourceTree = "<group>"; };
 		277E94F125F834240001926E /* VPNMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNMenuButton.swift; sourceTree = "<group>"; };
@@ -4830,6 +4832,7 @@
 				272B862A270BD96F005ED304 /* SandboxInspectorView.swift */,
 				2F1A8359274C35340089A8A9 /* RetentionPreferencesDebugMenuViewController.swift */,
 				274AD909278D455500FDF4D8 /* ManageWebsiteDataView.swift */,
+				2777954827E126AB00536D0C /* BraveCoreDebugSwitchesView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -8505,6 +8508,7 @@
 				27FD3F7825C8B0E700696156 /* BraveNewsAddSourceResultsViewController.swift in Sources */,
 				27E0652824CB6AE300134946 /* BraveNewsErrorView.swift in Sources */,
 				E650755C1E37F747006961AC /* Swizzling.m in Sources */,
+				2777954927E126AB00536D0C /* BraveCoreDebugSwitchesView.swift in Sources */,
 				2FE63DB8258BCC29004B219D /* BrowserViewController+OpenSearch.swift in Sources */,
 				2719DA09249D37490080AB48 /* SponsorCardView.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,

--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -33,7 +33,20 @@ extension AppDelegate {
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
-    var braveCore = BraveCoreMain(userAgent: UserAgent.mobile)
+    var braveCore: BraveCoreMain = {
+        var switches: [BraveCoreSwitch: String] = [:]
+        if !AppConstants.buildChannel.isPublic {
+            // Check prefs for additional switches
+            let activeSwitches = Preferences.BraveCore.activeSwitches.value
+            let switchValues = Preferences.BraveCore.switchValues.value
+            for activeSwitch in activeSwitches {
+                if let value = switchValues[activeSwitch], !value.isEmpty {
+                    switches[BraveCoreSwitch(rawValue: activeSwitch)] = value
+                }
+            }
+        }
+        return BraveCoreMain(userAgent: UserAgent.mobile, additionalSwitches: switches)
+    }()
     var migration: Migration?
 
     private weak var application: UIApplication?

--- a/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
+++ b/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
@@ -1,0 +1,248 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveShared
+import BraveCore
+
+extension BraveCoreSwitch {
+    fileprivate var displayString: String {
+        switch self {
+        case .vModule:
+            return "Log Verbosity"
+        case .componentUpdater:
+            return "Component Updater"
+        case .syncURL:
+            return "Sync URL"
+        case .skusEnvironment:
+            return "SKUs Environment"
+        default:
+            return ""
+        }
+    }
+}
+
+private enum SkusEnvironment: String, CaseIterable {
+    case development
+    case staging
+    case production
+}
+
+private struct BasicStringInputView: View {
+    @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
+    @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
+    @Environment(\.presentationMode) @Binding private var presentationMode
+    
+    var coreSwitch: BraveCoreSwitch
+    var hint: String?
+    
+    @State private var text: String = ""
+    
+    var body: some View {
+        List {
+            Section {
+                TextField(coreSwitch.displayString, text: $text)
+                    .disableAutocorrection(true)
+                    .autocapitalization(.none)
+            } footer: {
+                if let hint = hint {
+                    Text(hint)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(coreSwitch.displayString)
+        .onAppear {
+            // SwiftUI bug, has to wait a bit
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                text = switchValues.value[coreSwitch.rawValue, default: ""]
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .confirmationAction) {
+                Button {
+                    if text.isEmpty {
+                        switchValues.value[coreSwitch.rawValue] = nil
+                        activeSwitches.value.removeAll(where: { $0 == coreSwitch.rawValue })
+                    } else {
+                        switchValues.value[coreSwitch.rawValue] = text
+                        if !activeSwitches.value.contains(coreSwitch.rawValue) {
+                            activeSwitches.value.append(coreSwitch.rawValue)
+                        }
+                    }
+                    presentationMode.dismiss()
+                } label: {
+                    Text("Save")
+                        .foregroundColor(Color(.braveOrange))
+                }
+            }
+        }
+    }
+}
+
+private struct BasicPickerInputView: View {
+    @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
+    @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
+    @Environment(\.presentationMode) @Binding private var presentationMode
+    
+    var coreSwitch: BraveCoreSwitch
+    var options: [String]
+    
+    @State private var selectedItem: String = ""
+    
+    var body: some View {
+        List {
+            Picker("", selection: $selectedItem) {
+                Text("Default")
+                    .foregroundColor(Color(.secondaryBraveLabel))
+                    .tag("")
+                ForEach(options, id: \.self) { option in
+                    Text(option.capitalized).tag(option)
+                }
+            }
+            .pickerStyle(.inline)
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(coreSwitch.displayString)
+        .onAppear {
+            // SwiftUI bug, has to wait a bit
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                selectedItem = switchValues.value[coreSwitch.rawValue, default: ""]
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .confirmationAction) {
+                Button {
+                    if selectedItem.isEmpty {
+                        switchValues.value[coreSwitch.rawValue] = nil
+                        activeSwitches.value.removeAll(where: { $0 == coreSwitch.rawValue })
+                    } else {
+                        switchValues.value[coreSwitch.rawValue] = selectedItem
+                        if !activeSwitches.value.contains(coreSwitch.rawValue) {
+                            activeSwitches.value.append(coreSwitch.rawValue)
+                        }
+                    }
+                    presentationMode.dismiss()
+                } label: {
+                    Text("Save")
+                        .foregroundColor(Color(.braveOrange))
+                }
+            }
+        }
+    }
+}
+
+struct BraveCoreDebugSwitchesView: View {
+    @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
+    @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
+    
+    private struct SwitchContainer: View {
+        @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
+        @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
+        
+        var coreSwitch: BraveCoreSwitch
+        
+        init(_ coreSwitch: BraveCoreSwitch) {
+            self.coreSwitch = coreSwitch
+        }
+        
+        private var binding: Binding<Bool> {
+            .init(
+                get: {
+                    activeSwitches.value.contains(coreSwitch.rawValue) &&
+                        !switchValues.value[coreSwitch.rawValue, default: ""].isEmpty
+                }, set: { isOn in
+                    if isOn {
+                        activeSwitches.value.append(coreSwitch.rawValue)
+                    } else {
+                        activeSwitches.value.removeAll(where: { $0 == coreSwitch.rawValue })
+                    }
+                }
+            )
+        }
+        
+        var body: some View {
+            HStack(spacing: 16) {
+                Toggle(coreSwitch.displayString, isOn: binding)
+                    .labelsHidden()
+                VStack(alignment: .leading) {
+                    HStack {
+                        Text(coreSwitch.displayString)
+                            .font(.headline)
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(coreSwitch.rawValue)
+                            .font(.footnote)
+                            .foregroundColor(Color(.secondaryBraveLabel))
+                        if let value = switchValues.value[coreSwitch.rawValue], !value.isEmpty {
+                            Text("\(Image(systemName: "equal.square.fill")) \(value)")
+                                .font(.caption)
+                                .foregroundColor(binding.wrappedValue ? Color(.braveBlurpleTint) : Color(.secondaryBraveLabel))
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 6)
+        }
+    }
+    
+    var body: some View {
+        List {
+            Section {
+                Text("Switches only affect fresh launches")
+                    .frame(maxWidth: .infinity)
+                    .font(.footnote)
+                    .foregroundColor(Color(.braveLabel))
+                    .listRowBackground(Color(.braveGroupedBackground))
+                    .listRowInsets(.zero)
+            }
+            Section {
+                // Sync URL
+                NavigationLink {
+                    BasicStringInputView(coreSwitch: .syncURL)
+                        .keyboardType(.URL)
+                } label: {
+                    SwitchContainer(.syncURL)
+                }
+                NavigationLink {
+                    BasicPickerInputView(coreSwitch: .skusEnvironment, options: SkusEnvironment.allCases.map(\.rawValue))
+                } label: {
+                    SwitchContainer(.skusEnvironment)
+                }
+                NavigationLink {
+                    BasicStringInputView(coreSwitch: .componentUpdater, hint: "Should match the format: url-source={url}")
+                } label: {
+                    SwitchContainer(.componentUpdater)
+                }
+                NavigationLink {
+                    BasicStringInputView(coreSwitch: .vModule, hint: "Should match the format:\n\n{folder-expression}={level}\n\nDefaults to */brave/*=5")
+                } label: {
+                    SwitchContainer(.vModule)
+                }
+            }
+            Section {
+                Button("Disable All") {
+                    withAnimation {
+                        activeSwitches.value = []
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationBarTitle("BraveCore Switches")
+    }
+}
+
+#if DEBUG
+struct BraveCoreDebugSwitchesView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            BraveCoreDebugSwitchesView()
+                .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+#endif

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -548,6 +548,10 @@ class SettingsViewController: TableViewController {
                     self.navigationController?.pushViewController(UrpLogsViewController(), animated: true)
                 }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
                 Row(text: "URP Code: \(UserReferralProgram.getReferralCode() ?? "--")"),
+                Row(text: "BraveCore Switches", selection: { [unowned self] in
+                    let controller = UIHostingController(rootView: BraveCoreDebugSwitchesView())
+                    self.navigationController?.pushViewController(controller, animated: true)
+                }, accessory: .disclosureIndicator, cellClass: MultilineSubtitleCell.self),
                 Row(text: "View Rewards Debug Menu", selection: { [unowned self] in
                     self.displayRewardsDebugMenu()
                 }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Sets up some debug UI to set brave-core switches and use them at launch

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:


| | |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-03-15 at 18 31 52](https://user-images.githubusercontent.com/529104/158483224-251d66e2-9090-41df-b209-b48138110d2e.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-03-15 at 18 31 59](https://user-images.githubusercontent.com/529104/158483258-226a2a5c-ed46-4998-8011-640af6227f0e.png) |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-03-15 at 18 32 04](https://user-images.githubusercontent.com/529104/158483272-d5b01875-3cba-4244-b788-2e234a7a1a92.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-03-15 at 18 32 07](https://user-images.githubusercontent.com/529104/158483278-faf5fe70-eac2-4c18-9b2a-71a31a2b2194.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
