### PR TITLE
Fix #5285: LockIcon in address bar difficult to tap

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -399,6 +399,16 @@ extension TabLocationView: TabEventHandler {
   }
 }
 
+// MARK: - Hit Test
+extension TabLocationView {
+  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    if lockImageView.frame.insetBy(dx: -10, dy: -30).contains(point) {
+      return lockImageView
+    }
+    return super.hitTest(point, with: event)
+  }
+}
+
 class DisplayTextField: UITextField {
   weak var accessibilityActionsSource: AccessibilityActionsSource?
   var hostString: String = ""


### PR DESCRIPTION
## Summary of Changes
- Adds a hit-test around the lock icon (big enough that it doesn't interfere with tapping the URL/text)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5285

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
