### PR TITLE
Fix #5336: Update privacy hub copy

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -4401,7 +4401,7 @@ extension Strings {
     public static let riskiestWebsiteTitle = NSLocalizedString(
       "privacyHub.riskiestWebsiteTitle",
       bundle: .braveShared,
-      value: "Riskiest website you visited",
+      value: "Site with the most trackers",
       comment: "Title of a website that contained the most trackers per visit."
     )
     


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5336 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
