### PR TITLE
Fix #4341: Wallet default currency code setting

### DIFF
--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -36,11 +36,6 @@ struct AccountActivityView: View {
     return info
   }
 
-  private let currencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = "USD"
-  }
-
   private func emptyTextView(_ message: String) -> some View {
     Text(message)
       .font(.footnote.weight(.medium))
@@ -74,7 +69,7 @@ struct AccountActivityView: View {
               image: AssetIconView(token: asset.token),
               title: asset.token.name,
               symbol: asset.token.symbol,
-              amount: currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
+              amount: activityStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
               quantity: String(format: "%.04f", asset.decimalBalance)
             )
           }
@@ -96,7 +91,8 @@ struct AccountActivityView: View {
                 visibleTokens: activityStore.assets.map(\.token),
                 allTokens: activityStore.allTokens,
                 displayAccountCreator: false,
-                assetRatios: assetRatios
+                assetRatios: assetRatios,
+                currencyFormatter: activityStore.currencyFormatter
               )
             }
             .contextMenu {
@@ -136,7 +132,8 @@ struct AccountActivityView: View {
             keyringStore: keyringStore,
             visibleTokens: activityStore.assets.map(\.token),
             allTokens: activityStore.allTokens,
-            assetRatios: assetRatios
+            assetRatios: assetRatios,
+            currencyFormatter: activityStore.currencyFormatter
           )
         }
     )

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -92,7 +92,7 @@ struct AccountActivityView: View {
                 allTokens: activityStore.allTokens,
                 displayAccountCreator: false,
                 assetRatios: assetRatios,
-                currencyFormatter: activityStore.currencyFormatter
+                currencyCode: activityStore.currencyCode
               )
             }
             .contextMenu {
@@ -133,7 +133,7 @@ struct AccountActivityView: View {
             visibleTokens: activityStore.assets.map(\.token),
             allTokens: activityStore.allTokens,
             assetRatios: assetRatios,
-            currencyFormatter: activityStore.currencyFormatter
+            currencyCode: activityStore.currencyCode
           )
         }
     )

--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -107,7 +107,7 @@ struct AssetDetailHeaderView: View {
           HStack {
             Group {
               if let selectedCandle = selectedCandle,
-                let formattedString = AssetDetailStore.priceFormatter.string(from: NSNumber(value: selectedCandle.value)) {
+                let formattedString = assetDetailStore.currencyFormatter.string(from: NSNumber(value: selectedCandle.value)) {
                 Text(formattedString)
               } else {
                 Text(assetDetailStore.price)

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -91,7 +91,7 @@ struct AssetDetailView: View {
                 allTokens: [], // AssetDetailView is specific to a single token
                 displayAccountCreator: true,
                 assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue],
-                currencyFormatter: assetDetailStore.currencyFormatter
+                currencyCode: assetDetailStore.currencyCode
               )
             }
             .contextMenu {
@@ -150,7 +150,7 @@ struct AssetDetailView: View {
             visibleTokens: [assetDetailStore.token],
             allTokens: [], // AssetDetailView is specific to a single token
             assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue],
-            currencyFormatter: assetDetailStore.currencyFormatter
+            currencyCode: assetDetailStore.currencyCode
           )
         }
     )

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -90,7 +90,8 @@ struct AssetDetailView: View {
                 visibleTokens: [assetDetailStore.token],
                 allTokens: [], // AssetDetailView is specific to a single token
                 displayAccountCreator: true,
-                assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
+                assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue],
+                currencyFormatter: assetDetailStore.currencyFormatter
               )
             }
             .contextMenu {
@@ -148,7 +149,8 @@ struct AssetDetailView: View {
             keyringStore: keyringStore,
             visibleTokens: [],
             allTokens: [],
-            assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue]
+            assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue],
+            currencyFormatter: assetDetailStore.currencyFormatter
           )
         }
     )

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -147,8 +147,8 @@ struct AssetDetailView: View {
             info: tx,
             networkStore: networkStore,
             keyringStore: keyringStore,
-            visibleTokens: [],
-            allTokens: [],
+            visibleTokens: [assetDetailStore.token],
+            allTokens: [], // AssetDetailView is specific to a single token
             assetRatios: [assetDetailStore.token.symbol.lowercased(): assetDetailStore.assetPriceValue],
             currencyFormatter: assetDetailStore.currencyFormatter
           )

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -24,11 +24,6 @@ struct PortfolioView: View {
     !keyringStore.keyring.isBackedUp && !dismissedBackupBannerThisSession
   }
 
-  private let currencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = "USD"
-  }
-
   private var listHeader: some View {
     VStack(spacing: 0) {
       if isShowingBackupBanner {
@@ -84,7 +79,7 @@ struct PortfolioView: View {
               image: AssetIconView(token: asset.token),
               title: asset.token.name,
               symbol: asset.token.symbol,
-              amount: currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
+              amount: portfolioStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
               quantity: String(format: "%.04f", asset.decimalBalance)
             )
           }

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -12,12 +12,6 @@ class AccountActivityStore: ObservableObject {
   @Published private(set) var transactions: [BraveWallet.TransactionInfo] = []
   @Published private(set) var allTokens: [BraveWallet.BlockchainToken] = []
 
-  var currencyCode: CurrencyCode = .usd {
-    didSet {
-      currencyFormatter.currencyCode = currencyCode.code
-      update()
-    }
-  }
   let currencyFormatter: NumberFormatter
 
   private let walletService: BraveWalletBraveWalletService
@@ -46,8 +40,8 @@ class AccountActivityStore: ObservableObject {
     self.rpcService.add(self)
     self.txService.add(self)
     
-    walletService.defaultBaseCurrency { currencyCode in
-      self.currencyCode = CurrencyCode(code: currencyCode)
+    walletService.defaultBaseCurrency { [self] currencyCode in
+      self.currencyFormatter.currencyCode = currencyCode
     }
   }
 
@@ -72,7 +66,7 @@ class AccountActivityStore: ObservableObject {
         dispatchGroup.enter()
         assetRatioService.price(
           updatedTokens.map { $0.symbol.lowercased() },
-          toAssets: [currencyCode.code],
+          toAssets: [currencyFormatter.currencyCode],
           timeframe: .oneDay) { success, prices in
             defer { dispatchGroup.leave() }
             for price in prices {

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -11,8 +11,14 @@ class AccountActivityStore: ObservableObject {
   @Published private(set) var assets: [AssetViewModel] = []
   @Published private(set) var transactions: [BraveWallet.TransactionInfo] = []
   @Published private(set) var allTokens: [BraveWallet.BlockchainToken] = []
+  @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
+    didSet {
+      currencyFormatter.currencyCode = currencyCode
+      update()
+    }
+  }
 
-  let currencyFormatter: NumberFormatter
+  let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
 
   private let walletService: BraveWalletBraveWalletService
   private let rpcService: BraveWalletJsonRpcService
@@ -26,8 +32,7 @@ class AccountActivityStore: ObservableObject {
     rpcService: BraveWalletJsonRpcService,
     assetRatioService: BraveWalletAssetRatioService,
     txService: BraveWalletTxService,
-    blockchainRegistry: BraveWalletBlockchainRegistry,
-    currencyFormatter: NumberFormatter
+    blockchainRegistry: BraveWalletBlockchainRegistry
   ) {
     self.account = account
     self.walletService = walletService
@@ -35,10 +40,14 @@ class AccountActivityStore: ObservableObject {
     self.assetRatioService = assetRatioService
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
-    self.currencyFormatter = currencyFormatter
     
     self.rpcService.add(self)
     self.txService.add(self)
+    self.walletService.add(self)
+    
+    walletService.defaultBaseCurrency { [self] currencyCode in
+      self.currencyCode = currencyCode
+    }
   }
 
   func update() {
@@ -120,5 +129,23 @@ extension AccountActivityStore: BraveWalletTxServiceObserver {
     fetchTransactions()
   }
   func onUnapprovedTxUpdated(_ txInfo: BraveWallet.TransactionInfo) {
+  }
+}
+
+extension AccountActivityStore: BraveWalletBraveWalletServiceObserver {
+  public func onActiveOriginChanged(_ originInfo: BraveWallet.OriginInfo) {
+  }
+
+  public func onDefaultWalletChanged(_ wallet: BraveWallet.DefaultWallet) {
+  }
+
+  public func onDefaultBaseCurrencyChanged(_ currency: String) {
+    currencyCode = currency
+  }
+
+  public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) {
+  }
+
+  public func onNetworkListChanged() {
   }
 }

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -39,10 +39,6 @@ class AccountActivityStore: ObservableObject {
     
     self.rpcService.add(self)
     self.txService.add(self)
-    
-    walletService.defaultBaseCurrency { [self] currencyCode in
-      self.currencyFormatter.currencyCode = currencyCode
-    }
   }
 
   func update() {

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -12,6 +12,17 @@ class AccountActivityStore: ObservableObject {
   @Published private(set) var transactions: [BraveWallet.TransactionInfo] = []
   @Published private(set) var allTokens: [BraveWallet.BlockchainToken] = []
 
+  var currencyCode: CurrencyCode = .usd {
+    didSet {
+      currencyFormatter.currencyCode = currencyCode.code
+      update()
+    }
+  }
+  let currencyFormatter = NumberFormatter().then {
+    $0.numberStyle = .currency
+    $0.currencyCode = CurrencyCode.usd.code
+  }
+
   private let walletService: BraveWalletBraveWalletService
   private let rpcService: BraveWalletJsonRpcService
   private let assetRatioService: BraveWalletAssetRatioService
@@ -35,6 +46,10 @@ class AccountActivityStore: ObservableObject {
     
     self.rpcService.add(self)
     self.txService.add(self)
+    
+    walletService.defaultBaseCurrency { currencyCode in
+      self.currencyCode = CurrencyCode(code: currencyCode)
+    }
   }
 
   func update() {
@@ -58,7 +73,7 @@ class AccountActivityStore: ObservableObject {
         dispatchGroup.enter()
         assetRatioService.price(
           updatedTokens.map { $0.symbol.lowercased() },
-          toAssets: ["usd"],
+          toAssets: [currencyCode.code],
           timeframe: .oneDay) { success, prices in
             defer { dispatchGroup.leave() }
             for price in prices {

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -18,10 +18,7 @@ class AccountActivityStore: ObservableObject {
       update()
     }
   }
-  let currencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = CurrencyCode.usd.code
-  }
+  let currencyFormatter: NumberFormatter
 
   private let walletService: BraveWalletBraveWalletService
   private let rpcService: BraveWalletJsonRpcService
@@ -35,7 +32,8 @@ class AccountActivityStore: ObservableObject {
     rpcService: BraveWalletJsonRpcService,
     assetRatioService: BraveWalletAssetRatioService,
     txService: BraveWalletTxService,
-    blockchainRegistry: BraveWalletBlockchainRegistry
+    blockchainRegistry: BraveWalletBlockchainRegistry,
+    currencyFormatter: NumberFormatter
   ) {
     self.account = account
     self.walletService = walletService
@@ -43,6 +41,7 @@ class AccountActivityStore: ObservableObject {
     self.assetRatioService = assetRatioService
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
+    self.currencyFormatter = currencyFormatter
     
     self.rpcService.add(self)
     self.txService.add(self)

--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -45,10 +45,7 @@ class AssetDetailStore: ObservableObject {
       update()
     }
   }
-  let currencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = CurrencyCode.usd.code
-  }
+  let currencyFormatter: NumberFormatter
 
   private(set) var assetPriceValue: Double = 0.0
 
@@ -68,7 +65,8 @@ class AssetDetailStore: ObservableObject {
     walletService: BraveWalletBraveWalletService,
     txService: BraveWalletTxService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
-    token: BraveWallet.BlockchainToken
+    token: BraveWallet.BlockchainToken,
+    currencyFormatter: NumberFormatter
   ) {
     self.assetRatioService = assetRatioService
     self.keyringService = keyringService
@@ -77,6 +75,7 @@ class AssetDetailStore: ObservableObject {
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
     self.token = token
+    self.currencyFormatter = currencyFormatter
 
     self.keyringService.add(self)
     self.rpcService.add(self)

--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -46,7 +46,6 @@ class AssetDetailStore: ObservableObject {
   private let assetRatioService: BraveWalletAssetRatioService
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
-  private let walletService: BraveWalletBraveWalletService
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
 
@@ -56,7 +55,6 @@ class AssetDetailStore: ObservableObject {
     assetRatioService: BraveWalletAssetRatioService,
     keyringService: BraveWalletKeyringService,
     rpcService: BraveWalletJsonRpcService,
-    walletService: BraveWalletBraveWalletService,
     txService: BraveWalletTxService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
     token: BraveWallet.BlockchainToken,
@@ -65,7 +63,6 @@ class AssetDetailStore: ObservableObject {
     self.assetRatioService = assetRatioService
     self.keyringService = keyringService
     self.rpcService = rpcService
-    self.walletService = walletService
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
     self.token = token
@@ -74,10 +71,6 @@ class AssetDetailStore: ObservableObject {
     self.keyringService.add(self)
     self.rpcService.add(self)
     self.txService.add(self)
-    
-    walletService.defaultBaseCurrency { [self] currencyCode in
-      self.currencyFormatter.currencyCode = currencyCode
-    }
   }
 
   private let percentFormatter = NumberFormatter().then {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -43,11 +43,6 @@ public class CryptoStore: ObservableObject {
   @Published private(set) var hasUnapprovedTransactions: Bool = false
   @Published private(set) var pendingWebpageRequest: PendingWebpageRequest?
   
-  let currencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = CurrencyCode.usd.code
-  }
-  
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
   private let walletService: BraveWalletBraveWalletService
@@ -82,16 +77,11 @@ public class CryptoStore: ObservableObject {
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
-      blockchainRegistry: blockchainRegistry,
-      currencyFormatter: currencyFormatter
+      blockchainRegistry: blockchainRegistry
     )
     
     self.keyringService.add(self)
     self.txService.add(self)
-    self.walletService.add(self)
-    self.walletService.defaultBaseCurrency { [self] currencyCode in
-      self.currencyFormatter.currencyCode = currencyCode
-    }
   }
   
   private var buyTokenStore: BuyTokenStore?
@@ -155,10 +145,10 @@ public class CryptoStore: ObservableObject {
       assetRatioService: assetRatioService,
       keyringService: keyringService,
       rpcService: rpcService,
+      walletService: walletService,
       txService: txService,
       blockchainRegistry: blockchainRegistry,
-      token: token,
-      currencyFormatter: currencyFormatter
+      token: token
     )
     assetDetailStore = store
     return store
@@ -181,8 +171,7 @@ public class CryptoStore: ObservableObject {
       rpcService: rpcService,
       assetRatioService: assetRatioService,
       txService: txService,
-      blockchainRegistry: blockchainRegistry,
-      currencyFormatter: currencyFormatter
+      blockchainRegistry: blockchainRegistry
     )
     accountActivityStore = store
     return store
@@ -206,8 +195,7 @@ public class CryptoStore: ObservableObject {
       blockchainRegistry: blockchainRegistry,
       walletService: walletService,
       ethTxManagerProxy: ethTxManagerProxy,
-      keyringService: keyringService,
-      currencyFormatter: currencyFormatter
+      keyringService: keyringService
     )
     confirmationStore = store
     return store
@@ -309,29 +297,5 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
   public func autoLockMinutesChanged() {
   }
   public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-  }
-}
-
-extension CryptoStore: BraveWalletBraveWalletServiceObserver {
-  public func onActiveOriginChanged(_ originInfo: BraveWallet.OriginInfo) {
-  }
-  
-  public func onDefaultWalletChanged(_ wallet: BraveWallet.DefaultWallet) {
-  }
-  
-  public func onDefaultBaseCurrencyChanged(_ currency: String) {
-    currencyFormatter.currencyCode = currency
-    portfolioStore.update()
-    assetDetailStore?.update()
-    accountActivityStore?.update()
-    if let confirmationStore = confirmationStore {
-      confirmationStore.fetchDetails(for: confirmationStore.activeTransaction)
-    }
-  }
-  
-  public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) {
-  }
-  
-  public func onNetworkListChanged() {
   }
 }

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -313,7 +313,7 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
 }
 
 extension CryptoStore: BraveWalletBraveWalletServiceObserver {
-  public func onActiveOriginChanged(_ origin: String) {
+  public func onActiveOriginChanged(_ originInfo: BraveWallet.OriginInfo) {
   }
   
   public func onDefaultWalletChanged(_ wallet: BraveWallet.DefaultWallet) {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -319,11 +319,12 @@ extension CryptoStore: BraveWalletBraveWalletServiceObserver {
   
   public func onDefaultBaseCurrencyChanged(_ currency: String) {
     currencyFormatter.currencyCode = currency
-    portfolioStore.currencyCode = CurrencyCode(code: currency)
-    assetDetailStore?.currencyCode = CurrencyCode(code: currency)
-    accountActivityStore?.currencyCode = CurrencyCode(code: currency)
-    confirmationStore?.currencyCode = CurrencyCode(code: currency)
     portfolioStore.update()
+    assetDetailStore?.update()
+    accountActivityStore?.update()
+    if let confirmationStore = confirmationStore {
+      confirmationStore.fetchDetails(for: confirmationStore.activeTransaction)
+    }
   }
   
   public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -319,6 +319,10 @@ extension CryptoStore: BraveWalletBraveWalletServiceObserver {
   
   public func onDefaultBaseCurrencyChanged(_ currency: String) {
     currencyFormatter.currencyCode = currency
+    portfolioStore.currencyCode = CurrencyCode(code: currency)
+    assetDetailStore?.currencyCode = CurrencyCode(code: currency)
+    accountActivityStore?.currencyCode = CurrencyCode(code: currency)
+    confirmationStore?.currencyCode = CurrencyCode(code: currency)
     portfolioStore.update()
   }
   

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -89,6 +89,9 @@ public class CryptoStore: ObservableObject {
     self.keyringService.add(self)
     self.txService.add(self)
     self.walletService.add(self)
+    self.walletService.defaultBaseCurrency { [self] currencyCode in
+      self.currencyFormatter.currencyCode = currencyCode
+    }
   }
   
   private var buyTokenStore: BuyTokenStore?
@@ -152,7 +155,6 @@ public class CryptoStore: ObservableObject {
       assetRatioService: assetRatioService,
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService,
       txService: txService,
       blockchainRegistry: blockchainRegistry,
       token: token,

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -145,6 +145,7 @@ public class CryptoStore: ObservableObject {
       assetRatioService: assetRatioService,
       keyringService: keyringService,
       rpcService: rpcService,
+      walletService: walletService,
       txService: txService,
       blockchainRegistry: blockchainRegistry,
       token: token

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -43,6 +43,11 @@ public class CryptoStore: ObservableObject {
   @Published private(set) var hasUnapprovedTransactions: Bool = false
   @Published private(set) var pendingWebpageRequest: PendingWebpageRequest?
   
+  let currencyFormatter = NumberFormatter().then {
+    $0.numberStyle = .currency
+    $0.currencyCode = CurrencyCode.usd.code
+  }
+  
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
   private let walletService: BraveWalletBraveWalletService
@@ -77,7 +82,8 @@ public class CryptoStore: ObservableObject {
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
-      blockchainRegistry: blockchainRegistry
+      blockchainRegistry: blockchainRegistry,
+      currencyFormatter: currencyFormatter
     )
     
     self.keyringService.add(self)
@@ -148,7 +154,8 @@ public class CryptoStore: ObservableObject {
       walletService: walletService,
       txService: txService,
       blockchainRegistry: blockchainRegistry,
-      token: token
+      token: token,
+      currencyFormatter: currencyFormatter
     )
     assetDetailStore = store
     return store
@@ -171,7 +178,8 @@ public class CryptoStore: ObservableObject {
       rpcService: rpcService,
       assetRatioService: assetRatioService,
       txService: txService,
-      blockchainRegistry: blockchainRegistry
+      blockchainRegistry: blockchainRegistry,
+      currencyFormatter: currencyFormatter
     )
     accountActivityStore = store
     return store
@@ -195,7 +203,8 @@ public class CryptoStore: ObservableObject {
       blockchainRegistry: blockchainRegistry,
       walletService: walletService,
       ethTxManagerProxy: ethTxManagerProxy,
-      keyringService: keyringService
+      keyringService: keyringService,
+      currencyFormatter: currencyFormatter
     )
     confirmationStore = store
     return store

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -88,6 +88,7 @@ public class CryptoStore: ObservableObject {
     
     self.keyringService.add(self)
     self.txService.add(self)
+    self.walletService.add(self)
   }
   
   private var buyTokenStore: BuyTokenStore?
@@ -306,5 +307,24 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
   public func autoLockMinutesChanged() {
   }
   public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
+  }
+}
+
+extension CryptoStore: BraveWalletBraveWalletServiceObserver {
+  public func onActiveOriginChanged(_ origin: String) {
+  }
+  
+  public func onDefaultWalletChanged(_ wallet: BraveWallet.DefaultWallet) {
+  }
+  
+  public func onDefaultBaseCurrencyChanged(_ currency: String) {
+    currencyFormatter.currencyCode = currency
+    portfolioStore.update()
+  }
+  
+  public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) {
+  }
+  
+  public func onNetworkListChanged() {
   }
 }

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -59,10 +59,7 @@ public class PortfolioStore: ObservableObject {
       update()
     }
   }
-  let currencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = CurrencyCode.usd.code
-  }
+  let currencyFormatter: NumberFormatter
 
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -75,13 +72,15 @@ public class PortfolioStore: ObservableObject {
     rpcService: BraveWalletJsonRpcService,
     walletService: BraveWalletBraveWalletService,
     assetRatioService: BraveWalletAssetRatioService,
-    blockchainRegistry: BraveWalletBlockchainRegistry
+    blockchainRegistry: BraveWalletBlockchainRegistry,
+    currencyFormatter: NumberFormatter
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService
     self.walletService = walletService
     self.assetRatioService = assetRatioService
     self.blockchainRegistry = blockchainRegistry
+    self.currencyFormatter = currencyFormatter
 
     self.rpcService.add(self)
     self.keyringService.add(self)

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -84,7 +84,6 @@ public class PortfolioStore: ObservableObject {
 
     self.rpcService.add(self)
     self.keyringService.add(self)
-    self.walletService.add(self)
 
     keyringService.isLocked { [self] isLocked in
       if !isLocked {
@@ -264,23 +263,5 @@ extension PortfolioStore: BraveWalletKeyringServiceObserver {
   public func autoLockMinutesChanged() {
   }
   public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-  }
-}
-
-extension PortfolioStore: BraveWalletBraveWalletServiceObserver {
-  public func onActiveOriginChanged(_ origin: String) {
-  }
-  
-  public func onDefaultWalletChanged(_ wallet: BraveWallet.DefaultWallet) {
-  }
-  
-  public func onDefaultBaseCurrencyChanged(_ currency: String) {
-    currencyCode = CurrencyCode(code: currency)
-  }
-  
-  public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) {
-  }
-  
-  public func onNetworkListChanged() {
   }
 }

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -84,9 +84,6 @@ public class PortfolioStore: ObservableObject {
         update()
       }
     }
-    walletService.defaultBaseCurrency { currencyCode in
-      self.currencyFormatter.currencyCode = currencyCode
-    }
   }
 
   /// Fetches the balances for a given list of tokens for each of the given accounts, giving a dictionary with a balance for each token symbol.

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -53,12 +53,6 @@ public class PortfolioStore: ObservableObject {
     assetRatioService: self.assetRatioService
   )
   
-  var currencyCode: CurrencyCode = .usd {
-    didSet {
-      currencyFormatter.currencyCode = currencyCode.code
-      update()
-    }
-  }
   let currencyFormatter: NumberFormatter
 
   private let keyringService: BraveWalletKeyringService
@@ -91,7 +85,7 @@ public class PortfolioStore: ObservableObject {
       }
     }
     walletService.defaultBaseCurrency { currencyCode in
-      self.currencyCode = CurrencyCode(code: currencyCode)
+      self.currencyFormatter.currencyCode = currencyCode
     }
   }
 
@@ -123,7 +117,7 @@ public class PortfolioStore: ObservableObject {
   private func fetchPrices(for symbols: [String], completion: @escaping ([String: String]) -> Void) {
     assetRatioService.price(
       symbols.map { $0.lowercased() },
-      toAssets: [currencyCode.code],
+      toAssets: [currencyFormatter.currencyCode],
       timeframe: timeframe
     ) { success, assetPrices in
       // `success` only refers to finding _all_ prices and if even 1 of N prices
@@ -142,7 +136,7 @@ public class PortfolioStore: ObservableObject {
       group.enter()
       assetRatioService.priceHistory(
         symbol,
-        vsAsset: currencyCode.code,
+        vsAsset: currencyFormatter.currencyCode,
         timeframe: timeframe
       ) { success, history in
         defer { group.leave() }

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -26,6 +26,13 @@ public class SettingsStore: ObservableObject {
     LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
   }
 
+  /// The current default base currency code
+  @Published var currencyCode: CurrencyCode = .usd {
+    didSet {
+      walletService.setDefaultBaseCurrency(currencyCode.code)
+    }
+  }
+
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
   private let txService: BraveWalletTxService
@@ -39,8 +46,12 @@ public class SettingsStore: ObservableObject {
     self.walletService = walletService
     self.txService = txService
 
-    self.keyringService.autoLockMinutes { minutes in
+    keyringService.autoLockMinutes { minutes in
       self.autoLockInterval = .init(value: minutes)
+    }
+    
+    walletService.defaultBaseCurrency { currencyCode in
+      self.currencyCode = CurrencyCode(code: currencyCode)
     }
   }
 
@@ -63,4 +74,63 @@ public class SettingsStore: ObservableObject {
   public func addKeyringServiceObserver(_ observer: BraveWalletKeyringServiceObserver) {
     keyringService.add(observer)
   }
+}
+
+struct CurrencyCode: Hashable, Identifiable {
+  let code: String
+  var id: String { code }
+  
+  init(code: String) {
+    self.code = code
+  }
+  
+  static let aed: Self = .init(code: "AED")
+  static let ars: Self = .init(code: "ARS")
+  static let aud: Self = .init(code: "AUD")
+  static let bdt: Self = .init(code: "BDT")
+  static let bhd: Self = .init(code: "BHD")
+  static let bmd: Self = .init(code: "BMD")
+  static let brl: Self = .init(code: "BRL")
+  static let cad: Self = .init(code: "CAD")
+  static let chf: Self = .init(code: "CHF")
+  static let clp: Self = .init(code: "CLP")
+  static let czk: Self = .init(code: "CZK")
+  static let dkk: Self = .init(code: "DKK")
+  static let eur: Self = .init(code: "EUR")
+  static let gbp: Self = .init(code: "GBP")
+  static let hkd: Self = .init(code: "HKD")
+  static let huf: Self = .init(code: "HUF")
+  static let idr: Self = .init(code: "IDR")
+  static let ils: Self = .init(code: "ILS")
+  static let inr: Self = .init(code: "INR")
+  static let jpy: Self = .init(code: "JPY")
+  static let krw: Self = .init(code: "KRW")
+  static let kwd: Self = .init(code: "KWD")
+  static let lkr: Self = .init(code: "LKR")
+  static let mmk: Self = .init(code: "MMK")
+  static let mxn: Self = .init(code: "MXN")
+  static let myr: Self = .init(code: "MYR")
+  static let ngn: Self = .init(code: "NGN")
+  static let nok: Self = .init(code: "NOK")
+  static let nzd: Self = .init(code: "NZD")
+  static let php: Self = .init(code: "PHP")
+  static let pkr: Self = .init(code: "PKR")
+  static let pln: Self = .init(code: "PLN")
+  static let rub: Self = .init(code: "RUB")
+  static let sar: Self = .init(code: "SAR")
+  static let sek: Self = .init(code: "SEK")
+  static let sgd: Self = .init(code: "SGD")
+  static let thb: Self = .init(code: "THB")
+  static let `try`: Self = .init(code: "TRY")
+  static let twd: Self = .init(code: "TWD")
+  static let uah: Self = .init(code: "UAH")
+  static let usd: Self = .init(code: "USD")
+  static let vef: Self = .init(code: "VEF")
+  static let vnd: Self = .init(code: "VND")
+  static let zap: Self = .init(code: "ZAR")
+  static let xag: Self = .init(code: "XAG")
+  static let xau: Self = .init(code: "XAU")
+  static let xdr: Self = .init(code: "XDR")
+  
+  static let allCurrencyCodes: [CurrencyCode] = [aed, ars, aud, bdt, bhd, bmd, brl, cad, chf, clp, czk, dkk, eur, gbp, hkd, huf, idr, ils, inr, jpy, krw, kwd, lkr, mmk, mxn, myr, ngn, nok, nzd, php, pkr, pln, rub, sar, sek, sgd, thb, `try`, twd, uah, usd, vef, vnd, zap, xag, xau, xdr]
 }

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -46,11 +46,11 @@ public class SettingsStore: ObservableObject {
     self.walletService = walletService
     self.txService = txService
 
-    keyringService.autoLockMinutes { minutes in
+    keyringService.autoLockMinutes { [self] minutes in
       self.autoLockInterval = .init(value: minutes)
     }
     
-    walletService.defaultBaseCurrency { currencyCode in
+    walletService.defaultBaseCurrency { [self] currencyCode in
       self.currencyCode = CurrencyCode(code: currencyCode)
     }
   }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -95,9 +95,6 @@ public class TransactionConfirmationStore: ObservableObject {
     self.currencyFormatter = currencyFormatter
 
     self.txService.add(self)
-    walletService.defaultBaseCurrency { [self] currencyCode in
-      self.currencyFormatter.currencyCode = currencyCode
-    }
   }
 
   func updateGasValue(for transaction: BraveWallet.TransactionInfo) {

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -42,12 +42,6 @@ public class TransactionConfirmationStore: ObservableObject {
 
   private var assetRatios: [String: Double] = [:]
 
-  var currencyCode: CurrencyCode = .usd {
-    didSet {
-      currencyFormatter.currencyCode = currencyCode.code
-      fetchDetails(for: activeTransaction)
-    }
-  }
   let currencyFormatter: NumberFormatter
   
   var activeTransaction: BraveWallet.TransactionInfo {
@@ -101,8 +95,8 @@ public class TransactionConfirmationStore: ObservableObject {
     self.currencyFormatter = currencyFormatter
 
     self.txService.add(self)
-    walletService.defaultBaseCurrency { currencyCode in
-      self.currencyCode = CurrencyCode(code: currencyCode)
+    walletService.defaultBaseCurrency { [self] currencyCode in
+      self.currencyFormatter.currencyCode = currencyCode
     }
   }
 
@@ -234,7 +228,7 @@ public class TransactionConfirmationStore: ObservableObject {
       let symbols = symbolKey == gasKey ? [symbolKey] : [symbolKey, gasKey]
       assetRatioService.price(
         symbols,
-        toAssets: [currencyCode.code],
+        toAssets: [currencyFormatter.currencyCode],
         timeframe: .oneDay
       ) { [weak self] success, prices in
         // `success` only refers to finding _all_ prices and if even 1 of N prices

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -48,10 +48,7 @@ public class TransactionConfirmationStore: ObservableObject {
       fetchDetails(for: activeTransaction)
     }
   }
-  let currencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = CurrencyCode.usd.code
-  }
+  let currencyFormatter: NumberFormatter
   
   var activeTransaction: BraveWallet.TransactionInfo {
     transactions.first(where: { $0.id == activeTransactionId }) ?? (transactions.first ?? .init())
@@ -91,7 +88,8 @@ public class TransactionConfirmationStore: ObservableObject {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     walletService: BraveWalletBraveWalletService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
-    keyringService: BraveWalletKeyringService
+    keyringService: BraveWalletKeyringService,
+    currencyFormatter: NumberFormatter
   ) {
     self.assetRatioService = assetRatioService
     self.rpcService = rpcService
@@ -100,6 +98,7 @@ public class TransactionConfirmationStore: ObservableObject {
     self.walletService = walletService
     self.ethTxManagerProxy = ethTxManagerProxy
     self.keyringService = keyringService
+    self.currencyFormatter = currencyFormatter
 
     self.txService.add(self)
     walletService.defaultBaseCurrency { currencyCode in

--- a/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -125,7 +125,7 @@ struct EditPriorityFeeView: View {
     }
     let proposedGasValue = formatter.decimalString(for: gasFeeInWei.removingHexPrefix, radix: .hex, decimals: 18) ?? ""
     let proposedGasFiat =
-      confirmationStore.numberFormatter.string(
+      confirmationStore.currencyFormatter.string(
         from: NSNumber(value: confirmationStore.state.gasAssetRatio * (Double(proposedGasValue) ?? 0.0))
       ) ?? "–"
     return "\(proposedGasFiat) (\(proposedGasValue) \(confirmationStore.state.gasSymbol))"

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -18,17 +18,13 @@ struct TransactionDetailsView: View {
   var visibleTokens: [BraveWallet.BlockchainToken]
   var allTokens: [BraveWallet.BlockchainToken]
   var assetRatios: [String: Double]
+  var currencyFormatter: NumberFormatter
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
   
   private let dateFormatter = DateFormatter().then {
     $0.dateFormat = "h:mm a - MMM d, yyyy"
-  }
-  
-  private let numberFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = "USD"
   }
   
   private func token(for contractAddress: String) -> BraveWallet.BlockchainToken? {
@@ -81,12 +77,12 @@ struct TransactionDetailsView: View {
       return nil
     case .ethSend, .other:
       let amount = formatter.decimalString(for: info.ethTxValue.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) ?? ""
-      let fiat = numberFormatter.string(from: NSNumber(value: assetRatios[networkStore.selectedChain.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
+      let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[networkStore.selectedChain.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
       return fiat
     case .erc20Transfer:
       if let value = info.txArgs[safe: 1], let token = token(for: info.ethTxToAddress) {
         let amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
-        let fiat = numberFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
+        let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
         return fiat
       } else {
         return "$0.00"
@@ -107,7 +103,7 @@ struct TransactionDetailsView: View {
         guard let doubleValue = Double(value), let assetRatio = assetRatios[networkStore.selectedChain.symbol.lowercased()] else {
           return "$0.00"
         }
-        return numberFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00"
+        return currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00"
       }())
     }
     return nil
@@ -125,7 +121,7 @@ struct TransactionDetailsView: View {
   /// The market price for the asset
   private var marketPrice: String {
     let symbol = networkStore.selectedChain.symbol
-    let marketPrice = numberFormatter.string(from: NSNumber(value: assetRatios[symbol.lowercased(), default: 0])) ?? "$0.00"
+    let marketPrice = currencyFormatter.string(from: NSNumber(value: assetRatios[symbol.lowercased(), default: 0])) ?? "$0.00"
     return marketPrice
   }
 
@@ -256,7 +252,8 @@ struct TransactionDetailsView_Previews: PreviewProvider {
         keyringStore: .previewStore,
         visibleTokens: [.previewToken],
         allTokens: [],
-        assetRatios: ["eth": 4576.36]
+        assetRatios: ["eth": 4576.36],
+        currencyFormatter: .usdCurrencyFormatter
       )
         .previewColorSchemes()
       TransactionDetailsView(
@@ -265,7 +262,8 @@ struct TransactionDetailsView_Previews: PreviewProvider {
         keyringStore: .previewStore,
         visibleTokens: [.previewToken],
         allTokens: [],
-        assetRatios: ["eth": 4576.36]
+        assetRatios: ["eth": 4576.36],
+        currencyFormatter: .usdCurrencyFormatter
       )
         .previewColorSchemes()
       TransactionDetailsView(
@@ -274,7 +272,8 @@ struct TransactionDetailsView_Previews: PreviewProvider {
         keyringStore: .previewStore,
         visibleTokens: [.previewToken],
         allTokens: [],
-        assetRatios: ["eth": 4576.36]
+        assetRatios: ["eth": 4576.36],
+        currencyFormatter: .usdCurrencyFormatter
       )
         .previewColorSchemes()
     }

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -18,14 +18,33 @@ struct TransactionDetailsView: View {
   var visibleTokens: [BraveWallet.BlockchainToken]
   var allTokens: [BraveWallet.BlockchainToken]
   var assetRatios: [String: Double]
-  var currencyFormatter: NumberFormatter
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
   
+  init(
+    info: BraveWallet.TransactionInfo,
+    networkStore: NetworkStore,
+    keyringStore: KeyringStore,
+    visibleTokens: [BraveWallet.BlockchainToken],
+    allTokens: [BraveWallet.BlockchainToken],
+    assetRatios: [String: Double],
+    currencyCode: String
+  ) {
+    self.info = info
+    self.networkStore = networkStore
+    self.keyringStore = keyringStore
+    self.visibleTokens = visibleTokens
+    self.allTokens = allTokens
+    self.assetRatios = assetRatios
+    self.currencyFormatter.currencyCode = currencyCode
+  }
+  
   private let dateFormatter = DateFormatter().then {
     $0.dateFormat = "h:mm a - MMM d, yyyy"
   }
+  
+  private let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
   
   private func token(for contractAddress: String) -> BraveWallet.BlockchainToken? {
     let findToken: (BraveWallet.BlockchainToken) -> Bool = { $0.contractAddress.caseInsensitiveCompare(contractAddress) == .orderedSame }
@@ -253,7 +272,7 @@ struct TransactionDetailsView_Previews: PreviewProvider {
         visibleTokens: [.previewToken],
         allTokens: [],
         assetRatios: ["eth": 4576.36],
-        currencyFormatter: .usdCurrencyFormatter
+        currencyCode: CurrencyCode.usd.code
       )
         .previewColorSchemes()
       TransactionDetailsView(
@@ -263,7 +282,7 @@ struct TransactionDetailsView_Previews: PreviewProvider {
         visibleTokens: [.previewToken],
         allTokens: [],
         assetRatios: ["eth": 4576.36],
-        currencyFormatter: .usdCurrencyFormatter
+        currencyCode: CurrencyCode.usd.code
       )
         .previewColorSchemes()
       TransactionDetailsView(
@@ -273,7 +292,7 @@ struct TransactionDetailsView_Previews: PreviewProvider {
         visibleTokens: [.previewToken],
         allTokens: [],
         assetRatios: ["eth": 4576.36],
-        currencyFormatter: .usdCurrencyFormatter
+        currencyCode: CurrencyCode.usd.code
       )
         .previewColorSchemes()
     }

--- a/BraveWallet/Crypto/Transactions/TransactionView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionView.swift
@@ -18,15 +18,11 @@ struct TransactionView: View {
   var allTokens: [BraveWallet.BlockchainToken]
   var displayAccountCreator: Bool
   var assetRatios: [String: Double]
+  var currencyFormatter: NumberFormatter
 
   private let timeFormatter = RelativeDateTimeFormatter().then {
     $0.unitsStyle = .full
     $0.dateTimeStyle = .numeric
-  }
-
-  private let numberFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = "USD"
   }
 
   private func namedAddress(for address: String) -> String {
@@ -52,7 +48,7 @@ struct TransactionView: View {
           guard let doubleValue = Double(value), let assetRatio = assetRatios[networkStore.selectedChain.symbol.lowercased()] else {
             return "$0.00"
           }
-          return numberFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00"
+          return currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00"
         }()
       )
     }
@@ -76,7 +72,7 @@ struct TransactionView: View {
       }
     case .ethSend, .other:
       let amount = formatter.decimalString(for: info.ethTxValue.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) ?? ""
-      let fiat = numberFormatter.string(from: NSNumber(value: assetRatios[networkStore.selectedChain.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
+      let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[networkStore.selectedChain.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
       if info.isSwap {
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionSwapTitle, amount, networkStore.selectedChain.symbol, fiat))
       } else {
@@ -85,7 +81,7 @@ struct TransactionView: View {
     case .erc20Transfer:
       if let value = info.txArgs[safe: 1], let token = token(for: info.ethTxToAddress) {
         let amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
-        let fiat = numberFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
+        let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
         Text(String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, amount, token.symbol, fiat))
       } else {
         Text(Strings.Wallet.send)
@@ -219,7 +215,8 @@ struct Transaction_Previews: PreviewProvider {
         visibleTokens: [.previewToken],
         allTokens: [],
         displayAccountCreator: false,
-        assetRatios: ["eth": 4576.36]
+        assetRatios: ["eth": 4576.36],
+        currencyFormatter: .usdCurrencyFormatter
       )
       TransactionView(
         info: .previewConfirmedSwap,
@@ -228,7 +225,8 @@ struct Transaction_Previews: PreviewProvider {
         visibleTokens: [.previewToken],
         allTokens: [],
         displayAccountCreator: true,
-        assetRatios: ["eth": 4576.36]
+        assetRatios: ["eth": 4576.36],
+        currencyFormatter: .usdCurrencyFormatter
       )
       TransactionView(
         info: .previewConfirmedERC20Approve,
@@ -237,7 +235,8 @@ struct Transaction_Previews: PreviewProvider {
         visibleTokens: [.previewToken],
         allTokens: [],
         displayAccountCreator: false,
-        assetRatios: ["eth": 4576.36]
+        assetRatios: ["eth": 4576.36],
+        currencyFormatter: .usdCurrencyFormatter
       )
     }
     .padding(12)

--- a/BraveWallet/Crypto/Transactions/TransactionView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionView.swift
@@ -18,12 +18,33 @@ struct TransactionView: View {
   var allTokens: [BraveWallet.BlockchainToken]
   var displayAccountCreator: Bool
   var assetRatios: [String: Double]
-  var currencyFormatter: NumberFormatter
+
+  init(
+    info: BraveWallet.TransactionInfo,
+    keyringStore: KeyringStore,
+    networkStore: NetworkStore,
+    visibleTokens: [BraveWallet.BlockchainToken],
+    allTokens: [BraveWallet.BlockchainToken],
+    displayAccountCreator: Bool,
+    assetRatios: [String: Double],
+    currencyCode: String
+  ) {
+    self.info = info
+    self.keyringStore = keyringStore
+    self.networkStore = networkStore
+    self.visibleTokens = visibleTokens
+    self.allTokens = allTokens
+    self.displayAccountCreator = displayAccountCreator
+    self.assetRatios = assetRatios
+    self.currencyFormatter.currencyCode = currencyCode
+  }
 
   private let timeFormatter = RelativeDateTimeFormatter().then {
     $0.unitsStyle = .full
     $0.dateTimeStyle = .numeric
   }
+  
+  private let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
 
   private func namedAddress(for address: String) -> String {
     NamedAddresses.name(for: address, accounts: keyringStore.keyring.accountInfos)
@@ -216,7 +237,7 @@ struct Transaction_Previews: PreviewProvider {
         allTokens: [],
         displayAccountCreator: false,
         assetRatios: ["eth": 4576.36],
-        currencyFormatter: .usdCurrencyFormatter
+        currencyCode: CurrencyCode.usd.code
       )
       TransactionView(
         info: .previewConfirmedSwap,
@@ -226,7 +247,7 @@ struct Transaction_Previews: PreviewProvider {
         allTokens: [],
         displayAccountCreator: true,
         assetRatios: ["eth": 4576.36],
-        currencyFormatter: .usdCurrencyFormatter
+        currencyCode: CurrencyCode.usd.code
       )
       TransactionView(
         info: .previewConfirmedERC20Approve,
@@ -236,7 +257,7 @@ struct Transaction_Previews: PreviewProvider {
         allTokens: [],
         displayAccountCreator: false,
         assetRatios: ["eth": 4576.36],
-        currencyFormatter: .usdCurrencyFormatter
+        currencyCode: CurrencyCode.usd.code
       )
     }
     .padding(12)

--- a/BraveWallet/Extensions/WalletNumberFormatterExtensions.swift
+++ b/BraveWallet/Extensions/WalletNumberFormatterExtensions.swift
@@ -1,0 +1,14 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+extension NumberFormatter {
+  /// Currency number formatter in USD
+  static let usdCurrencyFormatter = NumberFormatter().then {
+    $0.numberStyle = .currency
+    $0.currencyCode = CurrencyCode.usd.code
+  }
+}

--- a/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -15,7 +15,7 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
     BraveWallet.MainnetChainId: [.previewToken],
     BraveWallet.RopstenChainId: [.previewToken],
   ]
-  private var defaultCurrency = "usd"
+  private var defaultCurrency = CurrencyCode.usd
   private var defaultCryptocurrency = "eth"
 
   func userAssets(_ chainId: String, coin: BraveWallet.CoinType, completion: @escaping ([BraveWallet.BlockchainToken]) -> Void) {
@@ -66,11 +66,11 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
   }
 
   func defaultBaseCurrency(_ completion: @escaping (String) -> Void) {
-    completion(defaultCurrency)
+    completion(defaultCurrency.code)
   }
 
   func setDefaultBaseCurrency(_ currency: String) {
-    defaultCurrency = currency.lowercased()
+    defaultCurrency = CurrencyCode(code: currency)
   }
 
   func defaultBaseCryptocurrency(_ completion: @escaping (String) -> Void) {

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -137,11 +137,4 @@ extension BraveWallet.TransactionInfo {
   }
 }
 
-extension NumberFormatter {
-  static let usdCurrencyFormatter = NumberFormatter().then {
-    $0.numberStyle = .currency
-    $0.currencyCode = CurrencyCode.usd.code
-  }
-}
-
 #endif

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -137,4 +137,11 @@ extension BraveWallet.TransactionInfo {
   }
 }
 
+extension NumberFormatter {
+  static let usdCurrencyFormatter = NumberFormatter().then {
+    $0.numberStyle = .currency
+    $0.currencyCode = CurrencyCode.usd.code
+  }
+}
+
 #endif

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -96,7 +96,8 @@ extension AssetDetailStore {
       walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
-      token: .previewToken
+      token: .previewToken,
+      currencyFormatter: .usdCurrencyFormatter
     )
   }
 }
@@ -136,7 +137,8 @@ extension AccountActivityStore {
       rpcService: MockJsonRpcService(),
       assetRatioService: MockAssetRatioService(),
       txService: MockTxService(),
-      blockchainRegistry: MockBlockchainRegistry()
+      blockchainRegistry: MockBlockchainRegistry(),
+      currencyFormatter: .usdCurrencyFormatter
     )
   }
 }
@@ -154,7 +156,8 @@ extension TransactionConfirmationStore {
         let service = MockKeyringService()
         service.createWallet("password") { _  in }
         return service
-      }()
+      }(),
+      currencyFormatter: .usdCurrencyFormatter
     )
   }
 }

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -93,10 +93,10 @@ extension AssetDetailStore {
       assetRatioService: MockAssetRatioService(),
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
+      walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
-      token: .previewToken,
-      currencyFormatter: .usdCurrencyFormatter
+      token: .previewToken
     )
   }
 }
@@ -136,8 +136,7 @@ extension AccountActivityStore {
       rpcService: MockJsonRpcService(),
       assetRatioService: MockAssetRatioService(),
       txService: MockTxService(),
-      blockchainRegistry: MockBlockchainRegistry(),
-      currencyFormatter: .usdCurrencyFormatter
+      blockchainRegistry: MockBlockchainRegistry()
     )
   }
 }
@@ -155,8 +154,7 @@ extension TransactionConfirmationStore {
         let service = MockKeyringService()
         service.createWallet("password") { _  in }
         return service
-      }(),
-      currencyFormatter: .usdCurrencyFormatter
+      }()
     )
   }
 }

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -93,6 +93,7 @@ extension AssetDetailStore {
       assetRatioService: MockAssetRatioService(),
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
+      walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       token: .previewToken

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -93,7 +93,6 @@ extension AssetDetailStore {
       assetRatioService: MockAssetRatioService(),
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
-      walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       token: .previewToken,

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -56,6 +56,20 @@ public struct WalletSettingsView: View {
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      Section {
+        Picker(selection: $settingsStore.currencyCode) {
+          ForEach(CurrencyCode.allCurrencyCodes) { currencyCode in
+            Text(currencyCode.code)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .tag(currencyCode)
+          }
+        } label: {
+          Text(Strings.Wallet.settingsDefaultBaseCurrencyTitle)
+            .foregroundColor(Color(.braveLabel))
+            .padding(.vertical, 4)
+        }
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       if settingsStore.isBiometricsAvailable, keyringStore.keyring.isKeyringCreated {
         Section(
           footer: Text(Strings.Wallet.settingsEnableBiometricsFooter)

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2094,5 +2094,12 @@ extension Strings {
       value: "View the addresses of your permitted accounts (required)",
       comment: "A text displayed below the account address in new site connection confirmation step, in order to make sure users double check the account address they are going to allow the dapp to connect with."
     )
+    public static let settingsDefaultBaseCurrencyTitle = NSLocalizedString(
+      "wallet.settingsDefaultBaseCurrencyTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Default base currency",
+      comment: "The title that appears before the current default base currency code. Example: \"Default base currency: USD\""
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1860,7 +1860,7 @@ extension Strings {
       "wallet.settingsResetTransactionTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Clear transaction & nonce info",
+      value: "Clear Transaction & Nonce Info",
       comment: "The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0"
     )
     public static let settingsResetTransactionFooter = NSLocalizedString(
@@ -2098,7 +2098,7 @@ extension Strings {
       "wallet.settingsDefaultBaseCurrencyTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Default base currency",
+      value: "Default Base Currency",
       comment: "The title that appears before the current default base currency code. Example: \"Default base currency: USD\""
     )
   }

--- a/BraveWalletTests/PortfolioStoreTests.swift
+++ b/BraveWalletTests/PortfolioStoreTests.swift
@@ -67,8 +67,7 @@ class PortfolioStoreTests: XCTestCase {
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
-      blockchainRegistry: BraveWallet.TestBlockchainRegistry(),
-      currencyFormatter: .usdCurrencyFormatter
+      blockchainRegistry: BraveWallet.TestBlockchainRegistry()
     )
     // test that `update()` will assign new value to `userVisibleAssets` publisher
     let userVisibleAssetsException = expectation(description: "update-userVisibleAssets")

--- a/BraveWalletTests/PortfolioStoreTests.swift
+++ b/BraveWalletTests/PortfolioStoreTests.swift
@@ -52,6 +52,8 @@ class PortfolioStoreTests: XCTestCase {
     walletService._userAssets = { _, _, completion in
       completion(mockUserAssets)
     }
+    walletService._addObserver = { _ in }
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
     let assetRatioService = BraveWallet.TestAssetRatioService()
     assetRatioService._price = { _, _, _, completion in
       completion(true, [mockEthAssetPrice])
@@ -65,7 +67,8 @@ class PortfolioStoreTests: XCTestCase {
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
-      blockchainRegistry: BraveWallet.TestBlockchainRegistry()
+      blockchainRegistry: BraveWallet.TestBlockchainRegistry(),
+      currencyFormatter: .usdCurrencyFormatter
     )
     // test that `update()` will assign new value to `userVisibleAssets` publisher
     let userVisibleAssetsException = expectation(description: "update-userVisibleAssets")

--- a/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -79,8 +79,7 @@ class TransactionConfirmationStoreTests: XCTestCase {
       blockchainRegistry: blockchainRegistry,
       walletService: walletService,
       ethTxManagerProxy: ethTxManagerProxy,
-      keyringService: keyringService,
-      currencyFormatter: .usdCurrencyFormatter
+      keyringService: keyringService
     )
   }
   

--- a/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -52,6 +52,7 @@ class TransactionConfirmationStoreTests: XCTestCase {
       completion([])
     }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
+    walletService._addObserver = { _ in }
     let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
     ethTxManagerProxy._gasEstimation1559 = { completion in
       completion(gasEstimation)

--- a/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -51,6 +51,7 @@ class TransactionConfirmationStoreTests: XCTestCase {
     walletService._userAssets = { _, _, completion in
       completion([])
     }
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
     let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
     ethTxManagerProxy._gasEstimation1559 = { completion in
       completion(gasEstimation)
@@ -78,7 +79,8 @@ class TransactionConfirmationStoreTests: XCTestCase {
       blockchainRegistry: blockchainRegistry,
       walletService: walletService,
       ethTxManagerProxy: ethTxManagerProxy,
-      keyringService: keyringService
+      keyringService: keyringService,
+      currencyFormatter: .usdCurrencyFormatter
     )
   }
   

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1215,6 +1215,7 @@
 		D511314B2800C16100C81683 /* TransactionConfirmationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */; };
 		D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */; };
 		D552E6922807231F00A847F3 /* Data.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1DC51320AC9AF900905E5A /* Data.framework */; };
+		D5412B452819F24000463106 /* WalletNumberFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5412B442819F24000463106 /* WalletNumberFormatterExtensions.swift */; };
 		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
 		D5ACA7CE27FB7D08002443CE /* BraveCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; };
 		D5ACA7D927FB7D0E002443CE /* MaterialComponents.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; };
@@ -3216,6 +3217,7 @@
 		D506715B27E2AAB700560631 /* TransactionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHeader.swift; sourceTree = "<group>"; };
 		D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionConfirmationStoreTests.swift; sourceTree = "<group>"; };
 		D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioStoreTests.swift; sourceTree = "<group>"; };
+		D5412B442819F24000463106 /* WalletNumberFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletNumberFormatterExtensions.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsPasscodeEntryView.swift; sourceTree = "<group>"; };
 		D5EFCB3827FF81AA00BD151D /* EditPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPermissionsView.swift; sourceTree = "<group>"; };
@@ -3892,6 +3894,7 @@
 				2792CBC7275951B10055151E /* UIPasteboardExtensions.swift */,
 				7DC054C127A9CCA400BBA042 /* KeyringServiceExtensions.swift */,
 				27117A5427DBDD6D002CF57B /* LegacyCoinTypeExtensions.swift */,
+				D5412B442819F24000463106 /* WalletNumberFormatterExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -8247,6 +8250,7 @@
 				271F68B426EBD27E00AA2A50 /* CreateWalletView.swift in Sources */,
 				2774303427332DAF00183725 /* BlockieGroup.swift in Sources */,
 				271F689F26EBD27E00AA2A50 /* AccountActivityView.swift in Sources */,
+				D5412B452819F24000463106 /* WalletNumberFormatterExtensions.swift in Sources */,
 				27E17B812744067A00F3C282 /* AccountActivityStore.swift in Sources */,
 				271F68AE26EBD27E00AA2A50 /* BackupWalletView.swift in Sources */,
 				7D758908271A172C00B643C3 /* BuyTokenView.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes
- Use a single `currencyFormatter: NumberFormatter` for currency display throughout Wallet. Kept in `CryptoStore` and shared with `PortfolioStore`, `AssetDetailStore`, `AccountActivityStore`, and `TransactionConfirmationStore`. `CryptoStore` observes `WalletService` for changes to default base currency and updates accordingly.
- Add picker to wallet settings to select a new currency code

This pull request fixes #4341

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open Wallet Settings and select a new default base currency
2. Open Portfolio, did currency display update?
3. Open Asset details, does currency match newly selected base currency?
4. Open Accounts tab and view account details, does currency match newly selected base currency?
5. Tap a transaction, does currency match newly selected base currency?
6. Force quit the app
7. Re-open and open Wallet. Is the newly selected default base currency preserved between launches?


## Screenshots:
Note: my phone locale is Canada, so I see 'US' beside USD prices.

![default (canada)](https://user-images.githubusercontent.com/5314553/164556858-97f8a1e0-ec40-40e9-ba27-c2d432929686.PNG) | ![settings](https://user-images.githubusercontent.com/5314553/164556863-7c995af5-fbb4-4588-b102-912df9e9473b.PNG) | ![eur](https://user-images.githubusercontent.com/5314553/164556865-22dff6b4-8fe9-4ce1-a5d1-77a1e1786556.jpeg)
-- | -- | -- 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
