### PR TITLE
Fix #5196: Fix Particle Emitter on iPad again (for HLS Streams)

### DIFF
--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -632,6 +632,14 @@ extension MediaPlayer {
 }
 
 extension AVPlayerItem {
+  private var isReadyToPlay: Bool {
+    var error: NSError?
+    if case .loaded = self.asset.statusOfValue(forKey: "tracks", error: &error) {
+      return true
+    }
+    return false
+  }
+  
   /// Returns whether or not the assetTrack has audio tracks OR the asset has audio tracks
   func isAudioTracksAvailable() -> Bool {
     tracks.filter({ $0.assetTrack?.mediaType == .audio }).isEmpty == false
@@ -643,6 +651,10 @@ extension AVPlayerItem {
   /// tracks may not always be available and the particle effect will show even on videos..
   /// It's best to assume this type of media is a video stream.
   func isVideoTracksAvailable() -> Bool {
+    if !isReadyToPlay {
+      return true
+    }
+    
     if tracks.isEmpty && asset.tracks.isEmpty {
       return true  // Assume video
     }

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -640,8 +640,8 @@ class VideoView: UIView, VideoTrackerBarDelegate {
             guard let self = self else { return }
             
             if let tracks = change.newValue,
-               tracks?.isEmpty == false,
-               self.delegate?.isVideoTracksAvailable == true {
+               !(tracks?.isEmpty ?? true),
+               !(self.delegate?.isVideoTracksAvailable ?? true) {
               self.particleView.alpha = 1.0
             } else {
               self.particleView.alpha = 0.0


### PR DESCRIPTION
## Summary of Changes
- Sometimes when playing an HLS stream and it isn't ready to play, the boolean for whether or not tracks are available can be 50% true or false (undefined).
- Flipped boolean logic to always not show the emitter unless there is a video track for sure.
- If no tracks are available, assume it is a video to avoid showing the emitter when tracks fail to load

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5196

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Test on iPad: https://bravesoftware.slack.com/archives/CKJCXTP9B/p1650123896011919?thread_ts=1650123794.109609&cid=CKJCXTP9B


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
