### PR TITLE
No Bug: Add action to auto-add tickets for triage.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Add ticket for triage
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add for triage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/brave/projects/39/
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          # Note: The Github projects 'workflow' sets up the proper 'needs triage label'
+          # See https://github.com/orgs/brave/projects/39/workflows/371900
+          #
+          # This action only handles project auto-add, there's no label control yet.


### PR DESCRIPTION
Blocked, we have to create repo secret first and pass sec-review

Security review https://github.com/brave/security/issues/900

The new action we add:
https://github.com/actions/add-to-project