### PR TITLE
Fix #5579: Capture Tab Weakly to prevent memory leak

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2687,7 +2687,9 @@ extension BrowserViewController: TabManagerDelegate {
       let duplicateActiveTab = UIAction(
         title: Strings.duplicateActiveTab,
         image: UIImage(systemName: "plus.square.on.square"),
-        handler: UIAction.deferredActionHandler { _ in
+        handler: UIAction.deferredActionHandler { [weak selectedTab] _ in
+          guard let selectedTab = selectedTab else { return }
+          
           tabManager.addTabAndSelect(
                URLRequest(url: url),
                afterTab: selectedTab,


### PR DESCRIPTION
## Summary of Changes
- Capture tab `weak` when duplicating tabs, so they do not leak and keep running even when they're not actually visible (supposed to be closed).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5579

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
