### PR TITLE
Fix #4964: Adds Picture-In-Picture support for videos on pages

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Playlist.js
+++ b/Client/Frontend/UserContent/UserScripts/Playlist.js
@@ -54,6 +54,7 @@ window.__firefox__.includeOnce("Playlist", function() {
         if (node) {
             if (!node.$<tagUUID>) {
                 node.$<tagUUID> = uuid_v4();
+                node.addEventListener('webkitpresentationmodechanged', (e) => e.stopPropagation(), true);
             }
         }
     }


### PR DESCRIPTION
## Summary of Changes
- Adds Picture-In-Picture support for videos on pages (at least for videos that can be added to playlist. Later one we can add it for ALL videos with a mutation observer which will be very light on performance).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4964

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
