### PR TITLE
Fix #5539: Block requests from inactive tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2363,6 +2363,10 @@ extension BrowserViewController: TabDelegate {
     }
     notificationsPresenter.display(notification: walletNotificaton, from: self)
   }
+  
+  func isTabVisible(_ tab: Tab) -> Bool {
+    tabManager.selectedTab == tab
+  }
 
   func updateURLBarWalletButton() {
     let shouldShowWalletButton = tabManager.selectedTab?.isWalletIconVisible == true

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2365,7 +2365,7 @@ extension BrowserViewController: TabDelegate {
   }
   
   func isTabVisible(_ tab: Tab) -> Bool {
-    tabManager.selectedTab == tab
+    tabManager.selectedTab === tab
   }
 
   func updateURLBarWalletButton() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -261,6 +261,10 @@ extension Tab: BraveWalletProviderDelegate {
   func showWalletOnboarding() {
     showPanel()
   }
+  
+  func isTabVisible() -> Bool {
+    tabDelegate?.isTabVisible(self) ?? false
+  }
 }
 
 extension Tab: BraveWalletEventsListener {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -33,6 +33,7 @@ protocol TabDelegate {
   func stopMediaPlayback(_ tab: Tab)
   func showWalletNotification(_ tab: Tab)
   func updateURLBarWalletButton()
+  func isTabVisible(_ tab: Tab) -> Bool
 }
 
 @objc

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.96/brave-core-ios-1.40.96.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.103/brave-core-ios-1.40.103.tgz",
         "page-metadata-parser": "^1.1.3",
         "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
         "webpack-cli": "^4.8.0"
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.40.96",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.40.96/brave-core-ios-1.40.96.tgz",
-      "integrity": "sha512-R9MLIB3keDymqDU+mFSluYROXbb55FQXdDVz/Cy33BHZF7O0IeyWNCr8xPFsEpRAX/aH7pk3zaqfiarfVyHA4A==",
+      "version": "1.40.103",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.40.103/brave-core-ios-1.40.103.tgz",
+      "integrity": "sha512-JnMrHUa5HNpurTwWE7ToV+n0ay2BnLGtbjj4WFoLdPgPmguRT0cPN/tcmtP171Y5fxuRB47w4rcpjVfYo20OQw==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1639,8 +1639,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.40.96/brave-core-ios-1.40.96.tgz",
-      "integrity": "sha512-R9MLIB3keDymqDU+mFSluYROXbb55FQXdDVz/Cy33BHZF7O0IeyWNCr8xPFsEpRAX/aH7pk3zaqfiarfVyHA4A=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.40.103/brave-core-ios-1.40.103.tgz",
+      "integrity": "sha512-JnMrHUa5HNpurTwWE7ToV+n0ay2BnLGtbjj4WFoLdPgPmguRT0cPN/tcmtP171Y5fxuRB47w4rcpjVfYo20OQw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.96/brave-core-ios-1.40.96.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.40.103/brave-core-ios-1.40.103.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Implement `isTabVisible` function for wallet provider delegate, using tab delegate to determine if tab is active
- Bump brave core to v1.40.103

This pull request fixes #5539

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Open 2 tabs with a different dapp site in each tab and connect your wallet to both
2. Open wallet settings, tap manage site connections and remove all connections
3. Some dapp sites will automatically send a web3 request upon receiving update they're no longer connected to wallet and will now be rejected
    * [Sushi Swap](https://app.sushi.com/swap) worked for testing as the inactive tab, sending a request after we remove wallet permissions (see video below).
    * [Uniswap](https://app.uniswap.org/) used to work very well as the inactive tab, sending a request after we remove wallet permissions. As of last night, this is no longer occuring 


## Screenshots:

https://user-images.githubusercontent.com/5314553/174338393-91493735-f690-47c3-a93e-8939f4c6fdb0.mov



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
