### PR TITLE
Fix #5430: Playlist crashes when streaming item

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -1010,7 +1010,6 @@ extension PlaylistViewController: VideoViewDelegate {
                 completion?(.none)
               }
             ).store(in: &self.assetLoadingStateObservers)
-            log.debug("Playing Live Video: \(self.player.isLiveMedia)")
           } else {
             PlaylistMediaStreamer.clearNowPlayingInfo()
             completion?(.expired)


### PR DESCRIPTION
## Summary of Changes
- Deleted code that causes Playlist to crash

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5430

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
