### PR TITLE
Fix #5235: Tab Tray Menu Button Long Press Action Improvements

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -128,7 +128,7 @@ extension Strings {
       value: "Are you sure you want to close all open tabs?",
       comment: "We ask users this prompt before attempting to close multiple tabs via context menu")
   public static let savedTabsFolderTitle = NSLocalizedString("SavedTabsFolderTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Saved Tabs", comment: "The title for the folder created when all bookmarks are being ")
-  public static let bookmarkAllTabsTitle = NSLocalizedString("BookmarkAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Bookmark All Tabs", comment: "Action item title of long press for Adding Bookmark for All Tabs in Tab List")
+  public static let bookmarkAllTabsTitle = NSLocalizedString("BookmarkAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add Bookmark for %i Tabs", comment: "Action item title of long press for Adding Bookmark for All Tabs in Tab List - The parameter indicates the number of tabs like Add Bookmark for 5 Tabs")
   public static let suppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "Title of alert that seeks permission from user to suppress future JS alerts")
   public static let suppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Prevent this page from creating additional alerts", comment: "Message body of alert that seeks permission from user to suppress future JS alerts")
   public static let openDownloadsFolderErrorDescription =

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -129,6 +129,13 @@ extension Strings {
       comment: "We ask users this prompt before attempting to close multiple tabs via context menu")
   public static let savedTabsFolderTitle = NSLocalizedString("SavedTabsFolderTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Saved Tabs", comment: "The title for the folder created when all bookmarks are being ")
   public static let bookmarkAllTabsTitle = NSLocalizedString("BookmarkAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add Bookmark for %i Tabs", comment: "Action item title of long press for Adding Bookmark for All Tabs in Tab List - The parameter indicates the number of tabs like Add Bookmark for 5 Tabs")
+  public static let duplicateActiveTab =
+    NSLocalizedString(
+      "DuplicateActiveTab",
+      tableName: "BraveShared",
+      bundle: Bundle.braveShared,
+      value: "Duplicate Active Tabs",
+      comment: "Action item title of long press for Opening the existing - active Tab url in a new Tab")
   public static let suppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "Title of alert that seeks permission from user to suppress future JS alerts")
   public static let suppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Prevent this page from creating additional alerts", comment: "Message body of alert that seeks permission from user to suppress future JS alerts")
   public static let openDownloadsFolderErrorDescription =

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -128,13 +128,13 @@ extension Strings {
       value: "Are you sure you want to close all open tabs?",
       comment: "We ask users this prompt before attempting to close multiple tabs via context menu")
   public static let savedTabsFolderTitle = NSLocalizedString("SavedTabsFolderTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Saved Tabs", comment: "The title for the folder created when all bookmarks are being ")
-  public static let bookmarkAllTabsTitle = NSLocalizedString("BookmarkAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add Bookmark for %i Tabs", comment: "Action item title of long press for Adding Bookmark for All Tabs in Tab List - The parameter indicates the number of tabs like Add Bookmark for 5 Tabs")
+  public static let bookmarkAllTabsTitle = NSLocalizedString("BookmarkAllTabsTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add Bookmark for %lld Tabs", comment: "Action item title of long press for Adding Bookmark for All Tabs in Tab List - The parameter indicates the number of tabs like Add Bookmark for 5 Tabs")
   public static let duplicateActiveTab =
     NSLocalizedString(
       "DuplicateActiveTab",
       tableName: "BraveShared",
       bundle: Bundle.braveShared,
-      value: "Duplicate Active Tabs",
+      value: "Duplicate Active Tab",
       comment: "Action item title of long press for Opening the existing - active Tab url in a new Tab")
   public static let suppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Suppress Alerts", comment: "Title of alert that seeks permission from user to suppress future JS alerts")
   public static let suppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Prevent this page from creating additional alerts", comment: "Message body of alert that seeks permission from user to suppress future JS alerts")

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,165 +1,169 @@
 {
-  "pins" : [
-    {
-      "identity" : "feedkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nmdias/FeedKit.git",
-      "state" : {
-        "revision" : "68493a33d862c33c9a9f67ec729b3b7df1b20ade",
-        "version" : "9.1.2"
+  "object": {
+    "pins": [
+      {
+        "package": "FeedKit",
+        "repositoryURL": "https://github.com/nmdias/FeedKit.git",
+        "state": {
+          "branch": null,
+          "revision": "68493a33d862c33c9a9f67ec729b3b7df1b20ade",
+          "version": "9.1.2"
+        }
+      },
+      {
+        "package": "Fuzi",
+        "repositoryURL": "https://github.com/cezheng/Fuzi",
+        "state": {
+          "branch": null,
+          "revision": "f08c8323da21e985f3772610753bcfc652c2103f",
+          "version": "3.1.3"
+        }
+      },
+      {
+        "package": "Lottie",
+        "repositoryURL": "https://github.com/airbnb/lottie-ios",
+        "state": {
+          "branch": null,
+          "revision": "e02e82c7c1b472e85e641a7624e99c855e21add1",
+          "version": "3.1.9"
+        }
+      },
+      {
+        "package": "PanModal",
+        "repositoryURL": "https://github.com/brave/PanModal",
+        "state": {
+          "branch": null,
+          "revision": "e4c07f8e6c5df937051fabc47e1e92901e1d068b",
+          "version": null
+        }
+      },
+      {
+        "package": "SDWebImage",
+        "repositoryURL": "https://github.com/rs/SDWebImage",
+        "state": {
+          "branch": null,
+          "revision": "4aaca57fb2f6dc5554a2228cf1d94289bd0a6c7d",
+          "version": "5.10.3"
+        }
+      },
+      {
+        "package": "SnapKit",
+        "repositoryURL": "https://github.com/SnapKit/SnapKit",
+        "state": {
+          "branch": null,
+          "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
+          "version": "5.0.1"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "BigNumber",
+        "repositoryURL": "https://github.com/mkrd/Swift-BigInt",
+        "state": {
+          "branch": null,
+          "revision": "0ec7214cacd8724fd94c2d829218edf023732fc8",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "cmark-gfm",
+        "repositoryURL": "https://github.com/apple/swift-cmark.git",
+        "state": {
+          "branch": "gfm",
+          "revision": "6ddaa3991789bd790a9a6004566f99d85bfcb675",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "3426dba9ee5c9f8e4981b0fc9d39a818d36eec28",
+          "version": "0.0.4"
+        }
+      },
+      {
+        "package": "swift-markdown",
+        "repositoryURL": "https://github.com/apple/swift-markdown",
+        "state": {
+          "branch": null,
+          "revision": "4f0c76fcd29fea648915f41e2aa896d47608087a",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a23770641f65a4de61daf5425a37ae32a3fd00d",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "SwiftKeychainWrapper",
+        "repositoryURL": "https://github.com/jrendel/SwiftKeychainWrapper",
+        "state": {
+          "branch": null,
+          "revision": "185a3165346a03767101c4f62e9a545a0fe0530f",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "package": "Introspect",
+        "repositoryURL": "https://github.com/siteline/SwiftUI-Introspect",
+        "state": {
+          "branch": null,
+          "revision": "2e09be8af614401bc9f87d40093ec19ce56ccaf2",
+          "version": "0.1.3"
+        }
+      },
+      {
+        "package": "SwiftyJSON",
+        "repositoryURL": "https://github.com/SwiftyJSON/SwiftyJSON",
+        "state": {
+          "branch": null,
+          "revision": "2b6054efa051565954e1d2b9da831680026cd768",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "package": "Then",
+        "repositoryURL": "https://github.com/devxoul/Then",
+        "state": {
+          "branch": null,
+          "revision": "e421a7b3440a271834337694e6050133a3958bc7",
+          "version": "2.7.0"
+        }
+      },
+      {
+        "package": "XCGLogger",
+        "repositoryURL": "https://github.com/DaveWoodCom/XCGLogger",
+        "state": {
+          "branch": null,
+          "revision": "a9c4667b247928a29bdd41be2ec2c8d304215a54",
+          "version": "7.0.1"
+        }
+      },
+      {
+        "package": "ZIPFoundation",
+        "repositoryURL": "https://github.com/weichsel/ZIPFoundation",
+        "state": {
+          "branch": null,
+          "revision": "ec32d62d412578542c0ffb7a6ce34d3e64b43b94",
+          "version": "0.9.11"
+        }
       }
-    },
-    {
-      "identity" : "fuzi",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/cezheng/Fuzi",
-      "state" : {
-        "revision" : "f08c8323da21e985f3772610753bcfc652c2103f",
-        "version" : "3.1.3"
-      }
-    },
-    {
-      "identity" : "lottie-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-ios",
-      "state" : {
-        "revision" : "e02e82c7c1b472e85e641a7624e99c855e21add1",
-        "version" : "3.1.9"
-      }
-    },
-    {
-      "identity" : "panmodal",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/brave/PanModal",
-      "state" : {
-        "revision" : "e4c07f8e6c5df937051fabc47e1e92901e1d068b"
-      }
-    },
-    {
-      "identity" : "sdwebimage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/rs/SDWebImage",
-      "state" : {
-        "revision" : "4aaca57fb2f6dc5554a2228cf1d94289bd0a6c7d",
-        "version" : "5.10.3"
-      }
-    },
-    {
-      "identity" : "snapkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SnapKit/SnapKit",
-      "state" : {
-        "revision" : "d458564516e5676af9c70b4f4b2a9178294f1bc6",
-        "version" : "5.0.1"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms",
-      "state" : {
-        "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "swift-bigint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mkrd/Swift-BigInt",
-      "state" : {
-        "revision" : "0ec7214cacd8724fd94c2d829218edf023732fc8",
-        "version" : "2.1.2"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
-      "state" : {
-        "branch" : "gfm",
-        "revision" : "6ddaa3991789bd790a9a6004566f99d85bfcb675"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
-      "state" : {
-        "revision" : "3426dba9ee5c9f8e4981b0fc9d39a818d36eec28",
-        "version" : "0.0.4"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown",
-      "state" : {
-        "revision" : "4f0c76fcd29fea648915f41e2aa896d47608087a"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0a23770641f65a4de61daf5425a37ae32a3fd00d",
-        "version" : "1.0.1"
-      }
-    },
-    {
-      "identity" : "swiftkeychainwrapper",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jrendel/SwiftKeychainWrapper",
-      "state" : {
-        "revision" : "185a3165346a03767101c4f62e9a545a0fe0530f",
-        "version" : "4.0.1"
-      }
-    },
-    {
-      "identity" : "swiftui-introspect",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect",
-      "state" : {
-        "revision" : "2e09be8af614401bc9f87d40093ec19ce56ccaf2",
-        "version" : "0.1.3"
-      }
-    },
-    {
-      "identity" : "swiftyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftyJSON/SwiftyJSON",
-      "state" : {
-        "revision" : "2b6054efa051565954e1d2b9da831680026cd768",
-        "version" : "5.0.0"
-      }
-    },
-    {
-      "identity" : "then",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devxoul/Then",
-      "state" : {
-        "revision" : "e421a7b3440a271834337694e6050133a3958bc7",
-        "version" : "2.7.0"
-      }
-    },
-    {
-      "identity" : "xcglogger",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/DaveWoodCom/XCGLogger",
-      "state" : {
-        "revision" : "a9c4667b247928a29bdd41be2ec2c8d304215a54",
-        "version" : "7.0.1"
-      }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation",
-      "state" : {
-        "revision" : "ec32d62d412578542c0ffb7a6ce34d3e64b43b94",
-        "version" : "0.9.11"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2512,23 +2512,25 @@ extension BrowserViewController: TabManagerDelegate {
       bookmarkMenuChildren.append(bookmarkActiveTab)
     }
     
-    let bookmarkAllTabs = UIAction(
-      title: String(format: Strings.bookmarkAllTabsTitle, tabManager.tabsForCurrentMode.count),
-      image: UIImage(systemName: "book"),
-      handler: UIAction.deferredActionHandler { [unowned self] _ in
-        let mode = BookmarkEditMode.addFolderUsingTabs(title: Strings.savedTabsFolderTitle, tabList: tabManager.tabsForCurrentMode)
-        let addBookMarkController = AddEditBookmarkTableViewController(bookmarkManager: bookmarkManager, mode: mode)
+    if tabManager.tabsForCurrentMode.count > 1 {
+      let bookmarkAllTabs = UIAction(
+        title: String(format: Strings.bookmarkAllTabsTitle, tabManager.tabsForCurrentMode.count),
+        image: UIImage(systemName: "book"),
+        handler: UIAction.deferredActionHandler { [unowned self] _ in
+          let mode = BookmarkEditMode.addFolderUsingTabs(title: Strings.savedTabsFolderTitle, tabList: tabManager.tabsForCurrentMode)
+          let addBookMarkController = AddEditBookmarkTableViewController(bookmarkManager: bookmarkManager, mode: mode)
 
-        presentSettingsNavigation(with: addBookMarkController, cancelEnabled: true)
-      })
+          presentSettingsNavigation(with: addBookMarkController, cancelEnabled: true)
+        })
 
-    bookmarkMenuChildren.append(bookmarkAllTabs)
+      bookmarkMenuChildren.append(bookmarkAllTabs)
+    }
     
     var duplicateTabMenuChildren: [UIAction] = []
 
     if containsWebPage, let selectedTab = tabManager.selectedTab, let url = selectedTab.fetchedURL {
       let duplicateActiveTab = UIAction(
-        title: "Duplicate Active Tab",
+        title: Strings.duplicateActiveTab,
         image: UIImage(systemName: "plus.square.on.square"),
         handler: UIAction.deferredActionHandler { _ in
           tabManager.addTabAndSelect(

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2532,7 +2532,7 @@ extension BrowserViewController: TabManagerDelegate {
       let duplicateActiveTab = UIAction(
         title: Strings.duplicateActiveTab,
         image: UIImage(systemName: "plus.square.on.square"),
-        handler: UIAction.deferredActionHandler { _ in
+        handler: UIAction.deferredActionHandler { [unowned self] _ in
           tabManager.addTabAndSelect(
                URLRequest(url: url),
                afterTab: selectedTab,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2514,7 +2514,7 @@ extension BrowserViewController: TabManagerDelegate {
     
     if tabManager.tabsForCurrentMode.count > 1 {
       let bookmarkAllTabs = UIAction(
-        title: String(format: Strings.bookmarkAllTabsTitle, tabManager.tabsForCurrentMode.count),
+        title: String.localizedStringWithFormat(Strings.bookmarkAllTabsTitle, tabManager.tabsForCurrentMode.count),
         image: UIImage(systemName: "book"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
           let mode = BookmarkEditMode.addFolderUsingTabs(title: Strings.savedTabsFolderTitle, tabList: tabManager.tabsForCurrentMode)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2361,9 +2361,7 @@ extension BrowserViewController: TabManagerDelegate {
       }
     }
 
-    if selected?.type != previous?.type {
-      updateToolbarUsingTabManager(tabManager)
-    }
+    updateToolbarUsingTabManager(tabManager)
 
     removeAllBars()
     if let bars = selected?.bars {
@@ -2500,19 +2498,47 @@ extension BrowserViewController: TabManagerDelegate {
     addTabMenuChildren.append(openNewTab)
 
     var bookmarkMenuChildren: [UIAction] = []
+    
+    let containsWebPage = tabManager.selectedTab?.containsWebPage == true
 
-    if tabManager.openedWebsitesCount > 0 {
-      let bookmarkAllTabs = UIAction(
-        title: Strings.bookmarkAllTabsTitle,
+    if tabManager.openedWebsitesCount > 0, containsWebPage {
+      let bookmarkActiveTab = UIAction(
+        title: Strings.addToMenuItem,
         image: UIImage(systemName: "book"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
-          let mode = BookmarkEditMode.addFolderUsingTabs(title: Strings.savedTabsFolderTitle, tabList: tabManager.tabsForCurrentMode)
-          let addBookMarkController = AddEditBookmarkTableViewController(bookmarkManager: bookmarkManager, mode: mode)
-
-          presentSettingsNavigation(with: addBookMarkController, cancelEnabled: true)
+          self.openAddBookmark()
         })
 
-      bookmarkMenuChildren.append(bookmarkAllTabs)
+      bookmarkMenuChildren.append(bookmarkActiveTab)
+    }
+    
+    let bookmarkAllTabs = UIAction(
+      title: String(format: Strings.bookmarkAllTabsTitle, tabManager.tabsForCurrentMode.count),
+      image: UIImage(systemName: "book"),
+      handler: UIAction.deferredActionHandler { [unowned self] _ in
+        let mode = BookmarkEditMode.addFolderUsingTabs(title: Strings.savedTabsFolderTitle, tabList: tabManager.tabsForCurrentMode)
+        let addBookMarkController = AddEditBookmarkTableViewController(bookmarkManager: bookmarkManager, mode: mode)
+
+        presentSettingsNavigation(with: addBookMarkController, cancelEnabled: true)
+      })
+
+    bookmarkMenuChildren.append(bookmarkAllTabs)
+    
+    var duplicateTabMenuChildren: [UIAction] = []
+
+    if containsWebPage, let selectedTab = tabManager.selectedTab, let url = selectedTab.fetchedURL {
+      let duplicateActiveTab = UIAction(
+        title: "Duplicate Active Tab",
+        image: UIImage(systemName: "plus.square.on.square"),
+        handler: UIAction.deferredActionHandler { _ in
+          tabManager.addTabAndSelect(
+               URLRequest(url: url),
+               afterTab: selectedTab,
+               isPrivate: selectedTab.isPrivate
+           )
+        })
+
+      duplicateTabMenuChildren.append(duplicateActiveTab)
     }
 
     var closeTabMenuChildren: [UIAction] = []
@@ -2565,10 +2591,11 @@ extension BrowserViewController: TabManagerDelegate {
     let newTabMenu = UIMenu(title: "", options: .displayInline, children: newTabMenuChildren)
     let addTabMenu = UIMenu(title: "", options: .displayInline, children: addTabMenuChildren)
     let bookmarkMenu = UIMenu(title: "", options: .displayInline, children: bookmarkMenuChildren)
+    let duplicateTabMenu = UIMenu(title: "", options: .displayInline, children: duplicateTabMenuChildren)
     let closeTabMenu = UIMenu(title: "", options: .displayInline, children: closeTabMenuChildren)
 
-    toolbar?.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, bookmarkMenu, newTabMenu])
-    topToolbar.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, bookmarkMenu, newTabMenu])
+    toolbar?.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu])
+    topToolbar.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu])
 
     // Update Actions for Add-Tab Button
     toolbar?.addTabButton.menu = UIMenu(title: "", identifier: nil, children: [addTabMenu])

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -185,7 +185,8 @@ class Tab: NSObject {
   
   var containsWebPage: Bool {
     if let url = url {
-      return url.isWebPage() && !(InternalURL(url)?.isAboutHomeURL ?? false)
+      let isHomeURL = InternalURL(url)?.isAboutHomeURL
+      return url.isWebPage() && isHomeURL != true
     }
     
     return false

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -182,6 +182,14 @@ class Tab: NSObject {
   var isDesktopSite: Bool {
     webView?.customUserAgent?.lowercased().contains("mobile") == false
   }
+  
+  var containsWebPage: Bool {
+    if let url = url {
+      return url.isWebPage() && !(InternalURL(url)?.isAboutHomeURL ?? false)
+    }
+    
+    return false
+  }
 
   /// In-memory dictionary of websites that were explicitly set to use either desktop or mobile user agent.
   /// Key is url's base domain, value is desktop mode on or off.


### PR DESCRIPTION
Adding "Add Bookmark" "Duplicate Active Tab" actions in long press Tab Tray icon in bottom toolbar.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5235

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open a new tab and check long press on tab tray icon in bottom toolbar
- Press Duplicate Active Tab and check the actual tab url is opened in a new tab next to the active one
- Long Press and check If Add Bookmark and Add Bookmark for # Tabs buttons work as expected
- "Add Bookmark" + "Duplicate Active Tab" should not exist in an empty open Tab.

## Screenshots:

https://user-images.githubusercontent.com/6643505/162527303-bde0aec7-b727-497b-acf8-35e2f8525701.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
