### PR TITLE
Fix #5179: Tab Tray does not work in landscape mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -33,7 +33,8 @@ extension BrowserViewController: TopToolbarDelegate {
     let tabTrayController = TabTrayController(tabManager: tabManager).then {
       $0.delegate = self
     }
-    let container = SettingsNavigationController(rootViewController: tabTrayController)
+    let container = UINavigationController(rootViewController: tabTrayController)
+
     if !UIAccessibility.isReduceMotionEnabled {
       container.transitioningDelegate = tabTrayController
       container.modalPresentationStyle = .fullScreen

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -95,6 +95,8 @@ class TabTrayController: LoadingViewController {
     }
 
     navigationItem.do {
+      // Place the search bar in the navigation item's title view.
+      $0.titleView = searchBarView
       $0.hidesSearchBarWhenScrolling = true
     }
 
@@ -126,10 +128,6 @@ class TabTrayController: LoadingViewController {
       UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil),
       UIBarButtonItem(customView: tabTrayView.doneButton),
     ]
-    
-    // Place the search bar in the navigation item's title view.
-    searchBarView?.frame = navigationController?.navigationBar.frame ?? .zero
-    navigationItem.titleView = searchBarView
   }
 
   private var initialScrollCompleted = false

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -54,6 +54,7 @@ class TabTrayController: LoadingViewController {
   private var isTabTrayBeingSearched = false
   private let tabTraySearchController = UISearchController(searchResultsController: nil)
   private var tabTraySearchQuery = ""
+  private var searchBarView: TabTraySearchBar?
 
   private lazy var emptyStateOverlayView: UIView = EmptyStateOverlayView(description: Strings.noSearchResultsfound)
 
@@ -79,7 +80,7 @@ class TabTrayController: LoadingViewController {
 
     definesPresentationContext = true
 
-    let searchBarView = TabTraySearchBar(searchBar: tabTraySearchController.searchBar).then {
+    searchBarView = TabTraySearchBar(searchBar: tabTraySearchController.searchBar).then {
       $0.searchBar.autocapitalizationType = .none
       $0.searchBar.autocorrectionType = .no
       $0.searchBar.placeholder = Strings.tabTraySearchBarTitle
@@ -94,8 +95,6 @@ class TabTrayController: LoadingViewController {
     }
 
     navigationItem.do {
-      // Place the search bar in the navigation item's title view.
-      $0.titleView = searchBarView
       $0.hidesSearchBarWhenScrolling = true
     }
 
@@ -127,6 +126,10 @@ class TabTrayController: LoadingViewController {
       UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil),
       UIBarButtonItem(customView: tabTrayView.doneButton),
     ]
+    
+    // Place the search bar in the navigation item's title view.
+    searchBarView?.frame = navigationController?.navigationBar.frame ?? .zero
+    navigationItem.titleView = searchBarView
   }
 
   private var initialScrollCompleted = false
@@ -145,6 +148,16 @@ class TabTrayController: LoadingViewController {
 
       initialScrollCompleted = true
     }
+  }
+  
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+
+    searchBarView?.frame = navigationController?.navigationBar.frame ?? .zero
+    navigationItem.titleView = searchBarView
+    
+    searchBarView?.setNeedsLayout()
+    searchBarView?.layoutIfNeeded()
   }
 
   // MARK: Snapshot handling
@@ -472,7 +485,19 @@ class TabTraySearchBar: UIView {
 
   override func layoutSubviews() {
     super.layoutSubviews()
-    searchBar.frame = bounds
+    
+    var adjustedFrame = bounds
+    
+    // Adjusting search bar bounds here for landscape iPhones, needs padding from top and bottom
+    if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .compact {
+      adjustedFrame = CGRect(
+        x: adjustedFrame.origin.x,
+        y: adjustedFrame.origin.y + 2,
+        width: adjustedFrame.size.width,
+        height: adjustedFrame.size.height - 4)
+    }
+    
+    searchBar.frame = adjustedFrame
   }
 
   override func sizeThatFits(_ size: CGSize) -> CGSize {


### PR DESCRIPTION
Changing Tray Tray Navigation controller and small changes are made for search bar frame to adjust properly with landscape.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5179

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Use Brave in landscape mode on iPhone
- Tap on Tabs button to open up the tab tray

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/6643505/160931543-fd549cc9-a69b-428a-8c20-9a0398c703a0.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
