### PR TITLE
Fix #5251: Keep user on Sync chain always (until they manually leave)

### DIFF
--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -98,11 +98,6 @@ class SyncAddDeviceViewController: SyncViewController {
     containerView.layer.cornerCurve = .continuous
     containerView.layer.masksToBounds = true
 
-    if !syncAPI.isInSyncGroup {
-      showInitializationError()
-      return
-    }
-
     qrCodeView = SyncQRCodeView(syncApi: syncAPI)
     containerView.addSubview(qrCodeView!)
     qrCodeView?.snp.makeConstraints { make in
@@ -114,11 +109,19 @@ class SyncAddDeviceViewController: SyncViewController {
     self.codewordsView.text = syncAPI.getSyncCode()
     self.setupVisuals()
   }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    
+    if !syncAPI.isInSyncGroup {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+        self?.showInitializationError()
+      }
+    }
+  }
 
   private func showInitializationError() {
-    present(SyncAlerts.initializationError, animated: true) {
-      self.syncAPI.leaveSyncGroup()
-    }
+    present(SyncAlerts.initializationError, animated: true)
   }
 
   private func setupVisuals() {

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -114,9 +114,7 @@ class SyncAddDeviceViewController: SyncViewController {
     super.viewDidAppear(animated)
     
     if !syncAPI.isInSyncGroup {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-        self?.showInitializationError()
-      }
+      showInitializationError()
     }
   }
 

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -400,8 +400,14 @@ extension SyncSettingsTableViewController {
           // So instead, we call `removeAllObservers` which won't hurt.
           // Calling `syncAPI.leaveSyncGroup() aka reset_sync` as of 1.34.x will crash the application.
 
-          syncAPI.removeAllObservers()
-          Preferences.Chromium.syncEnabled.value = false
+          // Commented out in 1.38.x to see if it helps users
+          // If it does, this will be removed in 1.39.x
+          // Reasoning: I suspect the server removes THIS device from the chain for some reason
+          // When that happens, we get `devices.count == 0` and we're removing observers and setting
+          // syncEnabled to false. What happens if we get 0 devices (including our own device), but the user is still on the chain??? This should not be possible afaik, because there has to be ONE device (our own) / this device at minimum.
+          // If this fixes it for users, it means someone changed something without telling us (same as 1.34.x).
+          //syncAPI.removeAllObservers()
+          //Preferences.Chromium.syncEnabled.value = false
           self.navigationController?.popToRootViewController(animated: true)
         } else {
           self.tableView.reloadData()

--- a/Client/Frontend/Sync/SyncViewController.swift
+++ b/Client/Frontend/Sync/SyncViewController.swift
@@ -37,10 +37,4 @@ class SyncViewController: UIViewController {
 
     code()
   }
-
-  @objc func didLeaveSyncGroup() {
-    DispatchQueue.main.async { [weak self] in
-      self?.navigationController?.popToRootViewController(animated: true)
-    }
-  }
 }

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -184,9 +184,10 @@ class SyncWelcomeViewController: SyncViewController {
       guard let self = self else { return }
 
       if !self.syncAPI.isInSyncGroup {
-        self.dismiss(animated: true)
         let bvc = self.currentScene?.browserViewController
-        bvc?.present(SyncAlerts.initializationError, animated: true)
+        self.dismiss(animated: true) {
+          bvc?.present(SyncAlerts.initializationError, animated: true)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary of Changes
- Do not ever leave the sync chain until a button is pressed
- Show error alert but do nothing after it is shown
- If no devices found on the chain, do nothing (technically this should never happen, but it seems like it is, based on this report: https://bravesoftware.slack.com/archives/C2HJYB45N/p1650373022612009?thread_ts=1649769016.099419&cid=C2HJYB45N)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5251

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test that syncing still works (joining, leaving, being removed by other device, etc)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
