### PR TITLE
Fix #5107: ERC20 Approve tx updates for transaction confirmation

### DIFF
--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -135,7 +135,7 @@ struct AccountActivityView: View {
             networkStore: networkStore,
             keyringStore: keyringStore,
             visibleTokens: activityStore.assets.map(\.token),
-            allTokens: [],
+            allTokens: activityStore.allTokens,
             assetRatios: assetRatios
           )
         }

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -28,7 +28,7 @@ extension String {
   }
 
   /// Adds the `0x` prefix that if it does not exist on the string
-  public var addingHexPrefix: String {
+  var addingHexPrefix: String {
     hasPrefix("0x") ? self : "0x\(self)"
   }
 

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -26,7 +26,12 @@ extension String {
   var removingHexPrefix: String {
     hasPrefix("0x") ? String(dropFirst(2)) : self
   }
-  
+
+  /// Adds the `0x` prefix that if it does not exist on the string
+  public var addingHexPrefix: String {
+    hasPrefix("0x") ? self : "0x\(self)"
+  }
+
   /// Check if the string is a valid ETH address
   var isETHAddress: Bool {
     // An address has to start with `0x`

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -20,6 +20,7 @@ public class TransactionConfirmationStore: ObservableObject {
     var totalFiat: String = ""
     var isBalanceSufficient: Bool = true
     var isUnlimitedApprovalRequested: Bool = false
+    var currentAllowance: String = ""
     var origin: URL?
   }
   @Published var state: State = .init()
@@ -148,6 +149,12 @@ public class TransactionConfirmationStore: ObservableObject {
                     self.state.value = formatter.decimalString(for: approvalValue.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
                   }
                 }
+                self.rpcService.erc20TokenAllowance(
+                  token.contractAddress(in: selectedChain),
+                  ownerAddress: transaction.fromAddress,
+                  spenderAddress: transaction.txArgs[safe: 0] ?? "") { allowance, status, _ in
+                    self.state.currentAllowance = formatter.decimalString(for: allowance.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
+                  }
               }
               if let proposedAllowance = transaction.txArgs[safe: 1] {
                 self.state.isUnlimitedApprovalRequested = proposedAllowance.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -299,6 +299,7 @@ public class TransactionConfirmationStore: ObservableObject {
       self.activeTransactionId = firstTx.id
       self.fetchGasEstimation1559()
     }
+    fetchTokens()
   }
 
   func editNonce(
@@ -335,14 +336,16 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
   
-  func fetchTokens(in network: BraveWallet.NetworkInfo) {
-    blockchainRegistry.allTokens(network.chainId) { [weak self] tokens in
-      self?.allTokens = tokens
+  func fetchTokens() {
+    rpcService.chainId(.eth) { [weak self] chainId in
+      self?.blockchainRegistry.allTokens(chainId) { tokens in
+        self?.allTokens = tokens
+      }
     }
   }
 
   func token(for contractAddress: String, in network: BraveWallet.NetworkInfo) -> BraveWallet.BlockchainToken? {
-    return allTokens.first(where: {
+    allTokens.first(where: {
       $0.contractAddress(in: network).caseInsensitiveCompare(contractAddress) == .orderedSame
     })
   }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -145,7 +145,7 @@ public class TransactionConfirmationStore: ObservableObject {
                   if approvalValue.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame {
                     self.state.value = Strings.Wallet.editPermissionsApproveUnlimited
                   } else {
-                    self.state.value = formatter.decimalString(for: approvalValue.removingHexPrefix, radix: .decimal, decimals: Int(token.decimals)) ?? ""
+                    self.state.value = formatter.decimalString(for: approvalValue.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
                   }
                 }
               }

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -35,7 +35,7 @@ struct EditPermissionsView: View {
       decimals = Int(token.decimals)
     }
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: decimals))
-    let customAllowanceInWei = weiFormatter.weiString(from: customAllowance, radix: .decimal, decimals: decimals) ?? "0"
+    let customAllowanceInWei = weiFormatter.weiString(from: customAllowance, radix: .hex, decimals: decimals) ?? "0"
     return customAllowanceInWei.addingHexPrefix
   }
   

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -24,21 +24,15 @@ struct EditPermissionsView: View {
     confirmationStore.transactions.first(where: { $0.id == confirmationStore.activeTransactionId }) ?? (confirmationStore.transactions.first ?? .init())
   }
   
-  private var isCustomAllowanceUnlimited: Bool {
-    customAllowance == Strings.Wallet.editPermissionsApproveUnlimited
-  }
-  
   private var customAllowanceAmountInWei: String {
-    if isCustomAllowanceUnlimited {
+    if customAllowance == Strings.Wallet.editPermissionsApproveUnlimited {
       // when user taps 'Set Unlimited' button we updated `customAllowance` to `Strings.Wallet.editPermissionsApproveUnlimited`
       return WalletConstants.MAX_UINT256
     }
     
-    let decimals: Int
+    var decimals: Int = 18
     if let contractAddress = activeTransaction.txDataUnion.ethTxData1559?.baseData.to, let token = confirmationStore.token(for: contractAddress, in: networkStore.selectedChain) {
       decimals = Int(token.decimals)
-    } else {
-      decimals = 18
     }
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: decimals))
     let customAllowanceInWei = weiFormatter.weiString(from: customAllowance, radix: .decimal, decimals: decimals) ?? "0"
@@ -97,7 +91,6 @@ struct EditPermissionsView: View {
             }
           )
             .keyboardType(.decimalPad)
-            .foregroundColor(Color(.braveLabel))
             .foregroundColor(Color(.braveLabel))
           if proposedAllowance.caseInsensitiveCompare(WalletConstants.MAX_UINT256) != .orderedSame {
             Button(action: {

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -15,7 +15,7 @@ struct EditPermissionsView: View {
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var networkStore: NetworkStore
   
-  @State private var customAllowance: String = "0"
+  @State private var customAllowance: String = ""
   @State private var isShowingAlert = false
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.sizeCategory) private var sizeCategory
@@ -64,13 +64,15 @@ struct EditPermissionsView: View {
           .resetListHeaderStyle()
           .padding(.vertical)
       ) {
-        VStack(alignment: .leading) {
-          Text(String.localizedStringWithFormat(Strings.Wallet.editPermissionsProposedAllowanceHeader, confirmationStore.state.symbol))
+        VStack(alignment: .leading, spacing: 2) {
+          Text(Strings.Wallet.editPermissionsProposedAllowanceHeader)
             .foregroundColor(Color(.bravePrimary))
-            .font(.footnote.weight(.semibold))
-          TextField("", text: Binding(get: { confirmationStore.state.value }, set: { _ in }))
-            .disabled(true)
+            .fontWeight(.semibold)
+          Text("\(confirmationStore.state.value) \(confirmationStore.state.symbol)")
+            .foregroundColor(Color(.secondaryBraveLabel))
         }
+        .font(.footnote)
+        .padding(.vertical, 6)
       }
       
       Section(
@@ -121,6 +123,7 @@ struct EditPermissionsView: View {
       }
       .buttonStyle(BraveFilledButtonStyle(size: .large))
       .frame(maxWidth: .infinity)
+      .disabled(customAllowance.isEmpty)
       .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
       .accessibility(hidden: sizeCategory.isAccessibilityCategory)
       .listRowBackground(Color(.braveGroupedBackground))

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -1,0 +1,167 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveUI
+import struct Shared.Strings
+import SwiftUI
+
+struct EditPermissionsView: View {
+  
+  let proposedAllowance: String
+  @ObservedObject var confirmationStore: TransactionConfirmationStore
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var networkStore: NetworkStore
+  
+  private enum AllowanceKind: Hashable, Equatable {
+    case proposedAllowance
+    case customAllowance
+  }
+  
+  @State private var allowanceKind: AllowanceKind = .proposedAllowance
+  @State private var customAllowance: String = "0"
+  @State private var isFieldFocused: Bool = false
+  @State private var isShowingAlert = false
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.sizeCategory) private var sizeCategory
+  
+  private var activeTransaction: BraveWallet.TransactionInfo {
+    confirmationStore.transactions.first(where: { $0.id == confirmationStore.activeTransactionId }) ?? (confirmationStore.transactions.first ?? .init())
+  }
+  
+  private var allowanceAmountInWei: String {
+    switch allowanceKind {
+    case .proposedAllowance:
+      return proposedAllowance
+    case .customAllowance:
+      let decimals: Int
+      if let contractAddress = activeTransaction.txDataUnion.ethTxData1559?.baseData.to, let token = confirmationStore.token(for: contractAddress, in: networkStore.selectedChain) {
+        decimals = Int(token.decimals)
+      } else {
+        decimals = 18
+      }
+      let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: decimals))
+      let customAllowanceInWei = weiFormatter.weiString(from: customAllowance, radix: .decimal, decimals: decimals) ?? "0"
+      return customAllowanceInWei.addingHexPrefix
+    }
+  }
+  
+  private var accountName: String {
+    NamedAddresses.name(for: activeTransaction.fromAddress, accounts: keyringStore.keyring.accountInfos)
+  }
+  
+  init(
+    proposedAllowance: String,
+    confirmationStore: TransactionConfirmationStore,
+    keyringStore: KeyringStore,
+    networkStore: NetworkStore
+  ) {
+    self.proposedAllowance = proposedAllowance
+    self.confirmationStore = confirmationStore
+    self.keyringStore = keyringStore
+    self.networkStore = networkStore
+  }
+  
+  var body: some View {
+    List {
+      Section(
+        header: Text(String.localizedStringWithFormat(Strings.Wallet.editPermissionsAllowanceHeader, accountName))
+          .foregroundColor(Color(.secondaryBraveLabel))
+          .font(.footnote)
+          .resetListHeaderStyle()
+          .padding(.vertical)
+      ) {
+        Picker(selection: $allowanceKind) {
+          VStack(alignment: .leading) {
+            Text(String.localizedStringWithFormat(Strings.Wallet.editPermissionsProposedAllowanceHeader, confirmationStore.state.symbol))
+              .foregroundColor(Color(.bravePrimary))
+              .font(.footnote.weight(.semibold))
+            TextField("", text: Binding(get: { confirmationStore.state.value }, set: { _ in }))
+              .disabled(true)
+          }.tag(AllowanceKind.proposedAllowance)
+          
+          VStack(alignment: .leading) {
+            Text(String.localizedStringWithFormat(Strings.Wallet.editPermissionsCustomAllowanceHeader, confirmationStore.state.symbol))
+              .foregroundColor(Color(.bravePrimary))
+              .font(.footnote.weight(.semibold))
+            TextField("", text: $customAllowance)
+              .keyboardType(.numberPad)
+              .foregroundColor(Color(.braveLabel))
+              .allowsHitTesting(allowanceKind == .customAllowance) // allow user to tap on this entire row in the `Picker`, we'll become first responder when `allowanceKind` changes to `.customAllowance`
+              .foregroundColor(Color(.braveLabel))
+              .introspectTextField { tf in
+                if allowanceKind == .customAllowance && !isFieldFocused && !tf.isFirstResponder {
+                  DispatchQueue.main.async {
+                    isFieldFocused = tf.becomeFirstResponder()
+                  }
+                }
+              }
+          }.tag(AllowanceKind.customAllowance)
+        } label: {
+          EmptyView()
+        }
+        .accentColor(Color(.braveBlurpleTint))
+        .pickerStyle(.inline)
+        .foregroundColor(Color(.braveLabel))
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      
+      Button(action: {
+        confirmationStore.editAllowance(
+          txMetaId: activeTransaction.id,
+          spenderAddress: activeTransaction.txArgs[safe: 0] ?? "",
+          amount: allowanceAmountInWei) { success in
+            if success {
+              presentationMode.dismiss()
+            } else {
+              isShowingAlert = true
+            }
+          }
+      }) {
+        Text(Strings.Wallet.saveButtonTitle)
+      }
+      .buttonStyle(BraveFilledButtonStyle(size: .large))
+      .frame(maxWidth: .infinity)
+      .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
+      .accessibility(hidden: sizeCategory.isAccessibilityCategory)
+      .listRowBackground(Color(.braveGroupedBackground))
+    }
+    .listStyle(InsetGroupedListStyle())
+    .navigationBarTitleDisplayMode(.inline)
+    .navigationTitle(Strings.Wallet.editPermissionsTitle)
+    .alert(isPresented: $isShowingAlert) {
+      Alert(
+        title: Text(Strings.Wallet.unknownError),
+        message: Text(Strings.Wallet.editTransactionError),
+        dismissButton: .default(Text(Strings.OKString))
+      )
+    }
+    .onChange(of: allowanceKind) { allowanceKind in
+      if allowanceKind != .customAllowance {
+        isFieldFocused = false
+        resignFirstResponder()
+      }
+    }
+  }
+  
+  private func resignFirstResponder() {
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+  }
+}
+
+#if DEBUG
+struct EditPermissionsView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      EditPermissionsView(
+        proposedAllowance: WalletConstants.MAX_UINT256,
+        confirmationStore: .previewStore,
+        keyringStore: .previewStoreWithWalletCreated,
+        networkStore: .previewStore
+      )
+    }
+  }
+}
+#endif

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -265,6 +265,7 @@ struct TransactionConfirmationView: View {
                     .font(.callout)
                     .padding()
                     .accessibilityElement(children: .contain)
+                    .foregroundColor(Color(.bravePrimary))
                   } else {
                     HStack {
                       Text(Strings.Wallet.total)

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -257,15 +257,26 @@ struct TransactionConfirmationView: View {
                   Divider()
                     .padding(.leading)
                   if activeTransaction.txType == .erc20Approve {
-                    HStack {
-                      Text(Strings.Wallet.confirmationViewCurrentAllowance)
-                      Spacer()
-                      Text("\(confirmationStore.state.value) \(confirmationStore.state.symbol)")
-                        .multilineTextAlignment(.trailing)
+                    Group {
+                      HStack {
+                        Text(Strings.Wallet.confirmationViewCurrentAllowance)
+                        Spacer()
+                        Text("\(confirmationStore.state.currentAllowance) \(confirmationStore.state.symbol)")
+                          .multilineTextAlignment(.trailing)
+                      }
+                      .padding()
+                      .accessibilityElement(children: .contain)
+                      Divider()
+                      HStack {
+                        Text(Strings.Wallet.editPermissionsProposedAllowanceHeader)
+                        Spacer()
+                        Text("\(confirmationStore.state.value) \(confirmationStore.state.symbol)")
+                          .multilineTextAlignment(.trailing)
+                      }
+                      .padding()
+                      .accessibilityElement(children: .contain)
                     }
                     .font(.callout)
-                    .padding()
-                    .accessibilityElement(children: .contain)
                     .foregroundColor(Color(.bravePrimary))
                   } else {
                     HStack {

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -136,6 +136,7 @@ struct TransactionConfirmationView: View {
           Text(String.localizedStringWithFormat(Strings.Wallet.confirmationViewAllowSpendSubtitle, confirmationStore.state.symbol))
             .font(.footnote)
         }
+        .multilineTextAlignment(.center)
       }
       if confirmationStore.state.isUnlimitedApprovalRequested {
         Label(Strings.Wallet.confirmationViewUnlimitedWarning, uiImage: #imageLiteral(resourceName: "warning-triangle").template)

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -18,6 +18,11 @@ struct TransactionConfirmationView: View {
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.presentationMode) @Binding private var presentationMode
 
+  /// Blockie size for ERC 20 Approve transactions
+  @ScaledMetric private var blockieSize = 24
+  /// Favicon size for ERC 20 Approve transactions
+  @ScaledMetric private var faviconSize = 48
+
   private enum ViewMode: Int {
     case transaction
     case details
@@ -82,6 +87,81 @@ struct TransactionConfirmationView: View {
     }
   }
 
+  /// View showing the currently selected account with a blockie
+  @ViewBuilder private var accountView: some View {
+    HStack {
+      Text(keyringStore.selectedAccount.address.truncatedAddress)
+        .fontWeight(.semibold)
+      Blockie(address: keyringStore.selectedAccount.address)
+        .frame(width: blockieSize, height: blockieSize)
+    }
+  }
+
+  /// The view for changing between available pending transactions. ex. '1 of 4 Next'
+  @ViewBuilder private var transactionsButton: some View {
+    if confirmationStore.transactions.count > 1 {
+      let index = confirmationStore.transactions.firstIndex(of: activeTransaction) ?? 0
+      HStack {
+        Text(String.localizedStringWithFormat(Strings.Wallet.transactionCount, index + 1, confirmationStore.transactions.count))
+          .fontWeight(.semibold)
+        Button(action: next) {
+          Text(Strings.Wallet.nextTransaction)
+            .fontWeight(.semibold)
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+      }
+    } else {
+      EmptyView()
+    }
+  }
+
+  /// The header displayed for an `erc20Approve` txType transaction
+  @ViewBuilder private var erc20ApproveHeader: some View {
+    VStack(spacing: 20) {
+      VStack(spacing: 8) {
+        if let origin = confirmationStore.state.origin {
+          Image(systemName: "globe")
+            .frame(width: faviconSize, height: faviconSize)
+            .background(Color(.braveDisabled))
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+          Text(verbatim: origin.absoluteString)
+            .font(.subheadline)
+            .foregroundColor(Color(.braveLabel))
+            .multilineTextAlignment(.center)
+        }
+        VStack(spacing: 10) {
+          Text(String.localizedStringWithFormat(Strings.Wallet.confirmationViewAllowSpendTitle, confirmationStore.state.symbol))
+            .fontWeight(.semibold)
+            .foregroundColor(Color(.bravePrimary))
+          Text(String.localizedStringWithFormat(Strings.Wallet.confirmationViewAllowSpendSubtitle, confirmationStore.state.symbol))
+            .font(.footnote)
+        }
+      }
+      if confirmationStore.state.isUnlimitedApprovalRequested {
+        Label(Strings.Wallet.confirmationViewUnlimitedWarning, uiImage: #imageLiteral(resourceName: "warning-triangle").template)
+          .padding()
+          .foregroundColor(Color(.braveErrorLabel))
+          .background(
+            Color(.braveErrorBackground)
+              .cornerRadius(10)
+          )
+      }
+      NavigationLink(
+        destination: EditPermissionsView(
+          proposedAllowance: activeTransaction.txArgs[safe: 1] ?? "",
+          confirmationStore: confirmationStore,
+          keyringStore: keyringStore,
+          networkStore: networkStore
+        )
+      ) {
+        Text(Strings.Wallet.confirmationViewEditPermissions)
+          .font(.subheadline.weight(.semibold))
+          .foregroundColor(Color(.braveBlurpleTint))
+      }
+    }
+    .padding()
+  }
+
   @ViewBuilder private var editGasFeeButton: some View {
     let titleView = Text(Strings.Wallet.editGasFeeButtonTitle)
       .fontWeight(.semibold)
@@ -118,31 +198,32 @@ struct TransactionConfirmationView: View {
       ScrollView(.vertical) {
         VStack {
           // Header
-          HStack {
+          HStack(alignment: .top) {
             Text(networkStore.selectedChain.shortChainName)
             Spacer()
-            if confirmationStore.transactions.count > 1 {
-              let index = confirmationStore.transactions.firstIndex(of: activeTransaction) ?? 0
-              Text(String.localizedStringWithFormat(Strings.Wallet.transactionCount, index + 1, confirmationStore.transactions.count))
-                .fontWeight(.semibold)
-              Button(action: next) {
-                Text(Strings.Wallet.nextTransaction)
-                  .fontWeight(.semibold)
-                  .foregroundColor(Color(.braveBlurpleTint))
+            VStack(alignment: .trailing) {
+              if activeTransaction.txType == .erc20Approve {
+                accountView // for other txTypes, account is shown in `TransactionHeader`
               }
+              transactionsButton
             }
           }
           .font(.callout)
           // Summary
-          TransactionHeader(
-            fromAccountAddress: activeTransaction.fromAddress,
-            fromAccountName: fromAccountName,
-            toAccountAddress: activeTransaction.ethTxToAddress,
-            toAccountName: toAccountName,
-            transactionType: transactionType,
-            value: "\(confirmationStore.state.value) \(confirmationStore.state.symbol)",
-            fiat: confirmationStore.state.fiat
-          )
+          if activeTransaction.txType == .erc20Approve {
+            erc20ApproveHeader
+          } else {
+            TransactionHeader(
+              fromAccountAddress: activeTransaction.fromAddress,
+              fromAccountName: fromAccountName,
+              toAccountAddress: activeTransaction.ethTxToAddress,
+              toAccountName: toAccountName,
+              transactionType: transactionType,
+              value: "\(confirmationStore.state.value) \(confirmationStore.state.symbol)",
+              fiat: confirmationStore.state.fiat
+            )
+          }
+
           // View Mode
           VStack(spacing: 12) {
             Picker("", selection: $viewMode) {
@@ -173,34 +254,46 @@ struct TransactionConfirmationView: View {
                   .accessibilityElement(children: .contain)
                   Divider()
                     .padding(.leading)
-                  HStack {
-                    Text(Strings.Wallet.total)
-                      .foregroundColor(Color(.bravePrimary))
-                      .font(.callout)
-                      .accessibility(sortPriority: 1)
-                    Spacer()
-                    VStack(alignment: .trailing) {
-                      Text(Strings.Wallet.amountAndGas)
-                        .font(.footnote)
-                        .foregroundColor(Color(.secondaryBraveLabel))
-                      Text("\(confirmationStore.state.value) \(confirmationStore.state.symbol) + \(confirmationStore.state.gasValue) \(confirmationStore.state.gasSymbol)")
-                        .foregroundColor(Color(.bravePrimary))
-                      HStack(spacing: 4) {
-                        if !confirmationStore.state.isBalanceSufficient {
-                          Text(Strings.Wallet.insufficientBalance)
-                            .foregroundColor(Color(.braveErrorLabel))
-                        }
-                        Text(confirmationStore.state.totalFiat)
-                          .foregroundColor(
-                            confirmationStore.state.isBalanceSufficient ? Color(.braveLabel) : Color(.braveErrorLabel)
-                          )
-                      }
-                      .accessibilityElement(children: .contain)
-                      .font(.footnote)
+                  if activeTransaction.txType == .erc20Approve {
+                    HStack {
+                      Text(Strings.Wallet.confirmationViewCurrentAllowance)
+                      Spacer()
+                      Text("\(confirmationStore.state.value) \(confirmationStore.state.symbol)")
+                        .multilineTextAlignment(.trailing)
                     }
+                    .font(.callout)
+                    .padding()
+                    .accessibilityElement(children: .contain)
+                  } else {
+                    HStack {
+                      Text(Strings.Wallet.total)
+                        .foregroundColor(Color(.bravePrimary))
+                        .font(.callout)
+                        .accessibility(sortPriority: 1)
+                      Spacer()
+                      VStack(alignment: .trailing) {
+                        Text(Strings.Wallet.amountAndGas)
+                          .font(.footnote)
+                          .foregroundColor(Color(.secondaryBraveLabel))
+                        Text("\(confirmationStore.state.value) \(confirmationStore.state.symbol) + \(confirmationStore.state.gasValue) \(confirmationStore.state.gasSymbol)")
+                          .foregroundColor(Color(.bravePrimary))
+                        HStack(spacing: 4) {
+                          if !confirmationStore.state.isBalanceSufficient {
+                            Text(Strings.Wallet.insufficientBalance)
+                              .foregroundColor(Color(.braveErrorLabel))
+                          }
+                          Text(confirmationStore.state.totalFiat)
+                            .foregroundColor(
+                              confirmationStore.state.isBalanceSufficient ? Color(.braveLabel) : Color(.braveErrorLabel)
+                            )
+                        }
+                        .accessibilityElement(children: .contain)
+                        .font(.footnote)
+                      }
+                    }
+                    .padding()
+                    .accessibilityElement(children: .contain)
                   }
-                  .padding()
-                  .accessibilityElement(children: .contain)
                   Divider()
                     .padding(.leading)
                   NavigationLink(
@@ -293,6 +386,7 @@ struct TransactionConfirmationView: View {
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
       confirmationStore.prepare()
+      confirmationStore.fetchTokens(in: networkStore.selectedChain)
     }
   }
 

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -203,10 +203,10 @@ struct TransactionConfirmationView: View {
             Text(networkStore.selectedChain.shortChainName)
             Spacer()
             VStack(alignment: .trailing) {
+              transactionsButton
               if activeTransaction.txType == .erc20Approve {
                 accountView // for other txTypes, account is shown in `TransactionHeader`
               }
-              transactionsButton
             }
           }
           .font(.callout)

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -387,7 +387,6 @@ struct TransactionConfirmationView: View {
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
       confirmationStore.prepare()
-      confirmationStore.fetchTokens(in: networkStore.selectedChain)
     }
   }
 

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -139,12 +139,13 @@ struct TransactionConfirmationView: View {
         .multilineTextAlignment(.center)
       }
       if confirmationStore.state.isUnlimitedApprovalRequested {
-        Label(Strings.Wallet.confirmationViewUnlimitedWarning, uiImage: #imageLiteral(resourceName: "warning-triangle").template)
-          .padding()
+        Label(Strings.Wallet.confirmationViewUnlimitedWarning, systemImage: "exclamationmark.triangle")
+          .padding(12)
           .foregroundColor(Color(.braveErrorLabel))
+          .font(.subheadline)
           .background(
             Color(.braveErrorBackground)
-              .cornerRadius(10)
+              .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
           )
       }
       NavigationLink(

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -56,7 +56,11 @@ struct TransactionDetailsView: View {
       if let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to,
          let value = info.txArgs[safe: 1],
          let token = token(for: contractAddress) {
-        amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
+        if value.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame {
+          amount = Strings.Wallet.editPermissionsApproveUnlimited
+        } else {
+          amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
+        }
         return String(format: "%@ %@", amount, token.symbol)
       } else {
         return "0.0"

--- a/BraveWallet/Crypto/Transactions/TransactionView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionView.swift
@@ -63,9 +63,14 @@ struct TransactionView: View {
     let formatter = WeiFormatter(decimalFormatStyle: .balance)
     switch info.txType {
     case .erc20Approve:
-      let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to ?? ""
-      if let value = info.txArgs[safe: 1], let token = token(for: contractAddress) {
-        Text(String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? "", token.symbol))
+      if let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to,
+          let value = info.txArgs[safe: 1],
+          let token = token(for: contractAddress) {
+        if value.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame {
+          Text(String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, Strings.Wallet.editPermissionsApproveUnlimited, token.symbol))
+        } else {
+          Text(String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? "", token.symbol))
+        }
       } else {
         Text(Strings.Wallet.transactionUnknownApprovalTitle)
       }

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -108,7 +108,7 @@ extension BraveWallet.TransactionInfo {
             nonce: "0x5",
             gasPrice: "0x0",
             gasLimit: "0x520ca",
-            to: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            to: "0xad6d458402f60fd3bd25163575031acdce07538d",
             value: "0x0",
             data: _transactionBase64ToData("CV6nswAAAAAAAAAAAAAAAOWSQnoK7Okt4+3uHxjgFXwFhhVk//////////////////////////////////////////8=")
           ),

--- a/BraveWallet/Preview Content/MockEthTxService.swift
+++ b/BraveWallet/Preview Content/MockEthTxService.swift
@@ -9,8 +9,14 @@ import BraveCore
 #if DEBUG
 
 class MockTxService: BraveWalletTxService {
+  private let txs: [BraveWallet.TransactionInfo] = [
+    .previewConfirmedERC20Approve,
+    .previewConfirmedSend,
+    .previewConfirmedSwap
+  ]
+  
   func transactionInfo(_ coinType: BraveWallet.CoinType, txMetaId: String, completion: @escaping (BraveWallet.TransactionInfo?) -> Void) {
-    completion(nil)
+    completion(txs.first(where: { $0.id == txMetaId }))
   }
 
   func addUnapprovedTransaction(_ txData: BraveWallet.TxDataUnion, from: String, completion: @escaping (Bool, String, String) -> Void) {
@@ -21,16 +27,10 @@ class MockTxService: BraveWalletTxService {
   }
 
   func allTransactionInfo(_ coinType: BraveWallet.CoinType, from: String, completion: @escaping ([BraveWallet.TransactionInfo]) -> Void) {
-    completion(
-      [
-        BraveWallet.TransactionInfo.previewConfirmedERC20Approve,
-        .previewConfirmedSend,
-        .previewConfirmedSwap,
-      ].map {
-        tx in
-        tx.txStatus = .unapproved
-        return tx
-      })
+    completion(txs.map { tx in
+      tx.txStatus = .unapproved
+      return tx
+    })
   }
 
   func add(_ observer: BraveWalletTxServiceObserver) {

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -149,7 +149,11 @@ extension TransactionConfirmationStore {
       blockchainRegistry: MockBlockchainRegistry(),
       walletService: MockBraveWalletService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
-      keyringService: MockKeyringService()
+      keyringService: {
+        let service = MockKeyringService()
+        service.createWallet("password") { _  in }
+        return service
+      }()
     )
   }
 }

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -11,6 +11,6 @@ struct WalletConstants {
   /// This value will be formatted to a string such as 0.875%)
   static let braveSwapFee: Double = 0.00875
 
-  /// The value used to determine if the proposed allowance for an ERC 20 transaction is unlimited.
+  /// The wei value used for unlimited allowance in an ERC 20 transaction.
   static let MAX_UINT256 = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -10,4 +10,7 @@ struct WalletConstants {
   ///
   /// This value will be formatted to a string such as 0.875%)
   static let braveSwapFee: Double = 0.00875
+
+  /// The value used to determine if the proposed allowance for an ERC 20 transaction is unlimited.
+  static let MAX_UINT256 = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2042,8 +2042,15 @@ extension Strings {
       "wallet.editPermissionsCustomAllowanceHeader",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Custom allowance (%@)",
-      comment: "The header text shown in the row that selects the custom allowance value. The '%@' becomes the name of the symbol being approved. For example: \"Custom allowance (DAI)\""
+      value: "Set custom allowance",
+      comment: "The header text above the field to input a custom allowance value."
+    )
+    public static let editPermissionsSetUnlimited = NSLocalizedString(
+      "wallet.editPermissionsSetUnlimited",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Set Unlimited",
+      comment: "The title of the button shown beside the custom allowance input field to make the custom allowance value \"Unlimited\"."
     )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2035,8 +2035,8 @@ extension Strings {
       "wallet.editPermissionsProposedAllowanceHeader",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Proposed allowance (%@)",
-      comment: "The header text shown in the row that selects the proposed allowance value. The '%@' becomes the name of the symbol being approved.  For example: \"Proposed allowance (DAI)\""
+      value: "Proposed allowance",
+      comment: "The header text shown in the row that selects the proposed allowance value."
     )
     public static let editPermissionsCustomAllowanceHeader = NSLocalizedString(
       "wallet.editPermissionsCustomAllowanceHeader",

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2014,7 +2014,7 @@ extension Strings {
       "wallet.editPermissionsTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Edit Permission",
+      value: "Edit Permissions",
       comment: "The title of the detail view to edit the permissions / allowance of an ERC 20 Approve transaction."
     )
     public static let editPermissionsApproveUnlimited = NSLocalizedString(

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2036,7 +2036,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Proposed allowance",
-      comment: "The header text shown in the row that selects the proposed allowance value."
+      comment: "The header text shown in the row that displays the proposed allowance value."
     )
     public static let editPermissionsCustomAllowanceHeader = NSLocalizedString(
       "wallet.editPermissionsCustomAllowanceHeader",

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1051,6 +1051,41 @@ extension Strings {
       value: "Details",
       comment: "One of the picker options while confirming a transaction. When selected it displays a transactions function details such as underlying data"
     )
+    public static let confirmationViewEditPermissions = NSLocalizedString(
+      "wallet.confirmationViewEditPermissions",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Edit permissions",
+      comment: "The title shown on the button to edit permissions / the allowance for an ERC 20 Approve transaction while confirming a transaction."
+    )
+    public static let confirmationViewAllowSpendTitle = NSLocalizedString(
+      "wallet.confirmationViewAllowSpendTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Allow this app to spend your %@?",
+      comment: "The title shown on transaction confirmation for an ERC 20 Approve transaction where the '%@' will be the name of the symbol being approved. For example: \"Allow this app to spend your DAI?\""
+    )
+    public static let confirmationViewAllowSpendSubtitle = NSLocalizedString(
+      "wallet.confirmationViewAllowSpendSubtitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "By granting this permission, you are allowing this app to withdraw your %@ and automate transactions for you.",
+      comment: "The subtitle shown on transaction confirmation for an ERC 20 Approve transaction where the '%@' will be the name of the symbol being approved. For example: \"By granting this permission, you are allowing this app to withdraw your DAI and automate transactions for you.\""
+    )
+    public static let confirmationViewUnlimitedWarning = NSLocalizedString(
+      "wallet.confirmationViewUnlimitedWarning",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Unlimited approval requested",
+      comment: "The warning shown on transaction confirmation for an ERC 20 Approve transaction when the proposed allowance is unlimited."
+    )
+    public static let confirmationViewCurrentAllowance = NSLocalizedString(
+      "wallet.confirmationViewCurrentAllowance",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Current Allowance",
+      comment: "The label shown beside the current allowance for a ERC20 approve transaction where the current allowance is a number followed by the symbol name. For example, \"Current Allowance  100 DAI\"."
+    )
     public static let gasFee = NSLocalizedString(
       "wallet.gasFee",
       tableName: "BraveWallet",
@@ -1875,7 +1910,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Please check your inputs and try again.",
-      comment: "The error alert body when something is wrong when users try to edit transaction gas fee, priority fee or nonce value."
+      comment: "The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value."
     )
     public static let editTransactionErrorCTA = NSLocalizedString(
       "wallet.editTransactionErrorCTA",
@@ -1974,6 +2009,41 @@ extension Strings {
       bundle: .braveWallet,
       value: "This page wants to interact with Brave Wallet",
       comment: "The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet."
+    )
+    public static let editPermissionsTitle = NSLocalizedString(
+      "wallet.editPermissionsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Edit Permission",
+      comment: "The title of the detail view to edit the permissions / allowance of an ERC 20 Approve transaction."
+    )
+    public static let editPermissionsApproveUnlimited = NSLocalizedString(
+      "wallet.editPermissionsApproveUnlimited",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Unlimited",
+      comment: "The value to show when the permissions / allowance of an ERC 20 Approve transaction are the maximum allowance or unlimited spending ammount."
+    )
+    public static let editPermissionsAllowanceHeader = NSLocalizedString(
+      "wallet.editPermissionsAllowanceHeader",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Spend limit permission allows %@ to withdraw and spend up to the following amount:",
+      comment: "The header text shown above the rows to selected the allowance for an ERC 20 Approve transaction. The '%@' becomes the name of the account approving the transaction. For example: \"Spend limit permission allows Account 1 to withdraw and spend up to the following amount:\""
+    )
+    public static let editPermissionsProposedAllowanceHeader = NSLocalizedString(
+      "wallet.editPermissionsProposedAllowanceHeader",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Proposed allowance (%@)",
+      comment: "The header text shown in the row that selects the proposed allowance value. The '%@' becomes the name of the symbol being approved.  For example: \"Proposed allowance (DAI)\""
+    )
+    public static let editPermissionsCustomAllowanceHeader = NSLocalizedString(
+      "wallet.editPermissionsCustomAllowanceHeader",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Custom allowance (%@)",
+      comment: "The header text shown in the row that selects the custom allowance value. The '%@' becomes the name of the symbol being approved. For example: \"Custom allowance (DAI)\""
     )
   }
 }

--- a/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -1,0 +1,279 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Combine
+import XCTest
+import BraveCore
+@testable import BraveWallet
+
+class TransactionConfirmationStoreTests: XCTestCase {
+  
+  private var cancellables: Set<AnyCancellable> = .init()
+  
+  private func setupStore(
+    network: BraveWallet.NetworkInfo = .ropsten,
+    accountInfos: [BraveWallet.AccountInfo] = [],
+    allTokens: [BraveWallet.BlockchainToken] = [],
+    transactions: [BraveWallet.TransactionInfo] = [],
+    gasEstimation: BraveWallet.GasEstimation1559 = .init(),
+    makeErc20ApproveDataSuccess: Bool = true,
+    setDataForUnapprovedTransactionSuccess: Bool = true
+  ) -> TransactionConfirmationStore {
+    let mockEthAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23")
+    let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    let mockBalanceWei = formatter.weiString(from: 0.0896, radix: .hex, decimals: 18) ?? ""
+    // setup test services
+    let assetRatioService = BraveWallet.TestAssetRatioService()
+    assetRatioService._price = { _, _, _, completion in
+      completion(true, [mockEthAssetPrice])
+    }
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._chainId = { $1(network.chainId) }
+    rpcService._network = { $1(network) }
+    rpcService._balance = { _, _, _, completion in
+      completion(mockBalanceWei, .success, "")
+    }
+    let txService = BraveWallet.TestTxService()
+    txService._addObserver = { _ in }
+    txService._allTransactionInfo = { _, _, completion in
+      completion(transactions)
+    }
+    let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
+    blockchainRegistry._allTokens = { _, completion in
+      completion(allTokens)
+    }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._userAssets = { _, completion in
+      completion([])
+    }
+    let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
+    ethTxManagerProxy._gasEstimation1559 = { completion in
+      completion(gasEstimation)
+    }
+    ethTxManagerProxy._makeErc20ApproveData = { _, _, completion in
+      completion(makeErc20ApproveDataSuccess, [])
+    }
+    ethTxManagerProxy._setDataForUnapprovedTransaction = { _, _, completion in
+      completion(setDataForUnapprovedTransactionSuccess)
+    }
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._keyringInfo = { _, completion in
+      let keyring: BraveWallet.KeyringInfo = .init(
+        id: BraveWallet.DefaultKeyringId,
+        isKeyringCreated: true,
+        isLocked: false,
+        isBackedUp: true,
+        accountInfos: accountInfos)
+      completion(keyring)
+    }
+    return TransactionConfirmationStore(
+      assetRatioService: assetRatioService,
+      rpcService: rpcService,
+      txService: txService,
+      blockchainRegistry: blockchainRegistry,
+      walletService: walletService,
+      ethTxManagerProxy: ethTxManagerProxy,
+      keyringService: keyringService
+    )
+  }
+  
+  /// Test `prepare()` will fetch all tokens, and update `state` data for symbol, value, isUnlimitedApprovalRequested.
+  func testPrepareERC20Approve() {
+    let mockAllTokens: [BraveWallet.BlockchainToken] = [.previewToken, .daiToken]
+    let mockTransaction: BraveWallet.TransactionInfo = .previewConfirmedERC20Approve
+    let mockTransactions: [BraveWallet.TransactionInfo] = [mockTransaction].map { tx in
+      tx.txStatus = .unapproved
+      return tx
+    }
+    let mockGasEstimation: BraveWallet.GasEstimation1559 = .init()
+    let store = setupStore(
+      accountInfos: [.previewAccount],
+      allTokens: mockAllTokens,
+      transactions: mockTransactions,
+      gasEstimation: mockGasEstimation
+    )
+    let allTokensExpectation = expectation(description: "allTokens")
+    store.$allTokens
+      .dropFirst()
+      .first()
+      .sink { allTokens in
+        defer { allTokensExpectation.fulfill() }
+        XCTAssertEqual(allTokens, mockAllTokens)
+      }
+      .store(in: &cancellables)
+    
+    let stateExpectation = expectation(description: "state")
+    store.$state
+      .dropFirst()
+      .collect(7) // collect until isUnlimitedApprovalRequested is set
+      .first()
+      .sink { state in
+        defer { stateExpectation.fulfill() }
+        guard let lastState = state.last else {
+          XCTFail("state not updated")
+          return
+        }
+        XCTAssertEqual(lastState.gasSymbol, BraveWallet.BlockchainToken.previewToken.symbol)
+        XCTAssertEqual(lastState.symbol, BraveWallet.BlockchainToken.daiToken.symbol)
+        XCTAssertEqual(lastState.value, "Unlimited")
+        XCTAssertTrue(lastState.isUnlimitedApprovalRequested)
+      }
+      .store(in: &cancellables)
+    
+    let prepareExpectation = expectation(description: "prepare")
+    store.prepare() {
+      defer { prepareExpectation.fulfill() }
+      XCTAssertEqual(store.activeTransactionId, mockTransaction.id)
+      XCTAssertEqual(store.gasEstimation1559, mockGasEstimation)
+    }
+    
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test `editAllowance(txMetaId:spenderAddress:amount:completion)` will return false if we fail to make ERC20 approve data with `BraveWalletEthTxManagerProxy`
+  func testEditAllowanceFailMakeERC20ApproveData() {
+    let mockAllTokens: [BraveWallet.BlockchainToken] = [.previewToken, .daiToken]
+    let mockTransaction: BraveWallet.TransactionInfo = .previewConfirmedERC20Approve
+    let mockTransactions: [BraveWallet.TransactionInfo] = [mockTransaction].map { tx in
+      tx.txStatus = .unapproved
+      return tx
+    }
+    let mockGasEstimation: BraveWallet.GasEstimation1559 = .init()
+    let store = setupStore(
+      accountInfos: [.previewAccount],
+      allTokens: mockAllTokens,
+      transactions: mockTransactions,
+      gasEstimation: mockGasEstimation,
+      makeErc20ApproveDataSuccess: false
+    )
+    
+    let prepareExpectation = expectation(description: "prepare")
+    store.prepare {
+      prepareExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+    
+    let editExpectation = expectation(description: "edit allowance")
+    store.editAllowance(
+      txMetaId: mockTransaction.id,
+      spenderAddress: mockTransaction.txArgs[safe: 0] ?? "",
+      amount: "0x0",
+      completion: { success in
+        if !success {
+          editExpectation.fulfill()
+        }
+      }
+    )
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test `editAllowance(txMetaId:spenderAddress:amount:completion)` will return false if we fail to set new ERC20 Approve data with `BraveWalletEthTxManagerProxy`
+  func testEditAllowanceFailSetData() {
+    let mockAllTokens: [BraveWallet.BlockchainToken] = [.previewToken, .daiToken]
+    let mockTransaction: BraveWallet.TransactionInfo = .previewConfirmedERC20Approve
+    let mockTransactions: [BraveWallet.TransactionInfo] = [mockTransaction].map { tx in
+      tx.txStatus = .unapproved
+      return tx
+    }
+    let mockGasEstimation: BraveWallet.GasEstimation1559 = .init()
+    let store = setupStore(
+      accountInfos: [.previewAccount],
+      allTokens: mockAllTokens,
+      transactions: mockTransactions,
+      gasEstimation: mockGasEstimation,
+      makeErc20ApproveDataSuccess: true,
+      setDataForUnapprovedTransactionSuccess: false
+    )
+    
+    let prepareExpectation = expectation(description: "prepare")
+    store.prepare {
+      prepareExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+    
+    let editExpectation = expectation(description: "edit allowance")
+    store.editAllowance(
+      txMetaId: mockTransaction.id,
+      spenderAddress: mockTransaction.txArgs[safe: 0] ?? "",
+      amount: "0x0",
+      completion: { success in
+        if !success {
+          editExpectation.fulfill()
+        }
+      }
+    )
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test `editAllowance(txMetaId:spenderAddress:amount:completion)` will return true if we suceed in creating and setting ERC20 Approve data with `BraveWalletEthTxManagerProxy`
+  func testEditAllowanceSuccess() {
+    let mockAllTokens: [BraveWallet.BlockchainToken] = [.previewToken, .daiToken]
+    let mockTransaction: BraveWallet.TransactionInfo = .previewConfirmedERC20Approve
+    let mockTransactions: [BraveWallet.TransactionInfo] = [mockTransaction].map { tx in
+      tx.txStatus = .unapproved
+      return tx
+    }
+    let mockGasEstimation: BraveWallet.GasEstimation1559 = .init()
+    let store = setupStore(
+      accountInfos: [.previewAccount],
+      allTokens: mockAllTokens,
+      transactions: mockTransactions,
+      gasEstimation: mockGasEstimation,
+      makeErc20ApproveDataSuccess: true,
+      setDataForUnapprovedTransactionSuccess: true
+    )
+    
+    let prepareExpectation = expectation(description: "prepare")
+    store.prepare {
+      prepareExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+    
+    let editExpectation = expectation(description: "edit allowance")
+    store.editAllowance(
+      txMetaId: mockTransaction.id,
+      spenderAddress: mockTransaction.txArgs[safe: 0] ?? "",
+      amount: "0x0",
+      completion: { success in
+        if success {
+          editExpectation.fulfill()
+        }
+      }
+    )
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+}
+
+private extension BraveWallet.BlockchainToken {
+  
+  /// DAI token with contract address matching `BraveWallet.TransactionInfo.previewConfirmedERC20Approve`
+  static let daiToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+    name: "DAI",
+    logo: "",
+    isErc20: true,
+    isErc721: false,
+    symbol: "DAI",
+    decimals: 18,
+    visible: false,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: ""
+  )
+}

--- a/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -264,7 +264,7 @@ private extension BraveWallet.BlockchainToken {
   
   /// DAI token with contract address matching `BraveWallet.TransactionInfo.previewConfirmedERC20Approve`
   static let daiToken: BraveWallet.BlockchainToken = .init(
-    contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+    contractAddress: "0xad6d458402f60fd3bd25163575031acdce07538d",
     name: "DAI",
     logo: "",
     isErc20: true,

--- a/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -35,6 +35,9 @@ class TransactionConfirmationStoreTests: XCTestCase {
     rpcService._balance = { _, _, _, completion in
       completion(mockBalanceWei, .success, "")
     }
+    rpcService._erc20TokenAllowance = { _, _, _, completion in
+      completion("16345785d8a0000", .success, "") // 0.1000
+    }
     let txService = BraveWallet.TestTxService()
     txService._addObserver = { _ in }
     txService._allTransactionInfo = { _, _, completion in
@@ -107,7 +110,7 @@ class TransactionConfirmationStoreTests: XCTestCase {
     let stateExpectation = expectation(description: "state")
     store.$state
       .dropFirst()
-      .collect(7) // collect until isUnlimitedApprovalRequested is set
+      .collect(8) // collect until isUnlimitedApprovalRequested is set
       .first()
       .sink { state in
         defer { stateExpectation.fulfill() }
@@ -118,6 +121,7 @@ class TransactionConfirmationStoreTests: XCTestCase {
         XCTAssertEqual(lastState.gasSymbol, BraveWallet.BlockchainToken.previewToken.symbol)
         XCTAssertEqual(lastState.symbol, BraveWallet.BlockchainToken.daiToken.symbol)
         XCTAssertEqual(lastState.value, "Unlimited")
+        XCTAssertEqual(lastState.currentAllowance, "0.1000")
         XCTAssertTrue(lastState.isUnlimitedApprovalRequested)
       }
       .store(in: &cancellables)

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1170,6 +1170,7 @@
 		D5ACA7DD27FB7D4B002443CE /* BraveCore.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D5ACA7DE27FB7D52002443CE /* MaterialComponents.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D5C51E6C27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */; };
+		D5EFCB3927FF81AA00BD151D /* EditPermissionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EFCB3827FF81AA00BD151D /* EditPermissionsView.swift */; };
 		D83822001FC7961D00303C12 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */; };
 		D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */; };
 		D8D33A7D1FBD080300A20A28 /* SnapKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */; };
@@ -3159,6 +3160,7 @@
 		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsPasscodeEntryView.swift; sourceTree = "<group>"; };
+		D5EFCB3827FF81AA00BD151D /* EditPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPermissionsView.swift; sourceTree = "<group>"; };
 		D83821FF1FC7961D00303C12 /* DispatchQueueExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensions.swift; sourceTree = "<group>"; };
 		D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientProgressBar.swift; sourceTree = "<group>"; };
 		D8D33A7C1FBD080300A20A28 /* SnapKitExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapKitExtensions.swift; sourceTree = "<group>"; };
@@ -4245,6 +4247,7 @@
 				2701B14B2735B65300BE6FC6 /* EditPriorityFeeView.swift */,
 				27D91E70274D55F0009B1FA3 /* EditGasFeeView.swift */,
 				7DE5B78B27D4188E000DA8E4 /* EditNonceView.swift */,
+				D5EFCB3827FF81AA00BD151D /* EditPermissionsView.swift */,
 			);
 			path = "Transaction Confirmations";
 			sourceTree = "<group>";
@@ -8072,6 +8075,7 @@
 				7D758917271A182800B643C3 /* TokenList.swift in Sources */,
 				271F68C226EBD27E00AA2A50 /* SwapButton.swift in Sources */,
 				27DDE85926FBE09A00A70C3A /* AccountPrivateKeyView.swift in Sources */,
+				D5EFCB3927FF81AA00BD151D /* EditPermissionsView.swift in Sources */,
 				271F68AA26EBD27E00AA2A50 /* TransactionView.swift in Sources */,
 				271F689126EBD27E00AA2A50 /* MockJsonRpcService.swift in Sources */,
 				277C0A9A273DC0890059AB0A /* NamedAddresses.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1163,6 +1163,7 @@
 		D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
 		D506715C27E2AAB700560631 /* TransactionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D506715B27E2AAB700560631 /* TransactionHeader.swift */; };
+		D511314B2800C16100C81683 /* TransactionConfirmationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */; };
 		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
 		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
 		D5ACA7CE27FB7D08002443CE /* BraveCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; };
@@ -3157,6 +3158,7 @@
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
 		D506715B27E2AAB700560631 /* TransactionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHeader.swift; sourceTree = "<group>"; };
+		D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionConfirmationStoreTests.swift; sourceTree = "<group>"; };
 		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsPasscodeEntryView.swift; sourceTree = "<group>"; };
@@ -4232,6 +4234,7 @@
 				279115362755597200033843 /* SendTokenStoreTests.swift */,
 				7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */,
 				D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */,
+				D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */,
 				277309E72721DF6D007643F6 /* WeiFormatterTests.swift */,
 				27EA1B0D2729E6C8003C5CF9 /* AddressTests.swift */,
 				7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */,
@@ -8123,6 +8126,7 @@
 				27EA1B0E2729E6C8003C5CF9 /* AddressTests.swift in Sources */,
 				7DF911DF27726E5E00EF0D8B /* BuyTokenStoreTest.swift in Sources */,
 				7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */,
+				D511314B2800C16100C81683 /* TransactionConfirmationStoreTests.swift in Sources */,
 				7DF911C0276A8D1600EF0D8B /* SwapTokenStoreTests.swift in Sources */,
 				277309E82721DF6D007643F6 /* WeiFormatterTests.swift in Sources */,
 			);


### PR DESCRIPTION
## Summary of Changes
- Update header in `TransactionConfirmationView` and showing current allowance instead of transaction total
- Added `EditPermissionsView` for assigning
- Unit tests for `TransactionConfirmationStore` for erc20 approve transaction
- Updated ERC 20 Approve creation to use Unlimited as default allowance to match desktop, now that we display proposed allowance and allow custom allowance to be set. [Relevant desktop code](https://github.com/brave/brave-core/blob/master/components/brave_wallet_ui/common/hooks/swap.ts#L455).

This pull request fixes #5107 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
To get a ERC 20 Approve transaction:
1. Open & unlock wallet
2. Switch to Ropsten network
3. If you have 0 DAI, swap some ETH to DAI
4. Open swap panel and try to swap DAI to ETH. Swap button should show 'Activate Token DAI' if you have never swapped DAI before. Tap it.
5. Confirm the Approve transaction
6. Open Accounts tab
7. Tap account to see account activity. Should see ETH, USDC, DAI now, and DAI approve tx should be shown as 'Approve x DAI'


## Screenshots:
![unlimited confirmation](https://user-images.githubusercontent.com/5314553/162535961-f369a4b1-294c-4c14-82f3-8e8140399e20.png)

![unlimited edit permissions](https://user-images.githubusercontent.com/5314553/162536070-bbe97570-a8ef-47e9-823c-fd8418791631.png)

![fixed confirmation](https://user-images.githubusercontent.com/5314553/162535976-5e966976-fed6-4311-834e-4616f37aa57b.png)
ebc2a.png)

![fixed edit permissions](https://user-images.githubusercontent.com/5314553/162535982-637e91cc-6e34-4015-b4e6-f650ee5a45c2.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
