### PR TITLE
Fix #5140: Add 1.37 translations.

### DIFF
--- a/BraveShared/de.lproj/BraveShared.strings
+++ b/BraveShared/de.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Verbergen";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Website öffnen";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Anzeigen";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Die Seite kann nicht in der Leseansicht angezeigt werden.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Lesemodus";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Textgröße verringern";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Ändert das Farbschema.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Dunkel";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Hell";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Entfernen";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Suchvorschläge";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Mit Brave suchen";
 
 /* Settings security section title */
 "Security" = "Sicherheit";

--- a/BraveShared/de.lproj/Localizable.strings
+++ b/BraveShared/de.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Dies ist Ihre erste Anzeige von Brave.";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Modus";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Der Nachtmodus wirkt sich gleichzeitig auf das Erscheinungsbild der Website und das allgemeine Erscheinungsbild des Systems aus.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Nachtmodus ein/ausschalten";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Nachtmodus";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Nein";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Gespeichert";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Wählen Sie einen Ordner aus, in den %lld Elemente verschoben werden sollen";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Wählen Sie einen Ordner aus, in den ein Element verschoben werden soll";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld Elemente";

--- a/BraveShared/es.lproj/BraveShared.strings
+++ b/BraveShared/es.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Ocultar";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Abrir sitio web";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Desvelar";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "No se ha podido mostrar la página en la vista de lectura.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Modo de lectura";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Reducir el tamaño del texto";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Cambia el tema de color.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Oscuro";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Claro";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Eliminar";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Sugerencias de búsqueda";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Buscar con Brave";
 
 /* Settings security section title */
 "Security" = "Seguridad";

--- a/BraveShared/es.lproj/Localizable.strings
+++ b/BraveShared/es.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Este es tu primer anuncio de Brave";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Modo";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "El modo nocturno modificará tanto la apariencia del sitio web como la del sistema general.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Activar/desactivar modo nocturno";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Modo nocturno";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "No";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Guardado";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Selecciona una carpeta para guardar %lld elementos";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Selecciona una carpeta para guardar 1 elemento";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld elementos";

--- a/BraveShared/fr.lproj/BraveShared.strings
+++ b/BraveShared/fr.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Masquer";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Ouvrir le site Web";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Afficher";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Impossible d'afficher la page en mode Lecteur.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Mode lecture";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Réduire la taille du texte";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Modifie le thème de couleur.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Sombre";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Lumineux";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sépia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Supprimer";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Suggestions de recherche";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Rechercher avec Brave";
 
 /* Settings security section title */
 "Security" = "Sécurité";

--- a/BraveShared/fr.lproj/Localizable.strings
+++ b/BraveShared/fr.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Voici votre première publicité Brave";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Mode";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Le mode sombre modifiera l'apparence des sites Web ainsi que de l'interface système générale.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Activer/Désactiver le mode sombre";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Mode sombre";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Non";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Enregistré";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Sélectionner un dossier vers lequel déplacer %lld éléments";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Sélectionner un dossier vers lequel déplacer 1 élément";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld éléments";

--- a/BraveShared/id-ID.lproj/BraveShared.strings
+++ b/BraveShared/id-ID.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Sembunyikan";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Buka Situs Web";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Tampilkan";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Laman tidak dapat ditampilkan pada Tampilan Baca";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Mode Pembaca";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Perkecil ukuran teks";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Ubah warna tema.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Gelap";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Terang";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Hapus";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Saran Pencarian";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Cari dengan Brave";
 
 /* Settings security section title */
 "Security" = "Keamanan";

--- a/BraveShared/id-ID.lproj/Localizable.strings
+++ b/BraveShared/id-ID.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Ini adalah iklan Brave perdana Anda";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Mode";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Mode malam akan memengaruhi tampilan situs web dan tampilan sistem secara umum pada saat yang sama.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Hidupkan/Matikan Mode Malam";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Mode Malam";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Tidak";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Disimpan";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Pilih folder untuk memindahkan %lld hal ke";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Pilih folder untuk memindahkan 1 hal ke";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld hal";

--- a/BraveShared/it.lproj/BraveShared.strings
+++ b/BraveShared/it.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Nascondi";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Apri sito web";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Mostra";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Impossibile visualizzare la pagina in modalità di lettura";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Modalità di lettura";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Diminuisci dimensioni testo";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Cambia schema colori.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Scuro";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Chiaro";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Seppiato";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Rimuovi";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Suggerimenti di ricerca";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Cerca con Brave";
 
 /* Settings security section title */
 "Security" = "Sicurezza";

--- a/BraveShared/it.lproj/Localizable.strings
+++ b/BraveShared/it.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Questo è il tuo primo annuncio Brave";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Modalità";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "La modalità notturna cambierà l’aspetto sia dei siti web che del sistema generale.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Attiva/disattiva la modalità notturna";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Modalità notturna";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "No";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Salvati";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Seleziona una cartella in cui spostare %lld elementi";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Seleziona una cartella in cui spostare 1 elemento";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld elementi";

--- a/BraveShared/ja.lproj/BraveShared.strings
+++ b/BraveShared/ja.lproj/BraveShared.strings
@@ -203,7 +203,7 @@
 "callout.defaultBrowserTitle" = "Braveをデフォルトのブラウザに設定する";
 
 /* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "動画を見る";
+"callout.playlistOnboardingViewButtonTitle" = "説明を見る";
 
 /* Description for Playlist Onboarding View */
 "callout.playlistOnboardingViewDescription" = "どこでも、好きなときに動画を楽しめます。バックグラウンド再生、ピクチャーインピクチャー再生、オフライン再生も可能です。そしてもちろん、広告は表示されません。";
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "非表示";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "ウェブサイトを開く";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "表示";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "ページをリーダービューで表示できませんでした。";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "リーダーモード";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "テキストサイズを小さくする";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "色テーマを変更します。";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "ダーク";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "ライト";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "セピア";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "削除";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "検索候補";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Braveで検索";
 
 /* Settings security section title */
 "Security" = "セキュリティ";

--- a/BraveShared/ja.lproj/Localizable.strings
+++ b/BraveShared/ja.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "これは初めてのBrave広告です";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "モード";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "ナイトモードは、ウェブサイトとシステム全般の外観に同時に適用されます。";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "ナイトモードをオン/オフ";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "ナイトモード";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "いいえ";
 
@@ -479,11 +491,13 @@
 "playlistFolders.newFolderSectionTitle" = "このフォルダに動画を追加";
 
 /* The title of the default playlist folder */
-"playlistFolders.savedFolderTitle" = "保存済み";
+"playlistFolders.savedFolderTitle" = "追加済み";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "%lld件のアイテムを移動するフォルダを選択";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "1件のアイテムを移動するフォルダを選択";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld件のアイテム";

--- a/BraveShared/ko-KR.lproj/BraveShared.strings
+++ b/BraveShared/ko-KR.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "숨기기";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "웹사이트 열기";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "공개";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "읽기 전용 뷰에서 페이지를 표시할 수 없습니다.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "리더 모드";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "텍스트 크기 축소";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "테마 색상을 변경합니다.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "어두운";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "밝은";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "제거";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "추천 검색어";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Brave로 검색";
 
 /* Settings security section title */
 "Security" = "보안";

--- a/BraveShared/ko-KR.lproj/Localizable.strings
+++ b/BraveShared/ko-KR.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "첫 번째로 표시되는 Brave 광고";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "모드";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "야간 모드 이용 시 웹사이트 비주얼과 일반적인 시스템 비주얼이 동시에 변경됩니다.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "야간 모드 켜기/끄기";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "야간 모드";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "아니요";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "저장됨";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "%lld개 항목을 이동할 폴더 선택";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "1개 항목을 이동할 폴더 선택";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld개 항목";

--- a/BraveShared/ms.lproj/BraveShared.strings
+++ b/BraveShared/ms.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Sembunyikan";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Buka Laman Web";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Dedah";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Halaman ini tidak dapat dipaparkan dalam Paparan Pembaca.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Mod Pembaca";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Kurangkan saiz teks";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Mengubah tema warna.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Gelap";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Cerah";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Alih Keluar";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Cadangan Carian";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Buat carian melalui Brave";
 
 /* Settings security section title */
 "Security" = "Sekuriti";

--- a/BraveShared/ms.lproj/Localizable.strings
+++ b/BraveShared/ms.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Ini ialah iklan Brave pertama anda";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Mod";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Mod Malam akan memberikan kesan kepada penampilan laman web dan juga penampilan sistem secara amnya.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Hidupkan/Matikan Mod Malam";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Mod Malam";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Tidak";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Disimpan";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Pilih folder untuk mengalih %lld item ke";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Pilih folder untuk sasaran pindahan 1 item";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld Item";

--- a/BraveShared/nb.lproj/BraveShared.strings
+++ b/BraveShared/nb.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Skjul";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Åpne nettsted";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Vis";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Siden kunne ikke vises i lesevisning.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Lesermodus";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Reduser tekststørrelse";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Endrer fargetema.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Mørkt";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Lyst";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Fjern";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Søkeforslag";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Søk med Brave";
 
 /* Settings security section title */
 "Security" = "Sikkerhet";

--- a/BraveShared/nb.lproj/Localizable.strings
+++ b/BraveShared/nb.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Dette er den første Brave-annonsen din";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Modus";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Nattmodus påvirker både hvordan nettsiden og det generelle systemet vises.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Slå nattmodus av/på";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Nattmodus";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Nei";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Lagret";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Velg en mappe å flytte %lld elementer til";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Velg en mappe som 1 element skal flyttes til";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld elementer";

--- a/BraveShared/pl.lproj/BraveShared.strings
+++ b/BraveShared/pl.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Ukryj";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Otwórz stronę";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Pokazuj";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Nie udało się wyświetlić strony w widoku odczytu.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Tryb Czytania";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Zmniejsz rozmiar tekstu";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Zmienia kolor motywu.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Ciemny";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Jasny";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Usuń";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Sugestie wyszukiwania";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Szukaj z Brave";
 
 /* Settings security section title */
 "Security" = "Bezpieczeństwo";

--- a/BraveShared/pl.lproj/Localizable.strings
+++ b/BraveShared/pl.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "To Twoja pierwsza reklama Brave";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Tryb";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Tryb nocny będzie miał wpływ na wygląd strony i ogólny wygląd systemu.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Włącz/wyłącz tryb nocny";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Tryb nocny";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Nie";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Zapisano";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Wybierz folder do przeniesienia %lld rzeczy";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Wybierz folder do przeniesienia 1 rzeczy";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld rzeczy";

--- a/BraveShared/pt-BR.lproj/BraveShared.strings
+++ b/BraveShared/pt-BR.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Ocultar";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Abrir site";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Exibir";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Não foi possível exibir a página na Visualização de leitor.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Modo leitor";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Diminuir o tamanho da fonte";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Altera o tema de cores.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Escuro";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Claro";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sépia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Remover";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Sugestões de pesquisa";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Pesquisar com o Brave";
 
 /* Settings security section title */
 "Security" = "Segurança";

--- a/BraveShared/pt-BR.lproj/Localizable.strings
+++ b/BraveShared/pt-BR.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Este é seu primeiro anúncio do Brave";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Modo";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "O modo noturno afetará a aparência dos sites e a aparência geral do sistema ao mesmo tempo.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Ativar/desativar o modo noturno";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Modo noturno";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Não";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Salva";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Selecione uma pasta para a qual %lld itens serão movidos";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Selecione uma pasta para a qual 1 item será movido";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld itens";

--- a/BraveShared/ru.lproj/BraveShared.strings
+++ b/BraveShared/ru.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Скрыть";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Открыть сайт";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Показать";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Не удалось открыть страницу в режиме чтения.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Режим чтения";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Уменьшить размер шрифта";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Изменение цветовой темы.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Темный";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Светлый";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Сепия";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Удалить";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Подсказки при поиске";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Искать в Brave";
 
 /* Settings security section title */
 "Security" = "Безопасность";

--- a/BraveShared/ru.lproj/Localizable.strings
+++ b/BraveShared/ru.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Это ваше первое объявление в Brave!";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Режим";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Ночной режим будет применен к сайту и системе в целом.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Включить/отключить ночной режим";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Ночной режим";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Нет";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Сохраненное";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Выбор новой папки для объектов (%lld)";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Выберите папку для 1 объекта";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "Объектов: %lld.";

--- a/BraveShared/sv.lproj/BraveShared.strings
+++ b/BraveShared/sv.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Dölj";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Öppna webbplats";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Avslöja";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Sidan kunde inte visas i läsläge.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Läsläge";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Minska textstorleken";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Ändrar färgtemat.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Mörkt";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Ljust";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepia";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Ta bort";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Sökförslag";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Sök med Brave";
 
 /* Settings security section title */
 "Security" = "Säkerhet";

--- a/BraveShared/sv.lproj/Localizable.strings
+++ b/BraveShared/sv.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Det här är din första Brave-annons";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Läge";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Nattläget påverkar webbplatsens utseende och allmänna systemutseende samtidigt.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Nattläge på/av";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Nattläge";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Nej";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Sparat";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Markera en mapp som %lld objekt ska flyttas till";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Markera en mapp som 1 objekt ska flyttas till";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld objekt";

--- a/BraveShared/tr.lproj/BraveShared.strings
+++ b/BraveShared/tr.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Gizle";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Web Sitesi Aç";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Göster";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Sayfa Okuyucu Görünümü'nde görüntülenemedi.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Okuyucu Modu";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Metin boyutunu küçült";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Renk temasını değiştirir.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Koyu";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Açık";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Sepya";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Kaldır";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Arama Önerileri";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Brave ile Ara";
 
 /* Settings security section title */
 "Security" = "Güvenlik";

--- a/BraveShared/tr.lproj/Localizable.strings
+++ b/BraveShared/tr.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Bu senin ilk Brave reklamın.";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Mod";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Gece modu web sitesi görünümünü ve genel sistem görünümünü aynı anda etkiler.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Gece Modunu aç/kapat";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Gece Modu";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Hayır";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Kaydedilenler";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "%lld öğeyi taşımak için bir klasör seçin";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "1 öğenin taşınacağı bir klasör seçin";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld Öğe";

--- a/BraveShared/uk.lproj/BraveShared.strings
+++ b/BraveShared/uk.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "Приховати";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "Відкрити вебсайт";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "Показати";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Неможливо відобразити сторінку в режимі читання.";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Режим читання";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Зменшити розмір шрифту";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "Зміна кольорової теми.";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "Темна";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "Світла";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "Сепія";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "Вилучити";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Пошукові підказки";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Пошук у Brave";
 
 /* Settings security section title */
 "Security" = "Безпека";

--- a/BraveShared/uk.lproj/Localizable.strings
+++ b/BraveShared/uk.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "Це ваша перша реклама Brave";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Режим";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Нічний режим змінить зовнішній вигляд вебсайту та системи.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Увімкнути / вимкнути нічний режим";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Нічний режим";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Ні";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "Збережено";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Виберіть папку, щоб перемістити ці об’єкти (%lld)";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Виберіть папку для переміщення 1 об’єкта";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "Об’єкти: %lld";

--- a/BraveShared/zh-TW.lproj/BraveShared.strings
+++ b/BraveShared/zh-TW.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "隱藏";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "開啟網站";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "顯示";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "頁面無法以閱讀檢視顯示。";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "閱讀模式";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "縮小字體";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "變更顏色主題。";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "深色";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "淺色";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "復古";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "刪除";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "搜尋建議";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "使用 Brave 搜尋";
 
 /* Settings security section title */
 "Security" = "安全";

--- a/BraveShared/zh-TW.lproj/Localizable.strings
+++ b/BraveShared/zh-TW.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "這是您的第一則 Brave 廣告";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "模式";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "深色模式會同時影響網站的呈現樣貌和一般的系統外觀。";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "開啟/關閉深色模式";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "深色模式";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "否";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "已儲存";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "選取要將 %lld 個項目移至其中的資料夾";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "選取要將 1 個項目移入的資料夾";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld 個項目";

--- a/BraveShared/zh.lproj/BraveShared.strings
+++ b/BraveShared/zh.lproj/BraveShared.strings
@@ -679,6 +679,9 @@
 /* Hide password text selection menu item */
 "MenuItemHidePasswordTitle" = "隐藏";
 
+/* Open and Fill website text selection menu item */
+"MenuItemOpenTitle" = "打开网站";
+
 /* Reveal password text selection menu item */
 "MenuItemRevealPasswordTitle" = "显示";
 
@@ -973,6 +976,9 @@
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "该页面无法在阅读器视图中显示。";
 
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "阅读器模式";
+
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "缩小字体";
 
@@ -981,15 +987,6 @@
 
 /* Accessibility hint for the color theme setting buttons in reader mode display settings */
 "ReaderModeThemeButtonAccessibilityHint" = "改变主题颜色";
-
-/* Dark theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleDark" = "暗";
-
-/* Light theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleLight" = "亮";
-
-/* Sepia theme setting in Reading View settings */
-"ReaderModeThemeButtonTitleSepia" = "墨色";
 
 /* Action button for removing sync device. */
 "RemoveDevice" = "移除";
@@ -1110,6 +1107,9 @@
 
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "搜索建议";
+
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "使用 Brave 搜寻";
 
 /* Settings security section title */
 "Security" = "安全";

--- a/BraveShared/zh.lproj/Localizable.strings
+++ b/BraveShared/zh.lproj/Localizable.strings
@@ -97,6 +97,18 @@
 /* No comment provided by engineer. */
 "MyFirstAdTitle" = "这是您的第一个 Brave 广告";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "模式";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "夜间模式会同时影响网站外观和一般的系统外观。";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "开启/关闭黑夜模式";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "深色模式";
+
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "否";
 
@@ -481,9 +493,11 @@
 /* The title of the default playlist folder */
 "playlistFolders.savedFolderTitle" = "已保存";
 
-/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.'
-   The title of the section indicating that the user should select a folder to move 1 item to. */
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "选择要将 %lld 个项目移动至其中的文件夹";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "选取要将 1 个项目移入的资料夹";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld 个项目";

--- a/BraveWallet/de.lproj/BraveWallet.strings
+++ b/BraveWallet/de.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Benutzerdefiniertes Token kann nicht hinzugefügt werden";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Erweiterte Einstellungen";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Betrag + Gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Gas bearbeiten";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Die Transaktion wird möglicherweise nicht an das Netzwerk weitergegeben, wenn der benutzerdefinierte Nonce-Wert nicht sequenziell ist oder andere Fehler aufweist";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Geben Sie einen benutzerdefinierten Nonce-Wert ein";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Bitte überprüfen Sie Ihre Eingaben und versuchen Sie es erneut.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Zurück";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Sichtbare Assets bearbeiten";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Kryptowährungskonto wiederherstellen";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Speichern";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "QR-Code scannen";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Zurücksetzen";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Zurücksetzen";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Diese Option wird hauptsächlich von Entwicklern verwendet, die einen lokalen Testserver betreiben";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Möchten Sie die Transaktions- und Nonce-Informationen wirklich zurücksetzen?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Das Löschen von Transaktionen kann für Entwickler oder beim Löschen des Status auf einem lokalen Server nützlich sein";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Klare Transaktions- und Nonce-Informationen";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Wallet zurücksetzen";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Nicht unterstützte Blockchain";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Token und Assets tauschen.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x verarbeitet die Ethereum-Adresse und IP-Adresse, um eine Transaktion auszuführen (einschließlich der Angebotseinholung). 0x verwendet diese Daten NUR zum Zwecke der Verarbeitung von Transaktionen.";

--- a/BraveWallet/es.lproj/BraveWallet.strings
+++ b/BraveWallet/es.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "No se puede añadir el token personalizado";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Ajustes avanzados";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Importe + Gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Editar gas";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "La transacción no se puede propagar por la red si el valor nonce personalizado no es secuencial o presenta otros errores";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce (valor de seguridad)";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Introduce el valor nonce personalizado";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Comprueba la información que has introducido y vuelve a intentarlo.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Volver";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Editar activos visibles";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Restaurar cuenta de criptomonedas";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Guardar";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Guardar código QR";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Restablecer";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Restablecer";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Esta opción la usan, principalmente, los desarrolladores que gestionan servidores de pruebas locales";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "¿Seguro que quieres restablecer la información de la transacción y del nonce?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Borrar transacciones puede ser útil para los desarrolladores o cuando se trata de eliminar el estado de un servidor local";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Borrar información de transacción y nonce";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Restablecer cartera";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Cadena no compatible";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Intercambia tokens y activos.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x procesará la dirección de Ethereum y la dirección IP para llevar a cabo una transacción (y obtener presupuestos). 0x utilizará estos datos SOLO para procesar transacciones.";

--- a/BraveWallet/fr.lproj/BraveWallet.strings
+++ b/BraveWallet/fr.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Impossible d'ajouter le jeton personnalisé";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Paramètres avancés";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Montant + Gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Modifier le Gas";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "La transaction risque de ne pas être propagée sur le réseau si le nonce personnalisé n'est pas séquentiel ou présente d'autres erreurs.";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Saisir un nonce personnalisé";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Vérifiez les valeurs saisies, puis réessayez.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Retour";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Modifier les actifs visibles";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Restaurer le compte de cryptomonnaie";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Enregistrer";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Scanner un code QR";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Réinitialiser";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Réinitialiser";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Cette option est généralement utilisée par les développeurs qui possèdent un serveur de test local";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Voulez-vous vraiment réinitialiser les informations sur les transactions et le nonce ?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "La suppression des transactions peut être utile pour les développeurs qui souhaitent repartir de zéro sur un serveur local";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Supprimer les informations sur les transactions et le nonce";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Réinitialiser le portefeuille";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Chaîne non prise en charge";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Échangez des jetons et des actifs.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x traitera l'adresse Ethereum et l'adresse IP pour compléter une transaction (y compris pour obtenir des devis). 0x utilisera ces données UNIQUEMENT dans le but de traiter les transactions.";

--- a/BraveWallet/id-ID.lproj/BraveWallet.strings
+++ b/BraveWallet/id-ID.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Tidak dapat menambahkan token khusus";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Pengaturan lanjutan";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Jumlah + Bensin";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Edit Bensin";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Transaksi mungkin tidak disebarkan ke jaringan jika nilai khusus yang sekarang tidak logis atau memiliki kesalahan lain";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Yang sekarang";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Masukkan nilai khusus yang sekarang";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Silakan periksa input Anda dan coba lagi";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Kembali";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Edit Aset yang Dapat Dilihat";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Pulihkan Akun Kripto";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Simpan";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Pindai kode QR";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Atur ulang";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Atur ulang";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Opsi ini biasanya digunakan oleh pengembang yang sedang menjalankan peladen uji coba lokal";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Anda yakin ingin mengatur ulang transaksi dan informasi yang sekarang?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Menghapus transaksi dapat berguna bagi pengembang atau ketika menghapus pada peladen lokal";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Hapus transaksi & info yang sekarang";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Atur Ulang Dompet";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Rantai yang tidak didukung";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Tukar token dan aset.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x akan memproses alamat Ethereum dan alamat IP untuk memenuhi transaksi (termasuk mendapatkan penawaran). 0x HANYA akan menggunakan data ini untuk keperluan pemrosesan transaksi.";

--- a/BraveWallet/it.lproj/BraveWallet.strings
+++ b/BraveWallet/it.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Impossibile aggiungere il token personalizzato";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Impostazioni avanzate";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Importo + gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Modifica gas";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Se il proprio nonce ha un valore non sequenziale o errori di altro tipo, la transazione potrebbe non essere propagata alla rete.";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Inserisci il valore del tuo nonce";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Controlla i dati inseriti e riprova.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Indietro";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Modifica asset visibili";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Ripristina l’account di criptovalute";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Salva";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Scansiona codice QR";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Azzera";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Azzera";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Questa opzione è la più usata dagli sviluppatori che usano un server di prova locale";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Vuoi davvero reimpostare le informazioni della transazione e del nonce?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "La cancellazione delle transazioni può essere utile per gli sviluppatori o quando si cancella lo stato su un server locale";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Cancella le informazioni della transazione e del nonce";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Azzera portafoglio";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Catena non supportata";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Scambia token e asset.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x elaborerà l’indirizzo Ethereum e l’indirizzo IP per eseguire una transazione (incluso l’ottenimento di quotazioni). 0x utilizzerà questi dati SOLO ai fini dell’elaborazione delle transazioni.";

--- a/BraveWallet/ja.lproj/BraveWallet.strings
+++ b/BraveWallet/ja.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "カスタムトークンを追加できません";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "詳細設定";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "数量 + Gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Gasを編集する";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "カスタムノンス値が非連続的であるか、その他のエラーがある場合、トランザクションがネットワークに伝搬されないことがあります。";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "ノンス";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "カスタムノンス値を入力";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "入力内容を確認して再度お試しください。";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "戻る";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "表示されているアセットを変更する";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "暗号資産アカウントを復元する";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "保存する";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "QRコードをスキャンする";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "リセット";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "リセット";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "このオプションは、主にローカルでテストサーバーを運用している開発者に向けたものです。";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "トランザクションやノンス情報をリセットしてよろしいですか？";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "トランザクションのクリアは、開発者にとって、またはローカルサーバーの状態をクリアするときに便利な機能です。";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "トランザクションとノンス情報をクリア";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "ウォレットをリセットする";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "チェーンがサポートされていません";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "トークンとアセットをスワップします。";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0xがイーサリアムアドレスとIPアドレスをトランザクション（クォートの入手を含む）を実行するために処理します。0xはこのデータをトランザクションの処理のためだけに用います。";

--- a/BraveWallet/ko-KR.lproj/BraveWallet.strings
+++ b/BraveWallet/ko-KR.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "맞춤 토큰을 추가할 수 없음";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "고급 설정";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "수량 + 가스비";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "가스 편집";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "맞춤 논스 값이 시퀀셜이 아니거나 기타 오류가 있으면 트랜잭션이 네트워크로 전파되지 않을 수 있습니다.";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "논스";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "맞춤 논스 값 입력";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "입력값을 확인하고 다시 시도하세요.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "뒤로 이동";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "표시되는 자산 편집";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "암호화폐 계정 복구";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "저장";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "QR 코드 스캔";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "재설정";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "재설정";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "주로 로컬 테스트 서버를 운영하는 개발자가 사용하는 옵션입니다.";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "트랜잭션 및 논스 정보를 초기화하시겠습니까?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "트랜잭션 지우기는 주로 개발자가 로컬 서버에서 상태를 지우는 데 유용합니다.";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "트랜잭션 및 논스 정보 지우기";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "월렛 재설정";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "지원되지 않는 체인";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "토큰 및 자산을 스왑합니다.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x는 이더리움 주소와 IP 주소를 처리하여 거래를 수행합니다(견적 받기 포함). 0x는 거래 처리 목적으로만 이 데이터를 사용합니다.";

--- a/BraveWallet/ms.lproj/BraveWallet.strings
+++ b/BraveWallet/ms.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Tidak dapat menambah token tersuai";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Tetapan lanjutan";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Jumlah + Gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Edit Gas";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Transaksi tidak boleh disebarluaskan ke rangkaian jika nilai nonce tersuai adalah bukan berjujukan atau mengandungi ralat lain";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Masukkan nilai nonce tersuai";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Sila semak input anda dan cuba lagi.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Undur";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Edit Aset Tampak";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Pulihkan Akaun Kripto";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Simpan";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Imbas kod QR";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Tetapkan semula";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Tetapkan semula";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Pilihan ini kebanyakannya digunakan oleh pembangun yang menjalankan pelayan ujian setempat";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Betulkah anda mahu menetapkan semula maklumat transaksi dan nonce?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Langkah mengosongkan transaksi mungkin berguna untuk pembangun atau apabila mengosongkan keadaan pada pelayan setempat";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Kosongkan maklumat transaksi & nonce";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Tetapkan Semula Dompet";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Rantaian tidak disokong";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Tukar token dengan aset";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x akan memproses alamat Ethereum dan alamat IP untuk memenuhi transaksi (termasuk mendapatkan sebut harga). 0x HANYA akan menggunakan data ini untuk tujuan memproses transaksi.";

--- a/BraveWallet/nb.lproj/BraveWallet.strings
+++ b/BraveWallet/nb.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Kan ikke legge til egendefinert token";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Avanserte innstillinger";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Beløp + Gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Endre Gas";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Transaksjonen kan ikke sendes ut i nettverket hvis den egendefinerte nonce-verdien ikke er i riktig rekkefølge, eller har andre feil";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Skriv inn egendefinert nonce-verdi";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Kontroller det du har skrevet inn, og prøv på nytt.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Gå tilbake";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Endre synlige ressurser";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Gjenopprett kryptokontoen";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Lagre";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Skann QR-kode";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Tilbakestill";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Tilbakestill";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Dette alternativet brukes primært av utviklere som kjører en lokal testserver";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Er du sikker på at du vil tilbakestille transaksjons- og nonce-informasjonen?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Sletting av transaksjoner kan være nyttig for utviklere eller ved tilbakestilling av status på en lokal server";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Slett transaksjons- og nonce-informasjon";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Tilbakestill lommebok";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Nettverket støttes ikke";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Bytt tokener og ressurser.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x behandler Ethereum-adressen og IP-adressen for å gjennomføre en transaksjon (herunder innhenting av pristilbud). 0x bruker KUN disse opplysningene til å behandle transaksjoner.";

--- a/BraveWallet/pl.lproj/BraveWallet.strings
+++ b/BraveWallet/pl.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Nie można dodać tokenu niestandardowego";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Ustawienia zaawansowane";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Kwota + gaz";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Edytuj gaz";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Transakcja może nie zostać wprowadzona do sieci, jeśli wartość własna jednorazowa jest niesekwencyjna lub zawiera inne błędy.";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Jednorazowa";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Wprowadź wartość własną jednorazową";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Sprawdź wprowadzoną zawartość i spróbuj ponownie.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Wróć";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Edytuj widoczne zasoby";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Przywróć konto kryptowalut";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Zapisz";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Skanuj kod QR";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Resetuj";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Resetuj";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Ta opcja jest zwykle wykorzystywana przez deweloperów prowadzących lokalny serwer testowy.";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Czy na pewno chcesz zresetować transakcję i informację o wartości jednorazowej?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Usuwanie transakcji może być przydatne dla deweloperów lub podczas czyszczenia lokalnego serwera.";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Wyczyść transakcję i informację o wartości jednorazowej";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Resetuj portfel";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Nieobsługiwany łańcuch";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Wymień tokeny";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x przetworzy adres Ethereum i adres IP w celu przeprowadzenia transakcji (w tym uzyskania ofert). 0x wykorzysta te dane JEDYNIE w celu przetworzenia transakcji.";

--- a/BraveWallet/pt-BR.lproj/BraveWallet.strings
+++ b/BraveWallet/pt-BR.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Não foi possível adicionar um token personalizado";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Configurações avançadas";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Valor + gás";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Editar gás";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "A transação poderá não ser propagada à rede se o valor nonce personalizado não for sequencial ou tiver outros erros";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Insira um valor nonce personalizado";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Verifique os dados informados e tente novamente.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Voltar";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Editar ativos visíveis";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Restaurar conta de criptomoedas";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Salvar";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Ler código QR";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Redefinir";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Redefinir";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Essa opção é usada principalmente por desenvolvedores que estejam executando um servidor de teste local";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Tem certeza de que deseja redefinir as informações de transações e nonce?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Limpar as transações pode ser útil para desenvolvedores ou ao limpar o estado em um servidor local";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Limpar informações de transações e nonce";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Redefinir carteira";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Cadeia incompatível";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Realize swap de tokens e ativos.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "A 0x processará o endereço Ethereum e o endereço IP para realizar uma transação (incluindo a obtenção de cotações). A 0x usará esses dados SOMENTE para fins de processamento de transações.";

--- a/BraveWallet/ru.lproj/BraveWallet.strings
+++ b/BraveWallet/ru.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Не удалось добавить пользовательский токен";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Расширенные настройки";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Сумма + газ";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Изменение газа";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Если одноразовый код не последователен или содержит ошибки, транзакция не будет передана в сеть";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Одноразовый код";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Введите собственный одноразовый код";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Проверьте, правильно ли вы ввели данные, и повторите попытку.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Назад";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Изменить видимые активы";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Восстановление криптовалютного счета";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Сохранить";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Сканировать QR-код";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Сбросить";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Сбросить";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Эту функцию обычно используют разработчики, запускающие локальный сервер тестирования";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Сбросить данные транзакции и одноразовый код?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Сброс данных транзакций может понадобится разработчикам или при очистке состояния на локальном сервере";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Очистить данные транзакции и одноразовый код";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Сбросить кошелек";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Цепочка не поддерживается";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Своп токенов и активов.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x обрабатывает Ethereum-адрес и IP-адрес ТОЛЬКО для выполнения транзакций (включая получение расценок).";

--- a/BraveWallet/sv.lproj/BraveWallet.strings
+++ b/BraveWallet/sv.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Kan inte lägga till anpassad token";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Avancerade inställningar";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Belopp + gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Ändra gas";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Transaktionen får inte spridas till nätverket om det anpassade nonce-värdet inte är sekventiellt eller har andra fel";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Ange anpassat nonce-värde";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Kontrollera de värde du har matat in och försök igen.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Gå tillbaka";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Redigera synliga tillgångar";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Återställ kryptokonto";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Spara";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Skanna QR-kod";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Återställ";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Återställ";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Det här alternativet används främst av utvecklare som kör en lokal testserver";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Är du säker på att du vill återställa transaktions- och nonce-information?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Att rensa transaktioner kan vara användbart för utvecklare eller vid clearingtillstånd på en lokal server";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Rensa transaktions- och nonce-information";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Återställ plånbok";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Kedjan stöds inte";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Byt tokens och tillgångar.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x bearbetar Ethereum- och IP-adressen för att genomföra en transaktion (vilket innefattar erhållande av kurser). 0x använder bara dessa data för att bearbeta transaktioner.";

--- a/BraveWallet/tr.lproj/BraveWallet.strings
+++ b/BraveWallet/tr.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Özel token eklenemiyor";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Gelişmiş ayarlar";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Tutar + GAS";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "GAS'ı Düzenleyin";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Özel bir kerelik anahtar sıralı değilse veya başka hatalar barındırıyorsa işlem ağa yayılamayabilir";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Bir Kerelik Anahtar";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Özel bir kerelik anahtar değeri girin";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Lütfen girdilerinizi kontrol edin ve tekrar deneyin.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Geri dön";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Görünür Varlıkları Düzenle";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Kripto Hesabınızı Geri Yükleyin";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Kaydet";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "QR kodunu tarayın";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Sıfırla";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Sıfırla";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Bu seçenekler en çok yerel bir test sunucusu çalıştıran geliştiriciler tarafından kullanılır";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "İşlem ve bir kerelik anahtar bilgilerini sıfırlamak istediğinize emin misiniz?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "İşlemleri temizlemek geliştiriciler için veya yerel bir sunucuda durum temizlenirken faydalı olabilir";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "İşlem ve bir kerelik anahtar bilgilerini temizle";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Cüzdanı Sıfırla";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Desteklenmeyen zincir";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Belirteç ve varlık takası yapın.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x, bir işlemi gerçekleştirmek için (teklif alımları dahil) Ethereum adresini ve IP adresini işleyecektir. 0X, bu verileri SADECE işlemi gerçekleştirmek amacıyla kullanacaktır.";

--- a/BraveWallet/uk.lproj/BraveWallet.strings
+++ b/BraveWallet/uk.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Неможливо додати користувацький токен";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Розширені налаштування";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Сума + газ";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Редагувати газ";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Транзакція може не розповсюджуватися в мережі, якщо користувацьке значення часу не послідовне або містить помилки";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Значення часу";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Уведіть користувацьке значення часу";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "Перевірте введену інформацію та спробуйте ще раз.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Назад";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Редагувати видимі активи";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "Відновити криптовалютний рахунок";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "Зберегти";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "Сканування QR-коду";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "Скинути";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "Скинути";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Ця опція в основному використовується розробниками для роботи з локальним тестовим сервером";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Справді очистити дані транзакції та значення часу?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Функція очищення транзакцій може стати в пригоді розробникам або під час очищення стану на локальному сервері";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "Очистити дані транзакції та значення часу";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "Скинути налаштування гаманця";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Непідтримуваний блокчейн.";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Обмін токенів і активів.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x опрацьовує адресу Ethereum і IP-адресу для транзакції (зокрема, отримання цін). 0x використовуватиме ці дані ЛИШЕ для проведення транзакцій.";

--- a/BraveWallet/zh-TW.lproj/BraveWallet.strings
+++ b/BraveWallet/zh-TW.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "無法新增自訂代幣";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "進階設定";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "金額 + 燃料費";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "編輯燃料設定";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "如果自訂的 Nonce 值並非連續值或具有其他錯誤，交易可能無法傳輸至網路";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "輸入自訂 Nonce 值";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "請檢查輸入內容並再試一次";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "返回";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "編輯可見資產";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "還原加密帳戶";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "儲存";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "掃描 QR 碼";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "重設";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "重設";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "開發人員執行本機測試伺服器時大多會選取這個選項";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "確定要重設交易和 Nonce 資訊？";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "執行開發工作或清除本機伺服器狀態時，清除交易或許很有幫助";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "清除交易和 Nonce 資訊";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "重設錢包";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "不支援的測試網路";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "交換代幣和資產。";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x 將處理以太坊網址和 IP 位址，以履行交易 (包括取得報價)。0x 只會使用此資料來處理交易，不會用於其他用途。";

--- a/BraveWallet/zh.lproj/BraveWallet.strings
+++ b/BraveWallet/zh.lproj/BraveWallet.strings
@@ -52,6 +52,9 @@
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "无法添加自定义令牌";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "进阶设置";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "金额 + Gas";
 
@@ -313,6 +316,21 @@
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "编辑 Gas";
 
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "如果自定义 nonce 值不连续或有其他错误，则交易可能不会传播到网络";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Nonce";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "输入自定义 nonce 值";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value. */
+"wallet.editTransactionError" = "请检查输入内容并再试一次。";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "返回";
+
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "编辑可见资产";
 
@@ -517,6 +535,9 @@
 /* The title on the restore wallet screen. */
 "wallet.restoreWalletTitle" = "还原加密账户";
 
+/* A button title for saving the users selected gas fee options. Or to save a custom nonce value. Or to save a custom network */
+"wallet.saveButtonTitle" = "保存";
+
 /* A description for a QR code icon which brings up the camera to read ETH addresses encoded as QR codes */
 "wallet.scanQRCodeAccessibilityLabel" = "扫描二维码";
 
@@ -583,6 +604,21 @@
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetButtonTitle" = "重置";
 
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertButtonTitle" = "重置";
+
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "此选项主要由运行本地测试服务器的开发人员使用";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "您确定要重置交易和 nonce 信息吗？";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "在开发人员执行开发工作或在本地服务器上清除状态时，清除交易可能很有用";
+
+/* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionTitle" = "清除交易和 nonce 信息";
+
 /* The title of a button that will reset the wallet. As in to erase the users wallet from the device */
 "wallet.settingsResetWalletAlertButtonTitle" = "重置钱包";
 
@@ -639,6 +675,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "不支持的区块链";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "兑换代币和资产";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x 将处理 Ethereum 地址和 IP 地址以履行交易（包括获得报价）。0x 仅会将数据用于处理交易目的。";

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1105,7 +1105,6 @@
 		CAC5342927A9B87600013056 /* PlaylistFolderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC5342827A9B87600013056 /* PlaylistFolderController.swift */; };
 		CAD0D5D927C007CC001071AC /* PlaylistEditFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD0D5D827C007CC001071AC /* PlaylistEditFolderView.swift */; };
 		CAFC6C9027CFE34800F9CACC /* BraveSyncAPIExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E09617F252B63F200F3AFBB /* BraveSyncAPIExtensions.swift */; };
-		CAFC6C9127CFE36C00F9CACC /* LoginInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB2F0CE26D3F92D00C8E576 /* LoginInfoViewController.swift */; };
 		CAFC6C9927D011C200F9CACC /* CosmeticFiltersResourceDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFC6C9827D011C200F9CACC /* CosmeticFiltersResourceDownloader.swift */; };
 		CE7F11941F3CEEC800ABFC0B /* RemoteDevices.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F115E1F3CCEF900ABFC0B /* RemoteDevices.swift */; };
 		D018F93E1F44A71A0098F8CA /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D018F93D1F44A7190098F8CA /* Schema.swift */; };


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5140 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Go to a reader mode, verify that the `Reader Mode` label below url bar is translated
- Go to appearance settings, verify that 'night mode' related text is translated

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
