### PR TITLE
No Bug: Bump GitHub Actions to macOS 12 public beta and Xcode 13.3.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,12 +11,12 @@ jobs:
   test:
     if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI/skip')) }}
     name: Run tests
-    runs-on: macOS-11
+    runs-on: macOS-12
     env:
         # The XCode version to use. If you want to update it please refer to this document:
         # https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software
         # and set proper version.
-        XCODE_VERSION: "13.2.1"
+        XCODE_VERSION: "13.3.1"
 
     steps:
       - name: Select XCode


### PR DESCRIPTION
As per https://github.blog/changelog/2022-04-25-github-actions-public-beta-of-macos-12-for-github-hosted-runners-is-now-available/ macOS 12 runners are now in public beta

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
