### PR TITLE
Fix #5588: Add padding to Brave Search promo cell on iOS 14.

### DIFF
--- a/Client/Frontend/Browser/Search/BraveSearchPromotionCell.swift
+++ b/Client/Frontend/Browser/Search/BraveSearchPromotionCell.swift
@@ -108,8 +108,15 @@ class BraveSearchPromotionCell: UITableViewCell {
     promotionContentView.snp.makeConstraints {
       $0.leading.equalTo(safeArea.leading).inset(8)
       $0.trailing.equalTo(safeArea.trailing).inset(8)
-      $0.top.equalTo(safeArea.top)
-      $0.bottom.equalTo(safeArea.bottom)
+      
+      if #available(iOS 15, *) {
+        $0.top.equalTo(safeArea.top)
+        $0.bottom.equalTo(safeArea.bottom)
+      } else {
+        // iOS 14 table headers look different, solid color, adding small inset to make it look better.
+        $0.top.equalTo(safeArea.top).inset(8)
+        $0.bottom.equalTo(safeArea.bottom).inset(8)
+      }
     }
     
     [tryButton, dismissButton].forEach(buttonsStackView.addArrangedSubview(_:))


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5588 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="337" alt="Zrzut ekranu 2022-06-27 o 16 13 16" src="https://user-images.githubusercontent.com/6950387/175964563-fb204426-3696-483c-9e68-f27049e01e21.png">



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
