### PR TITLE
No Bug: Safeguard divide by 0 operation for on the buy-vpn screen.

### DIFF
--- a/Client/Frontend/BraveVPN/BuyVPNView.swift
+++ b/Client/Frontend/BraveVPN/BuyVPNView.swift
@@ -366,9 +366,13 @@ extension BuyVPNViewController {
         // we have to calculate it manually.
         let yearlyDouble = yearlyProduct.price.doubleValue
         let discountDouble = monthlyProduct.price.multiplying(by: 12).doubleValue
-        let discountSavingPercentage = 100 - Int((yearlyDouble * 100) / discountDouble)
+        
+        if discountDouble > 0.0 {
+          let discountSavingPercentage = 100 - Int((yearlyDouble * 100) / discountDouble)
 
-        detail = String(format: Strings.VPN.yearlySubDetail, "\(discountSavingPercentage)%")
+          detail = String(format: Strings.VPN.yearlySubDetail, "\(discountSavingPercentage)%")
+        }
+        
         price = "\(formattedYearlyPrice) / \(Strings.yearAbbreviation)"
         priceDiscount = discountFormattedPrice
       }


### PR DESCRIPTION
This will probably never happen on production because the vpn price
will not go down to 0.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
