### PR TITLE
No Bug: Update some deprecated APIs and fixup swiftlint warnings

### DIFF
--- a/BraveUI/Popover/PopoverNavigationController.swift
+++ b/BraveUI/Popover/PopoverNavigationController.swift
@@ -52,7 +52,7 @@ open class PopoverNavigationController: UINavigationController, PopoverContentCo
 
   public override var additionalSafeAreaInsets: UIEdgeInsets {
     get { return UIEdgeInsets(top: PopoverArrowHeight, left: 0, bottom: 0, right: 0) }
-    set {}  // swiftlint:disable:this unused_setter_value
+    set {}
   }
 
   open override func viewDidLoad() {

--- a/BraveUI/SwiftUI/FixedHeightHostingPanModalController.swift
+++ b/BraveUI/SwiftUI/FixedHeightHostingPanModalController.swift
@@ -67,6 +67,6 @@ public class FixedHeightHostingPanModalController<Content: View>: UIViewControll
       let containerSize = CGSize(width: min(375, view.bounds.width), height: view.bounds.height)
       return .init(width: containerSize.width, height: hostingControllerIntrinsicHeight(for: containerSize))
     }
-    set {} // swiftlint:disable:this unused_setter_value
+    set {}
   }
 }

--- a/BraveWallet/WalletTableViewHeaderView.swift
+++ b/BraveWallet/WalletTableViewHeaderView.swift
@@ -136,12 +136,12 @@ class WalletTableViewHeaderView: UITableViewHeaderFooterView {
   @available(iOS, unavailable)
   override var textLabel: UILabel? {
     get { nil }
-    set {}  // swiftlint:disable:this unused_setter_value
+    set {}
   }
 
   @available(iOS, unavailable)
   override var detailTextLabel: UILabel? {
     get { nil }
-    set {}  // swiftlint:disable:this unused_setter_value
+    set {}
   }
 }

--- a/Client/Frontend/Brave Today/Cards/BraveNewsOptInView.swift
+++ b/Client/Frontend/Brave Today/Cards/BraveNewsOptInView.swift
@@ -190,6 +190,6 @@ private class MaskedNewLabel: UIView {
   }
   override var accessibilityLabel: String? {
     get { label.accessibilityLabel }
-    set {}  // swiftlint:disable:this unused_setter_value
+    set {}
   }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -790,7 +790,8 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     if AppConstants.buildChannel.isPublic && AppReview.shouldRequestReview() {
       // Request Review when the main-queue is free or on the next cycle.
       DispatchQueue.main.async {
-        SKStoreReviewController.requestReview()
+        guard let windowScene = self.currentScene else { return }
+        SKStoreReviewController.requestReview(in: windowScene)
       }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -267,9 +267,7 @@ extension BrowserViewController: WKNavigationDelegate {
       pendingRequests[url.absoluteString] = navigationAction.request
 
       // TODO: Downgrade to 14.5 once api becomes available.
-      if #available(iOS 15, *) {
-        // do nothing, use Apple's https solution.
-      } else {
+      if #unavailable(iOS 15.0) {
         if Preferences.Shields.httpsEverywhere.value,
           url.scheme == "http",
           let urlHost = url.normalizedHost() {
@@ -306,7 +304,7 @@ extension BrowserViewController: WKNavigationDelegate {
         off.compactMap { $0.rule }.forEach(controller.remove)
 
         let isScriptsEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
-          preferences.allowsContentJavaScript = isScriptsEnabled
+        preferences.allowsContentJavaScript = isScriptsEnabled
       }
 
       // Cookie Blocking code below

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -27,7 +27,7 @@ enum NTPLandscapeSizingBehavior {
 
 /// A section that will be shown in the NTP. Sections are responsible for the
 /// layout and interaction of their own items
-protocol NTPSectionProvider: NSObject, UICollectionViewDelegateFlowLayout & UICollectionViewDataSource {
+protocol NTPSectionProvider: NSObject, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
   /// Register cells and supplimentary views for your section to
   /// `collectionView`
   func registerCells(to collectionView: UICollectionView)

--- a/Client/Frontend/Browser/Onboarding/Welcome/PlaylistOnboardingView.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/PlaylistOnboardingView.swift
@@ -59,7 +59,7 @@ struct PlaylistOnboardingView_Previews: PreviewProvider {
 }
 #endif
 
-class PlaylistOnboardingViewController: UIHostingController<PlaylistOnboardingView> & PopoverContentComponent {
+class PlaylistOnboardingViewController: UIHostingController<PlaylistOnboardingView>, PopoverContentComponent {
 
   init() {
     super.init(rootView: PlaylistOnboardingView())

--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeNTPOnboardingView.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeNTPOnboardingView.swift
@@ -8,7 +8,7 @@ import UIKit
 import SnapKit
 import BraveUI
 
-class WelcomeNTPOnboardingController: UIViewController & PopoverContentComponent {
+class WelcomeNTPOnboardingController: UIViewController, PopoverContentComponent {
   private let textStackView = UIStackView().then {
     $0.spacing = 8.0
     $0.alignment = .top
@@ -125,7 +125,7 @@ class WelcomeNTPOnboardingController: UIViewController & PopoverContentComponent
   }
 }
 
-class WelcomeOmniBoxOnboardingController: UIViewController & PopoverContentComponent {
+class WelcomeOmniBoxOnboardingController: UIViewController, PopoverContentComponent {
   
   private let stackView = UIStackView().then {
     $0.spacing = 20.0

--- a/Client/Frontend/Browser/Playlist/PlaylistPopoverView.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistPopoverView.swift
@@ -155,7 +155,7 @@ struct PlaylistPopoverView_Previews: PreviewProvider {
 }
 #endif
 
-class PlaylistPopoverViewController: UIHostingController<PlaylistPopoverView> & PopoverContentComponent {
+class PlaylistPopoverViewController: UIHostingController<PlaylistPopoverView>, PopoverContentComponent {
 
   init(state: PlaylistPopoverState) {
     super.init(rootView: PlaylistPopoverView(state: state))

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -249,7 +249,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     let alert = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
     alert.popoverPresentationController?.barButtonItem = sender
     let importAction = UIAlertAction(title: Strings.bookmarksImportAction, style: .default) { [weak self] _ in
-      let vc = UIDocumentPickerViewController(documentTypes: [String(kUTTypeHTML)], in: .import)
+      let vc = UIDocumentPickerViewController(forOpeningContentTypes: [.html])
       vc.delegate = self
       self?.present(vc, animated: true)
     }

--- a/Client/Frontend/Browser/User Scripts/FarblingProtectionHelper.swift
+++ b/Client/Frontend/Browser/User Scripts/FarblingProtectionHelper.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+// swiftlint:disable legacy_random
+
 /// A class that helps in creating farbling data
 class FarblingProtectionHelper {
   /// Represents `JSON` data that needs to be passed to `FarblingProtection.js`
@@ -161,3 +163,5 @@ private extension Array {
     return self[randomIndex]
   }
 }
+
+// swiftlint:enable legacy_random

--- a/Client/Frontend/Settings/Brave News/BraveNewsAddSourceViewController.swift
+++ b/Client/Frontend/Settings/Brave News/BraveNewsAddSourceViewController.swift
@@ -83,7 +83,7 @@ class BraveNewsAddSourceViewController: UITableViewController {
   }
 
   private func tappedImportOPML() {
-    let picker = UIDocumentPickerViewController(documentTypes: ["public.opml"], in: .import)
+    let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.init("public.opml")!])
     picker.delegate = self
     picker.allowsMultipleSelection = false
     if #available(iOS 13.0, *) {

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -54,7 +54,7 @@ class CookiesAndCacheClearable: Clearable {
     UserDefaults.standard.synchronize()
     await BraveWebView.sharedNonPersistentStore().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: Date(timeIntervalSinceReferenceDate: 0))
     UserDefaults.standard.synchronize()
-    try await Domain.clearAllEthereumPermissions()
+    await Domain.clearAllEthereumPermissions()
   }
 }
 

--- a/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
+++ b/Client/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
@@ -377,7 +377,7 @@ class RewardsDebugSettingsViewController: TableViewController {
   }
 
   private func tappedImportRewardsDatabase() {
-    let docPicker = UIDocumentPickerViewController(documentTypes: [String(kUTTypeData), String(kUTTypeDatabase)], in: .import)
+    let docPicker = UIDocumentPickerViewController(forOpeningContentTypes: [.data, .database])
     docPicker.shouldShowFileExtensions = true
     docPicker.delegate = self
     self.present(docPicker, animated: true)

--- a/Client/Frontend/Shields/SimpleShieldsView.swift
+++ b/Client/Frontend/Shields/SimpleShieldsView.swift
@@ -78,9 +78,7 @@ class SimpleShieldsView: UIView {
         return string
       }()
       $0.backgroundColor = .clear
-      if #available(iOS 15.0, *) {
-        // do nothing
-      } else {
+      if #unavailable(iOS 15.0) {
         $0.setContentCompressionResistancePriority(.required, for: .horizontal)
       }
 

--- a/Client/Migration/BraveCoreMigrator.swift
+++ b/Client/Migration/BraveCoreMigrator.swift
@@ -494,7 +494,7 @@ extension BraveCoreMigrator {
 
 extension BraveCoreMigrator {
 
-  class BookmarksModelLoadedObserver: NSObject & BookmarkModelObserver {
+  class BookmarksModelLoadedObserver: NSObject, BookmarkModelObserver {
     private let onModelLoaded: () -> Void
 
     init(_ onModelLoaded: @escaping () -> Void) {
@@ -506,7 +506,7 @@ extension BraveCoreMigrator {
     }
   }
 
-  class HistoryServiceLoadedObserver: NSObject & HistoryServiceObserver {
+  class HistoryServiceLoadedObserver: NSObject, HistoryServiceObserver {
     private let onServiceLoaded: () -> Void
 
     init(_ onModelLoaded: @escaping () -> Void) {

--- a/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
@@ -104,9 +104,7 @@ class TPStatsBlocklistChecker {
       }
 
       // TODO: Downgrade to 14.5 once api becomes available.
-      if #available(iOS 15, *) {
-        // do nothing
-      } else {
+      if #unavailable(iOS 15.0) {
         HttpsEverywhereStats.shared.shouldUpgrade(url) { shouldUpgrade in
           DispatchQueue.main.async {
             if enabledLists.contains(.https) && shouldUpgrade {

--- a/Package.swift
+++ b/Package.swift
@@ -188,7 +188,8 @@ let package = Package(
       cxxSettings: [
         .headerSearchPath("include"),
         .headerSearchPath("ThirdParty/**"),
-        .headerSearchPath("Cpp")
+        .headerSearchPath("Cpp"),
+        .unsafeFlags(["-w"]),
       ]
     ),
     .target(


### PR DESCRIPTION
Deprecated APIs that were fixed:
- `UIDocumentPickerViewController` initializer
- `SKStoreReviewController.requestReview` call

SwiftLint version now matches what CI uses (`0.47.1`)

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
