### PR TITLE
 Fix #5447: Deleting tab from tab search result seems to clear the query to display full tabs

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -283,7 +283,9 @@ class TabTrayController: LoadingViewController {
 
   private func remove(tab: Tab) {
     tabManager.removeTab(tab)
-    applySnapshot()
+    
+    let query = isTabTrayBeingSearched ? tabTraySearchQuery : nil
+    applySnapshot(for: query)
   }
 
   func removeAllTabs() {


### PR DESCRIPTION
Applying the criteria of tab search to tab deletion

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5447

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

- Open few tabs (make sure you have some duplicated tabs e.x [www.brave.com](http://www.brave.com/))
- Search brave
- It should display all the tabs that has domain include the key words
- Delete one of the search result tabs
- It should display all the tabs that has domain include the key words minus the deleted 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->



https://user-images.githubusercontent.com/6643505/172476065-685f2fd4-1aa3-479f-b211-675212729afe.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
