### PR TITLE
No Bug: Fix `updateTabsBarVisibility()` crash.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1256,9 +1256,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
 
   func updateTabsBarVisibility() {
     defer {
-      if topToolbar != nil {
-        topToolbar.line.isHidden = !tabsBar.view.isHidden
-      }
+      topToolbar?.line.isHidden = !tabsBar.view.isHidden
     }
 
     if tabManager.selectedTab == nil {
@@ -2617,9 +2615,7 @@ extension BrowserViewController: TabManagerDelegate {
     // Update Tab Count on Tab-Tray Button
     let count = tabManager.tabsForCurrentMode.count
     toolbar?.updateTabCount(count)
-    if topToolbar != nil {
-      topToolbar.updateTabCount(count)
-    }
+    topToolbar?.updateTabCount(count)
 
     // Update Actions for Tab-Tray Button
     var newTabMenuChildren: [UIAction] = []

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2617,7 +2617,9 @@ extension BrowserViewController: TabManagerDelegate {
     // Update Tab Count on Tab-Tray Button
     let count = tabManager.tabsForCurrentMode.count
     toolbar?.updateTabCount(count)
-    topToolbar.updateTabCount(count)
+    if topToolbar != nil {
+      topToolbar.updateTabCount(count)
+    }
 
     // Update Actions for Tab-Tray Button
     var newTabMenuChildren: [UIAction] = []

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1256,7 +1256,9 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
 
   func updateTabsBarVisibility() {
     defer {
-      topToolbar.line.isHidden = !tabsBar.view.isHidden
+      if topToolbar != nil {
+        topToolbar.line.isHidden = !tabsBar.view.isHidden
+      }
     }
 
     if tabManager.selectedTab == nil {


### PR DESCRIPTION
Found in XCode. Not sure this fixes the root problem.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
