### PR TITLE
Fix #5290: Tab not deinitializing

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -196,6 +196,7 @@ class Tab: NSObject {
     didSet { TabMO.saveScreenshotUUID(screenshotUUID, tabId: id) }
   }
   
+  var webStateDebounceTimer: Timer?
   var onPageReadyStateChanged: ((ReadyState.State) -> Void)?
 
   // If this tab has been opened from another, its parent will point to the tab from which it was opened

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -488,15 +488,13 @@ class TabManager: NSObject {
     // When the state of the page changes, we debounce a call to save the screenshots and tab information
     // This fixes pages that have dynamic URL via changing history
     // as well as regular pages that load DOM normally.
-    var debounce_timer: Timer?
-    tab.onPageReadyStateChanged = { [weak self] state in
-      guard let self = self else { return }
-      
-      debounce_timer?.invalidate()
-      debounce_timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { _ in
-        debounce_timer?.invalidate()
+    tab.onPageReadyStateChanged = { [weak tab] state in
+      tab?.webStateDebounceTimer?.invalidate()
+      tab?.webStateDebounceTimer? = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self, weak tab] _ in
+        tab?.webStateDebounceTimer?.invalidate()
         
-        if state == .complete || state == .loaded || state == .pushstate || state == .popstate {
+        if let self = self, let tab = tab,
+            state == .complete || state == .loaded || state == .pushstate || state == .popstate {
           // Saving Tab Private Mode - not supported yet.
           if !tab.isPrivate {
             self.preserveScreenshots()


### PR DESCRIPTION
## Summary of Changes
- Fixed Tab state debouncing so the tab can properly deinitialize.
- Time must be retained outside of the current function, otherwise tab cannot deinit so long as the timer is retained locally (not sure why local retention [same as block], causes a leak).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5290

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
