### PR TITLE
Fix 5247: No rounding if users want to send/swap full token balance

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -256,8 +256,7 @@ struct SwapCryptoView: View {
       ),
       footer: VStack(spacing: 20) {
         ShortcutAmountGrid(action: { amount in
-          swapTokensStore.sellAmount = ((swapTokensStore.selectedFromTokenBalance ?? 0) * amount.rawValue)
-            .decimalExpansion(precisionAfterDecimalPoint: Int(swapTokensStore.selectedFromToken?.decimals ?? 18))
+          swapTokensStore.suggestedAmountTapped(amount)
         })
         Button(action: {
           swapTokensStore.swapSelectedTokens()

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -177,60 +177,12 @@ public class SwapTokenStore: ObservableObject {
       return
     }
     
-    let balanceFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: Int(token.decimals)))
-    func updateBalance(_ status: BraveWallet.ProviderError, _ balance: String) {
-      guard status == .success,
-            let decimalString = balanceFormatter.decimalString(
-              for: balance.removingHexPrefix,
-              radix: .hex,
-              decimals: Int(token.decimals)
-            ), !decimalString.isEmpty, let decimal = BDouble(decimalString)
-      else {
-        completion(nil)
-        return
-      }
-      completion(decimal)
-    }
-    self.rpcService.network { network in
-      // Get balance for ETH token
-      if token.symbol == network.symbol {
-        self.rpcService.balance(account.address, coin: .eth, chainId: network.chainId) { balance, status, _ in
-          guard status == .success else {
-            completion(nil)
-            return
-          }
-          updateBalance(status, balance)
-        }
-      }
-      // Get balance for erc20 token
-      else if token.isErc20 {
-        self.rpcService.erc20TokenBalance(
-          token.contractAddress,
-          address: account.address,
-          chainId: network.chainId
-        ) { balance, status, _ in
-          guard status == .success else {
-            completion(nil)
-            return
-          }
-          updateBalance(status, balance)
-        }
-      }
-      // Get balance for erc721 token
-      else if token.isErc721 {
-        self.rpcService.erc721TokenBalance(
-          token.contractAddress,
-          tokenId: token.id,
-          accountAddress: account.address,
-          chainId: network.chainId
-        ) { balance, status, _ in
-          guard status == .success else {
-            completion(nil)
-            return
-          }
-          updateBalance(status, balance)
-        }
-      }
+    rpcService.balance(
+      for: token,
+      in: account.address,
+      decimalFormatStyle: .decimals(precision: Int(token.decimals))
+    ) { balance in
+      completion(balance)
     }
   }
 


### PR DESCRIPTION
## Summary of Changes
Fetching token balance with all available decimals.
Displaying all decimals and no rounding if the user decides to send/swap full token balance.
Added unit tests.

This pull request fixes #5247 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. send a ERC20 token with full balance

https://user-images.githubusercontent.com/1187676/163272588-717e137e-967f-4825-9d2f-0859b19c7926.mp4

2. swap a ERC20 token with full balance (may require token activation)

https://user-images.githubusercontent.com/1187676/163274278-37b46d96-8dff-4135-a311-553052201a5c.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
