### PR TITLE
Fix #5365: web3 not being updated if wallet notification has been ignored by users

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -138,8 +138,8 @@ extension BrowserViewController {
         MenuItemButton(
           icon: #imageLiteral(resourceName: "menu-crypto").template,
           title: "\(Strings.Wallet.wallet) (\(Strings.Wallet.betaLabel))"
-        ) { [unowned self] in
-          self.presentWallet()
+        ) { [weak self] in
+          self?.presentWallet()
         }
         MenuItemButton(icon: #imageLiteral(resourceName: "playlist_menu").template, title: Strings.playlistMenuItem) { [weak self] in
           guard let self = self else { return }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -62,12 +62,10 @@ extension BrowserViewController {
             let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: .eth)
             let (accounts, status, _) = await self.allowedAccounts(false)
             if status == .success, !accounts.isEmpty {
-              // cancel the requests if `allowedAccounts` is not empty for this domain
               for request in pendingRequests {
+                // cancel the requests if `allowedAccounts` is not empty for this domain
                 permissionRequestManager.cancelRequest(request)
-              }
-              // let wallet provider know we have allowed accounts for this domain
-              for request in pendingRequests {
+                // let wallet provider know we have allowed accounts for this domain
                 request.providerHandler?(accounts, .success, "")
               }
             }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -44,7 +44,7 @@ extension WalletStore {
 }
 
 extension BrowserViewController {
-  func presentWalletPanel(_ completion: BraveWalletProviderResultsCallback? = nil) {
+  func presentWalletPanel() {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
     guard let walletStore = WalletStore.from(privateMode: privateMode) else {
       return
@@ -67,7 +67,9 @@ extension BrowserViewController {
                 permissionRequestManager.cancelRequest(request)
               }
               // let wallet provider know we have allowed accounts for this domain
-              completion?(accounts, .success, "")
+              for request in pendingRequests {
+                request.providerHandler?(accounts, .success, "")
+              }
             }
           }
         }
@@ -154,7 +156,7 @@ extension BrowserViewController: BraveWalletProviderDelegate {
       }
       
       // add permission request to the queue
-      _ = permissionRequestManager.beginRequest(for: origin, coinType: .eth, completion: { response in
+      _ = permissionRequestManager.beginRequest(for: origin, coinType: .eth, providerHandler: completion, completion: { response in
         switch response {
         case .granted(let accounts):
           completion(accounts, .success, "")
@@ -163,15 +165,7 @@ extension BrowserViewController: BraveWalletProviderDelegate {
         }
       })
       
-      // only display notification when BVC is front and center
-      if presentedViewController == nil {
-        let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
-          if action == .connectWallet {
-            self?.presentWalletPanel(completion)
-          }
-        }
-        notificationsPresenter.display(notification: walletNotificaton, from: self)
-      }
+      showPanel()
     }
   }
 


### PR DESCRIPTION
## Summary of Changes
Store provider delegate completion inside permission request for later use when user ignore the wallet notification which is triggered by web3 permission request.

This pull request fixes #5365 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. go to a web3 that your wallet gave permission to one or some accounts to connect to.
2. trigger the web3 to request eth permission
3. if this domain has not yet request eth permission in the current session, this should trigger a wallet notification
4. either ignore the notification to let it times out, or swipe up to dismiss the notification
5. observe that web3 still displays no account connects 
6. click the wallet icon from the url bar. this will prompt unlock wallet screen ask you to unlock 
7. unlock wallet
8. observe the wallet panel appears with no eth permission screen because there are already some accounts have been granted permission before
9. dismiss wallet panel 
10. observe now web3 should display one account connected.

## Screenshots:
https://user-images.githubusercontent.com/1187676/169442355-286fef94-5eae-4954-b02f-50ed05fa142f.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
