### PR TITLE
Fix #5134: Clear Private Data should reset the Shield Preferences on Domains 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1570,7 +1570,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
       openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true, isExternal: true)
       popToBVC()
     } else {
-      History.deleteAll { [weak self] in
+      braveCore.historyAPI.deleteAll { [weak self] in
         guard let self = self else { return }
 
         self.tabManager.clearTabHistory() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -120,7 +120,10 @@ extension BrowserViewController {
       }
 
       MenuItemButton(icon: #imageLiteral(resourceName: "menu-history").template, title: Strings.historyMenuItem) { [unowned self, unowned menuController] in
-        let vc = HistoryViewController(isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing, historyAPI: braveCore.historyAPI)
+        let vc = HistoryViewController(
+          isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing,
+          historyAPI: braveCore.historyAPI,
+          tabManager: tabManager)
         vc.toolbarUrlActionsDelegate = self
         menuController.pushInnerMenu(vc)
       }

--- a/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
+++ b/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
@@ -76,7 +76,10 @@ class BrowserNavigationHelper {
 
   func openHistory() {
     guard let bvc = bvc else { return }
-    let vc = HistoryViewController(isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing, historyAPI: bvc.braveCore.historyAPI)
+    let vc = HistoryViewController(
+      isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing,
+      historyAPI: bvc.braveCore.historyAPI,
+      tabManager: bvc.tabManager)
     vc.toolbarUrlActionsDelegate = bvc
 
     open(vc, doneButton: DoneButton(style: .done, position: .right))

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -21,6 +21,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     icon: #imageLiteral(resourceName: "emptyHistory"))
 
   private let historyAPI: BraveHistoryAPI
+  private let tabManager: TabManager
 
   var historyFRC: HistoryV2FetchResultsController?
 
@@ -34,9 +35,10 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
   private let searchController = UISearchController(searchResultsController: nil)
   private var searchQuery = ""
 
-  init(isPrivateBrowsing: Bool, historyAPI: BraveHistoryAPI) {
+  init(isPrivateBrowsing: Bool, historyAPI: BraveHistoryAPI, tabManager: TabManager) {
     self.isPrivateBrowsing = isPrivateBrowsing
     self.historyAPI = historyAPI
+    self.tabManager = tabManager
     super.init(nibName: nil, bundle: nil)
 
     historyFRC = historyAPI.frc()
@@ -183,9 +185,12 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
     alert.addAction(
       UIAlertAction(
         title: Strings.History.historyClearActionTitle, style: .destructive,
-        handler: { _ in
-          DispatchQueue.main.async {
-            self.historyAPI.removeAll {
+        handler: { [weak self] _ in
+          guard let self = self else { return }
+          
+          self.historyAPI.deleteAll {
+            // Clearing Tab History with entire history entry
+            self.tabManager.clearTabHistory() {
               self.refreshHistory()
             }
           }

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -114,7 +114,7 @@ class HistoryClearable: Clearable {
     let result = Success()
 
     DispatchQueue.main.async {
-      self.historyAPI.removeAll {
+      self.historyAPI.deleteAll() {
         NotificationCenter.default.post(name: .privateDataClearedHistory, object: nil)
         result.fill(Maybe<()>(success: ()))
       }

--- a/Client/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
+++ b/Client/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
@@ -52,6 +52,16 @@ extension BraveHistoryAPI {
       historyNode.dateAdded = date
     }
   }
+  
+  func deleteAll(completion: @escaping () -> Void) {
+    DispatchQueue.main.async {
+      self.removeAll {
+        Domain.deleteNonBookmarkedAndClearSiteVisits() {
+          completion()
+        }
+      }
+    }
+  }
 
   // MARK: Private
 

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -200,31 +200,34 @@ extension Domain {
     return domainOnCorrectContext
   }
 
-  class func deleteNonBookmarkedAndClearSiteVisits(
-    context: NSManagedObjectContext,
-    _ completionOnMain: @escaping () -> Void
-  ) {
-
-    let fetchRequest = NSFetchRequest<Domain>()
-    fetchRequest.entity = Domain.entity(context)
-    do {
-      let results = try context.fetch(fetchRequest)
-      results.forEach {
-        if let bms = $0.bookmarks, bms.count > 0 {
-          // Clear visit count
-          $0.visits = 0
-        } else {
-          // Delete
-          context.delete($0)
+  public class func deleteNonBookmarkedAndClearSiteVisits(_ completionOnMain: @escaping () -> Void) {
+    DataController.perform { context in
+      let fetchRequest = NSFetchRequest<Domain>()
+      fetchRequest.entity = Domain.entity(context)
+      do {
+        let results = try context.fetch(fetchRequest)
+        results.forEach {
+          if let bms = $0.bookmarks, bms.count > 0 {
+            // Clear visit count and clear the shield settings
+            $0.visits = 0
+            $0.shield_allOff = nil
+            $0.shield_adblockAndTp = nil
+            $0.shield_noScript = nil
+            $0.shield_fpProtection = nil
+            $0.shield_safeBrowsing = nil
+          } else {
+            // Delete
+            context.delete($0)
+          }
         }
+      } catch {
+        let fetchError = error as NSError
+        print(fetchError)
       }
-    } catch {
-      let fetchError = error as NSError
-      print(fetchError)
-    }
 
-    DispatchQueue.main.async {
-      completionOnMain()
+      DispatchQueue.main.async {
+        completionOnMain()
+      }
     }
   }
 

--- a/Data/models/History.swift
+++ b/Data/models/History.swift
@@ -79,8 +79,7 @@ public final class History: NSManagedObject, WebsitePresentable, CRUD {
   public class func deleteAll(_ completionOnMain: @escaping () -> Void) {
     DataController.perform { context in
       History.deleteAll(context: .existing(context), includesPropertyValues: false)
-
-      Domain.deleteNonBookmarkedAndClearSiteVisits(context: context) {
+      Domain.deleteNonBookmarkedAndClearSiteVisits() {
         completionOnMain()
       }
     }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5134

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open a website
- Disable Brave Shields for the website
- Close tab
- Tap 3-dot menu
- Tap 'Settings'
- Tap 'Brave Shields & Privacy'
- Tap 'Clear Data Now'
- Re-open website from step 1

## Screenshots:

https://user-images.githubusercontent.com/6643505/159777821-5aef5364-4f4b-4453-b80d-62709c7e72c7.mp4


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
