### PR TITLE
Fix #5537: Wallet panel loading state

### DIFF
--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -47,6 +47,18 @@ public struct WalletPanelContainerView: View {
     return .panel
   }
   
+  private var visibleScreenAnimation: Animation? {
+    if fetchingInitialKeyring {
+      return nil
+    }
+    switch visibleScreen {
+    case .panel:
+      return nil
+    default:
+      return .default
+    }
+  }
+  
   private var lockedView: some View {
     VStack(spacing: 36) {
       Image("graphic-lock", bundle: .current)
@@ -126,7 +138,7 @@ public struct WalletPanelContainerView: View {
           .zIndex(2)  // Needed or the dismiss animation messes up
       }
     }
-    .animation(fetchingInitialKeyring ? nil : .default, value: visibleScreen)
+    .animation(visibleScreenAnimation, value: visibleScreen)
     .frame(idealWidth: 320, maxWidth: .infinity)
     .onAppear {
       fetchingInitialKeyring = keyringStore.keyring.id.isEmpty

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -26,10 +26,6 @@ public struct WalletPanelContainerView: View {
   /// An invisible `UIView` background lives in SwiftUI for UIKit API to reference later
   var buySendSwapBackground: InvisibleUIView = .init()
   
-  // When the screen first apperas the keyring is set as the default value
-  // which causes an unnessary animation
-  @State private var fetchingInitialKeyring: Bool = true
-  
   private enum VisibleScreen: Equatable {
     case loading
     case panel
@@ -125,12 +121,7 @@ public struct WalletPanelContainerView: View {
       }
     }
     .frame(idealWidth: 320, maxWidth: .infinity)
-    .onAppear {
-      fetchingInitialKeyring = keyringStore.keyring.id.isEmpty
-    }
     .onChange(of: keyringStore.keyring) { newValue in
-      fetchingInitialKeyring = false
-      
       if !newValue.isKeyringCreated {
         visibleScreen = .onboarding
       } else if newValue.isLocked {


### PR DESCRIPTION
## Summary of Changes
- Update wallet panel to only animate between unlocked to locked state. When unlocking the wallet from the panel, a modal presents over the panel. The animation on the panel switching from locked to unlocked state was unnecessarily visible when the unlock modal

This pull request fixes #5537

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Use dapp on polygon network
2. Tap wallet icon


## Screenshots:

Video showing unlock animation removed from panel, but preserved when locking wallet:

https://user-images.githubusercontent.com/5314553/174321388-f75a8e77-a75e-47b4-b875-9f2af784dd13.mp4

Loading state not visible in video (tough to reproduce).

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
