### PR TITLE
Fix #5404: DApp is not updated on network change.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -279,11 +279,12 @@ extension Tab: BraveWalletEventsListener {
   
   func chainChangedEvent(_ chainId: String) {
     Task { @MainActor in
-      guard let provider = walletProvider,
-            case let currentChainId = await provider.chainId(),
-            chainId != currentChainId else { return }
+      /// Temporary fix for #5404
+      /// Ethereum properties have been updated correctly, however, dapp is not updated unless there is a reload
+      /// We keep the same as Metamask, that, we will reload tab on chain changes.
       emitEthereumEvent(.ethereumChainChanged(chainId: chainId))
       updateEthereumProperties()
+      reload()
     }
   }
   


### PR DESCRIPTION
## Summary of Changes
Ethereum properties have been updated correctly, however, dapp is not updated unless there is a reload
We keep the same as Metamask, that, we will reload tab on chain changes.

This pull request fixes #5404 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
please refer to the issue


https://user-images.githubusercontent.com/1187676/172953373-aca033de-b8f2-452c-a7af-30fd890ab722.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
