### PR TITLE
Fix #5208: Fixes Cosmetic Filters Crash on Network Call

### DIFF
--- a/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
+++ b/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
@@ -241,12 +241,12 @@ class FeedDataSource {
           fatalError("Incorrect URL generated for the given resource: \(resource)")
         }
         let deferred = Deferred<Result<Data, Error>>(value: nil, defaultQueue: .main)
-
-        Task {
-          do {
-            let (data, _) = try await self.session.dataRequest(with: url.appendingPathComponent(filename))
-            deferred.fill(.success(data))
-          } catch {
+        
+        self.session.dataRequest(with: url.appendingPathComponent(filename)) { result in
+          switch result {
+          case .success(let response):
+            deferred.fill(.success(response.0))
+          case .failure(let error):
             deferred.fill(.failure(error))
           }
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -414,11 +414,8 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     contentBlockListTask = ContentBlockerHelper.compileBundledLists()
       .receive(on: DispatchQueue.main)
       .sink { [weak self] res in
-        switch res {
-        case .failure(let error):
+        if case .failure(let error) = res {
           log.error("Content Blocker failed to compile bundled lists: \(error)")
-        default:
-          break
         }
           
         contentBlockListTask = nil

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -198,7 +198,7 @@ extension BrowserViewController {
   }
 
   private func createSearchEngine(_ url: URL, reference: String, icon: UIImage) {
-    NetworkManager().downloadResource(with: url) { [weak self] result in
+    NetworkManager().downloadResource(with: url) { result in
       switch result {
       case .success(let response):
         guard let openSearchEngine = OpenSearchParser(pluginMode: true).parse(
@@ -209,7 +209,7 @@ extension BrowserViewController {
           return
         }
 
-        self?.addSearchEngine(openSearchEngine)
+        self.addSearchEngine(openSearchEngine)
         
       case .failure(let error):
         log.error(error)

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -198,20 +198,20 @@ extension BrowserViewController {
   }
 
   private func createSearchEngine(_ url: URL, reference: String, icon: UIImage) {
-    Task {
-      do {
-        let response = try await NetworkManager().downloadResource(with: url)
-        await MainActor.run { [weak self] in
-          guard
-            let openSearchEngine = OpenSearchParser(pluginMode: true).parse(
-              response.data, referenceURL: reference, image: icon, isCustomEngine: true)
-          else {
-            return
-          }
-
-          self?.addSearchEngine(openSearchEngine)
+    NetworkManager().downloadResource(with: url) { [weak self] result in
+      switch result {
+      case .success(let response):
+        guard let openSearchEngine = OpenSearchParser(pluginMode: true).parse(
+          response.data,
+          referenceURL: reference,
+          image: icon,
+          isCustomEngine: true) else {
+          return
         }
-      } catch {
+
+        self?.addSearchEngine(openSearchEngine)
+        
+      case .failure(let error):
         log.error(error)
       }
     }

--- a/Client/Frontend/Settings/AdblockDebugMenuTableViewController.swift
+++ b/Client/Frontend/Settings/AdblockDebugMenuTableViewController.swift
@@ -44,13 +44,10 @@ class AdblockDebugMenuTableViewController: TableViewController {
           compileListsTask = ContentBlockerHelper.compileBundledLists()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] res in
-              switch res {
-              case .failure(let error):
+              if case .failure(let error) = res {
                 let alert = UIAlertController(title: nil, message: "Failed to Recompile Blockers: \(error)", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default))
                 self?.present(alert, animated: true)
-              default:
-                break
               }
               compileListsTask = nil
           } receiveValue: { [weak self] _ in

--- a/Client/Networking/NetworkSessionMock.swift
+++ b/Client/Networking/NetworkSessionMock.swift
@@ -3,11 +3,60 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import Combine
 
 class NetworkSessionMock: NetworkSession {
   var data: Data?
   var response: URLResponse?
   var error: Error?
+  
+  func dataRequest(with url: URL, _ completion: @escaping (Result<NetworkSessionDataResponse, Error>) -> Void) {
+    if let error = self.error {
+      completion(.failure(error))
+      return
+    }
+
+    let data = self.data ?? Data()
+    let response = self.response ?? HTTPURLResponse()
+    completion(.success((data, response)))
+  }
+  
+  func dataRequest(with urlRequest: URLRequest, _ completion: @escaping (Result<NetworkSessionDataResponse, Error>) -> Void) {
+    if let error = self.error {
+      completion(.failure(error))
+      return
+    }
+
+    let data = self.data ?? Data()
+    let response = self.response ?? HTTPURLResponse()
+    completion(.success((data, response)))
+  }
+  
+  func dataRequest(with url: URL) -> AnyPublisher<NetworkSessionDataResponse, Error> {
+    return Future { completion in
+      if let error = self.error {
+        completion(.failure(error))
+        return
+      }
+
+      let data = self.data ?? Data()
+      let response = self.response ?? HTTPURLResponse()
+      completion(.success((data, response)))
+    }.eraseToAnyPublisher()
+  }
+  
+  func dataRequest(with urlRequest: URLRequest) -> AnyPublisher<NetworkSessionDataResponse, Error> {
+    return Future { completion in
+      if let error = self.error {
+        completion(.failure(error))
+        return
+      }
+
+      let data = self.data ?? Data()
+      let response = self.response ?? HTTPURLResponse()
+      completion(.success((data, response)))
+    }.eraseToAnyPublisher()
+  }
 
   func dataRequest(with url: URL) async throws -> NetworkSessionDataResponse {
     try await Task.detached(priority: .userInitiated) {

--- a/Client/Networking/NetworkSessionMock.swift
+++ b/Client/Networking/NetworkSessionMock.swift
@@ -33,28 +33,32 @@ class NetworkSessionMock: NetworkSession {
   }
   
   func dataRequest(with url: URL) -> AnyPublisher<NetworkSessionDataResponse, Error> {
-    return Future { completion in
-      if let error = self.error {
-        completion(.failure(error))
-        return
-      }
+    Combine.Deferred {
+      Future { completion in
+        if let error = self.error {
+          completion(.failure(error))
+          return
+        }
 
-      let data = self.data ?? Data()
-      let response = self.response ?? HTTPURLResponse()
-      completion(.success((data, response)))
+        let data = self.data ?? Data()
+        let response = self.response ?? HTTPURLResponse()
+        completion(.success((data, response)))
+      }
     }.eraseToAnyPublisher()
   }
   
   func dataRequest(with urlRequest: URLRequest) -> AnyPublisher<NetworkSessionDataResponse, Error> {
-    return Future { completion in
-      if let error = self.error {
-        completion(.failure(error))
-        return
-      }
+    Combine.Deferred {
+      Future { completion in
+        if let error = self.error {
+          completion(.failure(error))
+          return
+        }
 
-      let data = self.data ?? Data()
-      let response = self.response ?? HTTPURLResponse()
-      completion(.success((data, response)))
+        let data = self.data ?? Data()
+        let response = self.response ?? HTTPURLResponse()
+        completion(.success((data, response)))
+      }
     }.eraseToAnyPublisher()
   }
 

--- a/Client/WebFilters/AdblockResourceDownloader.swift
+++ b/Client/WebFilters/AdblockResourceDownloader.swift
@@ -70,9 +70,7 @@ class AdblockResourceDownloader {
       return Empty(outputType: Void.self, failureType: Error.self).eraseToAnyPublisher()
     }
 
-    return downloadResources(
-      type: .regional(locale: locale),
-      queueName: "Regional adblock setup")
+    return downloadResources(type: .regional(locale: locale))
       .receive(on: DispatchQueue.main)
       .map {
         log.debug("Regional blocklists download and setup completed.")
@@ -81,9 +79,7 @@ class AdblockResourceDownloader {
   }
 
   func generalAdblockResourcesSetup() -> AnyPublisher<Void, Error> {
-    return downloadResources(
-      type: .general,
-      queueName: "General adblock setup")
+    return downloadResources(type: .general)
       .receive(on: DispatchQueue.main)
       .map {
         log.debug("General blocklists download and setup completed.")
@@ -91,7 +87,7 @@ class AdblockResourceDownloader {
       }.eraseToAnyPublisher()
   }
 
-  private func downloadResources(type: AdblockerType, queueName: String) -> AnyPublisher<Void, Error> {
+  private func downloadResources(type: AdblockerType) -> AnyPublisher<Void, Error> {
     let nm = networkManager
     let folderName = AdblockResourceDownloader.folderName
 
@@ -209,6 +205,10 @@ class AdblockResourceDownloader {
   }
 
   private func setUpFiles(resources: [AdBlockNetworkResource], compileJsonRules: Bool) -> AnyPublisher<Void, Error> {
+    if resources.isEmpty {
+      return Fail(error: "No Adblock Resource to Setup").eraseToAnyPublisher()
+    }
+    
     let resources: [AnyPublisher<Void, Error>] = resources.compactMap {
       switch $0.fileType {
       case .dat:

--- a/Client/WebFilters/AdblockResourceDownloader.swift
+++ b/Client/WebFilters/AdblockResourceDownloader.swift
@@ -250,17 +250,13 @@ extension AdblockResourceDownloader: PreferencesObserver {
         .subscribe(on: DispatchQueue.global(qos: .userInitiated))
         .receive(on: DispatchQueue.main)
         .sink { res in
-        switch res {
-        case .failure(let error):
-          log.error(error)
-        default:
-          break
+          if case .failure(let error) = res {
+            log.error(error)
+          }
+          cancellable = nil
+        } receiveValue: { _ in
+          log.debug("Successfully Setup Adblock Regional Preferences")
         }
-        
-        cancellable = nil
-      } receiveValue: { _ in
-        log.debug("Successfully Setup Adblock Regional Preferences")
-      }
     }
   }
 }

--- a/Client/WebFilters/ContentBlocker/BlocklistName.swift
+++ b/Client/WebFilters/ContentBlocker/BlocklistName.swift
@@ -96,7 +96,7 @@ class BlocklistName: CustomStringConvertible, ContentBlocker {
     allRules.append(BlocklistName.cookie.buildRule(ruleStore: ruleStore))
     return Publishers.MergeMany(allRules)
       .collect()
-      .flatMap({ $0.publisher })
+      .map({ _ in () })
       .eraseToAnyPublisher()
   }
 

--- a/Client/WebFilters/ContentBlocker/ContentBlocker.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlocker.swift
@@ -77,18 +77,20 @@ extension ContentBlocker {
   }
 
   private static func loadJsonFromBundle(forResource file: String) -> AnyPublisher<String, Error> {
-    return Future { completion in
-      do {
-        guard let path = Bundle.main.path(forResource: file, ofType: "json") else {
-          assert(false)
-          completion(.failure("Failed to Load JSON From Bundle - Resource: \(file)"))
-          return
+    Combine.Deferred {
+      Future { completion in
+        do {
+          guard let path = Bundle.main.path(forResource: file, ofType: "json") else {
+            assert(false)
+            completion(.failure("Failed to Load JSON From Bundle - Resource: \(file)"))
+            return
+          }
+          
+          let source = try String(contentsOfFile: path, encoding: .utf8)
+          completion(.success(source))
+        } catch {
+          completion(.failure(error))
         }
-        
-        let source = try String(contentsOfFile: path, encoding: .utf8)
-        completion(.success(source))
-      } catch {
-        completion(.failure(error))
       }
     }.eraseToAnyPublisher()
   }

--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -6,6 +6,7 @@ import WebKit
 import Shared
 import Data
 import BraveShared
+import Combine
 
 private let log = Logger.browserLogger
 
@@ -45,8 +46,8 @@ class ContentBlockerHelper {
   static let ruleStore: WKContentRuleListStore = WKContentRuleListStore.default()
   weak var tab: Tab?
 
-  static func compileBundledLists() async {
-    return await BlocklistName.compileBundledRules(ruleStore: ruleStore)
+  static func compileBundledLists() -> AnyPublisher<Void, Error> {
+    return BlocklistName.compileBundledRules(ruleStore: ruleStore)
   }
 
   var isUserEnabled: Bool? {

--- a/Client/WebFilters/CosmeticFiltersResourceDownloader.swift
+++ b/Client/WebFilters/CosmeticFiltersResourceDownloader.swift
@@ -71,11 +71,8 @@ class CosmeticFiltersResourceDownloader {
         initialLoad = loadDownloadedFiles(into: engine)
           .receive(on: DispatchQueue.main)
           .sink { res in
-            switch res {
-            case .failure(let error):
+            if case .failure(let error) = res {
               log.error("Error Loading Cosmetic-Filters: \(error)")
-            default:
-              break
             }
           } receiveValue: { _ in
             log.debug("Successfully Loaded Cosmetic-Filters")
@@ -118,11 +115,8 @@ class CosmeticFiltersResourceDownloader {
         }
         .flatMap { $0 }
         .sink { res in
-          switch res {
-          case .failure(let error):
+          if case .failure(let error) = res {
             log.error("Failed to Setup Cosmetic-Filters: \(error)")
-          default:
-            break
           }
         } receiveValue: { [weak self] engine in
           self?.engine = engine

--- a/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -79,11 +79,8 @@ class AdBlockStats: LocalAdblockResourceProtocol {
         .subscribe(on: DispatchQueue.global(qos: .userInitiated))
         .map({ _ in () })
         .sink { res in
-          switch res {
-          case .failure(let error):
+          if case .failure(let error) = res {
             log.error("Failed to Setup Adblock Stats: \(error)")
-          default:
-            break
           }
         } receiveValue: { _ in
           log.debug("Successfully Setup Adblock Stats")


### PR DESCRIPTION
## Summary of Changes
- Switch all Cosmetic Filters code to use publishers instead of Async Await (some sort of weird crash is happening that can't be reproduced)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5208

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Test Cosmetic Filters
Test Adblock and Adblock Stats

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
