### PR TITLE
Fix #5172: Adding blocklist functionality and night mode darker colors

### DIFF
--- a/BraveUI/Design System/Colors/Colors.swift
+++ b/BraveUI/Design System/Colors/Colors.swift
@@ -184,6 +184,9 @@ extension UIColor {
       return .braveSeparator
     }
   }
+  public static var nightModeBackground: UIColor {
+    return .secondaryBraveBackground
+  }
 }
 
 // MARK: - Static Colors

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -430,6 +430,9 @@ extension BrowserViewController: WKNavigationDelegate {
     guard let tab = tabManager[webView] else { return }
 
     tab.url = webView.url
+    // Need to evaluate Night mode script injection after url is set inside the Tab
+    tab.nightMode = Preferences.General.nightModeEnabled.value
+
     self.scrollController.resetZoomState()
 
     rewards.reportTabNavigation(tabId: tab.rewardsId)

--- a/Client/Frontend/Browser/Helpers/NightModeHelper.swift
+++ b/Client/Frontend/Browser/Helpers/NightModeHelper.swift
@@ -6,6 +6,7 @@ import Foundation
 import WebKit
 import Shared
 import BraveShared
+import Data
 
 class NightModeHelper: TabContentScript {
   fileprivate weak var tab: Tab?
@@ -34,13 +35,16 @@ class NightModeHelper: TabContentScript {
     Preferences.General.nightModeEnabled.value = enabled
 
     for tab in tabManager.allTabs {
-      tab.nightMode = enabled
 
-      // For WKWebView background color to take effect, isOpaque must be false,
-      // which is counter-intuitive. Default is true. The color is previously
-      // set to black in the WKWebView init.
-      tab.webView?.isOpaque = !enabled
-      tab.webView?.scrollView.indicatorStyle = enabled ? .white : .default
+      if let fetchedTabURL = tab.fetchedURL, !fetchedTabURL.isNightModeBlockedURL {
+        tab.nightMode = enabled
+
+        // For WKWebView background color to take effect, isOpaque must be false,
+        // which is counter-intuitive. Default is true. The color is previously
+        // set to black in the WKWebView init.
+        tab.webView?.isOpaque = !enabled
+        tab.webView?.scrollView.indicatorStyle = enabled ? .white : .default
+      }
     }
   }
 }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -220,7 +220,7 @@ class Tab: NSObject {
       
       webView?.evaluateSafeJavaScript(
         functionName: "window.__firefox__.NightMode.setEnabled",
-        args: [nightMode],
+        args: [isNightModeEnabled],
         contentWorld: .defaultClient,
         asFunction: true
       ) { _, error in
@@ -481,7 +481,9 @@ class Tab: NSObject {
         return url
       }
     } else {
-      if let tabID = id {
+      if let tabUrl = url, tabUrl.isWebPage() {
+        return tabUrl
+      } else if let tabID = id {
         let fetchedTab = TabMO.get(fromId: tabID)
         
         if let urlString = fetchedTab?.url, let url = URL(string: urlString), url.isWebPage() {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -472,6 +472,9 @@ class Tab: NSObject {
     return webView?.canGoForward ?? false
   }
   
+  /// This property is for fetching the actual URL for the Tab
+  /// In private browsing the URL is in memory but this is not the case for normal mode
+  /// For Normal  Mode Tab information is fetched using Tab ID from 
   var fetchedURL: URL? {
     if PrivateBrowsingManager.shared.isPrivateBrowsing {
       if let url = url, url.isWebPage() {
@@ -546,6 +549,7 @@ class Tab: NSObject {
     }
 
     if let _ = webView?.reloadFromOrigin() {
+      nightMode = Preferences.General.nightModeEnabled.value
       log.debug("reloaded zombified tab from origin")
       return
     }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -20,6 +20,7 @@ class TabsBarViewController: UIViewController {
   private let rightOverflowIndicator = CAGradientLayer()
 
   weak var delegate: TabsBarViewControllerDelegate?
+  private var cancellables: Set<AnyCancellable> = []
 
   private lazy var plusButton: UIButton = {
     let button = UIButton()
@@ -74,7 +75,7 @@ class TabsBarViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = .urlBarBackground
+    view.backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
     collectionView.backgroundColor = view.backgroundColor
 
     tabManager?.addDelegate(self)
@@ -141,6 +142,13 @@ class TabsBarViewController: UIViewController {
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
         self?.updateColors(isPrivateBrowsing)
       })
+    
+    Preferences.General.nightModeEnabled.objectWillChange
+      .receive(on: RunLoop.main)
+      .sink { [weak self] _ in
+        self?.updateColors(PrivateBrowsingManager.shared.isPrivateBrowsing)
+      }
+      .store(in: &cancellables)
   }
 
   private var privateModeCancellable: AnyCancellable?
@@ -149,7 +157,7 @@ class TabsBarViewController: UIViewController {
     if isPrivateBrowsing {
       backgroundColor = .privateModeBackground
     } else {
-      backgroundColor = .urlBarBackground
+      backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
     }
     view.backgroundColor = backgroundColor
     collectionView.backgroundColor = view.backgroundColor

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -24,13 +24,14 @@ class BottomToolbarView: UIView, ToolbarProtocol {
 
   var helper: ToolbarHelper?
   private let contentView = UIStackView()
+  private var cancellables: Set<AnyCancellable> = []
 
   fileprivate override init(frame: CGRect) {
     actionButtons = [backButton, forwardButton, addTabButton, searchButton, tabsButton, menuButton]
     super.init(frame: frame)
     setupAccessibility()
 
-    backgroundColor = .urlBarBackground
+    backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
 
     addSubview(contentView)
     helper = ToolbarHelper(toolbar: self)
@@ -46,6 +47,13 @@ class BottomToolbarView: UIView, ToolbarProtocol {
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
         self?.updateColors(isPrivateBrowsing)
       })
+    
+    Preferences.General.nightModeEnabled.objectWillChange
+      .receive(on: RunLoop.main)
+      .sink { [weak self] _ in
+        self?.updateColors(PrivateBrowsingManager.shared.isPrivateBrowsing)
+      }
+      .store(in: &cancellables)
   }
 
   private var privateModeCancellable: AnyCancellable?
@@ -53,7 +61,7 @@ class BottomToolbarView: UIView, ToolbarProtocol {
     if isPrivateBrowsing {
       backgroundColor = .privateModeBackground
     } else {
-      backgroundColor = .urlBarBackground
+      backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
     }
   }
 

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -435,16 +435,17 @@ extension URL {
   
   // Check if the website is a night mode blocked site
   public var isNightModeBlockedURL: Bool {
-    guard let domain = self.baseDomain else {
+    guard let host = self.normalizedHostAndPath else {
       return false
     }
 
     /// Site domains that should not inject night mode
     let siteList = ["twitter", "youtube", "twitch",
                     "macrumors", "9to5mac", "soundcloud",
-                    "netflix", "github", "developer.apple"]
+                    "netflix", "github", "developer.apple",
+                    "search.brave", "wowhead"]
 
-    return siteList.contains(where: domain.contains)
+    return siteList.contains(where: host.contains)
   }
 
   // Check if the website is supporting showing Add To playlist toast

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -440,7 +440,9 @@ extension URL {
     }
 
     /// Site domains that should not inject night mode
-    let siteList = ["twitter", "youtube", "amazon"]
+    let siteList = ["twitter", "youtube", "twitch",
+                    "macrumors", "9to5mac", "soundcloud",
+                    "netflix", "github", "developer.apple"]
 
     return siteList.contains(where: domain.contains)
   }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -432,6 +432,18 @@ extension URL {
 
     return siteList.contains(where: domain.contains)
   }
+  
+  // Check if the website is a night mode blocked site
+  public var isNightModeBlockedURL: Bool {
+    guard let domain = self.baseDomain else {
+      return false
+    }
+
+    /// Site domains that should not inject night mode
+    let siteList = ["twitter", "youtube", "amazon"]
+
+    return siteList.contains(where: domain.contains)
+  }
 
   // Check if the website is supporting showing Add To playlist toast
   public var isPlaylistSupportedSiteURL: Bool {


### PR DESCRIPTION
Some websites are automatically following Appearance Preferences of the system and we should not not invert the colours inside these websites.

The list of websites that should not inject Night Mode script which can be seen on ticket. 

In addition when Night Mode is activated, the Appearance of the application is automatically set to dark mode. In addition the colours for bottom and top toolbars colours will be set the darker solids black colour so the indication of dark mode will be better.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5172

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Enable Dark Mode
- Check Blocked website colours are not effected
- Check Un blocked website colours are inverted
- Check enable/disable Night Mode

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/6643505/160706190-b861fe6b-8850-4ca8-91dd-0eade7f980ee.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
