### PR TITLE
Fix #5477: Add context menu to all truncated Wallet account address to reveal full address

### DIFF
--- a/BraveWallet/AddressView.swift
+++ b/BraveWallet/AddressView.swift
@@ -1,0 +1,31 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct AddressView<Content: View>: View {
+  var address: String
+  var content: () -> Content
+  
+  init(
+    address: String,
+    @ViewBuilder content: @escaping () -> Content
+  ) {
+    self.address = address
+    self.content = content
+  }
+  
+  var body: some View {
+    content()
+      .contextMenu {
+        Text(address.zwspAddress)
+        Button(action: {
+          UIPasteboard.general.string = address
+        }) {
+          Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+        }
+      }
+  }
+}

--- a/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -22,17 +22,12 @@ struct AccountListView: View {
           header: WalletListHeaderView(title: Text(Strings.Wallet.accountsPageTitle))
         ) {
           ForEach(keyringStore.keyring.accountInfos) { account in
-            Button(action: {
-              keyringStore.selectedAccount = account
-              onDismiss()
-            }) {
-              AccountView(address: account.address, name: account.name)
-            }
-            .contextMenu {
+            AddressView(address: keyringStore.selectedAccount.address) {
               Button(action: {
-                UIPasteboard.general.string = account.address
+                keyringStore.selectedAccount = account
+                onDismiss()
               }) {
-                Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
+                AccountView(address: account.address, name: account.name)
               }
             }
           }

--- a/BraveWallet/Crypto/Accounts/AccountView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountView.swift
@@ -23,7 +23,7 @@ struct AccountView: View {
         Text(name)
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
-        Text(address.truncatedAddress)
+        Text(address)
           .foregroundColor(Color(.braveLabel))
       }
       .font(.caption)
@@ -31,7 +31,7 @@ struct AccountView: View {
     }
     .padding(.vertical, 6)
     .accessibilityElement()
-    .accessibilityLabel("\(name), \(address.truncatedAddress)")
+    .accessibilityLabel("\(name), \(address)")
   }
 }
 

--- a/BraveWallet/Crypto/Accounts/AccountView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountView.swift
@@ -23,7 +23,7 @@ struct AccountView: View {
         Text(name)
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
-        Text(address)
+        Text(address.truncatedAddress)
           .foregroundColor(Color(.braveLabel))
       }
       .font(.caption)

--- a/BraveWallet/Crypto/Accounts/AccountView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountView.swift
@@ -31,7 +31,7 @@ struct AccountView: View {
     }
     .padding(.vertical, 6)
     .accessibilityElement()
-    .accessibilityLabel("\(name), \(address)")
+    .accessibilityLabel("\(name), \(address.truncatedAddress)")
   }
 }
 

--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -24,14 +24,6 @@ struct AccountsView: View {
     keyringStore.keyring.accountInfos.filter(\.isImported)
   }
 
-  private func copyAccountAddressButton(_ address: String) -> some View {
-    Button(action: {
-      UIPasteboard.general.string = address
-    }) {
-      Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
-    }
-  }
-
   var body: some View {
     List {
       Section(
@@ -52,10 +44,9 @@ struct AccountsView: View {
           Button {
             selectedAccount = account
           } label: {
-            AccountView(address: account.address, name: account.name)
-          }
-          .contextMenu {
-            copyAccountAddressButton(account.address)
+            AddressView(address: account.address) {
+              AccountView(address: account.address, name: account.name)
+            }
           }
         }
       }
@@ -78,10 +69,9 @@ struct AccountsView: View {
             Button {
               selectedAccount = account
             } label: {
-              AccountView(address: account.address, name: account.name)
-            }
-            .contextMenu {
-              copyAccountAddressButton(account.address)
+              AddressView(address: account.address) {
+                AccountView(address: account.address, name: account.name)
+              }
             }
           }
         }

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -162,7 +162,7 @@ private struct AccountActivityHeaderView: View {
       VStack(spacing: 4) {
         Text(account.name)
           .fontWeight(.semibold)
-        Text(account.address.truncatedAddress)
+        Text(account.address)
           .font(.footnote)
       }
       .padding(.bottom, 12)

--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -162,8 +162,10 @@ private struct AccountActivityHeaderView: View {
       VStack(spacing: 4) {
         Text(account.name)
           .fontWeight(.semibold)
-        Text(account.address)
-          .font(.footnote)
+        AddressView(address: account.address) {
+          Text(account.address.truncatedAddress)
+            .font(.footnote)
+        }
       }
       .padding(.bottom, 12)
       HStack {

--- a/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -152,7 +152,7 @@ private struct AccountDetailsHeaderView: View {
         )
       Button(action: { UIPasteboard.general.string = address }) {
         HStack {
-          Text(address.truncatedAddress)
+          Text(address)
             .foregroundColor(Color(.secondaryBraveLabel))
           Label(Strings.Wallet.copyToPasteboard, braveSystemImage: "brave.clipboard")
             .labelStyle(.iconOnly)

--- a/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -56,7 +56,9 @@ struct AssetDetailView: View {
         } else {
           ForEach(assetDetailStore.accounts) { viewModel in
             HStack {
-              AccountView(address: viewModel.account.address, name: viewModel.account.name)
+              AddressView(address: viewModel.account.address) {
+                AccountView(address: viewModel.account.address, name: viewModel.account.name)
+              }
               let showFiatPlaceholder = viewModel.fiatBalance.isEmpty && assetDetailStore.isLoadingPrice
               let showBalancePlaceholder = viewModel.balance.isEmpty && assetDetailStore.isLoadingAccountBalances
               VStack(alignment: .trailing) {

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -105,7 +105,7 @@ struct AccountPicker: View {
       }
     }
     .accessibilityLabel(Strings.Wallet.selectedAccountAccessibilityLabel)
-    .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address)")
+    .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address.truncatedAddress)")
   }
 
   private var networkPickerView: some View {

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -48,7 +48,7 @@ struct AccountPicker: View {
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
           .multilineTextAlignment(.leading)
-        Text(keyringStore.selectedAccount.address.truncatedAddress)
+        Text(keyringStore.selectedAccount.address)
           .foregroundColor(Color(.braveLabel))
           .multilineTextAlignment(.leading)
       }
@@ -104,7 +104,7 @@ struct AccountPicker: View {
       }
     }
     .accessibilityLabel(Strings.Wallet.selectedAccountAccessibilityLabel)
-    .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address.truncatedAddress)")
+    .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address)")
   }
 
   private var networkPickerView: some View {

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -71,7 +71,7 @@ struct AccountPicker: View {
     Group {
       if #available(iOS 15.0, *) {
         Menu {
-          Text(keyringStore.selectedAccount.address)
+          Text(keyringStore.selectedAccount.address.zwspAddress)
           Button(action: copyAddress) {
             Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
           }

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -48,7 +48,7 @@ struct AccountPicker: View {
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
           .multilineTextAlignment(.leading)
-        Text(keyringStore.selectedAccount.address)
+        Text(keyringStore.selectedAccount.address.truncatedAddress)
           .foregroundColor(Color(.braveLabel))
           .multilineTextAlignment(.leading)
       }
@@ -71,6 +71,7 @@ struct AccountPicker: View {
     Group {
       if #available(iOS 15.0, *) {
         Menu {
+          Text(keyringStore.selectedAccount.address)
           Button(action: copyAddress) {
             Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
           }

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -42,4 +42,17 @@ extension String {
     // Check the length and the rest of the char is a hex digit
     return hex.count == 40 && hex.allSatisfy(\.isHexDigit)
   }
+  
+  /// Insert zero-width space every 10 characters inside account address string
+  var zwspAddress: String {
+    let characters = Array(self)
+    var result = ""
+    for index in stride(from: 0, through: characters.count, by: 10) {
+      result += String(characters[index..<min(index+10, characters.count)])
+      if index % 10 == 0 || index != 0 {
+        result += "\u{200b}"
+      }
+    }
+    return result
+  }
 }

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -43,16 +43,10 @@ extension String {
     return hex.count == 40 && hex.allSatisfy(\.isHexDigit)
   }
   
-  /// Insert zero-width space every 10 characters inside account address string
+  /// Insert zero-width space every character inside account address string
   var zwspAddress: String {
-    let characters = Array(self)
-    var result = ""
-    for index in stride(from: 0, through: characters.count, by: 10) {
-      result += String(characters[index..<min(index+10, characters.count)])
-      if index % 10 == 0 || index != 0 {
-        result += "\u{200b}"
-      }
-    }
-    return result
+    return map {
+      String($0) + "\u{200b}"
+    }.joined()
   }
 }

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -71,7 +71,7 @@ struct TransactionConfirmationView: View {
   /// View showing the currently selected account with a blockie
   @ViewBuilder private var accountView: some View {
     HStack {
-      Text(keyringStore.selectedAccount.address.truncatedAddress)
+      Text(keyringStore.selectedAccount.address)
         .fontWeight(.semibold)
       Blockie(address: keyringStore.selectedAccount.address)
         .frame(width: blockieSize, height: blockieSize)

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -71,8 +71,10 @@ struct TransactionConfirmationView: View {
   /// View showing the currently selected account with a blockie
   @ViewBuilder private var accountView: some View {
     HStack {
-      Text(keyringStore.selectedAccount.address)
-        .fontWeight(.semibold)
+      AddressView(address: keyringStore.selectedAccount.address) {
+        Text(keyringStore.selectedAccount.address.truncatedAddress)
+          .fontWeight(.semibold)
+      }
       Blockie(address: keyringStore.selectedAccount.address)
         .frame(width: blockieSize, height: blockieSize)
     }

--- a/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -31,15 +31,23 @@ struct TransactionHeader: View {
         Group {
           if sizeCategory.isAccessibilityCategory {
             VStack {
-              Text(fromAccountName)
+              AddressView(address: fromAccountAddress) {
+                Text(fromAccountName)
+              }
               Image(systemName: "arrow.down")
-              Text(toAccountName)
+              AddressView(address: toAccountAddress) {
+                Text(toAccountName)
+              }
             }
           } else {
             HStack {
-              Text(fromAccountName)
+              AddressView(address: fromAccountAddress) {
+                Text(fromAccountName)
+              }
               Image(systemName: "arrow.right")
-              Text(toAccountName)
+              AddressView(address: toAccountAddress) {
+                Text(toAccountName)
+              }
             }
           }
         }

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -118,7 +118,7 @@ struct SuggestedNetworkView: View {
   private var headerView: some View {
     VStack {
       Menu {
-        Text(keyringStore.selectedAccount.address)
+        Text(keyringStore.selectedAccount.address.zwspAddress)
         Button(action: {
           UIPasteboard.general.string = keyringStore.selectedAccount.address
         }) {

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -117,13 +117,22 @@ struct SuggestedNetworkView: View {
   
   private var headerView: some View {
     VStack {
-      HStack(spacing: 8) {
-        Spacer()
+      Menu {
         Text(keyringStore.selectedAccount.address)
-          .fontWeight(.semibold)
-        Blockie(address: keyringStore.selectedAccount.address)
-          .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-          .aspectRatio(1, contentMode: .fit)
+        Button(action: {
+          UIPasteboard.general.string = keyringStore.selectedAccount.address
+        }) {
+          Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+        }
+      } label: {
+        HStack(spacing: 8) {
+          Spacer()
+          Text(keyringStore.selectedAccount.address.truncatedAddress)
+            .fontWeight(.semibold)
+          Blockie(address: keyringStore.selectedAccount.address)
+            .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
+            .aspectRatio(1, contentMode: .fit)
+        }
       }
       .accessibilityLabel(Strings.Wallet.selectedAccountAccessibilityLabel)
       .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address)")
@@ -194,6 +203,7 @@ struct SuggestedNetworkView: View {
       .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
       .accessibility(hidden: sizeCategory.isAccessibilityCategory)
     }
+    .listStyle(InsetGroupedListStyle())
     .navigationTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .overlay(

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -119,14 +119,14 @@ struct SuggestedNetworkView: View {
     VStack {
       HStack(spacing: 8) {
         Spacer()
-        Text(keyringStore.selectedAccount.address.truncatedAddress)
+        Text(keyringStore.selectedAccount.address)
           .fontWeight(.semibold)
         Blockie(address: keyringStore.selectedAccount.address)
           .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
           .aspectRatio(1, contentMode: .fit)
       }
       .accessibilityLabel(Strings.Wallet.selectedAccountAccessibilityLabel)
-      .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address.truncatedAddress)")
+      .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address)")
       VStack(spacing: 8) {
         faviconAndOrigin
         Text(headerTitle)

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -135,7 +135,7 @@ struct SuggestedNetworkView: View {
         }
       }
       .accessibilityLabel(Strings.Wallet.selectedAccountAccessibilityLabel)
-      .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address)")
+      .accessibilityValue("\(keyringStore.selectedAccount.name), \(keyringStore.selectedAccount.address.truncatedAddress)")
       VStack(spacing: 8) {
         faviconAndOrigin
         Text(headerTitle)

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -127,13 +127,17 @@ struct EditSiteConnectionView: View {
             let action = editAction(for: account)
             if sizeCategory.isAccessibilityCategory {
               VStack {
-                AccountView(address: account.address, name: account.name)
+                AddressView(address: account.address) {
+                  AccountView(address: account.address, name: account.name)
+                }
                 Spacer()
                 editButton(action: action, account: account)
               }
             } else {
               HStack {
-                AccountView(address: account.address, name: account.name)
+                AddressView(address: account.address) {
+                  AccountView(address: account.address, name: account.name)
+                }
                 Spacer()
                 editButton(action: action, account: account)
               }

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -159,7 +159,7 @@ public struct NewSiteConnectionView: View {
   private var accountsAddressesToConfirm: String {
     keyringStore.keyring.accountInfos
       .filter { selectedAccounts.contains($0.id) }
-      .map(\.address.truncatedAddress)
+      .map(\.address)
       .joined(separator: ", ")
   }
   

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -93,7 +93,9 @@ public struct NewSiteConnectionView: View {
               }
             } label: {
               HStack {
-                AccountView(address: account.address, name: account.name)
+                AddressView(address: account.address) {
+                  AccountView(address: account.address, name: account.name)
+                }
                 Spacer()
                 Group {
                   if selectedAccounts.contains(account.id) {
@@ -159,7 +161,7 @@ public struct NewSiteConnectionView: View {
   private var accountsAddressesToConfirm: String {
     keyringStore.keyring.accountInfos
       .filter { selectedAccounts.contains($0.id) }
-      .map(\.address)
+      .map(\.address.truncatedAddress)
       .joined(separator: ", ")
   }
   

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -343,9 +343,11 @@ struct WalletPanelView: View {
             VStack(spacing: 4) {
               Text(keyringStore.selectedAccount.name)
                 .font(.headline)
-              Text(keyringStore.selectedAccount.address)
-                .font(.callout)
-                .multilineTextAlignment(.center)
+              AddressView(address: keyringStore.selectedAccount.address) {
+                Text(keyringStore.selectedAccount.address.truncatedAddress)
+                  .font(.callout)
+                  .multilineTextAlignment(.center)
+              }
             }
           }
           VStack(spacing: 4) {
@@ -406,6 +408,31 @@ struct WalletPanelView: View {
       }
       accountActivityStore.update()
     }
+  }
+}
+
+struct AddressView<Content: View>: View {
+  var address: String
+  var content: () -> Content
+  
+  init(
+    address: String,
+    @ViewBuilder content: @escaping () -> Content
+  ) {
+    self.address = address
+    self.content = content
+  }
+  
+  var body: some View {
+    content()
+      .contextMenu {
+        Text(address)
+        Button(action: {
+          UIPasteboard.general.string = address
+        }) {
+          Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+        }
+      }
   }
 }
 

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -343,8 +343,9 @@ struct WalletPanelView: View {
             VStack(spacing: 4) {
               Text(keyringStore.selectedAccount.name)
                 .font(.headline)
-              Text(keyringStore.selectedAccount.address.truncatedAddress)
+              Text(keyringStore.selectedAccount.address)
                 .font(.callout)
+                .multilineTextAlignment(.center)
             }
           }
           VStack(spacing: 4) {

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -411,31 +411,6 @@ struct WalletPanelView: View {
   }
 }
 
-struct AddressView<Content: View>: View {
-  var address: String
-  var content: () -> Content
-  
-  init(
-    address: String,
-    @ViewBuilder content: @escaping () -> Content
-  ) {
-    self.address = address
-    self.content = content
-  }
-  
-  var body: some View {
-    content()
-      .contextMenu {
-        Text(address)
-        Button(action: {
-          UIPasteboard.general.string = address
-        }) {
-          Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
-        }
-      }
-  }
-}
-
 struct InvisibleUIView: UIViewRepresentable {
   let uiView = UIView()
   func makeUIView(context: Context) -> UIView {

--- a/Tests/BraveWalletTests/AddressTests.swift
+++ b/Tests/BraveWalletTests/AddressTests.swift
@@ -42,7 +42,7 @@ class AddressTests: XCTestCase {
   
   func testZwspAddress() {
     let address = "0x1bBE4E6EF7294c99358377abAd15A6d9E98127A2"
-    let zwspAddress = "0x1bBE4E6E\u{200b}F7294c9935\u{200b}8377abAd15\u{200b}A6d9E98127\u{200b}A2\u{200b}"
+    let zwspAddress = "0\u{200b}x\u{200b}1\u{200b}b\u{200b}B\u{200b}E\u{200b}4\u{200b}E\u{200b}6\u{200b}E\u{200b}F\u{200b}7\u{200b}2\u{200b}9\u{200b}4\u{200b}c\u{200b}9\u{200b}9\u{200b}3\u{200b}5\u{200b}8\u{200b}3\u{200b}7\u{200b}7\u{200b}a\u{200b}b\u{200b}A\u{200b}d\u{200b}1\u{200b}5\u{200b}A\u{200b}6\u{200b}d\u{200b}9\u{200b}E\u{200b}9\u{200b}8\u{200b}1\u{200b}2\u{200b}7\u{200b}A\u{200b}2\u{200b}"
     let result = address.zwspAddress
     XCTAssertNotEqual(address, result)
     XCTAssertEqual(zwspAddress, result)

--- a/Tests/BraveWalletTests/AddressTests.swift
+++ b/Tests/BraveWalletTests/AddressTests.swift
@@ -39,4 +39,12 @@ class AddressTests: XCTestCase {
     let isAddressFalseNoHexDigits = "0x"
     XCTAssertFalse(isAddressFalseNoHexDigits.isETHAddress)
   }
+  
+  func testZwspAddress() {
+    let address = "0x1bBE4E6EF7294c99358377abAd15A6d9E98127A2"
+    let zwspAddress = "0x1bBE4E6E\u{200b}F7294c9935\u{200b}8377abAd15\u{200b}A6d9E98127\u{200b}A2\u{200b}"
+    let result = address.zwspAddress
+    XCTAssertNotEqual(address, result)
+    XCTAssertEqual(zwspAddress, result)
+  }
 }


### PR DESCRIPTION
This pull request fixes #5477 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
iOS Wallet displays truncated account addresses. 
To reveal the full address can either tap & hold to trigger a context menu or go to account details screen

## Screenshots:
![Simulator Screen Shot - iPhone 12 - 2022-06-09 at 15 48 42](https://user-images.githubusercontent.com/1187676/172938677-83aedfb0-2537-4d53-b8e7-0429228ba025.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-09 at 16 04 14](https://user-images.githubusercontent.com/1187676/172938684-02453311-aa99-425e-9d39-01e4002ed9e0.png)| ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-09 at 16 04 34](https://user-images.githubusercontent.com/1187676/172938689-344abaf8-a29c-4190-aaa5-40b6ce8c99f3.png)
--|--|--
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-09 at 16 05 03](https://user-images.githubusercontent.com/1187676/172938692-6080027a-03ac-43b7-a64e-4845d41616c5.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-09 at 16 06 19](https://user-images.githubusercontent.com/1187676/172938695-a552ce69-7ed2-498b-953e-b235f459c03f.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-09 at 16 14 38](https://user-images.githubusercontent.com/1187676/172938697-c44789ef-d8ad-4d77-b301-9494ce872bce.png)
--|--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
