### PR TITLE
Fix #5529: Add 1.40 translations. Fix duplicated localized string key.

### DIFF
--- a/App/BraveWidgets/pl.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/pl.lproj/BraveWidgets.strings
@@ -14,10 +14,10 @@
 "7JYzOv" = "Typ";
 
 /* (No Comment) */
-"8vyYRy" = "nr 3";
+"8vyYRy" = "#3";
 
 /* (No Comment) */
-"9E2oRR" = "nr 1";
+"9E2oRR" = "#1";
 
 /* (No Comment) */
 "AGMpus" = "Konfiguracja skrótów";
@@ -56,7 +56,7 @@
 "gpCwrM" = "Konfiguracja statystyk";
 
 /* (No Comment) */
-"joEZJM" = "nr 2";
+"joEZJM" = "#2";
 
 /* (No Comment) */
 "L1fziM-0W40Cl" = "Do „Nowa karta” pasuje następująca liczba opcji: ${count}";
@@ -77,7 +77,7 @@
 "L1fziM-vs094F" = "Do „Nowa karta w trybie prywatnym” pasuje następująca liczba opcji: ${count}";
 
 /* (No Comment) */
-"nthxSL" = "Pobrania";
+"nthxSL" = "Pobrane";
 
 /* (No Comment) */
 "r2EI05-0W40Cl" = "Czy na pewno masz na myśli „Nowa karta”?";
@@ -146,16 +146,16 @@
 "TxuMja-vs094F" = "Do „Nowa karta w trybie prywatnym” pasuje następująca liczba opcji: ${count}";
 
 /* (No Comment) */
-"tYwiRd" = "Szacowany zaoszczędzony czas";
+"tYwiRd" = "Zaoszczędzony czas";
 
 /* (No Comment) */
 "VBH4G6" = "Historia";
 
 /* (No Comment) */
-"vjA5pZ" = "Szacowane zaoszczędzone dane";
+"vjA5pZ" = "Zaoszczędzone dane";
 
 /* (No Comment) */
-"vs094F" = "Nowa karta w trybie prywatnym";
+"vs094F" = "Nowa karta prywatna";
 
 /* (No Comment) */
 "xcI3h9" = "Zablokowane reklamy";

--- a/App/iOS/Supporting Files/pl.lproj/InfoPlist.strings
+++ b/App/iOS/Supporting Files/pl.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
 /* (No Comment) */
-"1Password Fill Browser Action" = "1 Działanie przeglądarki – wypełnienie hasła";
+"1Password Fill Browser Action" = "Wypełnianie hasła 1Password";
 
 /* Privacy - NFC Scan Usage Description */
 "NFCReaderUsageDescription" = "Aplikacja wymaga dostępu do odczytu NFC w celu komunikacji z Twoim Yubikey.";

--- a/App/l10n/Resources/de.lproj/BraveShared.strings
+++ b/App/l10n/Resources/de.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave-Belohnungen";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Die Brave-Suche verfolgt Ihre Aktivitäten, Anfragen oder Klicks nicht nach.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Vielleicht später";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Unterstützen Sie eine unabhängige Suche mit besserem Datenschutz";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Brave-Suche testen";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Schließen";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Erweiterte Steuerelemente";
 
@@ -2177,6 +2192,9 @@
 "RewardsInternalsPromotionsTitle" = "Werbeaktionen";
 
 /* No comment provided by engineer. */
+"RewardsInternalsPublisher" = "Veröffentlicher";
+
+/* No comment provided by engineer. */
 "RewardsInternalsPublishers" = "Veröffentlicher";
 
 /* No comment provided by engineer. */
@@ -2301,6 +2319,9 @@
 
 /* Accessibility hint describing the action performed when a search suggestion is clicked */
 "SearchesForSuggestionButtonAccessibilityText" = "Sucht nach diesem Vorschlag";
+
+/* Section header for history and bookmarks and open tabs option */
+"SearchHistorySectionHeader" = "Geöffnete Tabs, Lesezeichen und Verlauf";
 
 /* Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode */
 "SearchInputViewClearButtonTitle" = "Suche löschen";
@@ -3149,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Mobilfunkanbieter";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Bitte nehmen Sie keine Änderungen an den Daten unten vor";
+"vpn.contactFormDoNotEditText" = "Brave verfolgt Ihre Aktivitäten nicht nach und weiß nicht, wie Sie unsere App nutzen, daher können wir nicht nachvollziehen, wie Sie Ihr VPN eingerichtet haben. Bitte geben Sie uns Einzelheiten zu Ihrem Problem und wir werden unser Bestes tun, es so schnell wie möglich zu lösen.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Es konnte keine E-Mail geschickt werden. Bitte überprüfen Sie Ihre E-Mail-Konfiguration.";
@@ -3196,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Art des Abonnements";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "iOS-Zeitzone";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/de.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/de.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Dezimalstellen";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Warnung: Ein Screenshot Ihrer Nachricht wird möglicherweise in einem Cloud-Dateidienst gesichert und kann von jeder Anwendung mit Fotozugriff gelesen werden. Brave empfiehlt, diesen Screenshot nicht zu speichern und so schnell wie möglich zu löschen.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Erlauben";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Anzeigen";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Diese DApp möchte diese Nachricht lesen, um Ihre Anfrage abzuschließen";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Anfrage entschlüsseln";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Konto %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Verbinden";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Trennen";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Wechseln";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "Konto";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ verbunden";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Verbindungen";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Bitte überprüfen Sie Ihre Eingaben und versuchen Sie es erneut.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optimal";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Bereitstellen";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "benötigt den öffentlichen Verschlüsselungsschlüssel Ihrer Wallet. Wenn Sie zustimmen, den Schlüssel bereitzustellen, kann diese Website verschlüsselte Nachrichten an Sie senden.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "Eine DApp fordert Ihren öffentlichen Verschlüsselungscode an";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Anforderung Ihres öffentlichen Verschlüsselungsschlüssels";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Privaten Schlüssel ausblenden";
@@ -727,6 +763,9 @@
 /* A warning that appears below the send crypto address text field, when the input `To` address is not a valid ETH address. */
 "wallet.sendWarningAddressNotValid" = "Keine gültige ETH-Adresse";
 
+/* As in sent cryptocurrency from one asset to another */
+"wallet.sent" = "Gesendet";
+
 /* The title of the settings option inside the menu when user clicks the three dots button beside assets search button. */
 "wallet.settings" = "Einstellungen";
 
@@ -925,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Bestätigt";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Abgebrochen";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Fehler";
 
@@ -988,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Wallet";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Wallet im Vollbildmodus öffnen";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Verbinden";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Verbunden …";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Verwenden Sie dieses Menü, um sicher auf web3 und all Ihre Krypto-Assets zuzugreifen.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Wallet entsperren";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Keine";

--- a/App/l10n/Resources/de.lproj/Localizable.strings
+++ b/App/l10n/Resources/de.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Neuer Tab";
 
-/* No comment provided by engineer. */
-"No server found" = "Kein Server gefunden";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/es.lproj/BraveShared.strings
+++ b/App/l10n/Resources/es.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Recompensas de Brave";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Búsqueda de Brave no rastrea tu actividad, tus consultas ni los enlaces en los que haces clic.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Quizás más tarde";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Apoya la búsqueda independiente disfrutando de mayor privacidad";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Probar Búsqueda de Brave";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Dismiss";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Controles avanzados";
 
@@ -3155,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Operador de telefonía móvil";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "No edites la siguiente información";
+"vpn.contactFormDoNotEditText" = "Brave no rastrea tu actividad ni recoge información sobre cómo usas la aplicación, por lo que no sabemos de qué forma has configurado la VPN. Descríbenos el problema y haremos todo lo que podamos para resolverlo cuanto antes.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "No se puede enviar el mensaje. Verifica la configuración del correo electrónico.";
@@ -3202,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Tipo de suscripción";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Zona horaria de iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/es.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/es.lproj/BraveWallet.strings
@@ -262,6 +262,9 @@
 /* The error message for the input field when users input an invalid address for a custom network in Custom Network Details Screen. */
 "wallet.customNetworkInvalidAddressErrMsg" = "Dirección no válida.";
 
+/* The title above the input fields for users to input network rpc urls in Custom Network Details Screen. */
+"wallet.customNetworkRpcUrlsTitle" = "URL de RPC";
+
 /* The title of custom network list screen */
 "wallet.customNetworksTitle" = "Redes personalizadas";
 
@@ -328,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Decimales de precisión";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Advertencia: Es posible que la captura de pantalla con tu mensaje se almacene en la nube, en cuyo caso podrán acceder a ella todas las aplicaciones que tengan permiso para acceder a tus fotos. Desde Brave te recomendamos que no guardes la captura de pantalla y la elimines en cuanto puedas. ";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Permitir";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Desvelar";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Esta dApp quiere leer este mensaje para responder a tu solicitud";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Descifrar la solicitud";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Cuenta %lld";
 
@@ -380,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Conectar";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Desvincular";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Cambiar";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -387,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "cuenta";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ conectada(s)";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Conexiones";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Comprueba la información que has introducido y vuelve a intentarlo.";
@@ -450,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Óptimo";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Proporcionar";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "solicita la clave de cifrado público de tu cartera. Si das tu consentimiento para facilitar esta clave, el sitio podrá enviarte mensajes cifrados.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "Una dApp solicita tu clave de cifrado público";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Solicitud de clave de cifrado público";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Ocultar clave privada";
@@ -925,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Confirmada";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Anulada";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Error";
 
@@ -988,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Cartera";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Abre la cartera en pantalla completa";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Conectar";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Conectado…";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Utiliza este panel para acceder de forma segura a Web3 y a todos tus criptoactivos.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Desbloquear cartera";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Ninguno";

--- a/App/l10n/Resources/es.lproj/Localizable.strings
+++ b/App/l10n/Resources/es.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Nueva pestaña";
 
-/* No comment provided by engineer. */
-"No server found" = "No se ha encontrado ningún servidor";
-
 /* OK button */
 "OKString" = "Aceptar";
 

--- a/App/l10n/Resources/fr.lproj/BraveShared.strings
+++ b/App/l10n/Resources/fr.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Le moteur de recherche Brave Search ne vous suit pas à la trace, et ne surveille pas vos requêtes ni vos clics.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Peut-être plus tard";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Prenez en charge la recherche indépendante avec une confidentialité accrue";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Essayer Brave Search";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Ignorer";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Contrôles avancés";
 
@@ -637,6 +652,9 @@
 /* Header title for bookmark save location */
 "EditBookmarkTableLocationHeader" = "Région";
 
+/* Title for editing a bookmark */
+"EditBookmarkTitle" = "Modifier le favori";
+
 /* Button to edit a favorite */
 "EditFavorite" = "Modifier les favoris";
 
@@ -756,6 +774,9 @@
 
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "findPreviousTitle" = "Rechercher le précédent";
+
+/* individual blocking statistic title */
+"FingerprintingMethods" = "Méthodes de relevé des empreintes digitales";
 
 /* No comment provided by engineer. */
 "FingerprintingProtection" = "Bloquer les empreintes numériques";
@@ -942,6 +963,12 @@
 
 /* Setting preference to always hide the browser tabs bar. */
 "NeverShow" = "Ne jamais afficher";
+
+/* Default name for creating a new bookmark. */
+"NewBookmarkDefaultName" = "Nouveau favori";
+
+/* Title for adding new bookmark */
+"NewBookmarkTitle" = "Nouveau favori";
 
 /* Title for new folder popup */
 "NewFolder" = "Nouveau dossier";
@@ -3143,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Opérateur mobile";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Merci de ne pas modifier les informations ci-dessous";
+"vpn.contactFormDoNotEditText" = "Brave ne vous suit pas à la trace et ne sait pas comment vous utilisez l'application. Nous ne savons donc pas comment vous avez configuré votre VPN. Donnez-nous des informations au sujet du problème que vous rencontrez et nous ferons de notre mieux pour le résoudre dans les meilleurs délais.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Échec d’envoi de l’e-mail. Vérifiez la configuration de votre messagerie.";
@@ -3190,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Type d'abonnement";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Fuseau horaire iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/fr.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/fr.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Précision décimale";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Avertissement : Une capture d'écran de votre message peut être sauvegardée sur un service de fichiers sur le cloud et lisible par n'importe quelle application disposant d'un accès aux photos. Brave vous recommande de ne pas enregistrer cette capture d'écran et de la supprimer dès que possible.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Autoriser";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Afficher";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Cette DApp souhaite lire ce message pour traiter votre demande";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Décrypter la demande";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Compte %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Connexion";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Déconnecter";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Changer";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "compte";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ connecté(s)";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Connexions";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Vérifiez les valeurs saisies, puis réessayez.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optimal";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Fournir";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "demande la clé de chiffrement publique de votre portefeuille. Si vous acceptez de la lui donner, le site pourra composer des messages chiffrés pour vous.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "Une DApp demande votre clé de chiffrement public";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Demande de clé de chiffrement publique";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Masquer la clé privée";
@@ -727,6 +763,9 @@
 /* A warning that appears below the send crypto address text field, when the input `To` address is not a valid ETH address. */
 "wallet.sendWarningAddressNotValid" = "Il ne s'agit pas d'une adresse ETH valide.";
 
+/* As in sent cryptocurrency from one asset to another */
+"wallet.sent" = "Envoyé";
+
 /* The title of the settings option inside the menu when user clicks the three dots button beside assets search button. */
 "wallet.settings" = "Paramètres";
 
@@ -925,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Confirmé";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Abandonné";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Erreur";
 
@@ -988,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Portefeuille";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Ouvrir le portefeuille en plein écran";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Connexion";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Connecté…";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Utilisez ce panneau pour accéder en toute sécurité au domaine web3 et à tous vos actifs crypto.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Déverrouiller le portefeuille";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Aucun";

--- a/App/l10n/Resources/fr.lproj/Localizable.strings
+++ b/App/l10n/Resources/fr.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Nouvel onglet";
 
-/* No comment provided by engineer. */
-"No server found" = "Aucun serveur trouvé";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/id-ID.lproj/BraveShared.strings
+++ b/App/l10n/Resources/id-ID.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Pencarian Brave tidak melacak Anda, pertanyaan Anda, atau klik Anda.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Mungkin nanti";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Mendukung pencarian independen dengan privasi yang lebih baik";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Coba Pencarian Brave";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Tutup";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Kontrol Tingkat Lanjut";
 
@@ -2602,6 +2617,9 @@
 /* Button to show the bookmarks list */
 "ShowBookmarks" = "Tampilkan Markah";
 
+/* Show code words instead */
+"ShowCodeWords" = "Sebaliknya, tampilkan kata-kata kode";
+
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "showDownloadsTitle" = "Tampilkan Unduhan";
 
@@ -3152,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Operator Telepon Seluler";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Mohon jangan mengedit informasi apa pun di bawah ini";
+"vpn.contactFormDoNotEditText" = "Brave tidak melacak Anda atau mengetahui cara Anda menggunakan aplikasi kami, sehingga kami tidak tahu cara Anda memasang VPN. Silakan bagikan info tentang masalah yang Anda alami dan kami akan melakukan yang terbaik untuk memecahkannya secepat mungkin.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Tidak dapat mengirim surel. Silakan periksa kembali konfigurasi surel Anda.";
@@ -3199,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Jenis Langganan";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Timezone iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/id-ID.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/id-ID.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Ketepatan dalam desimal";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Peringatan: Tangkapan layar pesan Anda mungkin dicadangkan ke layanan berkas awan, dan dapat dibaca aplikasi apa pun dengan akses foto. Brave merekomendasikan agar Anda tidak menyimpan tangkapan layar ini, dan menghapusnya sesegera mungkin.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Izinkan";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Tampilkan";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "DApp ini ingin membaca pesan ini sebelum menyelesaikan permintaan Anda";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Dekripsi Permintaan";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Akun %lld";
 
@@ -394,6 +409,12 @@
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "akun";
 
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ tersambung";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Koneksi";
+
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Silakan periksa input Anda dan coba lagi";
 
@@ -456,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optimal";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Sediakan";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "ingin mendapatkan kunci enkripsi publik dompet Anda. Jika Anda menyetujui untuk memberikan kunci ini, situs tersebut akan dapat membuat pesan terenkripsi kepada Anda.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "Ada DApp yang meminta kunci enkripsi publik Anda";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Permintaan Kunci Enkripsi Publik";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Sembunyikan Kunci Pribadi";
@@ -931,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Dikonfirmasi";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Dibatalkan";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Kesalahan";
 
@@ -994,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Dompet";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Buka dompet dalam layar penuh";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Hubungkan";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Tersambung...";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Gunakan panel ini untuk secara aman mengakses web3 dan menggunakan semua aset kripto Anda.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Buka kunci dompet";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Tidak ada";

--- a/App/l10n/Resources/id-ID.lproj/Localizable.strings
+++ b/App/l10n/Resources/id-ID.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Tab Baru";
 
-/* No comment provided by engineer. */
-"No server found" = "Server tak ditemukan";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/it.lproj/BraveShared.strings
+++ b/App/l10n/Resources/it.lproj/BraveShared.strings
@@ -37,6 +37,9 @@
 /* Shields Ads Stat */
 "AdsAndTrackersrBlocked" = "Tracker e annunci bloccati";
 
+/* Shields Ads Stat */
+"AdsrBlocked" = "Annunci \nbloccati";
+
 /* Setting to always request the desktop version of a website. */
 "AlwaysRequestDesktopSite" = "Richiedi sempre sito desktop";
 
@@ -171,6 +174,21 @@
 
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
+
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave Search non tiene traccia delle tue query né dei tuoi clic.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Forse più tardi";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Supporta la ricerca indipendente con maggiore privacy";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Prova Brave Search";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Ignora";
 
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Comandi avanzati";
@@ -579,6 +597,12 @@
 
 /* Prompt option for cancelling out of deletion */
 "DeleteLoginAlertCancelActionTitle" = "Annulla";
+
+/* Prompt message warning the user that deleting non-synced logins will permanently remove them */
+"DeleteLoginAlertLocalMessage" = "Gli accessi verranno rimossi in modo definitivo.";
+
+/* Prompt message warning the user that deleted logins will remove logins from all connected devices */
+"DeleteLoginAlertSyncedDevicesMessage" = "Gli accessi verranno rimossi da tutti i dispositivi connessi.";
 
 /* Prompt title when deleting logins */
 "DeleteLoginAlertTitle" = "Confermi?";
@@ -1585,6 +1609,9 @@
 /* Button text that takes user to a list of all trackers and ads we blocked. 'All time lists' refer to list of blocked trackers or websites which have the most trackers */
 "privacyHub.allTimeListsButtonText" = "Liste complete";
 
+/* Header text, under it we show items blocked by our ad blocker. 'All  time' sentence context is like 'All time items blocked by our ad blocker. */
+"privacyHub.allTimeListsHeader" = "Sempre";
+
 /* Title of a section to show total count of trackers blocked by Brave */
 "privacyHub.allTimeListsTrackersView" = "Tracker e annunci";
 
@@ -2265,6 +2292,9 @@
 
 /* Context menu item for saving an image */
 "SaveImageActionTitle" = "Salva immagine";
+
+/* Setting to enable the built-in password manager */
+"SaveLogins" = "Salva gli accessi";
 
 /* Scan sync code title */
 "Scan" = "Scansiona";
@@ -3140,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Operatore cellulare";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Non modificare le informazioni sottostanti";
+"vpn.contactFormDoNotEditText" = "Brave non tiene traccia e non è al corrente di come usi la nostra app, pertanto non sappiamo come hai configurato la VPN. Condividi le informazioni sul problema che stai riscontrando e faremo del nostro meglio per risolverlo il prima possibile.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Impossibile inviare l’email. Controlla la configurazione della tua email.";
@@ -3187,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Tipo di abbonamento";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Fuso orario iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/it.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/it.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Decimali di precisione";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Attenzione: è possibile acquisire una schermata del tuo messaggio, eseguirne il back up su un servizio di file cloud e visualizzarla da qualsiasi applicazione con accesso alle foto. Brave consiglia di non salvare questa schermata e di eliminarla il prima possibile.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Autorizzo";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Mostra";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Questa DApp vorrebbe leggere il messaggio per completare la tua richiesta";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Richiesta di decrittografia";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Account %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Connetti";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Disconnetti";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Cambia";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "account";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ connesso/i";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Connessioni";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Controlla i dati inseriti e riprova.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Ottimale";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Fornisci";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "richiede la chiave di crittografia pubblica del tuo portafoglio. Se acconsenti a fornire questa chiave, il sito sarà in grado di comporre messaggi crittografati per te.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "Una DApp richiede la tua chiave di crittografia pubblica";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Richiesta della chiave di crittografia pubblica";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Nascondi chiave privata";
@@ -829,6 +865,9 @@
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Catena non supportata";
 
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Scambia token e asset.";
+
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x elaborerà l’indirizzo Ethereum e l’indirizzo IP per eseguire una transazione (incluso l’ottenimento di quotazioni). 0x utilizzerà questi dati SOLO ai fini dell’elaborazione delle transazioni.";
 
@@ -925,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Confermata";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Interrotta";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Errore";
 
@@ -988,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Portafoglio";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Apri il portafoglio a schermo intero";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Connetti";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Connesso…";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Usa questo pannello per accedere a web3 e ai tuoi asset di criptovalute in tutta sicurezza.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Sblocca portafoglio";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Niente";

--- a/App/l10n/Resources/it.lproj/Localizable.strings
+++ b/App/l10n/Resources/it.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Nuova scheda";
 
-/* No comment provided by engineer. */
-"No server found" = "Non è stato trovato nessun server";
-
 /* OK button */
 "OKString" = "OK";
 
@@ -192,6 +189,9 @@
 
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "ShowPreviousTabTitle" = "Mostra la scheda precedente";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts which is for Showing Brave Shields */
+"showShieldsTitle" = "Apri Brave Shields";
 
 /* Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down. */
 "ShowTabTrayFromTabKeyCodeTitle" = "Mostra tutte le schede";

--- a/App/l10n/Resources/ja.lproj/BraveShared.strings
+++ b/App/l10n/Resources/ja.lproj/BraveShared.strings
@@ -8,6 +8,9 @@
 "AboutBraveShieldsBody" = "多くのサイトには、お客様とお客様のデバイスを識別するためのクッキーやスクリプトが含まれています。これによってインターネット上のいたる所であなたを特定・追跡し、行動データを収集しようとしています。\n\nBraveはそういったものをブロックするので、あなたが追跡されることなくブラウジングすることが可能になります。";
 
 /* See http://mzl.la/1G7uHo7 */
+"AccessPhotoDeniedAlertMessage" = "カメラロールに画像を保存します。";
+
+/* See http://mzl.la/1G7uHo7 */
 "AccessPhotoDeniedAlertTitle" = "Brave が写真にアクセスしようとしています";
 
 /* Button to add a bookmark */
@@ -171,6 +174,21 @@
 
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
+
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave検索はあなたの個人情報、クエリ、クリックした内容を追跡しません。";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "あとで";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "独立型検索でより良いプライバシーを確保";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Brave検索を試す";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "表示しない";
 
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "詳細設定";
@@ -961,6 +979,9 @@
 /* Title for adding new folder */
 "NewFolderTitle" = "新しいフォルダ";
 
+/* New sync code button title */
+"NewSyncCode" = "新たな同期チェーンを開始する";
+
 /* New Tab title */
 "NewTab" = "新しいタブ";
 
@@ -1747,8 +1768,14 @@
 /* Default engine for private search. */
 "PrivateTabSearch" = "プライベートタブ";
 
+/* QR Code section title */
+"QRCode" = "QRコード";
+
 /* Title for quick-search engines settings section. */
 "QuickSearchEngines" = "クイック検索エンジン";
+
+/* Open the App Store to rate Brave. */
+"RateBrave" = "Braveを評価する";
 
 /* Accessibility label for button increasing font size in display settings of reader mode */
 "ReaderModeBiggerFontButtonAccessibilityLabel" = "テキストサイズを大きくする";
@@ -2629,6 +2656,9 @@
 /* Text used for social sharing together with Brave Shield values */
 "socialSharing.shareDescriptionTitle" = "Braveでwebを閲覧してデータ通信量を節約しています";
 
+/* Open search section of settings */
+"StandardTabSearch" = "通常タブ";
+
 /* Support section title */
 "Support" = "サポート";
 
@@ -3140,7 +3170,7 @@
 "vpn.contactFormCarrier" = "通信キャリア";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "この下の情報は編集・変更しないでください";
+"vpn.contactFormDoNotEditText" = "Braveはお客様の個人情報を追跡したり、お客様がどのようにアプリを使用したかを把握していないため、VPNの設定内容についてお答えすることができません。できるだけ早く解決できるよう最善を尽くしますので、発生している問題の情報を共有してください。";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "メールを送信できませんでした。Eメールの設定をご確認ください。";
@@ -3187,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "購読タイプ";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "タイムゾーン";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/ja.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/ja.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "小数点桁数";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "警告: メッセージのスクリーンショットは、クラウドファイルサービスにバックアップされ、写真にアクセスできるアプリケーションから読み取ることができる場合があります。Braveでは、このスクリーンショットを保存せず、できるだけ早く削除することを推奨しています。";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "許可する";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "表示";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "このDAppは、このメッセージを読みリクエストを完了しようとしています";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "復号化要求";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "アカウント %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "接続";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "接続を切断する";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "切り替える";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "アカウント";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld件の%2$@を接続済み";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "接続";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "入力内容を確認して再度お試しください。";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "最適値";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "提供";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "がウォレットの公開暗号化キーを要求しています。このキーを提供することに同意すると、暗号化されたメッセージがサイトで作成されます。";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DAppがあなたの公開暗号鍵を要求しています。";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "公開暗号化キーの要求";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "プライベートキーを隠す";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "確認済";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "失敗";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "エラー";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "ウォレット";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "ウォレットを全画面で開く";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "接続";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "接続を見る";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "このパネルを使用して、Web3とすべての暗号資産に安全にアクセスできます";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "ウォレットのロックを解除";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "なし";

--- a/App/l10n/Resources/ja.lproj/Localizable.strings
+++ b/App/l10n/Resources/ja.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "新しいタブ";
 
-/* No comment provided by engineer. */
-"No server found" = "サーバーが見つかりません";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/ko-KR.lproj/BraveShared.strings
+++ b/App/l10n/Resources/ko-KR.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave 검색은 사용자의 신원이나 검색어, 클릭 활동을 추적하지 않습니다.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "나중에";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "프라이버시가 한층 강화된 독립적인 검색 엔진";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Brave 검색 사용해보기";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "숨기기";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "고급 컨트롤";
 
@@ -3155,7 +3170,7 @@
 "vpn.contactFormCarrier" = "이동통신사";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "아래 정보는 어떤 것도 편집하지 마세요.";
+"vpn.contactFormDoNotEditText" = "Brave는 사용자의 신원을 추적하지 않고, 앱 사용 패턴을 파악하지 않으며, VPN을 어떻게 설정했는지 전혀 알 수 없습니다. 겪으신 문제에 대한 정보를 공유해주시면 최대한 빨리 문제를 해결해드리겠습니다.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "이메일을 보낼 수 없습니다. 이메일 구성을 확인하세요.";
@@ -3202,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "구독 유형";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "iOS 시간대";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/ko-KR.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/ko-KR.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "소수점 이하 자릿수";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "경고: 메시지의 스크린샷을 찍어 클라우드 파일 서비스에 백업해두면 사진 앱으로 열어 볼 수 있습니다. 하지만 Brave는 스크린샷을 저장해두는 방법을 권장하지 않으며, 저장했을 경우에도 가급적 빨리 삭제하기를 권합니다.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "허용";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "공개";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "이 DApp이 이 메시지를 읽고 요청을 완료하고자 합니다.";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "해독 요청";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "계정 %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "연결";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "연결 해제";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "스위치";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "계정";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld개의 %2$@ 연결됨";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "연결";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "입력값을 확인하고 다시 시도하세요.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "최적";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "제공";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "월렛 공개 암호화 키를 요청합니다. 키 제공에 동의하시면 이 사이트가 암호화된 메시지를 작성하여 보내드릴 수 있습니다.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DApp이 공개 암호화 키를 요청합니다.";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "공개 암호화 키 요청";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "비공개 키 숨기기";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "확인됨";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "드롭됨";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "오류";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "월렛";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "전체 화면에서 월렛 열기";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "연결";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "연결됨...";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "이 패널을 사용하면 web3 및 모든 암호화폐 자산에 안전하게 액세스할 수 있습니다.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "월렛 잠금 해제";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "없음";

--- a/App/l10n/Resources/ko-KR.lproj/Localizable.strings
+++ b/App/l10n/Resources/ko-KR.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "새 탭";
 
-/* No comment provided by engineer. */
-"No server found" = "서버를 찾을 수 없음";
-
 /* OK button */
 "OKString" = "확인";
 

--- a/App/l10n/Resources/ms.lproj/BraveShared.strings
+++ b/App/l10n/Resources/ms.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Carian Brave tidak menjejaki anda, pertanyaan anda atau klikan anda.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Mungkin kemudian";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Sokong carian bebas dengan privasi lebih terjamin";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Cuba gunakan Carian Brave";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Singkirkan";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Kawalan lanjutan";
 
@@ -993,6 +1008,9 @@
 
 /* Sync Alert */
 "NotEnoughWordsTitle" = "Perkataan Tidak Cukup";
+
+/* Bookmark title for Brave Support */
+"ntp.braveSupportFavoriteTitle" = "Sokongan Brave";
 
 /* No comment provided by engineer. */
 "ntp.claimRewards" = "Tuntut Token";
@@ -3152,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Pembawa Selular";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Jangan edit maklumat di bawah";
+"vpn.contactFormDoNotEditText" = "Brave tidak menjejaki anda atau mengetahui cara anda menggunakan apl, oleh itu kami tidak tahu cara anda menyediakan VPN. Sila kongsikan maklumat tentang isu yang anda alami dan kami akan mencuba sedaya upaya kami untuk menyelesaikan isu secepat mungkin.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Tidak dapat menghantar e-mel. Sila semak konfigurasi e-mel anda.";
@@ -3199,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Jenis Langganan";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Zon Masa iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/ms.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/ms.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Perpuluhan tepat";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Amaran: Tangkapan skrin mesej anda mungkin disandarkan pada perkhidmatan fail awan, dan boleh dibaca oleh sebarang aplikasi dengan akses foto. Brave mengesyorkan supaya anda tidak menyimpan tangkapan skrin ini, dan memadamkannya secepat mungkin.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Benarkan";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Dedah";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "DApp ini mahu membaca mesej ini untuk melengkapkan permintaan anda";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Permintaan Nyahsulit";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Akaun %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Sambung";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Putuskan sambungan";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Tukar";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "akaun";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ disambungkan";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Sambungan";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Sila semak input anda dan cuba lagi.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optimum";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Sediakan";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "meminta kunci penyulitan awam dompet anda. Jika anda bersetuju memberikan kunci ini, tapak tersebut akan boleh mengarang mesej disulitkan kepada anda.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DApp meminta kekunci penyulitan awam anda";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Permintaan Kunci Penyulitan Awam";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Sembunyikan Kunci Peribadi";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Disahkan";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Menurun";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Ralat";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Dompet";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Bukan dompet dalam skrin penuh";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Sambung";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Bersambung…";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Gunakan panel ini untuk mengakses web3 dan semua aset kripto anda dengan selamat.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Buka kunci dompet";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Tiada";

--- a/App/l10n/Resources/ms.lproj/Localizable.strings
+++ b/App/l10n/Resources/ms.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Tab Baharu";
 
-/* No comment provided by engineer. */
-"No server found" = "Tiada pelayan ditemui";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/nb.lproj/BraveShared.strings
+++ b/App/l10n/Resources/nb.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Belønninger";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave Søk sporer ikke deg, søkene eller klikkene dine.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Kanskje senere";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Støtt uavhengige søk med bedre personvern";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Prøv Brave Søk";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Avvis";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Avanserte kontroller";
 
@@ -207,6 +222,9 @@
 
 /* The accessibility hint spoken when focused on the main shields toggle */
 "BraveShieldsToggleHint" = "Dobbeltklikk for å skru av og på Brave Shields";
+
+/* Sync page title */
+"BraveSync" = "Synkroniser";
 
 /* Sync-Internals screen title (Sync Internals or Sync Debugging is fine). */
 "BraveSyncInternalsTitle" = "Sync internt";
@@ -1786,6 +1804,9 @@
 /* Accessibility hint for the font type buttons in reader mode display settings */
 "ReaderModeFontTypeButtonAccessibilityHint" = "Endrer fonttypen.";
 
+/* Message displayed when the reader mode page is loading. This message will appear only when sharing to Brave reader mode from another app. */
+"ReaderModeLoadingContentDisplayText" = "Laster inn innhold …";
+
 /* Link for going to the non-reader page when the reader view could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModeLoadOriginalLinkText" = "Last inn original side";
 
@@ -2647,6 +2668,9 @@
 /* Title of alert that seeks permission from user to suppress future JS alerts */
 "SuppressAlertsActionTitle" = "Hold tilbake varsler";
 
+/* Sync settings section title */
+"Sync" = "Synkroniser";
+
 /* Title of the bookmark import popup. */
 "sync.bookmarksImportPopupErrorTitle" = "Bokmerker";
 
@@ -2802,6 +2826,9 @@
 
 /* Header title for Sync settings */
 "SyncSettingsHeader" = "På oversikten under ser du alle enhetene i synkkjeden din. Alle enhetene kan administreres fra enhver av de andre enhetene.";
+
+/* Switch back to camera button */
+"SyncSwitchBackToCameraButton" = "Jeg vil bruke kameraet";
 
 /* Tablet or phone button title */
 "SyncTabletOrMobileDevice" = "Nettbrett eller telefon";
@@ -3143,7 +3170,7 @@
 "vpn.contactFormCarrier" = "teleselskap";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Ikke rediger informasjonen nedenfor";
+"vpn.contactFormDoNotEditText" = "Brave sporer deg ikke og følger ikke med på hvordan du bruker appen, så vi vet ikke hvordan du har satt opp VPN-en. Fortell oss mer om problemet du opplever, så skal vi gjøre vårt beste for å løse det snarest.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Kan ikke sende e-post. Kontroller e-postkonfigurasjonen.";
@@ -3190,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Abonnementstype";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "iOS-tidssone";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/nb.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/nb.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Antall desimaler";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Advarsel: Et skjermbilde av meldingen din kan sikkerhetskopieres til en skybasert filtjeneste, og være lesbar for alle applikasjoner som har tilgang til bilder. Brave anbefaler at du ikke lagrer dette skjermbildet, og sletter det så snart som mulig.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Tillat";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Vis";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Denne DApp-instansen ønsker tilgang til å lese denne meldingen for å fullføre forespørselen din";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Dekrypter forespørsel";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Konto %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Koble til";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Koble fra";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Bytt";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "konto";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ er tilkoblet";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Tilkoblinger";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Kontroller det du har skrevet inn, og prøv på nytt.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optimal";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Godkjenn";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "ber om den offentlige krypteringsnøkkelen til lommeboken din. Hvis du samtykker til å oppgi nøkkelen, vil nettstedet kunne sende deg krypterte meldinger.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "En DApp ber om den offentlige krypteringsnøkkelen din";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Forespørsel om offentlig krypteringsnøkkel";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Skjul privat nøkkel";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Bekreftet";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Droppet";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Feil";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Lommebok";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Åpne lommeboken i fullskjerm";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Koble til";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Tilkoblet …";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Bruk dette panelet til å få sikker tilgang til Web3 og alle kryptoressursene dine.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Lås opp lommeboken";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Ingen";

--- a/App/l10n/Resources/nb.lproj/Localizable.strings
+++ b/App/l10n/Resources/nb.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Ny fane";
 
-/* No comment provided by engineer. */
-"No server found" = "Ingen server funnet";
-
 /* OK button */
 "OKString" = "OK";
 
@@ -192,6 +189,9 @@
 
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "ShowPreviousTabTitle" = "Vis forrige fane";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts which is for Showing Brave Shields */
+"showShieldsTitle" = "Åpne Brave Shields";
 
 /* Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down. */
 "ShowTabTrayFromTabKeyCodeTitle" = "Vis alle faner";

--- a/App/l10n/Resources/pl.lproj/BraveShared.strings
+++ b/App/l10n/Resources/pl.lproj/BraveShared.strings
@@ -89,7 +89,7 @@
 "AutoRedirectAMPPagesDescription" = "Zawsze odwiedzaj oryginalne adresy URL stron (nie AMP) zamiast wersji Accelerated Mobile Page Google";
 
 /* cookie settings option */
-"Block3rdPartyCookies" = "Blokuj pliki cookie stron trzecich";
+"Block3rdPartyCookies" = "Blokuj 3rd party cookies";
 
 /* No comment provided by engineer. */
 "BlockAdsAndTracking" = "Zablokuj trackery działające pomiędzy witrynami";
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Wyszukiwanie Brave nie śledzi Ciebie, Twwoich wyszukiwań i kliknięć.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Może później";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Wspieraj niezależne wyszukiwanie z lepszą ochroną prywatności";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Wypróbuj wyszukiwanie Brave";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Zamknij";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Opcje zaawansowane";
 
@@ -200,10 +215,10 @@
 "BraveShieldsStatusTitle" = "Brave Shields";
 
 /* Context: The 'Down' in 'Brave Shields Down' */
-"BraveShieldsStatusValueDown" = "Wyłącz";
+"BraveShieldsStatusValueDown" = "Wyłączone";
 
 /* Context: The 'Up' in 'Brave Shields Up' */
-"BraveShieldsStatusValueUp" = "Włącz";
+"BraveShieldsStatusValueUp" = "Włączone";
 
 /* The accessibility hint spoken when focused on the main shields toggle */
 "BraveShieldsToggleHint" = "Dotknij dwukrotnie, aby włączyć lub wyłączyć Brave Shields";
@@ -224,7 +239,7 @@
 "BrowserLock" = "Blokowanie przeglądarki";
 
 /* No comment provided by engineer. */
-"BrowserLockDescription" = "Odblokuj Brave za pomocą Touch ID, Face ID lub systemowego kodu dostępu.";
+"BrowserLockDescription" = "Odblokuj Brave za pomocą Touch ID, Face ID lub kodu PIN.";
 
 /* A button title for the action to move to the next step of the browser lock migration process. */
 "browserLockMigrationContinueButtonTitle" = "Kontynuuj";
@@ -443,7 +458,7 @@
 "CloseAllTabsTitle" = "Zamknij wszystkie karty (%i)";
 
 /* Code words input help */
-"CodeWordInputHelp" = "Wpisz podane słowa kodowe łańcucha synchronizacji w poniższym formularzu.";
+"CodeWordInputHelp" = "Wpisz podane słowa łańcucha synchronizacji w poniższym formularzu.";
 
 /* Code words section title */
 "CodeWords" = "Słowa kodowe";
@@ -486,6 +501,9 @@
 
 /* Create PDF share action. */
 "CreatePDF" = "Utwórz plik PDF";
+
+/* Currently usedd search engines section name. */
+"CurrentlyUsedSearchEngines" = "Obecnie używane silniki wyszukiwania";
 
 /* Button title for Adding Engine in navigation Bar */
 "customSearchEngine.addButtonTitle" = "Dodaj";
@@ -539,7 +557,7 @@
 "custonmSearchEngine.thirdPartySearchEngineAddedToastTitle" = "Dodano wyszukiwarkę!";
 
 /* Data Saved Shield Stat */
-"DataSavedStat" = "Szacunkowe dane\nzapisane";
+"DataSavedStat" = "Szacunkowe dane\nzaoszczędzone";
 
 /* Button text to close the default browser popup. */
 "defaultBrowserCallout.introCancelButtonText" = "Nie teraz";
@@ -599,7 +617,7 @@
 "DeviceTemplate" = "Urządzenie %1$@ (%2$@)";
 
 /* Section name for display preferences. */
-"DisplaySettingsSection" = "Wyświetl";
+"DisplaySettingsSection" = "Interfejs Użytkownika";
 
 /* No comment provided by engineer. */
 "Done" = "Gotowe";
@@ -614,7 +632,7 @@
 "DownloadedFiles" = "Pobierane pliki";
 
 /* Title for downloads menu item */
-"DownloadsMenuItem" = "Pobrania";
+"DownloadsMenuItem" = "Pobrane";
 
 /* Title for when a user has nothing downloaded onto their device, and the list is empty. */
 "DownloadsPanelEmptyStateTitle" = "W tym miejscu pojawią się pobrane pliki.";
@@ -662,7 +680,7 @@
 "errorPageCantBeReachedTry" = "Spróbuj ponownie wpisać adres URL lub wyszukaj nowy adres URL w wyszukiwarce.";
 
 /* Shown in error pages for files that can't be shown and need to be downloaded. */
-"ErrorPageOpenInSafariButtonTitle" = "Otwórz w przeglądarce Safari";
+"ErrorPageOpenInSafariButtonTitle" = "Otwórz w Safari";
 
 /* Shown in error pages on a button that will try to load the page again */
 "ErrorPageReloadButtonTitle" = "Wczytaj ponownie";
@@ -707,7 +725,7 @@
 "ErrorPagesProceedAnywayButton" = "Przejdź do %@ (niebezpieczne)";
 
 /* Shields Time Saved Stat */
-"EstTimerSaved" = "Szacowany czas\nzapisany";
+"EstTimerSaved" = "Szacowany czas\nzaoszczędzony";
 
 /* %@ will launch an external application */
 "ExternalAppURLAlertMessage" = "%@ uruchomi zewnętrzną aplikację";
@@ -758,10 +776,10 @@
 "findPreviousTitle" = "Znajdź poprzednie";
 
 /* individual blocking statistic title */
-"FingerprintingMethods" = "Metody pobierania odcisków palców";
+"FingerprintingMethods" = "Metody fingerprinting";
 
 /* No comment provided by engineer. */
-"FingerprintingProtection" = "Zablokuj odciski palca";
+"FingerprintingProtection" = "Zablokuj fingerprinting";
 
 /* No comment provided by engineer. */
 "FingerprintingProtectionDescription" = "Utrudnia stronom rozpoznawanie charakterystycznych cech Twojego urządzenia.";
@@ -1061,7 +1079,7 @@
 "OBErrorDetails" = "Coś poszło nie tak podczas tworzenia portfela. Spróbuj ponownie";
 
 /* No comment provided by engineer. */
-"OBErrorOkay" = "Okej\n";
+"OBErrorOkay" = "Ok";
 
 /* A generic error title for onboarding */
 "OBErrorTitle" = "Przepraszamy";
@@ -1331,7 +1349,7 @@
 "playList.noticeAlertTitle" = "Uwaga";
 
 /* Okay Alert button title */
-"playList.okayButtonTitle" = "Okej\n";
+"playList.okayButtonTitle" = "Ok";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Przepraszamy, wystąpił błąd podczas próby wyświetlenia obrazu w obrazie.";
@@ -1439,16 +1457,16 @@
 "playList.removeActionButtonTitle" = "Usuń";
 
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
-"playlist.removePlaylistOfflineDataAlertMessage" = "Spowoduje to usunięcie nośnika z pamięci masowej trybu offline. Czy na pewno chcesz kontynuować?";
+"playlist.removePlaylistOfflineDataAlertMessage" = "Spowoduje to usunięcie pliku z dysku. Kontynuować?";
 
 /* Title for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertTitle" = "Usuń dane trybu offline";
 
 /* Message for the alert shown when the user tries to remove a video from playlist */
-"playlist.removePlaylistVideoAlertMessage" = "Spowoduje to usunięcie pozycji multimedialnej z listy. Czy na pewno chcesz kontynuować?";
+"playlist.removePlaylistVideoAlertMessage" = "Spowoduje to pliku z listy. Czy na pewno chcesz kontynuować?";
 
 /* Title for the alert shown when the user tries to remove an item from playlist */
-"playlist.removePlaylistVideoAlertTitle" = "Usunąć pozycję multimedialną z listy odtwarzania?";
+"playlist.removePlaylistVideoAlertTitle" = "Usunąć plik z listy odtwarzania?";
 
 /* Reopen Alert button title */
 "playList.reopenButtonTitle" = "Otwórz ponownie";
@@ -1610,16 +1628,16 @@
 "privacyHub.allTimeSitesCount" = "Witryny: %lld";
 
 /* Displays a number of trackers we blocked on a particular website, example usage: '23 trackers & ads' */
-"privacyHub.allTimeTrackersCount" = "Pliki śledzące i reklamy: %lld";
+"privacyHub.allTimeTrackersCount" = "Trackery i reklamy: %lld";
 
 /* Title under which we display most name of the most blocked tracker or ad. */
-"privacyHub.allTimeTrackerTitle" = "Plik śledzący i reklama";
+"privacyHub.allTimeTrackerTitle" = "Tracker i reklama";
 
 /* Title under which we display a website on which there's the highest number of trackers or ads. */
 "privacyHub.allTimeWebsiteTitle" = "Strona";
 
 /* Text for a button to display a list of all alerts caught by the Brave VPN. VPN alert is a notificaion of what item has been blocked by the vpn, similar to a regular adblocker */
-"privacyHub.allVPNAlertsButtonText" = "Wszystkie alarmy";
+"privacyHub.allVPNAlertsButtonText" = "Wszystkie alerty";
 
 /* Text which explain by what type of ad blocker a given resource was blocked. Context is like: 'Blocked by Brave Shields', 'Blocked by BraveVPN */
 "privacyHub.blockedBy" = "Zablokowane przez";
@@ -1640,7 +1658,7 @@
 "privacyHub.mostFrequentTrackerAndAdBody" = "**%1$@** zostało zablokowane przez Brave Shields na **%2$lld** witrynach";
 
 /* Title under which we display a tracker which was most frequently detected by our ad blocking mechanism. */
-"privacyHub.mostFrequentTrackerAndAdTitle" = "Najczęstszy plik śledzący i reklama";
+"privacyHub.mostFrequentTrackerAndAdTitle" = "Najczęstszy tracker i reklama";
 
 /* Text of a callout that tell user they need to browser some websites first in order to see privacy stats data */
 "privacyHub.noDataCalloutBody" = "Odwiedź jakieś strony, aby zobaczyć tu dane.";
@@ -1649,7 +1667,7 @@
 "privacyHub.noDataToShow" = "Brak danych do wyświetlenia.";
 
 /* Text of a callout to encourage user to enable Apple notification system. */
-"privacyHub.notificationCalloutBody" = "Uzyskaj cotygodniowe aktualizacje dotyczące prywatności na temat blokowania plików śledzących i reklam.";
+"privacyHub.notificationCalloutBody" = "Uzyskaj cotygodniowe aktualizacje dotyczące prywatności na temat blokowania trackerów i reklam.";
 
 /* Text of a button to encourage user to enable Apple notification system. */
 "privacyHub.notificationCalloutButtonText" = "Włącz powiadomienia";
@@ -1670,7 +1688,7 @@
 "privacyHub.privacyReportsTitle" = "Centrum prywatności";
 
 /* Do NOT localize asterisk('*') characters, they are used to make the text bold in the app. It says which website had the most tracker per visit, example usage: 'example.com had an average of 10 trackers & ads blocked per visit ' */
-"privacyHub.riskiestWebsiteBody" = "**%1$@** miało średnio **%2$lld** plików śledzących i reklam zablokowanych na wizytę";
+"privacyHub.riskiestWebsiteBody" = "**%1$@** miało średnio **%2$lld** trackerów i reklam zablokowanych na wizytę";
 
 /* Title of a website that contained the most trackers per visit. */
 "privacyHub.riskiestWebsiteTitle" = "Strona z największą liczbą elementów śledzących";
@@ -1685,7 +1703,7 @@
 "privacyHub.settingsEnableVPNAlertsFooter" = "Ustawienie ma zastosowanie tylko, jeśli zakupiono subskrypcję VPN.";
 
 /* Title of a setting that lets Brave monitor blocked network requests captured by Brave VPN */
-"privacyHub.settingsEnableVPNAlertsTitle" = "Pokaż alarmy VPN";
+"privacyHub.settingsEnableVPNAlertsTitle" = "Pokaż alerty VPN";
 
 /* This text explains what the button to clear datain the Privacy Hub is for. */
 "privacyHub.settingsSlearDataFooter" = "Resetuje licznik wszystkich elementów zablokowanych przez Shields.";
@@ -1697,25 +1715,25 @@
 "privacyHub.shieldsLabel" = "Zabezpieczenia";
 
 /* Type of tracker blocked by the VPN, it's a tracker contained in an email. */
-"privacyHub.vpnAlertEmailTrackerTypePlural" = "Pliki śledzące w wiadomości e-mail";
+"privacyHub.vpnAlertEmailTrackerTypePlural" = "Trackery w e-mailach";
 
 /* Type of tracker blocked by the VPN, it's a tracker contained in an email. */
-"privacyHub.vpnAlertEmailTrackerTypeSingular" = "Plik śledzący w wiadomości e-mail";
+"privacyHub.vpnAlertEmailTrackerTypeSingular" = "Tracker e-mail";
 
 /* Type of tracker blocked by the VPN, it's a tracker that asks you for your location. */
-"privacyHub.vpnAlertLocationTrackerTypePlural" = "Pingi lokalizacyjne";
+"privacyHub.vpnAlertLocationTrackerTypePlural" = "Prośby o lokalizację";
 
 /* Type of tracker blocked by the VPN, it's a tracker that asks you for your location. */
-"privacyHub.vpnAlertLocationTrackerTypeSingular" = "Ping lokalizacyjny";
+"privacyHub.vpnAlertLocationTrackerTypeSingular" = "Prośba o lokalizację";
 
 /* Type of tracker blocked by the VPN, it's a regular tracker or an ad. */
-"privacyHub.vpnAlertRegularTrackerTypePlural" = "Pliki śledzące i reklamy";
+"privacyHub.vpnAlertRegularTrackerTypePlural" = "Trackery i reklamy";
 
 /* Type of tracker blocked by the VPN, it's a regular tracker or an ad. */
-"privacyHub.vpnAlertRegularTrackerTypeSingular" = "Plik śledzący lub reklama";
+"privacyHub.vpnAlertRegularTrackerTypeSingular" = "Tracker lub reklama";
 
 /* Section title, this section displays vpn alerts: items which the vpn managed to block on users behalf. */
-"privacyHub.vpnAlertsHeader" = "Firewall Brave + alerty VPN";
+"privacyHub.vpnAlertsHeader" = "Brave Firewall  + alerty VPN";
 
 /* This label says about Brave VPN, as a source of by what the resource was blocked by. Think of it in context of 'Blocked by VPN' */
 "privacyHub.vpnLabel" = "Firewall + VPN";
@@ -1793,7 +1811,7 @@
 "ReaderModeLoadOriginalLinkText" = "Wczytaj oryginalną stronę";
 
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
-"ReaderModePageCantShowDisplayText" = "Nie udało się wyświetlić strony w widoku odczytu.";
+"ReaderModePageCantShowDisplayText" = "Nie udało się wyświetlić strony w trybie czytania.";
 
 /* Title of a bar that show up when you enter reader mode. */
 "readerModeSettingsButton" = "Tryb Czytania";
@@ -1832,7 +1850,7 @@
 "RecentSearchPasteAndGo" = "Wklej i otwórz";
 
 /* Recent Search 'on' text when a user searches 'on' a website */
-"RecentSearchQuickSearchOnWebsite" = "na";
+"RecentSearchQuickSearchOnWebsite" = "w";
 
 /* Recent Search Scanned text when a user scans a qr code */
 "RecentSearchScanned" = "Przeskanowano";
@@ -1889,7 +1907,7 @@
 "RestoredFavoritesFolderName" = "Przywrócone ulubione";
 
 /* Restore Tabs Affirmative Action */
-"RestoreTabAffirmativeButtonTitle" = "Okej\n";
+"RestoreTabAffirmativeButtonTitle" = "Ok";
 
 /* Restore Tabs Negative Action */
 "RestoreTabNegativeButtonTitle" = "Nie";
@@ -2429,7 +2447,7 @@
 "shieldEducation.benchmarkSpecialTierTitle" = "Gratulacje. Jesteś naprawdę wyjątkową osobą.";
 
 /* Subtitle for  The parameter substituted for \"%@\" is the amount of data saved in MB. E.g.: Average Data Saved: 17.43 MB */
-"shieldEducation.domainSpecificDataSavedSubtitle" = "Średnia ilość zapisanych danych\n% w MB";
+"shieldEducation.domainSpecificDataSavedSubtitle" = "Średnia ilość oszczędzonych danych\n% w MB";
 
 /* Action title for button at domain specific data saved pop-up */
 "shieldEducation.dontShowThisTitle" = "Nie pokazuj tego ponownie";
@@ -2444,7 +2462,7 @@
 "shieldEducation.trackerCountShareSubtitle" = "Gratulacje. Jesteś naprawdę wyjątkową osobą.";
 
 /* Title for Shield Education Tracker Count Share. The parameter substituted for \"%ld\" is the count of the trackers and ads blocked in total until present. E.g.: 5000 trackers & ads blocked */
-"shieldEducation.trackerCountShareTitle" = " Zablokowane programy śledzące i reklamy: %ld";
+"shieldEducation.trackerCountShareTitle" = "Zablokowane trackery i reklamy: %ld";
 
 /* Subtitle for Shield Education Tracker Video Ad Block */
 "shieldEducation.videoAdBlockSubtitle" = "Filmy bez reklam zużywają mniej danych.";
@@ -2948,13 +2966,13 @@
 "Today" = "Dzisiaj";
 
 /* The button title for adding a user RSS feed */
-"today.addSource" = "Dodaj źródło";
+"today.addSource" = "Dodaj kanał";
 
 /* To add a list of 1 or more rss feeds */
 "today.addSourceAddButtonTitle" = "Dodaj";
 
 /* The title in the alert when a source fails to add */
-"today.addSourceFailureTitle" = "Nie udało się dodać źródła";
+"today.addSourceFailureTitle" = "Nie udało się dodać kanał";
 
 /* No comment provided by engineer. */
 "today.addSourceInvalidDataMessage" = "Przykro nam, nie udało się rozpoznać adresu tego kanału.";
@@ -2966,10 +2984,10 @@
 "today.addSourceNoFeedsFoundMessage" = "Przykro nam, adres tego kanału nie ma zawartości.";
 
 /* The action title displayed in the iOS share menu */
-"today.addSourceShareTitle" = "Dodaj źródło do Brave News";
+"today.addSourceShareTitle" = "Dodaj kanał do Brave News";
 
 /* No comment provided by engineer. */
-"today.allSources" = "Wszystkie źródła";
+"today.allSources" = "Wszystkie kanały";
 
 /* The name of the feature */
 "today.braveToday" = "Brave News";
@@ -2996,7 +3014,7 @@
 "today.disablePublisherContent" = "Wyłącz treści z %@";
 
 /* No comment provided by engineer. */
-"today.emptyFeedBody" = "Spróbuj włączyć kilka źródeł informacji";
+"today.emptyFeedBody" = "Spróbuj włączyć kilka kanałów informacji";
 
 /* No comment provided by engineer. */
 "today.emptyFeedTitle" = "Brak artykułów do wyświetlenia";
@@ -3017,7 +3035,7 @@
 "today.importOPML" = "Importuj OPML";
 
 /* The header above the list of insecure sources */
-"today.insecureSourcesHeader" = "Niepewne źródła – dodajesz na własną odpowiedzialność";
+"today.insecureSourcesHeader" = "Niezabezpieczony kanał – dodajesz na własną odpowiedzialność";
 
 /* No comment provided by engineer. */
 "today.introCardBody" = "Brave News wspierają w pełni prywatne i anonimizowane reklamy dopasowane na Twoim urządzeniu.";
@@ -3038,7 +3056,7 @@
 "today.learnMoreTitle" = "Dowiedz się więcej o swoich danych";
 
 /* 'Brave Offers' is a product name */
-"today.moreBraveOffers" = "Więcej Brave Offers";
+"today.moreBraveOffers" = "Więcej ofert Brave";
 
 /* No comment provided by engineer. */
 "today.noInternet" = "Brak Internetu";
@@ -3053,7 +3071,7 @@
 "today.refresh" = "Odśwież";
 
 /* No comment provided by engineer. */
-"today.resetSourceSettingsButtonTitle" = "Przywróć domyślne ustawienia źródła";
+"today.resetSourceSettingsButtonTitle" = "Przywróć domyślne ustawienia kanałów";
 
 /* An action title where the user is executing a search based on inputted text */
 "today.searchButtonTitle" = "Szukaj";
@@ -3062,10 +3080,10 @@
 "today.searchTextFieldPlaceholder" = "URL kanału lub strony";
 
 /* No comment provided by engineer. */
-"today.settingsSourceHeaderTitle" = "Domyślne źródła";
+"today.settingsSourceHeaderTitle" = "Domyślne kanały";
 
 /* No comment provided by engineer. */
-"today.sourcesAndSettings" = "Źródła i ustawienia";
+"today.sourcesAndSettings" = "Kanały i ustawienia";
 
 /* No comment provided by engineer. */
 "today.sourceSearchPlaceholder" = "Szukaj";
@@ -3080,7 +3098,7 @@
 "TrackersrBlocked" = "Śledzenie\nzablokowane";
 
 /* Prompt shown before enabling provider search queries */
-"Turn on search suggestions?" = "Czy włączyć sugestie wyszukiwania?";
+"Turn on search suggestions?" = "Włączyć sugestie wyszukiwania?";
 
 /* Sync Alert */
 "UnableToConnectDescription" = "Nie można dołączyć do grupy synchronizacji. Sprawdź wprowadzone słowa i spróbuj ponownie.";
@@ -3149,10 +3167,10 @@
 "vpn.contactFormAppVersion" = "Wersja aplikacji";
 
 /* Cellular Carrier field for customer support contact form. */
-"vpn.contactFormCarrier" = "Operator infrastrukturalny (komórkowy)";
+"vpn.contactFormCarrier" = "Operator komórkowy";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Proszę nie edytować poniższych informacji";
+"vpn.contactFormDoNotEditText" = "Brave Cię nie śledzi ani nie wie, jak korzystasz z naszej aplikacji, więc nie wiemy, jak mamy skonfigurowałeś VPN. Podziel się z nami informacjami na temat problemu, z którym się borykasz, a my dołożymy wszelkich starań, aby rozwiązać go jak najszybciej.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Nie można wysłać wiadomości e-mail. Proszę sprawdzić konfigurację poczty.";
@@ -3199,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Typ subskrypcji";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Strefa czasowa iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/pl.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/pl.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Miejsca po przecinku";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Ostrzeżenie: zrzut ekranu z Twoją wiadomością może zostać zapisany w chmurze i odczytany za pomocą każdej aplikacji z dostępem do zdjęć. Brave zaleca niezapisywanie zrzutu i jak najszybsze usunięcie go.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Zezwól";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Pokazuj";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Ten DApp chciałby przeczytać tę wiadomość, aby zrealizować Twoje żądanie";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Odszyfruj prośbę";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Konto %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Połącz";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Rozłącz";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Zmień";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "konto";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "Połączono: %1$lld %2$@";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Liczba połączeń";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Sprawdź wprowadzoną zawartość i spróbuj ponownie.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optymalne";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Dostarcz";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "prosi o publiczny klucz szyfrowania. Wyrażenie zgody oznacza, że strona będzie mogła tworzyć szyfrowane wiadomości do Ciebie.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DApp żąda Twojego publicznego klucza szyfrowania";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Prośba o publiczny klucz szyfrowania";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Ukryj klucz prywatny";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Potwierdzone";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Odrzucone";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Błąd";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Portfel";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Otwórz portfel na pełnym ekranie";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Połącz";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Połączono…";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Użyj tego panelu, aby uzyskać bezpieczny dostęp do Web3 i wszystkich kryptoaktywów.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Odblokuj portfel";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Brak";

--- a/App/l10n/Resources/pl.lproj/Localizable.strings
+++ b/App/l10n/Resources/pl.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Nowa karta";
 
-/* No comment provided by engineer. */
-"No server found" = "Nie znaleziono serwera";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/pt-BR.lproj/BraveShared.strings
+++ b/App/l10n/Resources/pt-BR.lproj/BraveShared.strings
@@ -46,6 +46,9 @@
 /* Used as a button label for crash dialog prompt */
 "AlwaysSendButtonTitle" = "Enviar sempre";
 
+/* Setting preference to always show the browser tabs bar. */
+"AlwaysShow" = "Mostrar sempre";
+
 /* Label for the Face ID/Passcode item in Settings */
 "AuthenticationFaceIDPasscodeSetting" = "Face ID e código de acesso";
 
@@ -171,6 +174,21 @@
 
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Recompensas Brave";
+
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "A Pesquisa Brave não rastreia você, suas consultas nem seus cliques.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Talvez mais tarde";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Apoie uma pesquisa independente com mais privacidade";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Testar a Pesquisa Brave";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Dispensar";
 
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Controles avançados";
@@ -3152,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Operadora de celular";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Não edite as informações abaixo";
+"vpn.contactFormDoNotEditText" = "Como o Brave não rastreia suas ações nem sabe de que forma você usa nosso app, não sabemos como você configurou a VPN. Compartilhe informações sobre o problema que você está enfrentando. Faremos o que estiver ao nosso alcance para resolvê-lo o mais rápido possível.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Não é possível enviar e-mails. Verifique sua configuração de e-mail.";
@@ -3199,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Tipo de assinatura";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Fuso horário do iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/pt-BR.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/pt-BR.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Decimais de precisão";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Aviso: uma captura de tela da sua mensagem pode ser armazenada em backup em um serviço de arquivos na nuvem e pode ser lida por qualquer aplicativo com acesso às fotos. O Brave recomenda que você não salve essa captura de tela e a exclua assim que possível.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Permitir";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Exibir";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Este DApp deseja ler esta mensagem para concluir sua solicitação";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Solicitação de descriptografia";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Conta %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Conectar";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Desconectar";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Alternar";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "conta";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ conectada(s)";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Conexões";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Verifique os dados informados e tente novamente.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Otimizado";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Providenciar";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "está solicitando a chave de criptografia pública da sua carteira. Se você consentir com o fornecimento dessa chave, o site poderá criar mensagens criptografadas para você.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "Um DApp está solicitando sua chave de criptografia pública";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Solicitação de chave de criptografia pública";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Ocultar chave privada";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Confirmada";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Descartada";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Erro";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Carteira";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Abrir carteira em tela cheia";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Conectar";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Conectada...";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Use este painel para acessar com segurança o web3 e todos os seus criptoativos.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Desbloquear carteira";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Nenhum";

--- a/App/l10n/Resources/pt-BR.lproj/Localizable.strings
+++ b/App/l10n/Resources/pt-BR.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Nova guia";
 
-/* No comment provided by engineer. */
-"No server found" = "Nenhum servidor encontrado";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/ru.lproj/BraveShared.strings
+++ b/App/l10n/Resources/ru.lproj/BraveShared.strings
@@ -25,6 +25,9 @@
 /* Cell title for add folder action */
 "AddFolderActionCellTitle" = "Новая папка";
 
+/* Add to favorites share action. */
+"AddToFavorites" = "Добавить в избранное";
+
 /* Title for the button to add a new website bookmark. */
 "AddToMenuItem" = "Добавить закладку";
 
@@ -84,6 +87,9 @@
 
 /* This is a description for a setting toggle that enables/disables auto-redirect of Google's AMP (Accelerated Mobile Page) pages to the original (non-AMP) pages. The text 'AMP' and 'Accelerated Mobile Page' is not to be translated. */
 "AutoRedirectAMPPagesDescription" = "Всегда использовать URL исходной страницы, а не AMP-страницы Google";
+
+/* cookie settings option */
+"Block3rdPartyCookies" = "Блокировать сторонние файлы cookie";
 
 /* No comment provided by engineer. */
 "BlockAdsAndTracking" = "Блокировка межсайтовых трекеров";
@@ -168,6 +174,21 @@
 
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Награды";
+
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "В Brave Поиске ваши запросы, действия и переходы на сайты не отслеживаются.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Не сейчас";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Поддержите независимую поисковую систему, которая заботится о вашей конфиденциальности";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Попробуйте Brave Поиск";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Dismiss";
 
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Дополнительные настройки";
@@ -372,6 +393,9 @@
 
 /* Title of the section for the address of where the certificate came from. */
 "certificateViewer.streetAddressTitle" = "Улица и номер дома";
+
+/* Section Title for Subject Name in the SSL Certificate */
+"certificateViewer.subjectNameTitle" = "Имя сертификата";
 
 /* Title of the section for the User's ID (Identifier). */
 "certificateViewer.userIDTitle" = "ID пользователя";
@@ -961,6 +985,9 @@
 /* New Tab title */
 "NewTab" = "Новая вкладка";
 
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Тема";
+
 /* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
 "nightMode.sectionDescription" = "Ночной режим будет применен к сайту и системе в целом.";
 
@@ -1008,6 +1035,9 @@
 
 /* A setting to enable or disable background images on the main screen. */
 "ntp.settingsBackgroundImages" = "Показывать фоновые изображения";
+
+/* A button that leads to a 'more' menu, letting users configure additional settings. */
+"ntp.settingsBackgroundImageSubMenu" = "Фоновые изображения";
 
 /* A selection to let the users only see a set of predefined, default images on the background of the app. */
 "ntp.settingsDefaultImagesOnly" = "Только изображения по умолчанию";
@@ -2081,6 +2111,18 @@
 "RewardsInternalsContributionsStepFailed" = "Произошла ошибка";
 
 /* No comment provided by engineer. */
+"RewardsInternalsContributionsStepNotEnoughFunds" = "Недостаточно средств";
+
+/* No comment provided by engineer. */
+"RewardsInternalsContributionsStepPrepare" = "Подготовка";
+
+/* No comment provided by engineer. */
+"RewardsInternalsContributionsStepReserve" = "Резерв";
+
+/* No comment provided by engineer. */
+"RewardsInternalsContributionsStepRewardsOff" = "Brave Награды отключены";
+
+/* No comment provided by engineer. */
 "RewardsInternalsContributionsStepStart" = "Начать";
 
 /* No comment provided by engineer. */
@@ -2680,6 +2722,9 @@
 /* Sync add device description */
 "SyncAddDeviceScanDescription" = "Запустите Brave на втором мобильном устройстве и откройте настройки. Перейдите в раздел «Синхронизация» и нажмите «Сканировать код синхронизации». Отсканируйте QR-код ниже с помощью камеры.\n\nОтноситесь к этому коду как к паролю. Не показывайте его никому, иначе другие пользователи смогут просматривать и изменять ваши синхронизированные данные.";
 
+/* Add device to sync with code words */
+"SyncAddDeviceWords" = "Введите код для синхронизации";
+
 /* Sync add device description */
 "SyncAddDeviceWordsDescription" = "Запустите Brave на устройстве и откройте настройки. Перейдите в раздел «Синхронизация» и нажмите кнопку «%@». Введите указанные ниже кодовые слова.\n\nОтноситесь к кодовым словам как к паролю. Не сообщайте их никому, иначе другие пользователи смогут просматривать и изменять ваши синхронизированные данные.";
 
@@ -3125,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Оператор сотовой связи";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Не вносите никаких изменений в приведенную ниже информацию";
+"vpn.contactFormDoNotEditText" = "Brave не отслеживает, как вы используете приложение, поэтому у нас нет информации об установленном VPN. Расскажите о вашей проблеме и мы постараемся решить ее как можно быстрее.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Нам не удалось отправить письмо. Проверьте настройки электронной почты.";
@@ -3172,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Тип подписки";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Часовой пояс iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/ru.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/ru.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Количество знаков после запятой";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Внимание! Копия скриншота может сохраниться в облачном сервисе. В таком случае у любого приложения для просмотра фото будет к ней доступ. Мы рекомендуем удалить скриншот как можно скорее.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Разрешить";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Показать";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Для выполнения запроса приложению DApp нужен доступ к этому сообщению";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Запрос на расшифровку";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Счет %lld";
 
@@ -355,6 +370,12 @@
 /* The footer title for edit nonce section in advanced settings screen. */
 "wallet.editNonceFooter" = "Если одноразовый код не последователен или содержит ошибки, транзакция не будет передана в сеть";
 
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Одноразовый код";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Введите одноразовый код";
+
 /* The header text shown above the rows to selected the allowance for an ERC 20 Approve transaction. The '%@' becomes the name of the account approving the transaction. For example: \"Spend limit permission allows Account 1 to withdraw and spend up to the following amount:\" */
 "wallet.editPermissionsAllowanceHeader" = "Установленный лимит расходов позволяет аккаунту «%@» использовать следующую сумму:";
 
@@ -377,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Подключиться";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Отключить";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Переключиться";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -384,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "Счет";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "Подключено: %1$lld %2$@";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Подключения";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Проверьте, правильно ли вы ввели данные, и повторите попытку.";
@@ -447,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Оптимальный";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Предоставить";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "запрашивает открытый ключ шифрования вашего кошелька. Если вы дадите согласие, этот сайт сможет отправлять вам зашифрованные сообщения.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DApp запрашивает открытый ключ шифрования";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Запрос на открытый ключ шифрования";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Скрыть закрытый ключ";
@@ -748,6 +790,9 @@
 /* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
 "wallet.settingsResetTransactionAlertMessage" = "Эту функцию обычно используют разработчики, запускающие локальный сервер тестирования";
 
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Сбросить данные о транзакциях и одноразовый код?";
+
 /* The footer message below the button to reset transaction */
 "wallet.settingsResetTransactionFooter" = "Сброс данных транзакций может понадобится разработчикам или при очистке состояния на локальном сервере";
 
@@ -919,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Подтверждено";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Отменено";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Ошибка";
 
@@ -982,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Brave Кошелек";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Развернуть кошелек на весь экран";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Подключиться";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Подключено";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Здесь вы можете безопасно использовать Web3 и управлять криптоактивами.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Разблокировать кошелек";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Нет";

--- a/App/l10n/Resources/ru.lproj/Localizable.strings
+++ b/App/l10n/Resources/ru.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Новая вкладка";
 
-/* No comment provided by engineer. */
-"No server found" = "Серверы не найдены";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/sv.lproj/BraveShared.strings
+++ b/App/l10n/Resources/sv.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave-belöningar";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave-sökning spårar inte dig, dina sökningar eller dina klick.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Kanske senare";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Stöd oberoende sökning med bättre sekretess";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Prova Brave-sökning";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Ta bort permanent";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Avancerade kontroller";
 
@@ -3155,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Mobilleverantör";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Redigera inte någon information nedan";
+"vpn.contactFormDoNotEditText" = "Brave spårar inte dig och vet inte hur du använder vår app, så vi vet inte hur du har konfigurerat VPN. Dela gärna med dig av information om problemet du upplever så ska vi göra vårt bästa för att lösa det så fort vi kan.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Det går inte att skicka e-post. Kontrollera din e-postkonfiguration.";
@@ -3202,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Prenumerationstyp";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "iOS tidszon";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/sv.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/sv.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Precisionsdecimaler";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Varning: En skärmbild av ditt meddelande kan säkerhetskopieras till en molnfiltjänst och vara läsbart av alla program med åtkomst till foton. Brave rekommenderar att du inte sparar den här skärmbilden och tar bort den så snart som möjligt.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Tillåt";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Avslöja";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Denna DApp vill läsa detta meddelande för att slutföra din förfrågan";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Dekryptera begäran";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Konto %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Anslut";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Koppla ifrån";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Växla";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "konto";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ ansluten";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Anslutningar";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "Kontrollera de värde du har matat in och försök igen.";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optimal";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Förse";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "begär din plånboks offentliga krypteringsnyckel. Om du samtycker till att tillhandahålla denna nyckel kan webbplatsen skriva krypterade meddelanden till dig.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "En DApp begär att få din offentliga krypteringsnyckel";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Begäran om offentlig krypteringsnyckel";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Dölj privat nyckel";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Bekräftad";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Fallit bort";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Fel";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Plånbok";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Öppna plånbok i helskärm";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Anslut";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Ansluten ...";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Använd den här panelen för att komma åt web3 och alla dina kryptotillgångar på ett säkert sätt.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Lås plånbok";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Ingen";

--- a/App/l10n/Resources/sv.lproj/Localizable.strings
+++ b/App/l10n/Resources/sv.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Ny flik";
 
-/* No comment provided by engineer. */
-"No server found" = "Ingen server hittades";
-
 /* OK button */
 "OKString" = "OK";
 

--- a/App/l10n/Resources/tr.lproj/BraveShared.strings
+++ b/App/l10n/Resources/tr.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Ödülleri";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave Arama sizi, sorgularınızı veya tıklamalarınızı takip etmez.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Belki daha sonra";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Bağımsız aramayı daha iyi bir güvenlikle destekleyin";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Brave ile Aramayı Deneyin";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Kapat";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Gelişmiş denetimler";
 
@@ -3155,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Hücresel Taşıyıcı";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Lütfen aşağıdaki bilgileri düzenlemeyin";
+"vpn.contactFormDoNotEditText" = "Brave sizi takip etmediği veya uygulamanızı nasıl kullandığınızı bilmediği için VPN'İ nasıl kurduğunuzu bilemeyiz. Lütfen yaşadığınız sorunu paylaşın, en kısa süre içinde çözmeye çalışacağız.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "E-posta gönderilemiyor. Lütfen e-posta yapılandırmanızı kontrol edin.";
@@ -3202,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Abonelik Türü";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "iOS Saat Dilimi";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/tr.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/tr.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Kesinlik ondalıkları";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Uyarı: Mesajınızın ekran görüntüsü bir bulut dosya hizmetinde saklanıyor ve fotoğraflara erişimi olan herhangi bir uygulama tarafından okunabiliyor olabilir. Brave, bu ekran görüntüsünü kaydetmemenizi ve en kısa sürede silmenizi öneriyor.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "İzin Ver";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Göster";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Bu DApp talebinizi tamamlamak için bu mesajı okumak istiyor";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "İsteği Çöz";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Hesap %lld";
 
@@ -462,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Optimum";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Ver";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "cüzdanınızın herkese açık şifreleme anahtarını talep ediyor. Bu anahtarın verilmesine rıza gösterirseniz site size şifrelenmiş mesajlar gönderebilecektir.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "Bir DApp, açık şifreleme anahtarınızı istiyor";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Herkese Açık Şifreleme Anahtarı İsteği";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Özel Anahtarı Gizle";

--- a/App/l10n/Resources/tr.lproj/Localizable.strings
+++ b/App/l10n/Resources/tr.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Yeni Sekme";
 
-/* No comment provided by engineer. */
-"No server found" = "Sunucu bulunamadı";
-
 /* OK button */
 "OKString" = "Tamam";
 

--- a/App/l10n/Resources/uk.lproj/BraveShared.strings
+++ b/App/l10n/Resources/uk.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Нагороди Brave";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Пошук Brave не відстежує вас, ваші запити або натискання.";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Можливо, пізніше";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "Підтримка незалежного пошуку з кращою конфіденційністю";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "Спробувати пошук Brave";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "Відхилити";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "Додаткові налаштування";
 
@@ -574,6 +589,9 @@
 /* No comment provided by engineer. */
 "Delete" = "Видалити";
 
+/* Message for the alert shown when the user tries to delete a bookmarks folder */
+"DeleteBookmarksFolderAlertMessage" = "Буде видалено всі папки й закладки всередині. Ви впевнені, що хочете продовжити?";
+
 /* Title for the alert shown when the user tries to delete a bookmarks folder */
 "DeleteBookmarksFolderAlertTitle" = "Видалити папку?";
 
@@ -966,6 +984,18 @@
 
 /* New Tab title */
 "NewTab" = "Нова вкладка";
+
+/* It refers to a night mode, to a type of mode a user can change referring to website appearance. */
+"nightMode.modeTitle" = "Режим";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.sectionDescription" = "Нічний режим вплине на зовнішній вигляд вебсайту, а також на загальний вигляд системи.";
+
+/* A table cell subtitle for Night Mode - explanatory element for the toggle preference */
+"nightMode.settingsDescription" = "Увімкнути/вимкнути нічний режим";
+
+/* A table cell title for Night Mode - defining element for the toggle */
+"nightMode.settingsTitle" = "Нічний режим";
 
 /* For search suggestions prompt. This string should be short so it fits nicely on the prompt row. */
 "No" = "Ні";
@@ -1540,6 +1570,9 @@
 /* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
 "playlistFolders.selectAFolderTitle" = "Виберіть папку, щоб перемістити ці об’єкти (%lld)";
 
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Виберіть папку, в яку перемістити 1 елемент";
+
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "Об’єкти: %lld";
 
@@ -1779,6 +1812,9 @@
 
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Brave reader mode from another app. */
 "ReaderModePageCantShowDisplayText" = "Неможливо відобразити сторінку в режимі читання.";
+
+/* Title of a bar that show up when you enter reader mode. */
+"readerModeSettingsButton" = "Режим читання";
 
 /* Accessibility label for button decreasing font size in display settings of reader mode */
 "ReaderModeSmallerFontButtonAccessibilityLabel" = "Зменшити розмір шрифту";
@@ -2329,6 +2365,9 @@
 /* Section header for search suggestions option */
 "SearchSuggestionsSectionHeader" = "Пошукові підказки";
 
+/* Title of an action that allows user to perform a one-click web search for selected text */
+"SearchWithBrave" = "Пошук у Brave";
+
 /* Settings security section title */
 "Security" = "Безпека";
 
@@ -2446,11 +2485,17 @@
 /* shields overview footer message */
 "ShieldsOverviewFooter" = "Примітка. Деякі сайти потребують скриптів для нормальної роботи. Цей екран вимкнено за замовчуванням.";
 
+/* Time Saved Days */
+"ShieldsTimeStatsDays" = "дн.";
+
 /* Time Saved Hours */
 "ShieldsTimeStatsHour" = "год.";
 
 /* Time Saved Minutes */
 "ShieldsTimeStatsMinutes" = "хв.";
+
+/* Time Saved Seconds */
+"ShieldsTimeStatsSeconds" = "с";
 
 /* Quick Action for 3D-Touch on the Application Icon */
 "ShortcutItemTitleNewPrivateTab" = "Нова приватна вкладка";
@@ -3125,7 +3170,7 @@
 "vpn.contactFormCarrier" = "Оператор стільникового зв’язку";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "Не редагуйте наведену нижче інформацію";
+"vpn.contactFormDoNotEditText" = "Brave не відстежує вас і не знає, як ви користуєтеся додатком, тож ми не знаємо ваших налаштувань VPN. Розкажіть, із якою проблемою ви зіткнулися, і ми постараємося якнайшвидше зробити все можливе, щоб її вирішити.";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "Неможливо надіслати лист на електронну пошту. Будь ласка, перевірте налаштування електронної пошти.";
@@ -3172,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "Тип підписки";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "Часовий пояс iOS";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/uk.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/uk.lproj/BraveWallet.strings
@@ -67,6 +67,9 @@
 /* The title of the view shown over a dapps website that requests the user add / approve a new token. */
 "wallet.addSuggestedTokenTitle" = "Додати запропонований токен";
 
+/* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
+"wallet.advancedSettingsTransaction" = "Розширені налаштування";
+
 /* A title displayed above two numbers (the amount and gas) showing the user the breakdown of the amount transferred and gas fee. The \"+\" is a literal plus as the label below will show such as \"0.004 ETH + 0.00064 ETH\" */
 "wallet.amountAndGas" = "Сума + газ";
 
@@ -328,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "Точність у знаках після коми";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "Попередження: знімок екрана з вашим повідомленням може бути збережено у файловому сховищі, його зможе прочитати будь-який додаток із доступом до фотографій. Brave рекомендує не зберігати цей знімок екрана та якомога швидше його видалити.";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "Дозволити";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "Показати";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "Децентралізований додаток запитує доступ на читання цього повідомлення, щоб завершити ваш запит";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "Запит на розшифровку";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "Рахунок %lld";
 
@@ -348,6 +366,15 @@
 
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Редагувати газ";
+
+/* The footer title for edit nonce section in advanced settings screen. */
+"wallet.editNonceFooter" = "Транзакцію неможливо поширювати в мережі, якщо спеціальне значення нонс не є послідовним або містить інші помилки";
+
+/* The header title for edit nonce section in advanced settings screen. */
+"wallet.editNonceHeader" = "Нонс";
+
+/* The placeholder for custom nonce textfield. */
+"wallet.editNoncePlaceholder" = "Уведіть спеціальне значення нонс";
 
 /* The header text shown above the rows to selected the allowance for an ERC 20 Approve transaction. The '%@' becomes the name of the account approving the transaction. For example: \"Spend limit permission allows Account 1 to withdraw and spend up to the following amount:\" */
 "wallet.editPermissionsAllowanceHeader" = "Дозвіл на витрати дає можливість стягувати %@ й витрачати таку суму:";
@@ -371,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "Підключити";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "Від’єднатися";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "Перейти";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -378,6 +408,18 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "рахунок";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "Підключено %1$lld %2$@";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "Підключення";
+
+/* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
+"wallet.editTransactionError" = "Перевірте введені дані та повторіть спробу.";
+
+/* The transaction edit error alert button which will dismiss the alert. */
+"wallet.editTransactionErrorCTA" = "Назад";
 
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Редагувати видимі активи";
@@ -435,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "Оптимальна";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "Надати";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "хоче отримати відкритий ключ шифрування вашого гаманця. За згодою надати цей ключ вебсайт зможе складати вам зашифровані повідомлення.";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DApp запитує ваш відкритий ключ шифрування";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "Запит на відкритий ключ шифрування";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "Приховати закритий ключ";
@@ -733,6 +787,15 @@
 /* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
 "wallet.settingsResetTransactionAlertButtonTitle" = "Скинути";
 
+/* The message the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertMessage" = "Це налаштування зазвичай використовується розробниками під час запуску локального тесту сервера";
+
+/* The title the confirmation dialog when resetting transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
+"wallet.settingsResetTransactionAlertTitle" = "Ви дійсно хочете скинути транзакцію та інформацію про нонс?";
+
+/* The footer message below the button to reset transaction */
+"wallet.settingsResetTransactionFooter" = "Очищення транзакцій може бути корисним для розробників або під час очищення стану на локальному сервері";
+
 /* The title of a button that will reset transaction and nonce information. As in to erase the users transaction history and reset nonce value starting from 0x0 */
 "wallet.settingsResetTransactionTitle" = "Видалити інформацію про транзакції та нонс";
 
@@ -801,6 +864,9 @@
 
 /* The title below account picker when user has selected a test network to swap cryptos */
 "wallet.swapCryptoUnsupportNetworkTitle" = "Непідтримуваний блокчейн.";
+
+/* The description of a swap button on the buy/send/swap modal */
+"wallet.swapDescription" = "Обмін токенів і активів.";
 
 /* A longer disclaimer about the DEX aggrigator used by Brave for swap transactions. '0x' is a company name. 'DEX aggregator' is a type of blockchain-based service (decentralized exchange). 'ONLY' is emphasized to show importance of 0x's data usage. */
 "wallet.swapDexAggrigatorDisclaimer" = "0x опрацьовує адресу Ethereum і IP-адресу для транзакції (зокрема, отримання цін). 0x використовуватиме ці дані ЛИШЕ для проведення транзакцій.";
@@ -898,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "Підтверджено";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "Скинуто";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "Помилка";
 
@@ -961,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "Гаманець";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "Відкрити гаманець на весь екран";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "Підключити";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "Підключено…";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "Використовуйте цю панель для безпечного доступу до web3 і всіх ваших криптовалютних активів.";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "Розблокувати гаманець";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "Немає";

--- a/App/l10n/Resources/uk.lproj/Localizable.strings
+++ b/App/l10n/Resources/uk.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "Нова вкладка";
 
-/* No comment provided by engineer. */
-"No server found" = "Сервер не знайдено";
-
 /* OK button */
 "OKString" = "ОК";
 
@@ -192,6 +189,9 @@
 
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "ShowPreviousTabTitle" = "Показати попередню вкладку";
+
+/* Label to display in the Discoverability overlay for keyboard shortcuts which is for Showing Brave Shields */
+"showShieldsTitle" = "Відкрити Brave Shields";
 
 /* Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down. */
 "ShowTabTrayFromTabKeyCodeTitle" = "Показати всі вкладки";

--- a/App/l10n/Resources/zh-TW.lproj/BraveShared.strings
+++ b/App/l10n/Resources/zh-TW.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave Rewards";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave 搜尋不會追蹤您、您的查詢內容或點擊項目。";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "稍後再說";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "支援獨立搜尋並提供更棒的隱私保護";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "試用 Brave 搜尋";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "關閉";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "進階控制項";
 
@@ -3155,7 +3170,7 @@
 "vpn.contactFormCarrier" = "行動通訊業者";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "請勿編輯下方任何資訊";
+"vpn.contactFormDoNotEditText" = "Brave 不會追蹤您，也不會知道您使用應用程式的情形，因此不會得知您的 VPN 設定方式。請與我們分享所發生問題的相關資訊，我們會在最短時間內盡力解決問題。";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "無法傳送電子郵件。請檢查電子郵件設定。";
@@ -3202,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "訂閱類型";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "iOS 時區";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/zh-TW.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/zh-TW.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "小數位數";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "警告：訊息的螢幕截圖可能會備份到雲端檔案服務，任何擁有相片存取權限的應用程式都能讀取。Brave 建議您不要儲存此螢幕截圖，並儘快刪除。";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "允許";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "顯示";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "此 DApp 想讀取此訊息，以完成您的要求";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "解密要求";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "帳戶 %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "連線";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "取消連結";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "切換";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "帳戶";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "已連結 %1$lld 個%2$@";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "連結";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "請檢查輸入內容並再試一次";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "最佳";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "提供";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "要求取得您錢包的公共加密金鑰。如果您同意提供此金鑰，網站就能編寫加密訊息給您。";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DApp 要求取得您的公共加密金鑰";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "公共加密金鑰要求";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "隱藏私密金鑰";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "已確認";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "放棄";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "錯誤";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "錢包";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "以全螢幕開啟錢包";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "連線";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "已連結…";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "此面板可供您安全存取 web3 和所有加密貨幣資產。";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "錢包解鎖";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "無";

--- a/App/l10n/Resources/zh-TW.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/zh-TW.lproj/BraveWallet.strings
@@ -965,7 +965,7 @@
 "wallet.transactionStatusConfirmed" = "已確認";
 
 /* A status that explains that the transaction has been dropped due to some error */
-"wallet.transactionStatusDropped" = "放棄";
+"wallet.transactionStatusDropped" = "取消";
 
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "錯誤";

--- a/App/l10n/Resources/zh-TW.lproj/Localizable.strings
+++ b/App/l10n/Resources/zh-TW.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "新分頁";
 
-/* No comment provided by engineer. */
-"No server found" = "找不到任何伺服器";
-
 /* OK button */
 "OKString" = "好";
 

--- a/App/l10n/Resources/zh.lproj/BraveShared.strings
+++ b/App/l10n/Resources/zh.lproj/BraveShared.strings
@@ -175,6 +175,21 @@
 /* Brave Rewards settings title */
 "BraveRewardsTitle" = "Brave 奖励";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave 搜索不会跟踪您、您查询和点击的内容。";
+
+/* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
+"braveSearchPromotion.bannerMaybeLaterButtonTitle" = "稍後再說";
+
+/* Brave Search Banner Promotion title in Search Suggestions */
+"braveSearchPromotion.bannerTitle" = "支持独立的搜索，具有更好的隐私性";
+
+/* Brave Search Banner Promotion title for try button in Search Suggestions */
+"braveSearchPromotion.bannerTryButtonTitle" = "尝试使用 Brave 搜索";
+
+/* Brave Search Banner Promotion title for dismiss button to remove promotion in Search Suggestions */
+"braveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle" = "關閉";
+
 /* No comment provided by engineer. */
 "BraveShieldsAdvancedControls" = "进阶控件";
 
@@ -3155,7 +3170,7 @@
 "vpn.contactFormCarrier" = "蜂窝网络提供商";
 
 /* Text to tell user to not modify support info below email's body. */
-"vpn.contactFormDoNotEditText" = "请勿修改以下信息";
+"vpn.contactFormDoNotEditText" = "Brave 不会跟踪您，也不知道您如何使用我们的应用程序，所以我们无法得知您如何设置 VPN。请告知您所遇到的问题，我们将尽最大努力尽快解决这些问题。";
 
 /* Button name to send contact form. */
 "vpn.contactFormEmailNotConfiguredBody" = "无法发送电子邮件。请检查您的电子邮箱配置。";
@@ -3202,7 +3217,8 @@
 /* Subscription Type field for customer support contact form. */
 "vpn.contactFormSubscriptionType" = "订阅类型";
 
-/* iOS Timezone field for customer support contact form. */
+/* A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'
+   iOS Timezone field for customer support contact form. */
 "vpn.contactFormTimezone" = "iOS 时区";
 
 /* Title for contact form email. */

--- a/App/l10n/Resources/zh.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/zh.lproj/BraveWallet.strings
@@ -331,6 +331,21 @@
 /* A title that will be displayed on top of the text field for users to input the custom token's decimals of precision */
 "wallet.decimalsPrecision" = "小数位数";
 
+/* The message displayed when the user takes a screenshot of their dapp decrypt request. */
+"wallet.decryptMessageScreenshotDetectedMessage" = "警告：您的消息截图可能会备份到云文件服务，并且可以被任何具有照片访问权限的应用程序读取。Brave 建议您不要保存此屏幕截图，尽快将其删除。";
+
+/* The title of the button to approve a decrypt request from a dapps website. */
+"wallet.decryptRequestApprove" = "允许";
+
+/* The title of the button to show the message of a decrypt request from a dapps website. */
+"wallet.decryptRequestReveal" = "显示";
+
+/* A subtitle of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestSubtitle" = "此 DApp 想讀取此訊息，以完成您的要求";
+
+/* A title of the view shown over a dapps website that requests the user decrypt a message. */
+"wallet.decryptRequestTitle" = "解密请求";
+
 /* The default account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Account 3\") */
 "wallet.defaultAccountName" = "账户 %lld";
 
@@ -383,6 +398,9 @@
 "wallet.editSiteConnectionAccountActionConnect" = "连接";
 
 /* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
+"wallet.editSiteConnectionAccountActionDisconnect" = "断开连接";
+
+/* The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen. */
 "wallet.editSiteConnectionAccountActionSwitch" = "切换";
 
 /* The plural word that will beused in `editSiteConnectionConnectedAccount`. */
@@ -390,6 +408,12 @@
 
 /* The singular word that will be used in `editSiteConnectionConnectedAccount`. */
 "wallet.editSiteConnectionAccountSingular" = "帐户";
+
+/* The amount of current permitted wallet accounts to the dapp site. It is displayed below the origin url of the dapp site in edit site connection screen. '%lld' refers to a number, %@ is `account` for singular and `accounts` for plural (for example \"1 account connected\" or \"2 accounts connected\") */
+"wallet.editSiteConnectionConnectedAccount" = "%1$lld %2$@ 已连接";
+
+/* The navigation title of the screen for users to edit dapps site connection with users' Brave Wallet accounts. */
+"wallet.editSiteConnectionScreenTitle" = "连接";
 
 /* The error alert body when something is wrong when users try to edit transaction gas fee, priority fee, nonce value or allowance value. */
 "wallet.editTransactionError" = "请检查输入内容并再试一次。";
@@ -453,6 +477,18 @@
 
 /* An option for the user to pick when selecting some predefined gas fee limits. The options are Low, Optimal, High and Custom */
 "wallet.gasFeePredefinedLimitOptimal" = "最佳";
+
+/* The title of the button to approve a encryption public key request from a dapps website. */
+"wallet.getEncryptionPublicKeyRequestApprove" = "提供";
+
+/* The text shown beside the URL origin of a get public encryption key request from a dapp site. Ex 'https://brave.com is requesting your wallets public encryption key. If you consent to providing this key, the site will be able to compose encrypted messages to you.' */
+"wallet.getEncryptionPublicKeyRequestMessage" = "正在请求您的钱包的公共加密密钥。如果您同意，本站点就能编写要发送给您的加密消息。";
+
+/* A subtitle of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestSubtitle" = "DApp 正在请求提供你的公共加密密钥";
+
+/* A title of the view shown over a dapps website that requests the users public encryption key. */
+"wallet.getEncryptionPublicKeyRequestTitle" = "公共加密密钥请求";
 
 /* A button title that will redact a private key on the screen */
 "wallet.hidePrivateKeyButtonTitle" = "隐藏隐私密钥";
@@ -928,6 +964,9 @@
 /* A status that explains that the transaction has been completed/confirmed */
 "wallet.transactionStatusConfirmed" = "已确认";
 
+/* A status that explains that the transaction has been dropped due to some error */
+"wallet.transactionStatusDropped" = "放弃";
+
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "错误";
 
@@ -991,8 +1030,20 @@
 /* The title shown on the menu to access Brave Wallet */
 "wallet.wallet" = "钱包";
 
+/* The label read out when a user is using VoiceOver and highlights the two-arrow button on the wallet panel top left corner. */
+"wallet.walletFullScreenAccessibilityTitle" = "全屏打开钱包";
+
 /* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently not connected any his/her wallet account to the dapp. */
 "wallet.walletPanelConnect" = "连接";
+
+/* The title of the button for users to click to go to edit site connection screen. This title indicates the user is currently connected his/her wallet account to the dapp. The title will be displayed to the right of a checkmark. */
+"wallet.walletPanelConnected" = "正在连接……";
+
+/* The description for wallet panel when users haven't set up a wallet yet. */
+"wallet.walletPanelSetupWalletDescription" = "使用此面板安全地访问 web3 及您的所有加密资产。";
+
+/* The title of the button in wallet panel when wallet is locked. Users can click it to open full screen unlock wallet screen. */
+"wallet.walletPanelUnlockWallet" = "解锁钱包";
 
 /* The value shown when selecting the default wallet as none / no wallet in wallet settings. */
 "wallet.walletTypeNone" = "无";

--- a/App/l10n/Resources/zh.lproj/BraveWallet.strings
+++ b/App/l10n/Resources/zh.lproj/BraveWallet.strings
@@ -965,7 +965,7 @@
 "wallet.transactionStatusConfirmed" = "已确认";
 
 /* A status that explains that the transaction has been dropped due to some error */
-"wallet.transactionStatusDropped" = "放弃";
+"wallet.transactionStatusDropped" = "取消";
 
 /* A status that explains that the transaction failed due to some error */
 "wallet.transactionStatusError" = "错误";

--- a/App/l10n/Resources/zh.lproj/Localizable.strings
+++ b/App/l10n/Resources/zh.lproj/Localizable.strings
@@ -103,9 +103,6 @@
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
 "NewTabTitle" = "新标签页";
 
-/* No comment provided by engineer. */
-"No server found" = "找不到服务器";
-
 /* OK button */
 "OKString" = "好";
 

--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -2520,7 +2520,7 @@ extension Strings {
         comment: "iOS Timezone field for customer support contact form.")
       
     public static let contactFormPlatform =
-    NSLocalizedString("vpn.contactFormTimezone", tableName: "BraveShared", bundle: .strings,
+    NSLocalizedString("vpn.contactFormPlatform", tableName: "BraveShared", bundle: .strings,
         value: "Platform",
         comment: "A contact form field that displays platform type: 'iOS' 'Android' or 'Desktop'")
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5529 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that copy in new wallet dapps screens is translated.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
