### PR TITLE
Fix #5328: No confirmation of deletion when deleting shields data via Shields Settings

### DIFF
--- a/Client/Frontend/Settings/PrivacyReportSettingsView.swift
+++ b/Client/Frontend/Settings/PrivacyReportSettingsView.swift
@@ -12,7 +12,7 @@ struct PrivacyReportSettingsView: View {
   @ObservedObject private var shieldsDataEnabled = Preferences.PrivacyReports.captureShieldsData
   @ObservedObject private var vpnAlertsEnabled = Preferences.PrivacyReports.captureVPNAlerts
   
-  @State private var clearButtonEnabled: Bool = true
+  @State private var showClearDataPrompt: Bool = false
   
   var body: some View {
     List {
@@ -31,15 +31,26 @@ struct PrivacyReportSettingsView: View {
       Section(footer: Text(Strings.PrivacyHub.settingsSlearDataFooter)) {
         HStack() {
           Button(action: {
-            PrivacyReportsManager.clearAllData()
-            clearButtonEnabled = false
+            showClearDataPrompt = true
           },
                  label: {
             Text(Strings.PrivacyHub.settingsSlearDataTitle)
               .frame(maxWidth: .infinity, alignment: .leading)
               .foregroundColor(Color.red)
           })
-            .disabled(!clearButtonEnabled)
+            .actionSheet(isPresented: $showClearDataPrompt) {
+              // Currently .actionSheet does not allow you leave empty title for the sheet.
+              // This could get converted to .confirmationPrompt or Menu with destructive buttons
+              // once iOS 15 is minimum supported version
+              .init(title: Text(Strings.PrivacyHub.clearAllDataPrompt),
+                    buttons: [
+                      .destructive(Text(Strings.yes), action: {
+                        PrivacyReportsManager.clearAllData()
+                      }),
+                      .cancel()
+                    ])
+            }
+          
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))


### PR DESCRIPTION
Adding confirmation using action sheet for general settings settings Hub Privacy Data Remove
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5328

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Add shields data to privacy hub
- Open Privacy hub and click on trash button, shows confirmation message to clear data
- Add more data to privacy hub
- Open Settings -> Shields -> Privacy Hub -> Clear Shields data, same confirmation shown

## Screenshots:

https://user-images.githubusercontent.com/6643505/168384356-790111bf-600d-412c-a94f-a740931552c5.mp4


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
