### PR TITLE
Fix #5483, #5501: Wallet icon showing in URL bar after tab/navigation changes

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -291,7 +291,7 @@ public class CryptoStore: ObservableObject {
       return true
     }
     let pendingRequest = await fetchPendingWebpageRequest()
-    if self.pendingRequest == nil {
+    if self.pendingRequest == nil, pendingRequest != nil {
       self.pendingRequest = pendingRequest
     }
     return pendingRequest != nil

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3167,6 +3167,7 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
     switch action {
     case .openInCurrentTab:
       finishEditingAndSubmit(url, visitType: visitType)
+      updateURLBarWalletButton()
     case .openInNewTab(let isPrivate):
       let tab = tabManager.addTab(PrivilegedRequest(url: url) as URLRequest, afterTab: tabManager.selectedTab, isPrivate: isPrivate)
       if isPrivate && !PrivateBrowsingManager.shared.isPrivateBrowsing {
@@ -3187,6 +3188,7 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
           })
         show(toast: toast)
       }
+      updateURLBarWalletButton()
     case .copy:
       UIPasteboard.general.url = url
     case .share:

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -71,7 +71,6 @@ class Tab: NSObject {
   var walletProviderJS: String?
   var isWalletIconVisible: Bool = false {
     didSet {
-      guard oldValue != isWalletIconVisible else { return }
       tabDelegate?.updateURLBarWalletButton()
     }
   }


### PR DESCRIPTION
## Summary of Changes
- Resolve issue where the wallet icon would show after navigating to a new web page, and when switching tabs
- Assignment to CryptoStore's `pendingRequest: PendingRequest?` when the pending request is nil was causing too many layout updates (we have an `onChange()` modifier for this property) + other issues so now also checking if `pendingReqeust` is non-nil before assigning it.

This pull request fixes #5483, #5501

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

For #5483:
  1. Visit a dapp site and perform some wallet interaction to show the wallet icon in the url bar
  2. Change URL to brave.com which does not have wallet integration
  3. Observe wallet icon in URL bar until next layout pass (clicking wallet button will remove it)

For #5501:
  1. Visit a Dapp and trigger wallet connect
  2. Open and close the panel
  3. Open coingecko in a second tab and try to add a token (fails)
  4. Switch back to tab 1 from step 1 so wallet icon is shown in URL
  5. Swipe to coingecko tab, wallet icon is shown
  6. Click the wallet button, hides the button

## Screenshots:

For #5483:

https://user-images.githubusercontent.com/5314553/173423489-8f347ee3-be68-414c-8587-7a7175d05c8b.mov

For #5501, issue notes it was only reproducible on iPhone XR. I was able to reproduce intermittently on simulator.

https://user-images.githubusercontent.com/5314553/173423847-3ee46386-134d-4f24-8577-f57d3d0508a3.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
