### PR TITLE
Fix #5162: Edit button is visible when playing a full screen video in the Playlist

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -556,11 +556,13 @@ extension PlaylistListViewController {
     if PlaylistManager.shared.numberOfAssets > 0 {
       tableView.backgroundView = nil
       tableView.separatorStyle = .singleLine
-
-      if !playerView.isFullscreen, UIDevice.current.orientation.isLandscape && UIDevice.isPhone {
-        navigationController?.setToolbarHidden(true, animated: true)
-      } else {
-        navigationController?.setToolbarHidden(false, animated: true)
+      
+      if !playerView.isFullscreen {
+        if UIDevice.current.orientation.isLandscape && UIDevice.isPhone {
+          navigationController?.setToolbarHidden(true, animated: true)
+        } else {
+          navigationController?.setToolbarHidden(false, animated: true)
+        }
       }
     } else {
       let messageLabel = UILabel(frame: view.bounds).then {
@@ -669,6 +671,8 @@ extension PlaylistListViewController {
 
   func onFullscreen() {
     navigationController?.setNavigationBarHidden(true, animated: true)
+    navigationController?.setToolbarHidden(true, animated: true)
+    
     tableView.isHidden = true
     playerView.snp.remakeConstraints {
       $0.edges.equalToSuperview()

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -489,6 +489,7 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
 
   func onFullscreen() {
     if !UIDevice.isIpad || splitController.isCollapsed {
+      navigationController?.setToolbarHidden(true, animated: false)
       listController.onFullscreen()
     } else {
       detailController.onFullscreen()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5162

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Add a video to playlist
2. Go to the folder where the video is stored
3. Tap on 'full screen' button in top right in the video player

## Screenshots:

https://user-images.githubusercontent.com/6643505/160492034-7c7ef363-37b8-46c3-91bd-714b53495319.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
