### PR TITLE
Fix #5241: Reader mode bar displayed in other tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2028,13 +2028,18 @@ extension BrowserViewController: TabsBarViewControllerDelegate {
     // The actions are carried to menu actions for Tab-Tray Button
   }
   
-  func tabsBarDidChangeReaderModeVisibility(_ isHidden: Bool) {
-    if topToolbar.locationView.readerModeState == .active {
+  func tabsBarDidChangeReaderModeVisibility(_ isHidden: Bool = true) {
+    switch topToolbar.locationView.readerModeState {
+    case .active:
       if isHidden {
         hideReaderModeBar(animated: false)
       } else {
         showReaderModeBar(animated: false)
       }
+    case .unavailable:
+      hideReaderModeBar(animated: false)
+    default:
+      break
     }
   }
 }

--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -426,6 +426,7 @@ extension TabsBarViewController: TabManagerDelegate {
   func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
     assert(Thread.current.isMainThread)
     updateData()
+    delegate?.tabsBarDidChangeReaderModeVisibility(false)
   }
 
   func tabManager(_ tabManager: TabManager, didAddTab tab: Tab) {


### PR DESCRIPTION
 [Follow up to #5150] but the case is entirely different. Adding the edge case for change tabs reader mode bar visibility where changing tabs from tabs bar scroll view might cause reader mode get stucked in certain cases

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open new tab, navigate to YT or Twitch
- Open another tab, navigate to wikipedia, select language
- Enable reader mode when content is displayed on wikipedia
- Switch tab to YT or Twitch.tv

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/6643505/168325746-0874a558-12f5-4316-8d01-850738aa25fa.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
