### PR TITLE
[No Bug]: Adding new sites to Night Mode exception list

### DIFF
--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -436,12 +436,22 @@ extension URL {
     }
 
     /// Site domains that should not inject night mode
-    let siteList = ["twitter", "youtube", "twitch",
-                    "macrumors", "9to5mac", "soundcloud",
-                    "netflix", "github", "developer.apple",
-                    "search.brave", "wowhead"]
-
-    return siteList.contains(where: host.contains)
+    let majorsiteList = ["twitter", "youtube", "twitch",
+                         "soundcloud", "github", "netflix",
+                         "imdb"]
+    
+    let searchSiteList = ["search.brave", "google", "qwant",
+                          "startpage", "duckduckgo"]
+    
+    let devSiteList = ["macrumors", "9to5mac", "developer.apple"]
+                    
+    let casualSiteList = ["wowhead", "xbox", "thegamer",
+                          "cineplex", "starwars"]
+    
+    let darkModeEnabledSiteList =
+      majorsiteList + searchSiteList + devSiteList + casualSiteList
+    
+    return darkModeEnabledSiteList.contains(where: host.contains)
   }
   
   // Check if the website is search engine


### PR DESCRIPTION
Adding new sites to Night Mode exceptions site list. Some new sites which support dark mode automatically is added to the list including some important search engine sites.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
N/A

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
