### PR TITLE
Fix #5363: Selected tab used for allowed accounts

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2312,14 +2312,15 @@ extension BrowserViewController: TabDelegate {
     })
   }
   
-  func showWalletNotification(_ tab: Tab, completion: BraveWalletProviderResultsCallback?) {
+  func showWalletNotification(_ tab: Tab) {
     // only display notification when BVC is front and center
-    guard presentedViewController == nil else {
+    guard presentedViewController == nil,
+          Preferences.Wallet.displayWeb3Notifications.value else {
       return
     }
     let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
       if action == .connectWallet {
-        self?.presentWalletPanel(tab: tab, completion: completion)
+        self?.presentWalletPanel(tab: tab)
       }
     }
     notificationsPresenter.display(notification: walletNotificaton, from: self)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -394,7 +394,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
     #if WALLET_DAPPS_ENABLED
     tabManager.makeWalletProvider = { [weak self] tab in
       guard let self = self,
-            let provider = self.braveCore.walletProvider(with: self, isPrivateBrowsing: tab.isPrivate) else {
+            let provider = self.braveCore.walletProvider(with: tab, isPrivateBrowsing: tab.isPrivate) else {
         return nil
       }
       return (provider, js: self.braveCore.walletProviderJS)
@@ -2465,7 +2465,7 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     updateInContentHomePanel(selected?.url as URL?)
-        updateURLBarWalletButton()
+    updateURLBarWalletButton()
   }
 
   func tabManager(_ tabManager: TabManager, willAddTab tab: Tab) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2477,6 +2477,7 @@ extension BrowserViewController: TabManagerDelegate {
       updateToolbarUsingTabManager(tabManager)
     }
     tab.tabDelegate = self
+    tab.walletKeyringService = BraveWallet.KeyringServiceFactory.get(privateMode: tab.isPrivate)
     updateTabsBarVisibility()
   }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2324,6 +2324,11 @@ extension BrowserViewController: TabDelegate {
     }
     notificationsPresenter.display(notification: walletNotificaton, from: self)
   }
+
+  func updateURLBarWalletButton() {
+    topToolbar.locationView.walletButton.buttonState =
+    tabManager.selectedTab?.isWalletIconVisible == true ? .active : .inactive
+  }
 }
 
 extension BrowserViewController: SearchViewControllerDelegate {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2311,6 +2311,19 @@ extension BrowserViewController: TabDelegate {
       PlaylistHelper.stopPlayback(tab: $0)
     })
   }
+  
+  func showWalletNotification(_ tab: Tab, completion: BraveWalletProviderResultsCallback?) {
+    // only display notification when BVC is front and center
+    guard presentedViewController == nil else {
+      return
+    }
+    let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
+      if action == .connectWallet {
+        self?.presentWalletPanel(tab: tab, completion: completion)
+      }
+    }
+    notificationsPresenter.display(notification: walletNotificaton, from: self)
+  }
 }
 
 extension BrowserViewController: SearchViewControllerDelegate {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -329,10 +329,10 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidTapWalletButton(_ urlBar: TopToolbarView) {
-    guard let urlOrigin = tabManager.selectedTab?.url?.origin else {
+    guard let selectedTab = tabManager.selectedTab else {
       return
     }
-    presentWalletPanel(origin: urlOrigin)
+    presentWalletPanel(tab: selectedTab, completion: nil)
   }
     
   private func hideSearchController() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -332,7 +332,7 @@ extension BrowserViewController: TopToolbarDelegate {
     guard let selectedTab = tabManager.selectedTab else {
       return
     }
-    presentWalletPanel(tab: selectedTab, completion: nil)
+    presentWalletPanel(tab: selectedTab)
   }
     
   private func hideSearchController() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -329,7 +329,10 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidTapWalletButton(_ urlBar: TopToolbarView) {
-    presentWalletPanel()
+    guard let urlOrigin = tabManager.selectedTab?.url?.origin else {
+      return
+    }
+    presentWalletPanel(origin: urlOrigin)
   }
     
   private func hideSearchController() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -63,8 +63,7 @@ extension BrowserViewController: WKNavigationDelegate {
       return
     }
 
-        tabManager.selectedTab?.isWalletIconVisible = false
-        updateURLBarWalletButton()
+    tabManager.selectedTab?.isWalletIconVisible = false
 
     updateFindInPageVisibility(visible: false)
     displayPageZoom(visible: false)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -190,13 +190,6 @@ extension Tab: BraveWalletProviderDelegate {
   }
 }
 
-extension BrowserViewController {
-  func updateURLBarWalletButton() {
-    topToolbar.locationView.walletButton.buttonState =
-    tabManager.selectedTab?.isWalletIconVisible == true ? .active : .inactive
-  }
-}
-
 extension Tab: BraveWalletEventsListener {
   func emitEthereumEvent(_ event: Web3ProviderEvent) {
     var arguments: [Any] = [event.name]

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -44,12 +44,12 @@ extension WalletStore {
 }
 
 extension BrowserViewController {
-  func presentWalletPanel() {
+  func presentWalletPanel(tab: Tab, completion: BraveWalletProviderResultsCallback? = nil) {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
     guard let walletStore = WalletStore.from(privateMode: privateMode) else {
       return
     }
-    let origin = getOrigin()
+    let origin = tab.getOrigin()
     let controller = WalletPanelHostingController(
       walletStore: walletStore,
       origin: origin,
@@ -60,7 +60,7 @@ extension BrowserViewController {
           let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
           if permissionRequestManager.hasPendingRequest(for: origin, coinType: .eth) {
             let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: .eth)
-            let (accounts, status, _) = await self.allowedAccounts(false)
+            let (accounts, status, _) = await tab.allowedAccounts(false)
             if status == .success, !accounts.isEmpty {
               for request in pendingRequests {
                 // cancel the requests if `allowedAccounts` is not empty for this domain
@@ -99,24 +99,13 @@ extension BrowserViewController: BraveWalletDelegate {
   }
 }
 
-extension BrowserViewController: BraveWalletProviderDelegate {
+extension Tab: BraveWalletProviderDelegate {
   func showPanel() {
-    // only display notification when BVC is front and center & `displayWeb3Notifications` is enabled
-    guard presentedViewController == nil,
-          Preferences.Wallet.displayWeb3Notifications.value else {
-      return
-    }
-    
-    let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
-      if action == .connectWallet {
-        self?.presentWalletPanel()
-      }
-    }
-    notificationsPresenter.display(notification: walletNotificaton, from: self)
+    tabDelegate?.showWalletNotification(self, completion: nil)
   }
 
   func getOrigin() -> URLOrigin {
-    guard let origin = tabManager.selectedTab?.url?.origin else {
+    guard let origin = url?.origin else {
       assert(false, "We should have a valid origin to get to this point")
       return .init()
     }
@@ -166,19 +155,42 @@ extension BrowserViewController: BraveWalletProviderDelegate {
           completion([], .userRejectedRequest, "User rejected request")
         }
       })
-      
-      showPanel()
+
+      self.tabDelegate?.showWalletNotification(self, completion: completion)
     }
   }
 
-  func allowedAccounts(_ includeAccountsWhenLocked: Bool) async -> ([String], BraveWallet.ProviderError, String) {
-    guard let selectedTab = tabManager.selectedTab else {
+  @MainActor func allowedAccounts(_ includeAccountsWhenLocked: Bool) async -> ([String], BraveWallet.ProviderError, String) {
+    func filterAccounts(
+      _ accounts: [String],
+      selectedAccount: String?
+    ) -> [String] {
+      if let selectedAccount = selectedAccount, accounts.contains(selectedAccount) {
+        return [selectedAccount]
+      }
+      return accounts
+    }
+    // This method is called immediately upon creation of the wallet provider, which happens at tab
+    // configuration, which means it may not be selected or ready yet.
+    guard let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: false),
+          let originURL = url?.origin.url else {
       return ([], .internalError, "Internal error")
     }
-    updateURLBarWalletButton()
-    return await selectedTab.allowedAccounts(includeAccountsWhenLocked)
+    let isLocked = await keyringService.isLocked()
+    if !includeAccountsWhenLocked && isLocked {
+      return ([], .success, "")
+    }
+    let selectedAccount = await keyringService.selectedAccount(.eth)
+    let permissions = Domain.ethereumPermissions(forUrl: originURL)
+    return (
+      filterAccounts(permissions ?? [], selectedAccount: selectedAccount),
+      .success,
+      ""
+    )
   }
+}
 
+extension BrowserViewController {
   func updateURLBarWalletButton() {
     topToolbar.locationView.walletButton.buttonState =
     tabManager.selectedTab?.isWalletIconVisible == true ? .active : .inactive
@@ -212,35 +224,6 @@ extension Tab: BraveWalletEventsListener {
   func accountsChangedEvent(_ accounts: [String]) {
     emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
     updateEthereumProperties()
-  }
-
-  @MainActor func allowedAccounts(_ includeAccountsWhenLocked: Bool) async -> ([String], BraveWallet.ProviderError, String) {
-    func filterAccounts(
-      _ accounts: [String],
-      selectedAccount: String?
-    ) -> [String] {
-      if let selectedAccount = selectedAccount, accounts.contains(selectedAccount) {
-        return [selectedAccount]
-      }
-      return accounts
-    }
-    // This method is called immediately upon creation of the wallet provider, which happens at tab
-    // configuration, which means it may not be selected or ready yet.
-    guard let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: false),
-          let originURL = url?.origin.url else {
-      return ([], .internalError, "Internal error")
-    }
-    let isLocked = await keyringService.isLocked()
-    if !includeAccountsWhenLocked && isLocked {
-      return ([], .success, "")
-    }
-    let selectedAccount = await keyringService.selectedAccount(.eth)
-    let permissions = Domain.ethereumPermissions(forUrl: originURL)
-    return (
-      filterAccounts(permissions ?? [], selectedAccount: selectedAccount),
-      .success,
-      ""
-    )
   }
   
   func updateEthereumProperties() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -44,7 +44,7 @@ extension WalletStore {
 }
 
 extension BrowserViewController {
-  func presentWalletPanel(tab: Tab, completion: BraveWalletProviderResultsCallback? = nil) {
+  func presentWalletPanel(tab: Tab) {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
     guard let walletStore = WalletStore.from(privateMode: privateMode) else {
       return
@@ -101,7 +101,7 @@ extension BrowserViewController: BraveWalletDelegate {
 
 extension Tab: BraveWalletProviderDelegate {
   func showPanel() {
-    tabDelegate?.showWalletNotification(self, completion: nil)
+    tabDelegate?.showWalletNotification(self)
   }
 
   func getOrigin() -> URLOrigin {
@@ -156,7 +156,7 @@ extension Tab: BraveWalletProviderDelegate {
         }
       })
 
-      self.tabDelegate?.showWalletNotification(self, completion: completion)
+      self.tabDelegate?.showWalletNotification(self)
     }
   }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -31,7 +31,7 @@ protocol TabDelegate {
   func tab(_ tab: Tab, willDeleteWebView webView: WKWebView)
   func showRequestRewardsPanel(_ tab: Tab)
   func stopMediaPlayback(_ tab: Tab)
-  func showWalletNotification(_ tab: Tab, completion: BraveWalletProviderResultsCallback?)
+  func showWalletNotification(_ tab: Tab)
   func updateURLBarWalletButton()
 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -73,7 +73,11 @@ class Tab: NSObject {
       webView?.currentScene?.browserViewController?.updateURLBarWalletButton()
     }
   }
-  var walletKeyringService: BraveWalletKeyringService?
+  var walletKeyringService: BraveWalletKeyringService? {
+    didSet {
+      walletKeyringService?.add(self)
+    }
+  }
   // PageMetadata is derived from the page content itself, and as such lags behind the
   // rest of the tab.
   var pageMetadata: PageMetadata?

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -32,6 +32,7 @@ protocol TabDelegate {
   func showRequestRewardsPanel(_ tab: Tab)
   func stopMediaPlayback(_ tab: Tab)
   func showWalletNotification(_ tab: Tab, completion: BraveWalletProviderResultsCallback?)
+  func updateURLBarWalletButton()
 }
 
 @objc
@@ -70,7 +71,7 @@ class Tab: NSObject {
   var walletProviderJS: String?
   var isWalletIconVisible: Bool = false {
     didSet {
-      webView?.currentScene?.browserViewController?.updateURLBarWalletButton()
+      tabDelegate?.updateURLBarWalletButton()
     }
   }
   var walletKeyringService: BraveWalletKeyringService? {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -68,7 +68,11 @@ class Tab: NSObject {
 
   var walletProvider: BraveWalletBraveWalletProvider?
   var walletProviderJS: String?
-  var isWalletIconVisible: Bool = false
+  var isWalletIconVisible: Bool = false {
+    didSet {
+      webView?.currentScene?.browserViewController?.updateURLBarWalletButton()
+    }
+  }
   var walletKeyringService: BraveWalletKeyringService?
   // PageMetadata is derived from the page content itself, and as such lags behind the
   // rest of the tab.

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -20,7 +20,6 @@ protocol TabContentScript {
   func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void)
 }
 
-@objc
 protocol TabDelegate {
   func tab(_ tab: Tab, didAddSnackbar bar: SnackBar)
   func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar)
@@ -28,10 +27,11 @@ protocol TabDelegate {
   func tab(_ tab: Tab, didSelectFindInPageFor selectedText: String)
   /// Triggered when "Search with Brave" is selected on selected web text
   func tab(_ tab: Tab, didSelectSearchWithBraveFor selectedText: String)
-  @objc optional func tab(_ tab: Tab, didCreateWebView webView: WKWebView)
-  @objc optional func tab(_ tab: Tab, willDeleteWebView webView: WKWebView)
+  func tab(_ tab: Tab, didCreateWebView webView: WKWebView)
+  func tab(_ tab: Tab, willDeleteWebView webView: WKWebView)
   func showRequestRewardsPanel(_ tab: Tab)
   func stopMediaPlayback(_ tab: Tab)
+  func showWalletNotification(_ tab: Tab, completion: BraveWalletProviderResultsCallback?)
 }
 
 @objc
@@ -325,7 +325,7 @@ class Tab: NSObject {
         isDeAMPEnabled: Preferences.Shields.autoRedirectAMPPages.value,
         walletProviderJS: walletProviderJS
       )
-      tabDelegate?.tab?(self, didCreateWebView: webView)
+      tabDelegate?.tab(self, didCreateWebView: webView)
 
       nightMode = Preferences.General.nightModeEnabled.value
     }
@@ -407,7 +407,7 @@ class Tab: NSObject {
 
     if let webView = webView {
       webView.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
-      tabDelegate?.tab?(self, willDeleteWebView: webView)
+      tabDelegate?.tab(self, willDeleteWebView: webView)
     }
     webView = nil
   }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -454,10 +454,6 @@ class TabManager: NSObject {
       tab.walletProvider?.`init`(tab)
       tab.walletProviderJS = js
     }
-    if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: tab.isPrivate) {
-      tab.walletKeyringService = keyringService
-      keyringService.add(tab)
-    }
     
     delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }
 


### PR DESCRIPTION
## Summary of Changes

- `BrowserViewController` was set as the `BraveWalletProviderDelegate` for every tab, which meant we didn't know which tab's provider was sending the delegate callback. Because of this, we were returning the allowed account(s) for the _selected_ tab; so when a non-selected tab's provider requested the allowed account(s) we would return the selected tab's allowed accounts. This PR changes the `BraveWalletProviderDelegate` to be the individual tab so we know which tab is making the allowed account(s) delegate callback.
- `walletKeyringService: BraveWalletKeyringService` assignment on `Tab` was moved to `BrowserViewController` delegate conformance to remove BraveCore usage from `Tab` so we don't fail in our Tab tests when they no longer use host application for testing.
- Two new functions were added to our `TabDelegate` protocol to delegate back to the BrowserViewController to present the wallet panel and update the bar icon. This was done to clean up some of the wallet dapp tab related logic.

This pull request fixes #5363

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
NOTE: Need https://github.com/brave/brave-ios/issues/5257 to access Manage Site Connections View to verify fix, and `WALLET_DAPPS_ENABLED` flag set. If #5257 is not merged, you can update `Domain.clearAllEthereumPermissions()` to skip deleting from a specific dapp site to verify.

1. Connect at least 1 wallet account address to at least 2 dapp sites. One must display the connected account address (I am using [Uniswap](https://app.uniswap.org/#/swap) for this).
2. Open Uniswap tab.
3. Visit Wallet Settings -> Manage Site Connections and remove all access to Uniswap. At least one dapp site must remain with account access.
4. Verify Uniswap is no longer displaying the connected account address.
Visit the other dapp site that still has an account connected and perform any ethereum dapp interaction, such as request accounts.
5. Visit Uniswap and see that it is now displaying the connected account address after permissions were revoked. Any interaction will fail as the site does not actually have permissions.


## Screenshots:

https://user-images.githubusercontent.com/5314553/169357058-d7437fa8-4c6e-4d6a-afcd-989192a353df.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
