### PR TITLE
Fix #5601: Disabled ability to tap on Sync-Types

### DIFF
--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -194,13 +194,19 @@ extension SyncSettingsTableViewController {
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     defer { tableView.deselectRow(at: indexPath, animated: true) }
+    
+    guard let section = Sections(rawValue: indexPath.section) else {
+      return
+    }
 
-    if indexPath.section == Sections.deviceActions.rawValue {
+    if section == .deviceActions {
       addAnotherDevice()
       return
     }
 
-    guard !devices.isEmpty, let device = devices[safe: indexPath.row] else {
+    guard section == .deviceList,
+          !devices.isEmpty,
+          let device = devices[safe: indexPath.row] else {
       return
     }
 


### PR DESCRIPTION
## Summary of Changes
- Disabled ability to tap on the sync type cells as they have switches already and the cell itself shouldn't be tappable.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5601

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
