### PR TITLE
Fix #5106: Wallet edit site connection integration 

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountView.swift
@@ -13,11 +13,12 @@ struct AccountView: View {
   var name: String
 
   @ScaledMetric private var avatarSize = 40.0
+  private let maxAvatarSize: CGFloat = 80.0
 
   var body: some View {
     HStack {
       Blockie(address: address)
-        .frame(width: avatarSize, height: avatarSize)
+        .frame(width: min(avatarSize, maxAvatarSize), height: min(avatarSize, maxAvatarSize))
       VStack(alignment: .leading, spacing: 2) {
         Text(name)
           .fontWeight(.semibold)

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -165,16 +165,14 @@ public struct CryptoView: View {
                 }
               }
             case .editSiteConnection(let origin, let handler):
-              if let url = origin.url {
-                EditSiteConnectionView(
-                  keyringStore: keyringStore,
-                  originURL: url,
-                  onDismiss: { accounts in
-                    handler(accounts)
-                    dismissAction?()
-                  }
-                )
-              }
+              EditSiteConnectionView(
+                keyringStore: keyringStore,
+                origin: origin,
+                onDismiss: { accounts in
+                  handler(accounts)
+                  dismissAction?()
+                }
+              )
             }
           }
           .transition(.asymmetric(insertion: .identity, removal: .opacity))

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -56,8 +56,9 @@ public struct CryptoView: View {
   private var dismissButtonToolbarContents: some ToolbarContent {
     ToolbarItemGroup(placement: .cancellationAction) {
       Button(action: {
-        if case .requestEthererumPermissions(let request) = presentingContext {
+        if case .requestEthererumPermissions(let request, let handler) = presentingContext {
           request.decisionHandler(.rejected)
+          handler([])
         }
         dismissAction?()
       }) {
@@ -90,16 +91,18 @@ public struct CryptoView: View {
                   dismissAction?()
                 }
               )
-            case .requestEthererumPermissions(let request):
+            case .requestEthererumPermissions(let request, let handler):
               NewSiteConnectionView(
                 origin: request.requestingOrigin,
                 keyringStore: keyringStore,
                 onConnect: {
                   request.decisionHandler(.granted(accounts: $0))
+                  handler($0)
                   dismissAction?()
                 },
                 onDismiss: {
                   request.decisionHandler(.rejected)
+                  handler([])
                   dismissAction?()
                 }
               )

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -164,6 +164,17 @@ public struct CryptoView: View {
                   dismissButtonToolbarContents
                 }
               }
+            case .editSiteConnection(let origin, let handler):
+              if let url = origin.url {
+                EditSiteConnectionView(
+                  keyringStore: keyringStore,
+                  originURL: url,
+                  onDismiss: { accounts in
+                    handler(accounts)
+                    dismissAction?()
+                  }
+                )
+              }
             }
           }
           .transition(.asymmetric(insertion: .identity, removal: .opacity))

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -56,9 +56,9 @@ public struct CryptoView: View {
   private var dismissButtonToolbarContents: some ToolbarContent {
     ToolbarItemGroup(placement: .cancellationAction) {
       Button(action: {
-        if case .requestEthererumPermissions(let request, let handler) = presentingContext {
+        if case .requestEthererumPermissions(let request, let onPermittedAccountsUpdated) = presentingContext {
           request.decisionHandler(.rejected)
-          handler([])
+          onPermittedAccountsUpdated([])
         }
         dismissAction?()
       }) {
@@ -91,18 +91,18 @@ public struct CryptoView: View {
                   dismissAction?()
                 }
               )
-            case .requestEthererumPermissions(let request, let handler):
+            case .requestEthererumPermissions(let request, let onPermittedAccountsUpdated):
               NewSiteConnectionView(
                 origin: request.requestingOrigin,
                 keyringStore: keyringStore,
                 onConnect: {
                   request.decisionHandler(.granted(accounts: $0))
-                  handler($0)
+                  onPermittedAccountsUpdated($0)
                   dismissAction?()
                 },
                 onDismiss: {
                   request.decisionHandler(.rejected)
-                  handler([])
+                  onPermittedAccountsUpdated([])
                   dismissAction?()
                 }
               )

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -54,6 +54,53 @@ struct EditSiteConnectionView: View {
     }
   }
   
+  @ViewBuilder private func editButton(action: EditAction, account: BraveWallet.AccountInfo) -> some View {
+    Button {
+      switch action {
+      case .connect:
+        if let url = origin.url {
+          Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: true)
+        }
+        permittedAccounts.append(account.address)
+        keyringStore.selectedAccount = account
+      case .disconnect:
+        if let url = origin.url {
+          Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: false)
+        }
+        permittedAccounts.removeAll(where: { $0 == account.address })
+        
+        if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
+          keyringStore.selectedAccount = firstAllowedAccount
+        }
+      case .switch:
+        keyringStore.selectedAccount = account
+      }
+    } label: {
+      Text(action.title)
+        .foregroundColor(Color(.braveBlurpleTint))
+        .font(.footnote.weight(.semibold))
+    }
+  }
+  
+  @ViewBuilder private var connectionInfo: some View {
+    Image(systemName: "globe")
+      .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
+      .background(Color(.braveDisabled))
+      .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    VStack(alignment: sizeCategory.isAccessibilityCategory ? .center : .leading, spacing: 2) {
+      origin.url.map { url in
+        Text(verbatim: url.absoluteString)
+          .font(.subheadline.weight(.semibold))
+          .multilineTextAlignment(.center)
+          .foregroundColor(Color(.bravePrimary))
+      }
+      Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
+        .font(.footnote)
+        .multilineTextAlignment(.center)
+        .foregroundColor(Color(.braveLabel))
+    }
+  }
+  
   var body: some View {
     NavigationView {
       Form {
@@ -64,61 +111,13 @@ struct EditSiteConnectionView: View {
               VStack {
                 AccountView(address: account.address, name: account.name)
                 Spacer()
-                Button {
-                  switch action {
-                  case .connect:
-                    if let url = origin.url {
-                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: true)
-                    }
-                    permittedAccounts.append(account.address)
-                    keyringStore.selectedAccount = account
-                  case .disconnect:
-                    if let url = origin.url {
-                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: false)
-                    }
-                    permittedAccounts.removeAll(where: { $0 == account.address })
-                    
-                    if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
-                      keyringStore.selectedAccount = firstAllowedAccount
-                    }
-                  case .switch:
-                    keyringStore.selectedAccount = account
-                  }
-                } label: {
-                  Text(action.title)
-                    .foregroundColor(Color(.braveBlurpleTint))
-                    .font(.footnote.weight(.semibold))
-                }
+                editButton(action: action, account: account)
               }
             } else {
               HStack {
                 AccountView(address: account.address, name: account.name)
                 Spacer()
-                Button {
-                  switch action {
-                  case .connect:
-                    if let url = origin.url {
-                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: true)
-                    }
-                    permittedAccounts.append(account.address)
-                    keyringStore.selectedAccount = account
-                  case .disconnect:
-                    if let url = origin.url {
-                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: false)
-                    }
-                    permittedAccounts.removeAll(where: { $0 == account.address })
-                    
-                    if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
-                      keyringStore.selectedAccount = firstAllowedAccount
-                    }
-                  case .switch:
-                    keyringStore.selectedAccount = account
-                  }
-                } label: {
-                  Text(action.title)
-                    .foregroundColor(Color(.braveBlurpleTint))
-                    .font(.footnote.weight(.semibold))
-                }
+                editButton(action: action, account: account)
               }
             }
           }
@@ -126,39 +125,11 @@ struct EditSiteConnectionView: View {
           Group {
             if sizeCategory.isAccessibilityCategory {
               VStack(spacing: 12) {
-                Image(systemName: "globe")
-                  .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
-                  .background(Color(.braveDisabled))
-                  .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                VStack(spacing: 2) {
-                  origin.url.map { url in
-                    Text(verbatim: url.absoluteString)
-                      .font(.subheadline.weight(.semibold))
-                      .multilineTextAlignment(.center)
-                      .foregroundColor(Color(.bravePrimary))
-                  }
-                  Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
-                    .font(.footnote)
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Color(.braveLabel))
-                }
+                connectionInfo
               }
             } else {
               HStack(spacing: 12) {    
-                Image(systemName: "globe")
-                  .frame(width: faviconSize, height: faviconSize)
-                  .background(Color(.braveDisabled))
-                  .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                VStack(alignment: .leading, spacing: 2) {
-                  origin.url.map { url in
-                    Text(verbatim: url.absoluteString)
-                      .font(.subheadline.weight(.semibold))
-                      .foregroundColor(Color(.bravePrimary))
-                  }
-                  Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
-                    .font(.footnote)
-                    .foregroundColor(Color(.braveLabel))
-                }
+                connectionInfo
               }
             }
           }

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -15,7 +15,10 @@ struct EditSiteConnectionView: View {
   var originURL: URL
   var onDismiss: (_ permittedAccounts: [String]) -> Void
   
+  @Environment(\.sizeCategory) private var sizeCategory
+  
   @ScaledMetric private var faviconSize = 48
+  private let maxFaviconSize: CGFloat = 96
   
   @State private var permittedAccounts: [String] = []
   
@@ -57,45 +60,94 @@ struct EditSiteConnectionView: View {
         Section {
           ForEach(keyringStore.keyring.accountInfos, id: \.self) { account in
             let action = editAction(for: account)
-            HStack {
-              AccountView(address: account.address, name: account.name)
-              Spacer()
-              Button {
-                switch action {
-                case .connect:
-                  Domain.setEthereumPermissions(forUrl: originURL, account: account.address, grant: true)
-                  permittedAccounts.append(account.address)
-                  keyringStore.selectedAccount = account
-                case .disconnect:
-                  Domain.setEthereumPermissions(forUrl: originURL, account: account.address, grant: false)
-                  permittedAccounts.removeAll(where: { $0 == account.address })
-                  
-                  if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
-                    keyringStore.selectedAccount = firstAllowedAccount
+            if sizeCategory.isAccessibilityCategory {
+              VStack {
+                AccountView(address: account.address, name: account.name)
+                Spacer()
+                Button {
+                  switch action {
+                  case .connect:
+                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: true)
+                    permittedAccounts.append(account.address)
+                    keyringStore.selectedAccount = account
+                  case .disconnect:
+                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: false)
+                    permittedAccounts.removeAll(where: { $0 == account.address })
+                    
+                    if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
+                      keyringStore.selectedAccount = firstAllowedAccount
+                    }
+                  case .switch:
+                    keyringStore.selectedAccount = account
                   }
-                case .switch:
-                  keyringStore.selectedAccount = account
+                } label: {
+                  Text(action.title)
+                    .foregroundColor(Color(.braveBlurpleTint))
+                    .font(.footnote.weight(.semibold))
                 }
-              } label: {
-                Text(action.title)
-                  .foregroundColor(Color(.braveBlurpleTint))
-                  .font(.footnote.weight(.semibold))
+              }
+            } else {
+              HStack {
+                AccountView(address: account.address, name: account.name)
+                Spacer()
+                Button {
+                  switch action {
+                  case .connect:
+                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: true)
+                    permittedAccounts.append(account.address)
+                    keyringStore.selectedAccount = account
+                  case .disconnect:
+                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: false)
+                    permittedAccounts.removeAll(where: { $0 == account.address })
+                    
+                    if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
+                      keyringStore.selectedAccount = firstAllowedAccount
+                    }
+                  case .switch:
+                    keyringStore.selectedAccount = account
+                  }
+                } label: {
+                  Text(action.title)
+                    .foregroundColor(Color(.braveBlurpleTint))
+                    .font(.footnote.weight(.semibold))
+                }
               }
             }
           }
         } header: {
-          HStack(spacing: 12) {
-            Image(systemName: "globe")
-              .frame(width: faviconSize, height: faviconSize)
-              .background(Color(.braveDisabled))
-              .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-            VStack(alignment: .leading, spacing: 2) {
-              Text(verbatim: originURL.absoluteDisplayString)
-                .font(.subheadline.weight(.semibold))
-                .foregroundColor(Color(.bravePrimary))
-              Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
-                .font(.footnote)
-                .foregroundColor(Color(.braveLabel))
+          Group {
+            if sizeCategory.isAccessibilityCategory {
+              VStack(spacing: 12) {
+                Image(systemName: "globe")
+                  .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
+                  .background(Color(.braveDisabled))
+                  .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                VStack(spacing: 2) {
+                  Text(verbatim: origin.absoluteString)
+                    .font(.subheadline.weight(.semibold))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Color(.bravePrimary))
+                  Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
+                    .font(.footnote)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Color(.braveLabel))
+                }
+              }
+            } else {
+              HStack(spacing: 12) {
+                Image(systemName: "globe")
+                  .frame(width: faviconSize, height: faviconSize)
+                  .background(Color(.braveDisabled))
+                  .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                VStack(alignment: .leading, spacing: 2) {
+                  Text(verbatim: origin.absoluteString)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Color(.bravePrimary))
+                  Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
+                    .font(.footnote)
+                    .foregroundColor(Color(.braveLabel))
+                }
+              }
             }
           }
           .frame(maxWidth: .infinity, alignment: .leading)

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -54,6 +54,16 @@ struct EditSiteConnectionView: View {
     }
   }
   
+  private var connectedAddresses: String {
+    let account = Strings.Wallet.editSiteConnectionAccountSingular
+    let accounts = Strings.Wallet.editSiteConnectionAccountPlural
+    return String.localizedStringWithFormat(
+      Strings.Wallet.editSiteConnectionConnectedAccount,
+      permittedAccounts.count,
+      permittedAccounts.count == 1 ? account : accounts
+    )
+  }
+  
   @ViewBuilder private func editButton(action: EditAction, account: BraveWallet.AccountInfo) -> some View {
     Button {
       switch action {
@@ -94,7 +104,7 @@ struct EditSiteConnectionView: View {
           .multilineTextAlignment(.center)
           .foregroundColor(Color(.bravePrimary))
       }
-      Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
+      Text(connectedAddresses)
         .font(.footnote)
         .multilineTextAlignment(.center)
         .foregroundColor(Color(.braveLabel))

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -13,7 +13,7 @@ import Data
 struct EditSiteConnectionView: View {
   @ObservedObject var keyringStore: KeyringStore
   var originURL: URL
-  var onDismiss: ([String]) -> Void
+  var onDismiss: (_ permittedAccounts: [String]) -> Void
   
   @ScaledMetric private var faviconSize = 48
   

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -12,7 +12,7 @@ import Data
 
 struct EditSiteConnectionView: View {
   @ObservedObject var keyringStore: KeyringStore
-  var originURL: URL
+  var origin: URLOrigin
   var onDismiss: (_ permittedAccounts: [String]) -> Void
   
   @Environment(\.sizeCategory) private var sizeCategory
@@ -67,11 +67,15 @@ struct EditSiteConnectionView: View {
                 Button {
                   switch action {
                   case .connect:
-                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: true)
+                    if let url = origin.url {
+                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: true)
+                    }
                     permittedAccounts.append(account.address)
                     keyringStore.selectedAccount = account
                   case .disconnect:
-                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: false)
+                    if let url = origin.url {
+                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: false)
+                    }
                     permittedAccounts.removeAll(where: { $0 == account.address })
                     
                     if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
@@ -93,11 +97,15 @@ struct EditSiteConnectionView: View {
                 Button {
                   switch action {
                   case .connect:
-                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: true)
+                    if let url = origin.url {
+                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: true)
+                    }
                     permittedAccounts.append(account.address)
                     keyringStore.selectedAccount = account
                   case .disconnect:
-                    Domain.setEthereumPermissions(forUrl: origin, account: account.address, grant: false)
+                    if let url = origin.url {
+                      Domain.setEthereumPermissions(forUrl: url, account: account.address, grant: false)
+                    }
                     permittedAccounts.removeAll(where: { $0 == account.address })
                     
                     if let firstAllowedAdd = permittedAccounts.first, let firstAllowedAccount = keyringStore.keyring.accountInfos.first(where: { $0.id == firstAllowedAdd }) {
@@ -123,10 +131,12 @@ struct EditSiteConnectionView: View {
                   .background(Color(.braveDisabled))
                   .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 VStack(spacing: 2) {
-                  Text(verbatim: origin.absoluteString)
-                    .font(.subheadline.weight(.semibold))
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Color(.bravePrimary))
+                  origin.url.map { url in
+                    Text(verbatim: url.absoluteString)
+                      .font(.subheadline.weight(.semibold))
+                      .multilineTextAlignment(.center)
+                      .foregroundColor(Color(.bravePrimary))
+                  }
                   Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
                     .font(.footnote)
                     .multilineTextAlignment(.center)
@@ -134,15 +144,17 @@ struct EditSiteConnectionView: View {
                 }
               }
             } else {
-              HStack(spacing: 12) {
+              HStack(spacing: 12) {    
                 Image(systemName: "globe")
                   .frame(width: faviconSize, height: faviconSize)
                   .background(Color(.braveDisabled))
                   .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 VStack(alignment: .leading, spacing: 2) {
-                  Text(verbatim: origin.absoluteString)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundColor(Color(.bravePrimary))
+                  origin.url.map { url in
+                    Text(verbatim: url.absoluteString)
+                      .font(.subheadline.weight(.semibold))
+                      .foregroundColor(Color(.bravePrimary))
+                  }
                   Text(String.localizedStringWithFormat(Strings.Wallet.editSiteConnectionConnectedAccount, permittedAccounts.count, permittedAccounts.count == 1 ? Strings.Wallet.editSiteConnectionAccountSingular : Strings.Wallet.editSiteConnectionAccountPlural))
                     .font(.footnote)
                     .foregroundColor(Color(.braveLabel))
@@ -169,7 +181,7 @@ struct EditSiteConnectionView: View {
         }
       }
       .onAppear {
-        if let accounts = Domain.ethereumPermissions(forUrl: originURL) {
+        if let url = origin.url, let accounts = Domain.ethereumPermissions(forUrl: url) {
           permittedAccounts = accounts
         }
       }
@@ -187,7 +199,7 @@ struct EditSiteConnectionView_Previews: PreviewProvider {
         store.addPrimaryAccount("Account 3", completion: nil)
         return store
       }(),
-      originURL: URL(string: "https://app.uniswap.org")!,
+      origin: .init(url: URL(string: "https://app.uniswap.org")!),
       onDismiss: { _ in }
     )
   }

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -31,6 +31,7 @@ public struct NewSiteConnectionView: View {
   }
 
   @ScaledMetric private var faviconSize = 48
+  private let maxFaviconSize: CGFloat = 96
   @State private var selectedAccounts: Set<BraveWallet.AccountInfo.ID> = []
   @State private var isConfirmationViewVisible: Bool = false
   
@@ -55,7 +56,19 @@ public struct NewSiteConnectionView: View {
   
   private var headerView: some View {
     VStack(spacing: 8) {
-      origin.url.map(originAndFavicon(url:))
+      Group {
+        Image(systemName: "globe")
+          .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
+          .background(Color(.braveDisabled))
+          .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        origin.url.map { url in
+          Text(verbatim: url.absoluteString)
+            .font(.subheadline)
+            .foregroundColor(Color(.braveLabel))
+            .multilineTextAlignment(.center)
+        }
+      }
+      .accessibilityElement(children: .combine)
       Text(Strings.Wallet.newSiteConnectMessage)
         .font(.headline)
         .foregroundColor(Color(.bravePrimary))
@@ -179,6 +192,7 @@ public struct NewSiteConnectionView: View {
         }
         .foregroundColor(Color(.braveLabel))
         .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
       } footer: {
         cautionFooterView
       }

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -87,7 +87,7 @@ public struct NewSiteConnectionView: View {
   
   public var body: some View {
     NavigationView {
-      List {
+      Form {
         Section {
           headerView
         }

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -188,7 +188,7 @@ struct WalletPanelView: View {
         if isConnected {
           Image(systemName: "checkmark")
         }
-        Text(isConnected ? "Connected…" : "Connect")
+        Text(isConnected ? Strings.Wallet.walletPanelConnected : Strings.Wallet.walletPanelConnect)
           .fontWeight(.bold)
           .lineLimit(1)
       }

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -388,7 +388,7 @@ struct WalletPanelView: View {
     .onAppear {
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       if let request = permissionRequestManager.pendingRequests(for: origin, coinType: .eth).first {
-        presentWalletWithContext(.requestEthererumPermissions(request, handler: { accounts in
+        presentWalletWithContext(.requestEthererumPermissions(request, onPermittedAccountsUpdated: { accounts in
           permittedAccounts = accounts
         }))
       } else {

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -392,7 +392,7 @@ struct WalletPanelView: View {
       } else {
         cryptoStore.prepare()
       }
-      if let url = origin.url, let accounts =  Domain.ethereumPermissions(forUrl: url) {
+      if let url = origin.url, let accounts = Domain.ethereumPermissions(forUrl: url) {
         permittedAccounts = accounts
       }
       accountActivityStore.update()

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -388,7 +388,9 @@ struct WalletPanelView: View {
     .onAppear {
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       if let request = permissionRequestManager.pendingRequests(for: origin, coinType: .eth).first {
-        presentWalletWithContext(.requestEthererumPermissions(request))
+        presentWalletWithContext(.requestEthererumPermissions(request, handler: { accounts in
+          permittedAccounts = accounts
+        }))
       } else {
         cryptoStore.prepare()
       }

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import BraveCore
 import BraveUI
 import struct Shared.Strings
+import Data
 
 public protocol WalletSiteConnectionDelegate {
   /// A list of accounts connected to this webpage (addresses)
@@ -171,13 +172,23 @@ struct WalletPanelView: View {
     currencyFormatter.currencyCode = accountActivityStore.currencyCode
   }
   
+  @State private var permittedAccounts: [String] = []
+  
+  private var isConnected: Bool {
+    return permittedAccounts.contains(keyringStore.selectedAccount.address)
+  }
+  
   private var connectButton: some View {
     Button {
-      
+      presentWalletWithContext(.editSiteConnection(origin, handler: { accounts in
+        permittedAccounts = accounts
+      }))
     } label: {
       HStack {
-        Image(systemName: "checkmark")
-        Text("Connected…")
+        if isConnected {
+          Image(systemName: "checkmark")
+        }
+        Text(isConnected ? "Connected…" : "Connect")
           .fontWeight(.bold)
           .lineLimit(1)
       }
@@ -380,6 +391,9 @@ struct WalletPanelView: View {
         presentWalletWithContext(.requestEthererumPermissions(request))
       } else {
         cryptoStore.prepare()
+      }
+      if let url = origin.url, let accounts =  Domain.ethereumPermissions(forUrl: url) {
+        permittedAccounts = accounts
       }
       accountActivityStore.update()
     }

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -35,6 +35,8 @@ public enum PresentingContext {
   case buySendSwap(_ destination: BuySendSwapDestination)
   /// Shows the user the wallet settings screen
   case settings
+  /// Shows when the users want to edit connected account the the webpage
+  case editSiteConnection(_ origin: URLOrigin, handler: ([String]) -> Void)
 }
 
 /// The initial wallet controller to present when the user wants to view their wallet

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -24,7 +24,7 @@ public enum PresentingContext {
   /// Shows the user any pending requests made by webpages such as transaction confirmations, adding networks, switch networks, add tokens, sign message, etc.
   case pendingRequests
   /// Shows when a webpage wants to connect with the users wallet
-  case requestEthererumPermissions(_ request: WebpagePermissionRequest, handler: (_ permittedAccounts: [String]) -> Void)
+  case requestEthererumPermissions(_ request: WebpagePermissionRequest, onPermittedAccountsUpdated: (_ permittedAccounts: [String]) -> Void)
   /// Shows the user only the unlock/setup screen then dismisses to view an unlocked panel
   case panelUnlockOrSetup
   /// Shows the user available wallet accounts to use

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -24,7 +24,7 @@ public enum PresentingContext {
   /// Shows the user any pending requests made by webpages such as transaction confirmations, adding networks, switch networks, add tokens, sign message, etc.
   case pendingRequests
   /// Shows when a webpage wants to connect with the users wallet
-  case requestEthererumPermissions(_ request: WebpagePermissionRequest)
+  case requestEthererumPermissions(_ request: WebpagePermissionRequest, handler: (_ permittedAccounts: [String]) -> Void)
   /// Shows the user only the unlock/setup screen then dismisses to view an unlocked panel
   case panelUnlockOrSetup
   /// Shows the user available wallet accounts to use

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -36,7 +36,7 @@ public enum PresentingContext {
   /// Shows the user the wallet settings screen
   case settings
   /// Shows when the users want to edit connected account the the webpage
-  case editSiteConnection(_ origin: URLOrigin, handler: ([String]) -> Void)
+  case editSiteConnection(_ origin: URLOrigin, handler: (_ permittedAccounts: [String]) -> Void)
 }
 
 /// The initial wallet controller to present when the user wants to view their wallet

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2360,5 +2360,54 @@ extension Strings {
       value: "Open wallet in full screen",
       comment: "The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner."
     )
+    public static let editSiteConnectionScreenTitle = NSLocalizedString(
+      "wallet.editSiteConnectionScreenTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Connections",
+      comment: "The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts."
+    )
+    public static let editSiteConnectionConnectedAccount = NSLocalizedString(
+      "wallet.editSiteConnectionConnectedAccount",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "%lld %@ connected",
+      comment: "The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\")"
+    )
+    public static let editSiteConnectionAccountSingular = NSLocalizedString(
+      "wallet.editSiteConnectionAccountSingular",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "account",
+      comment: "The singular word that will be used in `editSiteConnectionConnectedAccount`."
+    )
+    public static let editSiteConnectionAccountPlural = NSLocalizedString(
+      "wallet.editSiteConnectionAccountPlural",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "accounts",
+      comment: "The plural word that will beused in `editSiteConnectionConnectedAccount`."
+    )
+    public static let editSiteConnectionAccountActionConnect = NSLocalizedString(
+      "wallet.editSiteConnectionAccountActionConnect",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Connect",
+      comment: "The title of the button for users to click so that they connect wallet account to the dapp site(also permission given). It will be displayed at the right hand side of each account option in edit site connection screen."
+    )
+    public static let editSiteConnectionAccountActionDisconnect = NSLocalizedString(
+      "wallet.editSiteConnectionAccountActionDisconnect",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Disconnect",
+      comment: "The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen."
+    )
+    public static let editSiteConnectionAccountActionSwitch = NSLocalizedString(
+      "wallet.editSiteConnectionAccountActionDisconnect",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Switch",
+      comment: "The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2403,7 +2403,7 @@ extension Strings {
       comment: "The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen."
     )
     public static let editSiteConnectionAccountActionSwitch = NSLocalizedString(
-      "wallet.editSiteConnectionAccountActionDisconnect",
+      "wallet.editSiteConnectionAccountActionSwitch",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Switch",

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2409,5 +2409,19 @@ extension Strings {
       value: "Switch",
       comment: "The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen."
     )
+    public static let walletPanelConnected = NSLocalizedString(
+      "wallet.walletPanelConnected",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Connected…",
+      comment: "The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark."
+    )
+    public static let walletPanelConnect = NSLocalizedString(
+      "wallet.walletPanelConnect",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Connect",
+      comment: "The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp."
+    )
   }
 }


### PR DESCRIPTION
## Summary of Changes
Integrated dapps edit site connection screen.

This PR fixes: #5106

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Connect Brave Wallet with a dapp site
2. Open wallet panel and click `Connect` or `Connected...` button
3. (It should bring up the edit site connection screen)
4. Check if dapp site origin is being displayed
5. Check if number of "connected" (it actually means "permitted") is correct 
6. Check if button action behave correctly 
7. Check if dismiss this screen with some changes of the account permission reflect back to the wallet panel

## Screenshots:
![simulator_screenshot_3D63B2F8-CAD6-4D35-B3BB-E05C727AC2E6](https://user-images.githubusercontent.com/1187676/161078575-8b287b06-4100-457e-bd75-8b2d9f01604d.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
