### PR TITLE
Fix #5590: Crash with search suggestion with Brave Search promo active.

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -543,13 +543,12 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
       } else {
         cell = tableView.dequeueReusableCell(withIdentifier: SuggestionCell.identifier, for: indexPath)
 
-        if let suggestionCell = cell as? SuggestionCell {
-          suggestionCell.setTitle(dataSource.suggestions[indexPath.row])
+        if let suggestionCell = cell as? SuggestionCell, let suggestion = dataSource.suggestions[safe: indexPath.row] {
+          suggestionCell.setTitle(suggestion)
           suggestionCell.separatorInset = UIEdgeInsets(top: 0.0, left: view.bounds.width, bottom: 0.0, right: -view.bounds.width)
           suggestionCell.openButtonActionHandler = { [weak self] in
             guard let self = self else { return }
 
-            let suggestion = self.dataSource.suggestions[indexPath.row]
             self.searchDelegate?.searchViewController(self, didLongPressSuggestion: suggestion)
           }
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Might not be a root cause fix and it may drop last search suggestion. Did not investigate it too deeply, just fixing the out of bounds crash.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5590 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
