### PR TITLE
Fix #5345: Move to not save tab data for local host or reader-mode URLs!

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1896,11 +1896,11 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
           } else {
             braveCore.historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date(), isURLTyped: false)
           }
-        }
-        
-        // Saving Tab. Private Mode - not supported yet.
-        if !tab.isPrivate {
-          tabManager.saveTab(tab)
+          
+          // Saving Tab. Private Mode - not supported yet.
+          if !tab.isPrivate {
+            tabManager.saveTab(tab)
+          }
         }
       }
 


### PR DESCRIPTION
## Summary of Changes
- Tab data (screenshots and other info) should only be saved when the URL is not local.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5345

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test session restore for reader-mode.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
