### PR TITLE
Fix #5218: Dapps Sign Message Request Integration

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -9,7 +9,7 @@ enum PendingWebpageRequest: Equatable {
   case addChain(BraveWallet.AddChainRequest)
   case switchChain(BraveWallet.SwitchChainRequest)
   case addSuggestedToken(BraveWallet.AddSuggestTokenRequest)
-  case signMessage(BraveWallet.SignMessageRequest)
+  case signMessage([BraveWallet.SignMessageRequest])
 }
 
 enum WebpageRequestResponse: Equatable {
@@ -238,8 +238,8 @@ public class CryptoStore: ObservableObject {
       // TODO: Add check for eth permissions… get first eth request 
       if let chainRequest = await rpcService.pendingAddChainRequests().first {
         pendingWebpageRequest = .addChain(chainRequest)
-      } else if let signMessageRequest = await walletService.pendingSignMessageRequests().first {
-        pendingWebpageRequest = .signMessage(signMessageRequest)
+      } else if case let signMessageRequests = await walletService.pendingSignMessageRequests(), !signMessageRequests.isEmpty {
+        pendingWebpageRequest = .signMessage(signMessageRequests)
       } else if let switchRequest = await rpcService.pendingSwitchChainRequests().first {
         pendingWebpageRequest = .switchChain(switchRequest)
       } else if let addTokenRequest = await walletService.pendingAddSuggestTokenRequests().first {

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -132,6 +132,7 @@ extension BraveWallet.NetworkInfo: Identifiable {
 extension BraveWallet.SignMessageRequest {
   static var previewRequest: BraveWallet.SignMessageRequest {
     .init(
+      originInfo: .init(origin: .init(url: URL(string: "https://app.uniswap.org")!), originSpec: "", eTldPlusOne: "uniswap.org"),
       id: 1,
       address: "",
       message: "To avoid digital cat burglars, sign below to authenticate with CryptoKitties.",

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -129,6 +129,19 @@ extension BraveWallet.NetworkInfo: Identifiable {
   }
 }
 
+extension BraveWallet.SignMessageRequest {
+  static var previewRequest: BraveWallet.SignMessageRequest {
+    .init(
+      id: 1,
+      address: "",
+      message: "To avoid digital cat burglars, sign below to authenticate with CryptoKitties.",
+      isEip712: false,
+      domainHash: "",
+      primaryHash: ""
+    )
+  }
+}
+
 extension BraveWallet.BlockchainToken: Identifiable {
   public var id: String {
     symbol.lowercased()

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -160,3 +160,19 @@ extension BraveWallet {
   /// The address that is expected when you are swapping ETH via SwapService APIs
   public static let ethSwapAddress: String = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 }
+
+extension URL {
+  /// The origin of the request, with bold eTLD+1 when available.
+  var originWithEtldPlusOne: Text {
+    let origin = absoluteString
+    let eTldPlusOne = baseDomain ?? ""
+    if let range = origin.range(of: eTldPlusOne) {
+      let originStart = origin[origin.startIndex..<range.lowerBound]
+      let etldPlusOne = origin[range.lowerBound..<range.upperBound]
+      let originEnd = origin[range.upperBound...]
+      return Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
+    } else {
+      return Text(origin)
+    }
+  }
+}

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -160,19 +160,3 @@ extension BraveWallet {
   /// The address that is expected when you are swapping ETH via SwapService APIs
   public static let ethSwapAddress: String = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 }
-
-extension URL {
-  /// The origin of the request, with bold eTLD+1 when available.
-  var originWithEtldPlusOne: Text {
-    let origin = absoluteString
-    let eTldPlusOne = baseDomain ?? ""
-    if let range = origin.range(of: eTldPlusOne) {
-      let originStart = origin[origin.startIndex..<range.lowerBound]
-      let etldPlusOne = origin[range.lowerBound..<range.upperBound]
-      let originEnd = origin[range.upperBound...]
-      return Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
-    } else {
-      return Text(origin)
-    }
-  }
-}

--- a/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -19,6 +19,7 @@ struct SignatureRequestView: View {
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.presentationMode) @Binding private var presentationMode
   @ScaledMetric private var blockieSize = 54
+  private let maxBlockieSize: CGFloat = 108
   
   private var currentRequest: BraveWallet.SignMessageRequest {
     requests[requestIndex]
@@ -55,11 +56,14 @@ struct SignatureRequestView: View {
           }
         }
         VStack(spacing: 8) {
-          Blockie(address: account.address)
-            .frame(width: blockieSize, height: blockieSize)
-          Text(account.name)
-            .font(.subheadline.weight(.semibold))
-            .foregroundColor(Color(.secondaryBraveLabel))
+          VStack(spacing: 8) {
+            Blockie(address: account.address)
+              .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
+            Text(account.name)
+              .font(.subheadline.weight(.semibold))
+              .foregroundColor(Color(.secondaryBraveLabel))
+          }
+          .accessibilityElement(children: .combine)
           Text(Strings.Wallet.signatureRequestSubtitle)
             .font(.headline)
         }

--- a/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -10,7 +10,7 @@ import BraveShared
 import BraveUI
 
 struct SignatureRequestView: View {
-  @State var requests: [BraveWallet.SignMessageRequest]
+  var requests: [BraveWallet.SignMessageRequest]
   @ObservedObject var keyringStore: KeyringStore
   var cryptoStore: CryptoStore
   
@@ -37,7 +37,7 @@ struct SignatureRequestView: View {
     onDismiss: @escaping () -> Void
   ) {
     assert(!requests.isEmpty)
-    self._requests = State(initialValue: requests)
+    self.requests = requests
     self.keyringStore = keyringStore
     self.cryptoStore = cryptoStore
     self.onDismiss = onDismiss
@@ -150,9 +150,7 @@ struct SignatureRequestView: View {
   @ViewBuilder private var buttons: some View {
     Button(action: { // cancel
       cryptoStore.handleWebpageRequestResponse(.signMessage(approved: false, id: currentRequest.id))
-      if requests.count > 1 {
-        requests.removeFirst()
-      } else {
+      if requests.count == 1 {
         onDismiss()
       }
     }) {
@@ -163,9 +161,7 @@ struct SignatureRequestView: View {
     .disabled(isButtonsDisabled)
     Button(action: { // approve
       cryptoStore.handleWebpageRequestResponse(.signMessage(approved: true, id: currentRequest.id))
-      if requests.count > 1 {
-        requests.removeFirst()
-      } else {
+      if requests.count == 1 {
         onDismiss()
       }
     }) {

--- a/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -55,13 +55,18 @@ struct SignatureRequestView: View {
             }
           }
         }
-        VStack(spacing: 8) {
+        VStack(spacing: 12) {
           VStack(spacing: 8) {
             Blockie(address: account.address)
               .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
             Text(account.name)
               .font(.subheadline.weight(.semibold))
               .foregroundColor(Color(.secondaryBraveLabel))
+            
+            currentRequest.originInfo.origin.url?.originWithEtldPlusOne
+            .font(.subheadline)
+            .foregroundColor(Color(.braveLabel))
+            .multilineTextAlignment(.center)
           }
           .accessibilityElement(children: .combine)
           Text(Strings.Wallet.signatureRequestSubtitle)

--- a/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -64,13 +64,14 @@ struct SignatureRequestView: View {
               .foregroundColor(Color(.secondaryBraveLabel))
             
             currentRequest.originInfo.origin.url?.originWithEtldPlusOne
-            .font(.subheadline)
+            .font(.caption)
             .foregroundColor(Color(.braveLabel))
             .multilineTextAlignment(.center)
           }
           .accessibilityElement(children: .combine)
           Text(Strings.Wallet.signatureRequestSubtitle)
             .font(.headline)
+            .foregroundColor(Color(.bravePrimary))
         }
         .padding(.vertical, 32)
         VStack(spacing: 12) {

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -46,13 +46,16 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
               networkStore: cryptoStore.networkStore,
               onDismiss: onDismiss
             )
-          case let .signMessage(request):
+          case let .signMessage(requests):
             SignatureRequestView(
-              request: request,
+              requests: requests,
               keyringStore: keyringStore,
-              onDismiss: { approved in
-                cryptoStore.handleWebpageRequestResponse(.signMessage(approved: approved, id: request.id))
-                onDismiss()
+              handler: { approved, requestId in
+                cryptoStore.handleWebpageRequestResponse(.signMessage(approved: approved, id: requestId))
+                if requestId == requests.last?.id {
+                  // dismiss when handling action for last request
+                  onDismiss()
+                }
               }
             )
           default:

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -50,13 +50,8 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
             SignatureRequestView(
               requests: requests,
               keyringStore: keyringStore,
-              handler: { approved, requestId in
-                cryptoStore.handleWebpageRequestResponse(.signMessage(approved: approved, id: requestId))
-                if requestId == requests.last?.id {
-                  // dismiss when handling action for last request
-                  onDismiss()
-                }
-              }
+              cryptoStore: cryptoStore,
+              onDismiss: onDismiss
             )
           default:
             EmptyView()

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -17,7 +17,7 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
   var onDismiss: () -> Void
 
   var body: some View {
-    UIKitNavigationView {
+    NavigationView {
       Group {
         if let pendingRequest = cryptoStore.pendingWebpageRequest {
           switch pendingRequest {
@@ -62,6 +62,7 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
         toolbarDismissContent
       }
     }
+    .navigationViewStyle(.stack)
     .onAppear {
       // TODO: Fetch pending requests
     }

--- a/BraveWallet/Panels/WebpageRequestContainerView.swift
+++ b/BraveWallet/Panels/WebpageRequestContainerView.swift
@@ -13,8 +13,7 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var cryptoStore: CryptoStore
   var toolbarDismissContent: DismissContent
-
-  @available(iOS, introduced: 14.0, deprecated: 15.0, message: "Use PresentationMode on iOS 15")
+  
   var onDismiss: () -> Void
 
   var body: some View {
@@ -46,6 +45,15 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
               onDismiss: onDismiss
+            )
+          case let .signMessage(request):
+            SignatureRequestView(
+              request: request,
+              keyringStore: keyringStore,
+              onDismiss: { approved in
+                cryptoStore.handleWebpageRequestResponse(.signMessage(approved: approved, id: request.id))
+                onDismiss()
+              }
             )
           default:
             EmptyView()

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2206,5 +2206,26 @@ extension Strings {
       value: "View Details",
       comment: "The title for the button to view details about the network the dapp site is requesting the user switch to, or the network the dapp website is requesting the user add."
     )
+    public static let signatureRequestTitle = NSLocalizedString(
+      "wallet.signatureRequestTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Signature Requested",
+      comment: "A title of the view shown over a dapps website that requests the user sign a message."
+    )
+    public static let signatureRequestSubtitle = NSLocalizedString(
+      "wallet.signatureRequestSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Your signature is being requested",
+      comment: "A subtitle of the view shown over a dapps website that requests the user sign a message."
+    )
+    public static let sign = NSLocalizedString(
+      "wallet.sign",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Sign",
+      comment: "The title of the button used to sign a message request on the signature request view."
+    )
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Integrated `PendingWebpageRequest.signMessage` to open the `SignatureRequestView` modally using `WebpageRequestContainerView`.

This pull request fixes #5218

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Note: At time of PR creation, wallet dapps are disabled with a compiler flag. Add `-DWALLET_DAPPS_ENABLED` to `base.xcconfig` to enable dapps support.

Multiple requests supported:
1. Visit https://metamask.github.io/test-dapp, unlock & connect an account in your wallet via 'Connect' button in basic actions.
2. Tap 'Sign' under 'Personal Sign'. This should present a modal with some personal message. Close modal with interaction.
3. Tap 'Sign' under 'Eth Sign'. This should present the previous modal with a '1 of 2' in top right to navigate through signature requests.
4. You should only be able to sign/cancel the requests in a first-in-first-out order


## Screenshots:
![sign request 1](https://user-images.githubusercontent.com/5314553/167664423-4ae53cce-6894-48bb-af23-6ed94ec838ce.png) | ![sign request 2](https://user-images.githubusercontent.com/5314553/167664426-3abbcbf1-b857-48cb-9dae-c9a28ad61d06.png)
-- | -- 


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
