### PR TITLE
Fix #5268: Farble concurrency

### DIFF
--- a/Client/Frontend/Browser/User Scripts/FarblingProtectionHelper.swift
+++ b/Client/Frontend/Browser/User Scripts/FarblingProtectionHelper.swift
@@ -39,6 +39,10 @@ class FarblingProtectionHelper {
     ///
     /// It's important to have a value between 0 - 1 in order to be within the array bounds
     let randomVoiceIndexScale: Float
+    /// This value is used to get a random value between 2 and window.navigator.hardwareConcurrency
+    ///
+    /// Must be a value between 0 and 1
+    let randomHardwareIndexScale: Float
   }
 
   /// Variables representing the prefix of a randomly generated strings used as the plugin name
@@ -75,7 +79,8 @@ class FarblingProtectionHelper {
       fudgeFactor: Float.seededRandom(in: 0.99...1),
       fakeVoiceName: fakeVoiceNames.seededRandom() ?? "",
       fakePluginData: FarblingProtectionHelper.makeFakePluginData(),
-      randomVoiceIndexScale: Float(drand48())
+      randomVoiceIndexScale: Float(drand48()),
+      randomHardwareIndexScale: Float(drand48())
     )
 
     let encoder = JSONEncoder()

--- a/Client/Frontend/UserContent/UserScripts/FarblingProtection.js
+++ b/Client/Frontend/UserContent/UserScripts/FarblingProtection.js
@@ -248,6 +248,21 @@ window.braveFarble = (args) => {
     }
   }
 
+  // 4. Farble hardwareConcurrency
+  // Adds a random value between 2 and the original hardware concurrency
+  // using the provided `randomHardwareIndexScale` which must be a random value between 0 and 1.
+  const farbleHardwareConcurrency = (randomHardwareIndexScale) => {
+    const hardwareConcurrency = window.navigator.hardwareConcurrency
+    // We only farble amounts greater than 2
+    if (hardwareConcurrency <= 2) { return }
+    const remaining = hardwareConcurrency - 2
+    const newRemaining = Math.round(remaining * randomHardwareIndexScale)
+
+    Reflect.defineProperty(window.navigator, 'hardwareConcurrency', {
+      value: newRemaining + 2
+    })
+  }
+
   // A value between 0.99 and 1 to fudge the audio data
   // A value between 0.99 to 1 means the values in the destination will 
   // always be within the expected range of -1 and 1.
@@ -267,6 +282,12 @@ window.braveFarble = (args) => {
   // array bounds
   const randomVoiceIndexScale = args['randomVoiceIndexScale']
   farbleVoices(fakeVoiceName, randomVoiceIndexScale)
+
+  // This value lets us pick a value between 2 and window.navigator.hardwareConcurrency
+  // It is a value between 0 and 1. For example 0.5 will give us 3 and 
+  // thus return 2 + 3 = 5 for hardware concurrency
+  const randomHardwareIndexScale = args['randomHardwareIndexScale']
+  farbleHardwareConcurrency(randomHardwareIndexScale)
 }
 
 // Invoke window.braveFarble then delete the function


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Farble window.navigator.hardwareConcurrency to be a value between 2 and the true value:
1. Added additional scripts to `FarblingProtection.js`
2. Added random values injected to that script to farbling protection script in `FarblingProtectionHelper.swift`

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5268 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test plan can be found in the provided issue.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
