### PR TITLE
Fix #5406: Adding missed favicon fetcher in New Permission and Edit Permission

### DIFF
--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -92,11 +92,19 @@ struct EditSiteConnectionView: View {
     }
   }
   
-  @ViewBuilder private var connectionInfo: some View {
-    Image(systemName: "globe")
-      .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
-      .background(Color(.braveDisabled))
-      .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+  @ViewBuilder private func connectionInfo(url: URL) -> some View {
+    FaviconReader(url: url) { image in
+      if let image = image {
+        Image(uiImage: image)
+          .resizable()
+          .scaledToFit()
+          .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
+          .background(Color(.braveDisabled))
+          .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+      } else {
+        ProgressView()
+      }
+    }
     VStack(alignment: sizeCategory.isAccessibilityCategory ? .center : .leading, spacing: 2) {
       origin.url.map { url in
         Text(verbatim: url.absoluteString)
@@ -132,20 +140,22 @@ struct EditSiteConnectionView: View {
             }
           }
         } header: {
-          Group {
-            if sizeCategory.isAccessibilityCategory {
-              VStack(spacing: 12) {
-                connectionInfo
-              }
-            } else {
-              HStack(spacing: 12) {    
-                connectionInfo
+          origin.url.map { url in
+            Group {
+              if sizeCategory.isAccessibilityCategory {
+                VStack(spacing: 12) {
+                  connectionInfo(url: url)
+                }
+              } else {
+                HStack(spacing: 12) {
+                  connectionInfo(url: url)
+                }
               }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .resetListHeaderStyle()
+            .padding(.vertical)
           }
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .resetListHeaderStyle()
-          .padding(.vertical)
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -41,7 +41,7 @@ public struct NewSiteConnectionView: View {
         Image(uiImage: image)
           .resizable()
           .scaledToFit()
-          .frame(width: faviconSize, height: faviconSize)
+          .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
           .background(Color(.braveDisabled))
           .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
       } else {
@@ -56,19 +56,10 @@ public struct NewSiteConnectionView: View {
   
   private var headerView: some View {
     VStack(spacing: 8) {
-      Group {
-        Image(systemName: "globe")
-          .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
-          .background(Color(.braveDisabled))
-          .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-        origin.url.map { url in
-          Text(verbatim: url.absoluteString)
-            .font(.subheadline)
-            .foregroundColor(Color(.braveLabel))
-            .multilineTextAlignment(.center)
-        }
+      origin.url.map { url in
+        originAndFavicon(url: url)
+          .accessibilityElement(children: .combine)
       }
-      .accessibilityElement(children: .combine)
       Text(Strings.Wallet.newSiteConnectMessage)
         .font(.headline)
         .foregroundColor(Color(.bravePrimary))


### PR DESCRIPTION

This pull request fixes #5406 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
please refer to the issue. 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
