### PR TITLE
Fix #4820: Dismiss to Browser after open in a new tab action performed from Bookmarks

### DIFF
--- a/Client/Extensions/UIActionExtensions.swift
+++ b/Client/Extensions/UIActionExtensions.swift
@@ -13,7 +13,7 @@ extension UIAction {
   /// This ensures that the user can:
   ///   1. See a change that happens based on their selection
   ///   2. Ensure that if the view which has shown the context menu were to be removed from the view
-  ///      heirarchy as a result of the action, that the context menu does not crash on dismissal.
+  ///      hierarchy as a result of the action, that the context menu does not crash on dismissal.
   static func deferredActionHandler(_ handler: @escaping UIActionHandler) -> UIActionHandler {
     return { action in
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -116,7 +116,7 @@ extension BrowserViewController {
           bookmarkManager: bookmarkManager,
           isPrivateBrowsing: PrivateBrowsingManager.shared.isPrivateBrowsing)
         vc.toolbarUrlActionsDelegate = self
-        menuController.presentInnerMenu(vc)
+        menuController.pushInnerMenu(vc)
       }
 
       MenuItemButton(icon: #imageLiteral(resourceName: "menu-history").template, title: Strings.historyMenuItem) { [unowned self, unowned menuController] in

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -583,6 +583,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         image: UIImage(systemName: "plus.square.on.square"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
           self.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: isPrivateBrowsing)
+          self.dismiss(animated: true)
         })
 
       let newPrivateTabAction = UIAction(
@@ -590,6 +591,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
           self.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: true)
+          self.dismiss(animated: true)
         })
 
       let copyAction = UIAction(


### PR DESCRIPTION
Settings menu stays opened when long tapping and opening bookmark via Open in New Tab. It should dismiss all controller and show browser view controller after action is performed. 

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4820

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Download/install Brave 
- Save a bookmark into Mobile Bookmarks (doesn't need to be in another folder)

- Either Open That bookmarks screen from settings or top toolbar
- Long tap on the saved bookmark and select Open in New Tab

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/161837476-f8acddd5-0903-428d-b713-01a88072f7cc.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
