### PR TITLE
Fix #5297: Remove SwiftUI on iOS 14 release build crash workarounds (`FB9812596`)

### DIFF
--- a/BraveUI/SwiftUI/FilterableViewModifier.swift
+++ b/BraveUI/SwiftUI/FilterableViewModifier.swift
@@ -53,25 +53,6 @@ private class SearchDelegate: NSObject, UISearchBarDelegate, ObservableObject {
   }
 }
 
-// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
-@available(iOS 15.0, *)
-private struct SearchableViewModifier_FB9812596: ViewModifier {
-  var text: Binding<String>
-  var prompt: String?
-  var onSubmit: (() -> Void)?
-
-  func body(content: Content) -> some View {
-    content.searchable(
-      text: text,
-      placement: .navigationBarDrawer(displayMode: .always),
-      prompt: prompt.map { Text($0) }
-    )
-    .onSubmit(of: .search) {
-      onSubmit?()
-    }
-  }
-}
-
 extension View {
   /// Adds a search bar to the parent navigation controller to simply filter the contents of the View
   ///
@@ -82,7 +63,14 @@ extension View {
     onSubmit: (() -> Void)? = nil
   ) -> some View {
     if #available(iOS 15.0, *) {
-      modifier(SearchableViewModifier_FB9812596(text: text, prompt: prompt, onSubmit: onSubmit))
+      searchable(
+        text: text,
+        placement: .navigationBarDrawer(displayMode: .always),
+        prompt: prompt.map { Text($0) }
+      )
+      .onSubmit(of: .search) {
+        onSubmit?()
+      }
     } else {
       modifier(FilterableViewModifier(query: text, prompt: prompt, onSubmit: onSubmit))
     }

--- a/BraveWallet/Chart/LineChartView.swift
+++ b/BraveWallet/Chart/LineChartView.swift
@@ -272,22 +272,11 @@ extension CGPoint {
 
 // MARK: - Accessibility
 
-// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
-@available(iOS 15.0, *)
-private struct ChartAccessibilityModifier_FB9812596: ViewModifier {
-  var title: String
-  var dataPoints: [DataPoint]
-
-  func body(content: Content) -> some View {
-    content.accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
-  }
-}
-
 extension View {
   @ViewBuilder func chartAccessibility(title: String, dataPoints: [DataPoint]) -> some View {
     Group {
       if #available(iOS 15.0, *) {
-        self.modifier(ChartAccessibilityModifier_FB9812596(title: title, dataPoints: dataPoints))
+        self.accessibilityChartDescriptor(LineChartDescriptor(title: title, values: dataPoints))
       } else {
         self
       }

--- a/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -36,21 +36,6 @@ private struct EditTokenView: View {
   }
 }
 
-// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
-@available(iOS 15.0, *)
-private struct SwipeActionsViewModifier_FB9812596: ViewModifier {
-  var action: () -> Void
-
-  func body(content: Content) -> some View {
-    content
-      .swipeActions(edge: .trailing) {
-        Button(role: .destructive, action: action) {
-          Label(Strings.Wallet.delete, systemImage: "trash")
-        }
-      }
-  }
-}
-
 struct EditUserAssetsView: View {
   @ObservedObject var userAssetsStore: UserAssetsStore
   var assetsUpdated: () -> Void
@@ -115,10 +100,13 @@ struct EditUserAssetsView: View {
                   .osAvailabilityModifiers { content in
                     if #available(iOS 15.0, *) {
                       content
-                        .modifier(
-                          SwipeActionsViewModifier_FB9812596 {
+                        .swipeActions(edge: .trailing) {
+                          Button(role: .destructive, action: {
                             removeCustomToken(store.token)
-                          })
+                          }) {
+                            Label(Strings.Wallet.delete, systemImage: "trash")
+                          }
+                        }
                     } else {
                       content
                         .contextMenu {

--- a/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/BraveWallet/Settings/CustomNetworkListView.swift
@@ -7,21 +7,6 @@ import SwiftUI
 import BraveCore
 import Shared
 
-// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
-@available(iOS 15.0, *)
-private struct SwipeActionsViewModifier_FB9812596: ViewModifier {
-  var action: () -> Void
-
-  func body(content: Content) -> some View {
-    content
-      .swipeActions(edge: .trailing) {
-        Button(role: .destructive, action: action) {
-          Label(Strings.Wallet.delete, systemImage: "trash")
-        }
-      }
-  }
-}
-
 struct CustomNetworkListView: View {
   @ObservedObject var networkStore: NetworkStore
   @State private var isPresentingNetworkDetails: CustomNetworkModel?
@@ -80,12 +65,13 @@ struct CustomNetworkListView: View {
           .osAvailabilityModifiers { content in
             if #available(iOS 15.0, *) {
               content
-                .modifier(
-                  SwipeActionsViewModifier_FB9812596 {
-                    withAnimation(.default) {
-                      removeNetwork(network)
-                    }
-                  })
+                .swipeActions(edge: .trailing) {
+                  Button(role: .destructive, action: {
+                    removeNetwork(network)
+                  }) {
+                    Label(Strings.Wallet.delete, systemImage: "trash")
+                  }
+                }
             } else {
               content
             }

--- a/Client/Frontend/Settings/ManageWebsiteDataView.swift
+++ b/Client/Frontend/Settings/ManageWebsiteDataView.swift
@@ -120,10 +120,13 @@ struct ManageWebsiteDataView: View {
                 if #available(iOS 15.0, *) {
                   // Better swipe gestures
                   content
-                    .modifier(
-                      SwipeActionsViewModifier_FB9812596 {
+                    .swipeActions(edge: .trailing) {
+                      Button(role: .destructive, action: {
                         removeRecords([record])
-                      })
+                      }) {
+                        Label(Strings.removeDataRecord, systemImage: "trash")
+                      }
+                    }
                 } else {
                   content
                 }
@@ -213,20 +216,5 @@ private func localizedStringForDataRecordType(_ type: String) -> String? {
 extension WKWebsiteDataRecord: Identifiable {
   public var id: String {
     displayName
-  }
-}
-
-// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
-@available(iOS 15.0, *)
-private struct SwipeActionsViewModifier_FB9812596: ViewModifier {
-  var action: () -> Void
-
-  func body(content: Content) -> some View {
-    content
-      .swipeActions(edge: .trailing) {
-        Button(role: .destructive, action: action) {
-          Label(Strings.removeDataRecord, systemImage: "trash")
-        }
-      }
   }
 }


### PR DESCRIPTION
Xcode 13.3 and higher no longer reproduce the crash when running availability checks for iOS 15 APIs on iOS 14 devices so these workarounds can be removed

## Summary of Changes

This pull request fixes #5297 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

See issue

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
