### PR TITLE
Fix #5112: Wallet dapps notification integration 

### DIFF
--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -280,7 +280,7 @@ struct WalletPanelView: View {
     }
     .onAppear {
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
-      if let request = permissionRequestManager.pendingRequests(for: origin).first {
+      if let request = permissionRequestManager.pendingRequests(for: origin, coinType: .eth).first {
         presentWalletWithContext(.requestEthererumPermissions(request))
       } else {
         cryptoStore.prepare()

--- a/BraveWallet/WalletProviderPermissionRequestsManager.swift
+++ b/BraveWallet/WalletProviderPermissionRequestsManager.swift
@@ -66,8 +66,8 @@ public class WalletProviderPermissionRequestsManager {
   }
   
   /// Returns a list of pending requests waiting for a given origin
-  public func pendingRequests(for origin: URLOrigin) -> [WebpagePermissionRequest] {
-    requests.filter({ $0.requestingOrigin == origin })
+  public func pendingRequests(for origin: URLOrigin, coinType: BraveWallet.CoinType) -> [WebpagePermissionRequest] {
+    requests.filter({ $0.requestingOrigin == origin && $0.coinType == coinType })
   }
   
   /// Cancels an in-flight request without executing any decision

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
@@ -12,8 +12,9 @@ class WalletConnectionView: UIControl {
   private let stackView: UIStackView = {
     let result = UIStackView()
     result.axis = .horizontal
-    result.spacing = 15
+    result.spacing = 20
     result.alignment = .center
+    result.distribution = .fill
     result.isUserInteractionEnabled = false
     return result
   }()
@@ -21,6 +22,8 @@ class WalletConnectionView: UIControl {
   private let iconImageView: UIImageView = {
     let result = UIImageView(image: UIImage(imageLiteralResourceName: "brave.unlock"))
     result.tintColor = .white
+    result.setContentHuggingPriority(.required, for: .horizontal)
+    result.setContentCompressionResistancePriority(.required, for: .horizontal)
     return result
   }()
 
@@ -31,6 +34,7 @@ class WalletConnectionView: UIControl {
     result.adjustsFontForContentSizeCategory = true
     result.numberOfLines = 0
     result.text = Strings.Wallet.dappsConnectionNotificationTitle
+    result.setContentCompressionResistancePriority(.required, for: .horizontal)
     return result
   }()
 
@@ -39,7 +43,7 @@ class WalletConnectionView: UIControl {
 
     addSubview(stackView)
     stackView.snp.makeConstraints {
-      $0.edges.equalToSuperview().inset(20)
+      $0.edges.equalToSuperview().inset(24)
     }
     stackView.addArrangedSubview(iconImageView)
     stackView.addArrangedSubview(titleLabel)

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
@@ -14,7 +14,6 @@ class WalletConnectionView: UIControl {
     result.axis = .horizontal
     result.spacing = 20
     result.alignment = .center
-    result.distribution = .fill
     result.isUserInteractionEnabled = false
     return result
   }()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -119,11 +119,6 @@ extension BrowserViewController: BraveWalletProviderDelegate {
 
   func requestEthereumPermissions(_ completion: @escaping BraveWalletProviderResultsCallback) {
     Task { @MainActor in
-      if presentedViewController is WalletHostingViewController {
-        completion([], .internalError, "Wallet interaction session is currenty active")
-        return
-      }
-      
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       let origin = getOrigin()
       
@@ -165,14 +160,16 @@ extension BrowserViewController: BraveWalletProviderDelegate {
           completion([], .userRejectedRequest, "User rejected request")
         }
       })
-
-      // display notification
-      let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
-        if action == .connectWallet {
-          self?.presentWalletPanel(completion)
+      
+      // only display notification when BVC is front and center
+      if presentedViewController == nil {
+        let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
+          if action == .connectWallet {
+            self?.presentWalletPanel(completion)
+          }
         }
+        notificationsPresenter.display(notification: walletNotificaton, from: self)
       }
-      notificationsPresenter.display(notification: walletNotificaton, from: self)
     }
   }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -115,6 +115,11 @@ extension BrowserViewController: BraveWalletProviderDelegate {
 
   func requestEthereumPermissions(_ completion: @escaping BraveWalletProviderResultsCallback) {
     Task { @MainActor in
+      if presentedViewController is WalletHostingViewController {
+        completion([], .internalError, "Wallet interaction session is currenty active")
+        return
+      }
+      
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       let origin = getOrigin()
       

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -101,6 +101,8 @@ extension BrowserViewController: BraveWalletDelegate {
 
 extension BrowserViewController: BraveWalletProviderDelegate {
   func showPanel() {
+    guard presentedViewController == nil else { return }
+    
     let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
       if action == .connectWallet {
         self?.presentWalletPanel()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -58,7 +58,7 @@ extension BrowserViewController {
         Task { @MainActor in
           let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
           if permissionRequestManager.hasPendingRequest(for: origin, coinType: .eth) {
-            let pendingRequests = permissionRequestManager.pendingRequests(for: origin)
+            let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: .eth)
             let (accounts, status, _) = await self.allowedAccounts(false)
             if status == .success, !accounts.isEmpty {
               for request in pendingRequests {


### PR DESCRIPTION
This pull request fixes #5112 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
To test eth permission using brian's manual tests is very helpful (https://github.com/bbondy/eth-manual-tests)
1. no wallet set up

https://user-images.githubusercontent.com/1187676/162774312-c6aff251-cf1a-4c23-80bc-3a68fbe19ca5.mp4

2. account is locked

https://user-images.githubusercontent.com/1187676/162775336-3ff365f4-43c9-4fa2-b8fe-0afd8b36c0ef.mp4

3. account is not locked

https://user-images.githubusercontent.com/1187676/162775565-f7888bc4-06c0-4c6a-b327-1d1ef1f825a2.mp4

4. auto-dismiss in 30 seconds

https://user-images.githubusercontent.com/1187676/162776339-1f422b2e-16f8-4d02-aa6a-0ef1fb4f819a.mov

5. overdid by a rewards ad

https://user-images.githubusercontent.com/1187676/162779470-74e9abcd-30c2-45e7-ab1c-6ad90c6ac4cb.mp4

6. being queued after all rewards ads (no duplication)

https://user-images.githubusercontent.com/1187676/162780820-6ab7de33-a501-42af-828f-a5b7d9b3c7ce.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
