### PR TITLE
Fix #5265 - Bumping Brave-Core to 1.38.100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,8 +270,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.38.93/brave-core-ios-1.38.93.tgz",
-      "integrity": "sha512-y/jNbjDYQRLwfDGRlCWWA+NtvbkXmfo0zIxpaMl/PX9DxUVNVkiXV1tR9LAv8viL+wgyO+dipfWE6ndh5WUYNQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.38.100/brave-core-ios-1.38.100.tgz",
+      "integrity": "sha512-HB64NuKS31ZuWK9wygXvqKsKpAwaIt13ZxkzKoZGSs2nfvP6ubU+1wP3Yn4/aTnwdxGflRNxl7nxUxO5Q8pqog=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.38.93/brave-core-ios-1.38.93.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.38.100/brave-core-ios-1.38.100.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "github:mozilla/readability#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Bumps Brave-Core to 1.38.100

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5265

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
