### PR TITLE
Fix #4485: Add toggle to enable/disable wallet biometric unlock

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -53,7 +53,8 @@ struct AccountsHeaderView: View {
         NavigationLink(
           destination: WalletSettingsView(
             settingsStore: settingsStore,
-            networkStore: networkStore)
+            networkStore: networkStore,
+            keyringStore: keyringStore)
         ) {
           Label(Strings.Wallet.settings, image: "brave.gear")
             .labelStyle(.iconOnly)

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -60,7 +60,8 @@ struct CryptoPagesView: View {
       NavigationLink(
         destination: WalletSettingsView(
           settingsStore: cryptoStore.settingsStore,
-          networkStore: cryptoStore.networkStore
+          networkStore: cryptoStore.networkStore,
+          keyringStore: keyringStore
         ),
         isActive: $isShowingSettings
       ) {

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -143,6 +143,7 @@ public class KeyringStore: ObservableObject {
 
   func unlock(password: String, completion: @escaping (Bool) -> Void) {
     if !keyring.isKeyringCreated {
+      completion(false)
       return
     }
     keyringService.unlock(password) { [weak self] unlocked in
@@ -157,6 +158,7 @@ public class KeyringStore: ObservableObject {
   
   func validate(password: String, completion: @escaping (Bool) -> Void) {
     if !keyring.isKeyringCreated {
+      completion(false)
       return
     }
     keyringService.validatePassword(password, completion: completion)

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -154,6 +154,13 @@ public class KeyringStore: ObservableObject {
       self?.updateKeyringInfo()
     }
   }
+  
+  func validate(password: String, completion: @escaping (Bool) -> Void) {
+    if !keyring.isKeyringCreated {
+      return
+    }
+    keyringService.validatePassword(password, completion: completion)
+  }
 
   func isStrongPassword(_ password: String, completion: @escaping (Bool) -> Void) {
     keyringService.isStrongPassword(password, completion: completion)

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import LocalAuthentication
 import BraveCore
 
 public class SettingsStore: ObservableObject {
@@ -12,6 +13,16 @@ public class SettingsStore: ObservableObject {
     didSet {
       keyringService.setAutoLockMinutes(autoLockInterval.value) { _ in }
     }
+  }
+
+  /// If we should attempt to unlock via biometrics (Face ID / Touch ID)
+  var isBiometricsUnlockEnabled: Bool {
+    KeyringStore.isKeychainPasswordStored && isBiometricsAvailable
+  }
+
+  /// If the device has biometrics available
+  var isBiometricsAvailable: Bool {
+    LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
   }
 
   private let keyringService: BraveWalletKeyringService

--- a/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
+++ b/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
@@ -1,0 +1,112 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveUI
+import struct Shared.Strings
+import SwiftUI
+
+struct BiometricsPasscodeEntryView: View {
+  
+  @ObservedObject var keyringStore: KeyringStore
+  
+  private enum UnlockError: LocalizedError {
+    case incorrectPassword
+    
+    var errorDescription: String? {
+      switch self {
+      case .incorrectPassword:
+        return Strings.Wallet.incorrectPasswordErrorMessage
+      }
+    }
+  }
+  
+  @State private var password: String = ""
+  /// Error occured when user entered their password
+  @State private var unlockError: UnlockError?
+  /// Flag used to determine if we should show an error alert because we failed to store the password in the keychain
+  @State private var isShowingKeychainError: Bool = false
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
+  private var isPasswordValid: Bool {
+    !password.isEmpty
+  }
+  
+  private func unlock() {
+    keyringStore.validate(password: password) { isValid in
+      if isValid {
+        // store password in keychain
+        if case let status = KeyringStore.storePasswordInKeychain(password),
+           status != errSecSuccess {
+          self.isShowingKeychainError = true
+        } else {
+          // password stored in keychain, dismiss modal
+          presentationMode.dismiss()
+        }
+      } else {
+        // Conflict with the keyboard submit/dismissal that causes a bug
+        // with SwiftUI animating the screen away...
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+          unlockError = .incorrectPassword
+          UIImpactFeedbackGenerator(style: .medium).bzzt()
+        }
+      }
+    }
+  }
+  
+  var body: some View {
+    NavigationView {
+      ScrollView(.vertical) {
+        VStack(spacing: 46) {
+          Image("graphic-lock")
+            .padding(.bottom)
+            .accessibilityHidden(true)
+          VStack {
+            Text(Strings.Wallet.enterPasswordForBiometricsTitle)
+              .font(.headline)
+              .padding(.bottom)
+              .multilineTextAlignment(.center)
+              .fixedSize(horizontal: false, vertical: true)
+            SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: unlock)
+              .textContentType(.password)
+              .font(.subheadline)
+              .introspectTextField(customize: { tf in
+                tf.becomeFirstResponder()
+              })
+              .textFieldStyle(BraveValidatedTextFieldStyle(error: unlockError))
+              .padding(.horizontal, 48)
+          }
+          Button(action: unlock) {
+            Text(Strings.Wallet.saveButtonTitle)
+          }
+          .buttonStyle(BraveFilledButtonStyle(size: .normal))
+          .disabled(!isPasswordValid)
+          .frame(maxWidth: .infinity)
+          .listRowInsets(.zero)
+        }
+        .padding()
+        .padding(.vertical)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(Strings.Wallet.enterPasswordForBiometricsNavTitle)
+        .alert(isPresented: $isShowingKeychainError) {
+          Alert(
+            title: Text(Strings.Wallet.biometricsSetupErrorTitle),
+            message: Text(Strings.Wallet.biometricsSetupErrorMessage),
+            dismissButton: .default(Text(Strings.OKString))
+          )
+        }
+      }
+    }
+  }
+}
+
+#if DEBUG
+struct BiometricsPasscodeEntryView_Previews: PreviewProvider {
+  static var previews: some View {
+    BiometricsPasscodeEntryView(
+      keyringStore: .previewStore
+    )
+  }
+}
+#endif

--- a/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
+++ b/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
@@ -58,9 +58,8 @@ struct BiometricsPasscodeEntryView: View {
   var body: some View {
     NavigationView {
       ScrollView(.vertical) {
-        VStack(spacing: 46) {
+        VStack(spacing: 36) {
           Image("graphic-lock")
-            .padding(.bottom)
             .accessibilityHidden(true)
           VStack {
             Text(Strings.Wallet.enterPasswordForBiometricsTitle)

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -10,16 +10,21 @@ import BraveUI
 public struct WalletSettingsView: View {
   @ObservedObject var settingsStore: SettingsStore
   @ObservedObject var networkStore: NetworkStore
+  @ObservedObject var keyringStore: KeyringStore
 
   @State private var isShowingResetWalletAlert = false
   @State private var isShowingResetTransactionAlert = false
+  /// If we are showing the modal so the user can enter their password to enable unlock via biometrics.
+  @State private var isShowingBiometricsPasswordEntry = false
 
   public init(
     settingsStore: SettingsStore,
-    networkStore: NetworkStore
+    networkStore: NetworkStore,
+    keyringStore: KeyringStore
   ) {
     self.settingsStore = settingsStore
     self.networkStore = networkStore
+    self.keyringStore = keyringStore
   }
 
   private var autoLockIntervals: [AutoLockInterval] {
@@ -51,6 +56,21 @@ public struct WalletSettingsView: View {
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      if settingsStore.isBiometricsAvailable, keyringStore.keyring.isKeyringCreated, !keyringStore.keyring.isLocked {
+        Section(
+          footer: Text(Strings.Wallet.settingsEnableBiometricsFooter)
+            .foregroundColor(Color(.secondaryBraveLabel))
+        ) {
+          Toggle(
+            Strings.Wallet.settingsEnableBiometricsTitle,
+            isOn: Binding(get: { settingsStore.isBiometricsUnlockEnabled },
+                          set: { toggledBiometricsUnlock($0) })
+          )
+            .foregroundColor(Color(.braveLabel))
+            .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+        }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      }
       Section(
         footer: Text(Strings.Wallet.networkFooter)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -113,6 +133,20 @@ public struct WalletSettingsView: View {
           )
         }
     )
+    .background(
+      Color.clear
+        .sheet(isPresented: $isShowingBiometricsPasswordEntry) {
+          BiometricsPasscodeEntryView(keyringStore: keyringStore)
+        }
+    )
+  }
+  
+  private func toggledBiometricsUnlock(_ enabled: Bool) {
+    if enabled {
+      self.isShowingBiometricsPasswordEntry = true
+    } else {
+      KeyringStore.resetKeychainStoredPassword()
+    }
   }
 }
 
@@ -122,7 +156,8 @@ struct WalletSettingsView_Previews: PreviewProvider {
     NavigationView {
       WalletSettingsView(
         settingsStore: .previewStore,
-        networkStore: .previewStore
+        networkStore: .previewStore,
+        keyringStore: .previewStore
       )
     }
   }

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -56,7 +56,7 @@ public struct WalletSettingsView: View {
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
-      if settingsStore.isBiometricsAvailable, keyringStore.keyring.isKeyringCreated, !keyringStore.keyring.isLocked {
+      if settingsStore.isBiometricsAvailable, keyringStore.keyring.isKeyringCreated {
         Section(
           footer: Text(Strings.Wallet.settingsEnableBiometricsFooter)
             .foregroundColor(Color(.secondaryBraveLabel))

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1951,7 +1951,7 @@ extension Strings {
       "wallet.settingsEnableBiometricsFooter",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Toggle if biometrics can be used to unlock your wallet",
+      value: "Toggle on if you'd like to use biometrics (Face ID / Touch ID) to unlock your wallet",
       comment: "The footer beneath the toggle for allowing biometrics to unlock the wallet in wallet settings."
     )
     public static let enterPasswordForBiometricsNavTitle = NSLocalizedString(
@@ -1965,7 +1965,7 @@ extension Strings {
       "wallet.enterPasswordForBiometricsTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Enter passcode to enable biometrics for wallet",
+      value: "Enter passcode to enable biometrics for wallet (you'll only be asked for this once)",
       comment: "The title displayed on the screen to enter password to enable biometrics unlock from wallet settings."
     )
   }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1965,7 +1965,7 @@ extension Strings {
       "wallet.enterPasswordForBiometricsTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Enter passcode to enable biometrics for wallet (you'll only be asked for this once)",
+      value: "Enter your wallet password to enable biometrics for wallet (you'll only be asked for this once)",
       comment: "The title displayed on the screen to enter password to enable biometrics unlock from wallet settings."
     )
   }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1940,5 +1940,33 @@ extension Strings {
       value: "Sent",
       comment: "As in sent cryptocurrency from one asset to another"
     )
+    public static let settingsEnableBiometricsTitle = NSLocalizedString(
+      "wallet.settingsEnableBiometricsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Allow Biometric Unlock",
+      comment: "A label beside the toggle for allowing biometrics to unlock the wallet in wallet settings."
+    )
+    public static let settingsEnableBiometricsFooter = NSLocalizedString(
+      "wallet.settingsEnableBiometricsFooter",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Toggle if biometrics can be used to unlock your wallet",
+      comment: "The footer beneath the toggle for allowing biometrics to unlock the wallet in wallet settings."
+    )
+    public static let enterPasswordForBiometricsNavTitle = NSLocalizedString(
+      "wallet.enterPasswordForBiometricsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enable Biometrics",
+      comment: "The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings."
+    )
+    public static let enterPasswordForBiometricsTitle = NSLocalizedString(
+      "wallet.enterPasswordForBiometricsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Enter passcode to enable biometrics for wallet",
+      comment: "The title displayed on the screen to enter password to enable biometrics unlock from wallet settings."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1955,7 +1955,7 @@ extension Strings {
       comment: "The footer beneath the toggle for allowing biometrics to unlock the wallet in wallet settings."
     )
     public static let enterPasswordForBiometricsNavTitle = NSLocalizedString(
-      "wallet.enterPasswordForBiometricsTitle",
+      "wallet.enterPasswordForBiometricsNavTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Enable Biometrics",

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1152,6 +1152,7 @@
 		D506715C27E2AAB700560631 /* TransactionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D506715B27E2AAB700560631 /* TransactionHeader.swift */; };
 		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
 		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
+		D5C51E6C27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */; };
 		D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */; };
 		D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */; };
 		D8D33A7D1FBD080300A20A28 /* SnapKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */; };
@@ -3122,6 +3123,7 @@
 		D506715B27E2AAB700560631 /* TransactionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHeader.swift; sourceTree = "<group>"; };
 		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
+		D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsPasscodeEntryView.swift; sourceTree = "<group>"; };
 		D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensions.swift; sourceTree = "<group>"; };
 		D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientProgressBar.swift; sourceTree = "<group>"; };
 		D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapKitExtensions.swift; sourceTree = "<group>"; };
@@ -4097,6 +4099,7 @@
 				7DC054A327A200EC00BBA042 /* CustomNetworkListView.swift */,
 				7D4C49502791D2450073C37E /* CustomNetworkDetailsView.swift */,
 				275034E226EF9E6A00CF4C8A /* WalletSettingsView.swift */,
+				D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -7988,6 +7991,7 @@
 				7DC054C227A9CCA400BBA042 /* KeyringServiceExtensions.swift in Sources */,
 				D506715C27E2AAB700560631 /* TransactionHeader.swift in Sources */,
 				277309DE2721DDFB007643F6 /* WeiFormatter.swift in Sources */,
+				D5C51E6C27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift in Sources */,
 				271F689926EBD27E00AA2A50 /* Address.swift in Sources */,
 				270E5F3226F3E1B40024C70E /* BraveWalletSwiftUIExtensions.swift in Sources */,
 				27E17B8E2744128200F3C282 /* MockAssetRatioService.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -160,6 +160,11 @@ extension BrowserViewController {
         let networkStore = BraveWallet.JsonRpcServiceFactory
           .get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
           .map({ NetworkStore(rpcService: $0) })
+        
+        var keyringStore: KeyringStore?
+        if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
+            keyringStore = KeyringStore(keyringService: keyringService)
+        }
 
         let vc = SettingsViewController(
           profile: self.profile,
@@ -170,7 +175,8 @@ extension BrowserViewController {
           windowProtection: self.windowProtection,
           braveCore: self.braveCore,
           walletSettingsStore: settingsStore,
-          walletNetworkStore: networkStore)
+          walletNetworkStore: networkStore,
+          keyringStore: keyringStore)
         vc.settingsDelegate = self
         menuController.pushInnerMenu(vc)
       }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -65,6 +65,7 @@ class SettingsViewController: TableViewController {
   private let syncAPI: BraveSyncAPI
   private let walletSettingsStore: SettingsStore?
   private let walletNetworkStore: NetworkStore?
+  private let keyringStore: KeyringStore?
   private let windowProtection: WindowProtection?
 
   private let featureSectionUUID: UUID = .init()
@@ -79,7 +80,8 @@ class SettingsViewController: TableViewController {
     windowProtection: WindowProtection?,
     braveCore: BraveCoreMain,
     walletSettingsStore: SettingsStore? = nil,
-    walletNetworkStore: NetworkStore? = nil
+    walletNetworkStore: NetworkStore? = nil,
+    keyringStore: KeyringStore? = nil
   ) {
     self.profile = profile
     self.tabManager = tabManager
@@ -92,6 +94,7 @@ class SettingsViewController: TableViewController {
     self.syncAPI = braveCore.syncAPI
     self.walletSettingsStore = walletSettingsStore
     self.walletNetworkStore = walletNetworkStore
+    self.keyringStore = keyringStore
 
     super.init(style: .insetGrouped)
   }
@@ -667,7 +670,7 @@ class SettingsViewController: TableViewController {
   }()
 
   private func setUpSections() {
-    if let settingsStore = walletSettingsStore, let networkStore = walletNetworkStore {
+    if let settingsStore = walletSettingsStore, let networkStore = walletNetworkStore, let keyringStore = keyringStore {
       settingsStore.isDefaultKeyringCreated { [weak self] created in
         guard let self = self else { return }
         var copyOfSections = self.sections
@@ -683,7 +686,12 @@ class SettingsViewController: TableViewController {
               Row(
                 text: Strings.Wallet.braveWallet,
                 selection: { [unowned self] in
-                  let vc = UIHostingController(rootView: WalletSettingsView(settingsStore: settingsStore, networkStore: networkStore))
+                  let walletSettingsView = WalletSettingsView(
+                    settingsStore: settingsStore,
+                    networkStore: networkStore,
+                    keyringStore: keyringStore
+                  )
+                  let vc = UIHostingController(rootView: walletSettingsView)
                   self.navigationController?.pushViewController(vc, animated: true)
                 },
                 image: #imageLiteral(resourceName: "menu-crypto").template,


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #4485

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open and unlock Wallet 
2. Navigate to Wallet Settings
3. Enable/disable toggle 'Allow Biometric Unlock'. Enable should present modal for verifying password, disable should just disable.


## Screenshots:
![IMG_2424](https://user-images.githubusercontent.com/5314553/160923439-2a35deb8-255e-4ab2-98d0-81ee843e5f84.PNG)
![IMG_2425](https://user-images.githubusercontent.com/5314553/160923451-ba2e57a0-2678-4d35-b845-8f1b6ceff0cc.PNG)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
