### PR TITLE
Fix #5597, #5580: Wallet notification updates

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -314,6 +314,35 @@ public class CryptoStore: ObservableObject {
     }
     pendingRequest = nil
   }
+  
+  public func rejectAllPendingWebpageRequests() {
+    Task { @MainActor in
+      let pendingAddChainRequests = await rpcService.pendingAddChainRequests()
+      pendingAddChainRequests.forEach {
+        handleWebpageRequestResponse(.addNetwork(approved: false, chainId: $0.networkInfo.chainId))
+      }
+      let pendingSignMessageRequests = await walletService.pendingSignMessageRequests()
+      pendingSignMessageRequests.forEach {
+        handleWebpageRequestResponse(.signMessage(approved: false, id: $0.id))
+      }
+      let pendingSwitchChainRequests = await rpcService.pendingSwitchChainRequests()
+      pendingSwitchChainRequests.forEach {
+        handleWebpageRequestResponse(.switchChain(approved: false, originInfo: $0.originInfo))
+      }
+      let pendingAddSuggestedTokenRequets = await walletService.pendingAddSuggestTokenRequests()
+      pendingAddSuggestedTokenRequets.forEach {
+        handleWebpageRequestResponse(.addSuggestedToken(approved: false, contractAddresses: [$0.token.contractAddress]))
+      }
+      let pendingGetEncryptionPublicKeyRequests = await walletService.pendingGetEncryptionPublicKeyRequests()
+      pendingGetEncryptionPublicKeyRequests.forEach {
+        handleWebpageRequestResponse(.getEncryptionPublicKey(approved: false, originInfo: $0.originInfo))
+      }
+      let pendingDecryptRequests = await walletService.pendingDecryptRequests()
+      pendingDecryptRequests.forEach {
+        handleWebpageRequestResponse(.decrypt(approved: false, originInfo: $0.originInfo))
+      }
+    }
+  }
 }
 
 extension CryptoStore: BraveWalletTxServiceObserver {

--- a/BraveWallet/WalletProviderPermissionRequestsManager.swift
+++ b/BraveWallet/WalletProviderPermissionRequestsManager.swift
@@ -79,4 +79,9 @@ public class WalletProviderPermissionRequestsManager {
   public func cancelRequest(_ request: WebpagePermissionRequest) {
     requests.removeAll(where: { $0 == request })
   }
+  
+  /// Cancels all an in-flight requests without executing any decision
+  public func cancelAllPendingRequests() {
+    requests.removeAll()
+  }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2031,6 +2031,13 @@ extension Strings {
       value: "This page wants to interact with Brave Wallet",
       comment: "The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet."
     )
+    public static let dappsConnectionNotificationOriginTitle = NSLocalizedString(
+      "wallet.dappsConnectionNotificationOriginTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "%@ wants to interact with Brave Wallet",
+      comment: "The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\""
+    )
     public static let editPermissionsTitle = NSLocalizedString(
       "wallet.editPermissionsTitle",
       tableName: "BraveWallet",

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
@@ -11,6 +11,8 @@ import BraveCore
 import Combine
 
 class WalletConnectionView: UIControl {
+  private let scrollView = UIScrollView()
+
   private let stackView: UIStackView = {
     let result = UIStackView()
     result.axis = .horizontal
@@ -63,15 +65,30 @@ class WalletConnectionView: UIControl {
   }
   
   private func setup() {
-    addSubview(stackView)
+    addSubview(scrollView)
+    scrollView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    scrollView.addSubview(stackView)
     stackView.snp.makeConstraints {
       $0.edges.equalToSuperview().inset(24)
     }
     stackView.addArrangedSubview(iconImageView)
     stackView.addArrangedSubview(titleLabel)
     
+    scrollView.contentLayoutGuide.snp.makeConstraints {
+      $0.width.equalTo(self)
+      $0.top.bottom.equalTo(stackView).inset(24)
+    }
+    
     iconImageView.snp.makeConstraints {
       $0.width.height.equalTo(20)
+    }
+    
+    snp.makeConstraints {
+      $0.height.equalTo(stackView).inset(-24).priority(.low)
+      $0.height.lessThanOrEqualTo(UIScreen.main.bounds.height / 2)
     }
 
     layer.backgroundColor = UIColor.braveBlurpleTint.cgColor

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletConnectionView.swift
@@ -17,6 +17,7 @@ class WalletConnectionView: UIControl {
     result.spacing = 20
     result.alignment = .center
     result.isUserInteractionEnabled = false
+    result.setContentCompressionResistancePriority(.required, for: .vertical)
     return result
   }()
 
@@ -26,6 +27,7 @@ class WalletConnectionView: UIControl {
     result.contentMode = .scaleAspectFit
     result.setContentHuggingPriority(.required, for: .horizontal)
     result.setContentCompressionResistancePriority(.required, for: .horizontal)
+    result.setContentCompressionResistancePriority(.required, for: .vertical)
     return result
   }()
 
@@ -39,7 +41,7 @@ class WalletConnectionView: UIControl {
     result.setContentCompressionResistancePriority(.required, for: .horizontal)
     result.setContentCompressionResistancePriority(.required, for: .vertical)
     if #available(iOS 15, *) {
-      result.adjustsFontSizeToFitWidth = true
+      result.adjustsFontForContentSizeCategory = true
       result.maximumContentSizeCategory = .accessibilityMedium
     }
     return result

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
@@ -24,7 +24,6 @@ class WalletNotification: BraveNotification {
   var priority: BraveNotificationPriority
   var view: UIView
   var id: String { WalletNotification.Constant.id }
-  var origin: URLOrigin
   var dismissAction: (() -> Void)?
   
   private let handler: (Action) -> Void
@@ -39,7 +38,6 @@ class WalletNotification: BraveNotification {
     handler: @escaping (Action) -> Void
   ) {
     self.priority = priority
-    self.origin = origin
     self.view = WalletConnectionView(origin: origin)
     self.handler = handler
     self.setup()

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import BraveCore
 import UIKit
 
 class WalletNotification: BraveNotification {
@@ -23,6 +24,7 @@ class WalletNotification: BraveNotification {
   var priority: BraveNotificationPriority
   var view: UIView
   var id: String { WalletNotification.Constant.id }
+  var origin: URLOrigin
   var dismissAction: (() -> Void)?
   
   private let handler: (Action) -> Void
@@ -33,10 +35,12 @@ class WalletNotification: BraveNotification {
   
   init(
     priority: BraveNotificationPriority,
+    origin: URLOrigin,
     handler: @escaping (Action) -> Void
   ) {
     self.priority = priority
-    self.view = WalletConnectionView()
+    self.origin = origin
+    self.view = WalletConnectionView(origin: origin)
     self.handler = handler
     self.setup()
   }

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
@@ -47,7 +47,8 @@ class WalletNotification: BraveNotification {
   
   private func setup() {
     guard let walletPanel = view as? WalletConnectionView else { return }
-    walletPanel.addTarget(self, action: #selector(tappedWalletConnectionView(_:)), for: .touchUpInside)
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tappedWalletConnectionView(_:)))
+    walletPanel.addGestureRecognizer(tapGesture)
   }
   
   @objc private func tappedWalletConnectionView(_ sender: WalletConnectionView) {

--- a/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
+++ b/Client/Frontend/Brave Notifications/Brave Wallet/WalletNotification.swift
@@ -8,7 +8,7 @@ import BraveCore
 import UIKit
 
 class WalletNotification: BraveNotification {
-  private struct Constant {
+  struct Constant {
     static let id = "wallet-notification"
   }
   

--- a/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
+++ b/Client/Frontend/Brave Notifications/BraveNotificationsPresenter.swift
@@ -141,9 +141,12 @@ class BraveNotificationsPresenter: UIViewController {
     }
   }
   
-  func removeRewardsNotification(with id: String) {
+  func removeNotification(with id: String) {
     if let index = notificationsQueue.firstIndex(where: { $0.id == id }) {
       notificationsQueue.remove(at: index)
+    }
+    if let visibleNotification = visibleNotification, visibleNotification.id == id {
+      hide(visibleNotification)
     }
   }
   

--- a/Client/Frontend/Brave Rewards/Ads/AdsNotificationHandler.swift
+++ b/Client/Frontend/Brave Rewards/Ads/AdsNotificationHandler.swift
@@ -60,7 +60,7 @@ class AdsNotificationHandler: BraveAdsNotificationHandler {
   }
 
   func clearNotification(withIdentifier identifier: String) {
-    notificationsPresenter?.removeRewardsNotification(with: identifier)
+    notificationsPresenter?.removeNotification(with: identifier)
   }
 
   func shouldShowNotifications() -> Bool {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2346,13 +2346,13 @@ extension BrowserViewController: TabDelegate {
     })
   }
   
-  func showWalletNotification(_ tab: Tab) {
+  func showWalletNotification(_ tab: Tab, origin: URLOrigin) {
     // only display notification when BVC is front and center
     guard presentedViewController == nil,
           Preferences.Wallet.displayWeb3Notifications.value else {
       return
     }
-    let walletNotificaton = WalletNotification(priority: .low) { [weak self] action in
+    let walletNotificaton = WalletNotification(priority: .low, origin: origin) { [weak self] action in
       if action == .connectWallet {
         self?.presentWalletPanel(tab: tab)
       }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2545,6 +2545,9 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     updateInContentHomePanel(selected?.url as URL?)
+
+    notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
+    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests()
     updateURLBarWalletButton()
   }
 
@@ -3370,6 +3373,8 @@ extension BrowserViewController: PreferencesObserver {
     case Preferences.Wallet.defaultWallet.key:
       tabManager.reset()
       tabManager.reloadSelectedTab()
+      notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
+      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests()
     default:
       log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
       break

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3375,6 +3375,11 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.reloadSelectedTab()
       notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
       WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests()
+      let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
+      if let cryptoStore = CryptoStore.from(privateMode: privateMode) {
+        cryptoStore.rejectAllPendingWebpageRequests()
+      }
+      updateURLBarWalletButton()
     default:
       log.debug("Received a preference change for an unknown key: \(key) on \(type(of: self))")
       break

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -143,7 +143,11 @@ extension BrowserViewController: BraveWalletDelegate {
 
 extension Tab: BraveWalletProviderDelegate {
   func showPanel() {
-    tabDelegate?.showWalletNotification(self)
+    guard let origin = url?.origin else {
+      log.error("Failing to show Wallet panel due to unavailable tab url origin")
+      return
+    }
+    tabDelegate?.showWalletNotification(self, origin: origin)
   }
 
   func getOrigin() -> URLOrigin {
@@ -199,7 +203,7 @@ extension Tab: BraveWalletProviderDelegate {
         self.tabDelegate?.updateURLBarWalletButton()
       })
 
-      self.tabDelegate?.showWalletNotification(self)
+      self.tabDelegate?.showWalletNotification(self, origin: origin)
     }
   }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -31,7 +31,7 @@ protocol TabDelegate {
   func tab(_ tab: Tab, willDeleteWebView webView: WKWebView)
   func showRequestRewardsPanel(_ tab: Tab)
   func stopMediaPlayback(_ tab: Tab)
-  func showWalletNotification(_ tab: Tab)
+  func showWalletNotification(_ tab: Tab, origin: URLOrigin)
   func updateURLBarWalletButton()
   func isTabVisible(_ tab: Tab) -> Bool
 }

--- a/Sources/BraveUI/Extensions/UIFontExtensions.swift
+++ b/Sources/BraveUI/Extensions/UIFontExtensions.swift
@@ -6,9 +6,9 @@
 import UIKit
 
 extension UIFont {
-  public static func preferredFont(forTextStyle style: TextStyle, weight: Weight) -> UIFont {
+  public static func preferredFont(forTextStyle style: TextStyle, weight: Weight, traitCollection: UITraitCollection? = nil) -> UIFont {
     let metrics = UIFontMetrics(forTextStyle: style)
-    let desc = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+    let desc = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: traitCollection)
     let font = UIFont.systemFont(ofSize: desc.pointSize, weight: weight)
     return metrics.scaledFont(for: font)
   }


### PR DESCRIPTION
## Summary of Changes
- Dismiss wallet notification when changing tabs
- Add origin w/ bolded eTLD+1 to wallet notification. Max notification size is 50% of the screen.
- Changing 'Default Wallet' to 'None' will dismiss wallet notification and reject pending dapp permission requests & dapp requests

This pull request fixes #5597, #5580

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:

Notification updates:
1. Open 2 tabs
2. Navigate to a dapp page in one tab and trigger a wallet notification
3. Verify the origin is now displayed in the wallet notification
4. Switch tabs via swipe gesture on tab bar
5. Verify notification is dismissed automatically when tab changes

Default wallet updates:
1. Verify 'Default Wallet' is set to 'Brave Wallet'
2. Visit a dapp site and perform some dapp request (permission request or other request)
3. **Do not dismiss the wallet notification**
4. Open Settings -> Wallet Settings
5. Change 'Default Wallet' to 'None'
6. Verify notification dismisses off screen
7. Open main wallet, verify pending request does not exist (no bell icon in bottom right)

## Screenshots:

https://user-images.githubusercontent.com/5314553/176480265-319bdcf3-db88-40a2-9a40-6f847cf1b87a.mov

https://user-images.githubusercontent.com/5314553/176480284-6196acce-48fa-4534-91c0-08c23a1f2fb8.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
