### PR TITLE
Fix #5433: Auto show pending requests when wallet panel is open

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -281,6 +281,9 @@ public class CryptoStore: ObservableObject {
       return true
     }
     let pendingRequest = await fetchPendingWebpageRequest()
+    if self.pendingRequest == nil {
+      self.pendingRequest = pendingRequest
+    }
     return pendingRequest != nil
   }
 
@@ -296,7 +299,6 @@ public class CryptoStore: ObservableObject {
       walletService.notifySignMessageRequestProcessed(approved, id: id)
     }
     pendingRequest = nil
-    prepare()
   }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -195,6 +195,9 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
   var widgetFaviconFetchers: [FaviconFetcher] = []
   let deviceCheckClient: DeviceCheckClient?
 
+  /// The currently open WalletStore
+  weak var walletStore: WalletStore?
+
   public init(
     profile: Profile,
     diskImageStore: DiskImageStore?,
@@ -2374,7 +2377,9 @@ extension BrowserViewController: TabDelegate {
   @MainActor
   private func isPendingRequestAvailable() async -> Bool {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-    guard let cryptoStore = CryptoStore.from(privateMode: privateMode) else {
+    /// If we have an open `WalletStore`, use that so we can assign the pending request if the wallet is open,
+    /// which allows us to store the new `PendingRequest` triggering a modal presentation for that request.
+    guard let cryptoStore = self.walletStore?.cryptoStore ?? CryptoStore.from(privateMode: privateMode) else {
       return false
     }
     if await cryptoStore.isPendingRequestAvailable() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -185,10 +185,11 @@ extension BrowserViewController {
 
   private func presentWallet() {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-    guard let walletStore = WalletStore.from(privateMode: privateMode) else {
+    guard let walletStore = self.walletStore ?? WalletStore.from(privateMode: privateMode) else {
       log.error("Failed to load wallet. One or more services were unavailable")
       return
     }
+    self.walletStore = walletStore
     self.onPendingRequestUpdatedCancellable = walletStore.onPendingRequestUpdated
       .sink { [weak self] _ in
         self?.updateURLBarWalletButton()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -184,17 +184,7 @@ extension BrowserViewController {
   }
 
   private func presentWallet() {
-    let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-    guard let walletStore = self.walletStore ?? WalletStore.from(privateMode: privateMode) else {
-      log.error("Failed to load wallet. One or more services were unavailable")
-      return
-    }
-    self.walletStore = walletStore
-    self.onPendingRequestUpdatedCancellable = walletStore.onPendingRequestUpdated
-      .sink { [weak self] _ in
-        self?.updateURLBarWalletButton()
-      }
-
+    guard let walletStore = self.walletStore ?? newWalletStore() else { return }
     let vc = WalletHostingViewController(walletStore: walletStore, faviconRenderer: FavIconImageRenderer())
     vc.delegate = self
     self.dismiss(animated: true) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -74,9 +74,10 @@ extension CryptoStore {
 extension BrowserViewController {
   func presentWalletPanel(tab: Tab) {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-    guard let walletStore = WalletStore.from(privateMode: privateMode) else {
+    guard let walletStore = self.walletStore ?? WalletStore.from(privateMode: privateMode) else {
       return
     }
+    self.walletStore = walletStore
     self.onPendingRequestUpdatedCancellable = walletStore.onPendingRequestUpdated
       .sink { [weak self] _ in
         self?.updateURLBarWalletButton()
@@ -120,6 +121,7 @@ extension BrowserViewController: BraveWalletDelegate {
       faviconRenderer: FavIconImageRenderer()
     )
     walletHostingController.delegate = self
+    self.walletStore = walletStore
     
     switch presentWalletWithContext {
     case .default, .settings:

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -71,6 +71,7 @@ class Tab: NSObject {
   var walletProviderJS: String?
   var isWalletIconVisible: Bool = false {
     didSet {
+      guard oldValue != isWalletIconVisible else { return }
       tabDelegate?.updateURLBarWalletButton()
     }
   }


### PR DESCRIPTION
## Summary of Changes
- Keep a reference to the open `WalletStore` when presenting the wallet panel or the main wallet.
- When a new dapp request is received, we receive a call to our tab delegate `updateURLBarWalletButton()` function which asks the open `CryptoStore` if we have an available pending request. By keeping a reference to the open `WalletStore`, we can assign this new pending request (when current `pendingRequest` is nil to prevent changing open request) to show the new request modal while the wall is still open. Otherwise existing flow of creating a temporary `CryptoStore` to check for pending requests remains.

This pull request fixes #5433

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

Skiff:
  1. Remove web3 site connections for [app.skiff.com](https://app.skiff.com/) in wallet settings
  2. Visit [app.skiff.com](https://app.skiff.com/)
  3. Tap 'Log in with Brave Wallet'
  4. Tap wallet notification
  5. Connect a wallet account
  6. When new site connection view dismisses after connecting an account, leave panel open until wallet badge to appears on wallet button in URL bar
  7. Observe request is now automatically shown
  
  NOTE: To complete Skiff login/setup, we need #5424 for the encryption requests.

Add then switch network test:
1. Remove Binance from custom networks list if it is added
2. Using [eth-manual-tests](https://github.com/bbondy/eth-manual-tests), tap `wallet_addEthereumChain`
3. Accept add chain request
4. After accepting, the switch network requests should present automatically

## Screenshots:

Skiff:

https://user-images.githubusercontent.com/5314553/172172134-3cb188d3-b62b-4dc4-8c8b-8c1174035f74.mov

Add -> Switch network:

https://user-images.githubusercontent.com/5314553/172172395-f4930052-1e3a-468b-92b6-5d13c0b42710.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
