### PR TITLE
Fix #5534: Add zero-width space for eTLD+1 url to force the origin is wrapped as a whole.

### DIFF
--- a/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -65,6 +65,7 @@ struct TransactionHeader: View {
         Text(urlOrigin: originInfo.origin)
           .foregroundColor(Color(.braveLabel))
           .font(.subheadline)
+          .multilineTextAlignment(.center)
           .padding(.top, 8) // match vertical padding for tx type, value & fiat VStack
       }
       VStack(spacing: 4) {

--- a/BraveWallet/Extensions/Text+URLOrigin.swift
+++ b/BraveWallet/Extensions/Text+URLOrigin.swift
@@ -19,7 +19,8 @@ extension Text {
         let originStart = origin[origin.startIndex..<range.lowerBound]
         let etldPlusOne = origin[range.lowerBound..<range.upperBound]
         let originEnd = origin[range.upperBound...]
-        self = Text(originStart) + Text(etldPlusOne).bold() + Text(originEnd)
+        let zwspEtldPlusOne = "\u{200b}\(String(etldPlusOne))"
+        self = Text(originStart) + Text(zwspEtldPlusOne).bold() + Text(originEnd)
       } else {
         self = Text(origin)
       }

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -99,13 +99,13 @@ struct EditSiteConnectionView: View {
           Image(uiImage: image)
             .resizable()
             .scaledToFit()
-            .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
             .background(Color(.braveDisabled))
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         } else {
           ProgressView()
         }
       }
+      .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
     }
     VStack(alignment: sizeCategory.isAccessibilityCategory ? .center : .leading, spacing: 2) {
       Text(urlOrigin: urlOrigin)

--- a/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -110,7 +110,6 @@ struct EditSiteConnectionView: View {
     VStack(alignment: sizeCategory.isAccessibilityCategory ? .center : .leading, spacing: 2) {
       Text(urlOrigin: urlOrigin)
         .font(.subheadline)
-        .multilineTextAlignment(.center)
         .foregroundColor(Color(.bravePrimary))
       Text(connectedAddresses)
         .font(.footnote)

--- a/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -42,13 +42,13 @@ public struct NewSiteConnectionView: View {
           Image(uiImage: image)
             .resizable()
             .scaledToFit()
-            .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
             .background(Color(.braveDisabled))
             .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
         } else {
           ProgressView()
         }
       }
+      .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
     }
     Text(urlOrigin: urlOrigin)
       .font(.subheadline)


### PR DESCRIPTION
## This PR fixes: #5534 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Please refer to the issue

## Screenshots:
![simulator_screenshot_7EFEC0DC-DDAF-47F9-926A-F43C27E2C126](https://user-images.githubusercontent.com/1187676/173987448-9b0dba7e-1ffb-4534-9fad-b9955b26cb55.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
