### PR TITLE
Fix #5163: Pressing Brave Shields Icon while presenting Tracker Intro Pop-Over does not present Shields Screen

### DIFF
--- a/BraveUI/Popover/PopoverController.swift
+++ b/BraveUI/Popover/PopoverController.swift
@@ -336,13 +336,21 @@ public class PopoverController: UIViewController {
 
     viewController.present(self, animated: true, completion: completion)
   }
+  
+  public func dismissPopover(_ completion: (() -> Void)? = nil) {
+    dismiss(animated: true) { [weak self] in
+      guard let self = self else { return }
+      
+      self.popoverDidDismiss?(self)
+      completion?()
+    }
+  }
 
   override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
 
     if dismissesOnOrientationChanged {
-      dismiss(animated: true)
-      popoverDidDismiss?(self)
+      dismissPopover()
     }
   }
 }
@@ -353,10 +361,9 @@ extension PopoverController {
   @objc private func tappedBackgroundOverlay(_ tap: UITapGestureRecognizer) {
     if tap.state == .ended {
       if contentController.popoverShouldDismiss(self) {
-        dismiss(animated: true)
         // Not sure if we want this after dismissal completes or right away. Could always create a
         // `popoverWillDismiss` to put before and `did` after
-        popoverDidDismiss?(self)
+        dismissPopover()
       }
     }
   }
@@ -425,8 +432,7 @@ extension PopoverController {
       }
 
       if contentController.popoverShouldDismiss(self) && (passedVelocityThreshold || scale < 0.5) {
-        dismiss(animated: true)
-        popoverDidDismiss?(self)
+        dismissPopover()
       } else {
         UIView.animate(
           withDuration: 0.5, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0, options: [.beginFromCurrentState, .allowUserInteraction],

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -208,14 +208,21 @@ extension BrowserViewController {
     let popover = PopoverController(contentController: controller)
     popover.present(from: topToolbar.locationView.shieldsButton, on: self)
 
-    let pulseAnimation = RadialPulsingAnimation(ringCount: 3)
-    pulseAnimation.present(
+    let pulseAnimationView = RadialPulsingAnimation(ringCount: 3)
+    pulseAnimationView.present(
       icon: topToolbar.locationView.shieldsButton.imageView?.image,
       from: topToolbar.locationView.shieldsButton,
       on: popover,
       browser: self)
+    
+    pulseAnimationView.animationViewPressed = { [weak self] in
+      popover.dismissPopover() {
+        self?.presentBraveShieldsViewController()
+      }
+    }
+    
     popover.popoverDidDismiss = { [weak self] _ in
-      pulseAnimation.removeFromSuperview()
+      pulseAnimationView.removeFromSuperview()
 
       DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
         guard let self = self else { return }

--- a/Client/Frontend/Browser/Onboarding/Welcome/OnboardingPulseAnimationView.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/OnboardingPulseAnimationView.swift
@@ -8,11 +8,14 @@ import BraveUI
 
 class RadialPulsingAnimation: UIView {
   private var pulseLayers = [CAShapeLayer]()
+  private var isBreathing: Bool
+  
+  public var animationViewPressed: (() -> Void)?
 
-  init(ringCount: Int) {
+  init(ringCount: Int, isBreathing: Bool = false) {
+    self.isBreathing = isBreathing
     super.init(frame: .zero)
-    isUserInteractionEnabled = false
-
+    
     // [1, 4] => {Y ∈ ℝ: 1 <= Y <= 4} where Y = Thicc, X = amount of rings
     let idealThicc = 1.5
 
@@ -49,8 +52,6 @@ class RadialPulsingAnimation: UIView {
   }
 
   func animate() {
-    let isBreathing = false
-
     if isBreathing {
       let animation = CABasicAnimation(keyPath: "transform.scale")
       animation.toValue = 1.2
@@ -88,7 +89,10 @@ class RadialPulsingAnimation: UIView {
 
   func present(icon: UIImage?, from view: UIView, on popoverController: PopoverController, browser: BrowserViewController) {
     let origin = browser.view.convert(view.center, from: view.superview)
-    popoverController.view.insertSubview(self, aboveSubview: popoverController.backgroundOverlayView)
+    popoverController.view.insertSubview(self, aboveSubview: popoverController.view)
+    
+    let tap = UITapGestureRecognizer(target: self, action: #selector(onPresentShields(_:)))
+    addGestureRecognizer(tap)
 
     if let icon = icon {
       let imageView = UIImageView().then {
@@ -110,5 +114,10 @@ class RadialPulsingAnimation: UIView {
     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
       self.animate()
     }
+  }
+  
+  @objc
+  private func onPresentShields(_ tap: UITapGestureRecognizer) {
+    animationViewPressed?()
   }
 }


### PR DESCRIPTION
Onboarding information pop-over showing #of trackers should be updated. The wave animation is cut by the pop-over window itself and pressing Brave icon should dismiss this pop-over and present Shields screen.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5163

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Fresh Install Brave
- Go over the onboarding
- Open a website like Youtube that will have some trackers blocked
- Check out the display of the animation
- Click Brave Icon to check Brave Shields

## Screenshots:


https://user-images.githubusercontent.com/6643505/160477737-bf7c22e1-5f93-4868-b4b6-7277926369e9.mp4





## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
