### PR TITLE
Fix #5391: Update sync QR-Code to show Brave lion logo in the middle

### DIFF
--- a/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -157,5 +157,17 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
   func isBase58EncodedSolanaPubkey(_ key: String, completion: @escaping (Bool) -> Void) {
     completion(false)
   }
+  
+  func eTldPlusOne(fromOrigin origin: URLOrigin, completion: @escaping (BraveWallet.OriginInfo) -> Void) {
+    completion(.init(origin: origin, originSpec: origin.url?.absoluteString ?? "", eTldPlusOne: origin.url?.baseDomain ?? ""))
+  }
+  
+  func webSites(withPermission coin: BraveWallet.CoinType, completion: @escaping ([String]) -> Void) {
+    completion([])
+  }
+  
+  func resetWebSitePermission(_ coin: BraveWallet.CoinType, formedWebsite: String, completion: @escaping (Bool) -> Void) {
+    completion(false)
+  }
 }
 #endif

--- a/Client/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -6,6 +6,7 @@
 import Foundation
 import BraveCore
 import BraveShared
+import Shared
 
 extension BraveSyncAPI {
 
@@ -158,46 +159,5 @@ extension BraveSyncAPI {
     deinit {
       self.onRemoved(self)
     }
-  }
-}
-
-extension BraveSyncAPI {
-  func getQRCodeImageV2(_ size: CGSize) -> UIImage? {
-    let hexCode = hexSeed(fromSyncCode: getSyncCode())
-    if hexCode.isEmpty {
-      return nil
-    }
-
-    // Typically QR Codes use isoLatin1, but it doesn't matter here
-    // as we're not encoding any special characters
-    guard let syncCodeData = BraveSyncQRCodeModel(syncHexCode: hexCode).jsonData,
-      !syncCodeData.isEmpty
-    else {
-      return nil
-    }
-
-    guard let filter = CIFilter(name: "CIQRCodeGenerator") else {
-      return nil
-    }
-
-    filter.do {
-      $0.setValue(syncCodeData, forKey: "inputMessage")
-      $0.setValue("H", forKey: "inputCorrectionLevel")
-    }
-
-    if let image = filter.outputImage,
-      image.extent.size.width > 0.0,
-      image.extent.size.height > 0.0 {
-      let scaleX = size.width / image.extent.size.width
-      let scaleY = size.height / image.extent.size.height
-      let transform = CGAffineTransform(scaleX: scaleX, y: scaleY)
-
-      return UIImage(
-        ciImage: image.transformed(by: transform),
-        scale: UIScreen.main.scale,
-        orientation: .up)
-    }
-
-    return nil
   }
 }

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -131,6 +131,7 @@ class SyncAddDeviceViewController: SyncViewController {
     modeControl.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
     modeControl.selectedSegmentTintColor = UIColor.braveOrange
+    modeControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
     stackView.addArrangedSubview(modeControl)
 
     let titleDescriptionStackView = UIStackView()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.75/brave-core-ios-1.40.75.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.87/brave-core-ios-1.40.87.tgz",
         "page-metadata-parser": "^1.1.3",
         "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
         "webpack-cli": "^4.8.0"
@@ -295,9 +295,10 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.40.75",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.40.75/brave-core-ios-1.40.75.tgz",
-      "integrity": "sha512-cKLmiCiag2LdPAxgL2QLdisVkfnkfCB9sLGdFsT9elGNOGPmrLdR+i3NR5Dqa6UZDQUaLZSHoaKZXQ9jpBE0sA=="
+      "version": "1.40.87",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.40.87/brave-core-ios-1.40.87.tgz",
+      "integrity": "sha512-s+sdsRjaw8R9UQ6gjHsj0wD9lg2Qnv1bzo3wBcEdNAsHSgsnkzv2pmeUkDCdKR23YiAOEAj4oh8CAmwfP7VxGw==",
+      "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.17.1",
@@ -1638,8 +1639,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.40.75/brave-core-ios-1.40.75.tgz",
-      "integrity": "sha512-cKLmiCiag2LdPAxgL2QLdisVkfnkfCB9sLGdFsT9elGNOGPmrLdR+i3NR5Dqa6UZDQUaLZSHoaKZXQ9jpBE0sA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.40.87/brave-core-ios-1.40.87.tgz",
+      "integrity": "sha512-s+sdsRjaw8R9UQ6gjHsj0wD9lg2Qnv1bzo3wBcEdNAsHSgsnkzv2pmeUkDCdKR23YiAOEAj4oh8CAmwfP7VxGw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.75/brave-core-ios-1.40.75.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.87/brave-core-ios-1.40.87.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Update sync QR-Code to show Brave lion logo in the middle (matches Desktop and Android)
- Bump Brave-Core to 1.40.87

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5391

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test that joining and leaving a sync chain from any device works (should still work just fine as it's just a logo rendering).
- Old brave versions must be able to join by scanning this version's QR code and also by entering the words.


## Screenshots:
Added black boxes on the QR-Code so users reading this PR don't actually scan it and try to use it. On an actual device, these boxes will not be there!
<img width="390" alt="170733386-43811812-e881-4a82-a8cf-904c46238ec7" src="https://user-images.githubusercontent.com/1530031/170734035-ea28b46c-a0f1-42e9-84bf-7428be9fc595.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
