### PR TITLE
Fix #4425: Transaction Details UI

### DIFF
--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -135,6 +135,7 @@ struct AccountActivityView: View {
             networkStore: networkStore,
             keyringStore: keyringStore,
             visibleTokens: activityStore.assets.map(\.token),
+            allTokens: [],
             assetRatios: assetRatios
           )
         }

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -133,6 +133,7 @@ struct AccountActivityView: View {
           TransactionDetailsView(
             info: tx,
             networkStore: networkStore,
+            keyringStore: keyringStore,
             visibleTokens: activityStore.assets.map(\.token),
             assetRatios: assetRatios
           )

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -15,7 +15,8 @@ struct AccountActivityView: View {
   @ObservedObject var networkStore: NetworkStore
 
   @State private var detailsPresentation: DetailsPresentation?
-
+  @State private var transactionDetails: BraveWallet.TransactionInfo?
+  
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
 
@@ -87,15 +88,17 @@ struct AccountActivityView: View {
           emptyTextView(Strings.Wallet.noTransactions)
         } else {
           ForEach(activityStore.transactions) { tx in
-            TransactionView(
-              info: tx,
-              keyringStore: keyringStore,
-              networkStore: networkStore,
-              visibleTokens: activityStore.assets.map(\.token),
-              allTokens: activityStore.allTokens,
-              displayAccountCreator: false,
-              assetRatios: assetRatios
-            )
+            Button(action: { self.transactionDetails = tx }) {
+              TransactionView(
+                info: tx,
+                keyringStore: keyringStore,
+                networkStore: networkStore,
+                visibleTokens: activityStore.assets.map(\.token),
+                allTokens: activityStore.allTokens,
+                displayAccountCreator: false,
+                assetRatios: assetRatios
+              )
+            }
             .contextMenu {
               if !tx.txHash.isEmpty {
                 Button(action: {
@@ -114,13 +117,27 @@ struct AccountActivityView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
-    .sheet(item: $detailsPresentation) {
-      AccountDetailsView(
-        keyringStore: keyringStore,
-        account: accountInfo,
-        editMode: $0.inEditMode
-      )
-    }
+    .background(
+      Color.clear
+        .sheet(item: $detailsPresentation) {
+          AccountDetailsView(
+            keyringStore: keyringStore,
+            account: accountInfo,
+            editMode: $0.inEditMode
+          )
+        }
+    )
+    .background(
+      Color.clear
+        .sheet(item: $transactionDetails) { tx in
+          TransactionDetailsView(
+            info: tx,
+            networkStore: networkStore,
+            visibleTokens: activityStore.assets.map(\.token),
+            assetRatios: assetRatios
+          )
+        }
+    )
     .onReceive(keyringStore.$keyring) { keyring in
       if !keyring.accountInfos.contains(where: { $0.address == accountInfo.address }) {
         // Account was deleted

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -145,6 +145,7 @@ struct AssetDetailView: View {
           TransactionDetailsView(
             info: tx,
             networkStore: networkStore,
+            keyringStore: keyringStore,
             visibleTokens: [],
             assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
           )

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -17,6 +17,7 @@ struct AssetDetailView: View {
 
   @State private var tableInset: CGFloat = -16.0
   @State private var isShowingAddAccount: Bool = false
+  @State private var transactionDetails: BraveWallet.TransactionInfo?
 
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
@@ -81,15 +82,17 @@ struct AssetDetailView: View {
             .font(.footnote)
         } else {
           ForEach(assetDetailStore.transactions, id: \.id) { tx in
-            TransactionView(
-              info: tx,
-              keyringStore: keyringStore,
-              networkStore: networkStore,
-              visibleTokens: [assetDetailStore.token],
-              allTokens: [], // AssetDetailView is specific to a single token
-              displayAccountCreator: true,
-              assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
-            )
+            Button(action: { self.transactionDetails = tx }) {
+              TransactionView(
+                info: tx,
+                keyringStore: keyringStore,
+                networkStore: networkStore,
+                visibleTokens: [assetDetailStore.token],
+                allTokens: [], // AssetDetailView is specific to a single token
+                displayAccountCreator: true,
+                assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
+              )
+            }
             .contextMenu {
               if !tx.txHash.isEmpty {
                 Button(action: {
@@ -127,12 +130,26 @@ struct AssetDetailView: View {
     .introspectTableView { tableView in
       tableInset = -tableView.layoutMargins.left
     }
+    .background(
+      Color.clear
     .sheet(isPresented: $isShowingAddAccount) {
       NavigationView {
         AddAccountView(keyringStore: keyringStore)
       }
       .navigationViewStyle(StackNavigationViewStyle())
     }
+    )
+    .background(
+      Color.clear
+        .sheet(item: $transactionDetails) { tx in
+          TransactionDetailsView(
+            info: tx,
+            networkStore: networkStore,
+            visibleTokens: [],
+            assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
+          )
+        }
+    )
   }
 }
 

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -147,6 +147,7 @@ struct AssetDetailView: View {
             networkStore: networkStore,
             keyringStore: keyringStore,
             visibleTokens: [],
+            allTokens: [],
             assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
           )
         }

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -13,16 +13,25 @@ extension String {
     let prefixLength = hasPrefix("0x") ? 6 : 4
     return "\(prefix(prefixLength))…\(suffix(4))"
   }
+  
+  /// Truncates an hash to only show the first 6 digits and last 6 digits
+  var truncatedHash: String {
+    // All addresses should be at least 26 characters long but for the sake of this function, we will ensure
+    // its at least the length of the string
+    let prefixLength = hasPrefix("0x") ? 8 : 6
+    return "\(prefix(prefixLength))…\(suffix(6))"
+  }
+
   /// Removes the `0x` prefix that may exist on the string
   var removingHexPrefix: String {
     hasPrefix("0x") ? String(dropFirst(2)) : self
   }
-
+  
   /// Check if the string is a valid ETH address
   var isETHAddress: Bool {
     // An address has to start with `0x`
     guard starts(with: "0x") else { return false }
-
+    
     // removing `0x`
     let hex = removingHexPrefix
     // Check the length and the rest of the char is a hex digit

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -13,7 +13,7 @@ extension String {
     let prefixLength = hasPrefix("0x") ? 6 : 4
     return "\(prefix(prefixLength))…\(suffix(4))"
   }
-  
+
   /// Truncates an hash to only show the first 6 digits and last 6 digits
   var truncatedHash: String {
     // All addresses should be at least 26 characters long but for the sake of this function, we will ensure

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -134,50 +134,15 @@ struct TransactionConfirmationView: View {
           }
           .font(.callout)
           // Summary
-          VStack(spacing: 8) {
-            VStack {
-              BlockieGroup(
-                fromAddress: activeTransaction.fromAddress,
-                toAddress: activeTransaction.ethTxToAddress,
-                size: 48
-              )
-              Group {
-                if sizeCategory.isAccessibilityCategory {
-                  VStack {
-                    Text(fromAccountName)
-                    Image(systemName: "arrow.down")
-                    Text(toAccountName)
-                  }
-                } else {
-                  HStack {
-                    Text(fromAccountName)
-                    Image(systemName: "arrow.right")
-                    Text(toAccountName)
-                  }
-                }
-              }
-              .foregroundColor(Color(.bravePrimary))
-              .font(.callout)
-            }
-            .accessibilityElement()
-            .accessibility(addTraits: .isStaticText)
-            .accessibility(
-              label: Text(
-                String.localizedStringWithFormat(
-                  Strings.Wallet.transactionFromToAccessibilityLabel, fromAccountName, toAccountName
-                ))
-            )
-            VStack(spacing: 4) {
-              Text(transactionType)
-                .font(.footnote)
-              Text("\(confirmationStore.state.value) \(confirmationStore.state.symbol)")
-                .fontWeight(.semibold)
-                .foregroundColor(Color(.bravePrimary))
-              Text(confirmationStore.state.fiat)  // Value in Fiat
-                .font(.footnote)
-            }
-            .padding(.vertical, 8)
-          }
+          TransactionHeader(
+            fromAccountAddress: activeTransaction.fromAddress,
+            fromAccountName: fromAccountName,
+            toAccountAddress: activeTransaction.ethTxToAddress,
+            toAccountName: toAccountName,
+            transactionType: transactionType,
+            value: "\(confirmationStore.state.value) \(confirmationStore.state.symbol)",
+            fiat: confirmationStore.state.fiat
+          )
           // View Mode
           VStack(spacing: 12) {
             Picker("", selection: $viewMode) {

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -113,68 +113,36 @@ struct TransactionDetailsView: View {
     let marketPrice = numberFormatter.string(from: NSNumber(value: assetRatios[symbol.lowercased(), default: 0])) ?? "$0.00"
     return marketPrice
   }
-  
-  /// The transfer view between accounts
-  @ViewBuilder private var transferView: some View {
-    // For the time being, use the same subtitle label until we have the ability to parse
-    // Swap from/to addresses
-    let from = namedAddress(for: info.fromAddress)
-    let to = namedAddress(for: info.ethTxToAddress)
-    Text("\(from) \(Image(systemName: "arrow.right")) \(to)")
-      .font(.callout.weight(.semibold))
-      .accessibilityLabel(
-        String.localizedStringWithFormat(
-          Strings.Wallet.transactionFromToAccessibilityLabel, from, to
-        )
-      )
-  }
 
   private func namedAddress(for address: String) -> String {
     NamedAddresses.name(for: address, accounts: keyringStore.keyring.accountInfos)
   }
 
-  private var title: String? {
+  private var title: String {
     switch info.txType {
     case .erc20Approve:
       return Strings.Wallet.transactionUnknownApprovalTitle
-    case .ethSend, .other:
+    default:
       if info.isSwap {
         return Strings.Wallet.swap
       } else {
         return Strings.Wallet.sent
       }
-    case .erc20Transfer, .erc721TransferFrom, .erc721SafeTransferFrom:
-      return Strings.Wallet.sent
-    @unknown default:
-      return nil
     }
   }
 
   private var header: some View {
-    VStack(spacing: 16) {
-      BlockieGroup(
-        fromAddress: info.fromAddress,
-        toAddress: info.ethTxToAddress,
-        alignVisuallyCentered: true
-      )
-      transferView
-      VStack(spacing: 4) {
-        if let title = title {
-          Text(title)
-            .font(.callout)
-        }
-        Text(value)
-          .font(.title.weight(.semibold))
-          .foregroundColor(Color(.braveLabel))
-        if let fiat = fiat {
-          Text(fiat)
-            .font(.callout.weight(.medium))
-        }
-      }
-      .foregroundColor(Color(.secondaryBraveLabel))
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 30)
+    TransactionHeader(
+      fromAccountAddress: info.fromAddress,
+      fromAccountName: namedAddress(for: info.fromAddress),
+      toAccountAddress: info.ethTxToAddress,
+      toAccountName: namedAddress(for: info.ethTxToAddress),
+      transactionType: title,
+      value: value,
+      fiat: fiat
+    )
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 30)
   }
   
   var body: some View {
@@ -182,7 +150,7 @@ struct TransactionDetailsView: View {
       List {
         Section(
           header: header
-            .textCase(.none)
+            .resetListHeaderStyle()
             .osAvailabilityModifiers { content in
               if #available(iOS 15.0, *) {
                 content // Padding already applied

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -40,8 +40,9 @@ struct TransactionDetailsView: View {
     case .erc721TransferFrom, .erc721SafeTransferFrom:
       amount = "1" // Can only send 1 erc721 at a time
     case .erc20Approve:
+      let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to ?? ""
       if info.txArgs.count > 1, let token = visibleTokens.first(where: {
-        $0.contractAddress == info.txArgs[0]
+        $0.contractAddress(in: networkStore.selectedChain).caseInsensitiveCompare(contractAddress) == .orderedSame
       }) {
         amount = formatter.decimalString(for: info.txArgs[1].removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
         return String(format: "%@ %@", amount, token.symbol)

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -165,7 +165,18 @@ struct TransactionDetailsView: View {
           }
           detailRow(title: Strings.Wallet.transactionDetailsMarketPriceTitle, value: marketPrice)
           detailRow(title: Strings.Wallet.transactionDetailsDateTitle, value: dateFormatter.string(from: info.createdTime))
-          detailRow(title: Strings.Wallet.transactionDetailsTxHashTitle, value: !info.txHash.isEmpty ? info.txHash.truncatedHash : "***")
+          Button(action: {
+            if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+               let url = baseURL?.appendingPathComponent("tx/\(info.txHash)") {
+              openWalletURL?(url)
+            }
+          }) {
+            detailRow(title: Strings.Wallet.transactionDetailsTxHashTitle) {
+              Label(!info.txHash.isEmpty ? info.txHash.truncatedHash : "***", systemImage: "arrow.up.forward.square")
+                .foregroundColor(Color(.braveBlurple))
+            }
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
           detailRow(title: Strings.Wallet.transactionDetailsNetworkTitle, value: networkStore.selectedChain.chainName)
           detailRow(title: Strings.Wallet.transactionDetailsStatusTitle) {
             HStack(spacing: 4) {
@@ -182,22 +193,6 @@ struct TransactionDetailsView: View {
           }
         }
         .listRowInsets(.zero)
-        if !info.txHash.isEmpty {
-          Section {
-            Button(action: {
-              if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
-                 let url = baseURL?.appendingPathComponent("tx/\(info.txHash)") {
-                openWalletURL?(url)
-              }
-            }) {
-              Text(Strings.Wallet.transactionDetailsViewOnEtherscanTitle)
-            }
-            .buttonStyle(BraveFilledButtonStyle(size: .large))
-            .frame(maxWidth: .infinity)
-            .listRowInsets(.zero)
-            .listRowBackground(Color(.braveGroupedBackground))
-          }
-        }
       }
       .listStyle(.insetGrouped)
       .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -1,0 +1,217 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+import BraveUI
+import SwiftUI
+import Swift
+import struct Shared.Strings
+
+struct TransactionDetailsView: View {
+  
+  var info: BraveWallet.TransactionInfo
+  @ObservedObject var networkStore: NetworkStore
+  var visibleTokens: [BraveWallet.BlockchainToken]
+  var assetRatios: [String: Double]
+  
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.openWalletURLAction) private var openWalletURL
+  
+  private let dateFormatter = DateFormatter().then {
+    $0.dateFormat = "h:mm a - MMM d, yyyy"
+  }
+  
+  private let numberFormatter = NumberFormatter().then {
+    $0.numberStyle = .currency
+    $0.currencyCode = "USD"
+  }
+
+  private var value: String {
+    let formatter = WeiFormatter(decimalFormatStyle: .balance)
+    switch info.txType {
+    case .erc20Transfer:
+      return info.txArgs[1]
+    case .erc721TransferFrom, .erc721SafeTransferFrom:
+      return "1" // Can only send 1 erc721 at a time
+    case .erc20Approve:
+      if info.txArgs.count > 1, let token = visibleTokens.first(where: {
+        $0.contractAddress == info.txArgs[0]
+      }) {
+        return formatter.decimalString(for: info.txArgs[1].removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
+      } else {
+        return "0.0"
+      }
+    case .ethSend, .other:
+      return formatter.decimalString(for: info.ethTxValue.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) ?? ""
+    @unknown default:
+      return "0.0"
+    }
+  }
+  
+  private var fiat: String? {
+    let formatter = WeiFormatter(decimalFormatStyle: .balance)
+    switch info.txType {
+    case .erc721TransferFrom, .erc721SafeTransferFrom, .erc20Approve:
+      return nil
+    case .ethSend, .other:
+      let amount = formatter.decimalString(for: info.ethTxValue.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) ?? ""
+      let fiat = numberFormatter.string(from: NSNumber(value: assetRatios[networkStore.selectedChain.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
+      return fiat
+    case .erc20Transfer:
+      if info.txArgs.count > 1, let token = visibleTokens.first(where: {
+        $0.contractAddress.caseInsensitiveCompare(info.ethTxToAddress) == .orderedSame
+      }) {
+        let amount = formatter.decimalString(for: info.txArgs[1].removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
+        let fiat = numberFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
+        return fiat
+      } else {
+        return "$0.00"
+      }
+    @unknown default:
+      return nil
+    }
+  }
+  
+  private var gasFee: (String, fiat: String)? {
+    let isEIP1559Transaction = info.isEIP1559Transaction
+    let limit = info.ethTxGasLimit
+    let formatter = WeiFormatter(decimalFormatStyle: .gasFee(limit: limit.removingHexPrefix, radix: .hex))
+    let hexFee = isEIP1559Transaction ? (info.txDataUnion.ethTxData1559?.maxFeePerGas ?? "") : info.ethTxGasPrice
+    if let value = formatter.decimalString(for: hexFee.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) {
+      return (value, {
+        guard let doubleValue = Double(value), let assetRatio = assetRatios[networkStore.selectedChain.symbol.lowercased()] else {
+          return "$0.00"
+        }
+        return numberFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00"
+      }())
+    }
+    return nil
+  }
+  
+  private var transactionFee: String? {
+    guard let (fee, fiat) = gasFee else {
+      return nil
+    }
+    let symbol = networkStore.selectedChain.symbol
+    return String(format: "%@ %@\n%@", fee, symbol, fiat)
+  }
+  
+  private var marketPrice: String {
+    let symbol = networkStore.selectedChain.symbol
+    let marketPrice = numberFormatter.string(from: NSNumber(value: assetRatios[symbol.lowercased(), default: 0])) ?? "$0.00"
+    return marketPrice
+  }
+  
+  var body: some View {
+    NavigationView {
+      VStack {
+        VStack(spacing: 16) {
+          VStack(spacing: 8) {
+            if let fiat = fiat {
+              Text(fiat)
+                .font(.title.weight(.semibold))
+                .foregroundColor(Color(.braveLabel))
+            }
+            Text(String(format: "%@ %@", value, networkStore.selectedChain.symbol))
+              .font(.callout.weight(.medium))
+              .foregroundColor(Color(.secondaryBraveLabel))
+          }
+          HStack(spacing: 4) {
+            Image(systemName: "circle.fill")
+              .foregroundColor(info.txStatus.color)
+              .imageScale(.small)
+              .accessibilityHidden(true)
+            Text(info.txStatus.localizedDescription)
+              .foregroundColor(Color(.braveLabel))
+              .multilineTextAlignment(.trailing)
+          }
+          .accessibilityElement(children: .combine)
+          .font(.caption.weight(.semibold))
+        }
+        .padding(.top, 46)
+        .padding(.bottom, 32)
+        Divider()
+        VStack(spacing: 0) {
+          if let transactionFee = transactionFee {
+            detailRow(title: Strings.Wallet.transactionDetailsTxFeeTitle, value: transactionFee)
+          }
+          detailRow(title: Strings.Wallet.transactionDetailsMarketPriceTitle, value: marketPrice)
+          detailRow(title: Strings.Wallet.transactionDetailsToAddressTitle, value: info.ethTxToAddress.truncatedAddress)
+          detailRow(title: Strings.Wallet.transactionDetailsDateTitle, value: dateFormatter.string(from: info.createdTime))
+          detailRow(title: Strings.Wallet.transactionDetailsNetworkTitle, value: networkStore.selectedChain.chainName)
+          detailRow(title: Strings.Wallet.transactionDetailsTxHashTitle, value: !info.txHash.isEmpty ? info.txHash.truncatedHash : "***")
+        }
+        if !info.txHash.isEmpty {
+          Button(action: {
+            if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+               let url = baseURL?.appendingPathComponent("tx/\(info.txHash)") {
+              openWalletURL?(url)
+            }
+          }) {
+            Text(Strings.Wallet.transactionDetailsViewOnEtherscanTitle)
+          }
+          .buttonStyle(BraveFilledButtonStyle(size: .large))
+          .padding(.top)
+        }
+        Spacer()
+      }
+      .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
+      .navigationTitle(Strings.Wallet.transactionDetailsTitle)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItemGroup(placement: .confirmationAction) {
+          Button(action: { presentationMode.dismiss() }) {
+            Text(Strings.done)
+              .foregroundColor(Color(.braveOrange))
+          }
+        }
+      }
+    }
+  }
+  
+  private func detailRow(title: String, value: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(value)
+        .multilineTextAlignment(.trailing)
+    }
+    .font(.caption)
+    .foregroundColor(Color(.braveLabel))
+    .padding(.horizontal)
+    .padding(.vertical, 13)
+  }
+}
+
+#if DEBUG
+struct TransactionDetailsView_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      TransactionDetailsView(
+        info: .previewConfirmedSend,
+        networkStore: .previewStore,
+        visibleTokens: [.previewToken],
+        assetRatios: ["eth": 4576.36]
+      )
+        .previewColorSchemes()
+      TransactionDetailsView(
+        info: .previewConfirmedSwap,
+        networkStore: .previewStore,
+        visibleTokens: [.previewToken],
+        assetRatios: ["eth": 4576.36]
+      )
+        .previewColorSchemes()
+      TransactionDetailsView(
+        info: .previewConfirmedERC20Approve, // FIXME: failing to get value / fiat value
+        networkStore: .previewStore,
+        visibleTokens: [.previewToken],
+        assetRatios: ["eth": 4576.36]
+      )
+        .previewColorSchemes()
+    }
+  }
+}
+#endif

--- a/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -1,0 +1,69 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import struct Shared.Strings
+import SwiftUI
+
+struct TransactionHeader: View {
+  
+  let fromAccountAddress: String
+  let fromAccountName: String
+  let toAccountAddress: String
+  let toAccountName: String
+  
+  let transactionType: String
+  let value: String
+  let fiat: String?
+  
+  @Environment(\.sizeCategory) private var sizeCategory
+  
+  var body: some View {
+    VStack(spacing: 8) {
+      VStack {
+        BlockieGroup(
+          fromAddress: fromAccountAddress,
+          toAddress: toAccountAddress,
+          size: 48
+        )
+        Group {
+          if sizeCategory.isAccessibilityCategory {
+            VStack {
+              Text(fromAccountName)
+              Image(systemName: "arrow.down")
+              Text(toAccountName)
+            }
+          } else {
+            HStack {
+              Text(fromAccountName)
+              Image(systemName: "arrow.right")
+              Text(toAccountName)
+            }
+          }
+        }
+        .foregroundColor(Color(.bravePrimary))
+        .font(.callout)
+      }
+      .accessibilityElement()
+      .accessibility(addTraits: .isStaticText)
+      .accessibility(
+        label: Text(String.localizedStringWithFormat(
+          Strings.Wallet.transactionFromToAccessibilityLabel, fromAccountName, toAccountName
+        ))
+      )
+      VStack(spacing: 4) {
+        Text(transactionType)
+          .font(.footnote)
+        Text(value)
+          .fontWeight(.semibold)
+          .foregroundColor(Color(.bravePrimary))
+        if let fiat = fiat {
+          Text(fiat) // Value in Fiat
+            .font(.footnote)
+        }
+      }
+      .padding(.vertical, 8)
+    }
+  }
+}

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1891,13 +1891,6 @@ extension Strings {
       value: "Transaction Details",
       comment: "The title for the transaction details modal."
     )
-    public static let transactionDetailsViewOnEtherscanTitle = NSLocalizedString(
-      "wallet.transactionDetailsViewOnEtherscanTitle",
-      tableName: "BraveWallet",
-      bundle: .braveWallet,
-      value: "View on etherscan.io",
-      comment: "The title for the button to open on etherscan.io in the transaction details modal."
-    )
     public static let transactionDetailsTxFeeTitle = NSLocalizedString(
       "wallet.transactionDetailsTxFeeTitle",
       tableName: "BraveWallet",

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1884,5 +1884,61 @@ extension Strings {
       value: "Go back",
       comment: "The transaction edit error alert button which will dismiss the alert."
     )
+    public static let transactionDetailsTitle = NSLocalizedString(
+      "wallet.transactionDetailsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Transaction Details",
+      comment: "The title for the transaction details modal."
+    )
+    public static let transactionDetailsViewOnEtherscanTitle = NSLocalizedString(
+      "wallet.transactionDetailsViewOnEtherscanTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "View on etherscan.io",
+      comment: "The title for the button to open on etherscan.io in the transaction details modal."
+    )
+    public static let transactionDetailsTxFeeTitle = NSLocalizedString(
+      "wallet.transactionDetailsTxFeeTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Transaction fee",
+      comment: "The title for displaying the transaction fee of the transaction in the transaction details modal."
+    )
+    public static let transactionDetailsMarketPriceTitle = NSLocalizedString(
+      "wallet.transactionDetailsMarketPriceTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Market price",
+      comment: "The title for displaying the market price of the transaction in the transaction details modal."
+    )
+    public static let transactionDetailsToAddressTitle = NSLocalizedString(
+      "wallet.transactionDetailsToAddressTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "To address",
+      comment: "The title for displaying the to address of the transaction in the transaction details modal."
+    )
+    public static let transactionDetailsDateTitle = NSLocalizedString(
+      "wallet.transactionDetailsDateTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Date",
+      comment: "The title for displaying the date of the transaction in the transaction details modal."
+    )
+    public static let transactionDetailsNetworkTitle = NSLocalizedString(
+      "wallet.transactionDetailsNetworkTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Network",
+      comment: "The title for displaying the network of the transaction in the transaction details modal."
+    )
+    public static let transactionDetailsTxHashTitle = NSLocalizedString(
+      "wallet.transactionDetailsTransactionHashTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Transaction hash",
+      comment: "The title for displaying the transaction hash in the transaction details modal."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1912,13 +1912,6 @@ extension Strings {
       value: "Market price",
       comment: "The title for displaying the market price of the transaction in the transaction details modal."
     )
-    public static let transactionDetailsToAddressTitle = NSLocalizedString(
-      "wallet.transactionDetailsToAddressTitle",
-      tableName: "BraveWallet",
-      bundle: .braveWallet,
-      value: "To address",
-      comment: "The title for displaying the to address of the transaction in the transaction details modal."
-    )
     public static let transactionDetailsDateTitle = NSLocalizedString(
       "wallet.transactionDetailsDateTitle",
       tableName: "BraveWallet",
@@ -1939,6 +1932,20 @@ extension Strings {
       bundle: .braveWallet,
       value: "Transaction hash",
       comment: "The title for displaying the transaction hash in the transaction details modal."
+    )
+    public static let transactionDetailsStatusTitle = NSLocalizedString(
+      "wallet.transactionDetailsStatusTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Status",
+      comment: "The title for displaying the transaction status in the transaction details modal."
+    )
+    public static let sent = NSLocalizedString(
+      "wallet.sent",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Sent",
+      comment: "As in sending cryptocurrency from one asset to another"
     )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1889,56 +1889,56 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Transaction Details",
-      comment: "The title for the transaction details modal."
+      comment: "The title for the view displaying the details of a cryptocurrency transaction."
     )
     public static let transactionDetailsTxFeeTitle = NSLocalizedString(
       "wallet.transactionDetailsTxFeeTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Transaction fee",
-      comment: "The title for displaying the transaction fee of the transaction in the transaction details modal."
+      comment: "The label for the fees involved in a cryptocurrency transaction. Appears next to the value transferred and the currency amount."
     )
     public static let transactionDetailsMarketPriceTitle = NSLocalizedString(
       "wallet.transactionDetailsMarketPriceTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Market price",
-      comment: "The title for displaying the market price of the transaction in the transaction details modal."
+      comment: "The label for the market price of the asset used in a cryptocurrency transaction. Appears next to the formatted currency such as $1523.50"
     )
     public static let transactionDetailsDateTitle = NSLocalizedString(
       "wallet.transactionDetailsDateTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Date",
-      comment: "The title for displaying the date of the transaction in the transaction details modal."
+      comment: "The label for displaying the date a transaction occurred. Appears next to the formatted date such as '3:00PM - Jan 1 2022'"
     )
     public static let transactionDetailsNetworkTitle = NSLocalizedString(
       "wallet.transactionDetailsNetworkTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Network",
-      comment: "The title for displaying the network of the transaction in the transaction details modal."
+      comment: "The label for the network a transaction occurred on. Appears next to 'Ethereum Mainnet', 'Rinkeby Test Network', 'Ropsten Test Network', etc. "
     )
     public static let transactionDetailsTxHashTitle = NSLocalizedString(
       "wallet.transactionDetailsTransactionHashTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Transaction hash",
-      comment: "The title for displaying the transaction hash in the transaction details modal."
+      comment: "The label for the transaction hash (the identifier) of a cryptocurrency transaction. Appears next to a button that opens a URL for the transaction."
     )
     public static let transactionDetailsStatusTitle = NSLocalizedString(
       "wallet.transactionDetailsStatusTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Status",
-      comment: "The title for displaying the transaction status in the transaction details modal."
+      comment: "The label for the transaction status, which describes the how far along a transaction is to completing. Appears next to the words such as 'Approved', 'Submitted', 'Pending', etc."
     )
     public static let sent = NSLocalizedString(
       "wallet.sent",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Sent",
-      comment: "As in sending cryptocurrency from one asset to another"
+      comment: "As in sent cryptocurrency from one asset to another"
     )
   }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1146,6 +1146,7 @@
 		D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */; };
 		D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
+		D506715C27E2AAB700560631 /* TransactionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D506715B27E2AAB700560631 /* TransactionHeader.swift */; };
 		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
 		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
 		D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */; };
@@ -3112,6 +3113,7 @@
 		D3FA777A1A43B2990010CD32 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
+		D506715B27E2AAB700560631 /* TransactionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHeader.swift; sourceTree = "<group>"; };
 		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensions.swift; sourceTree = "<group>"; };
@@ -3808,6 +3810,7 @@
 			isa = PBXGroup;
 			children = (
 				271F687426EBD27D00AA2A50 /* TransactionView.swift */,
+				D506715B27E2AAB700560631 /* TransactionHeader.swift */,
 				D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */,
 			);
 			path = Transactions;
@@ -7972,6 +7975,7 @@
 				2792CBC8275951B10055151E /* UIPasteboardExtensions.swift in Sources */,
 				271F689D26EBD27E00AA2A50 /* AssetSearchView.swift in Sources */,
 				7DC054C227A9CCA400BBA042 /* KeyringServiceExtensions.swift in Sources */,
+				D506715C27E2AAB700560631 /* TransactionHeader.swift in Sources */,
 				277309DE2721DDFB007643F6 /* WeiFormatter.swift in Sources */,
 				271F689926EBD27E00AA2A50 /* Address.swift in Sources */,
 				270E5F3226F3E1B40024C70E /* BraveWalletSwiftUIExtensions.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1147,6 +1147,7 @@
 		D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
 		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
+		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
 		D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */; };
 		D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */; };
 		D8D33A7D1FBD080300A20A28 /* SnapKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */; };
@@ -3112,6 +3113,7 @@
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
 		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
+		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensions.swift; sourceTree = "<group>"; };
 		D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientProgressBar.swift; sourceTree = "<group>"; };
 		D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapKitExtensions.swift; sourceTree = "<group>"; };
@@ -3806,6 +3808,7 @@
 			isa = PBXGroup;
 			children = (
 				271F687426EBD27D00AA2A50 /* TransactionView.swift */,
+				D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */,
 			);
 			path = Transactions;
 			sourceTree = "<group>";
@@ -7933,6 +7936,7 @@
 				271F68A626EBD27E00AA2A50 /* PortfolioAssetView.swift in Sources */,
 				271F68A226EBD27E00AA2A50 /* AddAccountView.swift in Sources */,
 				271F68A126EBD27E00AA2A50 /* AccountsHeaderView.swift in Sources */,
+				D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */,
 				7D4C4914278E31E40073C37E /* WebImageReader.swift in Sources */,
 				271F68AB26EBD27E00AA2A50 /* AssetDetailView.swift in Sources */,
 				271F68C026EBD27E00AA2A50 /* WalletTableViewHeaderView.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes
- Moved header from confirmation view into `TransactionHeader` and reuse it's layout for tx details
- Added `TransactionDetailsView` presented from asset details and account activity
This pull request fixes #4425

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Create some transactions
2. Open asset detail and tap on a transaction to view the transaction details
3. Open account detail and tap on a transaction to view the transaction details


## Screenshots:
![IMG_2381](https://user-images.githubusercontent.com/5314553/159014610-54c4c738-dde5-4acb-afcd-62dc73b5d3bf.PNG)
![IMG_E0EF14817E7D-1](https://user-images.githubusercontent.com/5314553/159014621-e78ab29f-96f7-47b9-8ff1-a4b2a9071023.jpeg)




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
