### PR TITLE
Fix #5243: Update network session publisher API to receive on main queue

### DIFF
--- a/Client/Networking/NetworkSession.swift
+++ b/Client/Networking/NetworkSession.swift
@@ -62,6 +62,7 @@ extension URLSession: NetworkSession {
     return self.dataTaskPublisher(for: urlRequest)
       .map({ ($0, $1) })
       .mapError({ $0 as Error })
+      .receive(on: DispatchQueue.main)
       .eraseToAnyPublisher()
   }
 


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5243

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
