### PR TITLE
Fix #3014: Adding Open Tabs in Search Suggestions

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -396,7 +396,9 @@ extension Strings {
   public static let tabToolbarReaderViewButtonTitle = NSLocalizedString("TabToolbarReaderViewButtonTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add to Reading List", comment: "Accessibility label for action adding current page to reading list.")
   public static let searchSuggestionsSectionHeader = NSLocalizedString("SearchSuggestionsSectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Search Suggestions", comment: "Section header for search suggestions option")
   public static let findOnPageSectionHeader = NSLocalizedString("FindOnPageSectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "On This Page", comment: "Section header for find in page option")
-  public static let searchHistorySectionHeader = NSLocalizedString("SearchHistorySectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "History & Bookmarks & Open Tabs", comment: "Section header for history and bookmarks option")
+  public static let searchHistorySectionHeader = NSLocalizedString("SearchHistorySectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Open Tabs & Bookmarks & History", comment: "Section header for history and bookmarks and open tabs option")
+  public static let searchSuggestionOpenTabActionTitle = NSLocalizedString("searchSuggestionOpenTabActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Switch to this tab", comment: "Action title for Switching to an existing tab for the suggestion item shown on the table list")
+  
 }
 
 // MARK:-  TabPeekViewController.swift

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -396,7 +396,7 @@ extension Strings {
   public static let tabToolbarReaderViewButtonTitle = NSLocalizedString("TabToolbarReaderViewButtonTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add to Reading List", comment: "Accessibility label for action adding current page to reading list.")
   public static let searchSuggestionsSectionHeader = NSLocalizedString("SearchSuggestionsSectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Search Suggestions", comment: "Section header for search suggestions option")
   public static let findOnPageSectionHeader = NSLocalizedString("FindOnPageSectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "On This Page", comment: "Section header for find in page option")
-  public static let searchHistorySectionHeader = NSLocalizedString("SearchHistorySectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "History & Bookmarks", comment: "Section header for history and bookmarks option")
+  public static let searchHistorySectionHeader = NSLocalizedString("SearchHistorySectionHeader", tableName: "BraveShared", bundle: Bundle.braveShared, value: "History & Bookmarks & Open Tabs", comment: "Section header for history and bookmarks option")
 }
 
 // MARK:-  TabPeekViewController.swift

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2201,6 +2201,10 @@ extension BrowserViewController: SearchViewControllerDelegate {
     finishEditingAndSubmit(url, visitType: .typed)
   }
 
+  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTabURL url: URL) {
+    switchToTabForURLOrOpen(url, isPrivileged: false)
+  }
+  
   func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String) {
     self.topToolbar.setLocation(suggestion, search: true)
   }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1554,6 +1554,18 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
       openURLInNewTab(url, isPrivate: isPrivate, isPrivileged: isPrivileged)
     }
   }
+  
+  func switchToTabOrOpen(id: String?, url: URL) {
+    popToBVC()
+    
+    if let tabID = id, let tab = tabManager.getTabForID(tabID) {
+      tabManager.selectTab(tab)
+    } else if let tab = tabManager.getTabForURL(url) {
+      tabManager.selectTab(tab)
+    } else {
+      openURLInNewTab(url, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing, isPrivileged: false)
+    }
+  }
 
   func openURLInNewTab(_ url: URL?, isPrivate: Bool = false, isPrivileged: Bool) {
     topToolbar.leaveOverlayMode(didCancel: true)
@@ -2201,8 +2213,8 @@ extension BrowserViewController: SearchViewControllerDelegate {
     finishEditingAndSubmit(url, visitType: .typed)
   }
 
-  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTabURL url: URL) {
-    switchToTabForURLOrOpen(url, isPrivileged: false)
+  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTab tabInfo: (id: String?, url: URL)) {
+    switchToTabOrOpen(id: tabInfo.id, url: tabInfo.url)
   }
   
   func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -298,7 +298,10 @@ extension BrowserViewController: TopToolbarDelegate {
     searchController.searchDelegate = self
     searchController.profile = self.profile
 
-    searchLoader = SearchLoader(historyAPI: braveCore.historyAPI, bookmarkManager: bookmarkManager)
+    searchLoader = SearchLoader(
+      historyAPI: braveCore.historyAPI,
+      bookmarkManager: bookmarkManager,
+      tabManager: tabManager)
     searchLoader?.addListener(searchController)
     searchLoader?.autocompleteSuggestionHandler = { [weak self] completion in
       self?.topToolbar.setAutocompleteSuggestion(completion)

--- a/Client/Frontend/Browser/FrequencyQuery.swift
+++ b/Client/Frontend/Browser/FrequencyQuery.swift
@@ -40,7 +40,7 @@ class FrequencyQuery {
         // Bookmarks Fetch
         self.bookmarkManager.byFrequency(query: query) { sites in
           let bookmarkSites = sites.map { Site(url: $0.url ?? "", title: $0.title ?? "", siteType: .bookmark) }
-          
+
           // History Fetch
           self.historyAPI.byFrequency(query: query) { historyList in
             let historySites = historyList.map { Site(url: $0.url.absoluteString, title: $0.title ?? "", siteType: .history) }
@@ -78,5 +78,4 @@ class FrequencyQuery {
         
     return tabList
   }
-  
 }

--- a/Client/Frontend/Browser/FrequencyQuery.swift
+++ b/Client/Frontend/Browser/FrequencyQuery.swift
@@ -13,41 +13,75 @@ class FrequencyQuery {
 
   private let historyAPI: BraveHistoryAPI
   private let bookmarkManager: BookmarkManager
-  private let queue = DispatchQueue(label: "frequency-query-queue")
-  private var cancellable: DispatchWorkItem?
+  private let tabManager: TabManager
 
-  init(historyAPI: BraveHistoryAPI, bookmarkManager: BookmarkManager) {
+  private let frequencyQueue = DispatchQueue(label: "frequency-query-queue")
+  private var task: DispatchWorkItem?
+    
+  init(historyAPI: BraveHistoryAPI, bookmarkManager: BookmarkManager, tabManager: TabManager) {
     self.historyAPI = historyAPI
     self.bookmarkManager = bookmarkManager
+    self.tabManager = tabManager
   }
 
-  public func sitesByFrequency(containing query: String, completion: @escaping (Set<Site>) -> Void) {
-    historyAPI.byFrequency(query: query) { [weak self] historyList in
-      guard let self = self else {
-        completion(Set<Site>())
-        return
-      }
+  deinit {
+    task?.cancel()
+  }
 
-      let historySites =
-        historyList
-        .map { Site(url: $0.url.absoluteString, title: $0.title ?? "") }
+  public func sitesByFrequency(containing query: String, completion: @escaping ([Site]) -> Void) {
+    task?.cancel()
 
-      self.cancellable = DispatchWorkItem {
-        // brave-core fetch can be slow over 200ms per call,
-        // a cancellable serial queue is used for it.
-        DispatchQueue.main.async {
-          self.bookmarkManager.byFrequency(query: query) { sites in
-            let bookmarkSites = sites.map { Site(url: $0.url ?? "", title: $0.title ?? "", bookmarked: true) }
-            let result = Set<Site>(historySites + bookmarkSites)
+    var searchResult = [Site]()
 
-            completion(result)
+    task = DispatchWorkItem {
+      // brave-core fetch can be slow over 200ms per call,
+      // a cancellable serial queue is used for it.
+      DispatchQueue.main.async {
+        // Tab Fetch
+        let tabFetched = self.tabManager.tabsForCurrentMode(for: query)
+        searchResult += self.fetchSitesFromTabs(tabFetched)
+
+          // History Fetch
+          self.historyAPI.byFrequency(query: query) { historyList in
+            let historySites = historyList.map { Site(url: $0.url.absoluteString, title: $0.title ?? "", siteType: .history) }
+            searchResult += historySites
+                    
+            // Bookmarks Fetch
+            self.bookmarkManager.byFrequency(query: query) { sites in
+              let bookmarkSites = sites.map { Site(url: $0.url ?? "", title: $0.title ?? "", siteType: .bookmark) }
+              searchResult += bookmarkSites
+
+              completion(searchResult)
+            }
+          }
+        }
+    }
+        
+    if let task = self.task {
+      frequencyQueue.async(execute: task)
+    }
+  }
+    
+  private func fetchSitesFromTabs(_ tabs: [Tab]) -> [Site] {
+    var tabList = [Site]()
+        
+    for tab in tabs {
+      if PrivateBrowsingManager.shared.isPrivateBrowsing {
+        if let url = tab.url, url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
+          tabList.append(Site(url: url.absoluteString, title: tab.displayTitle, siteType: .tab))
+        }
+      } else {
+        if let tabID = tab.id {
+          let fetchedTab = TabMO.get(fromId: tabID)
+
+          if let urlString = fetchedTab?.url, let url = URL(string: urlString), url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
+            tabList.append(Site(url: url.absoluteString, title: fetchedTab?.title ?? tab.displayTitle, siteType: .tab))
           }
         }
       }
     }
-
-    if let task = cancellable {
-      queue.async(execute: task)
-    }
+        
+    return tabList
   }
+  
 }

--- a/Client/Frontend/Browser/FrequencyQuery.swift
+++ b/Client/Frontend/Browser/FrequencyQuery.swift
@@ -72,7 +72,7 @@ class FrequencyQuery {
             continue
           }
           
-          tabList.append(Site(url: url.absoluteString, title: tab.displayTitle, siteType: .tab))
+          tabList.append(Site(url: url.absoluteString, title: tab.displayTitle, siteType: .tab, tabID: tab.id))
         }
       } else {
         var tabURL: URL?
@@ -93,7 +93,7 @@ class FrequencyQuery {
             continue
           }
           
-          tabList.append(Site(url: url.absoluteString, title: tab.title ?? tab.displayTitle, siteType: .tab))
+          tabList.append(Site(url: url.absoluteString, title: tab.title ?? tab.displayTitle, siteType: .tab, tabID: tab.id))
         }
       }
     }

--- a/Client/Frontend/Browser/FrequencyQuery.swift
+++ b/Client/Frontend/Browser/FrequencyQuery.swift
@@ -29,7 +29,7 @@ class FrequencyQuery {
     task?.cancel()
   }
 
-  public func sitesByFrequency(containing query: String, completion: @escaping (OrderedSet<Site>) -> Void) {
+  public func sitesByFrequency(containing query: String, completion: @escaping (Set<Site>) -> Void) {
     task?.cancel()
 
     task = DispatchWorkItem {
@@ -48,7 +48,7 @@ class FrequencyQuery {
           self.historyAPI.byFrequency(query: query) { historyList in
             let historySites = historyList.map { Site(url: $0.url.absoluteString, title: $0.title ?? "", siteType: .history) }
 
-            let result = OrderedSet<Site>(openTabSites + historySites + bookmarkSites)
+            let result = Set<Site>(openTabSites + historySites + bookmarkSites)
             completion(result)
           }
         }

--- a/Client/Frontend/Browser/Search/SearchLoader.swift
+++ b/Client/Frontend/Browser/Search/SearchLoader.swift
@@ -28,7 +28,7 @@ class SearchLoader: Loader<[Site], SearchViewController> {
       frequencyQuery.sitesByFrequency(containing: query) { [weak self] result in
         guard let self = self else { return }
 
-        self.load(result)
+        self.load(Array(result))
 
         // If the new search string is not longer than the previous
         // we don't need to find an autocomplete suggestion.

--- a/Client/Frontend/Browser/Search/SearchLoader.swift
+++ b/Client/Frontend/Browser/Search/SearchLoader.swift
@@ -14,8 +14,8 @@ class SearchLoader: Loader<[Site], SearchViewController> {
 
   var autocompleteSuggestionHandler: ((String) -> Void)?
 
-  init(historyAPI: BraveHistoryAPI, bookmarkManager: BookmarkManager) {
-    frequencyQuery = FrequencyQuery(historyAPI: historyAPI, bookmarkManager: bookmarkManager)
+  init(historyAPI: BraveHistoryAPI, bookmarkManager: BookmarkManager, tabManager: TabManager) {
+    frequencyQuery = FrequencyQuery(historyAPI: historyAPI, bookmarkManager: bookmarkManager, tabManager: tabManager)
   }
 
   var query: String = "" {
@@ -28,7 +28,7 @@ class SearchLoader: Loader<[Site], SearchViewController> {
       frequencyQuery.sitesByFrequency(containing: query) { [weak self] result in
         guard let self = self else { return }
 
-        self.load(Array(result))
+        self.load(result)
 
         // If the new search string is not longer than the previous
         // we don't need to find an autocomplete suggestion.

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -353,16 +353,16 @@ class SearchViewController: SiteTableViewController, LoaderListener {
           let isSuggestClientError = error.domain == SearchSuggestClientErrorDomain
 
           switch error.code {
-            case NSURLErrorCancelled where error.domain == NSURLErrorDomain:
-              // Request was cancelled. Do nothing.
-              break
-            case SearchSuggestClientErrorInvalidEngine where isSuggestClientError:
-              // Engine does not support search suggestions. Do nothing.
-              break
-            case SearchSuggestClientErrorInvalidResponse where isSuggestClientError:
-              print("Error: Invalid search suggestion data")
-            default:
-              print("Error: \(error.description)")
+          case NSURLErrorCancelled where error.domain == NSURLErrorDomain:
+            // Request was cancelled. Do nothing.
+            break
+          case SearchSuggestClientErrorInvalidEngine where isSuggestClientError:
+            // Engine does not support search suggestions. Do nothing.
+            break
+          case SearchSuggestClientErrorInvalidResponse where isSuggestClientError:
+            print("Error: Invalid search suggestion data")
+          default:
+            print("Error: \(error.description)")
           }
         } else if let suggestionList = suggestions {
           self.suggestions = suggestionList
@@ -416,58 +416,56 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     guard let section = availableSections[safe: indexPath.section] else { return }
 
     switch section {
-      case .quickBar:
+    case .quickBar:
+      if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+        RecentSearch.addItem(type: .text, text: searchQuery, websiteUrl: nil)
+      }
+      searchDelegate?.searchViewController(self, didSubmit: searchQuery)
+    case .searchSuggestionsOptIn: return
+    case .searchSuggestions:
+      // Assume that only the default search engine can provide search suggestions.
+      let engine = searchEngines?.defaultEngine()
+      let suggestion = suggestions[indexPath.row]
+
+      var url = URIFixup.getURL(suggestion)
+      if url == nil {
+        url = engine?.searchURLForQuery(suggestion)
+      }
+
+      if let url = url {
         if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-          RecentSearch.addItem(type: .text, text: searchQuery, websiteUrl: nil)
+          RecentSearch.addItem(type: .website, text: suggestion, websiteUrl: url.absoluteString)
         }
-        searchDelegate?.searchViewController(self, didSubmit: searchQuery)
-      case .searchSuggestionsOptIn: return
-      case .searchSuggestions:
-        // Assume that only the default search engine can provide search suggestions.
-        let engine = searchEngines?.defaultEngine()
-        let suggestion = suggestions[indexPath.row]
-        
-        var url = URIFixup.getURL(suggestion)
-        if url == nil {
-          url = engine?.searchURLForQuery(suggestion)
-        }
-        
-        if let url = url {
-          if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-            RecentSearch.addItem(type: .website, text: suggestion, websiteUrl: url.absoluteString)
-          }
+        searchDelegate?.searchViewController(self, didSelectURL: url)
+      }
+    case .openTabsAndHistoryAndBookmarks:
+      let site = data[indexPath.row]
+      if let url = URL(string: site.url) {
+        if site.siteType == .tab {
+          searchDelegate?.searchViewController(self, didSelectOpenTabURL: url)
+        } else {
           searchDelegate?.searchViewController(self, didSelectURL: url)
         }
-      case .openTabsAndHistoryAndBookmarks:
-        let site = data[indexPath.row]
-        
-
-        if let url = URL(string: site.url) {
-          if site.siteType == .tab {
-            searchDelegate?.searchViewController(self, didSelectOpenTabURL: url)
-          } else {
-            searchDelegate?.searchViewController(self, didSelectURL: url)
-          }
-        }
-      case .findInPage:
-        let localSearchQuery = searchQuery.lowercased()
-        searchDelegate?.searchViewController(self, shouldFindInPage: localSearchQuery)
+      }
+    case .findInPage:
+      let localSearchQuery = searchQuery.lowercased()
+      searchDelegate?.searchViewController(self, shouldFindInPage: localSearchQuery)
     }
   }
 
   override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     if let currentSection = availableSections[safe: indexPath.section] {
       switch currentSection {
-        case .quickBar:
-          return super.tableView(tableView, heightForRowAt: indexPath)
-        case .searchSuggestionsOptIn:
-          return 100.0
-        case .searchSuggestions:
-          return 44.0
-        case .openTabsAndHistoryAndBookmarks:
-          return super.tableView(tableView, heightForRowAt: indexPath)
-        case .findInPage:
-          return super.tableView(tableView, heightForRowAt: indexPath)
+      case .quickBar:
+        return super.tableView(tableView, heightForRowAt: indexPath)
+      case .searchSuggestionsOptIn:
+        return 100.0
+      case .searchSuggestions:
+        return 44.0
+      case .openTabsAndHistoryAndBookmarks:
+        return super.tableView(tableView, heightForRowAt: indexPath)
+      case .findInPage:
+        return super.tableView(tableView, heightForRowAt: indexPath)
       }
     }
 
@@ -478,18 +476,18 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     guard let searchSection = availableSections[safe: section] else { return nil }
 
     switch searchSection {
-      case .quickBar: return nil
-      case .searchSuggestionsOptIn: return nil
-      case .searchSuggestions:
-        if let defaultSearchEngine = searchEngines?.defaultEngine() {
-          if defaultSearchEngine.shortName.contains(Strings.searchSuggestionSectionTitleNoSearchFormat) || defaultSearchEngine.shortName.lowercased().contains("search") {
-            return defaultSearchEngine.displayName
-          }
-          return String(format: Strings.searchSuggestionSectionTitleFormat, defaultSearchEngine.displayName)
+    case .quickBar: return nil
+    case .searchSuggestionsOptIn: return nil
+    case .searchSuggestions:
+      if let defaultSearchEngine = searchEngines?.defaultEngine() {
+        if defaultSearchEngine.shortName.contains(Strings.searchSuggestionSectionTitleNoSearchFormat) || defaultSearchEngine.shortName.lowercased().contains("search") {
+          return defaultSearchEngine.displayName
         }
-        return Strings.searchSuggestionsSectionHeader
-      case .openTabsAndHistoryAndBookmarks: return Strings.searchHistorySectionHeader
-      case .findInPage: return Strings.findOnPageSectionHeader
+        return String(format: Strings.searchSuggestionSectionTitleFormat, defaultSearchEngine.displayName)
+      }
+      return Strings.searchSuggestionsSectionHeader
+    case .openTabsAndHistoryAndBookmarks: return Strings.searchHistorySectionHeader
+    case .findInPage: return Strings.findOnPageSectionHeader
     }
   }
 
@@ -504,18 +502,18 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     let headerHeight: CGFloat = 22
 
     switch searchSection {
-      case .quickBar:
-        return 0.0
-      case .searchSuggestionsOptIn:
-        return 0.0
-      case .searchSuggestions:
-        return suggestions.isEmpty ? 0 : headerHeight * 2.0
-      case .openTabsAndHistoryAndBookmarks: return data.isEmpty ? 0 : 2.0 * headerHeight
-      case .findInPage:
-        if let sd = searchDelegate, sd.searchViewControllerAllowFindInPage() {
-          return headerHeight
-        }
-        return 0.0
+    case .quickBar:
+      return 0.0
+    case .searchSuggestionsOptIn:
+      return 0.0
+    case .searchSuggestions:
+      return suggestions.isEmpty ? 0 : headerHeight * 2.0
+    case .openTabsAndHistoryAndBookmarks: return data.isEmpty ? 0 : 2.0 * headerHeight
+    case .findInPage:
+      if let sd = searchDelegate, sd.searchViewControllerAllowFindInPage() {
+        return headerHeight
+      }
+      return 0.0
     }
   }
 
@@ -528,15 +526,12 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     let footerHeight: CGFloat = 10.0
 
     switch searchSection {
-      case .quickBar:
-        return CGFloat.leastNormalMagnitude
-      case .searchSuggestionsOptIn:
+    case .quickBar, .searchSuggestions, .findInPage:
+      return CGFloat.leastNormalMagnitude
+    case .searchSuggestionsOptIn:
+      return footerHeight
+    case .openTabsAndHistoryAndBookmarks:
         return footerHeight
-      case .searchSuggestions:
-        return CGFloat.leastNormalMagnitude
-      case .openTabsAndHistoryAndBookmarks: return footerHeight
-      case .findInPage:
-        return CGFloat.leastNormalMagnitude
     }
   }
 
@@ -546,98 +541,100 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     }
 
     switch section {
-      case .quickBar:
-        let cell = TwoLineTableViewCell()
-        cell.textLabel?.text = searchQuery
-        cell.textLabel?.textColor = .bravePrimary
-        cell.imageView?.image = #imageLiteral(resourceName: "search_bar_find_in_page_icon")
-        cell.imageView?.contentMode = .center
-        cell.backgroundColor = .secondaryBraveBackground
-        
-        return cell
-      case .searchSuggestionsOptIn:
-        let cell = tableView.dequeueReusableCell(withIdentifier: SearchSuggestionPromptCell.identifier, for: indexPath)
-        if let promptCell = cell as? SearchSuggestionPromptCell {
-          promptCell.selectionStyle = .none
-          promptCell.onOptionSelected = { [weak self] option in
-            guard let self = self else { return }
-            
-            self.searchEngines?.shouldShowSearchSuggestions = option
-            self.searchEngines?.shouldShowSearchSuggestionsOptIn = false
-            
-            if option {
-              self.querySuggestClient()
-            }
-            self.layoutSuggestionsOptInPrompt()
-            self.reloadSearchEngines()
-          }
-        }
-        return cell
-      case .searchSuggestions:
-        let cell = tableView.dequeueReusableCell(withIdentifier: SuggestionCell.identifier, for: indexPath)
-        if let suggestionCell = cell as? SuggestionCell {
-          suggestionCell.setTitle(suggestions[indexPath.row])
-          suggestionCell.separatorInset = UIEdgeInsets(top: 0.0, left: view.bounds.width, bottom: 0.0, right: -view.bounds.width)
-          suggestionCell.openButtonActionHandler = { [weak self] in
-            guard let self = self else { return }
-            
-            let suggestion = self.suggestions[indexPath.row]
-            self.searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
-          }
-        }
-        return cell
-        
-      case .openTabsAndHistoryAndBookmarks:
-        let cell = super.tableView(tableView, cellForRowAt: indexPath)
-        let site = data[indexPath.row]
-        
-        let detailTextForTabSuggestions = NSMutableAttributedString()
-        
-        detailTextForTabSuggestions.append(
-          NSAttributedString(
-            string: Strings.searchSuggestionOpenTabActionTitle,
-            attributes: [
-              .font: DynamicFontHelper.defaultHelper.SmallSizeBoldWeightAS,
-              .foregroundColor: UIColor.braveLabel
-            ]))
+    case .quickBar:
+      let cell = TwoLineTableViewCell()
+      cell.textLabel?.text = searchQuery
+      cell.textLabel?.textColor = .bravePrimary
+      cell.imageView?.image = #imageLiteral(resourceName: "search_bar_find_in_page_icon")
+      cell.imageView?.contentMode = .center
+      cell.backgroundColor = .secondaryBraveBackground
 
-        detailTextForTabSuggestions.append(
-          NSAttributedString(
-            string: " · \(site.url)",
-            attributes: [
-              .font: DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS,
-              .foregroundColor: UIColor.secondaryBraveLabel
-            ]))
-        
-        if let cell = cell as? TwoLineTableViewCell {
-          cell.textLabel?.textColor = .bravePrimary
-          if site.siteType == .tab {
-            cell.setLines(site.title, detailText: nil, detailAttributedText: detailTextForTabSuggestions)
-          } else {
-            cell.setLines(site.title, detailText: site.url)
+      return cell
+    case .searchSuggestionsOptIn:
+      let cell = tableView.dequeueReusableCell(withIdentifier: SearchSuggestionPromptCell.identifier, for: indexPath)
+      if let promptCell = cell as? SearchSuggestionPromptCell {
+        promptCell.selectionStyle = .none
+        promptCell.onOptionSelected = { [weak self] option in
+          guard let self = self else { return }
+
+          self.searchEngines?.shouldShowSearchSuggestions = option
+          self.searchEngines?.shouldShowSearchSuggestionsOptIn = false
+
+          if option {
+            self.querySuggestClient()
           }
-          cell.setRightBadge(site.siteType.icon?.template ?? nil)
-          cell.accessoryView?.tintColor = .secondaryButtonTint
-          
-          cell.imageView?.contentMode = .scaleAspectFit
-          cell.imageView?.layer.borderColor = SearchViewControllerUX.iconBorderColor.cgColor
-          cell.imageView?.layer.borderWidth = SearchViewControllerUX.iconBorderWidth
-          cell.imageView?.image = UIImage()
-          cell.imageView?.loadFavicon(for: site.tileURL)
-          cell.backgroundColor = .secondaryBraveBackground
+          self.layoutSuggestionsOptInPrompt()
+          self.reloadSearchEngines()
         }
-        return cell
+      }
         
-      case .findInPage:
-        let cell = tableView.dequeueReusableCell(withIdentifier: "default", for: indexPath)
-        cell.textLabel?.text = String(format: Strings.findInPageFormat, searchQuery)
+      return cell
+    case .searchSuggestions:
+      let cell = tableView.dequeueReusableCell(withIdentifier: SuggestionCell.identifier, for: indexPath)
+      if let suggestionCell = cell as? SuggestionCell {
+        suggestionCell.setTitle(suggestions[indexPath.row])
+        suggestionCell.separatorInset = UIEdgeInsets(top: 0.0, left: view.bounds.width, bottom: 0.0, right: -view.bounds.width)
+        suggestionCell.openButtonActionHandler = { [weak self] in
+          guard let self = self else { return }
+
+          let suggestion = self.suggestions[indexPath.row]
+          self.searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
+        }
+      }
+        
+      return cell
+    case .openTabsAndHistoryAndBookmarks:
+      let cell = super.tableView(tableView, cellForRowAt: indexPath)
+      let site = data[indexPath.row]
+      
+      let detailTextForTabSuggestions = NSMutableAttributedString()
+      
+      detailTextForTabSuggestions.append(
+        NSAttributedString(
+          string: Strings.searchSuggestionOpenTabActionTitle,
+          attributes: [
+            .font: DynamicFontHelper.defaultHelper.SmallSizeBoldWeightAS,
+            .foregroundColor: UIColor.braveLabel
+          ]))
+
+      detailTextForTabSuggestions.append(
+        NSAttributedString(
+          string: " · \(site.url)",
+          attributes: [
+            .font: DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS,
+            .foregroundColor: UIColor.secondaryBraveLabel
+          ]))
+      
+      if let cell = cell as? TwoLineTableViewCell {
         cell.textLabel?.textColor = .bravePrimary
-        cell.textLabel?.numberOfLines = 2
-        cell.textLabel?.font = .systemFont(ofSize: 15.0)
-        cell.textLabel?.lineBreakMode = .byWordWrapping
-        cell.textLabel?.textAlignment = .left
+        if site.siteType == .tab {
+          cell.setLines(site.title, detailText: nil, detailAttributedText: detailTextForTabSuggestions)
+        } else {
+          cell.setLines(site.title, detailText: site.url)
+        }
+        cell.setRightBadge(site.siteType.icon?.template ?? nil)
+        cell.accessoryView?.tintColor = .secondaryButtonTint
+        
+        cell.imageView?.contentMode = .scaleAspectFit
+        cell.imageView?.layer.borderColor = SearchViewControllerUX.iconBorderColor.cgColor
+        cell.imageView?.layer.borderWidth = SearchViewControllerUX.iconBorderWidth
+        cell.imageView?.image = UIImage()
+        cell.imageView?.loadFavicon(for: site.tileURL)
         cell.backgroundColor = .secondaryBraveBackground
-        return cell
+      }
+        
+      return cell
+    case .findInPage:
+      let cell = tableView.dequeueReusableCell(withIdentifier: "default", for: indexPath)
+      cell.textLabel?.text = String(format: Strings.findInPageFormat, searchQuery)
+      cell.textLabel?.textColor = .bravePrimary
+      cell.textLabel?.numberOfLines = 2
+      cell.textLabel?.font = .systemFont(ofSize: 15.0)
+      cell.textLabel?.lineBreakMode = .byWordWrapping
+      cell.textLabel?.textAlignment = .left
+      cell.backgroundColor = .secondaryBraveBackground
+        
+      return cell
     }
   }
 
@@ -647,32 +644,34 @@ class SearchViewController: SiteTableViewController, LoaderListener {
     }
 
     switch section {
-      case .quickBar:
+    case .quickBar:
+      return 1
+    case .searchSuggestionsOptIn:
+      return 1
+    case .searchSuggestions:
+      guard let shouldShowSuggestions = searchEngines?.shouldShowSearchSuggestions else { return 0 }
+      return shouldShowSuggestions &&
+        !searchQuery.looksLikeAURL() &&
+        !tabType.isPrivate ? min(suggestions.count, SearchViewControllerUX.maxSearchSuggestions) : 0
+    case .openTabsAndHistoryAndBookmarks:
+      return data.count
+    case .findInPage:
+      if let sd = searchDelegate, sd.searchViewControllerAllowFindInPage() {
         return 1
-      case .searchSuggestionsOptIn:
-        return 1
-      case .searchSuggestions:
-        guard let shouldShowSuggestions = searchEngines?.shouldShowSearchSuggestions else { return 0 }
-        return shouldShowSuggestions && !searchQuery.looksLikeAURL() && !tabType.isPrivate ? min(suggestions.count, SearchViewControllerUX.maxSearchSuggestions) : 0
-      case .openTabsAndHistoryAndBookmarks:
-        return data.count
-      case .findInPage:
-        if let sd = searchDelegate, sd.searchViewControllerAllowFindInPage() {
-          return 1
-        }
-        return 0
+      }
+      return 0
     }
   }
-  
+
   func numberOfSections(in tableView: UITableView) -> Int {
     return availableSections.count
   }
-  
+
   func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
     guard let section = availableSections[safe: indexPath.section] else {
       return
     }
-    
+
     if section == .openTabsAndHistoryAndBookmarks {
       let suggestion = data[indexPath.item]
       searchDelegate?.searchViewController(self, didHighlightText: suggestion.url, search: false)
@@ -697,7 +696,7 @@ extension SearchViewController: KeyboardHelperDelegate {
 extension SearchViewController {
   func handleKeyCommands(sender: UIKeyCommand) {
     let initialSection = SearchListSection.openTabsAndHistoryAndBookmarks.rawValue
-    
+
     guard let current = tableView.indexPathForSelectedRow else {
       let numberOfRows = tableView(tableView, numberOfRowsInSection: initialSection)
       if sender.input == UIKeyCommand.inputDownArrow, numberOfRows > 0 {
@@ -713,39 +712,39 @@ extension SearchViewController {
     guard let input = sender.input else { return }
 
     switch input {
-      case UIKeyCommand.inputUpArrow:
-        // we're going down, we should check if we've reached the first item in this section.
-        if current.item == 0 {
-          // We have, so check if we can decrement the section.
-          if current.section == initialSection {
-            // We've reached the first item in the first section.
-            searchDelegate?.searchViewController(self, didHighlightText: searchQuery, search: false)
-            return
-          } else {
-            nextSection = current.section - 1
-            nextItem = tableView(tableView, numberOfRowsInSection: nextSection) - 1
-          }
+    case UIKeyCommand.inputUpArrow:
+      // we're going down, we should check if we've reached the first item in this section.
+      if current.item == 0 {
+        // We have, so check if we can decrement the section.
+        if current.section == initialSection {
+          // We've reached the first item in the first section.
+          searchDelegate?.searchViewController(self, didHighlightText: searchQuery, search: false)
+          return
         } else {
-          nextSection = current.section
-          nextItem = current.item - 1
+          nextSection = current.section - 1
+          nextItem = tableView(tableView, numberOfRowsInSection: nextSection) - 1
         }
-      case UIKeyCommand.inputDownArrow:
-        let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
-        if current.item == currentSectionItemsCount - 1 {
-          if current.section == tableView.numberOfSections - 1 {
-            // We've reached the last item in the last section
-            return
-          } else {
-            // We can go to the next section.
-            nextSection = current.section + 1
-            nextItem = 0
-          }
+      } else {
+        nextSection = current.section
+        nextItem = current.item - 1
+      }
+    case UIKeyCommand.inputDownArrow:
+      let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
+      if current.item == currentSectionItemsCount - 1 {
+        if current.section == tableView.numberOfSections - 1 {
+          // We've reached the last item in the last section
+          return
         } else {
-          nextSection = current.section
-          nextItem = current.item + 1
+          // We can go to the next section.
+          nextSection = current.section + 1
+          nextItem = 0
         }
-      default:
-        return
+      } else {
+        nextSection = current.section
+        nextItem = current.item + 1
+      }
+    default:
+      return
     }
 
     guard nextItem >= 0 else { return }
@@ -761,9 +760,9 @@ extension SearchViewController {
     if gestureRecognizer.state == .began {
       let location = gestureRecognizer.location(in: self.tableView)
       if let indexPath = tableView.indexPathForRow(at: location),
-         let section = availableSections[safe: indexPath.section],
-         let suggestion = suggestions[safe: indexPath.row],
-         section == .searchSuggestions {
+        let section = availableSections[safe: indexPath.section],
+        let suggestion = suggestions[safe: indexPath.row],
+        section == .searchSuggestions {
         searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
       }
     }

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -13,7 +13,7 @@ import Data
 protocol SearchViewControllerDelegate: AnyObject {
   func searchViewController(_ searchViewController: SearchViewController, didSubmit query: String)
   func searchViewController(_ searchViewController: SearchViewController, didSelectURL url: URL)
-  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTabURL url: URL)
+  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTab tabInfo: (id: String?, url: URL))
   func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String)
   func presentSearchSettingsController()
   func searchViewController(_ searchViewController: SearchViewController, didHighlightText text: String, search: Bool)
@@ -442,7 +442,7 @@ class SearchViewController: SiteTableViewController, LoaderListener {
       let site = data[indexPath.row]
       if let url = URL(string: site.url) {
         if site.siteType == .tab {
-          searchDelegate?.searchViewController(self, didSelectOpenTabURL: url)
+          searchDelegate?.searchViewController(self, didSelectOpenTab: (site.tabID, url))
         } else {
           searchDelegate?.searchViewController(self, didSelectURL: url)
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -804,6 +804,12 @@ class TabManager: NSObject {
 
     return allTabs.filter { $0.webView?.url == url }.first
   }
+  
+  func getTabForID(_ id: String) -> Tab? {
+    assert(Thread.isMainThread)
+
+    return allTabs.filter { $0.id == id }.first
+  }
 
   func resetProcessPool() {
     assert(Thread.isMainThread)

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -10,7 +10,6 @@ struct TwoLineCellUX {
   static let imageCornerRadius: CGFloat = 8
   static let borderViewMargin: CGFloat = 16
   static let badgeSize: CGFloat = 16
-  static let badgeMargin: CGFloat = 16
   static let borderFrameSize: CGFloat = 32
   static let detailTextTopMargin: CGFloat = 0
 }
@@ -85,8 +84,8 @@ class TwoLineTableViewCell: UITableViewCell, TableViewReusable {
     twoLineHelper.hasRightBadge = badge != nil
   }
 
-  func setLines(_ text: String?, detailText: String?) {
-    twoLineHelper.setLines(text, detailText: detailText)
+  func setLines(_ text: String?, detailText: String?, detailAttributedText: NSAttributedString? = nil) {
+    twoLineHelper.setLines(text, detailText: detailText, detailAttributedText: detailAttributedText)
   }
 
   func mergeAccessibilityLabels(_ views: [AnyObject?]? = nil) {
@@ -244,7 +243,7 @@ private class TwoLineCellHelper {
       contentHeight += detailTextLabelHeight + TwoLineCellUX.detailTextTopMargin
     }
 
-    let textRightInset: CGFloat = hasRightBadge ? (TwoLineCellUX.badgeSize + TwoLineCellUX.badgeMargin) : 0
+    let textRightInset: CGFloat = hasRightBadge ? TwoLineCellUX.badgeSize : 0
 
     textLabel.frame = CGRect(
       x: textLeft, y: (height - contentHeight) / 2,
@@ -272,13 +271,17 @@ private class TwoLineCellHelper {
     }
   }
 
-  func setLines(_ text: String?, detailText: String?) {
+  func setLines(_ text: String?, detailText: String?, detailAttributedText: NSAttributedString? = nil) {
     if text?.isEmpty ?? true {
       textLabel.text = detailText
       detailTextLabel.text = nil
     } else {
       textLabel.text = text
-      detailTextLabel.text = detailText
+      if let attributedText = detailAttributedText {
+        detailTextLabel.attributedText = attributedText
+      } else {
+        detailTextLabel.text = detailText
+      }
     }
   }
 

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -103,6 +103,11 @@ class DynamicFontHelper: NSObject {
     let size = min(defaultSmallFontSize, 14)
     return UIFont.systemFont(ofSize: size, weight: UIFont.Weight.medium)
   }
+  
+  var SmallSizeBoldWeightAS: UIFont {
+    let size = min(defaultSmallFontSize, 14)
+    return UIFont.systemFont(ofSize: size, weight: UIFont.Weight.bold)
+  }
 
   var MediumSizeBoldFontAS: UIFont {
     let size = min(deviceFontSize, 18)

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -66,9 +66,9 @@ open class Site: Identifiable, Hashable {
         case .history:
           return UIImage(systemName: "clock.fill")
         case .bookmark:
-          return UIImage(systemName: "star.fill")
+          return UIImage(systemName: "book.fill")
         case .tab:
-          return UIImage(systemName: "folder.fill")
+          return UIImage(systemName: "square.filled.on.square")
         default:
           return nil
       }

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -58,6 +58,23 @@ open class Favicon: Identifiable {
 // TODO: Site shouldn't have all of these optional decorators. Include those in the
 // cursor results, perhaps as a tuple.
 open class Site: Identifiable, Hashable {
+  public enum SiteType {
+    case unknown, bookmark, history, tab
+    
+    public var icon: UIImage? {
+      switch self {
+        case .history:
+          return UIImage(systemName: "clock.fill")
+        case .bookmark:
+          return UIImage(systemName: "star.fill")
+        case .tab:
+          return UIImage(systemName: "folder.fill")
+        default:
+          return nil
+      }
+    }
+  }
+    
   open var id: Int?
   var guid: String?
 
@@ -70,21 +87,21 @@ open class Site: Identifiable, Hashable {
   open var metadata: PageMetadata?
   // Sites may have multiple favicons. We'll return the largest.
   open var icon: Favicon?
-  open fileprivate(set) var bookmarked: Bool?
+  open private(set) var siteType: SiteType
 
   public convenience init(url: String, title: String) {
-    self.init(url: url, title: title, bookmarked: false, guid: nil)
+    self.init(url: url, title: title, siteType: .unknown, guid: nil)
   }
 
-  public init(url: String, title: String, bookmarked: Bool?, guid: String? = nil) {
+  public init(url: String, title: String, siteType: SiteType, guid: String? = nil) {
     self.url = url
     self.title = title
-    self.bookmarked = bookmarked
+    self.siteType = siteType
     self.guid = guid
   }
 
   open func setBookmarked(_ bookmarked: Bool) {
-    self.bookmarked = bookmarked
+    self.siteType = .bookmark
   }
 
   // This hash is a bit limited in scope, but contains enough data to make a unique distinction.

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -81,6 +81,8 @@ open class Site: Identifiable, Hashable {
     
   open var id: Int?
   var guid: String?
+  // The id of associated Tab - Used for Tab Suggestions
+  open var tabID: String?
 
   open var tileURL: URL {
     return URL(string: url)?.domainURL ?? URL(string: "about:blank")!
@@ -94,14 +96,15 @@ open class Site: Identifiable, Hashable {
   open private(set) var siteType: SiteType
 
   public convenience init(url: String, title: String) {
-    self.init(url: url, title: title, siteType: .unknown, guid: nil)
+    self.init(url: url, title: title, siteType: .unknown, guid: nil, tabID: nil)
   }
 
-  public init(url: String, title: String, siteType: SiteType, guid: String? = nil) {
+  public init(url: String, title: String, siteType: SiteType, guid: String? = nil, tabID: String? = nil) {
     self.url = url
     self.title = title
     self.siteType = siteType
     self.guid = guid
+    self.tabID = tabID
   }
 
   open func setBookmarked(_ bookmarked: Bool) {

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -68,7 +68,11 @@ open class Site: Identifiable, Hashable {
         case .bookmark:
           return UIImage(systemName: "book.fill")
         case .tab:
-          return UIImage(systemName: "square.filled.on.square")
+          if #available(iOS 15, *) {
+            return UIImage(systemName: "square.filled.on.square")
+          } else {
+            return UIImage(systemName: "square.stack.3d.down.right.fill")
+          }
         default:
           return nil
       }


### PR DESCRIPTION
Typing text into omni-box (url bar) matches against open tabs and includes suggestions to section under the search keyword suggestions.

This section is renamed as Open Tabs & Bookmarks & History and every entry is marked with a right badge image according to their type.

The Open Tabs entry is also marked as **Switch to this tab** in detailed text before url is shown.

Pressing Open Tab entry should open (existing tab) instead of opening a new one. 

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3014

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Search "test" and open one of the suggestions in a tab
- Create a new tab and search for "test"
- Scroll down in search suggestions and find out Open Tab suggestion for the particular open tab
- Click and check existing tab is opened

## Screenshots:


![tabs open](https://user-images.githubusercontent.com/6643505/160012840-ce671e1e-5eab-4034-85a1-a4340ea21b88.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
