### PR TITLE
Fix #5075: Save Tab Data when navigation state changes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1832,6 +1832,11 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             braveCore.historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date(), isURLTyped: false)
           }
         }
+        
+        // Saving Tab. Private Mode - not supported yet.
+        if !tab.isPrivate {
+          tabManager.saveTab(tab)
+        }
       }
 
       TabEvent.post(.didChangeURL(url), for: tab)


### PR DESCRIPTION
## Summary of Changes
- Save the Tab data when the Navigation state changes (`navigateInTab`)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5075

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test session restore on `Youtube` (it should restore the exact video that was last watched)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
