### PR TITLE
Fix #5257: Wallet Ethereum Dapp Site Connections List + Dapp Settings

### DIFF
--- a/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -61,7 +61,9 @@ class ManageSiteConnectionsStore: ObservableObject {
       
       var updatedSiteConnections = siteConnections
       updatedSiteConnections.remove(at: index)
-      updatedSiteConnections.insert(updatedSiteConnection, at: index)
+      if !updatedConnectedAddresses.isEmpty {
+        updatedSiteConnections.insert(updatedSiteConnection, at: index)
+      }
       self.siteConnections = updatedSiteConnections
     }
     Domain.setEthereumPermissions(forUrl: url, accounts: accounts, grant: false)

--- a/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -77,6 +77,6 @@ class ManageSiteConnectionsStore: ObservableObject {
   }
   
   func accountInfo(for address: String) -> BraveWallet.AccountInfo? {
-    return keyringStore.keyring.accountInfos.first(where: { $0.address == address })
+    keyringStore.keyring.accountInfos.first(where: { $0.address == address })
   }
 }

--- a/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -1,0 +1,69 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Data
+
+struct SiteConnection: Equatable, Identifiable {
+  let url: String
+  let connectedAddresses: [String]
+  
+  var id: String { url }
+}
+
+extension Array where Element == SiteConnection {
+  /// Filters the array by checking if the given `text` exists in the `url` or `connectedAccountAddresses`
+  func filter(by text: String) -> [SiteConnection] {
+    filter { siteConnections in
+      guard !text.isEmpty else { return true }
+      let filterText = text.lowercased()
+      return siteConnections.url.lowercased().contains(filterText) || siteConnections.connectedAddresses.contains(where: { $0.lowercased().contains(filterText) })
+    }
+  }
+}
+
+class ManageSiteConnectionsStore: ObservableObject {
+  @Published var siteConnections: [SiteConnection] = []
+  
+  /// Fetch all site connections with 1+ accounts connected
+  func fetchSiteConnections() {
+    let domains = Domain.allDomainsWithEthereumPermissions()
+    let connections = domains.map {
+      SiteConnection(
+        url: $0.url ?? "",
+        connectedAddresses: ($0.wallet_permittedAccounts ?? "")
+          .split(separator: ",")
+          .map(String.init)
+      )
+    }
+    self.siteConnections = connections
+  }
+  
+  /// Remove permissions for all accounts on each given `SiteConnection`s
+  func removeAllPermissions(from siteConnectionsToRemove: [SiteConnection]) {
+    siteConnectionsToRemove.forEach { siteConnection in
+      guard let url = URL(string: siteConnection.url) else { return }
+      Domain.setEthereumPermissions(forUrl: url, accounts: siteConnection.connectedAddresses, grant: false)
+      if let index = self.siteConnections.firstIndex(where: { $0.id.caseInsensitiveCompare(siteConnection.id) == .orderedSame }) {
+        self.siteConnections.remove(at: index)
+      }
+    }
+  }
+  
+  /// Remove permissions from the given `accounts` for the given `url`
+  func removePermissions(from accounts: [String], url: URL) {
+    if let index = siteConnections.firstIndex(where: { $0.url == url.absoluteString }),
+        let siteConnection = siteConnections[safe: index] {
+      let updatedConnectedAddresses = siteConnection.connectedAddresses.filter { !accounts.contains($0) }
+      let updatedSiteConnection = SiteConnection(url: siteConnection.url, connectedAddresses: updatedConnectedAddresses)
+      
+      var updatedSiteConnections = siteConnections
+      updatedSiteConnections.remove(at: index)
+      updatedSiteConnections.insert(updatedSiteConnection, at: index)
+      self.siteConnections = updatedSiteConnections
+    }
+    Domain.setEthereumPermissions(forUrl: url, accounts: accounts, grant: false)
+  }
+}

--- a/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Data
+import BraveCore
 
 struct SiteConnection: Equatable, Identifiable {
   let url: String
@@ -26,6 +27,12 @@ extension Array where Element == SiteConnection {
 
 class ManageSiteConnectionsStore: ObservableObject {
   @Published var siteConnections: [SiteConnection] = []
+  
+  var keyringStore: KeyringStore
+  
+  init(keyringStore: KeyringStore) {
+    self.keyringStore = keyringStore
+  }
   
   /// Fetch all site connections with 1+ accounts connected
   func fetchSiteConnections() {
@@ -67,5 +74,9 @@ class ManageSiteConnectionsStore: ObservableObject {
       self.siteConnections = updatedSiteConnections
     }
     Domain.setEthereumPermissions(forUrl: url, accounts: accounts, grant: false)
+  }
+  
+  func accountInfo(for address: String) -> BraveWallet.AccountInfo? {
+    return keyringStore.keyring.accountInfos.first(where: { $0.address == address })
   }
 }

--- a/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -20,7 +20,7 @@ extension Array where Element == SiteConnection {
     filter { siteConnections in
       guard !text.isEmpty else { return true }
       let filterText = text.lowercased()
-      return siteConnections.url.caseInsensitiveCompare(filterText) == .orderedSame || siteConnections.connectedAddresses.contains(where: { $0.caseInsensitiveCompare(filterText) == .orderedSame })
+      return siteConnections.url.contains(filterText) || siteConnections.connectedAddresses.contains(where: { $0.caseInsensitiveCompare(filterText) == .orderedSame })
     }
   }
 }

--- a/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -19,7 +19,7 @@ extension Array where Element == SiteConnection {
     filter { siteConnections in
       guard !text.isEmpty else { return true }
       let filterText = text.lowercased()
-      return siteConnections.url.lowercased().contains(filterText) || siteConnections.connectedAddresses.contains(where: { $0.lowercased().contains(filterText) })
+      return siteConnections.url.caseInsensitiveCompare(filterText) == .orderedSame || siteConnections.connectedAddresses.contains(where: { $0.caseInsensitiveCompare(filterText) == .orderedSame })
     }
   }
 }

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -74,6 +74,21 @@ public class SettingsStore: ObservableObject {
   public func addKeyringServiceObserver(_ observer: BraveWalletKeyringServiceObserver) {
     keyringService.add(observer)
   }
+  
+  private var manageSiteConnectionsStore: ManageSiteConnectionsStore?
+
+  func manageSiteConnectionsStore(keyringStore: KeyringStore) -> ManageSiteConnectionsStore {
+    if let manageSiteConnectionsStore = manageSiteConnectionsStore {
+      return manageSiteConnectionsStore
+    }
+    let manageSiteConnectionsStore = ManageSiteConnectionsStore(keyringStore: keyringStore)
+    self.manageSiteConnectionsStore = manageSiteConnectionsStore
+    return manageSiteConnectionsStore
+  }
+  
+  func closeManageSiteConnectionStore() {
+    manageSiteConnectionsStore = nil
+  }
 }
 
 struct CurrencyCode: Hashable, Identifiable {

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -26,12 +26,27 @@ struct ManageSiteConnectionsView: View {
           SiteRow(
             siteConnection: siteConnection
           )
+          .osAvailabilityModifiers { content in
+            if #available(iOS 15.0, *) {
+              content
+                .modifier(
+                  SwipeActionsViewModifier_FB9812596 {
+                    withAnimation {
+                      siteConnectionStore.removeAllPermissions(from: [siteConnection])
+                    }
+                  })
+            } else {
+              content
+            }
+          }
         }
       }
       .onDelete { indexes in
         let visibleSiteConnections = siteConnectionStore.siteConnections.filter(by: filterText)
         let siteConnectionsToRemove = indexes.map { visibleSiteConnections[$0] }
-        siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
+        withAnimation {
+          siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
+        }
       }
     }
     .listStyle(.insetGrouped)

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -53,16 +53,16 @@ struct ManageSiteConnectionsView: View {
       }
     }
     .listStyle(.insetGrouped)
-    .navigationTitle(Strings.Wallet.mangeSiteConnectionsTitle)
+    .navigationTitle(Strings.Wallet.web3PreferencesManageSiteConnections)
     .navigationBarTitleDisplayMode(.inline)
-    .filterable(text: $filterText, prompt: Strings.Wallet.mangeSiteConnectionsFilterPlaceholder)
+    .filterable(text: $filterText, prompt: Strings.Wallet.manageSiteConnectionsFilterPlaceholder)
     .toolbar {
       ToolbarItemGroup(placement: .bottomBar) {
         Spacer()
         Button(action: {
           isShowingConfirmAlert = true
         }) {
-          Text(Strings.Wallet.mangeSiteConnectionsRemoveAll)
+          Text(Strings.Wallet.manageSiteConnectionsRemoveAll)
             .foregroundColor(siteConnectionStore.siteConnections.isEmpty ? Color(.braveDisabled) : .red)
         }
         .disabled(siteConnectionStore.siteConnections.isEmpty)
@@ -71,10 +71,10 @@ struct ManageSiteConnectionsView: View {
     .onAppear(perform: siteConnectionStore.fetchSiteConnections)
     .alert(isPresented: $isShowingConfirmAlert) {
       Alert(
-        title: Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertTitle),
-        message: Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertMessage),
+        title: Text(Strings.Wallet.manageSiteConnectionsConfirmAlertTitle),
+        message: Text(Strings.Wallet.manageSiteConnectionsConfirmAlertMessage),
         primaryButton: Alert.Button.destructive(
-          Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertRemove),
+          Text(Strings.Wallet.manageSiteConnectionsConfirmAlertRemove),
           action: removeAll
         ),
         secondaryButton: Alert.Button.cancel(Text(Strings.CancelString))
@@ -194,17 +194,17 @@ private struct SiteConnectionDetailView: View {
         Button(action: {
           isShowingConfirmAlert = true
         }) {
-          Text(Strings.Wallet.mangeSiteConnectionsRemoveAll)
+          Text(Strings.Wallet.manageSiteConnectionsRemoveAll)
             .foregroundColor(siteConnectionStore.siteConnections.isEmpty ? Color(.braveDisabled) : .red)
         }
       }
     }
     .alert(isPresented: $isShowingConfirmAlert) {
       Alert(
-        title: Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertTitle),
-        message: Text(Strings.Wallet.mangeSiteConnectionsDetailConfirmAlertMessage),
+        title: Text(Strings.Wallet.manageSiteConnectionsConfirmAlertTitle),
+        message: Text(Strings.Wallet.manageSiteConnectionsDetailConfirmAlertMessage),
         primaryButton: Alert.Button.destructive(
-          Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertRemove),
+          Text(Strings.Wallet.manageSiteConnectionsConfirmAlertRemove),
           action: {
             siteConnectionStore.removeAllPermissions(from: [siteConnection])
           }

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -29,12 +29,15 @@ struct ManageSiteConnectionsView: View {
           .osAvailabilityModifiers { content in
             if #available(iOS 15.0, *) {
               content
-                .modifier(
-                  SwipeActionsViewModifier_FB9812596 {
+                .swipeActions(edge: .trailing) {
+                  Button(role: .destructive, action: {
                     withAnimation {
                       siteConnectionStore.removeAllPermissions(from: [siteConnection])
                     }
-                  })
+                  }) {
+                    Label(Strings.Wallet.delete, systemImage: "trash")
+                  }
+                }
             } else {
               content
             }
@@ -154,21 +157,6 @@ private struct SiteRow: View {
   }
 }
 
-// Modifier workaround for FB9812596 to avoid crashing on iOS 14 on Release builds
-@available(iOS 15.0, *)
-private struct SwipeActionsViewModifier_FB9812596: ViewModifier {
-  var action: () -> Void
-  
-  func body(content: Content) -> some View {
-    content
-      .swipeActions(edge: .trailing) {
-        Button(role: .destructive, action: action) {
-          Label(Strings.Wallet.delete, systemImage: "trash")
-        }
-      }
-  }
-}
-
 private struct SiteConnectionDetailView: View {
   
   let siteConnection: SiteConnection
@@ -186,14 +174,17 @@ private struct SiteConnectionDetailView: View {
             .osAvailabilityModifiers { content in
               if #available(iOS 15.0, *) {
                 content
-                  .modifier(
-                    SwipeActionsViewModifier_FB9812596 {
+                  .swipeActions(edge: .trailing) {
+                    Button(role: .destructive, action: {
                       withAnimation(.default) {
                         if let url = URL(string: siteConnection.url) {
                           siteConnectionStore.removePermissions(from: [address], url: url)
                         }
                       }
-                    })
+                    }) {
+                      Label(Strings.Wallet.delete, systemImage: "trash")
+                    }
+                  }
               } else {
                 content
               }

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -1,0 +1,134 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveUI
+import SwiftUI
+
+struct ManageSiteConnectionsView: View {
+
+  @ObservedObject var siteConnectionStore: ManageSiteConnectionsStore
+  @State var filterText: String = ""
+  
+  var body: some View {
+    List {
+      ForEach(siteConnectionStore.siteConnections.filter(by: filterText)) { siteConnection in
+        NavigationLink(
+          destination: SiteConnectionDetailView(
+            siteConnection: siteConnection,
+            siteConnectionStore: siteConnectionStore
+          )
+        ) {
+          SiteRow(
+            siteConnection: siteConnection
+          )
+        }
+      }
+      .onDelete { indexes in
+        let visibleSiteConnections = siteConnectionStore.siteConnections.filter(by: filterText)
+        let siteConnectionsToRemove = indexes.map { visibleSiteConnections[$0] }
+        siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
+      }
+    }
+    .listStyle(.insetGrouped)
+    .navigationTitle("Manage Site Connections")
+    .navigationBarTitleDisplayMode(.inline)
+    .filterable(text: $filterText, prompt: "Filter")
+    .toolbar {
+      ToolbarItemGroup(placement: .bottomBar) {
+        Spacer()
+        Button(action: {
+          let visibleSiteConnections = siteConnectionStore.siteConnections.filter(by: filterText)
+          siteConnectionStore.removeAllPermissions(from: visibleSiteConnections)
+          filterText = ""
+        }) {
+          Text("Remove All")
+            .foregroundColor(siteConnectionStore.siteConnections.isEmpty ? Color(.braveDisabled) : .red)
+        }
+        .disabled(siteConnectionStore.siteConnections.isEmpty)
+      }
+    }
+    .onAppear(perform: siteConnectionStore.fetchSiteConnections)
+  }
+}
+
+/*
+#if DEBUG
+struct ManageSiteConnectionsView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      ManageSiteConnectionsView(
+        siteConnectionStore: .init()
+      )
+    }
+  }
+}
+#endif
+*/
+ 
+private struct SiteRow: View {
+
+  let siteConnection: SiteConnection
+
+  private let maxBlockies = 3
+  @ScaledMetric private var blockieSize: CGFloat = 10
+  private let maxBlockieSize: CGFloat = 20
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(verbatim: siteConnection.url)
+        .foregroundColor(Color(.bravePrimary))
+      HStack {
+        if siteConnection.connectedAddresses.count == 1 {
+          Text("1 account")
+            .foregroundColor(Color(.secondaryBraveLabel))
+        } else {
+          Text("\(siteConnection.connectedAddresses.count) accounts")
+            .foregroundColor(Color(.secondaryBraveLabel))
+        }
+        accountBlockies
+        Spacer()
+      }
+    }
+  }
+  
+  @ViewBuilder private var accountBlockies: some View {
+    if siteConnection.connectedAddresses.isEmpty {
+      EmptyView()
+    } else {
+      HStack(spacing: -5) {
+        ForEach(0...min(maxBlockies, siteConnection.connectedAddresses.count - 1), id: \.self) { index in
+          Blockie(address: siteConnection.connectedAddresses[index])
+            .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
+            .zIndex(Double(siteConnection.connectedAddresses.count - index + 1))
+        }
+        if siteConnection.connectedAddresses.count > maxBlockies { // TODO: Fix styling
+          Circle()
+            .foregroundColor(Color.pink)
+            .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
+            .overlay(Text("…"))
+        }
+      }
+    }
+  }
+}
+
+private struct SiteConnectionDetailView: View {
+  
+  let siteConnection: SiteConnection
+  @ObservedObject var siteConnectionStore: ManageSiteConnectionsStore
+  
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
+  var body: some View {
+    List {
+      ForEach(siteConnection.connectedAddresses, id: \.self) { address in
+        Text(address)
+      }
+    }
+    .navigationTitle(siteConnection.url)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -51,6 +51,7 @@ struct ManageSiteConnectionsView: View {
           siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
         }
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(.insetGrouped)
     .navigationTitle(Strings.Wallet.web3PreferencesManageSiteConnections)
@@ -109,16 +110,19 @@ private struct SiteRow: View {
   }
   
   var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
+    VStack(alignment: .leading, spacing: 4) {
       Text(verbatim: siteConnection.url)
-        .foregroundColor(Color(.bravePrimary))
+        .foregroundColor(Color(.braveLabel))
+        .font(.headline)
       HStack {
         Text(connectedAddresses)
+          .font(.subheadline)
           .foregroundColor(Color(.secondaryBraveLabel))
         accountBlockies
-        Spacer()
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
+    .padding(.vertical, 6)
   }
   
   @ViewBuilder private var accountBlockies: some View {
@@ -130,6 +134,7 @@ private struct SiteRow: View {
         ForEach(0..<numberOfBlockies, id: \.self) { index in
           Blockie(address: siteConnection.connectedAddresses[index])
             .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
+            .overlay(Circle().stroke(Color(.secondaryBraveGroupedBackground), lineWidth: 1))
             .zIndex(Double(numberOfBlockies - index))
         }
         if siteConnection.connectedAddresses.count > maxBlockies {
@@ -195,6 +200,7 @@ private struct SiteConnectionDetailView: View {
           }
         }
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .navigationTitle(siteConnection.url)
     .navigationBarTitleDisplayMode(.inline)

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -88,20 +88,6 @@ struct ManageSiteConnectionsView: View {
     filterText = ""
   }
 }
-
-/*
-#if DEBUG
-struct ManageSiteConnectionsView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      ManageSiteConnectionsView(
-        siteConnectionStore: .init()
-      )
-    }
-  }
-}
-#endif
-*/
  
 private struct SiteRow: View {
 

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -73,8 +73,9 @@ private struct SiteRow: View {
   let siteConnection: SiteConnection
 
   private let maxBlockies = 3
-  @ScaledMetric private var blockieSize: CGFloat = 10
-  private let maxBlockieSize: CGFloat = 20
+  @ScaledMetric private var blockieSize: CGFloat = 16
+  private let maxBlockieSize: CGFloat = 32
+  @ScaledMetric private var blockieDotSize: CGFloat = 2
   
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
@@ -98,17 +99,27 @@ private struct SiteRow: View {
     if siteConnection.connectedAddresses.isEmpty {
       EmptyView()
     } else {
-      HStack(spacing: -5) {
-        ForEach(0...min(maxBlockies, siteConnection.connectedAddresses.count - 1), id: \.self) { index in
+      HStack(spacing: -(min(blockieSize, maxBlockieSize) / 2)) {
+        ForEach(0..<min(maxBlockies, siteConnection.connectedAddresses.count - 1), id: \.self) { index in
           Blockie(address: siteConnection.connectedAddresses[index])
             .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
             .zIndex(Double(siteConnection.connectedAddresses.count - index + 1))
         }
-        if siteConnection.connectedAddresses.count > maxBlockies { // TODO: Fix styling
+        if siteConnection.connectedAddresses.count > maxBlockies {
           Circle()
-            .foregroundColor(Color.pink)
+            .foregroundColor(Color(.braveBlurple))
             .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-            .overlay(Text("…"))
+            .overlay(
+              HStack(spacing: 1) {
+                Circle()
+                  .frame(width: blockieDotSize, height: blockieDotSize)
+                Circle()
+                  .frame(width: blockieDotSize, height: blockieDotSize)
+                Circle()
+                  .frame(width: blockieDotSize, height: blockieDotSize)
+              }
+                .foregroundColor(.white)
+            )
         }
       }
     }

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -6,11 +6,13 @@
 import Foundation
 import BraveUI
 import SwiftUI
+import struct Shared.Strings
 
 struct ManageSiteConnectionsView: View {
 
   @ObservedObject var siteConnectionStore: ManageSiteConnectionsStore
-  @State var filterText: String = ""
+  @State private var filterText: String = ""
+  @State private var isShowingConfirmAlert: Bool = false
   
   var body: some View {
     List {
@@ -40,9 +42,7 @@ struct ManageSiteConnectionsView: View {
       ToolbarItemGroup(placement: .bottomBar) {
         Spacer()
         Button(action: {
-          let visibleSiteConnections = siteConnectionStore.siteConnections.filter(by: filterText)
-          siteConnectionStore.removeAllPermissions(from: visibleSiteConnections)
-          filterText = ""
+          isShowingConfirmAlert = true
         }) {
           Text("Remove All")
             .foregroundColor(siteConnectionStore.siteConnections.isEmpty ? Color(.braveDisabled) : .red)
@@ -51,6 +51,23 @@ struct ManageSiteConnectionsView: View {
       }
     }
     .onAppear(perform: siteConnectionStore.fetchSiteConnections)
+    .alert(isPresented: $isShowingConfirmAlert) {
+      Alert(
+        title: Text("Are you sure you wish to remove all permissions?"),
+        message: Text("This will remove all Wallet connection permissions for all websites."), // TODO: copy
+        primaryButton: Alert.Button.destructive(
+          Text("Remove"),
+          action: removeAll
+        ),
+        secondaryButton: Alert.Button.cancel(Text(Strings.CancelString))
+      )
+    }
+  }
+  
+  func removeAll() {
+    let visibleSiteConnections = siteConnectionStore.siteConnections.filter(by: filterText)
+    siteConnectionStore.removeAllPermissions(from: visibleSiteConnections)
+    filterText = ""
   }
 }
 

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -117,10 +117,11 @@ private struct SiteRow: View {
       EmptyView()
     } else {
       HStack(spacing: -(min(blockieSize, maxBlockieSize) / 2)) {
-        ForEach(0..<min(maxBlockies, siteConnection.connectedAddresses.count - 1), id: \.self) { index in
+        let numberOfBlockies = min(maxBlockies, siteConnection.connectedAddresses.count)
+        ForEach(0..<numberOfBlockies, id: \.self) { index in
           Blockie(address: siteConnection.connectedAddresses[index])
             .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-            .zIndex(Double(siteConnection.connectedAddresses.count - index + 1))
+            .zIndex(Double(numberOfBlockies - index))
         }
         if siteConnection.connectedAddresses.count > maxBlockies {
           Circle()

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -50,16 +50,16 @@ struct ManageSiteConnectionsView: View {
       }
     }
     .listStyle(.insetGrouped)
-    .navigationTitle("Manage Site Connections")
+    .navigationTitle(Strings.Wallet.mangeSiteConnectionsTitle)
     .navigationBarTitleDisplayMode(.inline)
-    .filterable(text: $filterText, prompt: "Filter")
+    .filterable(text: $filterText, prompt: Strings.Wallet.mangeSiteConnectionsFilterPlaceholder)
     .toolbar {
       ToolbarItemGroup(placement: .bottomBar) {
         Spacer()
         Button(action: {
           isShowingConfirmAlert = true
         }) {
-          Text("Remove All")
+          Text(Strings.Wallet.mangeSiteConnectionsRemoveAll)
             .foregroundColor(siteConnectionStore.siteConnections.isEmpty ? Color(.braveDisabled) : .red)
         }
         .disabled(siteConnectionStore.siteConnections.isEmpty)
@@ -68,10 +68,10 @@ struct ManageSiteConnectionsView: View {
     .onAppear(perform: siteConnectionStore.fetchSiteConnections)
     .alert(isPresented: $isShowingConfirmAlert) {
       Alert(
-        title: Text("Are you sure you wish to remove all permissions?"),
-        message: Text("This will remove all Wallet connection permissions for all websites."), // TODO: copy
+        title: Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertTitle),
+        message: Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertMessage),
         primaryButton: Alert.Button.destructive(
-          Text("Remove"),
+          Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertRemove),
           action: removeAll
         ),
         secondaryButton: Alert.Button.cancel(Text(Strings.CancelString))
@@ -114,13 +114,8 @@ private struct SiteRow: View {
       Text(verbatim: siteConnection.url)
         .foregroundColor(Color(.bravePrimary))
       HStack {
-        if siteConnection.connectedAddresses.count == 1 {
-          Text("1 account")
-            .foregroundColor(Color(.secondaryBraveLabel))
-        } else {
-          Text("\(siteConnection.connectedAddresses.count) accounts")
-            .foregroundColor(Color(.secondaryBraveLabel))
-        }
+        Text(String.localizedStringWithFormat(Strings.Wallet.manageSiteConnectionsAccount, siteConnection.connectedAddresses.count, siteConnection.connectedAddresses.count == 1 ? Strings.Wallet.manageSiteConnectionsAccountSingular : Strings.Wallet.manageSiteConnectionsAccountPlural))
+          .foregroundColor(Color(.secondaryBraveLabel))
         accountBlockies
         Spacer()
       }
@@ -185,7 +180,7 @@ private struct SiteConnectionDetailView: View {
   
   var body: some View {
     List {
-      Section(header: Text("Connected Ethereum Accounts")) {
+      Section(header: Text(Strings.Wallet.manageSiteConnectionsDetailHeader)) {
         ForEach(siteConnection.connectedAddresses, id: \.self) { address in
           AccountView(address: address, name: siteConnectionStore.accountInfo(for: address)?.name ?? "")
             .osAvailabilityModifiers { content in
@@ -222,17 +217,17 @@ private struct SiteConnectionDetailView: View {
         Button(action: {
           isShowingConfirmAlert = true
         }) {
-          Text("Remove All")
+          Text(Strings.Wallet.mangeSiteConnectionsRemoveAll)
             .foregroundColor(siteConnectionStore.siteConnections.isEmpty ? Color(.braveDisabled) : .red)
         }
       }
     }
     .alert(isPresented: $isShowingConfirmAlert) {
       Alert(
-        title: Text("Are you sure you wish to remove all permissions?"),
-        message: Text("This will remove all Wallet connection permissions for this website."),
+        title: Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertTitle),
+        message: Text(Strings.Wallet.mangeSiteConnectionsDetailConfirmAlertMessage),
         primaryButton: Alert.Button.destructive(
-          Text("Remove"),
+          Text(Strings.Wallet.mangeSiteConnectionsConfirmAlertRemove),
           action: {
             siteConnectionStore.removeAllPermissions(from: [siteConnection])
           }

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -94,16 +94,26 @@ private struct SiteRow: View {
   let siteConnection: SiteConnection
 
   private let maxBlockies = 3
-  @ScaledMetric private var blockieSize: CGFloat = 16
+  @ScaledMetric private var blockieSize = 16.0
   private let maxBlockieSize: CGFloat = 32
-  @ScaledMetric private var blockieDotSize: CGFloat = 2
+  @ScaledMetric private var blockieDotSize = 2.0
+  
+  private var connectedAddresses: String {
+    let account = Strings.Wallet.manageSiteConnectionsAccountSingular
+    let accounts = Strings.Wallet.manageSiteConnectionsAccountPlural
+    return String.localizedStringWithFormat(
+      Strings.Wallet.manageSiteConnectionsAccount,
+      siteConnection.connectedAddresses.count,
+      siteConnection.connectedAddresses.count == 1 ? account : accounts
+    )
+  }
   
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       Text(verbatim: siteConnection.url)
         .foregroundColor(Color(.bravePrimary))
       HStack {
-        Text(String.localizedStringWithFormat(Strings.Wallet.manageSiteConnectionsAccount, siteConnection.connectedAddresses.count, siteConnection.connectedAddresses.count == 1 ? Strings.Wallet.manageSiteConnectionsAccountSingular : Strings.Wallet.manageSiteConnectionsAccountPlural))
+        Text(connectedAddresses)
           .foregroundColor(Color(.secondaryBraveLabel))
         accountBlockies
         Spacer()

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -128,7 +128,7 @@ public struct WalletSettingsView: View {
         Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
           .foregroundColor(Color(.braveLabel))
           .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-        NavigationLink(destination: ManageSiteConnectionsView(siteConnectionStore: .init())) {
+        NavigationLink(destination: ManageSiteConnectionsView(siteConnectionStore: .init(keyringStore: keyringStore))) {
           Text(Strings.Wallet.web3PreferencesManageSiteConnections)
             .foregroundColor(Color(.braveLabel))
         }

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -111,15 +111,7 @@ public struct WalletSettingsView: View {
           Menu {
             ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
               Button(action: {
-                if defaultWallet.value != walletType.rawValue {
-                  defaultWallet.value = walletType.rawValue
-                  switch walletType {
-                  case .none:
-                    break
-                  case .brave:
-                    break
-                  }
-                }
+                defaultWallet.value = walletType.rawValue
               }) {
                 Text(walletType.name)
               }

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -128,7 +128,7 @@ public struct WalletSettingsView: View {
         Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
           .foregroundColor(Color(.braveLabel))
           .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-        NavigationLink(destination: EmptyView()) {
+        NavigationLink(destination: ManageSiteConnectionsView(siteConnectionStore: .init())) {
           Text(Strings.Wallet.web3PreferencesManageSiteConnections)
             .foregroundColor(Color(.braveLabel))
         }

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -6,11 +6,15 @@
 import SwiftUI
 import struct Shared.Strings
 import BraveUI
+import BraveShared
 
 public struct WalletSettingsView: View {
   @ObservedObject var settingsStore: SettingsStore
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var defaultWallet = Preferences.Wallet.defaultWallet
+  @ObservedObject var allowDappsRequestAccounts = Preferences.Wallet.allowEthereumProviderAccountRequests
+  @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
 
   @State private var isShowingResetWalletAlert = false
   @State private var isShowingResetTransactionAlert = false
@@ -81,7 +85,7 @@ public struct WalletSettingsView: View {
                           set: { toggledBiometricsUnlock($0) })
           )
             .foregroundColor(Color(.braveLabel))
-            .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+            .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
@@ -95,6 +99,50 @@ public struct WalletSettingsView: View {
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      #if WALLET_DAPPS_ENABLED
+      Section(
+        header: Text(Strings.Wallet.web3PreferencesSectionTitle)
+          .foregroundColor(Color(.secondaryBraveLabel))
+      ) {
+        HStack {
+          Text(Strings.Wallet.web3PreferencesDefaultWallet)
+            .foregroundColor(Color(.braveLabel))
+          Spacer()
+          Menu {
+            ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
+              Button(action: {
+                if defaultWallet.value != walletType.rawValue {
+                  defaultWallet.value = walletType.rawValue
+                  switch walletType {
+                  case .none:
+                    break
+                  case .brave:
+                    break
+                  }
+                }
+              }) {
+                Text(walletType.name)
+              }
+            }
+          } label: {
+            let wallet = Preferences.Wallet.WalletType(rawValue: defaultWallet.value) ?? .none
+            Text(wallet.name)
+              .foregroundColor(Color(.braveBlurpleTint))
+          }
+        }
+        Toggle(Strings.Wallet.web3PreferencesAllowSiteToRequestAccounts, isOn: $allowDappsRequestAccounts.value)
+          .foregroundColor(Color(.braveLabel))
+          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+        Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
+          .foregroundColor(Color(.braveLabel))
+          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+        NavigationLink(destination: EmptyView()) {
+          Text(Strings.Wallet.web3PreferencesManageSiteConnections)
+            .foregroundColor(Color(.braveLabel))
+        }
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      #endif
       Section(
         footer: Text(Strings.Wallet.settingsResetTransactionFooter)
           .foregroundColor(Color(.secondaryBraveLabel))

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -109,13 +109,13 @@ public struct WalletSettingsView: View {
             .foregroundColor(Color(.braveLabel))
           Spacer()
           Menu {
-            ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
-              Button(action: {
-                defaultWallet.value = walletType.rawValue
-              }) {
+            Picker("", selection: $defaultWallet.value) {
+              ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
                 Text(walletType.name)
+                  .tag(walletType)
               }
             }
+            .pickerStyle(.inline)
           } label: {
             let wallet = Preferences.Wallet.WalletType(rawValue: defaultWallet.value) ?? .none
             Text(wallet.name)

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -128,7 +128,14 @@ public struct WalletSettingsView: View {
         Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
           .foregroundColor(Color(.braveLabel))
           .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-        NavigationLink(destination: ManageSiteConnectionsView(siteConnectionStore: .init(keyringStore: keyringStore))) {
+        NavigationLink(
+          destination: ManageSiteConnectionsView(
+            siteConnectionStore: settingsStore.manageSiteConnectionsStore(keyringStore: keyringStore)
+          )
+          .onDisappear {
+            settingsStore.closeManageSiteConnectionStore()
+          }
+        ) {
           Text(Strings.Wallet.web3PreferencesManageSiteConnections)
             .foregroundColor(Color(.braveLabel))
         }

--- a/BraveWallet/WalletPreferences.swift
+++ b/BraveWallet/WalletPreferences.swift
@@ -33,6 +33,6 @@ extension Preferences {
       default: true
     )
     /// The option to display web3 notification
-    public static let displayWeb3Notifications = Option<Bool>(key: "wallet.display-web3-notifications", default: false)
+    public static let displayWeb3Notifications = Option<Bool>(key: "wallet.display-web3-notifications", default: true)
   }
 }

--- a/BraveWallet/WalletPreferences.swift
+++ b/BraveWallet/WalletPreferences.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import BraveShared
+import struct Shared.Strings
 
 extension Preferences {
   public final class Wallet {
@@ -18,9 +19,9 @@ extension Preferences {
       public var name: String {
         switch self {
         case .none:
-          return "None"
+          return Strings.Wallet.walletTypeNone
         case .brave:
-          return "Brave Wallet"
+          return Strings.Wallet.braveWallet
         }
       }
     }

--- a/BraveWallet/WalletPreferences.swift
+++ b/BraveWallet/WalletPreferences.swift
@@ -7,10 +7,31 @@ import BraveShared
 
 extension Preferences {
   public final class Wallet {
+    public enum WalletType: Int, Identifiable, CaseIterable {
+      case none
+      case brave
+      
+      public var id: Int {
+        rawValue
+      }
+      
+      public var name: String {
+        switch self {
+        case .none:
+          return "None"
+        case .brave:
+          return "Brave Wallet"
+        }
+      }
+    }
+    /// The options of wallet to be communicate with web3
+    public static let defaultWallet = Option<Int>(key: "wallet.default-wallet", default: WalletType.brave.rawValue)
     /// Whether or not webpages can use the Ethereum Provider API to communicate with users ethereum wallet
     public static let allowEthereumProviderAccountRequests: Option<Bool> = .init(
       key: "wallet.allow-eth-provider-account-requests",
       default: true
     )
+    /// The option to display web3 notification
+    public static let displayWeb3Notifications = Option<Bool>(key: "wallet.display-web3-notifications", default: false)
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2262,5 +2262,82 @@ extension Strings {
       value: "Manage site connections",
       comment: "The title for the entry that by clicking will direct users to the screen to manage web3 sites account connections."
     )
+    public static let mangeSiteConnectionsTitle = NSLocalizedString(
+      "wallet.mangeSiteConnectionsTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Manage Site Connections",
+      comment: "The title for the screen to manage web3 sites account connections."
+    )
+    public static let mangeSiteConnectionsFilterPlaceholder = NSLocalizedString(
+      "wallet.mangeSiteConnectionsFilterPlaceholder",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Filter",
+      comment: "The filter in the search bar for the screen to manage web3 sites account connections."
+    )
+    public static let mangeSiteConnectionsRemoveAll = NSLocalizedString(
+      "wallet.mangeSiteConnectionsRemoveAll",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Remove All",
+      comment: "The title of the button on the screen to manage web3 sites account connections that will show an alert to remove all connected website permissions."
+    )
+    public static let mangeSiteConnectionsConfirmAlertTitle = NSLocalizedString(
+      "wallet.mangeSiteConnectionsConfirmAlertTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Are you sure you wish to remove all permissions?",
+      comment: "The title of the alert to confirm the users wants to remove all site connections, shown on the screen to manage web3 sites account connections."
+    )
+    public static let mangeSiteConnectionsConfirmAlertMessage = NSLocalizedString(
+      "wallet.mangeSiteConnectionsConfirmAlertMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "This will remove all Wallet connection permissions for all websites.",
+      comment: "The message of the alert to confirm the users wants to remove all site connections, shown on the screen to manage web3 sites account connections."
+    )
+    public static let mangeSiteConnectionsDetailConfirmAlertMessage = NSLocalizedString(
+      "wallet.mangeSiteConnectionsDetailConfirmAlertMessage",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "This will remove all Wallet connection permissions for this website.",
+      comment: "The message of the alert to confirm the users wants to remove all site connections from this specific website, shown after selecting/opening a website on the screen to manage web3 sites account connections."
+    )
+    public static let mangeSiteConnectionsConfirmAlertRemove = NSLocalizedString(
+      "wallet.mangeSiteConnectionsConfirmAlertRemove",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Remove",
+      comment: "The title of the confirmation button in the alert to confirm the users wants to remove all site connections, shown on the screen to manage web3 sites account connections."
+    )
+    public static let manageSiteConnectionsAccount = NSLocalizedString(
+      "wallet.manageSiteConnectionsAccount",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "%lld %@",
+      comment: "The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in manage site connections screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account\" or \"2 accounts\")"
+    )
+    public static let manageSiteConnectionsAccountSingular = NSLocalizedString(
+      "wallet.manageSiteConnectionsAccountSingular",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "account",
+      comment: "The singular word that will be used in `manageSiteConnectionsAccount`."
+    )
+    public static let manageSiteConnectionsAccountPlural = NSLocalizedString(
+      "wallet.manageSiteConnectionsAccountPlural",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "accounts",
+      comment: "The plural word that will beused in `manageSiteConnectionsAccount`."
+    )
+    public static let manageSiteConnectionsDetailHeader = NSLocalizedString(
+      "wallet.manageSiteConnectionsDetailHeader",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Connected Ethereum Accounts",
+      comment: "The header shown above the list of connected accounts for a single website, shown after selecting/opening a website on the screen to manage web3 sites account connections."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2245,67 +2245,60 @@ extension Strings {
       "wallet.web3PreferencesAllowSiteToRequestAccounts",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Allow site to request accounts",
+      value: "Allow Sites to Request Accounts",
       comment: "The title for the entry displaying the preferred option to allow web3 sites to rquest account's permission."
     )
     public static let web3PreferencesDisplayWeb3Notifications = NSLocalizedString(
       "wallet.web3PreferencesDisplayWeb3Notifications",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Display Web3 notifications",
+      value: "Display Web3 Notifications",
       comment: "The title for the entry displaying the preferred option to display web3 site notifications."
     )
     public static let web3PreferencesManageSiteConnections = NSLocalizedString(
       "wallet.web3PreferencesManageSiteConnections",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Manage site connections",
-      comment: "The title for the entry that by clicking will direct users to the screen to manage web3 sites account connections."
-    )
-    public static let mangeSiteConnectionsTitle = NSLocalizedString(
-      "wallet.mangeSiteConnectionsTitle",
-      tableName: "BraveWallet",
-      bundle: .braveWallet,
       value: "Manage Site Connections",
-      comment: "The title for the screen to manage web3 sites account connections."
+      comment: "The title for the entry that by clicking will direct users to the screen to manage web3 sites account connections, and the title for the Manage Site Connections screen."
     )
-    public static let mangeSiteConnectionsFilterPlaceholder = NSLocalizedString(
-      "wallet.mangeSiteConnectionsFilterPlaceholder",
+    public static let manageSiteConnectionsFilterPlaceholder = NSLocalizedString(
+      "wallet.manageSiteConnectionsFilterPlaceholder",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Filter",
       comment: "The filter in the search bar for the screen to manage web3 sites account connections."
     )
-    public static let mangeSiteConnectionsRemoveAll = NSLocalizedString(
-      "wallet.mangeSiteConnectionsRemoveAll",
+    public static let manageSiteConnectionsRemoveAll = NSLocalizedString(
+      "wallet.manageSiteConnectionsRemoveAll",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Remove All",
       comment: "The title of the button on the screen to manage web3 sites account connections that will show an alert to remove all connected website permissions."
     )
-    public static let mangeSiteConnectionsConfirmAlertTitle = NSLocalizedString(
-      "wallet.mangeSiteConnectionsConfirmAlertTitle",
+    public static let manageSiteConnectionsConfirmAlertTitle = NSLocalizedString(
+      "wallet.manageSiteConnectionsConfirmAlertTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Remove all permissions?",
       comment: "The title of the alert to confirm the users wants to remove all site connections, shown on the screen to manage web3 sites account connections."
     )
-    public static let mangeSiteConnectionsConfirmAlertMessage = NSLocalizedString(
-      "wallet.mangeSiteConnectionsConfirmAlertMessage",
+    public static let manageSiteConnectionsConfirmAlertMessage = NSLocalizedString(
+      "wallet.manageSiteConnectionsConfirmAlertMessage",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "This will remove all Wallet connection permissions for all websites.",
       comment: "The message of the alert to confirm the users wants to remove all site connections, shown on the screen to manage web3 sites account connections."
     )
-    public static let mangeSiteConnectionsDetailConfirmAlertMessage = NSLocalizedString(
-      "wallet.mangeSiteConnectionsDetailConfirmAlertMessage",
+    public static let manageSiteConnectionsDetailConfirmAlertMessage = NSLocalizedString(
+      "wallet.manageSiteConnectionsDetailConfirmAlertMessage",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "This will remove all Wallet connection permissions for this website.",
       comment: "The message of the alert to confirm the users wants to remove all site connections from this specific website, shown after selecting/opening a website on the screen to manage web3 sites account connections."
     )
-    public static let mangeSiteConnectionsConfirmAlertRemove = NSLocalizedString(
-      "wallet.mangeSiteConnectionsConfirmAlertRemove",
+    public static let manageSiteConnectionsConfirmAlertRemove = NSLocalizedString(
+      "wallet.manageSiteConnectionsConfirmAlertRemove",
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Remove",

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2227,5 +2227,40 @@ extension Strings {
       value: "Sign",
       comment: "The title of the button used to sign a message request on the signature request view."
     )
+    public static let web3PreferencesSectionTitle = NSLocalizedString(
+      "wallet.web3PreferencesSectionTitle",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Web3 preferences",
+      comment: "The section title for users to set up preferences for interation with web3 sites."
+    )
+    public static let web3PreferencesDefaultWallet = NSLocalizedString(
+      "wallet.web3PreferencesDefaultWallet",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Default Wallet",
+      comment: "The title for the entry displaying the current preferred default wallet is."
+    )
+    public static let web3PreferencesAllowSiteToRequestAccounts = NSLocalizedString(
+      "wallet.web3PreferencesAllowSiteToRequestAccounts",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Allow site to request accounts",
+      comment: "The title for the entry displaying the preferred option to allow web3 sites to rquest account's permission."
+    )
+    public static let web3PreferencesDisplayWeb3Notifications = NSLocalizedString(
+      "wallet.web3PreferencesDisplayWeb3Notifications",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Display Web3 notifications",
+      comment: "The title for the entry displaying the preferred option to display web3 site notifications."
+    )
+    public static let web3PreferencesManageSiteConnections = NSLocalizedString(
+      "wallet.web3PreferencesManageSiteConnections",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "Manage site connections",
+      comment: "The title for the entry that by clicking will direct users to the screen to manage web3 sites account connections."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2287,7 +2287,7 @@ extension Strings {
       "wallet.mangeSiteConnectionsConfirmAlertTitle",
       tableName: "BraveWallet",
       bundle: .braveWallet,
-      value: "Are you sure you wish to remove all permissions?",
+      value: "Remove all permissions?",
       comment: "The title of the alert to confirm the users wants to remove all site connections, shown on the screen to manage web3 sites account connections."
     )
     public static let mangeSiteConnectionsConfirmAlertMessage = NSLocalizedString(

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -13,7 +13,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .braveWallet,
       value: "Brave Wallet",
-      comment: "The title shown on the wallet settings page."
+      comment: "The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings."
     )
     public static let wallet = NSLocalizedString(
       "wallet.wallet",
@@ -2331,6 +2331,13 @@ extension Strings {
       bundle: .braveWallet,
       value: "Connected Ethereum Accounts",
       comment: "The header shown above the list of connected accounts for a single website, shown after selecting/opening a website on the screen to manage web3 sites account connections."
+    )
+    public static let walletTypeNone = NSLocalizedString(
+      "wallet.walletTypeNone",
+      tableName: "BraveWallet",
+      bundle: .braveWallet,
+      value: "None",
+      comment: "The value shown when selecting the default wallet as none / no wallet in wallet settings."
     )
   }
 }

--- a/BraveWalletTests/ManageSiteConnectionsStoreTests.swift
+++ b/BraveWalletTests/ManageSiteConnectionsStoreTests.swift
@@ -1,0 +1,132 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Combine
+import XCTest
+import BraveCore
+import Data
+@testable import BraveWallet
+
+class ManageSiteConnectionsStoreTests: CoreDataTestCase {
+
+  let compound = URL(string: "https://compound.finance")!
+  let polygon = URL(string: "https://wallet.polygon.technology")!
+  let walletAccount = "0x4D60d71F411AB671f614eD0ec5B71bEedB46287d"
+  let walletAccount2 = "0x4d60d71f411ab671f614ed0ec5b71beedb46287d"
+  var cancellables: Set<AnyCancellable> = .init()
+  
+  override func setUp() {
+    super.setUp()
+    let compondDomain = Domain.getOrCreate(forUrl: compound, persistent: true)
+    let polygonDomain = Domain.getOrCreate(forUrl: polygon, persistent: true)
+
+    // add permissions for `compound` Domain
+    backgroundSaveAndWaitForExpectation {
+      Domain.setEthereumPermissions(forUrl: compound, accounts: [walletAccount, walletAccount2], grant: true)
+    }
+    XCTAssertTrue(compondDomain.ethereumPermissions(for: walletAccount))
+    // add permissions for `polygon` Domain
+    backgroundSaveAndWaitForExpectation {
+      Domain.setEthereumPermissions(forUrl: polygon, accounts: [walletAccount, walletAccount2], grant: true)
+    }
+    XCTAssertTrue(polygonDomain.ethereumPermissions(for: walletAccount))
+  }
+  
+  func testFetchSiteConnections() {
+    // Domains added with Ethereum permissions in `setUp()`
+    let store = ManageSiteConnectionsStore()
+    
+    // verify `siteConnections` is updated when `fetchSiteConnections()` is called
+    let siteConnectionsException = expectation(description: "siteConnections")
+    XCTAssertTrue(store.siteConnections.isEmpty)  // Initial state
+    store.$siteConnections
+      .dropFirst()
+      .first()
+      .sink { siteConnections in
+        defer { siteConnectionsException.fulfill() }
+        XCTAssertEqual(siteConnections[0], .init(url: self.polygon.absoluteString, connectedAddresses: [self.walletAccount, self.walletAccount2]))
+        XCTAssertEqual(siteConnections[1], .init(url: self.compound.absoluteString, connectedAddresses: [self.walletAccount, self.walletAccount2]))
+      }.store(in: &cancellables)
+    
+    store.fetchSiteConnections()
+
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test `removeAllPermissions(from:)` will remove all permissions from the given `SiteConnections` array
+  func testRemoveAllPermissions() {
+    // Domains added with Ethereum permissions in `setUp()`
+    let store = ManageSiteConnectionsStore()
+    store.fetchSiteConnections()
+    XCTAssertEqual(store.siteConnections.count, 2)
+    
+    // remove permissions
+    let siteConnectionToRemove = store.siteConnections[0]
+    backgroundSaveAndWaitForExpectation {
+      store.removeAllPermissions(from: [siteConnectionToRemove])
+    }
+    // verify `siteConnections` is updated
+    XCTAssertEqual(store.siteConnections.count, 1)
+    XCTAssertNotEqual(store.siteConnections[0].url, siteConnectionToRemove.url)
+    // verify `Domain` data is removed
+    let domain = Domain.getOrCreate(forUrl: URL(string: siteConnectionToRemove.url)!, persistent: true)
+    XCTAssertFalse(domain.ethereumPermissions(for: walletAccount))
+    XCTAssertFalse(domain.ethereumPermissions(for: walletAccount2))
+  }
+  
+  /// Test `removePermissions(from:url:)` will remove the given account permissions for the given url
+  func testRemovePermissions() {
+    // Domains added with Ethereum permissions in `setUp()`
+    let store = ManageSiteConnectionsStore()
+    store.fetchSiteConnections()
+    XCTAssertEqual(store.siteConnections.count, 2)
+    
+    // remove some account permissions but not all
+    let siteConnectionToRemoveAccount = store.siteConnections[1]
+    XCTAssertEqual(siteConnectionToRemoveAccount.connectedAddresses.count, 2)
+    backgroundSaveAndWaitForExpectation {
+      store.removePermissions(from: [walletAccount], url: URL(string: siteConnectionToRemoveAccount.url)!)
+    }
+    
+    // verify `siteConnections` is updated to remove specific accounts from the `SiteConnection`
+    XCTAssertEqual(store.siteConnections.count, 2)
+    XCTAssertEqual(store.siteConnections[1].connectedAddresses.count, 1)
+    XCTAssertFalse(store.siteConnections[1].connectedAddresses.contains(walletAccount))
+    
+    // verify `Domain` data is updated
+    let domain = Domain.getOrCreate(forUrl: URL(string: siteConnectionToRemoveAccount.url)!, persistent: true)
+    XCTAssertFalse(domain.ethereumPermissions(for: walletAccount))
+  }
+  
+  /// Test `removePermissions(from:url:)` will remove the `SiteConnection` from `siteConnections` when the last connected account is removed
+  func testRemovePermissionsLastPermission() {
+    // Domains added with Ethereum permissions in `setUp()`
+    let store = ManageSiteConnectionsStore()
+    store.fetchSiteConnections()
+    XCTAssertEqual(store.siteConnections.count, 2)
+    
+    // remove `walletAccount` permissions for this `SiteConnection`
+    let siteConnectionToRemove = store.siteConnections[0]
+    XCTAssertEqual(siteConnectionToRemove.connectedAddresses.count, 2)
+    backgroundSaveAndWaitForExpectation {
+      store.removePermissions(from: [walletAccount], url: URL(string: siteConnectionToRemove.url)!)
+    }
+    // remove `walletAccount2` permissions for this `SiteConnection`
+    XCTAssertEqual(store.siteConnections[0].connectedAddresses.count, 1)
+    backgroundSaveAndWaitForExpectation {
+      store.removePermissions(from: [walletAccount2], url: URL(string: siteConnectionToRemove.url)!)
+    }
+    
+    // verify `siteConnections` is updated to remove the `SiteConnection` as all `connectedAddresses` are removed
+    XCTAssertEqual(store.siteConnections.count, 1)
+    XCTAssertNotEqual(store.siteConnections[0].url, siteConnectionToRemove.url)
+    
+    // verify `Domain` data is removed
+    let domain = Domain.getOrCreate(forUrl: URL(string: siteConnectionToRemove.url)!, persistent: true)
+    XCTAssertFalse(domain.ethereumPermissions(for: walletAccount))
+  }
+}

--- a/BraveWalletTests/ManageSiteConnectionsStoreTests.swift
+++ b/BraveWalletTests/ManageSiteConnectionsStoreTests.swift
@@ -36,7 +36,7 @@ class ManageSiteConnectionsStoreTests: CoreDataTestCase {
   
   func testFetchSiteConnections() {
     // Domains added with Ethereum permissions in `setUp()`
-    let store = ManageSiteConnectionsStore()
+    let store = ManageSiteConnectionsStore(keyringStore: .previewStore)
     
     // verify `siteConnections` is updated when `fetchSiteConnections()` is called
     let siteConnectionsException = expectation(description: "siteConnections")
@@ -60,7 +60,7 @@ class ManageSiteConnectionsStoreTests: CoreDataTestCase {
   /// Test `removeAllPermissions(from:)` will remove all permissions from the given `SiteConnections` array
   func testRemoveAllPermissions() {
     // Domains added with Ethereum permissions in `setUp()`
-    let store = ManageSiteConnectionsStore()
+    let store = ManageSiteConnectionsStore(keyringStore: .previewStore)
     store.fetchSiteConnections()
     XCTAssertEqual(store.siteConnections.count, 2)
     
@@ -81,7 +81,7 @@ class ManageSiteConnectionsStoreTests: CoreDataTestCase {
   /// Test `removePermissions(from:url:)` will remove the given account permissions for the given url
   func testRemovePermissions() {
     // Domains added with Ethereum permissions in `setUp()`
-    let store = ManageSiteConnectionsStore()
+    let store = ManageSiteConnectionsStore(keyringStore: .previewStore)
     store.fetchSiteConnections()
     XCTAssertEqual(store.siteConnections.count, 2)
     
@@ -105,7 +105,7 @@ class ManageSiteConnectionsStoreTests: CoreDataTestCase {
   /// Test `removePermissions(from:url:)` will remove the `SiteConnection` from `siteConnections` when the last connected account is removed
   func testRemovePermissionsLastPermission() {
     // Domains added with Ethereum permissions in `setUp()`
-    let store = ManageSiteConnectionsStore()
+    let store = ManageSiteConnectionsStore(keyringStore: .previewStore)
     store.fetchSiteConnections()
     XCTAssertEqual(store.siteConnections.count, 2)
     

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1217,6 +1217,10 @@
 		D552E6922807231F00A847F3 /* Data.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1DC51320AC9AF900905E5A /* Data.framework */; };
 		D59CA29F282AE0FB00D02BEF /* FavIconImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CA29E282AE0FB00D02BEF /* FavIconImageRenderer.swift */; };
 		D59CA2B7282AE54500D02BEF /* OriginText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CA2B6282AE54500D02BEF /* OriginText.swift */; };
+		D51DFA9428173CCA00F92818 /* ManageSiteConnectionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51DFA9328173CCA00F92818 /* ManageSiteConnectionsStore.swift */; };
+		D51DFAA028173CE300F92818 /* ManageSiteConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51DFA9F28173CE300F92818 /* ManageSiteConnectionsView.swift */; };
+		D51DFAA52817406C00F92818 /* ManageSiteConnectionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51DFAA42817406C00F92818 /* ManageSiteConnectionsStoreTests.swift */; };
+		D51DFACB281838DA00F92818 /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF3B4E5213D8E3200695962 /* CoreDataTestCase.swift */; };
 		D5A691EC27DF93AD000CC4B3 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */; };
 		D5ACA7CE27FB7D08002443CE /* BraveCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; };
 		D5ACA7D927FB7D0E002443CE /* MaterialComponents.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; };
@@ -3035,6 +3039,7 @@
 		D59CA2B6282AE54500D02BEF /* OriginText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginText.swift; sourceTree = "<group>"; };
 		D51DFA9328173CCA00F92818 /* ManageSiteConnectionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSiteConnectionsStore.swift; sourceTree = "<group>"; };
 		D51DFA9F28173CE300F92818 /* ManageSiteConnectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSiteConnectionsView.swift; sourceTree = "<group>"; };
+		D51DFAA42817406C00F92818 /* ManageSiteConnectionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSiteConnectionsStoreTests.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsPasscodeEntryView.swift; sourceTree = "<group>"; };
 		D5EFCB3827FF81AA00BD151D /* EditPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPermissionsView.swift; sourceTree = "<group>"; };
@@ -4126,6 +4131,7 @@
 				7DF911BF276A8D1600EF0D8B /* SwapTokenStoreTests.swift */,
 				D51CD9C627DBC6A600C01104 /* PortfolioStoreTests.swift */,
 				D511314A2800C16100C81683 /* TransactionConfirmationStoreTests.swift */,
+				D51DFAA42817406C00F92818 /* ManageSiteConnectionsStoreTests.swift */,
 				277309E72721DF6D007643F6 /* WeiFormatterTests.swift */,
 				27EA1B0D2729E6C8003C5CF9 /* AddressTests.swift */,
 				7DC52B1E273D9D230067E237 /* WalletArrayExtensionTests.swift */,
@@ -7777,6 +7783,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D51DFACB281838DA00F92818 /* CoreDataTestCase.swift in Sources */,
 				2792CBD5275952C40055151E /* PasteboardTests.swift in Sources */,
 				279115422755597200033843 /* SendTokenStoreTests.swift in Sources */,
 				D51CD9C727DBC6A600C01104 /* PortfolioStoreTests.swift in Sources */,
@@ -7784,6 +7791,7 @@
 				7DF911DF27726E5E00EF0D8B /* BuyTokenStoreTest.swift in Sources */,
 				7DC52B1F273D9D230067E237 /* WalletArrayExtensionTests.swift in Sources */,
 				D511314B2800C16100C81683 /* TransactionConfirmationStoreTests.swift in Sources */,
+				D51DFAA52817406C00F92818 /* ManageSiteConnectionsStoreTests.swift in Sources */,
 				7DF911C0276A8D1600EF0D8B /* SwapTokenStoreTests.swift in Sources */,
 				277309E82721DF6D007643F6 /* WeiFormatterTests.swift in Sources */,
 			);

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -3033,6 +3033,8 @@
 		D5412B442819F24000463106 /* WalletNumberFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletNumberFormatterExtensions.swift; sourceTree = "<group>"; };
 		D59CA29E282AE0FB00D02BEF /* FavIconImageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavIconImageRenderer.swift; sourceTree = "<group>"; };
 		D59CA2B6282AE54500D02BEF /* OriginText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginText.swift; sourceTree = "<group>"; };
+		D51DFA9328173CCA00F92818 /* ManageSiteConnectionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSiteConnectionsStore.swift; sourceTree = "<group>"; };
+		D51DFA9F28173CE300F92818 /* ManageSiteConnectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSiteConnectionsView.swift; sourceTree = "<group>"; };
 		D5A691EB27DF93AD000CC4B3 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
 		D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsPasscodeEntryView.swift; sourceTree = "<group>"; };
 		D5EFCB3827FF81AA00BD151D /* EditPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPermissionsView.swift; sourceTree = "<group>"; };
@@ -3834,6 +3836,7 @@
 				27E17B802744067A00F3C282 /* AccountActivityStore.swift */,
 				27AAE240274FFBA900288E90 /* TransactionConfirmationStore.swift */,
 				7DC054D927AB30E700BBA042 /* SettingsStore.swift */,
+				D51DFA9328173CCA00F92818 /* ManageSiteConnectionsStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -4012,6 +4015,7 @@
 				7D4C49502791D2450073C37E /* CustomNetworkDetailsView.swift */,
 				275034E226EF9E6A00CF4C8A /* WalletSettingsView.swift */,
 				D5C51E6B27F4C8AA00E1F2D0 /* BiometricsPasscodeEntryView.swift */,
+				D51DFA9F28173CE300F92818 /* ManageSiteConnectionsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -7656,6 +7660,7 @@
 				271F689B26EBD27E00AA2A50 /* CryptoView.swift in Sources */,
 				7DC054DA27AB30E700BBA042 /* SettingsStore.swift in Sources */,
 				2701B14C2735B65300BE6FC6 /* EditPriorityFeeView.swift in Sources */,
+				D51DFAA028173CE300F92818 /* ManageSiteConnectionsView.swift in Sources */,
 				27842B5827AC8868002B3EDA /* NewSiteConnectionView.swift in Sources */,
 				27180150273ABD3A00F683E3 /* BiometricsPromptView.swift in Sources */,
 				271F689826EBD27E00AA2A50 /* NetworkStore.swift in Sources */,
@@ -7706,6 +7711,7 @@
 				271F68A726EBD27E00AA2A50 /* BackupNotifyView.swift in Sources */,
 				2729E7D326F502AC00200648 /* AccountPicker.swift in Sources */,
 				27F3AEF4271DDE0C00F75B7F /* OpenWalletURLAction.swift in Sources */,
+				D51DFA9428173CCA00F92818 /* ManageSiteConnectionsStore.swift in Sources */,
 				2762FF32271A2448001EF41D /* BuySendSwapDestination.swift in Sources */,
 				7D2D6EDD2731B7FF000650EA /* SwapTokenStore.swift in Sources */,
 				27D91E71274D55F0009B1FA3 /* EditGasFeeView.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3285,9 +3285,6 @@ extension BrowserViewController: PreferencesObserver {
     case Preferences.Wallet.defaultWallet.key:
       tabManager.reset()
       tabManager.reloadSelectedTab()
-      for tab in self.tabManager.allTabs where tab != self.tabManager.selectedTab {
-        tab.deleteWebView()
-      }
     default:
       log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
       break

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -433,6 +433,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     Preferences.Playlist.webMediaSourceCompatibility.observe(from: self)
     Preferences.PrivacyReports.captureShieldsData.observe(from: self)
     Preferences.PrivacyReports.captureVPNAlerts.observe(from: self)
+    Preferences.Wallet.defaultWallet.observe(from: self)
     
     // Lists need to be compiled before attempting tab restoration
     
@@ -3281,6 +3282,12 @@ extension BrowserViewController: PreferencesObserver {
       PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.buildChannel.isPublic)
     case Preferences.PrivacyReports.captureVPNAlerts.key:
       PrivacyReportsManager.scheduleVPNAlertsTask()
+    case Preferences.Wallet.defaultWallet.key:
+      tabManager.reset()
+      tabManager.reloadSelectedTab()
+      for tab in self.tabManager.allTabs where tab != self.tabManager.selectedTab {
+        tab.deleteWebView()
+      }
     default:
       log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
       break

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -101,7 +101,11 @@ extension BrowserViewController: BraveWalletDelegate {
 
 extension BrowserViewController: BraveWalletProviderDelegate {
   func showPanel() {
-    guard presentedViewController == nil else { return }
+    // only display notification when BVC is front and center & `displayWeb3Notifications` is enabled
+    guard presentedViewController == nil,
+          Preferences.Wallet.displayWeb3Notifications.value else {
+      return
+    }
     
     let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
       if action == .connectWallet {

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -6,6 +6,7 @@ import WebKit
 import Shared
 import Data
 import BraveCore
+import BraveShared
 
 private let log = Logger.browserLogger
 
@@ -459,7 +460,9 @@ class UserScriptManager {
       }
 
       #if WALLET_DAPPS_ENABLED
-      if let script = walletProviderScript, tab?.isPrivate == false {
+      if let script = walletProviderScript,
+         tab?.isPrivate == false,
+         Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultWallet.value) == .brave {
         $0.addUserScript(script)
         if let providerJS = walletProviderJS {
           $0.addUserScript(.init(source: providerJS, injectionTime: .atDocumentStart, forMainFrameOnly: true, in: .page))

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -115,6 +115,7 @@ class SettingsViewController: TableViewController {
 
     view.backgroundColor = .braveGroupedBackground
     view.tintColor = .braveOrange
+    navigationController?.view.backgroundColor = .braveGroupedBackground
   }
 
   private func displayRewardsDebugMenu() {

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -35,6 +35,8 @@ public final class Domain: NSManagedObject, CRUD {
   private var urlComponents: URLComponents? {
     return URLComponents(string: url ?? "")
   }
+  
+  private static let containsEthereumPermissionsPredicate = NSPredicate(format: "wallet_permittedAccounts != nil && wallet_permittedAccounts != ''")
 
   /// A domain can be created in many places,
   /// different save strategies are used depending on its relationship(eg. attached to a Bookmark) or browsing mode.
@@ -158,6 +160,11 @@ public final class Domain: NSManagedObject, CRUD {
       return permittedAccount.components(separatedBy: ",").contains(account)
     }
     return false
+  }
+
+  public class func allDomainsWithEthereumPermissions(context: NSManagedObjectContext? = nil) -> [Domain] {
+    let predicate = Domain.containsEthereumPermissionsPredicate
+    return all(where: predicate, context: context ?? DataController.viewContext) ?? []
   }
   
   public static func clearAllEthereumPermissions(_ completionOnMain: (() -> Void)? = nil) {

--- a/Data/models/Domain.swift
+++ b/Data/models/Domain.swift
@@ -59,6 +59,20 @@ public final class Domain: NSManagedObject, CRUD {
   }
 
   // MARK: - Public interface
+  
+  public class func frc() -> NSFetchedResultsController<Domain> {
+    let context = DataController.viewContext
+    let fetchRequest = NSFetchRequest<Domain>()
+    fetchRequest.entity = Domain.entity(context)
+    fetchRequest.sortDescriptors = [NSSortDescriptor(key: "url", ascending: false)]
+
+    return NSFetchedResultsController(
+      fetchRequest: fetchRequest,
+      managedObjectContext: context,
+      sectionNameKeyPath: nil,
+      cacheName: nil
+    )
+  }
 
   public class func getOrCreate(forUrl url: URL, persistent: Bool) -> Domain {
     let context = persistent ? DataController.viewContext : DataController.viewContextInMemory

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,10 @@ platform :ios do
         "ClientTests/HttpCookieExtensionTest/testSaveAndLoadCookie",
         "ClientTests/UserAgentTests",
         "DataTests",
-        "SPMLibrariesTests/WebServerTests/testWebServerIsServingRequests"
+        "SPMLibrariesTests/WebServerTests/testWebServerIsServingRequests",
+	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
+	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",
+	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissionsLastPermission"
       ]
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,9 +47,9 @@ platform :ios do
         "ClientTests/UserAgentTests",
         "DataTests",
         "SPMLibrariesTests/WebServerTests/testWebServerIsServingRequests",
-	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
-	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",
-	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissionsLastPermission"
+      	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
+      	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",
+      	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissionsLastPermission"
       ]
     )
 


### PR DESCRIPTION
## Summary of Changes
- Add dapp preferences to wallet settings
- Add Manage Site Connections view for viewing all sites granted ethereum permissions

This pull request fixes #5257

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Note: At time of PR creation, wallet dapps are disabled with a compiler flag. Add `-DWALLET_DAPPS_ENABLED` to `base.xcconfig` to enable dapps support.

Manage Site Connections:
1. Visit some dapp sites like [Uniswap](https://app.uniswap.org/) / [Metamask Test Dapp](https://metamask.github.io/test-dapp/) and connect >1 accounts
5. Navigate to Wallet Settings and tap 'Manage site connections'
7. Tap 'Remove All', tap 'Remove' in the confirmation alert
8. Verify dapp sites had account connections removed, and were properly updated to show account connection removed (if tab was still open)
9. Repeat step 1 & 2
10. Open detail view for a single dapp site connection
11. Remove individual account from list
12. Verify dapp site(s) had the account connection removed, and were properly updated to show account connection removed (if tab was still open)

Default Wallet:
1. Visit Wallet Settings
2. Toggle 'Default Wallet' preference to 'None'
3. Visit any dapp site, verify wallet icon not shown in URL bar, no interaction with wallet is enabled via the dapp. [Metamask Test Dapp](https://metamask.github.io/test-dapp/) works well for testing this.
4. Visit Wallet Settings
5. Toggle 'Default Wallet' preference to 'Brave Wallet'
6. Visit any dapp site, verify wallet icon is shown in URL bar once account access or any other dapp request is received. [Uniswap](https://app.uniswap.org/) will prompt for account connection immediately (if no accounts connected), or can use [Metamask Test Dapp](https://metamask.github.io/test-dapp/) 

Allow Sites to Request Accounts:
1. Remove all ethereum connected accounts via 'Remove All' in 'Manage Site Connections'
2. Visit Wallet Settings & toggle 'Allow Sites to Request Accounts' to on.
3. Visit [Uniswap](https://app.uniswap.org/) and connect at least one account when prompted.
4. Visit Wallet Settings & toggle 'Allow Sites to Request Accounts' to off.
5. Visit [Metamask Test Dapp](https://metamask.github.io/test-dapp/) and tap 'Connect'. Verify you are not prompted to connect any accounts

Display Web3 Notifications:
1. Remove all ethereum connected accounts via 'Remove All' in 'Manage Site Connections'
2. Visit Wallet Settings & toggle 'Display Web3 Notifications' to off.
3. Visit [Uniswap](https://app.uniswap.org/), you should not see the purple wallet dapp notification / toast
4. Tap wallet icon in URL bar
5. Verify still prompted to connect account.
6. Visit Wallet Settings & toggle 'Display Web3 Notifications' to on. Remove Uniswap account connection if granted.
7. Visit [Uniswap](https://app.uniswap.org/), you should now see the purple wallet dapp notification / toast for Uniswap requesting wallet account permissions

## Screenshots:

![settings](https://user-images.githubusercontent.com/5314553/168342704-71a3a4ba-097b-4f66-a025-37ff9bb6c125.png) | ![manage site connections list](https://user-images.githubusercontent.com/5314553/168342719-4f7b342c-73ac-458d-b24b-773e0eae904b.png) | ![manage site connections](https://user-images.githubusercontent.com/5314553/168342938-c09711b5-d746-4736-87f9-0467e81cba1a.png)
--|--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
