### PR TITLE
Fix #5211: Force BraveCore cleanup before it gets the notification which might b…

### DIFF
--- a/Client/Application/Delegates/AppDelegate.swift
+++ b/Client/Application/Delegates/AppDelegate.swift
@@ -335,6 +335,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Clean up BraveCore
     braveCore.syncAPI.removeAllObservers()
+    if braveCore.responds(to: Selector(("onAppWillTerminate:"))) {
+      braveCore.perform(Selector(("onAppWillTerminate:")), with: nil)
+    }
+    
+    log.debug("Cleanly Terminated the Application")
   }
 
   func updateShortcutItems(_ application: UIApplication) {


### PR DESCRIPTION
## Summary of Changes
- Force BraveCore cleanup before it gets the notification which might be too late.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5211

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
