### PR TITLE
Fix #5627: Background audio play on some websites not working

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/MediaBackgrounding.js
+++ b/Client/Frontend/UserContent/UserScripts/MediaBackgrounding.js
@@ -63,29 +63,12 @@ window.__firefox__.includeOnce("MediaBackgrounding", function() {
             element.visibilityState = visibilityState_Get.call(document);
             
             document.addEventListener("visibilitychange", function(e) {
-                element.visibilityState = visibilityState_Get.call(document);
-            }, false);
-            
-            element.addEventListener("pause", function(e) {
-                if (!element.userHitPause && visibilityState_Get.call(document) == "visible") {
-                    var onVisibilityChanged = (e) => {
-                        document.removeEventListener("visibilitychange", onVisibilityChanged);
-
-                        if (visibilityState_Get.call(document) != "visible" && !element.ended) {
-                            playControl.call(element);
-                        }
-                    };
-
-                    document.addEventListener("visibilitychange", onVisibilityChanged);
-
-                    setTimeout(function() {
-                        document.removeEventListener("visibilitychange", onVisibilityChanged);
-                    }, 2000);
-                } else {
-                    if (!element.userHitPause && element.visibilityState == "visible" && !element.ended) {
-                        playControl.call(element);
-                    }
-                }
+              e.stopPropagation();
+              element.visibilityState = visibilityState_Get.call(document);
+              
+              if (visibilityState_Get.call(document) != "visible" && !element.ended) {
+                  playControl.call(element);
+              }
             }, false);
         }
         
@@ -97,27 +80,21 @@ window.__firefox__.includeOnce("MediaBackgrounding", function() {
             }, true);
         }
     }
-    
-    const queue = [];
-    function onMutation() {
-      for (const mutations of queue) {
-          mutations.addedNodes.forEach(function (node) {
-              if (node.constructor.name == 'HTMLVideoElement') {
-                  addListeners(node);
-              }
-          });
-      }
-      queue.length = 0;
-    }
+  
+//                  Debugging JS Events - Do not Remove
+//    const dispatchEvent_original = EventTarget.prototype.dispatchEvent;
+//    EventTarget.prototype.dispatchEvent = function (event) {
+//      if (this.constructor.name == 'HTMLVideoElement') {
+//        addListeners(this);
+//      }
+//      dispatchEvent_original.apply(this, arguments);
+//    };
     
     var observer = new MutationObserver(function(mutations) {
-        if (!queue.length) {
-            // Debounce the mutation for performance
-            // with setTimeout | requestIdleCallback | requestAnimationFrame
-            // requestIdleCallback isn't available on iOS yet.
-            requestAnimationFrame(onMutation);
+        const videoElements = document.querySelectorAll('video');
+        for (const e of videoElements) {
+            addListeners(e);
         }
-        queue.push(...mutations);
     });
     
     observer.observe(document, {


### PR DESCRIPTION
## Summary of Changes
- Fixed background play for websites that do not propagate the `pause` or `play` events.
- Simplified background play code.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5627

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test plan
STR in the ticket

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
