### PR TITLE
Fix #5384: TabManager can provide incorrect selected account to web3 site

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -1216,8 +1216,10 @@ extension TabManager: NSFetchedResultsControllerDelegate {
       // fire `accountsChanged` event on open tabs for this `Domain`
       let tabsForDomain = self.allTabs.filter { $0.url?.domainURL.absoluteString.caseInsensitiveCompare(domainURL) == .orderedSame }
       tabsForDomain.forEach { tab in
-        let accounts = domain.wallet_permittedAccounts?.split(separator: ",").map(String.init) ?? []
-        tab.accountsChangedEvent(Array(accounts))
+        Task { @MainActor in
+          let accounts = await tab.allowedAccounts(false).0
+          tab.accountsChangedEvent(Array(accounts))
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary of Changes
- Selected account is now taken into account when calling `accountsChangedEvent(_:)` from `TabManager`'s `NSFetchedResultsControllerDelegate`

This pull request fixes #5384

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

  1. In Wallet Settings -> Manage Site Connections, remove all connections for `metamask.github.io`.
  2. Open [MetaMask test dapp site](https://metamask.github.io/test-dapp/).
  3. Tap Wallet button in URL bar
  4. In the wallet panel, tap the selected account blockie and change to any account *except* your first account
  5. Close wallet panel
  6. Tap 'Connect' on MetaMask test dapp site
  7. Connect all your accounts (first account and selected account must be give approval). Take note of your first account address, and selected account address.
  8. Verify the `Accounts` list on MetaMask displays the selected account


## Screenshots:

https://user-images.githubusercontent.com/5314553/170369475-d2a86136-c81c-4901-bb90-9a8623139f22.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
