### PR TITLE
Fix #5596: Fix removing last connected address on iOS 14

### DIFF
--- a/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -196,6 +196,11 @@ private struct SiteConnectionDetailView: View {
           withAnimation(.default) {
             if let url = URL(string: siteConnection.url) {
               siteConnectionStore.removePermissions(from: addressesToRemove, url: url)
+              if #available(iOS 15, *) {
+                // iOS 15 will dismiss itself (and will use `.swipeActions` instead of `.onDelete`)
+              } else if siteConnection.connectedAddresses.count == addressesToRemove.count {
+                presentationMode.dismiss()
+              }
             }
           }
         }
@@ -224,6 +229,10 @@ private struct SiteConnectionDetailView: View {
           Text(Strings.Wallet.manageSiteConnectionsConfirmAlertRemove),
           action: {
             siteConnectionStore.removeAllPermissions(from: [siteConnection])
+            if #available(iOS 15, *) { // iOS 15 will dismiss itself
+            } else {
+              presentationMode.dismiss()
+            }
           }
         ),
         secondaryButton: Alert.Button.cancel(Text(Strings.CancelString))


### PR DESCRIPTION
## Summary of Changes
- On iOS 14, when the model used in a `NavigationLink` within a `List` is removed, the detail view does not pop off the stack automatically, and because the model no longer exists the detail view doesn't update to show the final connected address as removed. We can programatically pop the detail view off the stack when the last

This pull request fixes #5596

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
  1. Create wallet and add 3 accounts
  2. Connect all 3 accounts to a Dapp
  3. Go to Settings -> Wallet -> Manage connected site  and click on `Remove all` button at the bottom right corner
  4. UI correctly removes all connected addresses and closes the detail view for that site

## Screenshots:

https://user-images.githubusercontent.com/5314553/176253254-38f277a4-e9e5-4489-91e8-f7d286fb2055.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
