### PR TITLE
Fix #5553: Update reader mode CSS to use correct custom fonts

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -140,6 +140,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Start the keyboard helper to monitor and cache keyboard state.
     KeyboardHelper.defaultHelper.startObserving()
     DynamicFontHelper.defaultHelper.startObserving()
+    ReaderModeFonts.registerCustomFonts()
 
     MenuHelper.defaultHelper.setItems()
 

--- a/App/iOS/Supporting Files/Info.plist
+++ b/App/iOS/Supporting Files/Info.plist
@@ -100,22 +100,6 @@
 	</array>
 	<key>SERVICES_KEY</key>
 	<string>$(BRAVE_SERVICES_KEY)</string>
-	<key>UIAppFonts</key>
-	<array>
-		<string>NewYorkMedium-Bold.otf</string>
-		<string>NewYorkMedium-BoldItalic.otf</string>
-		<string>NewYorkMedium-Regular.otf</string>
-		<string>NewYorkMedium-RegularItalic.otf</string>
-		<string>FiraSans-Bold.ttf</string>
-		<string>FiraSans-BoldItalic.ttf</string>
-		<string>FiraSans-Book.ttf</string>
-		<string>FiraSans-Italic.ttf</string>
-		<string>FiraSans-Light.ttf</string>
-		<string>FiraSans-Medium.ttf</string>
-		<string>FiraSans-Regular.ttf</string>
-		<string>FiraSans-SemiBold.ttf</string>
-		<string>FiraSans-UltraLight.ttf</string>
-	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -3,54 +3,54 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @font-face {
-    font-family: sans-serif;
+    font-family: FiraSans;
     src: url('/reader-mode/fonts/FiraSans-Regular.ttf');
 }
 
 @font-face {
-    font-family: sans-serif;
+    font-family: FiraSans;
     src: url('/reader-mode/fonts/FiraSans-Book.ttf');
     font-weight: medium;
     }
 
 @font-face {
-    font-family: sans-serif;
+    font-family: FiraSans;
     src: url('/reader-mode/fonts/FiraSans-Bold.ttf');
     font-weight: bold;
 }
 
 @font-face {
-    font-family: sans-serif;
+    font-family: FiraSans;
     src: url('/reader-mode/fonts/FiraSans-Italic.ttf');
     font-style: italic;
 }
 
 @font-face {
-    font-family: sans-serif;
+    font-family: FiraSans;
     src: url('/reader-mode/fonts/FiraSans-BoldItalic.ttf');
     font-weight: bold;
     font-style: italic;
 }
 
 @font-face {
-    font-family: serif;
+    font-family: NewYorkMedium;
     src: url('/reader-mode/fonts/NewYorkMedium-Regular.otf');
 }
 
 @font-face {
-    font-family: serif;
+    font-family: NewYorkMedium;
     src: url('/reader-mode/fonts/NewYorkMedium-Bold.otf');
     font-weight: bold;
 }
 
 @font-face {
-    font-family: serif;
+    font-family: NewYorkMedium;
     src: url('/reader-mode/fonts/NewYorkMedium-RegularItalic.otf');
     font-style: italic;
 }
 
 @font-face {
-    font-family: serif;
+    font-family: NewYorkMedium;
     src: url('/reader-mode/fonts/NewYorkMedium-BoldItalic.otf');
     font-weight: bold;
     font-style: italic;
@@ -90,11 +90,11 @@ body {
 }
 
 .sans-serif {
-  font-family: sans-serif;
+  font-family: FiraSans;
 }
 
 .serif {
-  font-family: serif;
+  font-family: NewYorkMedium;
 }
 
 .message {

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -16,7 +16,6 @@
   <div id="reader-header" class="header">
     <h1 id="reader-title"></h1>
     <div id="reader-credits" class="credits"></div>
-    <script type="text/javascript" src="/reader-mode/javascript/Reader.js"></script>
   </div>
 
   <div id="reader-content" class="content">

--- a/Client/Frontend/Reader/ReaderModeFonts.swift
+++ b/Client/Frontend/Reader/ReaderModeFonts.swift
@@ -1,0 +1,19 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreText
+
+public class ReaderModeFonts {
+  /// Registers the custom fonts that exist in the Brave bundle
+  public static func registerCustomFonts() {
+    if let ttfs = Bundle.current.urls(forResourcesWithExtension: "ttf", subdirectory: nil) {
+      CTFontManagerRegisterFontURLs(ttfs as CFArray, .process, true, nil)
+    }
+    if let otfs = Bundle.current.urls(forResourcesWithExtension: "otf", subdirectory: nil) {
+      CTFontManagerRegisterFontURLs(otfs as CFArray, .process, true, nil)
+    }
+  }
+}

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -14,6 +14,7 @@ public struct ReaderModeHandlers {
   public static func register(_ webServer: WebServer, profile: Profile) {
     // Register our fonts and css, which we want to expose to web content that we present in the WebView
     webServer.registerMainBundleResourcesOfType("ttf", module: "reader-mode/fonts")
+    webServer.registerMainBundleResourcesOfType("otf", module: "reader-mode/fonts")
     webServer.registerMainBundleResource("Reader.css", module: "reader-mode/styles")
 
     // Register a handler that simply lets us know if a document is in the cache or not. This is called from the

--- a/Client/Networking/WebServer.swift
+++ b/Client/Networking/WebServer.swift
@@ -72,12 +72,9 @@ public class WebServer {
 
   /// Convenience method to register all resources in the main bundle of a specific type. Will be mounted at $base/$module/$resource
   func registerMainBundleResourcesOfType(_ type: String, module: String) {
-    for path: String in Bundle.paths(forResourcesOfType: type, inDirectory: Bundle.current.bundlePath) {
-      if let resource = NSURL(string: path)?.lastPathComponent {
-        server.addGETHandler(forPath: "/\(module)/\(resource)", filePath: path as String, isAttachment: false, cacheAge: UInt.max, allowRangeRequests: true)
-      } else {
-        log.warning("Unable to locate resource at path: '\(path)'")
-      }
+    for url in Bundle.current.urls(forResourcesWithExtension: type, subdirectory: nil) ?? [] {
+      let resource = url.lastPathComponent
+      server.addGETHandler(forPath: "/\(module)/\(resource)", filePath: url.path, isAttachment: false, cacheAge: UInt.max, allowRangeRequests: true)
     }
   }
 


### PR DESCRIPTION
Also Ref #5380: Adds registering of custom fonts that don't live in the main bundle

## Summary of Changes

This pull request fixes #5553 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Screenshots

| Sans-Serif | Serif |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-20 at 12 57 59](https://user-images.githubusercontent.com/529104/174649205-8d9cfde7-e80b-4cd2-9c29-2835b4bac73e.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-20 at 12 58 04](https://user-images.githubusercontent.com/529104/174649218-d42d3e8d-5a25-4ab5-b512-60ba8b2c6478.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
