### PR TITLE
Fix #5518 : Only inject provider for secure context

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -409,14 +409,6 @@ class UserScriptManager {
       alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
     })
     
-    alteredSource = """
-    (function() {
-      if (window.isSecureContext) {
-        \(alteredSource)
-      }
-    })();
-    """
-    
     return WKUserScript(source: alteredSource,
                         injectionTime: .atDocumentStart,
                         forMainFrameOnly: true,

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -409,6 +409,14 @@ class UserScriptManager {
       alteredSource = alteredSource.replacingOccurrences(of: $0.key, with: $0.value, options: .literal)
     })
     
+    alteredSource = """
+    (function() {
+      if (window.isSecureContext) {
+        \(alteredSource)
+      }
+    })();
+    """
+    
     return WKUserScript(source: alteredSource,
                         injectionTime: .atDocumentStart,
                         forMainFrameOnly: true,
@@ -475,10 +483,16 @@ class UserScriptManager {
       if !AppConstants.buildChannel.isPublic {
         if let script = walletProviderScript,
            tab?.isPrivate == false,
-           (tab?.secureContentState == .localHost || tab?.secureContentState == .secure),
            Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultWallet.value) == .brave {
           $0.addUserScript(script)
-          if let providerJS = walletProviderJS {
+          if var providerJS = walletProviderJS {
+            providerJS = """
+            (function() {
+              if (window.isSecureContext) {
+                \(providerJS)
+              }
+            })();
+            """
             $0.addUserScript(.init(source: providerJS, injectionTime: .atDocumentStart, forMainFrameOnly: true, in: .page))
           }
         }

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -475,6 +475,7 @@ class UserScriptManager {
       if !AppConstants.buildChannel.isPublic {
         if let script = walletProviderScript,
            tab?.isPrivate == false,
+           (tab?.secureContentState == .localHost || tab?.secureContentState == .secure),
            Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultWallet.value) == .brave {
           $0.addUserScript(script)
           if let providerJS = walletProviderJS {

--- a/Client/Frontend/UserContent/UserScripts/WalletEthereumProvider.js
+++ b/Client/Frontend/UserContent/UserScripts/WalletEthereumProvider.js
@@ -4,86 +4,88 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 (function() {
-
-function post(method, payload) {
-  return new Promise((resolve, reject) => {
-    webkit.messageHandlers.$<handler>.postMessage({
-      "securitytoken": "$<security_token>",
-      "method": method,
-      "args": JSON.stringify(payload)
-    })
-    .then(resolve, (errorJSON) => {
-      try {
-        reject(JSON.parse(errorJSON))
-      } catch(e) {
-        reject(errorJSON)
-      }
-    })
-  })
-}
-
-Object.defineProperty(window, 'ethereum', {
-  configurable: true,
-  value: {
-    chainId: undefined,
-    networkVersion: undefined,
-    selectedAddress: undefined,
-    request: function (args) /* -> Promise<unknown> */  {
-      return post('request', args)
-    },
-    isConnected: function() /* -> bool */ {
-      return true;
-    },
-    enable: function() /* -> void */ {
-      return post('enable', {})
-    },
-    // ethereum.sendAsync(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
-    sendAsync: function(payload, callback) {
-      post('sendAsync', payload)
-        .then((response) => { 
-          callback(null, response)
-        })
-        .catch((response) => { 
-          callback(response, null)
-        })
-    },
-    /*
-    Available overloads for send:
-      ethereum.send(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
-      ethereum.send(method: string, params?: Array<unknown>): Promise<JsonRpcResponse>;
-    */
-    send: function(
-      methodOrPayload /* : string or JsonRpcRequest */, 
-      paramsOrCallback /*  : Array<unknown> or JsonRpcCallback */
-    ) {
-      var payload = {
-        method: '',
-        params: {}
-      }
-      if (typeof methodOrPayload === 'string') {
-        payload.method = methodOrPayload
-        payload.params = paramsOrCallback
-        return post('send', payload)
-      } else {
-        payload.params = methodOrPayload
-        if (paramsOrCallback != undefined) {
-          post('send', payload)
-            .then((response) => { 
-              paramsOrCallback(null, response)
-            })
-            .catch((response) => { 
-              paramsOrCallback(response, null)
-            }) 
-        } else {
-          // Unsupported usage of send
-          throw TypeError('Insufficient number of arguments.')
+  
+if (window.isSecureContext) {
+  function post(method, payload) {
+    return new Promise((resolve, reject) => {
+      webkit.messageHandlers.$<handler>.postMessage({
+        "securitytoken": "$<security_token>",
+        "method": method,
+        "args": JSON.stringify(payload)
+      })
+      .then(resolve, (errorJSON) => {
+        try {
+          reject(JSON.parse(errorJSON))
+        } catch(e) {
+          reject(errorJSON)
         }
-      }
-    },
-    isUnlocked: function() /* -> Promise<boolean> */ {
-      return post('isUnlocked', {})
-    },
+      })
+    })
   }
-});
-
+  
+  Object.defineProperty(window, 'ethereum', {
+    configurable: true,
+    value: {
+      chainId: undefined,
+      networkVersion: undefined,
+      selectedAddress: undefined,
+      request: function (args) /* -> Promise<unknown> */  {
+        return post('request', args)
+      },
+      isConnected: function() /* -> bool */ {
+        return true;
+      },
+      enable: function() /* -> void */ {
+        return post('enable', {})
+      },
+      // ethereum.sendAsync(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
+      sendAsync: function(payload, callback) {
+        post('sendAsync', payload)
+          .then((response) => {
+            callback(null, response)
+          })
+          .catch((response) => {
+            callback(response, null)
+          })
+      },
+      /*
+      Available overloads for send:
+        ethereum.send(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
+        ethereum.send(method: string, params?: Array<unknown>): Promise<JsonRpcResponse>;
+      */
+      send: function(
+        methodOrPayload /* : string or JsonRpcRequest */,
+        paramsOrCallback /*  : Array<unknown> or JsonRpcCallback */
+      ) {
+        var payload = {
+          method: '',
+          params: {}
+        }
+        if (typeof methodOrPayload === 'string') {
+          payload.method = methodOrPayload
+          payload.params = paramsOrCallback
+          return post('send', payload)
+        } else {
+          payload.params = methodOrPayload
+          if (paramsOrCallback != undefined) {
+            post('send', payload)
+              .then((response) => {
+                paramsOrCallback(null, response)
+              })
+              .catch((response) => {
+                paramsOrCallback(response, null)
+              })
+          } else {
+            // Unsupported usage of send
+            throw TypeError('Insufficient number of arguments.')
+          }
+        }
+      },
+      isUnlocked: function() /* -> Promise<boolean> */ {
+        return post('isUnlocked', {})
+      },
+    }
+  });
+}
+  
 })();


### PR DESCRIPTION
## Summary of Changes
For site does not have HTTPS scheme and insecure content (include mix-content), we will not inject wallet provider.
However, localhost will be excluded even its over HTTP 

This pull request fixes #5518 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. try to load a site that can send ethereum requests that is not have secure content or mix-content or its over HTTP
2. try to make the site make an ethereum request
3. Observe that no wallet icon will appear in the url bar and no wallet notification would show up. 
4. try to load a secure DApp and make an ethereum request
5. Observe that wallet icon will apear in theurl bar and wallet notification will show up if it is enabled in the wallet settings

Note: iOS doesnt support localhost for wallet. To test if provider is injected correctly for localhost, you need to verify it on a simulator with following steps:
1. try to load local test dapp(you can use `eth-manual-tests`) and make a request 
2. Observe that wallet icon will apear in theurl bar and wallet notification will show up if it is enabled in the wallet settings

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
