### PR TITLE
Fix #5359: Make Privacy Hub stats button look disabled in private mode.

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/Sections/StatsSectionProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/StatsSectionProvider.swift
@@ -118,20 +118,23 @@ class BraveShieldStatsView: SpringButton {
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    let image = UIImageView(image: #imageLiteral(resourceName: "privacy_reports_3dots").template)
-    image.tintColor = .white
-    
-    let background = UIView()
-    background.backgroundColor = .init(white: 0, alpha: 0.25)
-    background.layer.cornerRadius = 12
-    background.layer.cornerCurve = .continuous
-    background.isUserInteractionEnabled = false
-    insertSubview(background, at: 0)
-    background.snp.makeConstraints {
-      $0.edges.equalToSuperview()
+    if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+      let background = UIView()
+      background.backgroundColor = .init(white: 0, alpha: 0.25)
+      background.layer.cornerRadius = 12
+      background.layer.cornerCurve = .continuous
+      background.isUserInteractionEnabled = false
+      insertSubview(background, at: 0)
+      background.snp.makeConstraints {
+        $0.edges.equalToSuperview()
+      }
+      
+      let image = UIImageView(image: #imageLiteral(resourceName: "privacy_reports_3dots").template)
+      image.tintColor = .white
+      topStackView.addStackViewItems(.view(privacyReportLabel), .view(image))
     }
     
-    topStackView.addStackViewItems(.view(privacyReportLabel), .view(image))
+    isEnabled = !PrivateBrowsingManager.shared.isPrivateBrowsing
     statsStackView.addStackViewItems(.view(adsStatView), .view(dataSavedStatView), .view(timeStatView))
     contentStackView.addStackViewItems(.view(topStackView), .view(statsStackView))
     addSubview(contentStackView)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5359 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Enter private mode
- Make sure the privacy hub stats view on ntp does not look tappable

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="858" alt="Zrzut ekranu 2022-05-18 o 23 08 21" src="https://user-images.githubusercontent.com/6950387/169155971-4e19093e-1d7d-4067-b637-bfa98ff41096.png">



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
