### PR TITLE
Fix #5508, Fix #5615: Tab Screenshots Blank Regression and YouTube page restore

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -511,7 +511,7 @@ class TabManager: NSObject {
         guard let self = self, let tab = tab else { return }
         tab.webStateDebounceTimer?.invalidate()
         
-        if state == .complete || state == .loaded || state == .pushstate || state == .popstate {
+        if state == .complete || state == .loaded || state == .pushstate || state == .popstate || state == .replacestate {
           // Saving Tab Private Mode - not supported yet.
           if !tab.isPrivate {
             self.preserveScreenshots()

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -505,12 +505,13 @@ class TabManager: NSObject {
     // This fixes pages that have dynamic URL via changing history
     // as well as regular pages that load DOM normally.
     tab.onPageReadyStateChanged = { [weak tab] state in
-      tab?.webStateDebounceTimer?.invalidate()
-      tab?.webStateDebounceTimer? = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self, weak tab] _ in
-        tab?.webStateDebounceTimer?.invalidate()
+      guard let tab = tab else { return }
+      tab.webStateDebounceTimer?.invalidate()
+      tab.webStateDebounceTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self, weak tab] _ in
+        guard let self = self, let tab = tab else { return }
+        tab.webStateDebounceTimer?.invalidate()
         
-        if let self = self, let tab = tab,
-            state == .complete || state == .loaded || state == .pushstate || state == .popstate {
+        if state == .complete || state == .loaded || state == .pushstate || state == .popstate {
           // Saving Tab Private Mode - not supported yet.
           if !tab.isPrivate {
             self.preserveScreenshots()


### PR DESCRIPTION
## Summary of Changes
- Due to a fix with a memory leak in tabs previously, that fix broke Tab screenshots again.
- This fix keeps the memory leak fix + fixes the screenshots again by properly debouncing the requests (holding a reference to the tab for the duration of the method).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5508
This pull request fixes #5615

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
