### PR TITLE
Fix #5351: Update user agent to match iOS 15.5.

### DIFF
--- a/Shared/UserAgentBuilder.swift
+++ b/Shared/UserAgentBuilder.swift
@@ -50,7 +50,7 @@ public struct UserAgentBuilder {
       """
       Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
       AppleWebKit/605.1.15 (KHTML, like Gecko) \
-      Version/15.0 \
+      Version/15.5 \
       Safari/605.1.15
       """
 
@@ -97,7 +97,7 @@ public struct UserAgentBuilder {
     switch os.majorVersion {
     case 13: return "13_6_1"
     case 14: return "14_6"
-    case 15: return "15_0"
+    case 15: return "15_5"
     default: return "\(os.majorVersion)_0"
 
     }
@@ -108,7 +108,7 @@ public struct UserAgentBuilder {
     switch os.majorVersion {
     case 13: return "13.1.2"
     case 14: return "14.1.1"
-    case 15: return "15.0"
+    case 15: return "15.5"
     default: return "\(os.majorVersion).0"
 
     }

--- a/SharedTests/UserAgentBuilderTests.swift
+++ b/SharedTests/UserAgentBuilderTests.swift
@@ -42,7 +42,7 @@ class UserAgentBuilderTests: XCTestCase {
       """
       Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
       AppleWebKit/605.1.15 (KHTML, like Gecko) \
-      Version/15.0 \
+      Version/15.5 \
       Safari/605.1.15
       """
 
@@ -95,32 +95,32 @@ class UserAgentBuilderTests: XCTestCase {
 
     // MARK: - iOS 15
     let iPhone_safari_15_UA = """
-      Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-      Version/15.0 \
+      Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+      Version/15.5 \
       Mobile/15E148 \
       Safari/604.1
       """
 
     let iPad_safari_15_UA = """
-      Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
-      Version/15.0 \
+      Mozilla/5.0 (iPad; CPU OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) \
+      Version/15.5 \
       Mobile/15E148 \
       Safari/604.1
       """
 
-    // MARK: - 15.0
+    // MARK: - 15.5
 
-    let ios15_0 = OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+    let ios15_5 = OperatingSystemVersion(majorVersion: 15, minorVersion: 5, patchVersion: 0)
 
     XCTAssertEqual(
       iPhone_safari_15_UA,
-      UserAgentBuilder(device: iPhone, iOSVersion: ios15_0).build(desktopMode: false),
+      UserAgentBuilder(device: iPhone, iOSVersion: ios15_5).build(desktopMode: false),
       "User agent for iOS 54.0 iPhone doesn't match.")
 
     XCTAssertEqual(
       iPad_safari_15_UA,
-      UserAgentBuilder(device: iPad, iOSVersion: ios15_0).build(desktopMode: false),
-      "User agent for iOS 15.0 iPad doesn't match.")
+      UserAgentBuilder(device: iPad, iOSVersion: ios15_5).build(desktopMode: false),
+      "User agent for iOS 15.5 iPad doesn't match.")
 
     // MARK: - iOS 14
     let iPhone_safari_14_UA = """
@@ -210,7 +210,7 @@ class UserAgentBuilderTests: XCTestCase {
       """
       Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) \
       AppleWebKit/605.1.15 (KHTML, like Gecko) \
-      Version/15.0 \
+      Version/15.5 \
       Safari/605.1.15
       """
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5351 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Make sure your devices are on exact iOS 15.5
2. Verify that Safari's and Brave user agents are the same

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
