### PR TITLE
Fix #5105: Pending confirmations in wallet panel

### DIFF
--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -17,7 +17,7 @@ struct CryptoPagesView: View {
 
   @State private var isShowingSettings: Bool = false
   @State private var isShowingSearch: Bool = false
-  @State private var fetchedUnapprovedTransactionsThisSession: Bool = false
+  @State private var fetchedPendingRequestsThisSession: Bool = false
 
   var body: some View {
     _CryptoPagesView(
@@ -27,12 +27,12 @@ struct CryptoPagesView: View {
       isConfirmationsButtonVisible: cryptoStore.pendingRequest != nil
     )
     .onAppear {
-      // If a user chooses not to confirm/reject their transactions we shouldn't
+      // If a user chooses not to confirm/reject their requests we shouldn't
       // do it again until they close and re-open wallet
-      if !fetchedUnapprovedTransactionsThisSession {
+      if !fetchedPendingRequestsThisSession {
         // Give the animation time
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-          self.fetchedUnapprovedTransactionsThisSession = true
+          self.fetchedPendingRequestsThisSession = true
           self.cryptoStore.prepare()
         }
       }
@@ -134,7 +134,7 @@ struct CryptoPagesView: View {
       )
     }
     func updateUIViewController(_ uiViewController: CryptoPagesViewController, context: Context) {
-      uiViewController.confirmationsButton.isHidden = !isConfirmationsButtonVisible
+      uiViewController.pendingRequestsButton.isHidden = !isConfirmationsButtonVisible
     }
   }
 }
@@ -143,7 +143,7 @@ private class CryptoPagesViewController: TabbedPageViewController {
   private let keyringStore: KeyringStore
   private let cryptoStore: CryptoStore
   private let swapButton = SwapButton()
-  let confirmationsButton = ConfirmationsButton()
+  let pendingRequestsButton = ConfirmationsButton()
 
   @Binding private var buySendSwapDestination: BuySendSwapDestination?
   @Binding private var isShowingPendingRequest: Bool
@@ -207,16 +207,16 @@ private class CryptoPagesViewController: TabbedPageViewController {
 
     swapButton.addTarget(self, action: #selector(tappedSwapButton), for: .touchUpInside)
 
-    view.addSubview(confirmationsButton)
-    confirmationsButton.snp.makeConstraints {
+    view.addSubview(pendingRequestsButton)
+    pendingRequestsButton.snp.makeConstraints {
       $0.trailing.equalToSuperview().inset(16)
       $0.centerY.equalTo(swapButton)
       $0.bottom.lessThanOrEqualTo(view).inset(8)
     }
-    confirmationsButton.addTarget(self, action: #selector(tappedConfirmationsButton), for: .touchUpInside)
+    pendingRequestsButton.addTarget(self, action: #selector(tappedPendingRequestsButton), for: .touchUpInside)
   }
 
-  @objc private func tappedConfirmationsButton() {
+  @objc private func tappedPendingRequestsButton() {
     isShowingPendingRequest = true
   }
 

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -23,8 +23,8 @@ struct CryptoPagesView: View {
     _CryptoPagesView(
       keyringStore: keyringStore,
       cryptoStore: cryptoStore,
-      isShowingTransactions: $cryptoStore.isPresentingTransactionConfirmations,
-      isConfirmationsButtonVisible: cryptoStore.hasUnapprovedTransactions
+      isShowingPendingRequest: $cryptoStore.isPresentingPendingRequest,
+      isConfirmationsButtonVisible: cryptoStore.pendingRequest != nil
     )
     .onAppear {
       // If a user chooses not to confirm/reject their transactions we shouldn't
@@ -33,7 +33,7 @@ struct CryptoPagesView: View {
         // Give the animation time
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
           self.fetchedUnapprovedTransactionsThisSession = true
-          self.cryptoStore.fetchUnapprovedTransactions()
+          self.cryptoStore.prepare()
         }
       }
     }
@@ -122,7 +122,7 @@ struct CryptoPagesView: View {
   private struct _CryptoPagesView: UIViewControllerRepresentable {
     var keyringStore: KeyringStore
     var cryptoStore: CryptoStore
-    var isShowingTransactions: Binding<Bool>
+    var isShowingPendingRequest: Binding<Bool>
     var isConfirmationsButtonVisible: Bool
 
     func makeUIViewController(context: Context) -> CryptoPagesViewController {
@@ -130,7 +130,7 @@ struct CryptoPagesView: View {
         keyringStore: keyringStore,
         cryptoStore: cryptoStore,
         buySendSwapDestination: context.environment.buySendSwapDestination,
-        isShowingTransactions: isShowingTransactions
+        isShowingPendingRequest: isShowingPendingRequest
       )
     }
     func updateUIViewController(_ uiViewController: CryptoPagesViewController, context: Context) {
@@ -146,18 +146,18 @@ private class CryptoPagesViewController: TabbedPageViewController {
   let confirmationsButton = ConfirmationsButton()
 
   @Binding private var buySendSwapDestination: BuySendSwapDestination?
-  @Binding private var isShowingTransactions: Bool
+  @Binding private var isShowingPendingRequest: Bool
 
   init(
     keyringStore: KeyringStore,
     cryptoStore: CryptoStore,
     buySendSwapDestination: Binding<BuySendSwapDestination?>,
-    isShowingTransactions: Binding<Bool>
+    isShowingPendingRequest: Binding<Bool>
   ) {
     self.keyringStore = keyringStore
     self.cryptoStore = cryptoStore
     self._buySendSwapDestination = buySendSwapDestination
-    self._isShowingTransactions = isShowingTransactions
+    self._isShowingPendingRequest = isShowingPendingRequest
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -217,7 +217,7 @@ private class CryptoPagesViewController: TabbedPageViewController {
   }
 
   @objc private func tappedConfirmationsButton() {
-    isShowingTransactions = true
+    isShowingPendingRequest = true
   }
 
   @objc private func tappedSwapButton() {

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -81,8 +81,8 @@ public struct CryptoView: View {
                 cryptoStore: store,
                 toolbarDismissContent: dismissButtonToolbarContents
               )
-            case .webpageRequests:
-              WebpageRequestContainerView(
+            case .pendingRequests:
+              RequestContainerView(
                 keyringStore: keyringStore,
                 cryptoStore: store,
                 toolbarDismissContent: dismissButtonToolbarContents,
@@ -187,12 +187,13 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
     )
     .background(
       Color.clear
-        .sheet(isPresented: $cryptoStore.isPresentingTransactionConfirmations) {
-          if cryptoStore.hasUnapprovedTransactions {
-            TransactionConfirmationView(
-              confirmationStore: cryptoStore.openConfirmationStore(),
-              networkStore: cryptoStore.networkStore,
-              keyringStore: keyringStore
+        .sheet(isPresented: $cryptoStore.isPresentingPendingRequest) {
+          if cryptoStore.pendingRequest != nil {
+            RequestContainerView(
+              keyringStore: keyringStore,
+              cryptoStore: cryptoStore,
+              toolbarDismissContent: toolbarDismissContent,
+              onDismiss: { }
             )
           }
         }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -193,7 +193,9 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
               keyringStore: keyringStore,
               cryptoStore: cryptoStore,
               toolbarDismissContent: toolbarDismissContent,
-              onDismiss: { }
+              onDismiss: {
+                cryptoStore.isPresentingPendingRequest = false
+              }
             )
           }
         }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -5,11 +5,24 @@
 
 import BraveCore
 
-enum PendingWebpageRequest: Equatable {
+enum PendingRequest: Equatable {
+  case transactions
   case addChain(BraveWallet.AddChainRequest)
   case switchChain(BraveWallet.SwitchChainRequest)
   case addSuggestedToken(BraveWallet.AddSuggestTokenRequest)
   case signMessage([BraveWallet.SignMessageRequest])
+}
+
+extension PendingRequest: Identifiable {
+  var id: String {
+    switch self {
+    case .transactions: return "transactions"
+    case let .addChain(request): return "addChain-\(request.networkInfo.chainId)"
+    case let .switchChain(chainRequest): return "switchChain-\(chainRequest.chainId)"
+    case let .addSuggestedToken(tokenRequest): return "addSuggestedToken-\(tokenRequest.token.id)"
+    case let .signMessage(signRequests): return "signMessage-\(signRequests.map(\.id))"
+    }
+  }
 }
 
 enum WebpageRequestResponse: Equatable {
@@ -33,15 +46,14 @@ public class CryptoStore: ObservableObject {
     }
   }
   @Published var isPresentingAssetSearch: Bool = false
-  @Published var isPresentingTransactionConfirmations: Bool = false {
+  @Published var isPresentingPendingRequest: Bool = false {
     didSet {
-      if !isPresentingTransactionConfirmations {
+      if !isPresentingPendingRequest {
         confirmationStore = nil
       }
     }
   }
-  @Published private(set) var hasUnapprovedTransactions: Bool = false
-  @Published private(set) var pendingWebpageRequest: PendingWebpageRequest?
+  @Published private(set) var pendingRequest: PendingRequest?
   
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -207,44 +219,48 @@ public class CryptoStore: ObservableObject {
     txService: txService
   )
   
-  func fetchUnapprovedTransactions() {
-    keyringService.defaultKeyringInfo { [self] keyring in
-      var pendingTransactions: [BraveWallet.TransactionInfo] = []
-      let group = DispatchGroup()
-      for info in keyring.accountInfos {
-        group.enter()
-        txService.allTransactionInfo(.eth, from: info.address) { tx in
-          defer { group.leave() }
-          pendingTransactions.append(contentsOf: tx.filter { $0.txStatus == .unapproved })
-        }
-      }
-      group.notify(queue: .main) { [self] in
-        if !pendingTransactions.isEmpty && buySendSwapDestination != nil {
+  func prepare() {
+    Task { @MainActor in
+      let pendingTransactions = await fetchPendingTransactions()
+      if !pendingTransactions.isEmpty {
+        if self.buySendSwapDestination != nil {
           // Dismiss any buy send swap open to show the unapproved transactions
           self.buySendSwapDestination = nil
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-          // On iPad if we set these before the send or swap screens disappear for some reason it crashes
-          // within the SwiftUI runtime. Delaying it to give time for the animation to complete fixes it.
-          self.hasUnapprovedTransactions = !pendingTransactions.isEmpty
-          self.isPresentingTransactionConfirmations = !pendingTransactions.isEmpty
-        }
+        self.pendingRequest = .transactions
+        self.isPresentingPendingRequest = true
+      } else { // no pending transactions, check for webpage requests
+        let pendingWebpageRequest = await fetchPendingWebpageRequest()
+        self.pendingRequest = pendingWebpageRequest
+        self.isPresentingPendingRequest = pendingWebpageRequest != nil
       }
     }
   }
-  
-  func fetchPendingRequests() {
-    Task { @MainActor in
-      // TODO: Add check for eth permissions… get first eth request 
-      if let chainRequest = await rpcService.pendingAddChainRequests().first {
-        pendingWebpageRequest = .addChain(chainRequest)
-      } else if case let signMessageRequests = await walletService.pendingSignMessageRequests(), !signMessageRequests.isEmpty {
-        pendingWebpageRequest = .signMessage(signMessageRequests)
-      } else if let switchRequest = await rpcService.pendingSwitchChainRequests().first {
-        pendingWebpageRequest = .switchChain(switchRequest)
-      } else if let addTokenRequest = await walletService.pendingAddSuggestTokenRequests().first {
-        pendingWebpageRequest = .addSuggestedToken(addTokenRequest)
-      }
+
+  @MainActor
+  func fetchPendingTransactions() async -> [BraveWallet.TransactionInfo] {
+    let keyring = await keyringService.keyringInfo(BraveWallet.DefaultKeyringId)
+    var pendingTransactions: [BraveWallet.TransactionInfo] = []
+    for info in keyring.accountInfos {
+      let allTransactionInfo = await txService.allTransactionInfo(.eth, from: info.address)
+      pendingTransactions.append(contentsOf: allTransactionInfo.filter { $0.txStatus == .unapproved })
+    }
+    return pendingTransactions
+  }
+
+  @MainActor
+  func fetchPendingWebpageRequest() async -> PendingRequest? {
+    // TODO: Add check for eth permissions… get first eth request
+    if let chainRequest = await rpcService.pendingAddChainRequests().first {
+      return .addChain(chainRequest)
+    } else if case let signMessageRequests = await walletService.pendingSignMessageRequests(), !signMessageRequests.isEmpty {
+      return .signMessage(signMessageRequests)
+    } else if let switchRequest = await rpcService.pendingSwitchChainRequests().first {
+      return .switchChain(switchRequest)
+    } else if let addTokenRequest = await walletService.pendingAddSuggestTokenRequests().first {
+      return .addSuggestedToken(addTokenRequest)
+    } else {
+      return nil
     }
   }
 
@@ -252,30 +268,29 @@ public class CryptoStore: ObservableObject {
     switch response {
     case let .switchChain(approved, originInfo):
       rpcService.notifySwitchChainRequestProcessed(approved, origin: originInfo.origin)
-      pendingWebpageRequest = nil
+      pendingRequest = nil
     case let .addNetwork(approved, chainId):
       rpcService.addEthereumChainRequestCompleted(chainId, approved: approved)
-      pendingWebpageRequest = nil
+      pendingRequest = nil
     case let .addSuggestedToken(approved, contractAddresses):
       walletService.notifyAddSuggestTokenRequestsProcessed(approved, contractAddresses: contractAddresses)
-      pendingWebpageRequest = nil
+      pendingRequest = nil
     case let .signMessage(approved, id):
       walletService.notifySignMessageRequestProcessed(approved, id: id)
-      pendingWebpageRequest = nil
+      pendingRequest = nil
     }
-    fetchPendingRequests()
   }
 }
 
 extension CryptoStore: BraveWalletTxServiceObserver {
   public func onNewUnapprovedTx(_ txInfo: BraveWallet.TransactionInfo) {
-    fetchUnapprovedTransactions()
+    prepare()
   }
   public func onUnapprovedTxUpdated(_ txInfo: BraveWallet.TransactionInfo) {
-    fetchUnapprovedTransactions()
+    prepare()
   }
   public func onTransactionStatusChanged(_ txInfo: BraveWallet.TransactionInfo) {
-    fetchUnapprovedTransactions()
+    prepare()
   }
 }
 
@@ -287,7 +302,7 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
   public func keyringRestored(_ keyringId: String) {
   }
   public func locked() {
-    isPresentingTransactionConfirmations = false
+    isPresentingPendingRequest = false
   }
   public func unlocked() {
   }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -279,6 +279,7 @@ public class CryptoStore: ObservableObject {
       walletService.notifySignMessageRequestProcessed(approved, id: id)
       pendingRequest = nil
     }
+    prepare()
   }
 }
 

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -268,17 +268,14 @@ public class CryptoStore: ObservableObject {
     switch response {
     case let .switchChain(approved, originInfo):
       rpcService.notifySwitchChainRequestProcessed(approved, origin: originInfo.origin)
-      pendingRequest = nil
     case let .addNetwork(approved, chainId):
       rpcService.addEthereumChainRequestCompleted(chainId, approved: approved)
-      pendingRequest = nil
     case let .addSuggestedToken(approved, contractAddresses):
       walletService.notifyAddSuggestTokenRequestsProcessed(approved, contractAddresses: contractAddresses)
-      pendingRequest = nil
     case let .signMessage(approved, id):
       walletService.notifySignMessageRequestProcessed(approved, id: id)
-      pendingRequest = nil
     }
+    pendingRequest = nil
     prepare()
   }
 }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -228,11 +228,15 @@ public class CryptoStore: ObservableObject {
           self.buySendSwapDestination = nil
         }
         self.pendingRequest = .transactions
-        self.isPresentingPendingRequest = true
       } else { // no pending transactions, check for webpage requests
         let pendingWebpageRequest = await fetchPendingWebpageRequest()
         self.pendingRequest = pendingWebpageRequest
-        self.isPresentingPendingRequest = pendingWebpageRequest != nil
+      }
+      // If we set these before the send or swap screens disappear for some reason it may crash
+      // within the SwiftUI runtime or fail to dismiss. Delaying it to give time for the
+      // animation to complete fixes it.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        self.isPresentingPendingRequest = self.pendingRequest != nil
       }
     }
   }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -54,24 +54,6 @@ public class TransactionConfirmationStore: ObservableObject {
     transactions.first(where: { $0.id == activeTransactionId }) ?? (transactions.first ?? .init())
   }
 
-  func next() {
-    if let index = transactions.firstIndex(where: { $0.id == activeTransactionId }) {
-      var nextIndex = transactions.index(after: index)
-      if nextIndex == transactions.endIndex {
-        nextIndex = 0
-      }
-      activeTransactionId = transactions[nextIndex].id
-    } else {
-      activeTransactionId = transactions.first!.id
-    }
-  }
-
-  func rejectAll() {
-    for transaction in transactions {
-      reject(transaction: transaction, completion: { _ in })
-    }
-  }
-
   private let assetRatioService: BraveWalletAssetRatioService
   private let rpcService: BraveWalletJsonRpcService
   private let txService: BraveWalletTxService
@@ -103,6 +85,24 @@ public class TransactionConfirmationStore: ObservableObject {
     
     walletService.defaultBaseCurrency { [self] currencyCode in
       self.currencyCode = currencyCode
+    }
+  }
+  
+  func nextTransaction() {
+    if let index = transactions.firstIndex(where: { $0.id == activeTransactionId }) {
+      var nextIndex = transactions.index(after: index)
+      if nextIndex == transactions.endIndex {
+        nextIndex = 0
+      }
+      activeTransactionId = transactions[nextIndex].id
+    } else {
+      activeTransactionId = transactions.first!.id
+    }
+  }
+
+  func rejectAllTransactions() {
+    for transaction in transactions {
+      reject(transaction: transaction, completion: { _ in })
     }
   }
 

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -283,13 +283,15 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
 
-  func confirm(transaction: BraveWallet.TransactionInfo) {
+  func confirm(transaction: BraveWallet.TransactionInfo, completion: @escaping (_ error: String?) -> Void) {
     txService.approveTransaction(.eth, txMetaId: transaction.id) { success, error, message in
+      completion(success ? nil : message)
     }
   }
 
-  func reject(transaction: BraveWallet.TransactionInfo) {
+  func reject(transaction: BraveWallet.TransactionInfo, completion: @escaping (Bool) -> Void) {
     txService.rejectTransaction(.eth, txMetaId: transaction.id) { success in
+      completion(success)
     }
   }
 

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -68,7 +68,7 @@ public class TransactionConfirmationStore: ObservableObject {
 
   func rejectAll() {
     for transaction in transactions {
-      reject(transaction: transaction)
+      reject(transaction: transaction, completion: { _ in })
     }
   }
 

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -84,7 +84,7 @@ struct TransactionConfirmationView: View {
       HStack {
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionCount, index + 1, confirmationStore.transactions.count))
           .fontWeight(.semibold)
-        Button(action: confirmationStore.next) {
+        Button(action: confirmationStore.nextTransaction) {
           Text(Strings.Wallet.next)
             .fontWeight(.semibold)
             .foregroundColor(Color(.braveBlurpleTint))
@@ -326,7 +326,7 @@ struct TransactionConfirmationView: View {
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
           }
           if confirmationStore.transactions.count > 1 {
-            Button(action: confirmationStore.rejectAll) {
+            Button(action: confirmationStore.rejectAllTransactions) {
               Text(String.localizedStringWithFormat(Strings.Wallet.rejectAllTransactions, confirmationStore.transactions.count))
                 .font(.subheadline.weight(.semibold))
                 .foregroundColor(Color(.braveBlurpleTint))

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -15,6 +15,8 @@ struct TransactionConfirmationView: View {
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore
 
+  var onDismiss: () -> Void
+
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.presentationMode) @Binding private var presentationMode
 
@@ -174,7 +176,6 @@ struct TransactionConfirmationView: View {
   }
 
   var body: some View {
-    NavigationView {
       ScrollView(.vertical) {
         VStack {
           // Header
@@ -374,8 +375,6 @@ struct TransactionConfirmationView: View {
           }
         }
       }
-    }
-    .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
       confirmationStore.prepare()
     }
@@ -395,13 +394,21 @@ struct TransactionConfirmationView: View {
 
   @ViewBuilder private var rejectConfirmButtons: some View {
     Button(action: {
-      confirmationStore.reject(transaction: confirmationStore.activeTransaction)
+      confirmationStore.reject(transaction: confirmationStore.activeTransaction) { success in
+        if confirmationStore.transactions.count == 1 {
+          onDismiss()
+        }
+      }
     }) {
       Label(Strings.Wallet.rejectTransactionButtonTitle, systemImage: "xmark")
     }
     .buttonStyle(BraveOutlineButtonStyle(size: .large))
     Button(action: {
-      confirmationStore.confirm(transaction: confirmationStore.activeTransaction)
+      confirmationStore.confirm(transaction: confirmationStore.activeTransaction) { error in
+        if confirmationStore.transactions.count == 1 {
+          onDismiss()
+        }
+      }
     }) {
       Label(Strings.Wallet.confirm, systemImage: "checkmark.circle.fill")
     }
@@ -444,7 +451,8 @@ struct TransactionConfirmationView_Previews: PreviewProvider {
     TransactionConfirmationView(
       confirmationStore: .previewStore,
       networkStore: .previewStore,
-      keyringStore: .previewStoreWithWalletCreated
+      keyringStore: .previewStoreWithWalletCreated,
+      onDismiss: { }
     )
     .previewLayout(.sizeThatFits)
   }

--- a/BraveWallet/Panels/RequestContainerView.swift
+++ b/BraveWallet/Panels/RequestContainerView.swift
@@ -7,8 +7,8 @@ import Foundation
 import SwiftUI
 import BraveUI
 
-/// A container to present when a webpage wants to present some request to the user such as adding a suggested
-/// token, change networks, authorize a transaction, etc.
+/// A container to present when a webpage wants to present some request to the user such as transaction
+/// confirmations, adding networks, switch networks, add tokens, sign message, etc.
 struct RequestContainerView<DismissContent: ToolbarContent>: View {
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var cryptoStore: CryptoStore

--- a/BraveWallet/Panels/RequestContainerView.swift
+++ b/BraveWallet/Panels/RequestContainerView.swift
@@ -19,7 +19,7 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
   var body: some View {
     NavigationView {
       Group {
-        if let pendingRequest = cryptoStore.pendingWebpageRequest {
+        if let pendingRequest = cryptoStore.pendingRequest {
           switch pendingRequest {
           case .transactions:
             TransactionConfirmationView(
@@ -60,8 +60,6 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               cryptoStore: cryptoStore,
               onDismiss: onDismiss
             )
-          default:
-            EmptyView()
           }
         }
       }

--- a/BraveWallet/Panels/RequestContainerView.swift
+++ b/BraveWallet/Panels/RequestContainerView.swift
@@ -9,7 +9,7 @@ import BraveUI
 
 /// A container to present when a webpage wants to present some request to the user such as adding a suggested
 /// token, change networks, authorize a transaction, etc.
-struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
+struct RequestContainerView<DismissContent: ToolbarContent>: View {
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var cryptoStore: CryptoStore
   var toolbarDismissContent: DismissContent
@@ -21,6 +21,13 @@ struct WebpageRequestContainerView<DismissContent: ToolbarContent>: View {
       Group {
         if let pendingRequest = cryptoStore.pendingWebpageRequest {
           switch pendingRequest {
+          case .transactions:
+            TransactionConfirmationView(
+              confirmationStore: cryptoStore.openConfirmationStore(),
+              networkStore: cryptoStore.networkStore,
+              keyringStore: keyringStore,
+              onDismiss: onDismiss
+            )
           case .addSuggestedToken(let request):
             AddSuggestedTokenView(
               token: request.token,

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -175,8 +175,18 @@ struct WalletPanelView: View {
   var body: some View {
     ScrollView(.vertical, showsIndicators: false) {
       VStack(spacing: 0) {
-        Text("Brave Wallet")
-          .font(.headline)
+        HStack {
+          Spacer()
+          Text("Brave Wallet")
+            .font(.headline)
+          Spacer()
+          if cryptoStore.pendingRequest != nil {
+            Button(action: { presentWalletWithContext(.pendingRequests) }) {
+              Image(uiImage: UIImage(imageLiteralResourceName: "brave.bell.badge").template)
+                .foregroundColor(.white)
+            }
+          }
+        }
           .padding(16)
           .frame(maxWidth: .infinity)
           .overlay(
@@ -263,9 +273,9 @@ struct WalletPanelView: View {
       )
       .ignoresSafeArea()
     )
-    .onChange(of: cryptoStore.pendingWebpageRequest) { newValue in
+    .onChange(of: cryptoStore.pendingRequest) { newValue in
       if newValue != nil {
-        presentWalletWithContext(.webpageRequests)
+        presentWalletWithContext(.pendingRequests)
       }
     }
     .onAppear {
@@ -273,7 +283,7 @@ struct WalletPanelView: View {
       if let request = permissionRequestManager.pendingRequests(for: origin).first {
         presentWalletWithContext(.requestEthererumPermissions(request))
       } else {
-        cryptoStore.fetchPendingRequests()
+        cryptoStore.prepare()
       }
     }
   }

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -21,8 +21,8 @@ public protocol BraveWalletDelegate: AnyObject {
 public enum PresentingContext {
   /// The default context shows the main wallet view which includes portfolio, buy/send/swap, etc.
   case `default`
-  /// Shows the user any pending requests made by webpages such as new adding networks, tokens, etc.
-  case webpageRequests
+  /// Shows the user any pending requests made by webpages such as transaction confirmations, adding networks, switch networks, add tokens, sign message, etc.
+  case pendingRequests
   /// Shows when a webpage wants to connect with the users wallet
   case requestEthererumPermissions(_ request: WebpagePermissionRequest)
   /// Shows the user only the unlock/setup screen then dismisses to view an unlocked panel

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 		27C647832550AF34006D72FC /* WalletTransferCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C647822550AF34006D72FC /* WalletTransferCompleteView.swift */; };
 		27C6478F2551CD2B006D72FC /* RewardsInternalsDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C6478E2551CD2B006D72FC /* RewardsInternalsDebugViewController.swift */; };
 		27C647A62551F082006D72FC /* RewardsDebugSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C647A52551F082006D72FC /* RewardsDebugSettingsViewController.swift */; };
-		27C8C40227D2C9A100051226 /* WebpageRequestContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8C40127D2C9A100051226 /* WebpageRequestContainerView.swift */; };
+		27C8C40227D2C9A100051226 /* RequestContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8C40127D2C9A100051226 /* RequestContainerView.swift */; };
 		27CD682527F5014F00D30B5D /* WalletProviderConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CD682427F5014F00D30B5D /* WalletProviderConstants.swift */; };
 		27CFB71424E1F67B008DFC8C /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CFB71324E1F67B008DFC8C /* Observable.swift */; };
 		27D114D42358FBBF00166534 /* BraveRewardsSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D114D32358FBBF00166534 /* BraveRewardsSettingsViewController.swift */; };
@@ -2065,7 +2065,7 @@
 		27C647822550AF34006D72FC /* WalletTransferCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransferCompleteView.swift; sourceTree = "<group>"; };
 		27C6478E2551CD2B006D72FC /* RewardsInternalsDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsInternalsDebugViewController.swift; sourceTree = "<group>"; };
 		27C647A52551F082006D72FC /* RewardsDebugSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsDebugSettingsViewController.swift; sourceTree = "<group>"; };
-		27C8C40127D2C9A100051226 /* WebpageRequestContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebpageRequestContainerView.swift; sourceTree = "<group>"; };
+		27C8C40127D2C9A100051226 /* RequestContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestContainerView.swift; sourceTree = "<group>"; };
 		27CD682427F5014F00D30B5D /* WalletProviderConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletProviderConstants.swift; sourceTree = "<group>"; };
 		27CFB71324E1F67B008DFC8C /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		27D114D32358FBBF00166534 /* BraveRewardsSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveRewardsSettingsViewController.swift; sourceTree = "<group>"; };
@@ -4363,7 +4363,7 @@
 		27BC117F27A9A5430097ADCD /* Panels */ = {
 			isa = PBXGroup;
 			children = (
-				27C8C40127D2C9A100051226 /* WebpageRequestContainerView.swift */,
+				27C8C40127D2C9A100051226 /* RequestContainerView.swift */,
 				27BC119227A9C90E0097ADCD /* WalletPanelView.swift */,
 				27842B4C27AC8803002B3EDA /* Connect */,
 				2761CA1427B1C7400077D52A /* Signature Request */,
@@ -7732,7 +7732,7 @@
 				7D2D6F162735BCDB000650EA /* TokenView.swift in Sources */,
 				7D49CDDD271FA8B5008AB67E /* SendTokenSearchView.swift in Sources */,
 				2761CA2027B1C74F0077D52A /* SignatureRequestView.swift in Sources */,
-				27C8C40227D2C9A100051226 /* WebpageRequestContainerView.swift in Sources */,
+				27C8C40227D2C9A100051226 /* RequestContainerView.swift in Sources */,
 				271F689226EBD27E00AA2A50 /* MockKeyringService.swift in Sources */,
 				271F68BE26EBD27E00AA2A50 /* LineChartView.swift in Sources */,
 				2762FF30271A054A001EF41D /* AssetIconView.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes
- Added pending requests bell icon to wallet panel as a button
- Renamed `PendingWebpageRequest` to `PendingRequest` and added a `transactions` case for transaction confirmations
- Renamed `WebpageRequestContainerView` to `RequestContainerView` and integrated `TransactionConfirmationView` for the `transactions` case
- Updated `CryptoStore` to fetch pending/unapproved transactions and if none are found, fetch pending webpage requests. Both the panel and wallet use this `pendingRequest: PendingRequest?` property now for both transaction confirmations and webpage requests

This pull request fixes #5105 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
To get a pending transaction, you can send/swap within the wallet or use [Uniswap](https://app.uniswap.org).
To get a pending webpage request, you can use [eth-manual-tests](https://github.com/bbondy/eth-manual-tests) or [MetaMask's test dapp site](https://metamask.github.io/test-dapp/).
Both pending transactions, and webpage requests should be accessible via the bell icon on the wallet or wallet panel, with transaction confirmations taking priority.


## Screenshots:
![pending request](https://user-images.githubusercontent.com/5314553/162993542-6de5b4c4-a41f-4d37-8532-1d6e73e28b79.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
