### PR TITLE
Fix #4934: Adding Cancel into the Suppress Alerts modal on iPad 

### DIFF
--- a/Client/Frontend/Browser/Helpers/PrintHelper.swift
+++ b/Client/Frontend/Browser/Helpers/PrintHelper.swift
@@ -69,7 +69,13 @@ class PrintHelper: TabContentScript {
 
       if printCounter > 1 {
         // Show confirm alert here.
-        let suppressSheet = UIAlertController(title: nil, message: Strings.suppressAlertsActionMessage, preferredStyle: .actionSheet)
+        let suppressAlertStyle: UIAlertController.Style = UIDevice.isIpad ? .alert : .actionSheet
+        
+        let suppressSheet = UIAlertController(
+          title: nil, message:
+            Strings.suppressAlertsActionMessage,
+          preferredStyle: suppressAlertStyle)
+        
         suppressSheet.addAction(
           UIAlertAction(
             title: Strings.suppressAlertsActionTitle, style: .destructive,
@@ -83,6 +89,7 @@ class PrintHelper: TabContentScript {
             handler: { _ in
               showPrintSheet()
             }))
+        
         if UIDevice.current.userInterfaceIdiom == .pad, let popoverController = suppressSheet.popoverPresentationController {
           popoverController.sourceView = webView
           popoverController.sourceRect = CGRect(x: webView.bounds.midX, y: webView.bounds.midY, width: 0, height: 0)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4934

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Visit https://brandon-t.github.io/WindowPrint.html
- Check the suppress Warning alert is presented with alert style and having cancel

## Screenshots:

![alert-suppress](https://user-images.githubusercontent.com/6643505/162318927-23a12d21-c8d2-452d-8b33-359a2db3753a.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
