### PR TITLE
Fix #5423: Add eTLD+1 in new/edit site connection + various iPad fixes.

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -13,8 +13,7 @@ struct AccountListView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   @State private var isPresentingAddAccount: Bool = false
   
-  // Dismiss closure for DApps entries
-  var onDismiss: (() -> Void)?
+  var onDismiss: () -> Void
   
   var body: some View {
     NavigationView {
@@ -25,11 +24,7 @@ struct AccountListView: View {
           ForEach(keyringStore.keyring.accountInfos) { account in
             Button(action: {
               keyringStore.selectedAccount = account
-              if onDismiss == nil {
-                presentationMode.dismiss()
-              } else {
-                onDismiss?()
-              }
+              onDismiss()
             }) {
               AccountView(address: account.address, name: account.name)
             }
@@ -49,10 +44,7 @@ struct AccountListView: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
-          Button(action: {
-            presentationMode.dismiss()
-            onDismiss?()
-          }) {
+          Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
           }
@@ -83,7 +75,7 @@ struct AccountListView_Previews: PreviewProvider {
       store.addPrimaryAccount("Account 2", completion: nil)
       store.addPrimaryAccount("Account 3", completion: nil)
       return store
-    }())
+    }(), onDismiss: {})
   }
 }
 #endif

--- a/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -13,6 +13,9 @@ struct AccountListView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   @State private var isPresentingAddAccount: Bool = false
   
+  // Dismiss closure for DApps entries
+  var onDismiss: (() -> Void)?
+  
   var body: some View {
     NavigationView {
       List {
@@ -23,6 +26,7 @@ struct AccountListView: View {
             Button(action: {
               keyringStore.selectedAccount = account
               presentationMode.dismiss()
+              onDismiss?()
             }) {
               AccountView(address: account.address, name: account.name)
             }
@@ -37,11 +41,15 @@ struct AccountListView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
+      .listStyle(InsetGroupedListStyle())
       .navigationTitle(Strings.Wallet.selectAccountTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
-          Button(action: { presentationMode.dismiss() }) {
+          Button(action: {
+            presentationMode.dismiss()
+            onDismiss?()
+          }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
           }

--- a/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -25,8 +25,11 @@ struct AccountListView: View {
           ForEach(keyringStore.keyring.accountInfos) { account in
             Button(action: {
               keyringStore.selectedAccount = account
-              presentationMode.dismiss()
-              onDismiss?()
+              if onDismiss == nil {
+                presentationMode.dismiss()
+              } else {
+                onDismiss?()
+              }
             }) {
               AccountView(address: account.address, name: account.name)
             }

--- a/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
@@ -13,7 +13,6 @@ struct AccountTransactionListView: View {
   @ObservedObject var networkStore: NetworkStore
   
   @Environment(\.openWalletURLAction) private var openWalletURL
-  @Environment(\.presentationMode) @Binding private var presentationMode
   
   @State private var transactionDetails: BraveWallet.TransactionInfo?
   
@@ -29,65 +28,56 @@ struct AccountTransactionListView: View {
     let assetRatios = activityStore.assets.reduce(into: [String: Double](), {
       $0[$1.token.symbol.lowercased()] = Double($1.price)
     })
-    NavigationView {
-      List {
-        Section(
-          header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
-        ) {
-          if activityStore.transactions.isEmpty {
-            emptyTextView(Strings.Wallet.noTransactions)
-          } else {
-            ForEach(activityStore.transactions) { tx in
-              Button(action: { self.transactionDetails = tx }) {
-                TransactionView(
-                  info: tx,
-                  keyringStore: keyringStore,
-                  networkStore: networkStore,
-                  visibleTokens: activityStore.assets.map(\.token),
-                  allTokens: activityStore.allTokens,
-                  displayAccountCreator: false,
-                  assetRatios: assetRatios,
-                  currencyCode: activityStore.currencyCode
-                )
-              }
-              .contextMenu {
-                if !tx.txHash.isEmpty {
-                  Button(action: {
-                    if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
-                       let url = baseURL?.appendingPathComponent("tx/\(tx.txHash)") {
-                      openWalletURL?(url)
-                    }
-                  }) {
-                    Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
+    List {
+      Section(
+        header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
+      ) {
+        if activityStore.transactions.isEmpty {
+          emptyTextView(Strings.Wallet.noTransactions)
+        } else {
+          ForEach(activityStore.transactions) { tx in
+            Button(action: { self.transactionDetails = tx }) {
+              TransactionView(
+                info: tx,
+                keyringStore: keyringStore,
+                networkStore: networkStore,
+                visibleTokens: activityStore.assets.map(\.token),
+                allTokens: activityStore.allTokens,
+                displayAccountCreator: false,
+                assetRatios: assetRatios,
+                currencyCode: activityStore.currencyCode
+              )
+            }
+            .contextMenu {
+              if !tx.txHash.isEmpty {
+                Button(action: {
+                  if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+                     let url = baseURL?.appendingPathComponent("tx/\(tx.txHash)") {
+                    openWalletURL?(url)
                   }
+                }) {
+                  Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
                 }
               }
             }
           }
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .navigationTitle(Strings.Wallet.transactionsTitle)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItemGroup(placement: .confirmationAction) {
-          Button(action: { presentationMode.dismiss() }) {
-            Text(Strings.done)
-              .foregroundColor(Color(.braveOrange))
-          }
-        }
-      }
-      .sheet(item: $transactionDetails) { tx in
-        TransactionDetailsView(
-          info: tx,
-          networkStore: networkStore,
-          keyringStore: keyringStore,
-          visibleTokens: activityStore.assets.map(\.token),
-          allTokens: [],
-          assetRatios: assetRatios,
-          currencyCode: activityStore.currencyCode
-        )
-      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    .listStyle(InsetGroupedListStyle())
+    .navigationTitle(Strings.Wallet.transactionsTitle)
+    .navigationBarTitleDisplayMode(.inline)
+    .sheet(item: $transactionDetails) { tx in
+      TransactionDetailsView(
+        info: tx,
+        networkStore: networkStore,
+        keyringStore: keyringStore,
+        visibleTokens: activityStore.assets.map(\.token),
+        allTokens: [],
+        assetRatios: assetRatios,
+        currencyCode: activityStore.currencyCode
+      )
     }
   }
 }

--- a/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
@@ -74,7 +74,7 @@ struct AccountTransactionListView: View {
         networkStore: networkStore,
         keyringStore: keyringStore,
         visibleTokens: activityStore.assets.map(\.token),
-        allTokens: [],
+        allTokens: activityStore.allTokens,
         assetRatios: assetRatios,
         currencyCode: activityStore.currencyCode
       )

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -32,7 +32,10 @@ struct AccountPicker: View {
       }
     }
     .sheet(isPresented: $isPresentingPicker) {
-      AccountListView(keyringStore: keyringStore)
+      AccountListView(
+        keyringStore: keyringStore,
+        onDismiss: { isPresentingPicker = false }
+      )
     }
   }
 

--- a/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -118,8 +118,11 @@ struct BuyTokenView: View {
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: {
-            onDismiss?()
-            presentationMode.dismiss()
+            if onDismiss == nil {
+              presentationMode.dismiss()
+            } else {
+              onDismiss?()
+            }
           }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
@@ -130,6 +133,7 @@ struct BuyTokenView: View {
         buyTokenStore.fetchBuyTokens()
       }
     }
+    .navigationViewStyle(.stack)
   }
 }
 

--- a/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -15,10 +15,9 @@ struct BuyTokenView: View {
 
   @State private var amountInput = ""
 
-  @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
   
-  var onDismiss: (() -> Void)?
+  var onDismiss: (() -> Void)
 
   var body: some View {
     NavigationView {
@@ -117,13 +116,7 @@ struct BuyTokenView: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
-          Button(action: {
-            if onDismiss == nil {
-              presentationMode.dismiss()
-            } else {
-              onDismiss?()
-            }
-          }) {
+          Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
           }
@@ -143,7 +136,8 @@ struct BuyTokenView_Previews: PreviewProvider {
     BuyTokenView(
       keyringStore: .previewStore,
       networkStore: .previewStore,
-      buyTokenStore: .previewStore
+      buyTokenStore: .previewStore,
+      onDismiss: {}
     )
     .previewColorSchemes()
   }

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -13,15 +13,13 @@ struct SendTokenView: View {
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var sendTokenStore: SendTokenStore
 
-  @Environment(\.presentationMode) @Binding private var presentationMode
-
   @State private var isShowingScanner = false
   @State private var isShowingError = false
 
   @ScaledMetric private var length: CGFloat = 16.0
   
   var completion: ((_ success: Bool) -> Void)?
-  var onDismiss: (() -> Void)?
+  var onDismiss: () -> Void
 
   private var isSendDisabled: Bool {
     guard let sendAmount = BDouble(sendTokenStore.sendAmount),
@@ -191,13 +189,7 @@ struct SendTokenView: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
-          Button(action: {
-            if onDismiss == nil {
-              presentationMode.dismiss()
-            } else {
-              onDismiss?()
-            }
-          }) {
+          Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
           }
@@ -217,7 +209,8 @@ struct SendTokenView_Previews: PreviewProvider {
     SendTokenView(
       keyringStore: .previewStore,
       networkStore: .previewStore,
-      sendTokenStore: .previewStore
+      sendTokenStore: .previewStore,
+      onDismiss: {}
     )
     .previewColorSchemes()
   }

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -192,8 +192,11 @@ struct SendTokenView: View {
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: {
-            onDismiss?()
-            presentationMode.dismiss()
+            if onDismiss == nil {
+              presentationMode.dismiss()
+            } else {
+              onDismiss?()
+            }
           }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
@@ -204,6 +207,7 @@ struct SendTokenView: View {
     .onAppear {
       sendTokenStore.fetchAssets()
     }
+    .navigationViewStyle(.stack)
   }
 }
 

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -483,8 +483,11 @@ struct SwapCryptoView: View {
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: {
-            onDismiss?()
-            presentationMode.dismiss()
+            if onDismiss == nil {
+              presentationMode.dismiss()
+            } else {
+              onDismiss?()
+            }
           }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
@@ -495,6 +498,7 @@ struct SwapCryptoView: View {
         swapTokensStore.prepare(with: keyringStore.selectedAccount)
       }
     }
+    .navigationViewStyle(.stack)
   }
 }
 

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -170,11 +170,10 @@ struct SwapCryptoView: View {
   @State var hideSlippage = true
   @State private var isSwapDisclaimerVisible: Bool = false
 
-  @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
   
   var completion: ((_ success: Bool) -> Void)?
-  var onDismiss: (() -> Void)?
+  var onDismiss: () -> Void
 
   @ViewBuilder var unsupportedSwapChainSection: some View {
     Section {
@@ -483,11 +482,7 @@ struct SwapCryptoView: View {
       .toolbar {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: {
-            if onDismiss == nil {
-              presentationMode.dismiss()
-            } else {
-              onDismiss?()
-            }
+            onDismiss()
           }) {
             Text(Strings.cancelButtonTitle)
               .foregroundColor(Color(.braveOrange))
@@ -508,7 +503,8 @@ struct SwapCryptoView_Previews: PreviewProvider {
     SwapCryptoView(
       keyringStore: .previewStore,
       ethNetworkStore: .previewStore,
-      swapTokensStore: .previewStore
+      swapTokensStore: .previewStore,
+      onDismiss: {}
     )
     //      .previewSizeCategories([.large, .accessibilityLarge])
   }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -111,9 +111,7 @@ public struct CryptoView: View {
             case .accountSelection:
               AccountListView(
                 keyringStore: keyringStore,
-                onDismiss: {
-                  dismissAction?()
-                }
+                onDismiss: { dismissAction?() }
               )
             case .transactionHistory:
               NavigationView {
@@ -254,19 +252,22 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
             BuyTokenView(
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
-              buyTokenStore: cryptoStore.openBuyTokenStore(action.initialToken)
+              buyTokenStore: cryptoStore.openBuyTokenStore(action.initialToken),
+              onDismiss: { cryptoStore.buySendSwapDestination = nil }
             )
           case .send:
             SendTokenView(
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
-              sendTokenStore: cryptoStore.openSendTokenStore(action.initialToken)
+              sendTokenStore: cryptoStore.openSendTokenStore(action.initialToken),
+              onDismiss: { cryptoStore.buySendSwapDestination = nil }
             )
           case .swap:
             SwapCryptoView(
               keyringStore: keyringStore,
               ethNetworkStore: cryptoStore.networkStore,
-              swapTokensStore: cryptoStore.openSwapTokenStore(action.initialToken)
+              swapTokensStore: cryptoStore.openSwapTokenStore(action.initialToken),
+              onDismiss: { cryptoStore.buySendSwapDestination = nil }
             )
           }
         }

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -109,13 +109,24 @@ public struct CryptoView: View {
             case .panelUnlockOrSetup:
               EmptyView()
             case .accountSelection:
-              AccountListView(keyringStore: keyringStore)
-            case .transactionHistory:
-              AccountTransactionListView(
-                keyringStore: walletStore.keyringStore,
-                activityStore: store.accountActivityStore(for: walletStore.keyringStore.selectedAccount),
-                networkStore: store.networkStore
+              AccountListView(
+                keyringStore: keyringStore,
+                onDismiss: {
+                  dismissAction?()
+                }
               )
+            case .transactionHistory:
+              NavigationView {
+                AccountTransactionListView(
+                  keyringStore: walletStore.keyringStore,
+                  activityStore: store.accountActivityStore(for: walletStore.keyringStore.selectedAccount),
+                  networkStore: store.networkStore
+                )
+                .toolbar {
+                  dismissButtonToolbarContents
+                }
+              }
+              .navigationViewStyle(.stack)
             case .buySendSwap(let destination):
               switch destination.kind {
               case .buy:
@@ -125,6 +136,7 @@ public struct CryptoView: View {
                   buyTokenStore: store.openBuyTokenStore(destination.initialToken),
                   onDismiss: {
                     store.closeBSSStores()
+                    dismissAction?()
                   }
                 )
               case .send:
@@ -139,6 +151,7 @@ public struct CryptoView: View {
                   },
                   onDismiss: {
                     store.closeBSSStores()
+                    dismissAction?()
                   }
                 )
               case .swap:
@@ -153,6 +166,7 @@ public struct CryptoView: View {
                   },
                   onDismiss: {
                     store.closeBSSStores()
+                    dismissAction?()
                   }
                 )
               }
@@ -167,6 +181,7 @@ public struct CryptoView: View {
                   dismissButtonToolbarContents
                 }
               }
+              .navigationViewStyle(.stack)
             case .editSiteConnection(let origin, let handler):
               EditSiteConnectionView(
                 keyringStore: keyringStore,

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -92,26 +92,26 @@ struct EditSiteConnectionView: View {
     }
   }
   
-  @ViewBuilder private func connectionInfo(url: URL) -> some View {
-    FaviconReader(url: url) { image in
-      if let image = image {
-        Image(uiImage: image)
-          .resizable()
-          .scaledToFit()
-          .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
-          .background(Color(.braveDisabled))
-          .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-      } else {
-        ProgressView()
+  @ViewBuilder private func connectionInfo(urlOrigin: URLOrigin) -> some View {
+    urlOrigin.url.map { url in
+      FaviconReader(url: url) { image in
+        if let image = image {
+          Image(uiImage: image)
+            .resizable()
+            .scaledToFit()
+            .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
+            .background(Color(.braveDisabled))
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        } else {
+          ProgressView()
+        }
       }
     }
     VStack(alignment: sizeCategory.isAccessibilityCategory ? .center : .leading, spacing: 2) {
-      origin.url.map { url in
-        Text(verbatim: url.absoluteString)
-          .font(.subheadline.weight(.semibold))
-          .multilineTextAlignment(.center)
-          .foregroundColor(Color(.bravePrimary))
-      }
+      OriginText(urlOrigin: urlOrigin)
+        .font(.subheadline)
+        .multilineTextAlignment(.center)
+        .foregroundColor(Color(.bravePrimary))
       Text(connectedAddresses)
         .font(.footnote)
         .multilineTextAlignment(.center)
@@ -140,22 +140,20 @@ struct EditSiteConnectionView: View {
             }
           }
         } header: {
-          origin.url.map { url in
-            Group {
-              if sizeCategory.isAccessibilityCategory {
-                VStack(spacing: 12) {
-                  connectionInfo(url: url)
-                }
-              } else {
-                HStack(spacing: 12) {
-                  connectionInfo(url: url)
-                }
+          Group {
+            if sizeCategory.isAccessibilityCategory {
+              VStack(spacing: 12) {
+                connectionInfo(urlOrigin: origin)
+              }
+            } else {
+              HStack(spacing: 12) {
+                connectionInfo(urlOrigin: origin)
               }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .resetListHeaderStyle()
-            .padding(.vertical)
           }
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .resetListHeaderStyle()
+          .padding(.vertical)
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
@@ -177,6 +175,7 @@ struct EditSiteConnectionView: View {
         }
       }
     }
+    .navigationViewStyle(.stack)
   }
 }
 

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -35,20 +35,22 @@ public struct NewSiteConnectionView: View {
   @State private var selectedAccounts: Set<BraveWallet.AccountInfo.ID> = []
   @State private var isConfirmationViewVisible: Bool = false
   
-  @ViewBuilder private func originAndFavicon(url: URL) -> some View {
-    FaviconReader(url: url) { image in
-      if let image = image {
-        Image(uiImage: image)
-          .resizable()
-          .scaledToFit()
-          .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
-          .background(Color(.braveDisabled))
-          .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-      } else {
-        ProgressView()
+  @ViewBuilder private func originAndFavicon(urlOrigin: URLOrigin) -> some View {
+    urlOrigin.url.map { url in
+      FaviconReader(url: url) { image in
+        if let image = image {
+          Image(uiImage: image)
+            .resizable()
+            .scaledToFit()
+            .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
+            .background(Color(.braveDisabled))
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        } else {
+          ProgressView()
+        }
       }
     }
-    Text(verbatim: url.absoluteString)
+    OriginText(urlOrigin: urlOrigin)
       .font(.subheadline)
       .foregroundColor(Color(.braveLabel))
       .multilineTextAlignment(.center)
@@ -56,10 +58,8 @@ public struct NewSiteConnectionView: View {
   
   private var headerView: some View {
     VStack(spacing: 8) {
-      origin.url.map { url in
-        originAndFavicon(url: url)
-          .accessibilityElement(children: .combine)
-      }
+      originAndFavicon(urlOrigin: origin)
+        .accessibilityElement(children: .combine)
       Text(Strings.Wallet.newSiteConnectMessage)
         .font(.headline)
         .foregroundColor(Color(.bravePrimary))
@@ -78,7 +78,7 @@ public struct NewSiteConnectionView: View {
   
   public var body: some View {
     NavigationView {
-      Form {
+      List {
         Section {
           headerView
         }
@@ -136,6 +136,7 @@ public struct NewSiteConnectionView: View {
         }
         .listRowBackground(Color(.braveGroupedBackground))
       }
+      .listStyle(InsetGroupedListStyle())
       .navigationBarTitleDisplayMode(.inline)
       .navigationTitle(Strings.Wallet.newSiteConnectScreenTitle)
       .toolbar {
@@ -202,6 +203,7 @@ public struct NewSiteConnectionView: View {
       }
       .listRowBackground(Color(.braveGroupedBackground))
     }
+    .listStyle(InsetGroupedListStyle())
     .navigationTitle(Strings.Wallet.newSiteConnectScreenTitle)
     .navigationBarTitleDisplayMode(.inline)
   }

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -23,6 +23,7 @@ public struct WalletPanelContainerView: View {
   var origin: URLOrigin
   var presentWalletWithContext: ((PresentingContext) -> Void)?
   var presentBuySendSwap: (() -> Void)?
+  /// An invisible `UIView` background lives in SwiftUI for UIKit API to reference later
   var buySendSwapBackground: InvisibleUIView = .init()
   
   // When the screen first apperas the keyring is set as the default value

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -23,6 +23,7 @@ public struct WalletPanelContainerView: View {
   var origin: URLOrigin
   var presentWalletWithContext: ((PresentingContext) -> Void)?
   var presentBuySendSwap: (() -> Void)?
+  var buySendSwapBackground: InvisibleUIView = .init()
   
   // When the screen first apperas the keyring is set as the default value
   // which causes an unnessary animation
@@ -109,7 +110,8 @@ public struct WalletPanelContainerView: View {
             },
             presentBuySendSwap: {
               self.presentBuySendSwap?()
-            }
+            },
+            buySendSwapBackground: buySendSwapBackground
           )
           .transition(.asymmetric(insertion: .identity, removal: .opacity))
         }
@@ -145,6 +147,7 @@ struct WalletPanelView: View {
   var origin: URLOrigin
   var presentWalletWithContext: (PresentingContext) -> Void
   var presentBuySendSwap: () -> Void
+  var buySendSwapBackground: InvisibleUIView
   
   @Environment(\.pixelLength) private var pixelLength
   @Environment(\.sizeCategory) private var sizeCategory
@@ -159,7 +162,8 @@ struct WalletPanelView: View {
     accountActivityStore: AccountActivityStore,
     origin: URLOrigin,
     presentWalletWithContext: @escaping (PresentingContext) -> Void,
-    presentBuySendSwap: @escaping () -> Void
+    presentBuySendSwap: @escaping () -> Void,
+    buySendSwapBackground: InvisibleUIView
   ) {
     self.keyringStore = keyringStore
     self.cryptoStore = cryptoStore
@@ -168,6 +172,7 @@ struct WalletPanelView: View {
     self.origin = origin
     self.presentWalletWithContext = presentWalletWithContext
     self.presentBuySendSwap = presentBuySendSwap
+    self.buySendSwapBackground = buySendSwapBackground
     
     currencyFormatter.currencyCode = accountActivityStore.currencyCode
   }
@@ -358,6 +363,7 @@ struct WalletPanelView: View {
                 .padding(.horizontal, 44)
                 .padding(.vertical, 8)
             }
+            .background(buySendSwapBackground)
             Color.white.opacity(0.6)
               .frame(width: pixelLength)
             Button {
@@ -401,6 +407,16 @@ struct WalletPanelView: View {
   }
 }
 
+struct InvisibleUIView: UIViewRepresentable {
+  let uiView = UIView()
+  func makeUIView(context: Context) -> UIView {
+    uiView.backgroundColor = .clear
+    return uiView
+  }
+  func updateUIView(_ uiView: UIView, context: Context) {
+  }
+}
+
 #if DEBUG
 struct WalletPanelView_Previews: PreviewProvider {
   static var previews: some View {
@@ -412,7 +428,8 @@ struct WalletPanelView_Previews: PreviewProvider {
         accountActivityStore: .previewStore,
         origin: .init(url: URL(string: "https://app.uniswap.org")!),
         presentWalletWithContext: { _ in },
-        presentBuySendSwap: {}
+        presentBuySendSwap: {},
+        buySendSwapBackground: InvisibleUIView()
       )
       WalletPanelView(
         keyringStore: .previewStore,
@@ -421,7 +438,8 @@ struct WalletPanelView_Previews: PreviewProvider {
         accountActivityStore: .previewStore,
         origin: .init(url: URL(string: "https://app.uniswap.org")!),
         presentWalletWithContext: { _ in },
-        presentBuySendSwap: {}
+        presentBuySendSwap: {},
+        buySendSwapBackground: InvisibleUIView()
       )
       WalletPanelView(
         keyringStore: {
@@ -434,7 +452,8 @@ struct WalletPanelView_Previews: PreviewProvider {
         accountActivityStore: .previewStore,
         origin: .init(url: URL(string: "https://app.uniswap.org")!),
         presentWalletWithContext: { _ in },
-        presentBuySendSwap: {}
+        presentBuySendSwap: {},
+        buySendSwapBackground: InvisibleUIView()
       )
     }
     .fixedSize(horizontal: false, vertical: true)

--- a/BraveWallet/WalletPanelHostingController.swift
+++ b/BraveWallet/WalletPanelHostingController.swift
@@ -49,8 +49,20 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
               })
           })
       )
-      self.presentPanModal(controller)
+      self.presentPanModal(controller, sourceView: self.rootView.buySendSwapBackground.uiView, sourceRect: self.rootView.buySendSwapBackground.uiView.bounds)
     }
+    
+    // Dismiss Buy/Send/Swap Menu when Wallet becomes locked
+    cancellable = walletStore.keyringStore.$keyring
+      .dropFirst() // Drop initial value
+      .map(\.isLocked)
+      .removeDuplicates()
+      .dropFirst() // Drop first async fetch of keyring
+      .sink { [weak self] isLocked in
+        if let self = self, isLocked, self.presentedViewController != nil {
+          self.dismiss(animated: true)
+        }
+      }
   }
   
   @available(*, unavailable)


### PR DESCRIPTION
## Summary of Changes
Added eTLD+1 in new/edit site connection
Fixed lots iPad issues.

This pull request fixes #5423 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Please refer to the issue for eTLD+1
For iPad, please do a sanity test on UI and UX

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
