### PR TITLE
Fix #5458: Reset wallet preferences when resetting wallet

### DIFF
--- a/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -132,7 +132,7 @@ private struct CreateWalletView: View {
       .background(
         BiometricsPromptView(isPresented: $isShowingBiometricsPrompt) { enabled, navController in
           // Store password in keychain
-          if enabled, case let status = KeyringStore.storePasswordInKeychain(password),
+          if enabled, case let status = keyringStore.storePasswordInKeychain(password),
             status != errSecSuccess {
             let isPublic = AppConstants.buildChannel.isPublic
             let alert = UIAlertController(

--- a/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -89,7 +89,7 @@ private struct RestoreWalletView: View {
         if !success {
           restoreError = .invalidPhrase
         } else {
-          KeyringStore.resetKeychainStoredPassword()
+          keyringStore.resetKeychainStoredPassword()
           if isBiometricsAvailable {
             keyringStore.isRestoreFromUnlockBiometricsPromptVisible = true
           } else {
@@ -216,7 +216,7 @@ private struct RestoreWalletView: View {
           keyringStore.markOnboardingCompleted()
         }
         // Store password in keychain
-        if enabled, case let status = KeyringStore.storePasswordInKeychain(password),
+        if enabled, case let status = keyringStore.storePasswordInKeychain(password),
           status != errSecSuccess {
           let isPublic = AppConstants.buildChannel.isPublic
           let alert = UIAlertController(

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -7,6 +7,7 @@ import Foundation
 import LocalAuthentication
 import BraveCore
 import Data
+import BraveShared
 
 public class SettingsStore: ObservableObject {
   /// The number of minutes to wait until the Brave Wallet is automatically locked
@@ -46,10 +47,12 @@ public class SettingsStore: ObservableObject {
     self.walletService = walletService
     self.txService = txService
 
+    keyringService.add(self)
     keyringService.autoLockMinutes { [self] minutes in
       self.autoLockInterval = .init(value: minutes)
     }
     
+    walletService.add(self)
     walletService.defaultBaseCurrency { [self] currencyCode in
       self.currencyCode = CurrencyCode(code: currencyCode)
     }
@@ -59,6 +62,9 @@ public class SettingsStore: ObservableObject {
     walletService.reset()
     KeyringStore.resetKeychainStoredPassword()
     Domain.clearAllEthereumPermissions()
+    Preferences.Wallet.defaultWallet.reset()
+    Preferences.Wallet.allowEthereumProviderAccountRequests.reset()
+    Preferences.Wallet.displayWeb3Notifications.reset()
   }
 
   func resetTransaction() {
@@ -88,6 +94,56 @@ public class SettingsStore: ObservableObject {
   
   func closeManageSiteConnectionStore() {
     manageSiteConnectionsStore = nil
+  }
+}
+
+extension SettingsStore: BraveWalletKeyringServiceObserver {
+  public func keyringCreated(_ keyringId: String) {
+  }
+  
+  public func keyringRestored(_ keyringId: String) {
+  }
+  
+  public func keyringReset() {
+  }
+  
+  public func locked() {
+  }
+  
+  public func unlocked() {
+  }
+  
+  public func backedUp() {
+  }
+  
+  public func accountsChanged() {
+  }
+  
+  public func autoLockMinutesChanged() {
+    keyringService.autoLockMinutes { [weak self] minutes in
+      self?.autoLockInterval = .init(value: minutes)
+    }
+  }
+  
+  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+  }
+}
+
+extension SettingsStore: BraveWalletBraveWalletServiceObserver {
+  public func onActiveOriginChanged(_ originInfo: BraveWallet.OriginInfo) {
+  }
+  
+  public func onDefaultWalletChanged(_ wallet: BraveWallet.DefaultWallet) {
+  }
+  
+  public func onDefaultBaseCurrencyChanged(_ currency: String) {
+    currencyCode = CurrencyCode(code: currency)
+  }
+  
+  public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) {
+  }
+  
+  public func onNetworkListChanged() {
   }
 }
 

--- a/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -19,7 +19,7 @@ public class SettingsStore: ObservableObject {
 
   /// If we should attempt to unlock via biometrics (Face ID / Touch ID)
   var isBiometricsUnlockEnabled: Bool {
-    KeyringStore.isKeychainPasswordStored && isBiometricsAvailable
+    keychain.isPasswordStoredInKeychain(key: KeyringStore.passwordKeychainKey) && isBiometricsAvailable
   }
 
   /// If the device has biometrics available
@@ -37,15 +37,18 @@ public class SettingsStore: ObservableObject {
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
   private let txService: BraveWalletTxService
+  private let keychain: KeychainType
 
   public init(
     keyringService: BraveWalletKeyringService,
     walletService: BraveWalletBraveWalletService,
-    txService: BraveWalletTxService
+    txService: BraveWalletTxService,
+    keychain: KeychainType = Keychain()
   ) {
     self.keyringService = keyringService
     self.walletService = walletService
     self.txService = txService
+    self.keychain = keychain
 
     keyringService.add(self)
     keyringService.autoLockMinutes { [self] minutes in
@@ -60,7 +63,7 @@ public class SettingsStore: ObservableObject {
 
   func reset() {
     walletService.reset()
-    KeyringStore.resetKeychainStoredPassword()
+    keychain.resetPasswordInKeychain(key: KeyringStore.passwordKeychainKey)
     Domain.clearAllEthereumPermissions()
     Preferences.Wallet.defaultWallet.reset()
     Preferences.Wallet.allowEthereumProviderAccountRequests.reset()

--- a/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/BraveWallet/Crypto/UnlockWalletView.swift
@@ -44,7 +44,7 @@ struct UnlockWalletView: View {
   }
 
   private func fillPasswordFromKeychain() {
-    if let password = KeyringStore.retrievePasswordFromKeychain() {
+    if let password = keyringStore.retrievePasswordFromKeychain() {
       self.password = password
       unlock()
     }
@@ -87,7 +87,7 @@ struct UnlockWalletView: View {
                 tf.becomeFirstResponder()
               })
               .textFieldStyle(BraveValidatedTextFieldStyle(error: unlockError))
-            if KeyringStore.isKeychainPasswordStored, let icon = biometricsIcon {
+            if keyringStore.isKeychainPasswordStored, let icon = biometricsIcon {
               Button(action: fillPasswordFromKeychain) {
                 icon
                   .imageScale(.large)

--- a/BraveWallet/Keychain.swift
+++ b/BraveWallet/Keychain.swift
@@ -1,0 +1,124 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import LocalAuthentication
+import Security
+
+public protocol KeychainType: AnyObject {
+  func storePasswordInKeychain(key: String, password: String) -> OSStatus
+  @discardableResult func resetPasswordInKeychain(key: String) -> Bool
+  func isPasswordStoredInKeychain(key: String) -> Bool
+  func getPasswordFromKeychain(key: String) -> String?
+}
+
+public class Keychain: KeychainType {
+  
+  public init() {}
+  
+  public func storePasswordInKeychain(key: String, password: String) -> OSStatus {
+    guard let passwordData = password.data(using: .utf8) else { return errSecInvalidData }
+    #if targetEnvironment(simulator)
+    // There is a bug with iOS 15 simulators when attempting to add a keychain item with
+    // `kSecAttrAccessControl` set. This of course means that on simulator we will not ask for biometrics
+    // and it will just auto-fill the password field but at least to set it up you still need to enable
+    // biometrics on the simulator
+    //
+    // Last checked: Xcode 13.1 (13A1030d)
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecValueData as String: passwordData,
+    ]
+    #else
+    let accessControl = SecAccessControlCreateWithFlags(
+      nil,
+      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+      .userPresence,
+      nil
+    )
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecAttrAccessControl as String: accessControl as Any,
+      kSecValueData as String: passwordData,
+    ]
+    #endif
+    return SecItemAdd(query as CFDictionary, nil)
+  }
+  
+  @discardableResult
+  public func resetPasswordInKeychain(key: String) -> Bool {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+    ]
+    let status = SecItemDelete(query as CFDictionary)
+    return status == errSecSuccess
+  }
+  
+  public func isPasswordStoredInKeychain(key: String) -> Bool {
+    let context = LAContext()
+    context.interactionNotAllowed = true
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecUseAuthenticationContext as String: context,
+    ]
+    let status = SecItemCopyMatching(query as CFDictionary, nil)
+    #if targetEnvironment(simulator)
+    // See comment in `storePasswordInKeychain(_:)`
+    return status == errSecSuccess
+    #else
+    return status == errSecInteractionNotAllowed
+    #endif
+  }
+  
+  public func getPasswordFromKeychain(key: String) -> String? {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecReturnData as String: true,
+    ]
+    var passwordData: AnyObject?
+    let status = SecItemCopyMatching(query as CFDictionary, &passwordData)
+    guard status == errSecSuccess,
+      let data = passwordData as? Data,
+      let password = String(data: data, encoding: .utf8)
+    else {
+      return nil
+    }
+    return password
+  }
+}
+
+#if DEBUG
+public class TestableKeychain: KeychainType {
+  public var _storePasswordInKeychain: ((_ key: String, _ password: String) -> OSStatus)?
+  public var _resetPasswordInKeychain: ((_ key: String) -> Bool)?
+  public var _isPasswordStoredInKeychain: ((_ key: String) -> Bool)?
+  public var _getPasswordFromKeychain: ((_ key: String) -> String?)?
+  
+  public init() {}
+  
+  public func storePasswordInKeychain(key: String, password: String) -> OSStatus {
+    _storePasswordInKeychain?(key, password) ?? OSStatus(0)
+  }
+  
+  public func resetPasswordInKeychain(key: String) -> Bool {
+    _resetPasswordInKeychain?(key) ?? false
+  }
+  
+  public func isPasswordStoredInKeychain(key: String) -> Bool {
+    _isPasswordStoredInKeychain?(key) ?? false
+  }
+  
+  public func getPasswordFromKeychain(key: String) -> String? {
+    _getPasswordFromKeychain?(key)
+  }
+}
+#endif

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import BraveCore
+import BraveShared
 
 #if DEBUG
 
@@ -165,7 +166,8 @@ extension SettingsStore {
     .init(
       keyringService: MockKeyringService(),
       walletService: MockBraveWalletService(),
-      txService: MockTxService()
+      txService: MockTxService(),
+      keychain: TestableKeychain()
     )
   }
 }

--- a/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
+++ b/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
@@ -37,7 +37,7 @@ struct BiometricsPasscodeEntryView: View {
     keyringStore.validate(password: password) { isValid in
       if isValid {
         // store password in keychain
-        if case let status = KeyringStore.storePasswordInKeychain(password),
+        if case let status = keyringStore.storePasswordInKeychain(password),
            status != errSecSuccess {
           self.isShowingKeychainError = true
         } else {

--- a/BraveWallet/Settings/WalletSettingsView.swift
+++ b/BraveWallet/Settings/WalletSettingsView.swift
@@ -207,7 +207,7 @@ public struct WalletSettingsView: View {
     if enabled {
       self.isShowingBiometricsPasswordEntry = true
     } else {
-      KeyringStore.resetKeychainStoredPassword()
+      keyringStore.resetKeychainStoredPassword()
     }
   }
 }

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -1,0 +1,157 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Combine
+import BraveCore
+import BraveShared
+import BigNumber
+@testable import BraveWallet
+
+class SettingsStoreTests: XCTestCase {
+  
+  /// Sets up TestKeyringService, TestBraveWalletService and TestTxService with some default values.
+  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestBraveWalletService, BraveWallet.TestTxService) {
+    let mockAccountInfos: [BraveWallet.AccountInfo] = [.previewAccount]
+    let mockUserAssets: [BraveWallet.BlockchainToken] = [.previewToken.then { $0.visible = true }]
+    
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._keyringInfo = { _, completion in
+      let keyring: BraveWallet.KeyringInfo = .init(
+        id: BraveWallet.DefaultKeyringId,
+        isKeyringCreated: true,
+        isLocked: false,
+        isBackedUp: true,
+        accountInfos: mockAccountInfos)
+      completion(keyring)
+    }
+    keyringService._addObserver = { _ in }
+    keyringService._isLocked = { $0(false) }
+    keyringService._setAutoLockMinutes = { _, _ in }
+    keyringService._autoLockMinutes = { $0(5) } // default is 5mins
+    
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._userAssets = { _, _, completion in
+      completion(mockUserAssets)
+    }
+    walletService._addObserver = { _ in }
+    walletService._setDefaultBaseCurrency = { _ in }
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) } // default is USD
+    
+    let txService = BraveWallet.TestTxService()
+    
+    return (keyringService, walletService, txService)
+  }
+  
+  /// Test `init` will populate default values from keyring service / wallet service
+  func testInit() {
+    let (keyringService, walletService, txService) = setupServices()
+    keyringService._autoLockMinutes = { $0(1) }
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.cad.code) }
+
+    let sut = SettingsStore(
+      keyringService: keyringService,
+      walletService: walletService,
+      txService: txService
+    )
+
+    XCTAssertEqual(sut.autoLockInterval, .minute)
+    XCTAssertEqual(sut.currencyCode.code, CurrencyCode.cad.code)
+  }
+
+  /// Test `reset()` will call `reset()` on wallet service, update web3 preferences to default values, and update autolock & currency code values.
+  func testReset() {
+    let (keyringService, walletService, txService) = setupServices()
+    var keyringServiceAutolockMinutes: Int32 = 1
+    keyringService._autoLockMinutes = { $0(keyringServiceAutolockMinutes) }
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.cad.code) }
+
+    var walletServiceResetCalled = false
+    walletService._reset = {
+      walletServiceResetCalled = true
+    }
+
+    assert(
+      Preferences.Wallet.WalletType.none.rawValue != Preferences.Wallet.defaultWallet.defaultValue,
+      "Test assumes default wallet value is not `none`") 
+    Preferences.Wallet.defaultWallet.value = Preferences.Wallet.WalletType.none.rawValue
+    XCTAssertEqual(
+      Preferences.Wallet.defaultWallet.value,
+      Preferences.Wallet.WalletType.none.rawValue,
+      "Failed to update default wallet")
+    Preferences.Wallet.allowEthereumProviderAccountRequests.value = !Preferences.Wallet.allowEthereumProviderAccountRequests.defaultValue
+    XCTAssertEqual(
+      Preferences.Wallet.allowEthereumProviderAccountRequests.value,
+      !Preferences.Wallet.allowEthereumProviderAccountRequests.defaultValue,
+      "Failed to update allow ethereum requests")
+    Preferences.Wallet.displayWeb3Notifications.value = !Preferences.Wallet.displayWeb3Notifications.defaultValue
+    XCTAssertEqual(
+      Preferences.Wallet.displayWeb3Notifications.value,
+      !Preferences.Wallet.displayWeb3Notifications.defaultValue,
+      "Failed to update display web3 notifications")
+
+    let sut = SettingsStore(
+      keyringService: keyringService,
+      walletService: walletService,
+      txService: txService
+    )
+    
+    XCTAssertEqual(sut.autoLockInterval, .minute)
+    XCTAssertEqual(sut.currencyCode.code, CurrencyCode.cad.code)
+
+    // reset internally in services, mock reset here.
+    keyringServiceAutolockMinutes = 5
+    
+    // Begin test
+    sut.reset()
+    
+    // simulate service observation updates
+    sut.autoLockMinutesChanged()
+    sut.onDefaultBaseCurrencyChanged(CurrencyCode.usd.code)
+    
+    XCTAssertEqual(sut.autoLockInterval, .fiveMinutes)
+    XCTAssertEqual(sut.currencyCode.code, CurrencyCode.usd.code)
+
+    XCTAssert(
+      walletServiceResetCalled,
+      "WalletService reset() not called")
+    XCTAssertEqual(
+      Preferences.Wallet.defaultWallet.value,
+      Preferences.Wallet.defaultWallet.defaultValue,
+      "Default Wallet was not reset to default")
+    XCTAssertEqual(
+      Preferences.Wallet.allowEthereumProviderAccountRequests.value,
+      Preferences.Wallet.allowEthereumProviderAccountRequests.defaultValue,
+      "Allow ethereum requests was not reset to default")
+    XCTAssertEqual(
+      Preferences.Wallet.displayWeb3Notifications.value,
+      Preferences.Wallet.displayWeb3Notifications.defaultValue,
+      "Display web3 notifications was not reset to default")
+    /// Testing against `Domain.clearAllEthereumPermissions` has proven flakey
+    /// on CI, verified in `ManageSiteConnectionsStoreTests`, `DomainTests`.
+    /// Testing against `KeyringStore.resetKeychainStoredPassword`
+    /// accesses keychain, requiring host app or testable keychain wrapper
+    // TODO: Add testable keychain wrapper
+  }
+
+  /// Test `resetTransaction()` will call `reset()` on TxService
+  func testResetTransaction() {
+    let (keyringService, walletService, txService) = setupServices()
+    var txServiceResetCalled = false
+    txService._reset = {
+      txServiceResetCalled = true
+    }
+    
+    let sut = SettingsStore(
+      keyringService: keyringService,
+      walletService: walletService,
+      txService: txService
+    )
+    
+    sut.resetTransaction()
+    
+    XCTAssert(txServiceResetCalled, "TxService reset() not called")
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Reset web3 preferences when resetting wallet
- Fix autolock minutes and default base currency not appearing to reset in settings after resetting wallet
- Added unit tests for settings store
- Added a `KeychainType` to add a testable keychain wrapper

This pull request fixes #5458

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Go to wallet settings
2. Change preferences from defaults:
![settings defaults](https://user-images.githubusercontent.com/5314553/172880981-f00ca5a0-5b5c-4c88-9c91-eaf6dc02cdd8.png)
3. Reset wallet
4. Setup / Restore wallet
5. Verify preferences are reset

## Screenshots:

https://user-images.githubusercontent.com/5314553/172880805-2e6d39f1-baf2-41b5-a34b-a735608d3853.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
