### PR TITLE
Fix #5402: Account selection not updating to new account on some sites

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -280,22 +280,13 @@ extension Tab: BraveWalletEventsListener {
   }
   
   func accountsChangedEvent(_ accounts: [String]) {
-    if let lastEmittedAccount = lastEmittedAccount {
-      if lastEmittedAccount != "" {
-        /// Temporary fix for #5402.
-        /// If we emit from one account directly to another we're not seeing dapp sites
-        /// update our selected account. If we emit an  undefined/empty string before
-        /// emitting the new account, we're seeing correct account change behaviour
-        self.lastEmittedAccount = ""
-        emitEthereumEvent(.ethereumAccountsChanged(accounts: [""]))
-        self.lastEmittedAccount = accounts.first
-        emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
-      }
-    } else {
-      lastEmittedAccount = accounts.first
-      emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
-      updateEthereumProperties()
-    }
+    /// Temporary fix for #5402.
+    /// If we emit from one account directly to another we're not seeing dapp sites
+    /// update our selected account. If we emit an undefined/empty string before
+    /// emitting the new account, we're seeing correct account change behaviour
+    emitEthereumEvent(.ethereumAccountsChanged(accounts: []))
+    emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
+    updateEthereumProperties()
   }
   
   func updateEthereumProperties() {
@@ -336,9 +327,6 @@ extension Tab: BraveWalletEventsListener {
       let coin = await walletService.selectedCoin()
       let accounts = await keyringService.keyringInfo(coin.keyringId).accountInfos.map(\.address)
       let selectedAccount = valueOrUndefined(await allowedAccounts(coin, accounts: accounts).1.first)
-      if self.lastEmittedAccount == nil {
-        self.lastEmittedAccount = selectedAccount
-      }
       webView.evaluateSafeJavaScript(
         functionName: "window.ethereum.selectedAddress = \(selectedAccount)",
         contentWorld: .page,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -280,8 +280,22 @@ extension Tab: BraveWalletEventsListener {
   }
   
   func accountsChangedEvent(_ accounts: [String]) {
-    emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
-    updateEthereumProperties()
+    if let lastEmittedAccount = lastEmittedAccount {
+      if lastEmittedAccount != "" {
+        /// Temporary fix for #5402.
+        /// If we emit from one account directly to another we're not seeing dapp sites
+        /// update our selected account. If we emit an  undefined/empty string before
+        /// emitting the new account, we're seeing correct account change behaviour
+        self.lastEmittedAccount = ""
+        emitEthereumEvent(.ethereumAccountsChanged(accounts: [""]))
+        self.lastEmittedAccount = accounts.first
+        emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
+      }
+    } else {
+      lastEmittedAccount = accounts.first
+      emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
+      updateEthereumProperties()
+    }
   }
   
   func updateEthereumProperties() {
@@ -322,6 +336,9 @@ extension Tab: BraveWalletEventsListener {
       let coin = await walletService.selectedCoin()
       let accounts = await keyringService.keyringInfo(coin.keyringId).accountInfos.map(\.address)
       let selectedAccount = valueOrUndefined(await allowedAccounts(coin, accounts: accounts).1.first)
+      if self.lastEmittedAccount == nil {
+        self.lastEmittedAccount = selectedAccount
+      }
       webView.evaluateSafeJavaScript(
         functionName: "window.ethereum.selectedAddress = \(selectedAccount)",
         contentWorld: .page,

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -79,7 +79,6 @@ class Tab: NSObject {
       walletKeyringService?.add(self)
     }
   }
-  var lastEmittedAccount: String?
   // PageMetadata is derived from the page content itself, and as such lags behind the
   // rest of the tab.
   var pageMetadata: PageMetadata?

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -79,6 +79,7 @@ class Tab: NSObject {
       walletKeyringService?.add(self)
     }
   }
+  var lastEmittedAccount: String?
   // PageMetadata is derived from the page content itself, and as such lags behind the
   // rest of the tab.
   var pageMetadata: PageMetadata?


### PR DESCRIPTION
## Summary of Changes
- Resolves account selection issue on some sites by emitting an empty string for the `accountsChanged` event prior to emitting the new account. Resolves Uniswap & Metamask test dapp site among some others

This pull request fixes #5402 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Open [Uniswap](https://app.uniswap.org/) and connect 2 or more accounts
2. Close the panel and observe displayed connected account
3. Tap wallet icon and tap account blockie and select a new account
4. Close wallet panel and verify the displayed connected account has updated to the new account

Please test on some other dapp sites too, some don't seem to observe the `accountsChanged` event, while some don't reload their displayed info when we change.


## Screenshots:

https://user-images.githubusercontent.com/5314553/171641382-5c538fa5-786d-4b65-91fa-64bffa4200ec.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
