### PR TITLE
Fix #5551: Update `window.ethereum` to be non-configurable

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/WalletEthereumProvider.js
+++ b/Client/Frontend/UserContent/UserScripts/WalletEthereumProvider.js
@@ -24,7 +24,6 @@ if (window.isSecureContext) {
   }
   
   Object.defineProperty(window, 'ethereum', {
-    configurable: true,
     value: {
       chainId: undefined,
       networkVersion: undefined,


### PR DESCRIPTION
## Summary of Changes
- Define `window.ethereum` as non-configurable (defaults to false)

This pull request fixes #5551

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
