### PR TITLE
Ref #4435: Fetch persistent favicons for Privacy Hub websites list.

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
@@ -39,7 +39,7 @@ class PlaylistFolderImageLoader: ObservableObject {
   }
 
   func load(domainUrl: URL) {
-    fetcher.loadIcon(siteURL: domainUrl) { [weak self] image in
+    fetcher.loadIcon(siteURL: domainUrl, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing) { [weak self] image in
       self?.image = image
     }
   }

--- a/Client/Frontend/Browser/Playlist/Utilities/PlaylistThumbnailUtility.swift
+++ b/Client/Frontend/Browser/Playlist/Utilities/PlaylistThumbnailUtility.swift
@@ -131,7 +131,7 @@ public class PlaylistThumbnailRenderer {
 
   private func loadFavIconThumbnail(url: URL, completion: @escaping (UIImage?) -> Void) {
     favIconGenerator = FavIconImageRenderer()
-    favIconGenerator?.loadIcon(siteURL: url) { icon in
+    favIconGenerator?.loadIcon(siteURL: url, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing) { icon in
       DispatchQueue.main.async {
         completion(icon)
       }
@@ -269,10 +269,10 @@ class FavIconImageRenderer {
     task?.cancel()
   }
 
-  func loadIcon(siteURL: URL, completion: ((UIImage?) -> Void)?) {
+  func loadIcon(siteURL: URL, persistent: Bool, completion: ((UIImage?) -> Void)?) {
     task?.cancel()
     task = DispatchWorkItem {
-      let domain = Domain.getOrCreate(forUrl: siteURL, persistent: false)
+      let domain = Domain.getOrCreate(forUrl: siteURL, persistent: persistent)
       var faviconFetcher: FaviconFetcher? = FaviconFetcher(siteURL: siteURL, kind: .favicon, domain: domain)
       faviconFetcher?.load() { [weak self] _, attributes in
         faviconFetcher = nil


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #4435 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
