### PR TITLE
Fix #5267: Notification gets cut off when NTP is showing.

### DIFF
--- a/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
+++ b/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
@@ -44,7 +44,7 @@ class BraveNotificationsPresenter: UIViewController {
   private var notificationsQueue: [BraveNotification] = []
   private var widthAnchor: NSLayoutConstraint?
   private var visibleNotification: BraveNotification?
-  private var currentPresntingVC: UIViewController?
+  private weak var currentPresentingVC: UIViewController?
   
   override func loadView() {
     let view = PresenterView(frame: UIScreen.main.bounds)
@@ -67,9 +67,9 @@ class BraveNotificationsPresenter: UIViewController {
       }
     }
     
-    guard let window = presentingController.view.window, parent == nil else { return }
+    guard let window = presentingController.view.window else { return }
     
-    currentPresntingVC = presentingController
+    currentPresentingVC = presentingController
     window.addSubview(view)
     view.snp.makeConstraints {
       $0.edges.equalTo(window.safeAreaLayoutGuide.snp.edges)
@@ -159,7 +159,7 @@ class BraveNotificationsPresenter: UIViewController {
           self.view.removeFromSuperview()
           self.removeFromParent()
         } else {
-          guard let presentingController = self.currentPresntingVC else { return }
+          guard let presentingController = self.currentPresentingVC else { return }
           self.display(notification: self.notificationsQueue.popLast()!, from: presentingController)
         }
       }

--- a/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
+++ b/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
@@ -44,6 +44,7 @@ class BraveNotificationsPresenter: UIViewController {
   private var notificationsQueue: [BraveNotification] = []
   private var widthAnchor: NSLayoutConstraint?
   private var visibleNotification: BraveNotification?
+  private var currentPresntingVC: UIViewController?
   
   override func loadView() {
     let view = PresenterView(frame: UIScreen.main.bounds)
@@ -66,14 +67,12 @@ class BraveNotificationsPresenter: UIViewController {
       }
     }
     
-    if parent == nil {
-      presentingController.addChild(self)
-      presentingController.view.addSubview(view)
-      didMove(toParent: presentingController)
-    }
+    guard let window = presentingController.view.window, parent == nil else { return }
     
+    currentPresntingVC = presentingController
+    window.addSubview(view)
     view.snp.makeConstraints {
-      $0.edges.equalTo(presentingController.view.safeAreaLayoutGuide.snp.edges)
+      $0.edges.equalTo(window.safeAreaLayoutGuide.snp.edges)
     }
     
     let notificationView = notification.view
@@ -160,7 +159,7 @@ class BraveNotificationsPresenter: UIViewController {
           self.view.removeFromSuperview()
           self.removeFromParent()
         } else {
-          guard let presentingController = self.parent else { return }
+          guard let presentingController = self.currentPresntingVC else { return }
           self.display(notification: self.notificationsQueue.popLast()!, from: presentingController)
         }
       }


### PR DESCRIPTION
## Summary of Changes
Present `BraveNotification` on window instead of view. 

This pull request fixes #5267 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open browser and open a website
2. Wait for a ad to show up
3. click `+` to open a NTP
(Notification should not be cut off)

## Screenshots:
(fixed version)
https://user-images.githubusercontent.com/1187676/164332498-f3798ee8-effd-46be-b71c-27c269462630.mp4

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
