### PR TITLE
Ref #5305: Fix crash when downloading temp resource directly on iOS 14

### DIFF
--- a/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/Client/Frontend/Browser/TemporaryDocument.swift
@@ -50,7 +50,7 @@ class TemporaryDocument: NSObject {
       return await task.value
     }
     
-    let task = Task<URL, Never> {
+    let task = Task<URL, Never> { @MainActor in
       return await withCheckedContinuation { continuation in
         pendingContinuation = continuation
         


### PR DESCRIPTION
Small follow up to #5305 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
