### PR TITLE
Fix #5394: Handle local notifications when app is not in memory.

### DIFF
--- a/Client/Application/Delegates/SceneDelegate.swift
+++ b/Client/Application/Delegates/SceneDelegate.swift
@@ -129,6 +129,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     if let shortcutItem = connectionOptions.shortcutItem {
       QuickActions.sharedInstance.launchedShortcutItem = shortcutItem
     }
+    
+    if let response = connectionOptions.notificationResponse {
+      if response.notification.request.identifier == BrowserViewController.defaultBrowserNotificationId {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+          log.error("Failed to unwrap iOS settings URL")
+          return
+        }
+        UIApplication.shared.open(settingsUrl)
+      } else if response.notification.request.identifier == PrivacyReportsManager.notificationID {
+        browserViewController.openPrivacyReport()
+      }
+    }
         
     PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.buildChannel.isPublic)
     PrivacyReportsManager.consolidateData()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -837,7 +837,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
       .store(in: &cancellables)
   }
 
-  fileprivate let defaultBrowserNotificationId = "defaultBrowserNotification"
+  static let defaultBrowserNotificationId = "defaultBrowserNotification"
 
   private func scheduleDefaultBrowserNotification() {
     let center = UNUserNotificationCenter.current()
@@ -855,7 +855,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
 
       center.getPendingNotificationRequests { [weak self] requests in
         guard let self = self else { return }
-        if requests.contains(where: { $0.identifier == self.defaultBrowserNotificationId }) {
+        if requests.contains(where: { $0.identifier == Self.defaultBrowserNotificationId }) {
           // Already has one scheduled no need to schedule again.
           return
         }
@@ -869,7 +869,7 @@ class BrowserViewController: UIViewController, BrowserViewControllerDelegate {
         let timeTrigger = UNTimeIntervalNotificationTrigger(timeInterval: timeToShow, repeats: false)
 
         let request = UNNotificationRequest(
-          identifier: self.defaultBrowserNotificationId,
+          identifier: Self.defaultBrowserNotificationId,
           content: content,
           trigger: timeTrigger)
 
@@ -3308,7 +3308,7 @@ extension BrowserViewController {
 
 extension BrowserViewController: UNUserNotificationCenterDelegate {
   func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-    if response.notification.request.identifier == defaultBrowserNotificationId {
+    if response.notification.request.identifier == Self.defaultBrowserNotificationId {
       guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
         log.error("Failed to unwrap iOS settings URL")
         return


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5394 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket, better to test it in the dev environment

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
