### PR TITLE
No Bug: Bump BraveCore beta to 1.38.86

### DIFF
--- a/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -11,14 +11,6 @@ import BraveCore
 ///
 /// - note: Do not use this directly, use ``NetworkStore.previewStore``
 class MockBraveWalletService: BraveWalletBraveWalletService {
-  func notifyGetPublicKeyRequestProcessed(_ approved: Bool, origin: URL) {
-    
-  }
-  
-  func pendingGetEncryptionPublicKeyRequests(_ completion: @escaping ([BraveWallet.GetEncryptionPublicKeyRequest]) -> Void) {
-    completion([])
-  }
-
   private var assets: [String: [BraveWallet.BlockchainToken]] = [
     BraveWallet.MainnetChainId: [.previewToken],
     BraveWallet.RopstenChainId: [.previewToken],

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.38.73/brave-core-ios-1.38.73.tgz",
-      "integrity": "sha512-GxX1X9eIh0SsQfzCxbwWOF67nqG5WSQZN7w0kov500FvkNTOzqPKvdamJ/VRYOawbuD4NeMAPu+77okxEbpIeg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.38.86/brave-core-ios-1.38.86.tgz",
+      "integrity": "sha512-3Abvg9t4yWmFcbjUMYXC7AGCNunWvNqPwn+WTxGQC2k0GBlUrHCj5jjMlYUfVC2F1U0xDH2vKBaqnn8kNUgNWg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.38.73/brave-core-ios-1.38.73.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.38.86/brave-core-ios-1.38.86.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
This version unlocks the usage of Chromium's `URLPattern` type to do pattern matching on URLs/hosts/etc.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
