### PR TITLE
Fix #5612: Wrong full address in context menu

### DIFF
--- a/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -22,7 +22,7 @@ struct AccountListView: View {
           header: WalletListHeaderView(title: Text(Strings.Wallet.accountsPageTitle))
         ) {
           ForEach(keyringStore.keyring.accountInfos) { account in
-            AddressView(address: keyringStore.selectedAccount.address) {
+            AddressView(address: account.address) {
               Button(action: {
                 keyringStore.selectedAccount = account
                 onDismiss()


### PR DESCRIPTION

This pull request fixes #5612 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
Please refer to the issue.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
