### PR TITLE
No bug: Resolve `WalletStore` leak after locking wallet

### DIFF
--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -219,7 +219,7 @@ public struct CryptoView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .environment(
       \.openWalletURLAction,
-      .init(action: { url in
+      .init(action: { [openWalletURLAction] url in
         openWalletURLAction?(url)
       }))
     .environment(
@@ -292,15 +292,15 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
     .environment(
       \.buySendSwapDestination,
       Binding(
-        get: { cryptoStore.buySendSwapDestination },
-        set: { destination in
-          if cryptoStore.isPresentingAssetSearch {
-            cryptoStore.isPresentingAssetSearch = false
+        get: { [weak cryptoStore] in cryptoStore?.buySendSwapDestination },
+        set: { [weak cryptoStore] destination in
+          if cryptoStore?.isPresentingAssetSearch == true {
+            cryptoStore?.isPresentingAssetSearch = false
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-              self.cryptoStore.buySendSwapDestination = destination
+              cryptoStore?.buySendSwapDestination = destination
             }
           } else {
-            cryptoStore.buySendSwapDestination = destination
+            cryptoStore?.buySendSwapDestination = destination
           }
         }))
   }


### PR DESCRIPTION
## Summary of Changes
- After opening Wallet in fullscreen (not the panel) and then locking the wallet, the `WalletStore` object was being kept alive. 
- This was causing `lockedManually` property to preserve it's previous value, preventing us from automatically showing the unlock modal when the user opens the Wallet panel.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
reproduce on `development` steps:
1. Open Wallet from `...` menu
2. Unlock Wallet
3. Tap `...` and hit 'Lock`
4. Dismiss the wallet modal
5. Open Memory Graph to see `WalletStore` object still alive. Using this branch, `WalletStore` should be released.
6. Visit any dapp site and tap Wallet icon to see the unlock state on the panel, and modal not presented. Using this branch, the unlock modal should be shown automatically


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
