### PR TITLE
Fix #5292: Add "Force Paste" item in menu to bypass onpaste handlers

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -958,6 +958,7 @@ extension Strings {
   public static let cookies = NSLocalizedString("Cookies", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Cookies and Site Data", comment: "Settings item for clearing cookies and site data")
   public static let findInPage = NSLocalizedString("FindInPage", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Find in Page", comment: "Share action title")
   public static let searchWithBrave = NSLocalizedString("SearchWithBrave", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Search with Brave", comment: "Title of an action that allows user to perform a one-click web search for selected text")
+  public static let forcePaste = NSLocalizedString("ForcePaste", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Force Paste", comment: "A label which when tapped pastes from the users clipboard forcefully (so as to ignore any paste restrictions placed by the website)")
   public static let addToFavorites = NSLocalizedString("AddToFavorites", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Add to Favorites", comment: "Add to favorites share action.")
   public static let createPDF = NSLocalizedString("CreatePDF", tableName: "BraveShared", bundle: Bundle.braveShared, value: "Create PDF", comment: "Create PDF share action.")
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		2729E7D326F502AC00200648 /* AccountPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2729E7D226F502AC00200648 /* AccountPicker.swift */; };
 		272B862B270BD96F005ED304 /* SandboxInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272B862A270BD96F005ED304 /* SandboxInspectorView.swift */; };
 		273EB3A72422AB24002A8AAF /* PaymentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9616E6A240EE43F00667C2D /* PaymentRequest.swift */; };
+		273F981A281884A400C7E7D4 /* ForcePasteHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 273F980F281884A400C7E7D4 /* ForcePasteHelper.js */; };
 		273F9857281AE3D100C7E7D4 /* BraveCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; };
 		273FCB9A25A7BC5500F279B5 /* BraveNewsDebugSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273FCB9925A7BC5500F279B5 /* BraveNewsDebugSettingsView.swift */; };
 		274398E224E4827800E79605 /* FeedCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274398E124E4827800E79605 /* FeedCard.swift */; };
@@ -1997,6 +1998,7 @@
 		2727369A24A65F650096DCB9 /* UIActionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActionExtensions.swift; sourceTree = "<group>"; };
 		2729E7D226F502AC00200648 /* AccountPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountPicker.swift; sourceTree = "<group>"; };
 		272B862A270BD96F005ED304 /* SandboxInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxInspectorView.swift; sourceTree = "<group>"; };
+		273F980F281884A400C7E7D4 /* ForcePasteHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ForcePasteHelper.js; sourceTree = "<group>"; };
 		273FCB9925A7BC5500F279B5 /* BraveNewsDebugSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveNewsDebugSettingsView.swift; sourceTree = "<group>"; };
 		274398E124E4827800E79605 /* FeedCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCard.swift; sourceTree = "<group>"; };
 		274398E424E4829900E79605 /* FeedFillStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedFillStrategy.swift; sourceTree = "<group>"; };
@@ -6920,6 +6922,7 @@
 				CA225DEF2795CDFD0024C104 /* __firefox__.js */,
 				2755AB7C23107BC600F0721F /* AdsReporting.js */,
 				D0C95DF5200EADD500E4E51C /* LoginsHelper.js */,
+				273F980F281884A400C7E7D4 /* ForcePasteHelper.js */,
 			);
 			path = AtDocumentStart;
 			sourceTree = "<group>";
@@ -8033,6 +8036,7 @@
 				4481F23526CBD27B00658EAC /* GlobalSignRootCA_R5.cer in Resources */,
 				F9E0F38B25772E57003A6A30 /* ReaderMode.js in Resources */,
 				E4ECCDAE1AB131770005E717 /* FiraSans-Medium.ttf in Resources */,
+				273F981A281884A400C7E7D4 /* ForcePasteHelper.js in Resources */,
 				F9B23EE223F61173000EB3D8 /* PaymentRequest.js in Resources */,
 				E4424B3C1AC71FB400F44C38 /* FiraSans-Book.ttf in Resources */,
 				2F676FAD260BA4860048A1DB /* blocking-summary.json in Resources */,

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -789,7 +789,21 @@ class TabWebView: BraveWebView, MenuHelperInterface {
   fileprivate weak var delegate: TabWebViewDelegate?
 
   override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+    if action == MenuHelper.selectorForcePaste {
+      // If paste is allowed, show force paste as well
+      return super.canPerformAction(#selector(paste(_:)), withSender: sender)
+    }
     return super.canPerformAction(action, withSender: sender) || action == MenuHelper.selectorFindInPage
+  }
+  
+  @objc func menuHelperForcePaste() {
+    if let string = UIPasteboard.general.string {
+      evaluateSafeJavaScript(
+        functionName: "window.__firefox__.forcePaste",
+        args: [string, UserScriptManager.messageHandlerTokenString],
+        contentWorld: .defaultClient
+      ) { _, _ in }
+    }
   }
 
   @objc func menuHelperFindInPage() {

--- a/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/ForcePasteHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/ForcePasteHelper.js
@@ -1,0 +1,32 @@
+/* vim: set ts=2 sts=2 sw=2 et tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+Object.defineProperty(window.__firefox__, "forcePaste", {
+  enumerable: false,
+  configurable: false,
+  writable: false,
+  value: function(contents, securityToken) {
+    if (securityToken !== SECURITY_TOKEN) {
+      return;
+    }
+    var element = document.activeElement;
+    if (element instanceof HTMLIFrameElement) {
+      // If the element is an iframe, grab its active element
+      element = element.contentWindow.document.activeElement;
+    }
+    if (element === undefined) {
+      return;
+    }
+    var start = element.selectionStart;
+    // Paste into expected position, replacing contents if any are selected
+    element.value = element.value.slice(0, start) + contents + element.value.slice(element.selectionEnd);
+    // Reset caret position to expected position
+    var newSelection = start + contents.length;
+    element.selectionStart = newSelection;
+    element.selectionEnd = newSelection;
+  }
+});

--- a/Client/Helpers/MenuHelper.swift
+++ b/Client/Helpers/MenuHelper.swift
@@ -10,6 +10,8 @@ import Shared
   @objc optional func menuHelperCopy()
   /// Triggered when "Open website" menu item is selected
   @objc optional func menuHelperOpenWebsite()
+  /// Triggered when "Force Paste" menu item is selected"
+  @objc optional func menuHelperForcePaste()
   /// Triggered when "Reveal" menu item is selected
   @objc optional func menuHelperReveal()
   /// Triggered when "Hide" menu item is selected
@@ -25,6 +27,8 @@ open class MenuHelper: NSObject {
   public static let selectorCopy: Selector = #selector(MenuHelperInterface.menuHelperCopy)
   /// Selector for the "Hide" menu item
   public static let selectorHide: Selector = #selector(MenuHelperInterface.menuHelperSecure)
+  /// Selector for the "Force Paste" menu item
+  public static let selectorForcePaste: Selector = #selector(MenuHelperInterface.menuHelperForcePaste)
   /// Selector for the "Open website" menu item
   public static let selectorOpenWebsite: Selector = #selector(MenuHelperInterface.menuHelperOpenWebsite)
   /// Selector for the "Reveal" menu item
@@ -49,7 +53,8 @@ open class MenuHelper: NSObject {
     let openWebsiteItem = UIMenuItem(title: Strings.menuItemOpenWebsiteTitle, action: MenuHelper.selectorOpenWebsite)
     let findInPageItem = UIMenuItem(title: Strings.findInPage, action: MenuHelper.selectorFindInPage)
     let searchWithBraveItem = UIMenuItem(title: Strings.searchWithBrave, action: MenuHelper.selectorSearchWithBrave)
+    let forcePaste = UIMenuItem(title: Strings.forcePaste, action: MenuHelper.selectorForcePaste)
 
-    UIMenuController.shared.menuItems = [copyItem, revealPasswordItem, hidePasswordItem, openWebsiteItem, findInPageItem, searchWithBraveItem]
+    UIMenuController.shared.menuItems = [copyItem, forcePaste, revealPasswordItem, hidePasswordItem, openWebsiteItem, findInPageItem, searchWithBraveItem]
   }
 }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5292

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan

- See https://github.com/brave/brave-browser/issues/22567
- On top of this, ensure matches regular paste behavior re: caret selection and text replacement

## Screenshots:

![image](https://user-images.githubusercontent.com/529104/165386989-e79e8196-43aa-476b-bb06-9f132d24bfd8.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
