### PR TITLE
No Bug: Fix possible crash when fetching RSS/Customized News sources

### DIFF
--- a/Client/Frontend/Brave Today/Composer/FeedDataSource+RSS.swift
+++ b/Client/Frontend/Brave Today/Composer/FeedDataSource+RSS.swift
@@ -21,7 +21,7 @@ struct RSSFeedLocation: Hashable {
 extension FeedDataSource {
   // MARK: - RSS Sources
 
-  var rssFeedLocations: [RSSFeedLocation] {
+  @MainActor var rssFeedLocations: [RSSFeedLocation] {
     RSSFeedSource.all().compactMap {
       guard let url = URL(string: $0.feedUrl) else { return nil }
       return RSSFeedLocation(title: $0.title, url: url)

--- a/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
+++ b/Client/Frontend/Brave Today/Composer/FeedDataSource.swift
@@ -386,7 +386,7 @@ public class FeedDataSource {
 
   /// Load all RSS feeds that the user has enabled
   private func loadRSSFeeds() async -> [Result<RSSDataFeed, Error>] {
-    let locations = rssFeedLocations.filter(isRSSFeedEnabled)
+    let locations = await rssFeedLocations.filter(isRSSFeedEnabled)
     return await withTaskGroup(
       of: Result<RSSDataFeed, Error>.self,
       returning: [Result<RSSDataFeed, Error>].self
@@ -504,7 +504,7 @@ public class FeedDataSource {
   static let topNewsCategory = "Top News"
 
   /// Get a map of customized sources IDs and their overridden enabled states
-  var customizedSources: [String: Bool] {
+  @MainActor var customizedSources: [String: Bool] {
     let all = FeedSourceOverride.all()
     return all.reduce(into: [:]) { (result, source) in
       result[source.publisherID] = source.enabled


### PR DESCRIPTION
## Summary of Changes

Something that showed up when I built with Xcode 14. This currently does not crash in Xcode 13, but these calls to CoreData related functions should be isolated to MainActor anyways

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
