### PR TITLE
Revert "Fix #5141: Update brave-core to 1.37.104 (#5151)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.37.104/brave-core-ios-1.37.104.tgz",
-      "integrity": "sha512-3pJzh2K0p7KNcuFDmNK5LAVoNi1UlCXWoon6Ydb+K/oPKSHSAVjhCNknI3sMeY1H6b1BW8N17uA5lwxRZKaIwQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.37.101/brave-core-ios-1.37.101.tgz",
+      "integrity": "sha512-Q8dJl4PqocA3bTGUKGo9ff5DtZ0nN/NOHQR/Pz00K1LNJeHzp2mZSWhvviZD4H3JDfGwYykYrILtFigKCp5OCg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.37.104/brave-core-ios-1.37.104.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.37.101/brave-core-ios-1.37.101.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
This reverts commit eb53c3e8589ccceb13f87370c1d4692cae714706.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
1.37.104 Crashes on devices and M1 simulators. We revert to latest working brave-core version

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #5141 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
