### PR TITLE
No bug: Fix store not being closed after successfully made a transaction

### DIFF
--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -144,6 +144,7 @@ public struct CryptoView: View {
                   sendTokenStore: store.openSendTokenStore(destination.initialToken),
                   completion: { success in
                     if success {
+                      store.closeBSSStores()
                       dismissAction?()
                     }
                   },
@@ -159,6 +160,7 @@ public struct CryptoView: View {
                   swapTokensStore: store.openSwapTokenStore(destination.initialToken),
                   completion: { success in
                     if success {
+                      store.closeBSSStores()
                       dismissAction?()
                     }
                   },


### PR DESCRIPTION
## Summary of Changes
Store is not being closed after users successfully create a transaction via wallet panel.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Open wallet panel
- click two arrows button at the bottom of the panel
- choose either send or swap
- make a transaction and either reject or confirm the transaction
- click the two arrows button again and choose the previous transaction type either send or swap
- observe that send and swap view should start from fresh and has no pre-filled number (the number you filled in from the previous transaction)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
