### PR TITLE
Fix #5104: Dapps Add Suggested Token Request Integration

### DIFF
--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -81,7 +81,10 @@ public struct CryptoView: View {
               WebpageRequestContainerView(
                 keyringStore: keyringStore,
                 cryptoStore: store,
-                toolbarDismissContent: dismissButtonToolbarContents
+                toolbarDismissContent: dismissButtonToolbarContents,
+                onDismiss: {
+                  dismissAction?()
+                }
               )
             case .requestEthererumPermissions(let request):
               NewSiteConnectionView(

--- a/BraveWallet/Crypto/OriginText.swift
+++ b/BraveWallet/Crypto/OriginText.swift
@@ -1,0 +1,26 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import SwiftUI
+
+/// View used to display a URLOrigin, bolding the eTLD+1.
+struct OriginText: View {
+  
+  let urlOrigin: URLOrigin
+  
+  var body: some View {
+    let origin = urlOrigin.url?.absoluteString ?? ""
+    let eTldPlusOne = urlOrigin.url?.baseDomain ?? ""
+    if let range = origin.range(of: eTldPlusOne) {
+      let originStart = origin[origin.startIndex..<range.lowerBound]
+      let etldPlusOne = origin[range.lowerBound..<range.upperBound]
+      let originEnd = origin[range.upperBound...]
+      Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
+    } else {
+      Text(origin)
+    }
+  }
+}

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -263,6 +263,7 @@ public class CryptoStore: ObservableObject {
       walletService.notifySignMessageRequestProcessed(approved, id: id)
       pendingWebpageRequest = nil
     }
+    fetchPendingRequests()
   }
 }
 

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -23,8 +23,7 @@ public class NetworkStore: ObservableObject {
     .init(
       get: { self.ethereumChains.first(where: { $0.chainId == self.selectedChainId }) ?? .init() },
       set: {
-        self.selectedChainId = $0.chainId
-        self.rpcService.setNetwork($0.chainId) { _ in }
+        self.setSelectedChain(chainId: $0.chainId)
       }
     )
   }
@@ -35,9 +34,7 @@ public class NetworkStore: ObservableObject {
     self.rpcService = rpcService
     self.updateChainList()
     rpcService.chainId { chainId in
-      let id = chainId.isEmpty ? BraveWallet.MainnetChainId : chainId
-      self.selectedChainId = id
-      self.rpcService.setNetwork(id) { _ in }
+      self.selectedChainId = chainId.isEmpty ? BraveWallet.MainnetChainId : chainId
     }
     rpcService.add(self)
   }
@@ -48,6 +45,12 @@ public class NetworkStore: ObservableObject {
         $0.chainId != BraveWallet.LocalhostChainId
       }
     }
+  }
+
+  func setSelectedChain(chainId: String) {
+    guard self.selectedChainId != chainId else { return }
+    self.selectedChainId = chainId
+    self.rpcService.setNetwork(chainId) { _ in }
   }
 
   // MARK: - Custom Networks

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -47,7 +47,7 @@ public class NetworkStore: ObservableObject {
     }
   }
 
-  func setSelectedChain(chainId: String) {
+  private func setSelectedChain(chainId: String) {
     guard self.selectedChainId != chainId else { return }
     self.selectedChainId = chainId
     self.rpcService.setNetwork(chainId) { _ in }

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -146,19 +146,3 @@ extension BraveWallet {
   /// The address that is expected when you are swapping ETH via SwapService APIs
   public static let ethSwapAddress: String = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 }
-
-extension URL {
-  /// The origin of the URL, with bold eTLD+1 when available.
-  var originWithEtldPlusOne: Text {
-    let origin = absoluteString
-    let eTldPlusOne = baseDomain ?? ""
-    if let range = origin.range(of: eTldPlusOne) {
-      let originStart = origin[origin.startIndex..<range.lowerBound]
-      let etldPlusOne = origin[range.lowerBound..<range.upperBound]
-      let originEnd = origin[range.upperBound...]
-      return Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
-    } else {
-      return Text(origin)
-    }
-  }
-}

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -146,3 +146,19 @@ extension BraveWallet {
   /// The address that is expected when you are swapping ETH via SwapService APIs
   public static let ethSwapAddress: String = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 }
+
+extension URL {
+  /// The origin of the URL, with bold eTLD+1 when available.
+  var originWithEtldPlusOne: Text {
+    let origin = absoluteString
+    let eTldPlusOne = baseDomain ?? ""
+    if let range = origin.range(of: eTldPlusOne) {
+      let originStart = origin[origin.startIndex..<range.lowerBound]
+      let etldPlusOne = origin[range.lowerBound..<range.upperBound]
+      let originEnd = origin[range.upperBound...]
+      return Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
+    } else {
+      return Text(origin)
+    }
+  }
+}

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -24,10 +24,13 @@ struct AddSuggestedTokenView: View {
           .foregroundColor(Color(.braveLabel))
           .font(.subheadline)
         VStack {
-          AssetIconView(token: token, length: 64)
-          Text(token.symbol)
-            .font(.headline)
-            .foregroundColor(Color(.bravePrimary))
+          VStack {
+            AssetIconView(token: token, length: 64)
+            Text(token.symbol)
+              .font(.headline)
+              .foregroundColor(Color(.bravePrimary))
+          }
+          .accessibilityElement(children: .combine)
           Button(action: {
             if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
                let url = baseURL?.appendingPathComponent("token/\(token.contractAddress)") {
@@ -41,6 +44,8 @@ struct AddSuggestedTokenView: View {
             .font(.subheadline)
             .foregroundColor(Color(.braveBlurpleTint))
           }
+          .accessibilityLabel(Strings.Wallet.contractAddressAccessibilityLabel)
+          .accessibilityValue(token.contractAddress.truncatedAddress)
         }
         actionButtonContainer
           .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -12,8 +12,7 @@ struct AddSuggestedTokenView: View {
   var token: BraveWallet.BlockchainToken
   var networkStore: NetworkStore
   
-  var onApprove: () -> Void
-  var onCancel: () -> Void
+  var onDismiss: (_ approved: Bool) -> Void
   
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.openWalletURLAction) private var openWalletURL
@@ -67,14 +66,14 @@ struct AddSuggestedTokenView: View {
   }
 
   @ViewBuilder private var actionButtons: some View {
-    Button(action: onCancel) {
+    Button(action: { onDismiss(false) }) {
       HStack {
         Image(systemName: "xmark")
         Text(Strings.cancelButtonTitle)
       }
     }
     .buttonStyle(BraveOutlineButtonStyle(size: .large))
-    Button(action: onApprove) {
+    Button(action: { onDismiss(true) }) {
       HStack {
         Image("brave.checkmark.circle.fill")
         Text(Strings.Wallet.add)
@@ -91,8 +90,7 @@ struct AddSuggestedTokenView_Previews: PreviewProvider {
     AddSuggestedTokenView(
       token: .previewToken,
       networkStore: .previewStore,
-      onApprove: {},
-      onCancel: {}
+      onDismiss: { _ in }
     )
   }
 }

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -43,6 +43,8 @@ struct AddSuggestedTokenView: View {
           }
         }
         actionButtonContainer
+          .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
+          .accessibility(hidden: sizeCategory.isAccessibilityCategory)
       }
       .frame(maxWidth: .infinity)
       .padding(.top, 64)
@@ -51,6 +53,29 @@ struct AddSuggestedTokenView: View {
     .background(Color(.braveGroupedBackground).ignoresSafeArea())
     .navigationTitle(Strings.Wallet.addSuggestedTokenTitle)
     .navigationBarTitleDisplayMode(.inline)
+    .overlay(
+      Group {
+        if sizeCategory.isAccessibilityCategory {
+          actionButtonContainer
+            .frame(maxWidth: .infinity)
+            .padding(.top)
+            .background(
+              LinearGradient(
+                stops: [
+                  .init(color: Color(.braveGroupedBackground).opacity(0), location: 0),
+                  .init(color: Color(.braveGroupedBackground).opacity(1), location: 0.05),
+                  .init(color: Color(.braveGroupedBackground).opacity(1), location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+              )
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+            )
+        }
+      },
+      alignment: .bottom
+    )
   }
   
   @ViewBuilder private var actionButtonContainer: some View {

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -10,55 +10,90 @@ import BraveUI
 
 struct AddSuggestedTokenView: View {
   var token: BraveWallet.BlockchainToken
+  var networkStore: NetworkStore
+  
+  var onApprove: () -> Void
+  var onCancel: () -> Void
+  
+  @Environment(\.sizeCategory) private var sizeCategory
+  @Environment(\.openWalletURLAction) private var openWalletURL
   
   var body: some View {
-    NavigationView {
-      ScrollView(.vertical) {
-        VStack(spacing: 44) {
-          Text("Would you like to import this token?")
-            .foregroundColor(Color(.braveLabel))
+    ScrollView(.vertical) {
+      VStack(spacing: 44) {
+        Text(Strings.Wallet.addSuggestedTokenSubtitle)
+          .foregroundColor(Color(.braveLabel))
+          .font(.subheadline)
+        VStack {
+          AssetIconView(token: token, length: 64)
+          Text(token.symbol)
+            .font(.headline)
+            .foregroundColor(Color(.bravePrimary))
+          Button(action: {
+            if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+               let url = baseURL?.appendingPathComponent("token/\(token.contractAddress)") {
+              openWalletURL?(url)
+            }
+          }) {
+            HStack {
+              Text(token.contractAddress.truncatedAddress)
+              Image(systemName: "arrow.up.forward.square")
+            }
             .font(.subheadline)
-          VStack {
-            AssetIconView(token: token, length: 64)
-            Text(token.symbol)
-              .font(.headline)
-              .foregroundColor(Color(.bravePrimary))
-            Text("0 \(token.symbol)")
-              .font(.subheadline)
-              .foregroundColor(Color(.secondaryBraveLabel))
-          }
-          Button {
-            
-          } label: {
-            Text(Strings.Wallet.add)
-          }
-          .buttonStyle(BraveFilledButtonStyle(size: .large))
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.top, 64)
-        .padding([.leading, .trailing, .bottom])
-      }
-      .background(Color(.braveGroupedBackground).ignoresSafeArea())
-      .toolbar {
-        ToolbarItemGroup(placement: .cancellationAction) {
-          Button {
-            
-          } label: {
-            Text(Strings.cancelButtonTitle)
+            .foregroundColor(Color(.braveBlurpleTint))
           }
         }
+        actionButtonContainer
       }
-      .navigationTitle("Add Suggested Token")
-      .navigationBarTitleDisplayMode(.inline)
+      .frame(maxWidth: .infinity)
+      .padding(.top, 64)
+      .padding([.leading, .trailing, .bottom])
     }
-    .navigationViewStyle(.stack)
+    .background(Color(.braveGroupedBackground).ignoresSafeArea())
+    .navigationTitle(Strings.Wallet.addSuggestedTokenTitle)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+  
+  @ViewBuilder private var actionButtonContainer: some View {
+    if sizeCategory.isAccessibilityCategory {
+      VStack {
+        actionButtons
+      }
+    } else {
+      HStack {
+        actionButtons
+      }
+    }
+  }
+
+  @ViewBuilder private var actionButtons: some View {
+    Button(action: onCancel) {
+      HStack {
+        Image(systemName: "xmark")
+        Text(Strings.cancelButtonTitle)
+      }
+    }
+    .buttonStyle(BraveOutlineButtonStyle(size: .large))
+    Button(action: onApprove) {
+      HStack {
+        Image("brave.checkmark.circle.fill")
+        Text(Strings.Wallet.add)
+          .multilineTextAlignment(.center)
+      }
+    }
+    .buttonStyle(BraveFilledButtonStyle(size: .large))
   }
 }
 
 #if DEBUG
 struct AddSuggestedTokenView_Previews: PreviewProvider {
   static var previews: some View {
-    AddSuggestedTokenView(token: .previewToken)
+    AddSuggestedTokenView(
+      token: .previewToken,
+      networkStore: .previewStore,
+      onApprove: {},
+      onCancel: {}
+    )
   }
 }
 #endif

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -10,6 +10,7 @@ import BraveUI
 
 struct AddSuggestedTokenView: View {
   var token: BraveWallet.BlockchainToken
+  var originInfo: BraveWallet.OriginInfo
   var networkStore: NetworkStore
   
   var onDismiss: (_ approved: Bool) -> Void
@@ -119,6 +120,7 @@ struct AddSuggestedTokenView_Previews: PreviewProvider {
   static var previews: some View {
     AddSuggestedTokenView(
       token: .previewToken,
+      originInfo: .init(origin: .init(url: URL(string: "https://app.uniswap.org")!), originSpec: "", eTldPlusOne: "uniswap.org"),
       networkStore: .previewStore,
       onDismiss: { _ in }
     )

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -20,10 +20,16 @@ struct AddSuggestedTokenView: View {
   
   var body: some View {
     ScrollView(.vertical) {
-      VStack(spacing: 44) {
-        Text(Strings.Wallet.addSuggestedTokenSubtitle)
-          .foregroundColor(Color(.braveLabel))
-          .font(.subheadline)
+      VStack(spacing: 22) {
+        VStack(spacing: 8) {
+          Text(Strings.Wallet.addSuggestedTokenSubtitle)
+            .font(.headline)
+            .foregroundColor(Color(.bravePrimary))
+          originInfo.origin.url?.originWithEtldPlusOne
+            .font(.footnote)
+            .foregroundColor(Color(.braveLabel))
+        }
+        .padding(.top)
         VStack {
           VStack {
             AssetIconView(token: token, length: 64)
@@ -51,10 +57,10 @@ struct AddSuggestedTokenView: View {
         actionButtonContainer
           .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
           .accessibility(hidden: sizeCategory.isAccessibilityCategory)
+          .padding(.top, 20)
       }
       .frame(maxWidth: .infinity)
-      .padding(.top, 64)
-      .padding([.leading, .trailing, .bottom])
+      .padding()
     }
     .background(Color(.braveGroupedBackground).ignoresSafeArea())
     .navigationTitle(Strings.Wallet.addSuggestedTokenTitle)

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -25,7 +25,7 @@ struct AddSuggestedTokenView: View {
           Text(Strings.Wallet.addSuggestedTokenSubtitle)
             .font(.headline)
             .foregroundColor(Color(.bravePrimary))
-          originInfo.origin.url?.originWithEtldPlusOne
+          OriginText(urlOrigin: originInfo.origin)
             .font(.footnote)
             .foregroundColor(Color(.braveLabel))
         }

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -11,9 +11,8 @@ import BraveUI
 struct AddSuggestedTokenView: View {
   var token: BraveWallet.BlockchainToken
   var originInfo: BraveWallet.OriginInfo
-  var networkStore: NetworkStore
-  
-  var onDismiss: (_ approved: Bool) -> Void
+  var cryptoStore: CryptoStore
+  var onDismiss: () -> Void
   
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.openWalletURLAction) private var openWalletURL
@@ -39,7 +38,7 @@ struct AddSuggestedTokenView: View {
           }
           .accessibilityElement(children: .combine)
           Button(action: {
-            if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+            if let baseURL = cryptoStore.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
                let url = baseURL?.appendingPathComponent("token/\(token.contractAddress)") {
               openWalletURL?(url)
             }
@@ -103,14 +102,24 @@ struct AddSuggestedTokenView: View {
   }
 
   @ViewBuilder private var actionButtons: some View {
-    Button(action: { onDismiss(false) }) {
+    Button(action: { // cancel
+      cryptoStore.handleWebpageRequestResponse(
+        .addSuggestedToken(approved: false, contractAddresses: [token.contractAddress])
+      )
+      onDismiss()
+    }) {
       HStack {
         Image(systemName: "xmark")
         Text(Strings.cancelButtonTitle)
       }
     }
     .buttonStyle(BraveOutlineButtonStyle(size: .large))
-    Button(action: { onDismiss(true) }) {
+    Button(action: { // approve
+      cryptoStore.handleWebpageRequestResponse(
+        .addSuggestedToken(approved: true, contractAddresses: [token.contractAddress])
+      )
+      onDismiss()
+    }) {
       HStack {
         Image("brave.checkmark.circle.fill")
         Text(Strings.Wallet.add)
@@ -126,9 +135,13 @@ struct AddSuggestedTokenView_Previews: PreviewProvider {
   static var previews: some View {
     AddSuggestedTokenView(
       token: .previewToken,
-      originInfo: .init(origin: .init(url: URL(string: "https://app.uniswap.org")!), originSpec: "", eTldPlusOne: "uniswap.org"),
-      networkStore: .previewStore,
-      onDismiss: { _ in }
+      originInfo: .init(
+        origin: .init(url: URL(string: "https://app.uniswap.org")!),
+        originSpec: "",
+        eTldPlusOne: "uniswap.org"
+      ),
+      cryptoStore: .previewStore,
+      onDismiss: { }
     )
   }
 }

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -26,12 +26,10 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
             AddSuggestedTokenView(
               token: request.token,
               networkStore: cryptoStore.networkStore,
-              onApprove: {
-                cryptoStore.handleWebpageRequestResponse(.addSuggestedToken(approved: true, contractAddresses: [request.token.contractAddress]))
-                onDismiss()
-              },
-              onCancel: {
-                cryptoStore.handleWebpageRequestResponse(.addSuggestedToken(approved: false, contractAddresses: [request.token.contractAddress]))
+              onDismiss: { approved in
+                cryptoStore.handleWebpageRequestResponse(
+                  .addSuggestedToken(approved: approved, contractAddresses: [request.token.contractAddress])
+                )
                 onDismiss()
               }
             )

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -13,12 +13,31 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var cryptoStore: CryptoStore
   var toolbarDismissContent: DismissContent
-  
+
+  @available(iOS, introduced: 14.0, deprecated: 15.0, message: "Use PresentationMode on iOS 15")
+  var onDismiss: () -> Void
+
   var body: some View {
     UIKitNavigationView {
       Group {
         if let pendingRequest = cryptoStore.pendingWebpageRequest {
-
+          switch pendingRequest {
+          case .addSuggestedToken(let request):
+            AddSuggestedTokenView(
+              token: request.token,
+              networkStore: cryptoStore.networkStore,
+              onApprove: {
+                cryptoStore.handleWebpageRequestResponse(.addSuggestedToken(approved: true, contractAddresses: [request.token.contractAddress]))
+                onDismiss()
+              },
+              onCancel: {
+                cryptoStore.handleWebpageRequestResponse(.addSuggestedToken(approved: false, contractAddresses: [request.token.contractAddress]))
+                onDismiss()
+              }
+            )
+          default:
+            EmptyView()
+          }
         }
       }
       .toolbar {

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -25,6 +25,7 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
           case .addSuggestedToken(let request):
             AddSuggestedTokenView(
               token: request.token,
+              originInfo: request.origin,
               networkStore: cryptoStore.networkStore,
               onDismiss: { approved in
                 cryptoStore.handleWebpageRequestResponse(

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -26,13 +26,8 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
             AddSuggestedTokenView(
               token: request.token,
               originInfo: request.origin,
-              networkStore: cryptoStore.networkStore,
-              onDismiss: { approved in
-                cryptoStore.handleWebpageRequestResponse(
-                  .addSuggestedToken(approved: approved, contractAddresses: [request.token.contractAddress])
-                )
-                onDismiss()
-              }
+              cryptoStore: cryptoStore,
+              onDismiss: onDismiss
             )
           default:
             EmptyView()

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2101,5 +2101,19 @@ extension Strings {
       value: "Default Base Currency",
       comment: "The title that appears before the current default base currency code. Example: \"Default base currency: USD\""
     )
+    public static let addSuggestedTokenTitle = NSLocalizedString(
+      "wallet.addSuggestedTokenTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Add Suggested Token",
+      comment: "The title of the view shown over a dapps website that requests the user add / approve a new token."
+    )
+    public static let addSuggestedTokenSubtitle = NSLocalizedString(
+      "wallet.addSuggestedTokenSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Would you like to import this token?",
+      comment: "The subtitle of the view shown over a dapps website that requests the user add / approve a new token, explaining to the user what this request does."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2115,5 +2115,12 @@ extension Strings {
       value: "Would you like to import this token?",
       comment: "The subtitle of the view shown over a dapps website that requests the user add / approve a new token, explaining to the user what this request does."
     )
+    public static let contractAddressAccessibilityLabel = NSLocalizedString(
+      "wallet.contractAddressAccessibilityLabel",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Contract Address",
+      comment: "The accessibility label for the contract address of a token / asset."
+    )
   }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1216,6 +1216,7 @@
 		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
 		D552E6922807231F00A847F3 /* Data.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1DC51320AC9AF900905E5A /* Data.framework */; };
 		D5412B452819F24000463106 /* WalletNumberFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5412B442819F24000463106 /* WalletNumberFormatterExtensions.swift */; };
+		D59CA2B7282AE54500D02BEF /* OriginText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CA2B6282AE54500D02BEF /* OriginText.swift */; };
 		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
 		D5ACA7CE27FB7D08002443CE /* BraveCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; };
 		D5ACA7D927FB7D0E002443CE /* MaterialComponents.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; };
@@ -3218,6 +3219,7 @@
 		D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionConfirmationStoreTests.swift; sourceTree = "<group>"; };
 		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
 		D5412B442819F24000463106 /* WalletNumberFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletNumberFormatterExtensions.swift; sourceTree = "<group>"; };
+		D59CA2B6282AE54500D02BEF /* OriginText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginText.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsPasscodeEntryView.swift; sourceTree = "<group>"; };
 		D5EFCB3827FF81AA00BD151D /* EditPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPermissionsView.swift; sourceTree = "<group>"; };
@@ -3984,6 +3986,7 @@
 				271F687726EBD27D00AA2A50 /* Onboarding */,
 				2762FF2F271A054A001EF41D /* AssetIconView.swift */,
 				277C0A99273DC0890059AB0A /* NamedAddresses.swift */,
+				D59CA2B6282AE54500D02BEF /* OriginText.swift */,
 			);
 			path = Crypto;
 			sourceTree = "<group>";
@@ -8168,6 +8171,7 @@
 				271F689E26EBD27E00AA2A50 /* MockBlockchainRegistry.swift in Sources */,
 				27DDE88626FD2BC400A70C3A /* PortfolioStore.swift in Sources */,
 				271F68B126EBD27E00AA2A50 /* EnableBiometricsView.swift in Sources */,
+				D59CA2B7282AE54500D02BEF /* OriginText.swift in Sources */,
 				271F68BF26EBD27E00AA2A50 /* DateRangeView.swift in Sources */,
 				7D4C49512791D2450073C37E /* CustomNetworkDetailsView.swift in Sources */,
 				7DC52B12273D99E70067E237 /* WalletArrayExtension.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes
- Integrated `PendingWebpageRequest.addSuggestedToken` to open the `AddSuggestedTokenView` modally using `WebpageRequestContainerView`.

This pull request fixes #5104

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Note: At time of PR creation, wallet dapps are disabled with a compiler flag. Add `-DWALLET_DAPPS_ENABLED` to `base.xcconfig` to enable dapps support.

1. Navigate to the [CAROT add token request page](https://vittominacori.github.io/watch-token/page/?hash=0x7b2261646472657373223a22307831666635316461373163336435623866383531313265613361343434306265623637613632616439222c226c6f676f223a22227d&network=mainnet). Alternatively you can setup your own token request in `eth-manual-tests` using examples from [here](https://docs.metamask.io/guide/registering-your-token.html#example).
2. Tap 'Add to MetaMask' button, you should see the wallet panel to unlock (if locked) and then the Add Suggested Token modal.
3. Tap 'Add' on modal (or cancel to remove the request)
4. If you added the coin, open the main Wallet and you should see CAROT token added in user visible assets list.


## Screenshots:
![add suggested token](https://user-images.githubusercontent.com/5314553/167666812-3308a080-edf8-4841-858c-347fe0708a8c.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
