### PR TITLE
Fix #5594: Reset Ethereum dapp permissions when restoring wallet

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -11,6 +11,7 @@ import Security
 import Strings
 import LocalAuthentication
 import Combine
+import Data
 
 struct AutoLockInterval: Identifiable, Hashable {
   var value: Int32
@@ -210,6 +211,7 @@ public class KeyringStore: ObservableObject {
         self.updateKeyringInfo()
         self.resetKeychainStoredPassword()
       }
+      Domain.clearAllEthereumPermissions()
       completion?(isMnemonicValid)
     }
   }

--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -202,6 +202,7 @@ private struct SiteConnectionDetailView: View {
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
+    .listStyle(.insetGrouped)
     .navigationTitle(siteConnection.url)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {


### PR DESCRIPTION
## Summary of Changes
- When restoring the wallet without first resetting the wallet (available on wallet unlock screen), the ethereum dapp permissions were not being reset like they are when a wallet is reset.
- Additionally fixed the List style on iOS 14 in the Manage Site Connections detail view.

This pull request fixes #5594

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

1. Connect your wallet to at least 1 dapp site
2. Verify site appears in Manage Site Connections list in Wallet Settings
3. Lock the wallet manually
4. On unlock screen, tap restore and restore your wallet
5. Open wallet settings and verify that the Manage Site Connections


## Screenshots:
Restore wallet:

https://user-images.githubusercontent.com/5314553/175962808-33df3290-dcfc-47d6-9562-0bdbe7c4cb72.mp4

Manage site connections detail view on iOS 14:

<img width="522" alt="manage site connections detail view" src="https://user-images.githubusercontent.com/5314553/175963241-35b50f2c-573a-42a4-a9d3-1c1b974c7b91.png">

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
