### PR TITLE
Fix #5518: Reject dapp requests from mixed-content pages

### DIFF
--- a/Client/Wallet/EthereumProviderHelper.swift
+++ b/Client/Wallet/EthereumProviderHelper.swift
@@ -74,9 +74,11 @@ class EthereumProviderHelper: TabContentScript {
           JSONSerialization.isValidJSONObject(message.body),
           let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
           let body = try? JSONDecoder().decode(MessageBody.self, from: messageData),
-          body.securityToken == UserScriptManager.securityTokenString
+          body.securityToken == UserScriptManager.securityTokenString,
+          message.webView?.hasOnlySecureContent == true  // prevent communication in mixed-content scenarios
     else {
       log.error("Failed to handle ethereum provider communication")
+      replyHandler(nil, "Failed Security Test")
       return
     }
     

--- a/Client/Wallet/EthereumProviderHelper.swift
+++ b/Client/Wallet/EthereumProviderHelper.swift
@@ -82,7 +82,7 @@ class EthereumProviderHelper: TabContentScript {
     
     if message.webView?.url?.isLocal == false,
         message.webView?.hasOnlySecureContent == false { // prevent communication in mixed-content scenarios
-      replyHandler(nil, "Failed Security Test")
+      log.error("Failed ethereum provider communication security test")
       return
     }
     

--- a/Client/Wallet/EthereumProviderHelper.swift
+++ b/Client/Wallet/EthereumProviderHelper.swift
@@ -74,10 +74,14 @@ class EthereumProviderHelper: TabContentScript {
           JSONSerialization.isValidJSONObject(message.body),
           let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
           let body = try? JSONDecoder().decode(MessageBody.self, from: messageData),
-          body.securityToken == UserScriptManager.securityTokenString,
-          message.webView?.hasOnlySecureContent == true  // prevent communication in mixed-content scenarios
+          body.securityToken == UserScriptManager.securityTokenString
     else {
       log.error("Failed to handle ethereum provider communication")
+      return
+    }
+    
+    if message.webView?.url?.isLocal == false,
+        message.webView?.hasOnlySecureContent == false { // prevent communication in mixed-content scenarios
       replyHandler(nil, "Failed Security Test")
       return
     }


### PR DESCRIPTION
## Summary of Changes
- If a page has loaded insecure content, reject the request(s). Exempt localhost / treat local host as secure.

This pull request fixes #5518

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Verify dapps still work as expected, assuming they don't load insecure content
2. Verify localhost still works as expected, as it's exempt from this check


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
