### PR TITLE
update docs to symlink node

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Building the code
 1. Add a symlink to `npm` (M1 Macs)
     ```shell
     sudo ln -s $(which npm) /usr/local/bin/npm
+    sudo ln -s $(which node) /usr/local/bin/node
     ```
 1. Open `Client.xcodeproj` in Xcode.
 1. Build the `Debug` scheme in Xcode.


### PR DESCRIPTION
I was getting an error of `env: node: No such file or directory` when trying to build in X Code on an M1 mac. By setting up a symlink for node as well I was able to fix it.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
