### PR TITLE
Fix #5150: Reader Mode bar stuck on page after closing tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -721,7 +721,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     }
     header.addArrangedSubview(topToolbar)
 
-    tabsBar = TabsBarViewController(tabManager: tabManager)
+    tabsBar = TabsBarViewController(tabManager: tabManager, browserViewController: self)
     tabsBar.delegate = self
     header.addArrangedSubview(tabsBar.view)
 
@@ -2463,8 +2463,12 @@ extension BrowserViewController: TabManagerDelegate {
       image: UIImage(systemName: "xmark"),
       attributes: .destructive,
       handler: UIAction.deferredActionHandler { [unowned self] _ in
-        if let tab = self.tabManager.selectedTab {
-          self.tabManager.removeTab(tab)
+        if let tab = tabManager.selectedTab {
+          if topToolbar.locationView.readerModeState == .active {
+            hideReaderModeBar(animated: false)
+          }
+          
+          tabManager.removeTab(tab)
         }
       })
 
@@ -2675,12 +2679,6 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     return false
-  }
-
-  func webViewDidClose(_ webView: WKWebView) {
-    if let tab = tabManager[webView] {
-      self.tabManager.removeTab(tab)
-    }
   }
 
   func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo, completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -721,7 +721,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     }
     header.addArrangedSubview(topToolbar)
 
-    tabsBar = TabsBarViewController(tabManager: tabManager, browserViewController: self)
+    tabsBar = TabsBarViewController(tabManager: tabManager)
     tabsBar.delegate = self
     header.addArrangedSubview(tabsBar.view)
 
@@ -1989,6 +1989,16 @@ extension BrowserViewController: TabsBarViewControllerDelegate {
 
   func tabsBarDidLongPressAddTab(_ tabsBarController: TabsBarViewController, button: UIButton) {
     // The actions are carried to menu actions for Tab-Tray Button
+  }
+  
+  func tabsBarDidChangeReaderModeVisibility(_ isHidden: Bool) {
+    if topToolbar.locationView.readerModeState == .active {
+      if isHidden {
+        hideReaderModeBar(animated: false)
+      } else {
+        showReaderModeBar(animated: false)
+      }
+    }
   }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -57,6 +57,11 @@ extension BrowserViewController {
     guard let currentTab = tabManager.selectedTab else {
       return
     }
+    
+    if topToolbar.locationView.readerModeState == .active {
+      hideReaderModeBar(animated: false)
+    }
+    
     tabManager.removeTab(currentTab)
   }
 

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -13,6 +13,8 @@ protocol TabsBarViewControllerDelegate: AnyObject {
   func tabsBarDidSelectTab(_ tabsBarController: TabsBarViewController, _ tab: Tab)
   func tabsBarDidLongPressAddTab(_ tabsBarController: TabsBarViewController, button: UIButton)
   func tabsBarDidSelectAddNewTab(_ isPrivate: Bool)
+  func tabsBarDidChangeReaderModeVisibility(_ isHidden: Bool)
+
 }
 
 class TabsBarViewController: UIViewController {
@@ -61,12 +63,10 @@ class TabsBarViewController: UIViewController {
   }
 
   private weak var tabManager: TabManager?
-  private weak var browserViewController: BrowserViewController?
   private var tabList = WeakList<Tab>()
 
-  init(tabManager: TabManager, browserViewController: BrowserViewController) {
+  init(tabManager: TabManager) {
     self.tabManager = tabManager
-    self.browserViewController = browserViewController
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -386,14 +386,11 @@ extension TabsBarViewController: UICollectionViewDataSource {
     cell.closeTabCallback = { [weak self] tab in
       guard let self = self,
               let tabManager = self.tabManager,
-              let bvc = self.browserViewController,
               let previousIndex = self.tabList.index(of: tab) else {
         return
       }
       
-      if bvc.topToolbar.locationView.readerModeState == .active {
-        bvc.hideReaderModeBar(animated: false)
-      }
+      self.delegate?.tabsBarDidChangeReaderModeVisibility(true)
       
       tabManager.removeTab(tab)
       self.updateData()


### PR DESCRIPTION
Hiding reader mode toolbar when tab is closed. This action will dismiss the bar before tab is killed so it will not stuck on other tab opened.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5150

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Navigate to m.youtube.com
- Open new tab, navigate to wikipedia
- Click on any article and enable Reader Mode
- Now close current tab


## Screenshots:

https://user-images.githubusercontent.com/6643505/162323565-ccec42e7-7d98-44da-a1db-75e898bf8ad0.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
