### PR TITLE
Ref #5482: Temporarily disable audio farbling

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/FarblingProtection.js
+++ b/Client/Frontend/UserContent/UserScripts/FarblingProtection.js
@@ -10,7 +10,6 @@ window.braveFarble = (args) => {
   // Adds slight randization when reading data for audio files
   // Randomization is determined by the fudge factor
   const farbleAudio = (fudgeFactor) => {
-    const farbledChannels = new WeakMap()
     const braveNacl = window.nacl
     delete window.nacl
 
@@ -58,32 +57,9 @@ window.braveFarble = (args) => {
     const getChannelData = window.AudioBuffer.prototype.getChannelData
     window.AudioBuffer.prototype.getChannelData = function () {
       const channelData = Reflect.apply(getChannelData, this, arguments)
-      let hashes = farbledChannels.get(channelData)
-
-      // First let's check if we already farbled this set
-      if (hashes !== undefined) {
-        // We had this data set farbled already.
-        // Lets see if it changed it's shape since then.
-        const hash = hashArray(channelData)
-
-        if (hashes.has(hash)) {
-          // We already farbled this version of the channel data
-          // Let's not farble it again
-          return channelData
-        }
-      } else {
-        // If we dont have any hashes of farbled data at all for this
-        // channel, then we trivially haven't hashed this channel data yet.
-        hashes = new Set()
-        farbledChannels.set(channelData, hashes)
-      }
-
-      // Farble the array and store the hash of this
-      // so that we don't farble the same data again.
-      farbleArrayData(channelData)
-      const hash = hashArray(channelData)
-      hashes.add(hash)
-
+      // TODO: @JS Add more optimized audio farbling.
+      // Will be done as a future PR of #5482 here:
+      // https://github.com/brave/brave-ios/pull/5485
       return channelData
     }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Disable `getChannelData` farbling temporarily while looking for an optimized algorithm to do this.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5482 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Steps in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
