### PR TITLE
Fix #5178: URL Bar Button Priority

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2361,12 +2361,10 @@ extension BrowserViewController: TabDelegate {
     if shouldShowWalletButton {
       Task { @MainActor in
         let isPendingRequestAvailable = await isPendingRequestAvailable()
-        topToolbar.locationView.walletButton.buttonState = isPendingRequestAvailable ? .activeWithPendingRequest : .active
-        topToolbar.updateReaderModeState(.unavailable)
-        topToolbar.locationView.playlistButton.buttonState = .none
+        topToolbar.updateWalletButtonState(isPendingRequestAvailable ? .activeWithPendingRequest : .active)
       }
     } else {
-      topToolbar.locationView.walletButton.buttonState = .inactive
+      topToolbar.updateWalletButtonState(.inactive)
     }
   }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2362,6 +2362,8 @@ extension BrowserViewController: TabDelegate {
       Task { @MainActor in
         let isPendingRequestAvailable = await isPendingRequestAvailable()
         topToolbar.locationView.walletButton.buttonState = isPendingRequestAvailable ? .activeWithPendingRequest : .active
+        topToolbar.updateReaderModeState(.unavailable)
+        topToolbar.locationView.playlistButton.buttonState = .none
       }
     } else {
       topToolbar.locationView.walletButton.buttonState = .inactive

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -30,7 +30,7 @@ extension BrowserViewController: ReaderModeDelegate {
     if tabManager.selectedTab === tab {
       let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true
 
-      if !shouldShowPlaylistURLBarButton || tab.playlistItemState == .none {
+      if (!shouldShowPlaylistURLBarButton || tab.playlistItemState == .none) && !tab.isWalletIconVisible {
         topToolbar.updateReaderModeState(state)
       }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -28,11 +28,7 @@ extension BrowserViewController: ReaderModeDelegate {
     // If this reader mode availability state change is for the tab that we currently show, then update
     // the button. Otherwise do nothing and the button will be updated when the tab is made active.
     if tabManager.selectedTab === tab {
-      let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true
-
-      if (!shouldShowPlaylistURLBarButton || tab.playlistItemState == .none) && !tab.isWalletIconVisible {
-        topToolbar.updateReaderModeState(state)
-      }
+      topToolbar.updateReaderModeState(state)
     }
   }
 

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -84,7 +84,7 @@ extension BrowserViewController: PlaylistHelperDelegate {
       tab.playlistItemState = state
       tab.playlistItem = item
 
-      let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true && Preferences.Playlist.enablePlaylistURLBarButton.value
+      let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true && Preferences.Playlist.enablePlaylistURLBarButton.value && !tab.isWalletIconVisible
 
       let playlistButton = topToolbar.locationView.playlistButton
       switch state {
@@ -94,7 +94,7 @@ extension BrowserViewController: PlaylistHelperDelegate {
         toolbar?.menuButton.removeBadge(.playlist, animated: true)
       case .newItem:
         if shouldShowPlaylistURLBarButton {
-          topToolbar.locationView.readerModeState = .unavailable
+          topToolbar.updateReaderModeState(.unavailable)
         }
         playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addToPlaylist : .none
         if Preferences.Playlist.enablePlaylistMenuBadge.value {
@@ -106,7 +106,7 @@ extension BrowserViewController: PlaylistHelperDelegate {
         }
       case .existingItem:
         if shouldShowPlaylistURLBarButton {
-          topToolbar.locationView.readerModeState = .unavailable
+          topToolbar.updateReaderModeState(.unavailable)
         }
         playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addedToPlaylist : .none
         topToolbar.menuButton.removeBadge(.playlist, animated: true)

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -84,7 +84,7 @@ extension BrowserViewController: PlaylistHelperDelegate {
       tab.playlistItemState = state
       tab.playlistItem = item
 
-      let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true && Preferences.Playlist.enablePlaylistURLBarButton.value && !tab.isWalletIconVisible
+      let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true && Preferences.Playlist.enablePlaylistURLBarButton.value
 
       switch state {
       case .none:
@@ -92,9 +92,6 @@ extension BrowserViewController: PlaylistHelperDelegate {
         topToolbar.menuButton.removeBadge(.playlist, animated: true)
         toolbar?.menuButton.removeBadge(.playlist, animated: true)
       case .newItem:
-        if shouldShowPlaylistURLBarButton {
-          topToolbar.updateReaderModeState(.unavailable)
-        }
         topToolbar.updatePlaylistButtonState(shouldShowPlaylistURLBarButton ? .addToPlaylist : .none)
         if Preferences.Playlist.enablePlaylistMenuBadge.value {
           topToolbar.menuButton.addBadge(.playlist, animated: true)
@@ -104,9 +101,6 @@ extension BrowserViewController: PlaylistHelperDelegate {
           toolbar?.menuButton.removeBadge(.playlist, animated: true)
         }
       case .existingItem:
-        if shouldShowPlaylistURLBarButton {
-          topToolbar.updateReaderModeState(.unavailable)
-        }
         topToolbar.updatePlaylistButtonState(shouldShowPlaylistURLBarButton ? .addedToPlaylist : .none)
         topToolbar.menuButton.removeBadge(.playlist, animated: true)
         toolbar?.menuButton.removeBadge(.playlist, animated: true)

--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -86,17 +86,16 @@ extension BrowserViewController: PlaylistHelperDelegate {
 
       let shouldShowPlaylistURLBarButton = tab.url?.isPlaylistSupportedSiteURL == true && Preferences.Playlist.enablePlaylistURLBarButton.value && !tab.isWalletIconVisible
 
-      let playlistButton = topToolbar.locationView.playlistButton
       switch state {
       case .none:
-        playlistButton.buttonState = .none
+        topToolbar.updatePlaylistButtonState(.none)
         topToolbar.menuButton.removeBadge(.playlist, animated: true)
         toolbar?.menuButton.removeBadge(.playlist, animated: true)
       case .newItem:
         if shouldShowPlaylistURLBarButton {
           topToolbar.updateReaderModeState(.unavailable)
         }
-        playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addToPlaylist : .none
+        topToolbar.updatePlaylistButtonState(shouldShowPlaylistURLBarButton ? .addToPlaylist : .none)
         if Preferences.Playlist.enablePlaylistMenuBadge.value {
           topToolbar.menuButton.addBadge(.playlist, animated: true)
           toolbar?.menuButton.addBadge(.playlist, animated: true)
@@ -108,7 +107,7 @@ extension BrowserViewController: PlaylistHelperDelegate {
         if shouldShowPlaylistURLBarButton {
           topToolbar.updateReaderModeState(.unavailable)
         }
-        playlistButton.buttonState = shouldShowPlaylistURLBarButton ? .addedToPlaylist : .none
+        topToolbar.updatePlaylistButtonState(shouldShowPlaylistURLBarButton ? .addedToPlaylist : .none)
         topToolbar.menuButton.removeBadge(.playlist, animated: true)
         toolbar?.menuButton.removeBadge(.playlist, animated: true)
       }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/PlaylistURLBarButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/PlaylistURLBarButton.swift
@@ -21,17 +21,14 @@ class PlaylistURLBarButton: UIButton {
         setImage(UIImage(named: "playlist_toolbar_add_button", in: .current, compatibleWith: nil)!, for: .normal)
         gradientView.isHidden = false
         backgroundView.isHidden = true
-        isHidden = false
       case .addedToPlaylist:
         setImage(UIImage(named: "playlist_toolbar_added_button", in: .current, compatibleWith: nil)!, for: .normal)
         gradientView.isHidden = true
         backgroundView.isHidden = false
-        isHidden = false
       case .none:
         setImage(nil, for: .normal)
         gradientView.isHidden = true
         backgroundView.isHidden = true
-        isHidden = true
       }
     }
   }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -153,7 +153,7 @@ class TabLocationView: UIView {
     $0.addTarget(self, action: #selector(didTapLockImageView), for: .touchUpInside)
   }
 
-  fileprivate lazy var readerModeButton: ReaderModeButton = {
+  private(set) lazy var readerModeButton: ReaderModeButton = {
     let readerModeButton = ReaderModeButton(frame: .zero)
     readerModeButton.addTarget(self, action: #selector(tapReaderModeButton), for: .touchUpInside)
     readerModeButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(longPressReaderModeButton)))
@@ -169,7 +169,7 @@ class TabLocationView: UIView {
     return readerModeButton
   }()
 
-  lazy var playlistButton = PlaylistURLBarButton(frame: .zero).then {
+  private(set) lazy var playlistButton = PlaylistURLBarButton(frame: .zero).then {
     $0.accessibilityIdentifier = "TabToolbar.playlistButton"
     $0.isAccessibilityElement = true
     $0.accessibilityLabel = Strings.tabToolbarPlaylistButtonAccessibilityLabel
@@ -178,7 +178,7 @@ class TabLocationView: UIView {
     $0.addTarget(self, action: #selector(didClickPlaylistButton), for: .touchUpInside)
   }
   
-  lazy var walletButton = WalletURLBarButton(frame: .zero).then {
+  private(set) lazy var walletButton = WalletURLBarButton(frame: .zero).then {
     $0.accessibilityIdentifier = "TabToolbar.walletButton"
     $0.isAccessibilityElement = true
     $0.buttonState = .inactive

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -98,8 +98,7 @@ class TabLocationView: UIView {
       if newReaderModeState != self.readerModeButton.readerModeState {
         let wasHidden = readerModeButton.isHidden
         self.readerModeButton.readerModeState = newReaderModeState
-        readerModeButton.isHidden = (newReaderModeState == ReaderModeState.unavailable)
-        if wasHidden != readerModeButton.isHidden {
+        if wasHidden != (newReaderModeState == ReaderModeState.unavailable) {
           UIAccessibility.post(notification: .layoutChanged, argument: nil)
           if !readerModeButton.isHidden {
             // Delay the Reader Mode accessibility announcement briefly to prevent interruptions.

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -414,6 +414,43 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
   func updateReaderModeState(_ state: ReaderModeState) {
     locationView.readerModeState = state
+    updateURLBarButtonsVisibility()
+  }
+  
+  func updatePlaylistButtonState(_ state: PlaylistURLBarButton.State) {
+    locationView.playlistButton.buttonState = state
+    updateURLBarButtonsVisibility()
+  }
+  
+  func updateWalletButtonState(_ state: WalletURLBarButton.ButtonState) {
+    locationView.walletButton.buttonState = state
+    updateURLBarButtonsVisibility()
+  }
+  
+  private func updateURLBarButtonsVisibility() {
+    if locationView.walletButton.buttonState != .inactive {
+      currentURLBarButton = .wallet
+    } else if locationView.playlistButton.buttonState != .none {
+      currentURLBarButton = .playlist
+    } else if locationView.readerModeState != .unavailable {
+      currentURLBarButton = .readerMode
+    } else {
+      currentURLBarButton = nil
+    }
+  }
+  
+  enum URLBarButton {
+    case wallet
+    case playlist
+    case readerMode
+  }
+  
+  private(set) var currentURLBarButton: URLBarButton? {
+    didSet {
+      locationView.walletButton.isHidden = currentURLBarButton != .wallet
+      locationView.playlistButton.isHidden = currentURLBarButton != .playlist
+      locationView.readerModeButton.isHidden = currentURLBarButton != .readerMode
+    }
   }
 
   func setAutocompleteSuggestion(_ suggestion: String?) {

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -427,6 +427,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     updateURLBarButtonsVisibility()
   }
   
+  /// Updates the `currentURLBarButton` based on priority: 1) Wallet 2) Playlist 3) ReaderMode.
   private func updateURLBarButtonsVisibility() {
     if locationView.walletButton.buttonState != .inactive {
       currentURLBarButton = .wallet
@@ -445,6 +446,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     case readerMode
   }
   
+  /// The currently visible URL bar button beside the refresh button.
   private(set) var currentURLBarButton: URLBarButton? {
     didSet {
       locationView.walletButton.isHidden = currentURLBarButton != .wallet

--- a/Client/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
@@ -16,7 +16,6 @@ class WalletURLBarButton: UIButton {
   
   var buttonState: ButtonState = .inactive {
     didSet {
-      isHidden = buttonState == .inactive
       // We may end up having different states here where active is actually blurple
       tintColor = .braveLabel
 


### PR DESCRIPTION
## Summary of Changes
- Previously we had two URL bar buttons: Reader Mode and Playlist, and only one is shown at a time. With dapp support, we have added a 3rd button for Wallet. 
- I've removed the `isHidden` logic from each buttons' state `didSet`s and moved visibility handling to `TopToolbarView` itself whenever any button state updates. Using an enum to track which button is visible (enum so only one can be visible), and handling the `isHidden` logic there accordingly.

This pull request fixes #5178

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Test reader mode still displays & works as expected
2. Test playlist button still displays & works as expected; additionally the reader mode should still be hidden if we encounter 
3. Test wallet button still displays & works as expected.

For testing when all 3 buttons are visible, I updated [eth-manual-tests](https://github.com/bbondy/eth-manual-tests) to include a video. This meant this page could show reader mode, playlist, and once a wed3 wallet request is sent the wallet button. I added the following line to the `request.html` page to embed a video:
`<video webkit-playsinline playsinline src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" title="Thirst"> </video>` & added `"localhost"` to `isPlaylistSupportedSiteURL`.

## Screenshots:

https://user-images.githubusercontent.com/5314553/171901519-604840be-bfdc-4ecb-9663-3dfa24a41203.mov

If you have any other sites that try to show >1 of these buttons, please leave a comment as local server isn't easiest way to test if live public site is available.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
