### PR TITLE
Ref #5380: Load sync device images correctly when making a sync chain

### DIFF
--- a/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
+++ b/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
@@ -45,7 +45,7 @@ class SyncDeviceTypeButton: UIControl {
     layer.shadowOpacity = 0.1
     layer.shadowOffset = CGSize(width: 0, height: 1)
 
-    imageView.image = UIImage(named: image)
+    imageView.image = UIImage(named: image, in: .current, compatibleWith: nil)
     imageView.contentMode = .center
     imageView.tintColor = .braveLabel
     addSubview(imageView)


### PR DESCRIPTION
## Summary of Changes

Follow up fix to #5380 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots:

![image](https://user-images.githubusercontent.com/529104/173399275-b11a9edc-5adf-4198-8f07-3e8fe21bbb47.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
