### PR TITLE
Fix # 5450: Transaction confirmation dismissal fix

### DIFF
--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -434,7 +434,7 @@ struct TransactionConfirmationView: View {
   @ViewBuilder private var rejectConfirmButtons: some View {
     Button(action: {
       confirmationStore.reject(transaction: confirmationStore.activeTransaction) { success in
-        if confirmationStore.transactions.count == 1 {
+        if confirmationStore.transactions.count <= 1 {
           onDismiss()
         }
       }
@@ -444,7 +444,7 @@ struct TransactionConfirmationView: View {
     .buttonStyle(BraveOutlineButtonStyle(size: .large))
     Button(action: {
       confirmationStore.confirm(transaction: confirmationStore.activeTransaction) { error in
-        if confirmationStore.transactions.count == 1 {
+        if confirmationStore.transactions.count <= 1 {
           onDismiss()
         }
       }


### PR DESCRIPTION
## Summary of Changes
- Transaction was being removed from `TransactionConfirmationStore` before the completion closure was called, so our check for `transactions.count == 1` was not calling dismiss closure because the transaction was already removed so the count is 0.

This pull request fixes #5450

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
  1. Open [Uniswap](https://app.uniswap.org/) and connect an account
  2. Choose a 'to' token
  3. Enter a value to swap
  4. Tap 'Swap'
  5. Tap 'Confirm Swap'
  6. Tap Wallet notification
  7. Tap 'Confirm'
  8. View should now dismiss correctly


## Screenshots:


https://user-images.githubusercontent.com/5314553/172193795-f7360e71-9c94-407a-b389-5d276882bac5.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
