### PR TITLE
Fix #4950 Same animation parameters for skip and bottom image view.

### DIFF
--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
@@ -720,7 +720,8 @@ private class WelcomeAnimator: NSObject, UIViewControllerAnimatedTransitioning {
             }
             
             if fromView == fromWelcomeView.topImageView ||
-                fromView == fromWelcomeView.bottomImageView {
+                fromView == fromWelcomeView.bottomImageView ||
+                fromView == fromWelcomeView.skipButton {
                 UIView.animate(withDuration: totalAnimationTime, delay: 0.0, options: .curveEaseInOut) {
                     fromView.transform = toView.transform
                 } completion: { finished in


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4950

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Install Brave with new profile to get the onboarding screens
- In the Default Browser screen tap the Not now button
- After the button is tapped, the Skip button should not be temporary hidden by the bottom image
- In the Search screen, tap the Skip button
- After the button is tapped, the Skip button should not be temporary hidden by the bottom image

## Screenshots:

![transitions](https://user-images.githubusercontent.com/3075586/158511036-71d97a7c-9029-4114-a411-e5a7533f2036.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
