### PR TITLE
Ref #5505: Add Label override to use brave symbols and fix usages

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -32,7 +32,7 @@ struct AccountListView: View {
               Button(action: {
                 UIPasteboard.general.string = account.address
               }) {
-                Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+                Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
               }
             }
           }

--- a/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -57,7 +57,7 @@ struct AccountsHeaderView: View {
             networkStore: networkStore,
             keyringStore: keyringStore)
         ) {
-          Label(Strings.Wallet.settings, image: "brave.gear")
+          Label(Strings.Wallet.settings, braveSystemImage: "brave.gear")
             .labelStyle(.iconOnly)
         }
       }

--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -28,7 +28,7 @@ struct AccountsView: View {
     Button(action: {
       UIPasteboard.general.string = address
     }) {
-      Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+      Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
     }
   }
 

--- a/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -154,7 +154,7 @@ private struct AccountDetailsHeaderView: View {
         HStack {
           Text(address.truncatedAddress)
             .foregroundColor(Color(.secondaryBraveLabel))
-          Label(Strings.Wallet.copyToPasteboard, image: "brave.clipboard")
+          Label(Strings.Wallet.copyToPasteboard, braveSystemImage: "brave.clipboard")
             .labelStyle(.iconOnly)
             .foregroundColor(Color(.braveLabel))
         }

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -72,7 +72,7 @@ struct AccountPicker: View {
       if #available(iOS 15.0, *) {
         Menu {
           Button(action: copyAddress) {
-            Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+            Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
           }
         } label: {
           accountView

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -134,7 +134,7 @@ struct SendTokenView: View {
                 sendTokenStore.sendAddress = string
               }
             }) {
-              Label(Strings.Wallet.pasteFromPasteboard, image: "brave.clipboard")
+              Label(Strings.Wallet.pasteFromPasteboard, braveSystemImage: "brave.clipboard")
                 .labelStyle(.iconOnly)
                 .foregroundColor(Color(.primaryButtonTint))
                 .font(.body)
@@ -143,7 +143,7 @@ struct SendTokenView: View {
             Button(action: {
               isShowingScanner = true
             }) {
-              Label(Strings.Wallet.scanQRCodeAccessibilityLabel, image: "brave.qr-code")
+              Label(Strings.Wallet.scanQRCodeAccessibilityLabel, braveSystemImage: "brave.qr-code")
                 .labelStyle(.iconOnly)
                 .foregroundColor(Color(.primaryButtonTint))
                 .font(.body)

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -151,7 +151,7 @@ struct MarketPriceView: View {
       Button(action: {
         swapTokenStore.fetchPriceQuote(base: .perSellAsset)
       }) {
-        Label(Strings.Wallet.refreshMarketPriceLabel, image: "brave.arrow.triangle.2.circlepath")
+        Label(Strings.Wallet.refreshMarketPriceLabel, braveSystemImage: "brave.arrow.triangle.2.circlepath")
           .labelStyle(.iconOnly)
           .foregroundColor(Color(.braveBlurpleTint))
           .font(.title3)

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -91,12 +91,12 @@ struct CryptoPagesView: View {
           Button(action: {
             keyringStore.lock()
           }) {
-            Label(Strings.Wallet.lock, image: "brave.lock")
+            Label(Strings.Wallet.lock, braveSystemImage: "brave.lock")
               .imageScale(.medium)  // Menu inside nav bar implicitly gets large
           }
           Divider()
           Button(action: { isShowingSettings = true }) {
-            Label(Strings.Wallet.settings, image: "brave.gear")
+            Label(Strings.Wallet.settings, braveSystemImage: "brave.gear")
               .imageScale(.medium)  // Menu inside nav bar implicitly gets large
           }
         } label: {

--- a/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -183,7 +183,7 @@ private struct RestoreWalletView: View {
               phrase = string
             }
           }) {
-            Label(Strings.Wallet.pasteFromPasteboard, image: "brave.clipboard")
+            Label(Strings.Wallet.pasteFromPasteboard, braveSystemImage: "brave.clipboard")
               .labelStyle(.iconOnly)
           }
         }

--- a/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -215,7 +215,7 @@ struct EncryptionView: View {
     Button(action: { // approve
       handleAction(approved: true)
     }) {
-      Label(approveButtonTitle, image: "brave.checkmark.circle.fill")
+      Label(approveButtonTitle, braveSystemImage: "brave.checkmark.circle.fill")
         .imageScale(.large)
     }
     .buttonStyle(BraveFilledButtonStyle(size: .large))

--- a/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -165,7 +165,7 @@ struct SignatureRequestView: View {
         onDismiss()
       }
     }) {
-      Label(Strings.Wallet.sign, image: "brave.key")
+      Label(Strings.Wallet.sign, braveSystemImage: "brave.key")
         .imageScale(.large)
     }
     .buttonStyle(BraveFilledButtonStyle(size: .large))

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -242,11 +242,11 @@ struct WalletPanelView: View {
   private var menuButton: some View {
     Menu {
       Button(action: { keyringStore.lock() }) {
-        Label(Strings.Wallet.lock, image: "brave.lock")
+        Label(Strings.Wallet.lock, braveSystemImage: "brave.lock")
       }
       Divider()
       Button(action: { presentWalletWithContext(.settings) }) {
-        Label(Strings.Wallet.settings, image: "brave.gear")
+        Label(Strings.Wallet.settings, braveSystemImage: "brave.gear")
       }
     } label: {
       Image(systemName: "ellipsis")

--- a/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -422,7 +422,7 @@ struct CustomNetworkDetailsView: View {
       Text(item.wrappedValue.input)
         .contextMenu {
           Button(action: { UIPasteboard.general.string = item.wrappedValue.input }) {
-            Label(Strings.Wallet.copyToPasteboard, image: "brave.clipboard")
+            Label(Strings.Wallet.copyToPasteboard, braveSystemImage: "brave.clipboard")
           }
         }
     } else {

--- a/Client/Frontend/Browser/PrivacyHub/NotificationCalloutView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/NotificationCalloutView.swift
@@ -52,7 +52,7 @@ extension PrivacyReportsView {
             if sizeCategory.isAccessibilityCategory {
               Text(Strings.PrivacyHub.notificationCalloutButtonText)
             } else {
-              Label(Strings.PrivacyHub.notificationCalloutButtonText, image: "brave.bell")
+              Label(Strings.PrivacyHub.notificationCalloutButtonText, braveSystemImage: "brave.bell")
             }
           }
           .font(.callout)

--- a/Sources/DesignSystem/Icons/BraveSymbols.swift
+++ b/Sources/DesignSystem/Icons/BraveSymbols.swift
@@ -24,3 +24,14 @@ extension Image {
     self.init(name, bundle: .current)
   }
 }
+
+extension Label where Title == Text, Icon == Image {
+  /// Creates a label with a brave system icon image and a title generated from a string.
+  public init<S: StringProtocol>(_ title: S, braveSystemImage name: String) {
+    self.init {
+      Text(title)
+    } icon: {
+      Image(braveSystemName: name)
+    }
+  }
+}


### PR DESCRIPTION
## Summary of Changes

Follow up fix for #5505 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
