### PR TITLE
Fix #5377: Tapping on playlist icon does not dismiss callout animation.

### DIFF
--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -276,7 +276,11 @@ extension BrowserViewController: PlaylistHelperDelegate {
             on: popover,
             browser: self)
           pulseAnimation.frame = pulseAnimation.frame.insetBy(dx: 10.0, dy: 12.0)
-
+          
+          pulseAnimation.animationViewPressed = {
+            popover.dismissPopover()
+          }
+          
           popover.popoverDidDismiss = { _ in
             pulseAnimation.removeFromSuperview()
           }


### PR DESCRIPTION
Adding Dismissal Case to Pop-over playlist, this is a regression after adding click event to Radial View Animation

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5377

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Clean Install
- Navigate to video site
- Play video
- click on animation

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/170356890-3a0672db-f00a-422e-9e11-bcf34f3f72bc.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
