### PR TITLE
Ref #5374: Move request blocking stats tracking to `RequestBlockingContentHelper`

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2311,7 +2311,7 @@ extension BrowserViewController: TabDelegate {
     tab.addContentScript(AdsMediaReporting(rewards: rewards, tab: tab), name: AdsMediaReporting.name(), contentWorld: .defaultClient)
     tab.addContentScript(ReadyStateScriptHelper(tab: tab), name: ReadyStateScriptHelper.name(), contentWorld: .page)
     tab.addContentScript(DeAmpHelper(tab: tab), name: DeAmpHelper.name(), contentWorld: .defaultClient)
-    tab.addContentScript(RequestBlockingContentHelper(), name: RequestBlockingContentHelper.name(), contentWorld: .page)
+    tab.addContentScript(tab.requestBlockingContentHelper, name: RequestBlockingContentHelper.name(), contentWorld: .page)
   }
 
   func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -398,7 +398,7 @@ extension BrowserViewController: WKNavigationDelegate {
       if url.scheme == "https", let _ = pendingHTTPUpgrades.removeValue(forKey: urlHost) {
         BraveGlobalShieldStats.shared.httpse += 1
         if let stats = self.tabManager[webView]?.contentBlocker.stats {
-          self.tabManager[webView]?.contentBlocker.stats = stats.create(byAddingListItem: .https)
+          self.tabManager[webView]?.contentBlocker.stats = stats.adding(httpsCount: 1)
         }
       }
     }

--- a/Client/Frontend/Browser/FingerprintingProtection.swift
+++ b/Client/Frontend/Browser/FingerprintingProtection.swift
@@ -25,7 +25,7 @@ class FingerprintingProtection: TabContentScript {
   func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
     defer { replyHandler(nil, nil) }
     if let stats = self.tab?.contentBlocker.stats {
-      self.tab?.contentBlocker.stats = stats.addingFingerprintingBlock()
+      self.tab?.contentBlocker.stats = stats.adding(fingerprintingCount: 1)
       BraveGlobalShieldStats.shared.fpProtection += 1
     }
   }

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -715,7 +715,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
       // If an upgraded https load happens with a host which was upgraded, increase the stats
       if url.scheme == "https", let _ = pendingHTTPUpgrades.removeValue(forKey: urlHost) {
         BraveGlobalShieldStats.shared.httpse += 1
-        tab.contentBlocker.stats = tab.contentBlocker.stats.create(byAddingListItem: .https)
+        tab.contentBlocker.stats = tab.contentBlocker.stats.adding(httpsCount: 1)
       }
     }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -200,6 +200,7 @@ class Tab: NSObject {
 
   // There is no 'available macro' on props, we currently just need to store ownership.
   lazy var contentBlocker = ContentBlockerHelper(tab: self)
+  lazy var requestBlockingContentHelper = RequestBlockingContentHelper(tab: self)
 
   /// The last title shown by this tab. Used by the tab tray to show titles for zombie tabs.
   var lastTitle: String?

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -999,6 +999,7 @@ extension TabManager: WKNavigationDelegate {
   func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
     if let tab = self[webView] {
       tab.contentBlocker.clearPageStats()
+      tab.requestBlockingContentHelper.clearBlockedRequests()
     }
   }
 

--- a/Client/WebFilters/AdblockRustEngine.swift
+++ b/Client/WebFilters/AdblockRustEngine.swift
@@ -38,16 +38,6 @@ extension AdblockEngine {
     ).didMatchRule
   }
   
-  public func shouldBlock(requestUrl: String, requestHost: String, sourceHost: String) -> Bool {
-    return matches(
-      url: requestUrl,
-      host: requestHost,
-      tabHost: sourceHost,
-      isThirdParty: requestUrl != sourceHost,
-      resourceType: "script"
-    ).didMatchRule
-  }
-  
   @available(*, deprecated, renamed: "deserialize(data:)")
   @discardableResult
   public func set(data: Data) -> Bool {

--- a/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Client/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
@@ -9,6 +9,7 @@ import Shared
 import BraveShared
 import Data
 import Foundation
+import BraveCore
 
 struct TPPageStats {
   let adCount: Int
@@ -26,93 +27,56 @@ struct TPPageStats {
     self.fingerprintingCount = fingerprintingCount
     self.httpsCount = httpsCount
   }
-
-  func addingFingerprintingBlock() -> TPPageStats {
-    return TPPageStats(adCount: adCount, trackerCount: trackerCount, scriptCount: scriptCount, fingerprintingCount: fingerprintingCount + 1, httpsCount: httpsCount)
+  
+  func adding(adCount: Int = 0, trackerCount: Int = 0, scriptCount: Int = 0, fingerprintingCount: Int = 0, httpsCount: Int = 0) -> TPPageStats {
+    TPPageStats(
+      adCount: self.adCount + adCount,
+      trackerCount: self.trackerCount + trackerCount,
+      scriptCount: self.scriptCount + scriptCount,
+      fingerprintingCount: self.fingerprintingCount + fingerprintingCount,
+      httpsCount: self.httpsCount + httpsCount)
   }
-
-  func addingScriptBlock() -> TPPageStats {
-    return TPPageStats(adCount: adCount, trackerCount: trackerCount, scriptCount: scriptCount + 1, fingerprintingCount: fingerprintingCount, httpsCount: httpsCount)
-  }
-
-  func create(byAddingListItem listItem: BlocklistName) -> TPPageStats {
-    switch listItem {
-    case .ad: return TPPageStats(adCount: adCount + 1, trackerCount: trackerCount, scriptCount: scriptCount, fingerprintingCount: fingerprintingCount, httpsCount: httpsCount)
-    case .tracker: return TPPageStats(adCount: adCount, trackerCount: trackerCount + 1, scriptCount: scriptCount, fingerprintingCount: fingerprintingCount, httpsCount: httpsCount)
-    case .https: return TPPageStats(adCount: adCount, trackerCount: trackerCount, scriptCount: scriptCount, fingerprintingCount: fingerprintingCount, httpsCount: httpsCount + 1)
-    default:
-      break
-    }
-    return self
-  }
-}
-
-enum TPStatsResourceType: String {
-  case script
-  case image
 }
 
 class TPStatsBlocklistChecker {
   static let shared = TPStatsBlocklistChecker()
   private let adblockSerialQueue = AdBlockStats.adblockSerialQueue
 
-  func isBlocked(request: URLRequest, domain: Domain, resourceType: TPStatsResourceType? = nil, _ completion: @escaping (BlocklistName?) -> Void) {
-
-    guard let url = request.url, let host = url.host, !host.isEmpty, let domainUrl = domain.url else {
+  func isBlocked(requestURL: URL, sourceURL: URL, enabledLists: Set<BlocklistName>, resourceType: AdblockEngine.ResourceType, callback: @escaping (BlocklistName?) -> Void) {
+    guard let host = requestURL.host, !host.isEmpty else {
       // TP Stats init isn't complete yet
-      completion(nil)
+      callback(nil)
       return
     }
 
-    // Getting this domain and current tab urls before going into asynchronous closure
-    // to avoid threading problems(#1094, #1096)
-    assertIsMainThread("Getting enabled blocklists should happen on main thread")
-    let domainBlockLists = BlocklistName.blocklists(forDomain: domain).on
-    let currentTabUrl = request.mainDocumentURL
+    if resourceType == .image && enabledLists.contains(.image) {
+      callback(.image)
+    }
 
     adblockSerialQueue.async {
-      let enabledLists = domainBlockLists
-
-      if let resourceType = resourceType {
-        switch resourceType {
-        case .script:
-          break
-        case .image:
-          if enabledLists.contains(.image) {
-            completion(.image)
-            return
-          }
+      if (enabledLists.contains(.ad) || enabledLists.contains(.tracker))
+          && AdBlockStats.shared.shouldBlock(requestURL: requestURL, sourceURL: sourceURL, resourceType: resourceType) {
+        DispatchQueue.main.async {
+          callback(.ad)
         }
-      }
-
-      let isAdOrTrackerListEnabled = enabledLists.contains(.ad) || enabledLists.contains(.tracker)
-
-      if isAdOrTrackerListEnabled
-        && AdBlockStats.shared.shouldBlock(
-          request,
-          currentTabUrl: currentTabUrl) {
-
-        if Preferences.PrivacyReports.captureShieldsData.value,
-          let domainUrl = URL(string: domainUrl),
-          let blockedResourceHost = url.baseDomain,
-           !PrivateBrowsingManager.shared.isPrivateBrowsing {
-          PrivacyReportsManager.pendingBlockedRequests.append((blockedResourceHost, domainUrl, Date()))
-        }
-
-        completion(BlocklistName.ad)
+        
         return
       }
 
       // TODO: Downgrade to 14.5 once api becomes available.
       if #unavailable(iOS 15.0) {
-        HttpsEverywhereStats.shared.shouldUpgrade(url) { shouldUpgrade in
+        HttpsEverywhereStats.shared.shouldUpgrade(requestURL) { shouldUpgrade in
           DispatchQueue.main.async {
             if enabledLists.contains(.https) && shouldUpgrade {
-              completion(BlocklistName.https)
+              callback(.https)
             } else {
-              completion(nil)
+              callback(nil)
             }
           }
+        }
+      } else {
+        DispatchQueue.main.async {
+          callback(nil)
         }
       }
     }

--- a/Tests/ClientTests/AdblockRustTests.swift
+++ b/Tests/ClientTests/AdblockRustTests.swift
@@ -22,11 +22,23 @@ class AdblockRustTests: XCTestCase {
     let engine = AdblockEngine(rules: rules)
     AdblockEngine.setDomainResolver(AdblockEngine.defaultDomainResolver)
 
-    XCTAssert(engine.shouldBlock(requestUrl: "http://example.com/-advertisement-icon.", requestHost: "example.com", sourceHost: "example.com"))
-
-    XCTAssertFalse(engine.shouldBlock(requestUrl: "https://brianbondy.com", requestHost: "https://brianbondy.com", sourceHost: "example.com"))
-
-    XCTAssertFalse(engine.shouldBlock(requestUrl: "http://example.com/good-advertisement-icon.", requestHost: "example.com", sourceHost: "example.com"))
+    XCTAssertTrue(engine.shouldBlock(
+      requestURL: URL(string: "http://example.com/-advertisement-icon.")!,
+      sourceURL: URL(string: "https://example.com")!,
+      resourceType: .xmlhttprequest
+    ))
+    
+    XCTAssertFalse(engine.shouldBlock(
+      requestURL: URL(string: "https://brianbondy.com")!,
+      sourceURL: URL(string: "https://example.com")!,
+      resourceType: .xmlhttprequest
+    ))
+    
+    XCTAssertFalse(engine.shouldBlock(
+      requestURL: URL(string: "http://example.com/good-advertisement-icon.")!,
+      sourceURL: URL(string: "https://example.com")!,
+      resourceType: .xmlhttprequest
+    ))
   }
 
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Continuation of https://github.com/brave/brave-ios/pull/5444


<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #5374

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
