### PR TITLE
Fix #4744: Add checksum validation for send token address.

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -37,7 +37,7 @@ struct SendTokenView: View {
     return sendAmount == 0
       || sendAmount > balance
       || sendTokenStore.sendAmount.isEmpty
-      || sendTokenStore.addressError != nil
+      || (sendTokenStore.addressError != nil && sendTokenStore.addressError != .missingChecksum)
   }
 
   var body: some View {

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -184,19 +184,26 @@ public class SendTokenStore: ObservableObject {
     }
     let normalizedSendAddress = sendAddress.lowercased()
     if !sendAddress.isETHAddress {
+      // 1. check if send address is a valid eth address
       addressError = .notEthAddress
     } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
+      // 2. check if send address is the same as the from address
       addressError = .sameAsFromAddress
     } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil)
       || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil) {
+      // 3. check if send address is a contract address
       addressError = .contractAddress
     } else {
       keyringService.checksumEthAddress(sendAddress) { [self] checksumAddress in
         if sendAddress == checksumAddress {
+          // 4. check if send address is the same as the checksum address from the `KeyringService`
           addressError = nil
         } else if sendAddress.removingHexPrefix.lowercased() == sendAddress.removingHexPrefix || sendAddress.removingHexPrefix.uppercased() == sendAddress.removingHexPrefix {
+          // 5. check if send address has each of the alphabetic character as uppercase, or has each of
+          // the alphabeic character as lowercase
           addressError = .missingChecksum
         } else {
+          // 6. send address has mixed with uppercase and lowercase and does not match with the checksum address
           addressError = .invalidChecksum
         }
       }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1597,6 +1597,20 @@ extension Strings {
       value: "Not a valid ETH address",
       comment: "A warning that appears below the send crypto address text field, when the input `To` address is not a valid ETH address."
     )
+    public static let sendWarningAddressMissingChecksumInfo = NSLocalizedString(
+      "wallet.sendWarningAddressMissingChecksumInfo",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "This address cannot be verified (missing checksum). Proceed?",
+      comment: "A warning that appears below the send crypto address text field, when the input `To` address is missing checksum information."
+    )
+    public static let sendWarningAddressInvalidChecksum = NSLocalizedString(
+      "wallet.sendWarningAddressInvalidChecksum",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Address did not pass verification (invalid checksum). Please try again, replacing lowercase letters with uppercase.",
+      comment: "A warning that appears below the send crypto address text field, when the input `To` address has invalid checksum."
+    )
     public static let betaLabel = NSLocalizedString(
       "wallet.betaLabel",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
Add checksum validation for send token address.

This pull request fixes #4744 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Test invalid ETH address
2. Test address is own
3. Test address is token contract address
4. Test address is all lowercase or all uppercase 
5. Test address will give unmatched checksum address 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
