### PR TITLE
Fix #4960: Private Mode Change Color Glitching 

### DIFF
--- a/Client/Frontend/Browser/TabsBar/TabBarCell.swift
+++ b/Client/Frontend/Browser/TabsBar/TabBarCell.swift
@@ -79,8 +79,11 @@ class TabBarCell: UICollectionViewCell {
   private var privateModeCancellable: AnyCancellable?
   private func updateColors(_ isPrivateBrowsing: Bool) {
     if isPrivateBrowsing {
+      overrideUserInterfaceStyle = .dark
       backgroundColor = .privateModeBackground
     } else {
+      overrideUserInterfaceStyle = DefaultTheme(
+        rawValue: Preferences.General.themeNormalMode.value)?.userInterfaceStyleOverride ?? .unspecified
       backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
     }
   }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -59,8 +59,11 @@ class BottomToolbarView: UIView, ToolbarProtocol {
   private var privateModeCancellable: AnyCancellable?
   private func updateColors(_ isPrivateBrowsing: Bool) {
     if isPrivateBrowsing {
+      overrideUserInterfaceStyle = .dark
       backgroundColor = .privateModeBackground
     } else {
+      overrideUserInterfaceStyle = DefaultTheme(
+        rawValue: Preferences.General.themeNormalMode.value)?.userInterfaceStyleOverride ?? .unspecified
       backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
     }
   }


### PR DESCRIPTION
This PR fixes the problem where horizontal tab tray & omni-box quickly go white then return to expected them when opening tabs in PB.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4960

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Install the Browser
- Switch over the PB and start opening NTP via +

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
