### PR TITLE
Fix #5120: Account activity view not showing all available assets on Ropsten

### DIFF
--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -49,6 +49,9 @@ struct AccountActivityView: View {
   }
 
   var body: some View {
+    let assetRatios = activityStore.assets.reduce(into: [String: Double](), {
+      $0[$1.token.symbol.lowercased()] = Double($1.price)
+    })
     List {
       Section {
         AccountActivityHeaderView(account: accountInfo) { editMode in
@@ -89,12 +92,9 @@ struct AccountActivityView: View {
               keyringStore: keyringStore,
               networkStore: networkStore,
               visibleTokens: activityStore.assets.map(\.token),
+              allTokens: activityStore.allTokens,
               displayAccountCreator: false,
-              assetRatios: activityStore.assets.reduce(
-                into: [String: Double](),
-                {
-                  $0[$1.token.symbol.lowercased()] = Double($1.price)
-                })
+              assetRatios: assetRatios
             )
             .contextMenu {
               if !tx.txHash.isEmpty {

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -85,7 +85,8 @@ struct AssetDetailView: View {
               info: tx,
               keyringStore: keyringStore,
               networkStore: networkStore,
-              visibleTokens: [],
+              visibleTokens: [assetDetailStore.token],
+              allTokens: [], // AssetDetailView is specific to a single token
               displayAccountCreator: true,
               assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
             )

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -11,11 +11,11 @@ import struct Shared.Strings
 struct AssetSearchView: View {
   var keyringStore: KeyringStore
   var cryptoStore: CryptoStore
-
+  
   @Environment(\.presentationMode) @Binding private var presentationMode
-
+  
   @State private var allTokens: [BraveWallet.BlockchainToken] = []
-
+  
   var body: some View {
     NavigationView {
       TokenList(tokens: allTokens.filter({ $0.isErc20 || $0.symbol == cryptoStore.networkStore.selectedChain.symbol })) { token in
@@ -25,9 +25,9 @@ struct AssetSearchView: View {
             keyringStore: keyringStore,
             networkStore: cryptoStore.networkStore
           )
-          .onDisappear {
-            cryptoStore.closeAssetDetailStore(for: token)
-          }
+            .onDisappear {
+              cryptoStore.closeAssetDetailStore(for: token)
+            }
         ) {
           TokenView(token: token)
         }
@@ -47,8 +47,8 @@ struct AssetSearchView: View {
     }
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
-      cryptoStore.blockchainRegistry.allTokens(BraveWallet.MainnetChainId) { tokens in
-        self.allTokens = tokens.sorted(by: { $0.symbol < $1.symbol })
+      cryptoStore.blockchainRegistry.allTokens(cryptoStore.networkStore.selectedChainId) { tokens in
+        self.allTokens = ([cryptoStore.networkStore.selectedChain.nativeToken] + tokens).sorted(by: { $0.symbol < $1.symbol })
       }
     }
   }

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -52,20 +52,7 @@ class AccountActivityStore: ObservableObject {
             let additionalAssets = allTokens
               .filter { BraveWallet.assetsSwapInRopsten.contains($0.symbol) }
               .sorted(by: { $0.symbol < $1.symbol })
-              .map {
-                AssetViewModel(
-                  token: $0.then {
-                    if $0.symbol == "USDC" {
-                      $0.contractAddress = BraveWallet.usdcSwapAddress
-                    } else if $0.symbol == "DAI" {
-                      $0.contractAddress = BraveWallet.daiSwapAddress
-                    }
-                  },
-                  decimalBalance: 0,
-                  price: "",
-                  history: []
-                )
-              }
+              .map { AssetViewModel(token: $0, decimalBalance: 0, price: "", history: []) }
             updatedAssets.append(contentsOf: additionalAssets)
           }
           let updatedTokens = updatedAssets.map { $0.token }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -8,7 +8,7 @@ import BraveCore
 public class CryptoStore: ObservableObject {
   public let networkStore: NetworkStore
   public let portfolioStore: PortfolioStore
-
+  
   @Published var buySendSwapDestination: BuySendSwapDestination? {
     didSet {
       if buySendSwapDestination == nil {
@@ -27,7 +27,7 @@ public class CryptoStore: ObservableObject {
     }
   }
   @Published private(set) var hasUnapprovedTransactions: Bool = false
-
+  
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
   private let walletService: BraveWalletBraveWalletService
@@ -36,7 +36,7 @@ public class CryptoStore: ObservableObject {
   let blockchainRegistry: BraveWalletBlockchainRegistry
   private let txService: BraveWalletTxService
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
-
+  
   public init(
     keyringService: BraveWalletKeyringService,
     rpcService: BraveWalletJsonRpcService,
@@ -55,7 +55,7 @@ public class CryptoStore: ObservableObject {
     self.blockchainRegistry = blockchainRegistry
     self.txService = txService
     self.ethTxManagerProxy = ethTxManagerProxy
-
+    
     self.networkStore = .init(rpcService: rpcService)
     self.portfolioStore = .init(
       keyringService: keyringService,
@@ -64,11 +64,11 @@ public class CryptoStore: ObservableObject {
       assetRatioService: assetRatioService,
       blockchainRegistry: blockchainRegistry
     )
-
+    
     self.keyringService.add(self)
     self.txService.add(self)
   }
-
+  
   private var buyTokenStore: BuyTokenStore?
   func openBuyTokenStore(_ prefilledToken: BraveWallet.BlockchainToken?) -> BuyTokenStore {
     if let store = buyTokenStore {
@@ -82,7 +82,7 @@ public class CryptoStore: ObservableObject {
     buyTokenStore = store
     return store
   }
-
+  
   private var sendTokenStore: SendTokenStore?
   func openSendTokenStore(_ prefilledToken: BraveWallet.BlockchainToken?) -> SendTokenStore {
     if let store = sendTokenStore {
@@ -100,7 +100,7 @@ public class CryptoStore: ObservableObject {
     sendTokenStore = store
     return store
   }
-
+  
   private var swapTokenStore: SwapTokenStore?
   func openSwapTokenStore(_ prefilledToken: BraveWallet.BlockchainToken?) -> SwapTokenStore {
     if let store = swapTokenStore {
@@ -120,7 +120,7 @@ public class CryptoStore: ObservableObject {
     swapTokenStore = store
     return store
   }
-
+  
   private var assetDetailStore: AssetDetailStore?
   func assetDetailStore(for token: BraveWallet.BlockchainToken) -> AssetDetailStore {
     if let store = assetDetailStore, store.token.id == token.id {
@@ -137,13 +137,13 @@ public class CryptoStore: ObservableObject {
     assetDetailStore = store
     return store
   }
-
+  
   func closeAssetDetailStore(for token: BraveWallet.BlockchainToken) {
     if let store = assetDetailStore, store.token.id == token.id {
       assetDetailStore = nil
     }
   }
-
+  
   private var accountActivityStore: AccountActivityStore?
   func accountActivityStore(for account: BraveWallet.AccountInfo) -> AccountActivityStore {
     if let store = accountActivityStore, store.account.address == account.address {
@@ -154,18 +154,19 @@ public class CryptoStore: ObservableObject {
       walletService: walletService,
       rpcService: rpcService,
       assetRatioService: assetRatioService,
-      txService: txService
+      txService: txService,
+      blockchainRegistry: blockchainRegistry
     )
     accountActivityStore = store
     return store
   }
-
+  
   func closeAccountActivityStore(for account: BraveWallet.AccountInfo) {
     if let store = accountActivityStore, store.account.address == account.address {
       accountActivityStore = nil
     }
   }
-
+  
   private var confirmationStore: TransactionConfirmationStore?
   func openConfirmationStore() -> TransactionConfirmationStore {
     if let store = confirmationStore {
@@ -183,13 +184,13 @@ public class CryptoStore: ObservableObject {
     confirmationStore = store
     return store
   }
-
+  
   private(set) lazy var settingsStore = SettingsStore(
     keyringService: keyringService,
     walletService: walletService,
     txService: txService
   )
-
+  
   func fetchUnapprovedTransactions() {
     keyringService.defaultKeyringInfo { [self] keyring in
       var pendingTransactions: [BraveWallet.TransactionInfo] = []

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -105,7 +105,7 @@ public class SendTokenStore: ObservableObject {
       }
 
       // store tokens in `allTokens` for address validation
-      self.blockchainRegistry.allTokens(BraveWallet.MainnetChainId) { tokens in
+      self.blockchainRegistry.allTokens(network.chainId) { tokens in
         self.allTokens = tokens + [network.nativeToken]
       }
     }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -138,7 +138,8 @@ public class TransactionConfirmationStore: ObservableObject {
                 self.state.value = formatter.decimalString(for: approvalValue, radix: .hex, decimals: Int(token.decimals)) ?? ""
               }
             case .erc20Transfer:
-              if let token = allTokens.first(where: { $0.contractAddress(in: selectedChain).caseInsensitiveCompare(transaction.ethTxToAddress) == .orderedSame
+              if let token = allTokens.first(where: {
+                $0.contractAddress(in: selectedChain).caseInsensitiveCompare(transaction.ethTxToAddress) == .orderedSame
               }) {
                 self.state.symbol = token.symbol
                 let value = transaction.txArgs[1].removingHexPrefix

--- a/BraveWallet/Crypto/Transactions/TransactionView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionView.swift
@@ -15,6 +15,7 @@ struct TransactionView: View {
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var networkStore: NetworkStore
   var visibleTokens: [BraveWallet.BlockchainToken]
+  var allTokens: [BraveWallet.BlockchainToken]
   var displayAccountCreator: Bool
   var assetRatios: [String: Double]
 
@@ -30,6 +31,13 @@ struct TransactionView: View {
 
   private func namedAddress(for address: String) -> String {
     NamedAddresses.name(for: address, accounts: keyringStore.keyring.accountInfos)
+  }
+
+  private func token(for contractAddress: String) -> BraveWallet.BlockchainToken? {
+    let findToken: (BraveWallet.BlockchainToken) -> Bool = {
+      $0.contractAddress(in: networkStore.selectedChain).caseInsensitiveCompare(contractAddress) == .orderedSame
+    }
+    return visibleTokens.first(where: findToken) ?? allTokens.first(where: findToken)
   }
 
   private var gasFee: (String, fiat: String)? {
@@ -56,10 +64,8 @@ struct TransactionView: View {
     switch info.txType {
     case .erc20Approve:
       let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to ?? ""
-      if info.txArgs.count > 1, let token = visibleTokens.first(where: {
-        $0.contractAddress(in: networkStore.selectedChain).caseInsensitiveCompare(contractAddress) == .orderedSame
-      }) {
-        Text(String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, formatter.decimalString(for: info.txArgs[1].removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? "", token.symbol))
+      if let value = info.txArgs[safe: 1], let token = token(for: contractAddress) {
+        Text(String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? "", token.symbol))
       } else {
         Text(Strings.Wallet.transactionUnknownApprovalTitle)
       }
@@ -72,21 +78,15 @@ struct TransactionView: View {
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, amount, networkStore.selectedChain.symbol, fiat))
       }
     case .erc20Transfer:
-      if info.txArgs.count > 1,
-        let token = visibleTokens.first(where: {
-          $0.contractAddress.caseInsensitiveCompare(info.ethTxToAddress) == .orderedSame
-        })
-      {
-        let amount = formatter.decimalString(for: info.txArgs[1].removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
+      if let value = info.txArgs[safe: 1], let token = token(for: info.ethTxToAddress) {
+        let amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
         let fiat = numberFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, amount, token.symbol, fiat))
       } else {
         Text(Strings.Wallet.send)
       }
     case .erc721TransferFrom, .erc721SafeTransferFrom:
-      if let token = visibleTokens.first(where: {
-        $0.contractAddress.caseInsensitiveCompare(info.ethTxToAddress) == .orderedSame
-      }) {
+      if let token = token(for: info.ethTxToAddress) {
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionUnknownSendTitle, token.symbol))
       } else {
         Text(Strings.Wallet.send)
@@ -212,6 +212,7 @@ struct Transaction_Previews: PreviewProvider {
         keyringStore: .previewStoreWithWalletCreated,
         networkStore: .previewStore,
         visibleTokens: [.previewToken],
+        allTokens: [],
         displayAccountCreator: false,
         assetRatios: ["eth": 4576.36]
       )
@@ -220,6 +221,7 @@ struct Transaction_Previews: PreviewProvider {
         keyringStore: .previewStoreWithWalletCreated,
         networkStore: .previewStore,
         visibleTokens: [.previewToken],
+        allTokens: [],
         displayAccountCreator: true,
         assetRatios: ["eth": 4576.36]
       )
@@ -228,6 +230,7 @@ struct Transaction_Previews: PreviewProvider {
         keyringStore: .previewStoreWithWalletCreated,
         networkStore: .previewStore,
         visibleTokens: [.previewToken],
+        allTokens: [],
         displayAccountCreator: false,
         assetRatios: ["eth": 4576.36]
       )

--- a/BraveWallet/Crypto/Transactions/TransactionView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionView.swift
@@ -55,11 +55,10 @@ struct TransactionView: View {
     let formatter = WeiFormatter(decimalFormatStyle: .balance)
     switch info.txType {
     case .erc20Approve:
-      if info.txArgs.count > 1,
-        let token = visibleTokens.first(where: {
-          $0.contractAddress == info.txArgs[0]
-        })
-      {
+      let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to ?? ""
+      if info.txArgs.count > 1, let token = visibleTokens.first(where: {
+        $0.contractAddress.caseInsensitiveCompare(contractAddress) == .orderedSame
+      }) {
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, formatter.decimalString(for: info.txArgs[1].removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? "", token.symbol))
       } else {
         Text(Strings.Wallet.transactionUnknownApprovalTitle)

--- a/BraveWallet/Crypto/Transactions/TransactionView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionView.swift
@@ -57,7 +57,7 @@ struct TransactionView: View {
     case .erc20Approve:
       let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to ?? ""
       if info.txArgs.count > 1, let token = visibleTokens.first(where: {
-        $0.contractAddress.caseInsensitiveCompare(contractAddress) == .orderedSame
+        $0.contractAddress(in: networkStore.selectedChain).caseInsensitiveCompare(contractAddress) == .orderedSame
       }) {
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, formatter.decimalString(for: info.txArgs[1].removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? "", token.symbol))
       } else {

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -133,34 +133,14 @@ extension BraveWallet.BlockchainToken: Identifiable {
   }
 
   public func contractAddress(in network: BraveWallet.EthereumChain) -> String {
-    if network.chainId == BraveWallet.RopstenChainId {
-      switch symbol.uppercased() {
-      case "ETH": return BraveWallet.ethSwapAddress
-      case "DAI": return BraveWallet.daiSwapAddress
-      case "USDC": return BraveWallet.usdcSwapAddress
-      default: return contractAddress
-      }
-    } else {
-      // ETH special swap address in Ropsten network
-      // Only checking token.symbol with selected network.symbol is sufficient
-      // since there is no swap support for custom networks.
-      return symbol == network.symbol ? BraveWallet.ethSwapAddress : contractAddress
-    }
+    // ETH special swap address
+    // Only checking token.symbol with selected network.symbol is sufficient
+    // since there is no swap support for custom networks.
+    return symbol == network.symbol ? BraveWallet.ethSwapAddress : contractAddress
   }
 }
 
 extension BraveWallet {
   /// The address that is expected when you are swapping ETH via SwapService APIs
   public static let ethSwapAddress: String = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-
-  ///  The address that is expected when you are swapping DAI via SwapService APIs
-  ///  Also the contract address to fetch DAI balance on Ropsten
-  public static let daiSwapAddress: String = "0xad6d458402f60fd3bd25163575031acdce07538d"
-
-  ///  The address that is expected when you are swapping USDC via SwapService APIs
-  ///  Also the contract address to fetch USDC balance on Ropsten
-  public static let usdcSwapAddress: String = "0x07865c6e87b9f70255377e024ace6630c1eaa37f"
-
-  /// A list of supported assets' symbols for swapping in `Ropsten` network
-  public static let assetsSwapInRopsten: [String] = ["DAI", "USDC"]
 }

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -44,7 +44,7 @@ extension NetworkStore {
       rpcService: MockJsonRpcService()
     )
   }
-
+  
   static var previewStoreWithCustomNetworkAdded: NetworkStore {
     let store = NetworkStore.previewStore
     store.addCustomNetwork(.init(chainId: "0x100", chainName: "MockChain", blockExplorerUrls: ["https://mockchainscan.com"], iconUrls: [], rpcUrls: ["https://rpc.mockchain.com"], symbol: "MOCK", symbolName: "MOCK", decimals: 18, isEip1559: false)) { _, _ in }
@@ -134,7 +134,8 @@ extension AccountActivityStore {
       walletService: MockBraveWalletService(),
       rpcService: MockJsonRpcService(),
       assetRatioService: MockAssetRatioService(),
-      txService: MockTxService()
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry()
     )
   }
 }


### PR DESCRIPTION
## Summary of Changes
- ~On Ropsten network we add USDC and DAI as swap options manually, but missed adding them to Account Activity (desktop shows them).~ 
- Currently we are fetching tokens from the Blockchain Registry on the Ethereum Mainnet network, no matter which network is currently selected. The Blockchain Registry now returns the correct tokens and addresses for the Ropsten test network, so we should remove the hardcoded DAI / USDC addresses used for swapping on Ropsten test network.

This affects a number of views:

- Edit user visible assets
  - Should be able to add DAI / USDC as user visible assets on Ropsten network without adding as custom assets.
- Account activity view (account detail)
  - Asset list updated for new DAI / USDC user visible assets (if added by user)
  - Transaction list should show symbol for ERC 20 Approve transactions
- Asset search view
  - Should only show assets for that network
- Send Token
  - Same as before, should see ETH / DAI / USDC (previously they were hardcoded addresses for the assets)
- Swap Token
  - Should function the same as before, should see ETH / DAI / USDC (previously they were hardcoded addresses for the assets)

This pull request fixes #5120

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Edit visible assets:
1. Switch to Ropsten network
2. Tap 'edit visible assets' button
3. DAI / USDC should now be listed to add

To get a ERC 20 Approve transaction:
1. Open & unlock wallet
4. Switch to Ropsten network
5. If you have 0 DAI, swap some ETH to DAI
6. Open swap panel and try to swap DAI to ETH. Swap button should show 'Activate Token DAI' if you have never swapped DAI before. Tap it.
7. Confirm the Approve transaction
8. Open Accounts tab
9. Tap account to see account activity. Should see ETH, USDC, DAI now, and DAI approve tx should be shown as 'Approve x DAI'

Search assets:
1. Search button on Portfolio / Accounts root
2. Should now show only ETH / DAI / USDC on Ropsten test network now

Swap / Send
1. Tap brave button to open buy / send / swap quick action sheet
2. Tap send/swap
3. Tap TO/FROM asset should still see USDC / DAI as options, and swap/send should still work as expected

## Screenshots:
<img src="https://user-images.githubusercontent.com/5314553/159270206-f293b328-935f-486a-82d1-3e26d734a399.png" width="300" /> <img src="https://user-images.githubusercontent.com/5314553/159270218-ccc0e89c-fe76-4bb7-b346-ea06a1f50511.png" width="300" />
<img src="https://user-images.githubusercontent.com/5314553/159270228-104b9643-4928-4675-b491-7703c227eae1.png" width="300" /> <img src="https://user-images.githubusercontent.com/5314553/159270244-ac895525-6d00-481d-abd9-5c0a5e7f0641.png" width="300" />


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
