### PR TITLE
Fix #5413: Fix textfield text color when adding/editing a network

### DIFF
--- a/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -22,7 +22,7 @@ struct NetworkTextField: View {
       TextField(placeholder, text: $item.input)
         .autocapitalization(.none)
         .disableAutocorrection(true)
-        .foregroundColor(.black)
+        .foregroundColor(Color(.braveLabel))
       if let error = item.error {
         HStack(alignment: .firstTextBaseline, spacing: 4) {
           Image(systemName: "exclamationmark.circle.fill")


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5413

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Set theme to dark mode
2. Create brave wallet, open brave wallet
3. Navigate to settings > networks > +
4. Start typing in the fields
5. Save the network
6. Tap on existing network
7. Tap on fields
8. Observe


## Screenshots:

![add network](https://user-images.githubusercontent.com/5314553/171421937-d02498c8-0e13-44b0-8367-e5776fc054c1.png) | ![edit network](https://user-images.githubusercontent.com/5314553/171421946-019db176-5e7f-45e7-b22c-424fe9568cea.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
