### PR TITLE
Fix #5646: Show/hide test networks toggle

### DIFF
--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -44,14 +44,18 @@ struct NetworkPicker: View {
   }
   
   private var availableChains: [BraveWallet.NetworkInfo] {
-    networkStore.ethereumChains.filter {
-      if !Preferences.Wallet.showTestNetworks.value,
-          WalletConstants.supportedTestNetworkChainIds.contains($0.chainId) {
-        return false
+    networkStore.ethereumChains.filter { chain in
+      if !Preferences.Wallet.showTestNetworks.value {
+        var testNetworkChainIdsToRemove = WalletConstants.supportedTestNetworkChainIds
+        // Don't remove selected network (possible if selected then disabled showing test networks)
+        testNetworkChainIdsToRemove.removeAll(where: { $0 == selectedNetwork.chainId })
+        if testNetworkChainIdsToRemove.contains(chain.chainId) {
+          return false
+        }
       }
       if let destination = buySendSwapDestination {
         if destination.kind != .send {
-          return !$0.isCustom
+          return !chain.isCustom
         }
       }
       return true

--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import BraveCore
+import BraveShared
 import Strings
 
 extension BraveWallet.NetworkInfo {
@@ -43,14 +44,18 @@ struct NetworkPicker: View {
   }
   
   private var availableChains: [BraveWallet.NetworkInfo] {
-    networkStore.ethereumChains.filter({
+    networkStore.ethereumChains.filter {
+      if !Preferences.Wallet.showTestNetworks.value,
+          WalletConstants.supportedTestNetworkChainIds.contains($0.chainId) {
+        return false
+      }
       if let destination = buySendSwapDestination {
         if destination.kind != .send {
           return !$0.isCustom
         }
       }
       return true
-    })
+    }
   }
   
   var body: some View {

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -5,8 +5,6 @@
 
 import Foundation
 import BraveCore
-import BraveShared
-import Combine
 import SwiftUI
 import Strings
 
@@ -32,7 +30,6 @@ public class NetworkStore: ObservableObject {
 
   private let rpcService: BraveWalletJsonRpcService
   private let walletService: BraveWalletBraveWalletService
-  private var cancellable: AnyCancellable?
 
   public init(
     rpcService: BraveWalletJsonRpcService,
@@ -47,10 +44,6 @@ public class NetworkStore: ObservableObject {
       }
     }
     rpcService.add(self)
-    cancellable = Preferences.Wallet.showTestNetworks.$value
-      .sink { [weak self] showTestNetworks in
-        self?.updateChainList()
-      }
   }
 
   private func updateChainList() {

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 import BraveCore
+import BraveShared
+import Combine
 import SwiftUI
 import Strings
 
@@ -30,6 +32,7 @@ public class NetworkStore: ObservableObject {
 
   private let rpcService: BraveWalletJsonRpcService
   private let walletService: BraveWalletBraveWalletService
+  private var cancellable: AnyCancellable?
 
   public init(
     rpcService: BraveWalletJsonRpcService,
@@ -44,6 +47,10 @@ public class NetworkStore: ObservableObject {
       }
     }
     rpcService.add(self)
+    cancellable = Preferences.Wallet.showTestNetworks.$value
+      .sink { [weak self] showTestNetworks in
+        self?.updateChainList()
+      }
   }
 
   private func updateChainList() {

--- a/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/BraveWallet/Settings/CustomNetworkListView.swift
@@ -64,6 +64,7 @@ struct CustomNetworkListView: View {
         }
         .padding(.vertical, 6)
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       .osAvailabilityModifiers { content in
         if #available(iOS 15.0, *) {
           content
@@ -95,13 +96,13 @@ struct CustomNetworkListView: View {
         Section {
           customNetworksList
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       
       Section {
         Toggle(Strings.Wallet.showTestNetworksTitle, isOn: $showTestNetworks.value)
           .foregroundColor(Color(.braveLabel))
           .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
     .listStyle(.insetGrouped)

--- a/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/BraveWallet/Settings/CustomNetworkListView.swift
@@ -90,7 +90,7 @@ struct CustomNetworkListView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
       
       Section {
-        Toggle("Show test networks", isOn: $showTestNetworks.value)
+        Toggle(Strings.Wallet.showTestNetworksTitle, isOn: $showTestNetworks.value)
           .foregroundColor(Color(.braveLabel))
           .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
       }

--- a/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/BraveWallet/Settings/CustomNetworkListView.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import SwiftUI
+import BraveShared
 import BraveCore
 import Strings
 
@@ -12,6 +13,7 @@ struct CustomNetworkListView: View {
   @State private var isPresentingNetworkDetails: CustomNetworkModel?
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.sizeCategory) private var sizeCategory
+  @ObservedObject private var showTestNetworks = Preferences.Wallet.showTestNetworks
 
   private struct CustomNetworkDetails: Identifiable {
     var isEditMode: Bool
@@ -86,6 +88,12 @@ struct CustomNetworkListView: View {
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      
+      Section {
+        Toggle("Show test networks", isOn: $showTestNetworks.value)
+          .foregroundColor(Color(.braveLabel))
+          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+      }
     }
     .listStyle(.insetGrouped)
     .overlay(

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -17,4 +17,16 @@ struct WalletConstants {
   
   /// The origin used for transactions/requests from Brave Wallet.
   static let braveWalletOrigin: URLOrigin = .init(url: URL(string: "chrome://wallet")!)
+
+  /// The currently supported test networks.
+  static let supportedTestNetworkChainIds = [
+    BraveWallet.RinkebyChainId,
+    BraveWallet.RopstenChainId,
+    BraveWallet.GoerliChainId,
+    BraveWallet.KovanChainId,
+    BraveWallet.LocalhostChainId,
+    BraveWallet.SolanaDevnet,
+    BraveWallet.SolanaTestnet,
+    BraveWallet.FilecoinTestnet
+  ]
 }

--- a/BraveWallet/WalletPreferences.swift
+++ b/BraveWallet/WalletPreferences.swift
@@ -34,5 +34,7 @@ extension Preferences {
     )
     /// The option to display web3 notification
     public static let displayWeb3Notifications = Option<Bool>(key: "wallet.display-web3-notifications", default: true)
+    // The option to determine if we show or hide test networks in network lists
+    public static let showTestNetworks = Option<Bool>(key: "wallet.show-test-networks", default: false)
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2115,6 +2115,13 @@ extension Strings {
       value: "Default Base Currency",
       comment: "The title that appears before the current default base currency code. Example: \"Default base currency: USD\""
     )
+    public static let showTestNetworksTitle = NSLocalizedString(
+      "wallet.showTestNetworksTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Show Test Networks",
+      comment: "A label beside the toggle for showing / hiding test networks in the Networks screen of Wallet settings"
+    )
     public static let addSuggestedTokenTitle = NSLocalizedString(
       "wallet.addSuggestedTokenTitle",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Adds a toggle to wallet settings to determine if we show or hide the test networks. Test networks are hidden by default.
- If test networks are hidden and selected network is a test network it will be shown.

This pull request fixes #5646

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
1. Launch wallet and verify test networks are hidden by default
2. Open wallet settings, tap networks and enable 'Show test networks' toggle.
3. Verify test networks are now shown

## Screenshots:
![Show test networks setting](https://user-images.githubusercontent.com/5314553/177784130-6fbccfd1-f3e5-433a-98f0-8799ff1b9f6e.png) | ![network picker](https://user-images.githubusercontent.com/5314553/177784139-673ed576-79be-4840-928d-984fd9794e51.png)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
