### PR TITLE
No bug: Fix tap area on wallet panel buttons

### DIFF
--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -216,7 +216,38 @@ struct WalletPanelView: View {
     Button(action: { presentWalletWithContext(.pendingRequests) }) {
       Image("brave.bell.badge")
         .foregroundColor(.white)
+        .frame(minWidth: 30, minHeight: 44)
+        .contentShape(Rectangle())
     }
+  }
+  
+  private var fullscreenButton: some View {
+    Button {
+      presentWalletWithContext(.default)
+    } label: {
+      Image(systemName: "arrow.up.left.and.arrow.down.right")
+        .rotationEffect(.init(degrees: 90))
+        .frame(minWidth: 30, minHeight: 44)
+        .contentShape(Rectangle())
+    }
+    .accessibilityLabel(Strings.Wallet.walletFullScreenAccessibilityTitle)
+  }
+  
+  private var menuButton: some View {
+    Menu {
+      Button(action: { keyringStore.lock() }) {
+        Label(Strings.Wallet.lock, image: "brave.lock")
+      }
+      Divider()
+      Button(action: { presentWalletWithContext(.settings) }) {
+        Label(Strings.Wallet.settings, image: "brave.gear")
+      }
+    } label: {
+      Image(systemName: "ellipsis")
+        .frame(minWidth: 30, minHeight: 44)
+        .contentShape(Rectangle())
+    }
+    .accessibilityLabel(Strings.Wallet.otherWalletActionsAccessibilityTitle)
   }
   
   var body: some View {
@@ -230,33 +261,17 @@ struct WalletPanelView: View {
                 Color.clear
               )
             HStack {
-              Button {
-                presentWalletWithContext(.default)
-              } label: {
-                Image(systemName: "arrow.up.left.and.arrow.down.right")
-                  .rotationEffect(.init(degrees: 90))
-              }
-              .accessibilityLabel(Strings.Wallet.walletFullScreenAccessibilityTitle)
+              fullscreenButton
               Spacer()
               if cryptoStore.pendingRequest != nil {
                 pendingRequestsButton
                 Spacer()
               }
-              Menu {
-                Button(action: { keyringStore.lock() }) {
-                  Label(Strings.Wallet.lock, image: "brave.lock")
-                }
-                Divider()
-                Button(action: { presentWalletWithContext(.settings) }) {
-                  Label(Strings.Wallet.settings, image: "brave.gear")
-                }
-              } label: {
-                Image(systemName: "ellipsis")
-              }
-              .accessibilityLabel(Strings.Wallet.otherWalletActionsAccessibilityTitle)
+              menuButton
             }
           }
-          .padding(16)
+          .padding(.horizontal, 16)
+          .padding(.vertical, 4)
           .overlay(
             Color.white.opacity(0.3) // Divider
               .frame(height: pixelLength),
@@ -264,13 +279,7 @@ struct WalletPanelView: View {
           )
         } else {
           HStack {
-            Button {
-              presentWalletWithContext(.default)
-            } label: {
-              Image(systemName: "arrow.up.left.and.arrow.down.right")
-                .rotationEffect(.init(degrees: 90))
-            }
-            .accessibilityLabel(Strings.Wallet.walletFullScreenAccessibilityTitle)
+            fullscreenButton
             if cryptoStore.pendingRequest != nil {
               // fake bell icon for layout
               pendingRequestsButton
@@ -286,20 +295,10 @@ struct WalletPanelView: View {
             if cryptoStore.pendingRequest != nil {
               pendingRequestsButton
             }
-            Menu {
-              Button(action: { keyringStore.lock() }) {
-                Label(Strings.Wallet.lock, image: "brave.lock")
-              }
-              Divider()
-              Button(action: { presentWalletWithContext(.settings) }) {
-                Label(Strings.Wallet.settings, image: "brave.gear")
-              }
-            } label: {
-              Image(systemName: "ellipsis")
-            }
-            .accessibilityLabel(Strings.Wallet.otherWalletActionsAccessibilityTitle)
+            menuButton
           }
-          .padding(16)
+          .padding(.horizontal, 16)
+          .padding(.vertical, 4)
           .overlay(
             Color.white.opacity(0.3) // Divider
               .frame(height: pixelLength),


### PR DESCRIPTION
## Summary of Changes
- Set a minimum height and width on the wallet panel buttons so they're more tappable

This pull request fixes #5216

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Unlock wallet
2. Navigate to dapp site like [Uniswap](https://app.uniswap.org/)
3. Tap wallet notification or wallet icon in url bar
4. Test tapping on fullscreen button in top left
5. Test tapping on ellipsis menu button in top right


## Screenshots:

https://user-images.githubusercontent.com/5314553/171735838-5d76b0cf-e9bc-4495-a5fb-c217ecae2fed.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
