### PR TITLE
Fix #5604: Custom networks list not empty after reset wallet

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -13,7 +13,6 @@ import Strings
 struct AccountsView: View {
   var cryptoStore: CryptoStore
   @ObservedObject var keyringStore: KeyringStore
-  @State private var navigationController: UINavigationController?
   @State private var selectedAccount: BraveWallet.AccountInfo?
 
   private var primaryAccounts: [BraveWallet.AccountInfo] {
@@ -101,16 +100,6 @@ struct AccountsView: View {
         })
     )
     .listStyle(InsetGroupedListStyle())
-    .osAvailabilityModifiers { content in
-      if #available(iOS 15.0, *) {
-        content
-      } else {
-        content
-          .introspectNavigationController { nc in
-            navigationController = nc
-          }
-      }
-    }
   }
 }
 

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -308,6 +308,7 @@ public class KeyringStore: ObservableObject {
 extension KeyringStore: BraveWalletKeyringServiceObserver {
   public func keyringReset() {
     isOnboardingVisible = true
+    updateKeyringInfo()
   }
 
   public func autoLockMinutesChanged() {


### PR DESCRIPTION
## Summary of Changes
- 2 separate issues resolved in this PR: 
    1. iOS 14 memory leak. Opening the 'Accounts' tab on iOS 14 in the main wallet would cause `WalletStore` (+ `CryptoStore`, `NetworkStore`, etc.) to be leaked / not released from memory. This caused us to not update the custom networks list because `NetworkStore` was not released and we only refresh the list at initialization. 
    2. All iOS versions bug: `KeyringStore`s keyring was not updated after the wallet was reset, so `WalletStore` never reset it's `CryptoStore` reference to nil. Similar to above, this meant `NetworkStore` was not released which caused us to not update the custom networks list.

This pull request fixes #5604

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
iOS 14 memory leak:
1. Open main wallet
2. Tap 'Accounts'
3. Close wallet
4. Add custom network
5. Navigate to wallet settings
6. Tap 'Reset Wallet'
7. Open main wallet
8. Re-open main wallet
9. Setup wallet
10. Navigate to wallet settings
11. Verify the custom network is removed

All versions bug:
1. Add custom network
2. Open main wallet
4. Navigate to wallet settings
5. Verify custom network exists in custom networks list
6. Tap 'Reset Wallet'
7. **Do not dismiss/close wallet**
8. Tap 'Get Started' / Restore and setup wallet
9. Navigate to wallet settings
10. Verify custom network is removed


## Screenshots:

iOS 14 leak fixed:

https://user-images.githubusercontent.com/5314553/176206578-e42ffb46-39bc-4068-ba9f-960b2f8f9c16.mp4

All versions bug fixed:

https://user-images.githubusercontent.com/5314553/176206790-c0ec84e9-1c1d-42b5-9092-1b20b8692a7e.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
