### PR TITLE
Fix #4862 - #5215: Some problems around Custom Search Engine

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -605,7 +605,7 @@ extension Strings {
       comment: "The alert title shown to user when custom search engine will be deleted while it is default search engine. The parameter will be replace with name of the search engine.")
     
     public static let deleteEngineAlertDescription = NSLocalizedString(
-      "customSearchEngine.deleteEngineAlertTitle",
+      "customSearchEngine.deleteEngineAlertDescription",
       bundle: .braveShared,
       value: "Deleting a custom search engine while it is default will switch default engine automatically.",
       comment: "The warning description shown to user when custom search engine will be deleted while it is default search engine.")

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -597,6 +597,18 @@ extension Strings {
       bundle: .braveShared,
       value: "The new search engine will appear in the quick search bar.",
       comment: "The message that asks the user to Add the search provider explaining where the search engine will appear")
+  
+    public static let deleteEngineAlertTitle = NSLocalizedString(
+      "customSearchEngine.deleteEngineAlertTitle",
+      bundle: .braveShared,
+      value: "Are you sure you want to delete %@?",
+      comment: "The alert title shown to user when custom search engine will be deleted while it is default search engine. The parameter will be replace with name of the search engine.")
+    
+    public static let deleteEngineAlertDescription = NSLocalizedString(
+      "customSearchEngine.deleteEngineAlertTitle",
+      bundle: .braveShared,
+      value: "Deleting a custom search engine while it is default will switch default engine automatically.",
+      comment: "The warning description shown to user when custom search engine will be deleted while it is default search engine.")
   }
 }
 

--- a/Client/Frontend/Browser/Search/OpenSearch.swift
+++ b/Client/Frontend/Browser/Search/OpenSearch.swift
@@ -93,11 +93,12 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
     self.isCustomEngine = isCustomEngine
     self.image = image
     self.engineID = aDecoder.decodeObject(of: NSString.self, forKey: "engineID") as String?
-    self.suggestTemplate = nil
+    self.suggestTemplate = aDecoder.decodeObject(of: NSString.self, forKey: "suggestTemplate") as String?
   }
 
   func encode(with aCoder: NSCoder) {
     aCoder.encode(searchTemplate, forKey: "searchTemplate")
+    aCoder.encode(suggestTemplate, forKey: "suggestTemplate")
     aCoder.encode(shortName, forKey: "shortName")
     aCoder.encode(isCustomEngine, forKey: "isCustomEngine")
     aCoder.encode(image, forKey: "image")

--- a/Client/Frontend/Browser/Search/SearchEngines.swift
+++ b/Client/Frontend/Browser/Search/SearchEngines.swift
@@ -194,8 +194,8 @@ class SearchEngines {
   }
 
   func deleteCustomEngine(_ engine: OpenSearchEngine) throws {
-    // We can't delete a preinstalled engine or an engine that is currently the default.
-    if !engine.isCustomEngine || isEngineDefault(engine) {
+    // We can't delete a preinstalled engine
+    if !engine.isCustomEngine {
       return
     }
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -325,8 +325,8 @@ class SearchSettingsTableViewController: UITableViewController {
 
       if engine == searchEngines.defaultEngine(forType: .standard) {
         let alert = UIAlertController(
-          title: "Are you sure you want to delete \(engine.displayName)?",
-          message: "Deleting a custom search engine while it is default will switch default engine to Brave Search.",
+          title: String(format: Strings.CustomSearchEngine.deleteEngineAlertTitle, engine.displayName),
+          message: Strings.CustomSearchEngine.deleteEngineAlertDescription,
           preferredStyle: .alert)
         
         alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel) { _ in
@@ -334,7 +334,12 @@ class SearchSettingsTableViewController: UITableViewController {
         })
         
         alert.addAction(UIAlertAction(title: Strings.delete, style: .destructive) { [weak self] _ in
-          self?.searchEngines.updateDefaultEngine(OpenSearchEngine.EngineNames.brave, forType: .standard)
+          guard let self = self else { return }
+          
+          self.searchEngines.updateDefaultEngine(
+            self.searchEngines.defaultEngine(forType: .privateMode).shortName,
+            forType: .standard)
+          
           deleteCustomEngine()
         })
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -329,9 +329,7 @@ class SearchSettingsTableViewController: UITableViewController {
           message: Strings.CustomSearchEngine.deleteEngineAlertDescription,
           preferredStyle: .alert)
         
-        alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel) { _ in
-          return
-        })
+        alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel))
         
         alert.addAction(UIAlertAction(title: Strings.delete, style: .destructive) { [weak self] _ in
           guard let self = self else { return }


### PR DESCRIPTION
Issue #4862 is around suggestions from custom search engines. Clearing and Launching the application makes custom search engines suggestions not work properly. As indicated in the ticket:

- Adding a custom search engine via Menu ---> Add Search Engine allows the search suggestions to work properly. However, if you relaunch Brave, they no longer work and the search engine has to be deleted and re-added. 

Issue #5215 is about deletion of Custom Search Engines.

- When a Custom Search Engine is defined as default search engine, we cant delete the engine until default engine is changed to some other engine. To prevent this behaviour and give more functionality we allowed users to delete custom search engines and added a warning related with this, also after deleting the custom search engine, default engine private mode will be changed as default engine on default browse.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4862
This pull request fixes #5215

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

Issue #4862

- Add a custom search engine like SearX or Whoogle using Menu --> Add Search Engine
- Assign that search engine to be the default in Standard Tab in Search Engine settings
- Ensure Show Search Suggestions is toggled on.
- DO NOT CLOSE Brave and try to search for something.
- Notice how the search suggestions are populating.
- Now close Brave completely using the App Switcher
- Relaunch Brave and search for something.
- Search suggestions should be working.

Issue #5215

- Add a custom search engine like SearX or Whoogle using Menu --> Add Search Engine
- Assign that search engine to be the default in Standard Tab in Search Engine settings
- Try to delete that engine edit or action
- An lert should be presented to user and accepting the warning should delete the engine 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/6643505/162036217-a123c4be-d975-411e-9c7f-99f452ef8ddb.mp4

https://user-images.githubusercontent.com/6643505/162036237-72586b39-307a-4153-913d-4f5a827f1b55.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
