### PR TITLE
Fix #5569: Duplicate Wallet notification enqueued when wallet notification visible

### DIFF
--- a/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
+++ b/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
@@ -60,6 +60,9 @@ class BraveNotificationsPresenter: UIViewController {
         enqueueNotification(notification)
         return
       } else {
+        if let timer = dismissTimers[visibleNotification.id] {
+          timer.invalidate()
+        }
         // will hide the current visible notification and display the incoming notification
         // if the notification has higher priority
         self.hide(visibleNotification)
@@ -75,6 +78,7 @@ class BraveNotificationsPresenter: UIViewController {
     }
     
     let notificationView = notification.view
+    view.subviews.forEach { $0.removeFromSuperview() }
     view.addSubview(notificationView)
     notificationView.snp.makeConstraints {
       $0.leading.greaterThanOrEqualTo(view).inset(8)

--- a/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
+++ b/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
@@ -168,7 +168,7 @@ class BraveNotificationsPresenter: UIViewController {
   private func enqueueNotification(_ notification: BraveNotification) {
     // We will skip duplication checking for notifications that have empty id. These notifications are usually custom ads
     if !notification.id.isEmpty,
-       notificationsQueue.contains(where: { $0.id == notification.id }) {
+       notificationsQueue.contains(where: { $0.id == notification.id }) || visibleNotification?.id == notification.id {
       return
     }
     


### PR DESCRIPTION
## Summary of Changes
- When we receive two requests that both cause us to show a Wallet notification, we send 2 notifications to our `BraveNotificationsPresenter`. In this class, before enqueuing the second notification we check if we already have one with the same id in the queue. However we missed checking if the same notification was already visible (not in queue because it's visible). This caused the issue where if you tap the first notification, we present the wallet and show the next notification (which meant the second notification appeared over the wallet).
- Additionally we have a hopeful fix for #5573 which could cause a wallet notification to layer on top of a Rewards already on screen due to a timing issue. This issue is very hard to reproduce.

This pull request fixes #5569

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Remove any site connections for `app.1inch.io` in Wallet Settings -> Manage Site Connections
2. Visit `app.1inch.io`
3. Tap 'Connect wallet'
4. Agree to terms, click 'Metamask' in choose wallet section
5. Tap wallet notification
6. Observe second wallet notification no longer shown over the main wallet UI


## Screenshots:

https://user-images.githubusercontent.com/5314553/175567710-2c03d228-a51d-44de-8cd3-e50e34a06e71.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
