### PR TITLE
Fix #5461: Infinite redirect loop between amp page and non-amp page

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2225,6 +2225,7 @@ extension BrowserViewController: TabDelegate {
     tab.addContentScript(RewardsReporting(rewards: rewards, tab: tab), name: RewardsReporting.name(), contentWorld: .page)
     tab.addContentScript(AdsMediaReporting(rewards: rewards, tab: tab), name: AdsMediaReporting.name(), contentWorld: .defaultClient)
     tab.addContentScript(ReadyStateScriptHelper(tab: tab), name: ReadyStateScriptHelper.name(), contentWorld: .page)
+    tab.addContentScript(DeAmpHelper(tab: tab), name: DeAmpHelper.name(), contentWorld: .defaultClient)
   }
 
   func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -455,8 +455,9 @@ extension BrowserViewController: WKNavigationDelegate {
 
   public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
     guard let tab = tabManager[webView] else { return }
-
-    tab.url = webView.url
+    // Set the committed url which will also set tab.url
+    tab.committedURL = webView.url
+    
     // Need to evaluate Night mode script injection after url is set inside the Tab
     tab.nightMode = Preferences.General.nightModeEnabled.value
 

--- a/Client/Frontend/Browser/Helpers/DeAmpHelper.swift
+++ b/Client/Frontend/Browser/Helpers/DeAmpHelper.swift
@@ -1,0 +1,70 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import WebKit
+
+public class DeAmpHelper: TabContentScript {
+  private struct DeAmpDTO: Decodable {
+    enum CodingKeys: String, CodingKey {
+      case destURL, securityToken
+    }
+    
+    let securityToken: String
+    let destURL: URL
+    
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.securityToken = try container.decode(String.self, forKey: .securityToken)
+      let destURLString = try container.decode(String.self, forKey: .destURL)
+      
+      guard let destURL = URL(string: destURLString) else {
+        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "`resourceURL` is not a valid URL. Fix the `RequestBlocking.js` script"))
+      }
+      
+      self.destURL = destURL
+    }
+  }
+  
+  private weak var tab: Tab?
+  
+  init(tab: Tab) {
+    self.tab = tab
+  }
+  
+  static func name() -> String {
+    return "DeAmpHelper"
+  }
+  
+  static func scriptMessageHandlerName() -> String {
+    return ["deAmpHelper", UserScriptManager.messageHandlerTokenString].joined(separator: "_")
+  }
+  
+  func scriptMessageHandlerName() -> String? {
+    return Self.scriptMessageHandlerName()
+  }
+  
+  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
+    do {
+      let data = try JSONSerialization.data(withJSONObject: message.body)
+      let dto = try JSONDecoder().decode(DeAmpDTO.self, from: data)
+      
+      guard dto.securityToken == UserScriptManager.securityTokenString else {
+        assertionFailure("Invalid security token. Fix the `RequestBlocking.js` script")
+        replyHandler(false, nil)
+        return
+      }
+      
+      // Check that the destination is not the same as the previousURL
+      // or that previousURL is nil
+      let shouldRedirect = dto.destURL != tab?.previousComittedURL
+      replyHandler(shouldRedirect, nil)
+    } catch {
+      assertionFailure("Invalid type of message. Fix the `RequestBlocking.js` script")
+      replyHandler(false, nil)
+    }
+  }
+}

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -117,6 +117,21 @@ class Tab: NSObject {
   fileprivate var lastRequest: URLRequest?
   var restoring: Bool = false
   var pendingScreenshot = false
+  
+  /// The url set after a successful navigation. This will also set the `url` property.
+  ///
+  /// - Note: Unlike the `url` property, which may be set during pre-navigation,
+  /// the `committedURL` is only assigned when navigation was committed..
+  var committedURL: URL? {
+    willSet {
+      url = newValue
+      previousComittedURL = committedURL
+    }
+  }
+  
+  /// The previous url that was set before `comittedURL` was set again
+  private(set) var previousComittedURL: URL?
+  
   var url: URL? {
     didSet {
       if let _url = url, let internalUrl = InternalURL(_url), internalUrl.isAuthorized {

--- a/Client/Frontend/Browser/User Scripts/UserScriptHelper.swift
+++ b/Client/Frontend/Browser/User Scripts/UserScriptHelper.swift
@@ -72,4 +72,15 @@ class UserScriptHelper {
 
     return userScriptTypes
   }
+  
+  static func makeDeAmpScriptParamters() throws -> String {
+    let arguments: [String: String] = [
+      "handlerName": DeAmpHelper.scriptMessageHandlerName(),
+      "securityToken": UserScriptManager.securityTokenString
+    ]
+    
+    let encoder = JSONEncoder()
+    let data = try encoder.encode(arguments)
+    return String(data: data, encoding: .utf8)!
+  }
 }

--- a/Client/Frontend/UserContent/UserScripts/DeAMP.js
+++ b/Client/Frontend/UserContent/UserScripts/DeAMP.js
@@ -45,10 +45,11 @@
     const targetHref = canonicalLinkElm.getAttribute('href')
     try {
       const destUrl = new URL(targetHref)
+      const locationUrl = W.location
       W.clearInterval(intervalId)
-      
-      if (W.location.href == destUrl.href || !(destUrl.protocol === 'http:' || destUrl.protocol === 'https:')) {
+      if (locationUrl.href == destUrl.href || destUrl.href == D.referrer || !(destUrl.protocol === 'http:' || destUrl.protocol === 'https:')) {
         // Only handle http/https and only if the canoncial url is different than the current url
+        // Also add a check the referrer to prevent an infinite load loop in some cases
         return
       }
       W.location.replace(destUrl.href)

--- a/Client/Frontend/UserContent/UserScripts/DeAMP.js
+++ b/Client/Frontend/UserContent/UserScripts/DeAMP.js
@@ -36,7 +36,7 @@
     }
 
     const canonicalLinkElm = D.querySelector('head > link[rel="canonical"][href^="http"]')
-    if (!canonicalLinkElm === null) {
+    if (canonicalLinkElm === null || canonicalLinkElm === undefined) {
       // didn't find a link elm.
       checkIfShouldStopChecking()
       return


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5461 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See steps on the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
See video on ticket

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
