### PR TITLE
Fix 5403: Close wallet panel when user goes to full screen wallet or full screen wallet settings from panel

### DIFF
--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -16,7 +16,7 @@ public protocol BraveWalletDelegate: AnyObject {
   /// This will be called after the wallet UI is dismissed
   func openWalletURL(_ url: URL)
   /// Present Wallet with or without dismiss the Wallet Panel depends on the value of the `presentWalletWithContext`
-  func walletPanel(_ presentWalletWithContext: PresentingContext)
+  func walletPanel(_ panel: WalletPanelHostingController, presentWalletWithContext: PresentingContext)
 }
 
 /// The context of which wallet is being presented. Controls what content is shown when the wallet is unlocked

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -15,8 +15,8 @@ public protocol BraveWalletDelegate: AnyObject {
   ///
   /// This will be called after the wallet UI is dismissed
   func openWalletURL(_ url: URL)
-  /// Will dismiss wallet panel and open full screen wallet or full screen wallet settings
-  func onFullScreenWallet(_ viewController: UIViewController)
+  /// Present Wallet with or without dismiss the Wallet Panel depends on the value of the `presentWalletWithContext`
+  func walletPanel(_ presentWalletWithContext: PresentingContext)
 }
 
 /// The context of which wallet is being presented. Controls what content is shown when the wallet is unlocked

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -16,7 +16,7 @@ public protocol BraveWalletDelegate: AnyObject {
   /// This will be called after the wallet UI is dismissed
   func openWalletURL(_ url: URL)
   /// Present Wallet with or without dismiss the Wallet Panel depends on the value of the `presentWalletWithContext`
-  func walletPanel(_ panel: WalletPanelHostingController, presentWalletWithContext: PresentingContext)
+  func walletPanel(_ panel: WalletPanelHostingController, presentWalletWithContext: PresentingContext, walletStore: WalletStore)
 }
 
 /// The context of which wallet is being presented. Controls what content is shown when the wallet is unlocked

--- a/BraveWallet/WalletHostingViewController.swift
+++ b/BraveWallet/WalletHostingViewController.swift
@@ -15,6 +15,8 @@ public protocol BraveWalletDelegate: AnyObject {
   ///
   /// This will be called after the wallet UI is dismissed
   func openWalletURL(_ url: URL)
+  /// Will dismiss wallet panel and open full screen wallet or full screen wallet settings
+  func onFullScreenWallet(_ viewController: UIViewController)
 }
 
 /// The context of which wallet is being presented. Controls what content is shown when the wallet is unlocked

--- a/BraveWallet/WalletPanelHostingController.swift
+++ b/BraveWallet/WalletPanelHostingController.swift
@@ -38,7 +38,12 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
         faviconRenderer: faviconRenderer
       )
       walletHostingController.delegate = self.delegate
-      self.present(walletHostingController, animated: true)
+      switch context {
+      case .default, .settings:
+        self.delegate?.onFullScreenWallet(walletHostingController)
+      default:
+        self.present(walletHostingController, animated: true)
+      }
     }
     rootView.presentBuySendSwap = { [weak self] in
       guard let self = self, let store = walletStore.cryptoStore else { return }

--- a/BraveWallet/WalletPanelHostingController.swift
+++ b/BraveWallet/WalletPanelHostingController.swift
@@ -31,19 +31,7 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
       origin: origin
     ))
     rootView.presentWalletWithContext = { [weak self] context in
-      guard let self = self else { return }
-      let walletHostingController = WalletHostingViewController(
-        walletStore: walletStore,
-        presentingContext: context,
-        faviconRenderer: faviconRenderer
-      )
-      walletHostingController.delegate = self.delegate
-      switch context {
-      case .default, .settings:
-        self.delegate?.onFullScreenWallet(walletHostingController)
-      default:
-        self.present(walletHostingController, animated: true)
-      }
+      self?.delegate?.walletPanel(context)
     }
     rootView.presentBuySendSwap = { [weak self] in
       guard let self = self, let store = walletStore.cryptoStore else { return }

--- a/BraveWallet/WalletPanelHostingController.swift
+++ b/BraveWallet/WalletPanelHostingController.swift
@@ -32,7 +32,7 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
     ))
     rootView.presentWalletWithContext = { [weak self] context in
       guard let self = self else { return }
-      self.delegate?.walletPanel(self, presentWalletWithContext: context)
+      self.delegate?.walletPanel(self, presentWalletWithContext: context, walletStore: walletStore)
     }
     rootView.presentBuySendSwap = { [weak self] in
       guard let self = self, let store = walletStore.cryptoStore else { return }

--- a/BraveWallet/WalletPanelHostingController.swift
+++ b/BraveWallet/WalletPanelHostingController.swift
@@ -31,7 +31,8 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
       origin: origin
     ))
     rootView.presentWalletWithContext = { [weak self] context in
-      self?.delegate?.walletPanel(context)
+      guard let self = self else { return }
+      self.delegate?.walletPanel(self, presentWalletWithContext: context)
     }
     rootView.presentBuySendSwap = { [weak self] in
       guard let self = self, let store = walletStore.cryptoStore else { return }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -112,6 +112,12 @@ extension BrowserViewController: BraveWalletDelegate {
       )
     }
   }
+  
+  func onFullScreenWallet(_ viewController: UIViewController) {
+    self.dismiss(animated: true) { [weak self] in
+      self?.present(viewController, animated: true)
+    }
+  }
 }
 
 extension Tab: BraveWalletProviderDelegate {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -113,7 +113,7 @@ extension BrowserViewController: BraveWalletDelegate {
     }
   }
   
-  func walletPanel(_ presentWalletWithContext: PresentingContext) {
+  public func walletPanel(_ panel: WalletPanelHostingController, presentWalletWithContext: PresentingContext) {
     if let walletStore = WalletStore.from(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
       let walletHostingController = WalletHostingViewController(
         walletStore: walletStore,
@@ -129,9 +129,7 @@ extension BrowserViewController: BraveWalletDelegate {
           self?.present(walletHostingController, animated: true)
         }
       default:
-        if let presentedViewController = presentedViewController {
-          presentedViewController.present(walletHostingController, animated: true)
-        }
+        panel.present(walletHostingController, animated: true)
       }
     }
   }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -113,9 +113,26 @@ extension BrowserViewController: BraveWalletDelegate {
     }
   }
   
-  func onFullScreenWallet(_ viewController: UIViewController) {
-    self.dismiss(animated: true) { [weak self] in
-      self?.present(viewController, animated: true)
+  func walletPanel(_ presentWalletWithContext: PresentingContext) {
+    if let walletStore = WalletStore.from(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
+      let walletHostingController = WalletHostingViewController(
+        walletStore: walletStore,
+        presentingContext: presentWalletWithContext,
+        faviconRenderer: FavIconImageRenderer()
+      )
+      walletHostingController.delegate = self
+  
+      switch presentWalletWithContext {
+      case .default, .settings:
+        // Dismiss Wallet Panel first, then present Wallet
+        self.dismiss(animated: true) { [weak self] in
+          self?.present(walletHostingController, animated: true)
+        }
+      default:
+        if let presentedViewController = presentedViewController {
+          presentedViewController.present(walletHostingController, animated: true)
+        }
+      }
     }
   }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -113,24 +113,22 @@ extension BrowserViewController: BraveWalletDelegate {
     }
   }
   
-  public func walletPanel(_ panel: WalletPanelHostingController, presentWalletWithContext: PresentingContext) {
-    if let walletStore = WalletStore.from(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
-      let walletHostingController = WalletHostingViewController(
-        walletStore: walletStore,
-        presentingContext: presentWalletWithContext,
-        faviconRenderer: FavIconImageRenderer()
-      )
-      walletHostingController.delegate = self
-  
-      switch presentWalletWithContext {
-      case .default, .settings:
-        // Dismiss Wallet Panel first, then present Wallet
-        self.dismiss(animated: true) { [weak self] in
-          self?.present(walletHostingController, animated: true)
-        }
-      default:
-        panel.present(walletHostingController, animated: true)
+  public func walletPanel(_ panel: WalletPanelHostingController, presentWalletWithContext: PresentingContext, walletStore: WalletStore) {
+    let walletHostingController = WalletHostingViewController(
+      walletStore: walletStore,
+      presentingContext: presentWalletWithContext,
+      faviconRenderer: FavIconImageRenderer()
+    )
+    walletHostingController.delegate = self
+    
+    switch presentWalletWithContext {
+    case .default, .settings:
+      // Dismiss Wallet Panel first, then present Wallet
+      self.dismiss(animated: true) { [weak self] in
+        self?.present(walletHostingController, animated: true)
       }
+    default:
+      panel.present(walletHostingController, animated: true)
     }
   }
 }


### PR DESCRIPTION
Changing UX: Close wallet panel when user goes to full screen wallet or full screen wallet settings from panel

This pull request fixes #5403 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Please refer to the issue.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
