### PR TITLE
Fix #5131: Reader mode URLs show up in history

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1809,7 +1809,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
 
       if (!InternalURL.isValid(url: url) || url.isReaderModeURL), !url.isFileURL {
         // Fire the readability check. This is here and not in the pageShow event handler in ReaderMode.js anymore
-        // because that event wil not always fire due to unreliable page caching. This will either let us know that
+        // because that event will not always fire due to unreliable page caching. This will either let us know that
         // the currently loaded page can be turned into reading mode or if the page already is in reading mode. We
         // ignore the result because we are being called back asynchronous when the readermode status changes.
         webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).checkReadability", contentWorld: .defaultClient)
@@ -1818,11 +1818,10 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
         runScriptsOnWebView(webView)
 
         // Only add history of a url which is not a localhost url
-        if !tab.isPrivate {
+        if !tab.isPrivate, !url.isReaderModeURL {
           // The visitType is checked If it is "typed" or not to determine the History object we are adding
           // should be synced or not. This limitation exists on browser side so we are aligning with this
-          if let visitType =
-            typedNavigation.first(where: { $0.key.typedDisplayString == url.typedDisplayString })?.value,
+          if let visitType = typedNavigation.first(where: { $0.key.typedDisplayString == url.typedDisplayString })?.value,
             visitType == .typed {
             braveCore.historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date())
           } else {


### PR DESCRIPTION
Fixing side effects of internal url logic related with reader mode while adding history

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5131

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Go to a wikipedia article
- Enter reader mode
- Navigate history

## Screenshots:


https://user-images.githubusercontent.com/6643505/159552530-8431b798-03f4-451b-8add-d5d223f0ebeb.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
