### PR TITLE
Fix #5424: Dapp get public encryption key / decrypt requests

### DIFF
--- a/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
@@ -32,26 +32,10 @@ struct AccountPrivateKeyView: View {
               )
               .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
           )
-        VStack(spacing: 32) {
-          Text(key)
-            .multilineTextAlignment(.center)
-            .font(.system(.body, design: .monospaced))
-            .blur(radius: isKeyVisible ? 0 : 5)
-            .accessibilityHidden(!isKeyVisible)
-            .noCapture()
-          Button(action: {
-            UIPasteboard.general.setSecureString(key)
-          }) {
-            Text("\(Strings.Wallet.copyToPasteboard) \(Image("brave.clipboard"))")
-              .font(.subheadline)
-              .foregroundColor(Color(.braveBlurpleTint))
-          }
-        }
-        .padding(20)
-        .background(
-          Color(.secondaryBraveBackground).clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        )
-        .padding(40)
+        SensitiveTextView(text: key, isShowingText: $isKeyVisible)
+          .multilineTextAlignment(.center)
+          .font(.system(.body, design: .monospaced))
+          .padding(40)
 
         Button(action: {
           withAnimation {

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -11,6 +11,8 @@ enum PendingRequest: Equatable {
   case switchChain(BraveWallet.SwitchChainRequest)
   case addSuggestedToken(BraveWallet.AddSuggestTokenRequest)
   case signMessage([BraveWallet.SignMessageRequest])
+  case getEncryptionPublicKey(BraveWallet.GetEncryptionPublicKeyRequest)
+  case decrypt(BraveWallet.DecryptRequest)
 }
 
 extension PendingRequest: Identifiable {
@@ -21,6 +23,8 @@ extension PendingRequest: Identifiable {
     case let .switchChain(chainRequest): return "switchChain-\(chainRequest.chainId)"
     case let .addSuggestedToken(tokenRequest): return "addSuggestedToken-\(tokenRequest.token.id)"
     case let .signMessage(signRequests): return "signMessage-\(signRequests.map(\.id))"
+    case let .getEncryptionPublicKey(request): return "getEncryptionPublicKey-\(request.address)-\(request.originInfo.origin)"
+    case let .decrypt(request): return "decrypt-\(request.address)-\(request.originInfo.origin)"
     }
   }
 }
@@ -30,6 +34,8 @@ enum WebpageRequestResponse: Equatable {
   case addNetwork(approved: Bool, chainId: String)
   case addSuggestedToken(approved: Bool, contractAddresses: [String])
   case signMessage(approved: Bool, id: Int32)
+  case getEncryptionPublicKey(approved: Bool, originInfo: BraveWallet.OriginInfo)
+  case decrypt(approved: Bool, originInfo: BraveWallet.OriginInfo)
 }
 
 public class CryptoStore: ObservableObject {
@@ -268,6 +274,10 @@ public class CryptoStore: ObservableObject {
       return .switchChain(switchRequest)
     } else if let addTokenRequest = await walletService.pendingAddSuggestTokenRequests().first {
       return .addSuggestedToken(addTokenRequest)
+    } else if let getEncryptionPublicKeyRequest = await walletService.pendingGetEncryptionPublicKeyRequests().first {
+      return .getEncryptionPublicKey(getEncryptionPublicKeyRequest)
+    } else if let decryptRequest = await walletService.pendingDecryptRequests().first {
+      return .decrypt(decryptRequest)
     } else {
       return nil
     }
@@ -294,6 +304,10 @@ public class CryptoStore: ObservableObject {
       walletService.notifyAddSuggestTokenRequestsProcessed(approved, contractAddresses: contractAddresses)
     case let .signMessage(approved, id):
       walletService.notifySignMessageRequestProcessed(approved, id: id)
+    case let .getEncryptionPublicKey(approved, originInfo):
+      walletService.notifyGetPublicKeyRequestProcessed(approved, origin: originInfo.origin)
+    case let .decrypt(approved, originInfo):
+      walletService.notifyDecryptRequestProcessed(approved, origin: originInfo.origin)
     }
     pendingRequest = nil
     prepare()

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -132,7 +132,7 @@ struct TransactionConfirmationView: View {
         }
         .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
         .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-        OriginText(urlOrigin: originInfo.origin)
+        Text(urlOrigin: originInfo.origin)
           .font(.subheadline)
           .foregroundColor(Color(.braveLabel))
           .multilineTextAlignment(.center)

--- a/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -54,7 +54,7 @@ struct TransactionHeader: View {
         ))
       )
       if let originInfo = originInfo {
-        OriginText(urlOrigin: originInfo.origin)
+        Text(urlOrigin: originInfo.origin)
           .foregroundColor(Color(.braveLabel))
           .font(.subheadline)
           .padding(.top, 8) // match vertical padding for tx type, value & fiat VStack

--- a/BraveWallet/Extensions/Text+URLOrigin.swift
+++ b/BraveWallet/Extensions/Text+URLOrigin.swift
@@ -7,14 +7,11 @@ import BraveCore
 import SwiftUI
 import Strings
 
-/// View used to display a URLOrigin, bolding the eTLD+1.
-struct OriginText: View {
-  
-  let urlOrigin: URLOrigin
-  
-  var body: some View {
+extension Text {
+  /// Creates a text view that displays a URLOrigin, bolding the eTLD+1.
+  init(urlOrigin: URLOrigin) {
     if urlOrigin == WalletConstants.braveWalletOrigin {
-      Text(Strings.Wallet.braveWallet)
+      self = Text(Strings.Wallet.braveWallet)
     } else {
       let origin = urlOrigin.url?.absoluteString ?? ""
       let eTldPlusOne = urlOrigin.url?.baseDomain ?? ""
@@ -22,9 +19,9 @@ struct OriginText: View {
         let originStart = origin[origin.startIndex..<range.lowerBound]
         let etldPlusOne = origin[range.lowerBound..<range.upperBound]
         let originEnd = origin[range.upperBound...]
-        Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
+        self = Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
       } else {
-        Text(origin)
+        self = Text(origin)
       }
     }
   }

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -106,7 +106,7 @@ struct SuggestedNetworkView: View {
       }
       .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
       .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-      OriginText(urlOrigin: originInfo.origin)
+      Text(urlOrigin: originInfo.origin)
         .font(.subheadline)
         .foregroundColor(Color(.braveLabel))
         .multilineTextAlignment(.center)

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -24,7 +24,7 @@ struct AddSuggestedTokenView: View {
           Text(Strings.Wallet.addSuggestedTokenSubtitle)
             .font(.headline)
             .foregroundColor(Color(.bravePrimary))
-          OriginText(urlOrigin: originInfo.origin)
+          Text(urlOrigin: originInfo.origin)
             .font(.footnote)
             .foregroundColor(Color(.braveLabel))
         }

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -108,7 +108,7 @@ struct EditSiteConnectionView: View {
       }
     }
     VStack(alignment: sizeCategory.isAccessibilityCategory ? .center : .leading, spacing: 2) {
-      OriginText(urlOrigin: urlOrigin)
+      Text(urlOrigin: urlOrigin)
         .font(.subheadline)
         .multilineTextAlignment(.center)
         .foregroundColor(Color(.bravePrimary))

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -50,7 +50,7 @@ public struct NewSiteConnectionView: View {
         }
       }
     }
-    OriginText(urlOrigin: urlOrigin)
+    Text(urlOrigin: urlOrigin)
       .font(.subheadline)
       .foregroundColor(Color(.braveLabel))
       .multilineTextAlignment(.center)

--- a/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -99,7 +99,6 @@ struct EncryptionView: View {
           ScrollView {
             Text(urlOrigin: request.originInfo.origin) + Text(" \(Strings.Wallet.getEncryptionPublicKeyRequestMessage)")
           }
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
           .padding(20)
         } else if case let .decrypt(decryptRequest) = request {
           ScrollView {

--- a/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -1,0 +1,263 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveUI
+import SwiftUI
+
+struct EncryptionView: View {
+  
+  enum EncryptionType: Hashable {
+    case getEncryptionPublicKey(BraveWallet.GetEncryptionPublicKeyRequest)
+    case decrypt(BraveWallet.DecryptRequest)
+    
+    var address: String {
+      switch self {
+      case let .getEncryptionPublicKey(request):
+        return request.address
+      case let .decrypt(request):
+        return request.address
+      }
+    }
+    
+    var originInfo: BraveWallet.OriginInfo {
+      switch self {
+      case .getEncryptionPublicKey(let request):
+        return request.originInfo
+      case .decrypt(let request):
+        return request.originInfo
+      }
+    }
+  }
+  
+  var request: EncryptionType
+  @ObservedObject var cryptoStore: CryptoStore
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var networkStore: NetworkStore
+  var onDismiss: () -> Void
+  
+  @State private var isShowingDecryptMessage = false
+
+  @ScaledMetric private var blockieSize = 54
+  private let maxBlockieSize: CGFloat = 108
+  @Environment(\.sizeCategory) private var sizeCategory
+  
+  private var account: BraveWallet.AccountInfo {
+    keyringStore.keyring.accountInfos.first(where: { $0.address.caseInsensitiveCompare(request.address) == .orderedSame }) ?? keyringStore.selectedAccount
+  }
+  
+  private var subtitle: String {
+    switch request {
+    case .getEncryptionPublicKey:
+      return "A DApp is requesting your public encryption key"
+    case .decrypt:
+      return "This DApp would like to read this message to complete your request"
+    }
+  }
+  
+  var body: some View {
+    ScrollView(.vertical) {
+      if let chain = networkStore.selectedChain {
+        HStack(alignment: .top) {
+          Text(chain.chainName)
+          Spacer()
+        }
+        .font(.callout)
+      }
+      VStack(spacing: 12) {
+        VStack(spacing: 8) {
+          Blockie(address: request.address)
+            .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
+          Text(account.name)
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(Color(.secondaryBraveLabel))
+          Text(urlOrigin: request.originInfo.origin)
+            .font(.caption)
+            .foregroundColor(Color(.braveLabel))
+            .multilineTextAlignment(.center)
+        }
+        .accessibilityElement(children: .combine)
+        Text(subtitle)
+          .font(.headline)
+          .foregroundColor(Color(.bravePrimary))
+      }
+      .padding(.vertical, 32)
+      .multilineTextAlignment(.center)
+      Group {
+        if case .getEncryptionPublicKey = request {
+          ScrollView {
+            Text(urlOrigin: request.originInfo.origin) + Text(" is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.")
+          }
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+          .padding(20)
+        } else if case let .decrypt(decryptRequest) = request {
+          ScrollView {
+            SensitiveTextView(
+              text: decryptRequest.unsafeMessage ?? "",
+              isCopyEnabled: false,
+              isShowingText: $isShowingDecryptMessage
+            )
+          }
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+          .overlay(
+            Group {
+              if !isShowingDecryptMessage {
+                Button(action: { isShowingDecryptMessage.toggle() }) {
+                  Text("Reveal")
+                }
+                .buttonStyle(BraveFilledButtonStyle(size: .normal))
+              }
+            }
+          )
+          .alertOnScreenshot {
+            Alert(
+              title: Text(Strings.Wallet.screenshotDetectedTitle),
+              message: Text("Warning: A screenshot of your message may get backed up to a cloud file service, and be readable by any application with photos access. Brave recommends that you not save this screenshot, and delete it as soon as possible."),
+              dismissButton: .cancel(Text(Strings.OKString))
+            )
+          }
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .frame(height: 200)
+      .background(Color(.tertiaryBraveGroupedBackground))
+      .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+      .padding()
+      .background(
+        Color(.secondaryBraveGroupedBackground)
+      )
+      .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+      
+      buttonsContainer
+        .padding(.top, 20)
+        .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
+        .accessibility(hidden: sizeCategory.isAccessibilityCategory)
+    }
+    .padding()
+    .overlay(
+      Group {
+        if sizeCategory.isAccessibilityCategory {
+          buttonsContainer
+            .frame(maxWidth: .infinity)
+            .padding(.top)
+            .background(
+              LinearGradient(
+                stops: [
+                  .init(color: Color(.braveGroupedBackground).opacity(0), location: 0),
+                  .init(color: Color(.braveGroupedBackground).opacity(1), location: 0.05),
+                  .init(color: Color(.braveGroupedBackground).opacity(1), location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+              )
+              .ignoresSafeArea()
+              .allowsHitTesting(false)
+            )
+        }
+      },
+      alignment: .bottom
+    )
+    .frame(maxWidth: .infinity)
+    .navigationTitle(Strings.Wallet.signatureRequestTitle)
+    .navigationBarTitleDisplayMode(.inline)
+    .foregroundColor(Color(.braveLabel))
+    .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
+    .toolbar {
+      ToolbarItemGroup(placement: .cancellationAction) {
+        Button(action: { onDismiss() }) {
+          Text(Strings.cancelButtonTitle)
+            .foregroundColor(Color(.braveOrange))
+        }
+      }
+    }
+  }
+
+  @ViewBuilder private var buttonsContainer: some View {
+    if sizeCategory.isAccessibilityCategory {
+      VStack {
+        buttons
+      }
+    } else {
+      HStack {
+        buttons
+      }
+    }
+  }
+  
+  private var approveButtonTitle: String {
+    switch request {
+    case .getEncryptionPublicKey:
+      return "Provide"
+    case .decrypt:
+      return "Allow"
+    }
+  }
+  
+  @ViewBuilder private var buttons: some View {
+    Button(action: { // cancel
+      handleAction(approved: false)
+    }) {
+      Label(Strings.cancelButtonTitle, systemImage: "xmark")
+        .imageScale(.large)
+    }
+    .buttonStyle(BraveOutlineButtonStyle(size: .large))
+    Button(action: { // approve
+      handleAction(approved: true)
+    }) {
+      Label(approveButtonTitle, image: "brave.checkmark.circle.fill")
+        .imageScale(.large)
+    }
+    .buttonStyle(BraveFilledButtonStyle(size: .large))
+  }
+  
+  func handleAction(approved: Bool) {
+    switch request {
+    case .getEncryptionPublicKey(let request):
+      cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: approved, originInfo: request.originInfo))
+    case .decrypt(let request):
+      cryptoStore.handleWebpageRequestResponse(.decrypt(approved: approved, originInfo: request.originInfo))
+    }
+    onDismiss()
+  }
+}
+
+#if DEBUG
+struct EncryptionView_Previews: PreviewProvider {
+  static var previews: some View {
+    let address = BraveWallet.AccountInfo.previewAccount.address
+    let originInfo = BraveWallet.OriginInfo(
+      origin: .init(url: URL(string: "https://brave.com")!),
+      originSpec: "",
+      eTldPlusOne: ""
+    )
+    let requests: [EncryptionView.EncryptionType] = [
+      .getEncryptionPublicKey(
+        .init(
+          originInfo: originInfo,
+          address: address
+        )
+      ),
+      .decrypt(
+        .init(
+          originInfo: originInfo,
+          address: address,
+          unsafeMessage: "Secret message"
+        )
+      )
+    ]
+    Group {
+      ForEach(requests, id: \.self) { request in
+        EncryptionView(
+          request: request,
+          cryptoStore: .previewStore,
+          keyringStore: .previewStoreWithWalletCreated,
+          networkStore: .previewStore,
+          onDismiss: { }
+        )
+      }
+    }
+  }
+}
+#endif

--- a/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -74,6 +74,7 @@ struct EncryptionView: View {
           Spacer()
         }
         .font(.callout)
+        .padding(.bottom, 6)
       }
       VStack(spacing: 12) {
         VStack(spacing: 8) {

--- a/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -48,12 +48,21 @@ struct EncryptionView: View {
     keyringStore.keyring.accountInfos.first(where: { $0.address.caseInsensitiveCompare(request.address) == .orderedSame }) ?? keyringStore.selectedAccount
   }
   
+  private var navigationTitle: String {
+    switch request {
+    case .getEncryptionPublicKey:
+      return Strings.Wallet.getEncryptionPublicKeyRequestTitle
+    case .decrypt:
+      return Strings.Wallet.decryptRequestTitle
+    }
+  }
+  
   private var subtitle: String {
     switch request {
     case .getEncryptionPublicKey:
-      return "A DApp is requesting your public encryption key"
+      return Strings.Wallet.getEncryptionPublicKeyRequestSubtitle
     case .decrypt:
-      return "This DApp would like to read this message to complete your request"
+      return Strings.Wallet.decryptRequestSubtitle
     }
   }
   
@@ -88,7 +97,7 @@ struct EncryptionView: View {
       Group {
         if case .getEncryptionPublicKey = request {
           ScrollView {
-            Text(urlOrigin: request.originInfo.origin) + Text(" is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.")
+            Text(urlOrigin: request.originInfo.origin) + Text(" \(Strings.Wallet.getEncryptionPublicKeyRequestMessage)")
           }
           .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
           .padding(20)
@@ -105,7 +114,7 @@ struct EncryptionView: View {
             Group {
               if !isShowingDecryptMessage {
                 Button(action: { isShowingDecryptMessage.toggle() }) {
-                  Text("Reveal")
+                  Text(Strings.Wallet.decryptRequestReveal)
                 }
                 .buttonStyle(BraveFilledButtonStyle(size: .normal))
               }
@@ -114,7 +123,7 @@ struct EncryptionView: View {
           .alertOnScreenshot {
             Alert(
               title: Text(Strings.Wallet.screenshotDetectedTitle),
-              message: Text("Warning: A screenshot of your message may get backed up to a cloud file service, and be readable by any application with photos access. Brave recommends that you not save this screenshot, and delete it as soon as possible."),
+              message: Text(Strings.Wallet.decryptMessageScreenshotDetectedMessage),
               dismissButton: .cancel(Text(Strings.OKString))
             )
           }
@@ -160,7 +169,7 @@ struct EncryptionView: View {
       alignment: .bottom
     )
     .frame(maxWidth: .infinity)
-    .navigationTitle(Strings.Wallet.signatureRequestTitle)
+    .navigationTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .foregroundColor(Color(.braveLabel))
     .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
@@ -189,9 +198,9 @@ struct EncryptionView: View {
   private var approveButtonTitle: String {
     switch request {
     case .getEncryptionPublicKey:
-      return "Provide"
+      return Strings.Wallet.getEncryptionPublicKeyRequestApprove
     case .decrypt:
-      return "Allow"
+      return Strings.Wallet.decryptRequestApprove
     }
   }
   
@@ -212,7 +221,7 @@ struct EncryptionView: View {
     .buttonStyle(BraveFilledButtonStyle(size: .large))
   }
   
-  func handleAction(approved: Bool) {
+  private func handleAction(approved: Bool) {
     switch request {
     case .getEncryptionPublicKey(let request):
       cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: approved, originInfo: request.originInfo))

--- a/BraveWallet/Panels/RequestContainerView.swift
+++ b/BraveWallet/Panels/RequestContainerView.swift
@@ -61,60 +61,21 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               onDismiss: onDismiss
             )
           case let .getEncryptionPublicKey(request):
-            // TODO: Replace with real UI
-            VStack {
-              Text("Get Encryption Public Key Request")
-              Text("Origin: \(request.originInfo.origin.url?.absoluteString ?? "nil origin url")")
-              Text("Address: \(request.address)")
-              
-              HStack {
-                Button(action: {
-                  cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: false, originInfo: request.originInfo))
-                  onDismiss()
-                }) {
-                  Text("Reject")
-                }
-                .buttonStyle(BraveOutlineButtonStyle(size: .large))
-                
-                Button(action: {
-                  cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: true, originInfo: request.originInfo))
-                  onDismiss()
-                }) {
-                  Text("Accept")
-                }
-                .buttonStyle(BraveFilledButtonStyle(size: .large))
-              }
-              .padding()
-            }
-            .padding()
+            EncryptionView(
+              request: .getEncryptionPublicKey(request),
+              cryptoStore: cryptoStore,
+              keyringStore: keyringStore,
+              networkStore: cryptoStore.networkStore,
+              onDismiss: onDismiss
+            )
           case let .decrypt(request):
-            // TODO: Replace with real UI
-            VStack {
-              Text("Decrypt Request")
-              Text("Origin: \(request.originInfo.origin.url?.absoluteString ?? "nil origin url")")
-              Text("Address: \(request.address)")
-              Text("Unsafe Message: \(request.unsafeMessage ?? "nil message")")
-              
-              HStack {
-                Button(action: {
-                  cryptoStore.handleWebpageRequestResponse(.decrypt(approved: false, originInfo: request.originInfo))
-                  onDismiss()
-                }) {
-                  Text("Reject")
-                }
-                .buttonStyle(BraveOutlineButtonStyle(size: .large))
-                
-                Button(action: {
-                  cryptoStore.handleWebpageRequestResponse(.decrypt(approved: true, originInfo: request.originInfo))
-                  onDismiss()
-                }) {
-                  Text("Accept")
-                }
-                .buttonStyle(BraveFilledButtonStyle(size: .large))
-              }
-              .padding()
-            }
-            .padding()
+            EncryptionView(
+              request: .decrypt(request),
+              cryptoStore: cryptoStore,
+              keyringStore: keyringStore,
+              networkStore: cryptoStore.networkStore,
+              onDismiss: onDismiss
+            )
           }
         }
       }

--- a/BraveWallet/Panels/RequestContainerView.swift
+++ b/BraveWallet/Panels/RequestContainerView.swift
@@ -60,6 +60,61 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               cryptoStore: cryptoStore,
               onDismiss: onDismiss
             )
+          case let .getEncryptionPublicKey(request):
+            // TODO: Replace with real UI
+            VStack {
+              Text("Get Encryption Public Key Request")
+              Text("Origin: \(request.originInfo.origin.url?.absoluteString ?? "nil origin url")")
+              Text("Address: \(request.address)")
+              
+              HStack {
+                Button(action: {
+                  cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: false, originInfo: request.originInfo))
+                  onDismiss()
+                }) {
+                  Text("Reject")
+                }
+                .buttonStyle(BraveOutlineButtonStyle(size: .large))
+                
+                Button(action: {
+                  cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: true, originInfo: request.originInfo))
+                  onDismiss()
+                }) {
+                  Text("Accept")
+                }
+                .buttonStyle(BraveFilledButtonStyle(size: .large))
+              }
+              .padding()
+            }
+            .padding()
+          case let .decrypt(request):
+            // TODO: Replace with real UI
+            VStack {
+              Text("Decrypt Request")
+              Text("Origin: \(request.originInfo.origin.url?.absoluteString ?? "nil origin url")")
+              Text("Address: \(request.address)")
+              Text("Unsafe Message: \(request.unsafeMessage ?? "nil message")")
+              
+              HStack {
+                Button(action: {
+                  cryptoStore.handleWebpageRequestResponse(.decrypt(approved: false, originInfo: request.originInfo))
+                  onDismiss()
+                }) {
+                  Text("Reject")
+                }
+                .buttonStyle(BraveOutlineButtonStyle(size: .large))
+                
+                Button(action: {
+                  cryptoStore.handleWebpageRequestResponse(.decrypt(approved: true, originInfo: request.originInfo))
+                  onDismiss()
+                }) {
+                  Text("Accept")
+                }
+                .buttonStyle(BraveFilledButtonStyle(size: .large))
+              }
+              .padding()
+            }
+            .padding()
           }
         }
       }

--- a/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -65,7 +65,7 @@ struct SignatureRequestView: View {
             Text(account.name)
               .font(.subheadline.weight(.semibold))
               .foregroundColor(Color(.secondaryBraveLabel))
-            OriginText(urlOrigin: currentRequest.originInfo.origin)
+            Text(urlOrigin: currentRequest.originInfo.origin)
               .font(.caption)
               .foregroundColor(Color(.braveLabel))
               .multilineTextAlignment(.center)

--- a/BraveWallet/SensitiveTextView.swift
+++ b/BraveWallet/SensitiveTextView.swift
@@ -1,0 +1,46 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Strings
+import SwiftUI
+
+struct SensitiveTextView: View {
+  
+  var text: String
+  var isCopyEnabled: Bool
+  @Binding var isShowingText: Bool
+  
+  init(
+    text: String,
+    isCopyEnabled: Bool = true,
+    isShowingText: Binding<Bool>
+  ) {
+    self.text = text
+    self.isCopyEnabled = isCopyEnabled
+    self._isShowingText = isShowingText
+  }
+  
+  var body: some View {
+    VStack(spacing: 32) {
+      Text(text)
+        .blur(radius: isShowingText ? 0 : 5)
+        .accessibilityHidden(!isShowingText)
+        .noCapture()
+      if isCopyEnabled {
+        Button(action: {
+          UIPasteboard.general.setSecureString(text)
+        }) {
+          Text("\(Strings.Wallet.copyToPasteboard) \(Image("brave.clipboard"))")
+            .font(.subheadline)
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+      }
+    }
+    .padding(20)
+    .background(
+      Color(.secondaryBraveBackground).clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    )
+  }
+}

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2448,7 +2448,7 @@ extension Strings {
       "wallet.getEncryptionPublicKeyRequestMessage",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.",
+      value: "is requesting your wallet's public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.",
       comment: "The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.'"
     )
     public static let getEncryptionPublicKeyRequestApprove = NSLocalizedString(

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2430,5 +2430,68 @@ extension Strings {
       value: "Connect",
       comment: "The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp."
     )
+    public static let getEncryptionPublicKeyRequestTitle = NSLocalizedString(
+      "wallet.getEncryptionPublicKeyRequestTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Public Encryption Key Request",
+      comment: "A title of the view shown over a dapps website that requests the users public encryption key."
+    )
+    public static let getEncryptionPublicKeyRequestSubtitle = NSLocalizedString(
+      "wallet.getEncryptionPublicKeyRequestSubtitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "A DApp is requesting your public encryption key",
+      comment: "A subtitle of the view shown over a dapps website that requests the users public encryption key."
+    )
+    public static let getEncryptionPublicKeyRequestMessage = NSLocalizedString(
+      "wallet.getEncryptionPublicKeyRequestMessage",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.",
+      comment: "The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.'"
+    )
+    public static let getEncryptionPublicKeyRequestApprove = NSLocalizedString(
+      "wallet.getEncryptionPublicKeyRequestApprove",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Provide",
+      comment: "The title of the button to approve a encryption public key request from a dapps website."
+    )
+    public static let decryptRequestTitle = NSLocalizedString(
+      "wallet.decryptRequestTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Decrypt Request",
+      comment: "A title of the view shown over a dapps website that requests the user decrypt a message."
+    )
+    public static let decryptRequestSubtitle = NSLocalizedString(
+      "wallet.decryptRequestSubtitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "This DApp would like to read this message to complete your request",
+      comment: "A subtitle of the view shown over a dapps website that requests the user decrypt a message."
+    )
+    public static let decryptRequestApprove = NSLocalizedString(
+      "wallet.decryptRequestApprove",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Allow",
+      comment: "The title of the button to approve a decrypt request from a dapps website."
+    )
+    public static let decryptRequestReveal = NSLocalizedString(
+      "wallet.decryptRequestReveal",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Reveal",
+      comment: "The title of the button to show the message of a decrypt request from a dapps website."
+    )
+    public static let decryptMessageScreenshotDetectedMessage = NSLocalizedString(
+      "wallet.decryptMessageScreenshotDetectedMessage",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Warning: A screenshot of your message may get backed up to a cloud file service, and be readable by any application with photos access. Brave recommends that you not save this screenshot, and delete it as soon as possible.",
+      comment: "The message displayed when the user takes a screenshot of their dapp decrypt request."
+    )
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Added support for handling Get Public Encryption Key & Decrypt requests from dapp sites
- `OriginText` was replaced with a `Text` initializer so we can use it when concatenating other text views (used in get public encryption key request view).

This pull request fixes #5424

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

For get public encryption key requests
  1. Open [Metamask Test Dapp Site](https://metamask.github.io/test-dapp/) 
  2. Tap 'GET ENCRYPTION KEY'
  3. Tap 'Provide' on modal get public encryption key request view
 
For decrypt request please verify on device (for screenshot alert)
  1. Open [Metamask Test Dapp Site](https://metamask.github.io/test-dapp/) 
  2. Enter message in field under 'GET ENCRYPTION KEY' button
  4. Tap 'ENCRYPT'
  5. Tap 'DECRYPT'
  6. Tap 'Reveal' to see message
  7. Trigger device screenshot: should see an alert warning
  8. Trigger a screen recording: should not see message in screen recording
  9. Tap 'Allow'

Please also verify Account private key screen is working as expected on device (view was extracted for re-use)
1. Open main brave wallet
2. Tap Accounts
3. Tap your account
4. Tap 'Details'
5. Tap 'Private Key'
6. Trigger device screenshot: should see an alert warning
7. Trigger a screen recording: should not see message in screen recording

## Screenshots:

https://user-images.githubusercontent.com/5314553/172480093-fa91a290-3fae-4119-9d5d-aeb293f88e38.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
