### PR TITLE
Fix #4940: Changing some force portrait mode criteria

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -51,8 +51,6 @@ extension BrowserViewController {
 
     updateRewardsButtonState()
 
-    UIDevice.current.forcePortraitIfIphone(for: UIApplication.shared)
-
     guard let tab = tabManager.selectedTab else { return }
 
     let braveRewardsPanel = BraveRewardsViewController(

--- a/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
+++ b/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
@@ -85,21 +85,6 @@ class BrowserNavigationHelper {
     open(vc, doneButton: DoneButton(style: .done, position: .right))
   }
 
-  func openSettings() {
-    guard let bvc = bvc else { return }
-    let vc = SettingsViewController(
-      profile: bvc.profile,
-      tabManager: bvc.tabManager,
-      feedDataSource: bvc.feedDataSource,
-      rewards: bvc.rewards,
-      windowProtection: bvc.windowProtection,
-      braveCore: bvc.braveCore)
-    vc.settingsDelegate = bvc
-    open(
-      vc, doneButton: DoneButton(style: .done, position: .right),
-      allowSwipeToDismiss: false)
-  }
-
   func openShareSheet() {
     guard let bvc = bvc else { return }
     dismissView()

--- a/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
+++ b/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
@@ -22,15 +22,11 @@ class BrowserNavigationHelper {
     _ viewController: UIViewController, doneButton: DoneButton,
     allowSwipeToDismiss: Bool = true
   ) {
-    let nav = SettingsNavigationController(rootViewController: viewController)
-
-    // All menu views should be opened in portrait on iPhones.
-    UIDevice.current.forcePortraitIfIphone(for: UIApplication.shared)
-
-    nav.isModalInPresentation = !allowSwipeToDismiss
-
-    nav.modalPresentationStyle =
-      UIDevice.current.userInterfaceIdiom == .phone ? .pageSheet : .formSheet
+    let nav = SettingsNavigationController(rootViewController: viewController).then {
+      $0.isModalInPresentation = !allowSwipeToDismiss
+      $0.modalPresentationStyle =
+        UIDevice.current.userInterfaceIdiom == .phone ? .pageSheet : .formSheet
+    }
 
     let button = UIBarButtonItem(barButtonSystemItem: doneButton.style, target: nav, action: #selector(nav.done))
 

--- a/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
+++ b/Client/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
@@ -58,22 +58,6 @@ class BrowserNavigationHelper {
     FileManager.default.openBraveDownloadsFolder(completion)
   }
 
-  func openAddBookmark() {
-    guard let bvc = bvc,
-      let tab = bvc.tabManager.selectedTab,
-      let url = tab.url
-    else { return }
-
-    let bookmarkUrl = url.decodeReaderModeURL ?? url
-
-    let mode = BookmarkEditMode.addBookmark(title: tab.displayTitle, url: bookmarkUrl.absoluteString)
-
-    let vc = AddEditBookmarkTableViewController(bookmarkManager: bvc.bookmarkManager, mode: mode)
-
-    open(vc, doneButton: DoneButton(style: .cancel, position: .left))
-
-  }
-
   func openHistory() {
     guard let bvc = bvc else { return }
     let vc = HistoryViewController(


### PR DESCRIPTION
This PR is making necessary changes related with force portrait mode while 

Presenting Bookmarks from top toolbar and menu
Presenting Rewards Popover

It is also deleting some unused Navigation methods

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4940

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
 
Task 1

1. Open Brave and change landscape orientation
2. Click Rewards Button and check if orientation doesn't change and rewards open in landscape


Task 2

1. Add Bookmarks Icon to URL Bar from settings
2. Change to landscape orientation
3. Click Bookmarks Button and check bookmarks screen is opened at that orientation

## Screenshots:

https://user-images.githubusercontent.com/6643505/161833600-29192815-1c3b-48c3-9741-88c57ad1b04f.mp4

![4144111](https://user-images.githubusercontent.com/6643505/161834086-807d379a-36d0-426c-88cc-21e9ceae4ef5.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
