### PR TITLE
Fix #5331: Fix sharing link not showing up when sharing a bookmark

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3038,12 +3038,23 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
     case .copy:
       UIPasteboard.general.url = url
     case .share:
-      presentActivityViewController(
-        url,
-        sourceView: view,
-        sourceRect: view.convert(topToolbar.shareButton.frame, from: topToolbar.shareButton.superview),
-        arrowDirection: [.up]
-      )
+      if presentedViewController != nil {
+        dismiss(animated: true) {
+          self.presentActivityViewController(
+            url,
+            sourceView: self.view,
+            sourceRect: self.view.convert(self.topToolbar.shareButton.frame, from: self.topToolbar.shareButton.superview),
+            arrowDirection: [.up]
+          )
+        }
+      } else {
+        presentActivityViewController(
+          url,
+          sourceView: view,
+          sourceRect: view.convert(topToolbar.shareButton.frame, from: topToolbar.shareButton.superview),
+          arrowDirection: [.up]
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Fix sharing link when sharing a bookmark via long-press context menu, which wasn't working because it tries to present the sharing controller when the menu controller is already presented.
- Dismiss menu controller before sharing bookmarks link.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5331

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
