### PR TITLE
Fix #5486: Update known networks list

### DIFF
--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -117,15 +117,23 @@ extension BraveWallet.NetworkInfo: Identifiable {
   }
 
   public var isCustom: Bool {
-    let ethNetworks = [
+    /// Will be able to get known/custom networks after
+    /// https://github.com/brave/brave-ios/issues/5489
+    let knownEthNetworks = [
       BraveWallet.MainnetChainId,
       BraveWallet.RinkebyChainId,
       BraveWallet.RopstenChainId,
       BraveWallet.GoerliChainId,
       BraveWallet.KovanChainId,
       BraveWallet.LocalhostChainId,
+      BraveWallet.PolygonMainnetChainId,
+      BraveWallet.BinanceSmartChainMainnetChainId,
+      BraveWallet.CeloMainnetChainId,
+      BraveWallet.AvalancheMainnetChainId,
+      BraveWallet.FantomMainnetChainId,
+      BraveWallet.OptimismMainnetChainId
     ]
-    return !ethNetworks.contains(id)
+    return !knownEthNetworks.contains(id)
   }
 }
 


### PR DESCRIPTION
## Summary of Changes
- Update the list of known/pre-defined networks so they do not appear in Custom Networks list which allows deletion (causing a crash).

This pull request fixes #5486

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Setup a new wallet
2. Go to wallet settings
3. Observe known networks

## Screenshots:

https://user-images.githubusercontent.com/5314553/172930644-6dca6a21-d7d0-4f21-b653-fa16929439ea.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
