### PR TITLE
Fix #5376: NTP set to default banner still shown after setting brave as default in onboarding

### DIFF
--- a/Client/Application/ClientPreferences.swift
+++ b/Client/Application/ClientPreferences.swift
@@ -92,9 +92,9 @@ extension Preferences {
       key: "general.basic-onboarding-completed",
       default: OnboardingState.undetermined.rawValue)
     /// The time until the next on-boarding shows
-    static let basicOnboardingNextOnboardingPrompt = Option<Date?>(
-      key: "general.basic-onboarding-days",
-      default: nil)
+    static let basicOnboardingDefaultBrowserSelected = Option<Bool>(
+      key: "general.basic-onboarding-default-browser-selected",
+      default: false)
 
     /// The progress the user has made with onboarding
     static let basicOnboardingProgress = Option<Int>(key: "general.basic-onboarding-progress", default: OnboardingProgress.none.rawValue)

--- a/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
+++ b/Client/Frontend/Browser/New Tab Page/Sections/NTPDefaultBrowserCalloutProvider.swift
@@ -15,9 +15,10 @@ class NTPDefaultBrowserCalloutProvider: NSObject, NTPObservableSectionProvider {
   private typealias DefaultBrowserCalloutCell = NewTabCenteredCollectionViewCell<DefaultBrowserCalloutView>
   
   static var shouldShowCallout: Bool {
-    !Preferences.General.defaultBrowserCalloutDismissed.value
-    && AppConstants.iOSVersionGreaterThanOrEqual(to: 14)
-    && AppConstants.buildChannel == .release
+    !Preferences.General.defaultBrowserCalloutDismissed.value &&
+    !Preferences.General.basicOnboardingDefaultBrowserSelected.value &&
+    AppConstants.iOSVersionGreaterThanOrEqual(to: 14) &&
+    AppConstants.buildChannel == .release
   }
   
   func registerCells(to collectionView: UICollectionView) {

--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
@@ -368,7 +368,9 @@ class WelcomeViewController: UIViewController {
             details: Strings.Onboarding.navigateSettingsOnboardingScreenDescription))
       }
 
-    present(nextController, animated: true, completion: nil)
+    present(nextController, animated: true) {
+      Preferences.General.basicOnboardingDefaultBrowserSelected.value = true
+    }
   }
 
   private func onSetDefaultBrowser() {


### PR DESCRIPTION
Since we cant detect If the browser is set default or not, in this particular case we are detecting is user navigated to Settings from set default browser page in onboarding and in that case we do not show pop-over on NTP.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5376

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Clean install
- Select Set to Default in the second slide to load default browser settings
- Select brave from the list under Default Browser App
- Navigate back to Brave app, NTP will load

## Screenshots:


https://user-images.githubusercontent.com/6643505/170330174-b30aacf3-21f6-4305-86f7-09552b646d52.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
