### PR TITLE
Fix #5196: Fixes Playlist ParticleEmitter showing when it shouldn't

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -854,9 +854,7 @@ extension PlaylistViewController: VideoViewDelegate {
 
             // Live media item
             let isPlayingLiveMedia = self.player.isLiveMedia
-            self.playerView.controlsView.trackBar.isUserInteractionEnabled = !isPlayingLiveMedia
-            self.playerView.controlsView.skipBackButton.isEnabled = !isPlayingLiveMedia
-            self.playerView.controlsView.skipForwardButton.isEnabled = !isPlayingLiveMedia
+            self.playerView.setMediaIsLive(isPlayingLiveMedia)
 
             // Track-bar
             let endTime = CMTimeConvertScale(item.asset.duration, timescale: self.player.currentTime.timescale, method: .roundHalfAwayFromZero)

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -643,7 +643,16 @@ extension AVPlayerItem {
   /// tracks may not always be available and the particle effect will show even on videos..
   /// It's best to assume this type of media is a video stream.
   func isVideoTracksAvailable() -> Bool {
-    tracks.isEmpty || tracks.filter({ $0.assetTrack?.mediaType == .video }).isEmpty == false
+    if tracks.isEmpty && asset.tracks.isEmpty {
+      return true  // Assume video
+    }
+    
+    // All tracks are null (not loaded yet)
+    if tracks.allSatisfy({ $0.assetTrack == nil }) {
+      return true  // Assume video
+    }
+    
+    return (tracks.filter({ $0.assetTrack?.mediaType == .video }).isEmpty == false) || asset.isVideoTracksAvailable()
   }
 }
 
@@ -659,6 +668,6 @@ extension AVAsset {
   /// tracks may not always be available and the particle effect will show even on videos..
   /// It's best to assume this type of media is a video stream.
   func isVideoTracksAvailable() -> Bool {
-    tracks.isEmpty || tracks.filter({ $0.mediaType == .video }).isEmpty == false
+    tracks.filter({ $0.mediaType == .video }).isEmpty == false
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Fixes Playlist ParticleEmitter showing on Live videos or due to a gesture swipe.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5196

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
