### PR TITLE
Fix #5255: Bump Brave-Core to 1.38.93

### DIFF
--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -11,6 +11,7 @@ import BraveCore
 ///
 /// - note: Do not use this directly, use ``NetworkStore.previewStore``
 class MockJsonRpcService: BraveWalletJsonRpcService {
+  
   private var chainId: String = BraveWallet.MainnetChainId
   private var networks: [BraveWallet.NetworkInfo] = [.mainnet, .rinkeby, .ropsten]
   private var networkURL: URL?
@@ -119,6 +120,10 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
   
   func splTokenAccountBalance(_ pubkey: String, completion: @escaping (String, UInt8, String, BraveWallet.SolanaProviderError, String) -> Void) {
     completion("", 0, "", .internalError, "Error Message")
+  }
+  
+  func erc721Owner(of contract: String, tokenId: String, chainId: String, completion: @escaping (String, BraveWallet.ProviderError, String) -> Void) {
+    
   }
 }
 

--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -123,7 +123,7 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
   }
   
   func erc721Owner(of contract: String, tokenId: String, chainId: String, completion: @escaping (String, BraveWallet.ProviderError, String) -> Void) {
-    
+    completion("", .internalError, "erc721Owner error")
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.38.86/brave-core-ios-1.38.86.tgz",
-      "integrity": "sha512-3Abvg9t4yWmFcbjUMYXC7AGCNunWvNqPwn+WTxGQC2k0GBlUrHCj5jjMlYUfVC2F1U0xDH2vKBaqnn8kNUgNWg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.38.93/brave-core-ios-1.38.93.tgz",
+      "integrity": "sha512-y/jNbjDYQRLwfDGRlCWWA+NtvbkXmfo0zIxpaMl/PX9DxUVNVkiXV1tR9LAv8viL+wgyO+dipfWE6ndh5WUYNQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.38.86/brave-core-ios-1.38.86.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.38.93/brave-core-ios-1.38.93.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Bumps Brave-Core to 1.38.93
- New Brave-Core contains the `URLPattern` and `URL` changes to parse the `host` as a String.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5255

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
