### PR TITLE
Fix #5500: Fix wallet notification icon

### DIFF
--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
@@ -21,6 +21,7 @@ class WalletConnectionView: UIControl {
   private let iconImageView: UIImageView = {
     let result = UIImageView(image: UIImage(braveSystemNamed: "brave.unlock")!)
     result.tintColor = .white
+    result.contentMode = .scaleAspectFit
     result.setContentHuggingPriority(.required, for: .horizontal)
     result.setContentCompressionResistancePriority(.required, for: .horizontal)
     return result


### PR DESCRIPTION
## Summary of Changes
- Set a content mode on the image view displaying the icon

This pull request fixes #5500

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Use iPhone XR
2. Interact with any dapp site ('Display web3 notifications' preference must be enabled in Wallet Settings).

## Screenshots:

![#5500 wallet notification icon fix](https://user-images.githubusercontent.com/5314553/173613273-8500f630-c360-4388-8965-f5a853799e30.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
