### PR TITLE
Fix #5189: Clear ETH permissions when resetting wallet, clearing cookies & site data

### DIFF
--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -6,6 +6,7 @@
 import Foundation
 import LocalAuthentication
 import BraveCore
+import Data
 
 public class SettingsStore: ObservableObject {
   /// The number of minutes to wait until the Brave Wallet is automatically locked
@@ -46,6 +47,7 @@ public class SettingsStore: ObservableObject {
   func reset() {
     walletService.reset()
     KeyringStore.resetKeychainStoredPassword()
+    Domain.clearAllEthereumPermissions()
   }
 
   func resetTransaction() {

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -45,9 +45,11 @@ public class SettingsStore: ObservableObject {
   }
 
   func reset() {
-    walletService.reset()
-    KeyringStore.resetKeychainStoredPassword()
-    Domain.clearAllEthereumPermissions()
+    Task { @MainActor in
+      walletService.reset()
+      KeyringStore.resetKeychainStoredPassword()
+      try await Domain.clearAllEthereumPermissions()
+    }
   }
 
   func resetTransaction() {

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -45,11 +45,9 @@ public class SettingsStore: ObservableObject {
   }
 
   func reset() {
-    Task { @MainActor in
-      walletService.reset()
-      KeyringStore.resetKeychainStoredPassword()
-      try await Domain.clearAllEthereumPermissions()
-    }
+    walletService.reset()
+    KeyringStore.resetKeychainStoredPassword()
+    Domain.clearAllEthereumPermissions()
   }
 
   func resetTransaction() {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1214,6 +1214,7 @@
 		D506715C27E2AAB700560631 /* TransactionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D506715B27E2AAB700560631 /* TransactionHeader.swift */; };
 		D511314B2800C16100C81683 /* TransactionConfirmationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */; };
 		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
+		D552E6922807231F00A847F3 /* Data.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1DC51320AC9AF900905E5A /* Data.framework */; };
 		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
 		D5ACA7CE27FB7D08002443CE /* BraveCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; };
 		D5ACA7D927FB7D0E002443CE /* MaterialComponents.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; };
@@ -1592,6 +1593,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = CA0391B1271E1023000EB13C;
 			remoteInfo = BraveWidgetsExtension;
+		};
+		D552E6862807231A00A847F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5D1DC51220AC9AF900905E5A;
+			remoteInfo = Data;
 		};
 		E63CD1B11B31B66400A63AFF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -3348,6 +3356,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D552E6922807231F00A847F3 /* Data.framework in Frameworks */,
 				271F68DE26EBD50400AA2A50 /* BraveCore.xcframework in Frameworks */,
 				271F68D526EBD4F900AA2A50 /* BraveShared.framework in Frameworks */,
 				271F68E026EBD51100AA2A50 /* BraveUI.framework in Frameworks */,
@@ -7105,6 +7114,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D552E6872807231A00A847F3 /* PBXTargetDependency */,
 				271F68D826EBD4F900AA2A50 /* PBXTargetDependency */,
 				271F68E326EBD51100AA2A50 /* PBXTargetDependency */,
 			);
@@ -9334,6 +9344,11 @@
 			isa = PBXTargetDependency;
 			target = CA0391B1271E1023000EB13C /* BraveWidgetsExtension */;
 			targetProxy = CA8B4AE3276A830F002120F7 /* PBXContainerItemProxy */;
+		};
+		D552E6872807231A00A847F3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5D1DC51220AC9AF900905E5A /* Data */;
+			targetProxy = D552E6862807231A00A847F3 /* PBXContainerItemProxy */;
 		};
 		E6F965141B2F1CF20034B023 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -395,6 +395,10 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             let provider = self.braveCore.walletProvider(with: self, isPrivateBrowsing: tab.isPrivate) else {
         return nil
       }
+      if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: tab.isPrivate) {
+        tab.walletKeyringService = keyringService
+        keyringService.add(tab)
+      }
       return (provider, js: self.braveCore.walletProviderJS)
     }
     #endif

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -395,10 +395,6 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
             let provider = self.braveCore.walletProvider(with: self, isPrivateBrowsing: tab.isPrivate) else {
         return nil
       }
-      if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: tab.isPrivate) {
-        tab.walletKeyringService = keyringService
-        keyringService.add(tab)
-      }
       return (provider, js: self.braveCore.walletProviderJS)
     }
     #endif

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -268,3 +268,34 @@ extension Tab: BraveWalletEventsListener {
     }
   }
 }
+
+extension Tab: BraveWalletKeyringServiceObserver {
+  func keyringCreated(_ keyringId: String) {
+  }
+  
+  func keyringRestored(_ keyringId: String) {
+  }
+  
+  func keyringReset() {
+    emitEthereumEvent(.ethereumAccountsChanged(accounts: []))
+    updateEthereumProperties()
+  }
+  
+  func locked() {
+  }
+  
+  func unlocked() {
+  }
+  
+  func backedUp() {
+  }
+  
+  func accountsChanged() {
+  }
+  
+  func autoLockMinutesChanged() {
+  }
+  
+  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+  }
+}

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -281,8 +281,6 @@ extension Tab: BraveWalletKeyringServiceObserver {
   }
   
   func locked() {
-    updateEthereumProperties()
-    emitEthereumEvent(.ethereumAccountsChanged(accounts: []))
   }
   
   func unlocked() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -281,6 +281,8 @@ extension Tab: BraveWalletKeyringServiceObserver {
   }
   
   func locked() {
+    updateEthereumProperties()
+    emitEthereumEvent(.ethereumAccountsChanged(accounts: []))
   }
   
   func unlocked() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -277,8 +277,7 @@ extension Tab: BraveWalletKeyringServiceObserver {
   }
   
   func keyringReset() {
-    emitEthereumEvent(.ethereumAccountsChanged(accounts: []))
-    updateEthereumProperties()
+    reload()
   }
   
   func locked() {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -69,6 +69,7 @@ class Tab: NSObject {
   var walletProvider: BraveWalletBraveWalletProvider?
   var walletProviderJS: String?
   var isWalletIconVisible: Bool = false
+  var walletKeyringService: BraveWalletKeyringService?
   // PageMetadata is derived from the page content itself, and as such lags behind the
   // rest of the tab.
   var pageMetadata: PageMetadata?

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -444,6 +444,10 @@ class TabManager: NSObject {
       tab.walletProvider?.`init`(tab)
       tab.walletProviderJS = js
     }
+    if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: tab.isPrivate) {
+      tab.walletKeyringService = keyringService
+      keyringService.add(tab)
+    }
     
     delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }
 

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -39,7 +39,7 @@ struct ClearableErrorType: Error {
 }
 
 // Remove all cookies and website data stored by the site.
-// This includes localStorage, sessionStorage, and WebSQL/IndexedDB and web cache.
+// This includes localStorage, sessionStorage, WebSQL/IndexedDB, web cache and wallet eth permissions.
 class CookiesAndCacheClearable: Clearable {
 
   var label: String {

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -54,6 +54,7 @@ class CookiesAndCacheClearable: Clearable {
     UserDefaults.standard.synchronize()
     await BraveWebView.sharedNonPersistentStore().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: Date(timeIntervalSinceReferenceDate: 0))
     UserDefaults.standard.synchronize()
+    try await Domain.clearAllEthereumPermissions()
   }
 }
 

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -158,6 +158,32 @@ public final class Domain: NSManagedObject, CRUD {
     }
     return false
   }
+  
+  public static func clearAllEthereumPermissions(_ completionOnMain: (() -> Void)? = nil) {
+    DataController.perform { context in
+      let fetchRequest = NSFetchRequest<Domain>()
+      fetchRequest.entity = Domain.entity(context)
+      do {
+        let results = try context.fetch(fetchRequest)
+        results.forEach {
+          if let bms = $0.bookmarks, bms.count > 0 {
+            // reset eth permissions only
+            $0.wallet_permittedAccounts = nil
+          } else {
+            // Delete
+            context.delete($0)
+          }
+        }
+      } catch {
+        let fetchError = error as NSError
+        print(fetchError)
+      }
+
+      DispatchQueue.main.async {
+        completionOnMain?()
+      }
+    }
+  }
 }
 
 // MARK: - Internal implementations

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -166,13 +166,7 @@ public final class Domain: NSManagedObject, CRUD {
       do {
         let results = try context.fetch(fetchRequest)
         results.forEach {
-          if let bms = $0.bookmarks, bms.count > 0 {
-            // reset eth permissions only
-            $0.wallet_permittedAccounts = nil
-          } else {
-            // Delete
-            context.delete($0)
-          }
+          $0.wallet_permittedAccounts = nil
         }
       } catch {
         let fetchError = error as NSError

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -178,7 +178,7 @@ public final class Domain: NSManagedObject, CRUD {
     }
   }
 
-  public static func clearAllEthereumPermissions() async {
+  @MainActor public static func clearAllEthereumPermissions() async {
     await withCheckedContinuation { continuation in
       Domain.clearAllEthereumPermissions {
         continuation.resume()

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -169,8 +169,7 @@ public final class Domain: NSManagedObject, CRUD {
           $0.wallet_permittedAccounts = nil
         }
       } catch {
-        let fetchError = error as NSError
-        print(fetchError)
+        log.error("Clear ethereum permissions error: \(error)")
       }
 
       DispatchQueue.main.async {

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -158,22 +158,22 @@ public final class Domain: NSManagedObject, CRUD {
     }
     return false
   }
-  
-  public static func clearAllEthereumPermissions(_ completionOnMain: (() -> Void)? = nil) {
-    DataController.perform { context in
-      let fetchRequest = NSFetchRequest<Domain>()
-      fetchRequest.entity = Domain.entity(context)
-      do {
-        let results = try context.fetch(fetchRequest)
-        results.forEach {
-          $0.wallet_permittedAccounts = nil
-        }
-      } catch {
-        log.error("Clear ethereum permissions error: \(error)")
-      }
 
-      DispatchQueue.main.async {
-        completionOnMain?()
+  public static func clearAllEthereumPermissions() async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      DataController.perform { context in
+        let fetchRequest = NSFetchRequest<Domain>()
+        fetchRequest.entity = Domain.entity(context)
+        do {
+          let results = try context.fetch(fetchRequest)
+          results.forEach {
+            $0.wallet_permittedAccounts = nil
+          }
+          continuation.resume()
+        } catch {
+          log.error("Clear ethereum permissions error: \(error)")
+          continuation.resume(throwing: error)
+        }
       }
     }
   }

--- a/DataTests/DomainTests.swift
+++ b/DataTests/DomainTests.swift
@@ -142,4 +142,26 @@ class DomainTests: CoreDataTestCase {
 
     XCTAssertNil(polygonDomain.wallet_permittedAccounts)
   }
+  
+  func testClearAllEthereumPermissions() {
+    let compondDomain = Domain.getOrCreate(forUrl: compound, persistent: true)
+    let polygonDomain = Domain.getOrCreate(forUrl: polygon, persistent: true)
+    
+    // add permissions for `compound` Domain
+    backgroundSaveAndWaitForExpectation {
+      Domain.setEthereumPermissions(forUrl: compound, account: walletAccount, grant: true)
+    }
+    XCTAssertTrue(compondDomain.ethereumPermissions(for: walletAccount))
+    // add permissions for `polygon` Domain
+    backgroundSaveAndWaitForExpectation {
+      Domain.setEthereumPermissions(forUrl: polygon, account: walletAccount, grant: true)
+    }
+    XCTAssertTrue(polygonDomain.ethereumPermissions(for: walletAccount))
+    // Remove all permissions
+    backgroundSaveAndWaitForExpectation {
+      Domain.clearAllEthereumPermissions()
+    }
+    XCTAssertFalse(compondDomain.ethereumPermissions(for: walletAccount))
+    XCTAssertFalse(polygonDomain.ethereumPermissions(for: walletAccount))
+  }
 }


### PR DESCRIPTION
## Summary of Changes
- Update 'Reset Wallet' action to remove all ETH Permissions
- Update 'Clear Data Now' action with 'Cookies and Site Data' toggle enabled

This pull request fixes #5189 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Reset Wallet:
1. Connect Wallet / a wallet account to a dapp site like [app.uniswap.org](https://app.uniswap.org/#/swap)
2. Open wallet settings
3. Tap 'Reset Wallet'
4. Restore the same wallet / account used in step 1
5. Visit the same dapp site connected in step 1
6. You should be prompted to connect the wallet/account again, as permissions were cleared

Clear Cookies and Site Data:
1. Connect Wallet / a wallet account to a dapp site like [app.uniswap.org](https://app.uniswap.org/#/swap)
2. Open Settings -> Brave Shields & Privacy and toggle on 'Cookies and Site Data' in the 'Clear Private Data' section.
3. Visit the same dapp site connected in step 1
4. You should be prompted to connect the wallet/account again, as permissions were cleared


## Screenshots:
Reset Wallet:

https://user-images.githubusercontent.com/5314553/163427433-570b0090-a7a7-416a-a4dc-3d10dddd4a13.mov

Clear Cookies and Site Data:

https://user-images.githubusercontent.com/5314553/163427460-950bb341-f1f5-4fa4-ae69-0d8db27b2776.mov




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
