### PR TITLE
Fix #5125: Playlist migrates with 20 Fetch Limit instead of Batch Size

### DIFF
--- a/Client/Application/Migration.swift
+++ b/Client/Application/Migration.swift
@@ -208,7 +208,7 @@ fileprivate extension Preferences {
         static let playlistV1FileSettingsLocationCompleted =
             Option<Bool>(key: "migration.playlistv1-file-settings-location-completed", default: false)
         static let playlistV2FoldersInitialMigrationCompleted =
-            Option<Bool>(key: "migration.playlistv2-folders-initial-migration-completed", default: false)
+            Option<Bool>(key: "migration.playlistv2-folders-initial-migration-2-completed", default: false)
         static let removeLargeFaviconsMigrationCompleted =
             Option<Bool>(key: "migration.remove-large-favicons", default: false)
         // This is new preference introduced in iOS 1.32.3, tracks whether we should perform database migration.

--- a/Data/models/CRUDProtocols.swift
+++ b/Data/models/CRUDProtocols.swift
@@ -20,8 +20,7 @@ protocol Deletable where Self: NSManagedObject {
 protocol Readable where Self: NSManagedObject {
     static func count(predicate: NSPredicate?, context: NSManagedObjectContext) -> Int?
     static func first(where predicate: NSPredicate?, sortDescriptors: [NSSortDescriptor]?, context: NSManagedObjectContext) -> Self?
-    static func all(where predicate: NSPredicate?, sortDescriptors: [NSSortDescriptor]?, fetchLimit: Int, 
-                    context: NSManagedObjectContext) -> [Self]?
+    static func all(where predicate: NSPredicate?, sortDescriptors: [NSSortDescriptor]?, fetchLimit: Int, fetchBatchSize: Int, context: NSManagedObjectContext) -> [Self]?
 }
 
 // MARK: - Implementations
@@ -108,12 +107,14 @@ extension Readable {
     static func all(where predicate: NSPredicate? = nil,
                     sortDescriptors: [NSSortDescriptor]? = nil,
                     fetchLimit: Int = 0,
+                    fetchBatchSize: Int = 0,
                     context: NSManagedObjectContext = DataController.viewContext) -> [Self]? {
         let request = getFetchRequest()
         
         request.predicate = predicate
         request.sortDescriptors = sortDescriptors
         request.fetchLimit = fetchLimit
+        request.fetchBatchSize = fetchBatchSize
         
         do {
             return try context.fetch(request)

--- a/Data/models/PlaylistItem.swift
+++ b/Data/models/PlaylistItem.swift
@@ -109,7 +109,7 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
         let createdSort = NSSortDescriptor(key: "dateAdded", ascending: false)
         return PlaylistItem.all(where: predicate,
                                      sortDescriptors: [orderSort, createdSort],
-                                     fetchLimit: 20) ?? []
+                                     fetchBatchSize: 20) ?? []
     }
     
     public static func getItem(pageSrc: String) -> PlaylistItem? {


### PR DESCRIPTION
## Summary of Changes
- Changed FetchLimit to FetchBatchSize so we batch upgrade, but not limit.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5125

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test plan

1. For 1.35/not affected users:
- Install a 1.35 build
- add 23-25 media items to the playlist
- Upgrade to 1.36.1
- Verify that all media items added on build 1.35 are there

2. For 1.36/affected users
- Install a 1.35 build
- add 23-25 media items to the playlist
- Install a 1.36 RC build `1.36 (22.3.11.16)` for example
- Verify that not all media items are there, there is 20 items, not 23 or more
- Add one or two videos to playlist
- Upgrade to 1.36.1
- Verify that all media items added on build 1.35 are there

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
