### PR TITLE
Fix #5419: Run post-setup tasks immediately if tabs are already setup

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -886,6 +886,14 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
       }
     }
   }
+  
+  private func executeAfterSetup(_ block: @escaping () -> Void) {
+    if setupTasksCompleted {
+      block()
+    } else {
+      postSetupTasks.append(block)
+    }
+  }
 
   fileprivate func setupTabs() {
     assert(contentBlockListCompiled, "Tabs should not be set up until after blocker lists are compiled")
@@ -3356,15 +3364,15 @@ extension BrowserViewController: PreferencesObserver {
 
 extension BrowserViewController {
   public func openReferralLink(url: URL) {
-    postSetupTasks.append({
-      self.openURLInNewTab(url, isPrivileged: false)
-    })
+    executeAfterSetup { [self] in
+      openURLInNewTab(url, isPrivileged: false)
+    }
   }
 
   public func handleNavigationPath(path: NavigationPath) {
-    postSetupTasks.append({
+    executeAfterSetup {
       NavigationPath.handle(nav: path, with: self)
-    })
+    }
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5419

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
