### PR TITLE
Fix #5438: Save password prompt does not surface to the page after login

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1908,13 +1908,15 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
   }
   
   func displayPageZoom(visible: Bool) {
-    if !visible || pageZoomBar != nil {
-      alertStackView.arrangedSubviews.forEach({
-        $0.removeFromSuperview()
-      })
-      
+    if !visible || pageZoomBar != nil {     
+      pageZoomBar?.view.removeFromSuperview()
       updateViewConstraints()
       pageZoomBar = nil
+      
+      if let zoomBarView = pageZoomBar?.view {
+        alertStackView.removeArrangedSubview(zoomBarView)
+      }
+      
       return
     }
     

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1910,12 +1910,13 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
   func displayPageZoom(visible: Bool) {
     if !visible || pageZoomBar != nil {     
       pageZoomBar?.view.removeFromSuperview()
-      updateViewConstraints()
-      pageZoomBar = nil
-      
+
       if let zoomBarView = pageZoomBar?.view {
         alertStackView.removeArrangedSubview(zoomBarView)
       }
+        
+      updateViewConstraints()
+      pageZoomBar = nil
       
       return
     }


### PR DESCRIPTION
AlertStackView contains prompts also not related with page zoom, while altering visibility only pageZoomView should be removed.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5438

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Clean install
- Navigate to Google.com
- Sign in
- Observe Login save prompt is shown

## Screenshots:

![IMG_0363](https://user-images.githubusercontent.com/6643505/171852991-1868c91b-8a80-4e43-a96f-66f9a661a1e5.PNG)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
