### PR TITLE
Fix #5543: Relax SSL Trust Validation and Remove Mixed-Content Validation

### DIFF
--- a/BraveShared/BraveCertificateUtils.swift
+++ b/BraveShared/BraveCertificateUtils.swift
@@ -189,7 +189,6 @@ public extension BraveCertificateUtils {
   
   static func evaluateTrust(_ trust: SecTrust, for host: String?, completion: @escaping (_ error: NSError?) -> Void) {
     let policies = [
-      SecPolicyCreateBasicX509(),
       SecPolicyCreateSSL(true, host as CFString?),
     ]
 
@@ -198,7 +197,7 @@ public extension BraveCertificateUtils {
     queue.async {
       let result = SecTrustEvaluateAsyncWithError(trust, queue) { _, isTrusted, error in
         DispatchQueue.main.async {
-          if let error = error {
+          if !isTrusted, let error = error {
             completion(error as Error as NSError)
           } else {
             completion(nil)

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -794,6 +794,12 @@ extension Strings {
   public static let errorPagesNoInternetTryItem1 = NSLocalizedString("ErrorPagesNoInternetTryItem1", tableName: "BraveShared", bundle: .strings, value: "Checking the network cables, modem, and router", comment: "List of things to try when internet is not working")
 
   public static let errorPagesNoInternetTryItem2 = NSLocalizedString("ErrorPagesNoInternetTryItem2", tableName: "BraveShared", bundle: .strings, value: "Reconnecting to Wi-Fi", comment: "List of things to try when internet is not working")
+  
+  public static let errorPagesMixedContentTitle = NSLocalizedString("ErrorPagesMixedContentTitle", tableName: "BraveShared", bundle: .strings, value: "The information you're about to submit is not secure", comment: "Title of the page when mixed-content is about to be executed")
+  
+  public static let errorPagesMixedContentDescription = NSLocalizedString("ErrorPagesMixedContentDescription", tableName: "BraveShared", bundle: .strings, value: "This form is being submitted using a connection that's not secure, your information will be visible to others.", comment: "Description of the page when mixed-content is about to be executed")
+  
+  public static let errorPagesSendAnyway = NSLocalizedString("ErrorPagesSendAnyway", tableName: "BraveShared", bundle: .strings, value: "Send Anyway", comment: "Title of the button on the error page, to send information anyway, when a page is not secure")
 }
 
 // MARK: - Sync

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -331,6 +331,12 @@ extension BrowserViewController: WKNavigationDelegate {
         self.tabManager.selectedTab?.alertShownCount = 0
         self.tabManager.selectedTab?.blockAllAlerts = false
       }
+      
+      // Mixed-Content validation
+      if let target = navigationAction.targetFrame?.request.url,
+         url.scheme == "http", target.scheme == "https" {
+        return
+      }
 
       decisionHandler(.allow, preferences)
       return

--- a/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingWebViewController.swift
@@ -148,23 +148,17 @@ class OnboardingWebViewController: UIViewController, WKNavigationDelegate {
   private func updateWebPageSecurity() {
     if let trust = webView.serverTrust {
       toolbar.secureIcon.isHidden = false
-
-      let policies = [
-        SecPolicyCreateBasicX509(),
-        SecPolicyCreateSSL(true, webView.url?.host as CFString?),
-      ]
-
-      SecTrustSetPolicies(trust, policies as CFTypeRef)
-
-      var error: CFError?
-      let result = SecTrustEvaluateWithError(trust, &error)
-
-      if result && webView.hasOnlySecureContent {
-        toolbar.secureIcon.tintColor = UX.secureWebPageColor
-        toolbar.urlLabel.textColor = UX.secureWebPageColor
-      } else {
-        toolbar.secureIcon.tintColor = UX.insecureWebPageColor
-        toolbar.urlLabel.textColor = UX.insecureWebPageColor
+      
+      BraveCertificateUtils.evaluateTrust(trust, for: webView.url?.host) { [weak self] error in
+        guard let self = self else { return }
+        
+        if error != nil {
+          self.toolbar.secureIcon.tintColor = UX.insecureWebPageColor
+          self.toolbar.urlLabel.textColor = UX.insecureWebPageColor
+        } else {
+          self.toolbar.secureIcon.tintColor = UX.secureWebPageColor
+          self.toolbar.urlLabel.textColor = UX.secureWebPageColor
+        }
       }
     } else {
       toolbar.secureIcon.isHidden = true


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/922

## Summary of Changes
- Relaxes SSL Trust Validation
- Our validation now matches Safari on iOS (Shows an alert)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5543

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test `https://kevsong.com`
- Test the usual `https://badssl.com`


## Screenshots:
SSL Validation: 
<img width="411" alt="image" src="https://user-images.githubusercontent.com/1530031/174393504-f1a2bfb1-a6bf-4dd0-b2a4-a8badc961a1d.png">

Mixed-Content blocked: 
<img width="394" alt="image" src="https://user-images.githubusercontent.com/1530031/174650649-767d12b7-7376-494a-9905-8308488aafa5.png">
<img width="1525" alt="image" src="https://user-images.githubusercontent.com/1530031/174393672-ce3f0ffc-b6d3-4297-82ee-6af6675cb5ea.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
