### PR TITLE
Fix #5586: Account address on Sign, Encryption requests

### DIFF
--- a/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -80,9 +80,16 @@ struct EncryptionView: View {
         VStack(spacing: 8) {
           Blockie(address: request.address)
             .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-          Text(account.name)
-            .font(.subheadline.weight(.semibold))
-            .foregroundColor(Color(.secondaryBraveLabel))
+          AddressView(address: account.address) {
+            VStack(spacing: 4) {
+              Text(account.name)
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(Color(.braveLabel))
+              Text(account.address.truncatedAddress)
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(Color(.secondaryBraveLabel))
+            }
+          }
           Text(urlOrigin: request.originInfo.origin)
             .font(.caption)
             .foregroundColor(Color(.braveLabel))

--- a/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -62,9 +62,16 @@ struct SignatureRequestView: View {
           VStack(spacing: 8) {
             Blockie(address: account.address)
               .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-            Text(account.name)
-              .font(.subheadline.weight(.semibold))
-              .foregroundColor(Color(.secondaryBraveLabel))
+            AddressView(address: account.address) {
+              VStack(spacing: 4) {
+                Text(account.name)
+                  .font(.subheadline.weight(.semibold))
+                  .foregroundColor(Color(.braveLabel))
+                Text(account.address.truncatedAddress)
+                  .font(.subheadline.weight(.semibold))
+                  .foregroundColor(Color(.secondaryBraveLabel))
+              }
+            }
             Text(urlOrigin: currentRequest.originInfo.origin)
               .font(.caption)
               .foregroundColor(Color(.braveLabel))


### PR DESCRIPTION
## Summary of Changes
- Added truncated address below the account name on each of the 3 views (Get Public Encryption Key request / Decrypt request share the same view)

This pull request fixes #5586

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
  1. Visit https://metamask.github.io/test-dapp/
  2. Tap 'Get encryption key'
  3. Observe account address shown below account name. Tap and hold to see context menu with full address.
  4. Click 'Provide'
  5. Enter a message in text box below 'Get encryption key' button
  6. Tap 'Encrypt', tap 'Decrypt'
  7. Observe account address shown below account name. Tap and hold to see context menu with full address.
  8. Reject/approve request
  9. Tap 'Sign' under `Eth Sign` or `Personal Sign`
  10. Observe account address shown below account name. Tap and hold to see context menu with full address.


## Screenshots:
![get encryption public key](https://user-images.githubusercontent.com/5314553/175648177-cfbe68a0-2b66-46e7-aec2-a058c8fe6cac.png) | ![get encryption public key - address](https://user-images.githubusercontent.com/5314553/175648184-598a788c-f998-4875-a6dd-7c8af50e8d52.png)
--|--

![decrypt](https://user-images.githubusercontent.com/5314553/175648227-69a361dd-8cf5-41a6-b6b6-3ccc73a6f31b.png) | ![decrypt - address](https://user-images.githubusercontent.com/5314553/175648232-5a5402fe-6a75-4048-ad82-fd8f3f138efb.png)
--|--

![sign message](https://user-images.githubusercontent.com/5314553/175648250-165c38d2-12c2-485e-af8d-eb8824d7c697.png) | ![sign message - address](https://user-images.githubusercontent.com/5314553/175648258-9ab50708-a156-42f5-9303-88ab2758e829.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
