### PR TITLE
No Bug: Portfolio balance calculation incorrect with multiple accounts

### DIFF
--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -100,11 +100,7 @@ public class PortfolioStore: ObservableObject {
             return
           }
           let symbol = token.symbol.lowercased()
-          if let oldBalance = balances[token.symbol] {
-            balances[symbol] = oldBalance + balance
-          } else {
-            balances[symbol] = balance
-          }
+          balances[symbol, default: 0] += balance
         }
       }
     }


### PR DESCRIPTION
## Summary of Changes

- Fixes issue caused in #5098 where balance calculation is incorrect when using multiple accounts. Symbol was not lowercased before checking for existing balance in dictionary

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Need >1 account
1. Unlock wallet
2. Balance total will only be the last fetched balance (aka balance from one account or the other, not total balance)


## Screenshots:
![IMG_2367](https://user-images.githubusercontent.com/5314553/158695572-e0a0bae3-025f-44c4-8c0b-27f29673811f.PNG)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
