### PR TITLE
Fix #5414: iOS needs showWalletOnboarding delegate method to trigger the onboarding flow

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -251,7 +251,7 @@ extension Tab: BraveWalletProviderDelegate {
   }
   
   func showWalletOnboarding() {
-    // No usage for iOS
+    showPanel()
   }
 }
 


### PR DESCRIPTION
## Summary of Changes
`showPanel` delegate method will not be called, instead, `showWalletOnboarding` is be called when user hasnt created a wallet account and DApp `ethereum.request` with `eth_requestAccounts`.

This pull request fixes #5414 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
please refer to the issue


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
