### PR TITLE
Fix #5219: Crash verifying recovery phrase

### DIFF
--- a/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
@@ -158,6 +158,7 @@ private struct SelectedWordsBox: View {
   }
 
   private func tappedWord(atIndex index: Int) {
+    guard index < selectedWords.count else { return }
     withAnimation(.default) {
       _ = selectedWords.remove(at: index)
     }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5219

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Start setup for a new wallet
2. On verify recovery phrase view, tap a single word box to move it to the 'selected words' at the top
3. When there is only 1 word in the top 'selected words' box, double tap the word
4. Crashes


## Screenshots:
https://user-images.githubusercontent.com/5314553/161987220-4284e1bc-c8d6-4576-b595-b8421548d281.mov



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
