### PR TITLE
Fix #5381: Permissions request modal can be shown unnecessarily 

### DIFF
--- a/BraveWallet/WalletPanelHostingController.swift
+++ b/BraveWallet/WalletPanelHostingController.swift
@@ -20,8 +20,7 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
   public init(
     walletStore: WalletStore,
     origin: URLOrigin,
-    faviconRenderer: WalletFaviconRenderer,
-    onUnlock: (() -> Void)? = nil
+    faviconRenderer: WalletFaviconRenderer
   ) {
     gesture = WalletInteractionGestureRecognizer(
       keyringStore: walletStore.keyringStore
@@ -58,17 +57,6 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
       )
       self.presentPanModal(controller)
     }
-    
-    cancellable = walletStore.keyringStore.$keyring
-      .dropFirst() // Drop initial value
-      .map(\.isLocked)
-      .removeDuplicates()
-      .dropFirst() // Drop first async fetch of keyring
-      .sink { isLocked in
-        if !isLocked {
-          onUnlock?()
-        }
-      }
   }
   
   @available(*, unavailable)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -53,25 +53,7 @@ extension BrowserViewController {
     let controller = WalletPanelHostingController(
       walletStore: walletStore,
       origin: origin,
-      faviconRenderer: FavIconImageRenderer(),
-      onUnlock: {
-        Task { @MainActor in
-          // check domain already has some permitted accouts
-          let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
-          if permissionRequestManager.hasPendingRequest(for: origin, coinType: .eth) {
-            let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: .eth)
-            let (accounts, status, _) = await tab.allowedAccounts(false)
-            if status == .success, !accounts.isEmpty {
-              for request in pendingRequests {
-                // cancel the requests if `allowedAccounts` is not empty for this domain
-                permissionRequestManager.cancelRequest(request)
-                // let wallet provider know we have allowed accounts for this domain
-                request.providerHandler?(accounts, .success, "")
-              }
-            }
-          }
-        }
-      }
+      faviconRenderer: FavIconImageRenderer()
     )
     controller.delegate = self
     let popover = PopoverController(contentController: controller)
@@ -276,6 +258,23 @@ extension Tab: BraveWalletKeyringServiceObserver {
   }
   
   func unlocked() {
+    guard let origin = url?.origin else { return }
+    Task { @MainActor in
+      // check domain already has some permitted accounts for this Tab's URLOrigin
+      let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
+      if permissionRequestManager.hasPendingRequest(for: origin, coinType: .eth) {
+        let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: .eth)
+        let (accounts, status, _) = await self.allowedAccounts(false)
+        if status == .success, !accounts.isEmpty {
+          for request in pendingRequests {
+            // cancel the requests if `allowedAccounts` is not empty for this domain
+            permissionRequestManager.cancelRequest(request)
+            // let wallet provider know we have allowed accounts for this domain
+            request.providerHandler?(accounts, .success, "")
+          }
+        }
+      }
+    }
   }
   
   func backedUp() {


### PR DESCRIPTION
## Summary of Changes
- Permissions request modal might be shown incorrectly for a web3 site that already had access because we were only cancelling requests.
- Previously we were passing an `onUnlock` closure to the wallet panel hosting controller, and on unlock we checked permission requests but only for the current tab. Now each Tab checks it's own requests in `unlocked()` observation function.

This pull request fixes #5381

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

  1. Open [Uniswap](https://app.uniswap.org/) in one tab and connect at least 1 account
  2. Open [Aave](https://app.aave.com/) in another tab and connect at least 1 account
  3. Quit the app, relaunch (might not required after #5363 merges, possibly just manually lock wallet)
  4. Open Uniswap tab and swipe away the web3 wallet notification
  5. Open Aave tab and tap the web3 wallet notification and unlock your wallet
  6. Visit Uniswap tab
  7. Verify Uniswap now shows the connected account without refreshing the page. Additionally if you tap the wallet icon in the URL bar, it should not prompt for approving accounts for uniswap (they are already approved)

Additional steps to reproduce similar & related issue:
  1. Open [Uniswap](https://app.uniswap.org/) in one tab and connect at least 1 account
  2. Quit the app, relaunch
  3. Open Uniswap tab and swipe away the web3 wallet notification
  4. Open main wallet from 3-dot menu, unlock your wallet and close the wallet modal
  5. Bug: Uniswap does not show the connected account

## Screenshots:

Original issue fixed:

https://user-images.githubusercontent.com/5314553/170558316-bb4ad724-81ec-452c-acb7-bb6c49db1bac.mov

Additional related issue fixed:

https://user-images.githubusercontent.com/5314553/170558413-c42f60eb-9508-470b-9b91-53f85cabb9ca.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
