### PR TITLE
Fix #5118: Using 'Search with Brave' in the context menu does not log in recent searches

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2124,16 +2124,16 @@ extension BrowserViewController: TabDelegate {
   }
 
   /// Triggered when "Find in Page" is selected on selected text
-  func tab(_ tab: Tab, didSelectFindInPageForSelection selection: String) {
+  func tab(_ tab: Tab, didSelectFindInPageFor selectedText: String) {
     updateFindInPageVisibility(visible: true)
-    findInPageBar?.text = selection
+    findInPageBar?.text = selectedText
   }
 
   /// Triggered when "Search with Brave" is selected on selected web text
-  func tab(_ tab: Tab, didSelectSearchWithBraveForSelection selection: String) {
+  func tab(_ tab: Tab, didSelectSearchWithBraveFor selectedText: String) {
     let engine = profile.searchEngines.defaultEngine()
 
-    guard let url = engine.searchURLForQuery(selection) else {
+    guard let url = engine.searchURLForQuery(selectedText) else {
       assertionFailure("If this returns nil, investigate why and add proper handling or commenting")
       return
     }
@@ -2143,6 +2143,10 @@ extension BrowserViewController: TabDelegate {
       afterTab: tab,
       isPrivate: tab.isPrivate
     )
+    
+    if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+      RecentSearch.addItem(type: .text, text: selectedText, websiteUrl: url.absoluteString)
+    }
   }
 
   func showRequestRewardsPanel(_ tab: Tab) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -32,7 +32,7 @@ extension BrowserViewController {
 
   @objc private func findInPageKeyCommand() {
     if let tab = tabManager.selectedTab, favoritesController == nil {
-      self.tab(tab, didSelectFindInPageForSelection: "")
+      self.tab(tab, didSelectFindInPageFor: "")
     }
   }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -25,9 +25,9 @@ protocol TabDelegate {
   func tab(_ tab: Tab, didAddSnackbar bar: SnackBar)
   func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar)
   /// Triggered when "Find in Page" is selected on selected web text
-  func tab(_ tab: Tab, didSelectFindInPageForSelection selection: String)
+  func tab(_ tab: Tab, didSelectFindInPageFor selectedText: String)
   /// Triggered when "Search with Brave" is selected on selected web text
-  func tab(_ tab: Tab, didSelectSearchWithBraveForSelection selection: String)
+  func tab(_ tab: Tab, didSelectSearchWithBraveFor selectedText: String)
   @objc optional func tab(_ tab: Tab, didCreateWebView webView: WKWebView)
   @objc optional func tab(_ tab: Tab, willDeleteWebView webView: WKWebView)
   func showRequestRewardsPanel(_ tab: Tab)
@@ -717,13 +717,13 @@ class Tab: NSObject {
 
 extension Tab: TabWebViewDelegate {
   /// Triggered when "Find in Page" is selected on selected text
-  fileprivate func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String) {
-    tabDelegate?.tab(self, didSelectFindInPageForSelection: selection)
+  fileprivate func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageFor selectedText: String) {
+    tabDelegate?.tab(self, didSelectFindInPageFor: selectedText)
   }
 
   /// Triggered when "Search with Brave" is selected on selected text
-  fileprivate func tabWebView(_ tabWebView: TabWebView, didSelectSearchWithBraveForSelection selection: String) {
-    tabDelegate?.tab(self, didSelectSearchWithBraveForSelection: selection)
+  fileprivate func tabWebView(_ tabWebView: TabWebView, didSelectSearchWithBraveFor selectedText: String) {
+    tabDelegate?.tab(self, didSelectSearchWithBraveFor: selectedText)
   }
 }
 
@@ -774,9 +774,9 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandlerWithReply
 
 private protocol TabWebViewDelegate: AnyObject {
   /// Triggered when "Find in Page" is selected on selected text
-  func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String)
+  func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageFor selectedText: String)
   /// Triggered when "Search with Brave" is selected on selected text
-  func tabWebView(_ tabWebView: TabWebView, didSelectSearchWithBraveForSelection selection: String)
+  func tabWebView(_ tabWebView: TabWebView, didSelectSearchWithBraveFor selectedText: String)
 }
 
 class TabWebView: BraveWebView, MenuHelperInterface {
@@ -794,7 +794,7 @@ class TabWebView: BraveWebView, MenuHelperInterface {
         return
       }
 
-      self.delegate?.tabWebView(self, didSelectFindInPageForSelection: selectedText)
+      self.delegate?.tabWebView(self, didSelectFindInPageFor: selectedText)
     }
   }
 
@@ -806,7 +806,7 @@ class TabWebView: BraveWebView, MenuHelperInterface {
         return
       }
 
-      self.delegate?.tabWebView(self, didSelectSearchWithBraveForSelection: selectedText)
+      self.delegate?.tabWebView(self, didSelectSearchWithBraveFor: selectedText)
     }
   }
 
@@ -847,8 +847,8 @@ class TabWebViewMenuHelper: UIView {
   @objc func swizzledMenuHelperFindInPage() {
     if let tabWebView = superview?.superview as? TabWebView {
       tabWebView.evaluateSafeJavaScript(functionName: "getSelection().toString", contentWorld: .defaultClient) { result, _ in
-        let selection = result as? String ?? ""
-        tabWebView.delegate?.tabWebView(tabWebView, didSelectFindInPageForSelection: selection)
+        let selectedText = result as? String ?? ""
+        tabWebView.delegate?.tabWebView(tabWebView, didSelectFindInPageFor: selectedText)
       }
     }
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5118

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open website with text
- Select text will bring up context menu, select 'Search with Brave' (to the right of find in page)
- Once search results are displayed, open new tab and highlight the search field
- Observe the recent searches, and check the new entry exists

## Screenshots:

https://user-images.githubusercontent.com/6643505/162316132-bc247b30-d2d2-45b4-82fc-5726c22f5ce7.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
