### PR TITLE
No bug: Fix Wallet SF Symbols references

### DIFF
--- a/BraveWallet/AddressView.swift
+++ b/BraveWallet/AddressView.swift
@@ -24,7 +24,7 @@ struct AddressView<Content: View>: View {
         Button(action: {
           UIPasteboard.general.string = address
         }) {
-          Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+          Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
         }
       }
   }

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -123,6 +123,7 @@ struct SuggestedNetworkView: View {
           UIPasteboard.general.string = keyringStore.selectedAccount.address
         }) {
           Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
+            .font(.body)
         }
       } label: {
         HStack(spacing: 8) {

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -122,7 +122,7 @@ struct SuggestedNetworkView: View {
         Button(action: {
           UIPasteboard.general.string = keyringStore.selectedAccount.address
         }) {
-          Label(Strings.Wallet.copyAddressButtonTitle, image: "brave.clipboard")
+          Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
         }
       } label: {
         HStack(spacing: 8) {


### PR DESCRIPTION
## Summary of Changes

ref: #5477

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Tap / hold on any truncated address in wallet to see context menu showing clipboard image beside 'copy address'
Dapp request


## Screenshots:
![suggested network view](https://user-images.githubusercontent.com/5314553/174151158-487e16fa-3163-40f2-b52f-66d54315911b.png) | ![panel view](https://user-images.githubusercontent.com/5314553/174151167-62eef947-11d7-4383-90d3-7c071b6a2b95.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
