### PR TITLE
Fix 5557: Fix eTLD+1 is truncated in XR

### DIFF
--- a/BraveWallet/AddressView.swift
+++ b/BraveWallet/AddressView.swift
@@ -20,7 +20,7 @@ struct AddressView<Content: View>: View {
   var body: some View {
     content()
       .contextMenu {
-        Text(address.zwspAddress)
+        Text(address.zwspOutput)
         Button(action: {
           UIPasteboard.general.string = address
         }) {

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -71,7 +71,7 @@ struct AccountPicker: View {
     Group {
       if #available(iOS 15.0, *) {
         Menu {
-          Text(keyringStore.selectedAccount.address.zwspAddress)
+          Text(keyringStore.selectedAccount.address.zwspOutput)
           Button(action: copyAddress) {
             Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "brave.clipboard")
           }

--- a/BraveWallet/Crypto/Stores/Address.swift
+++ b/BraveWallet/Crypto/Stores/Address.swift
@@ -43,8 +43,8 @@ extension String {
     return hex.count == 40 && hex.allSatisfy(\.isHexDigit)
   }
   
-  /// Insert zero-width space every character inside account address string
-  var zwspAddress: String {
+  /// Insert zero-width space every character inside this string
+  var zwspOutput: String {
     return map {
       String($0) + "\u{200b}"
     }.joined()

--- a/BraveWallet/Extensions/Text+URLOrigin.swift
+++ b/BraveWallet/Extensions/Text+URLOrigin.swift
@@ -19,8 +19,7 @@ extension Text {
         let originStart = origin[origin.startIndex..<range.lowerBound]
         let etldPlusOne = origin[range.lowerBound..<range.upperBound]
         let originEnd = origin[range.upperBound...]
-        let zwspEtldPlusOne = "\u{200b}\(String(etldPlusOne))"
-        self = Text(originStart) + Text(zwspEtldPlusOne).bold() + Text(originEnd)
+        self = Text(String(originStart).zwspOutput) + Text(etldPlusOne).bold() + Text(String(originEnd).zwspOutput)
       } else {
         self = Text(origin)
       }

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -118,7 +118,7 @@ struct SuggestedNetworkView: View {
   private var headerView: some View {
     VStack {
       Menu {
-        Text(keyringStore.selectedAccount.address.zwspAddress)
+        Text(keyringStore.selectedAccount.address.zwspOutput)
         Button(action: {
           UIPasteboard.general.string = keyringStore.selectedAccount.address
         }) {

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
@@ -47,6 +47,10 @@ class WalletConnectionView: UIControl {
     }
     stackView.addArrangedSubview(iconImageView)
     stackView.addArrangedSubview(titleLabel)
+    
+    iconImageView.snp.makeConstraints {
+      $0.width.height.equalTo(20)
+    }
 
     layer.backgroundColor = UIColor.braveBlurpleTint.cgColor
     layer.cornerRadius = 10

--- a/Tests/BraveWalletTests/AddressTests.swift
+++ b/Tests/BraveWalletTests/AddressTests.swift
@@ -40,10 +40,10 @@ class AddressTests: XCTestCase {
     XCTAssertFalse(isAddressFalseNoHexDigits.isETHAddress)
   }
   
-  func testZwspAddress() {
+  func testZwspOutput() {
     let address = "0x1bBE4E6EF7294c99358377abAd15A6d9E98127A2"
     let zwspAddress = "0\u{200b}x\u{200b}1\u{200b}b\u{200b}B\u{200b}E\u{200b}4\u{200b}E\u{200b}6\u{200b}E\u{200b}F\u{200b}7\u{200b}2\u{200b}9\u{200b}4\u{200b}c\u{200b}9\u{200b}9\u{200b}3\u{200b}5\u{200b}8\u{200b}3\u{200b}7\u{200b}7\u{200b}a\u{200b}b\u{200b}A\u{200b}d\u{200b}1\u{200b}5\u{200b}A\u{200b}6\u{200b}d\u{200b}9\u{200b}E\u{200b}9\u{200b}8\u{200b}1\u{200b}2\u{200b}7\u{200b}A\u{200b}2\u{200b}"
-    let result = address.zwspAddress
+    let result = address.zwspOutput
     XCTAssertNotEqual(address, result)
     XCTAssertEqual(zwspAddress, result)
   }


### PR DESCRIPTION
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5557 #5500 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Please refer to the issues.
Both issues only reproducible in iPhone XR

## Screenshots:
![simulator_screenshot_5D955F4A-C33D-4C67-8734-2962E904CA7A](https://user-images.githubusercontent.com/1187676/175142711-925a184b-0f62-499d-bac5-4ec1f974e5c3.png)
![simulator_screenshot_A8C3CA42-BE78-4800-8658-B876241EDF6B](https://user-images.githubusercontent.com/1187676/175142748-682245f7-173e-4013-907b-b87374a78bee.png)
![simulator_screenshot_546D17E7-ECEC-4C61-AF0B-4AA9E23C3070](https://user-images.githubusercontent.com/1187676/175142825-11ab76f5-db12-46c6-bc74-f414418ae340.png)
![simulator_screenshot_A8C1EDF6-3E92-48D9-A6B1-84432BF21D17](https://user-images.githubusercontent.com/1187676/175142936-5f6601e0-edd1-4c3c-8e2e-5313a54f8a2c.png)
![simulator_screenshot_DA57606B-4937-45D9-B07F-3FC2B4CBD60F](https://user-images.githubusercontent.com/1187676/175142976-80990710-0d74-4150-91d8-2d1ebac44918.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
