### PR TITLE
Fix #5657: Alternative Website Frontends feature.

### DIFF
--- a/BraveShared/BraveStrings.swift
+++ b/BraveShared/BraveStrings.swift
@@ -3823,3 +3823,23 @@ extension Strings {
   public static let invalidDetailsMessage = NSLocalizedString("invalidDetailsMessage", tableName: "BraveShared", bundle: .strings, value: "Invalid details in payment request", comment: "Error message if details don't have the right type or values")
   public static let clientErrorMessage = NSLocalizedString("clientErrorMessage", tableName: "BraveShared", bundle: .strings, value: "Client error", comment: "Client is in an invalid state which caused the error")
 }
+
+extension Strings {
+  public static let urlRedirectsSettings =
+  NSLocalizedString("urlRedirectsSettings", tableName: "BraveShared",
+                    bundle: .strings,
+                    value: "Website Redirects",
+                    comment: "Setting title for option to automatically redirect a url to another url")
+  
+  public static let redditRedirectFooter =
+  NSLocalizedString("redditRedirectFooter", tableName: "BraveShared",
+                    bundle: .strings,
+                    value: "Automatically redirects Reddit links to the older interface (at old.reddit.com). To force the new Reddit interface, use new.reddit.com instead.",
+                    comment: "Setting title for option to automatically redirect a url to another url")
+  
+  public static let nprRedirectFooter =
+  NSLocalizedString("nprRedirectFooter", tableName: "BraveShared",
+                    bundle: .strings,
+                    value: "Automatically redirects NPR links to their text-based version (at text.npr.org).",
+                    comment: "Setting title for option to automatically redirect a url to another url")
+}

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -208,7 +208,7 @@ extension BrowserViewController: WKNavigationDelegate {
     // Website redirection logic
     if url.isWebPage(includeDataURIs: false),
        navigationAction.targetFrame?.isMainFrame == true,
-       let redirectURL = WebsiteRedirects.websiteRedirect(for: url) {
+       let redirectURL = WebsiteRedirects.redirect(for: url) {
       
       decisionHandler(.cancel, preferences)
       tab?.loadRequest(URLRequest(url: redirectURL))

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -204,7 +204,17 @@ extension BrowserViewController: WKNavigationDelegate {
       forUrl: url,
       persistent: !isPrivateBrowsing
     )
-
+    
+    // Website redirection logic
+    if url.isWebPage(includeDataURIs: false),
+       navigationAction.targetFrame?.isMainFrame == true,
+       let redirectURL = WebsiteRedirects.websiteRedirect(for: url) {
+      
+      decisionHandler(.cancel, preferences)
+      tab?.loadRequest(URLRequest(url: redirectURL))
+      return
+    }
+        
     // Debouncing logic
     // Handle debouncing for main frame only and only if the site (etld+1) changes
     // We also only handle `http` and `https` requests

--- a/Client/Frontend/ClientPreferences.swift
+++ b/Client/Frontend/ClientPreferences.swift
@@ -325,4 +325,9 @@ extension Preferences {
     public static let ntpOnboardingCompleted =
     Option<Bool>(key: "privacy-hub.onboarding-completed", default: true)
   }
+  
+  final public class WebsiteRedirects {
+    static let reddit = Option<Bool>(key: "website-redirect.reddit", default: false)
+    static let npr = Option<Bool>(key: "website-redirect.npr", default: false)
+  }
 }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -315,14 +315,14 @@ class SettingsViewController: TableViewController {
         image: UIImage(named: "background_play_settings_icon", in: .current, compatibleWith: nil)!.template),
     ])
     
-    let privacyReportRow = Row(
+    let websiteRedirectsRow = Row(
       text: Strings.urlRedirectsSettings,
       selection: { [unowned self] in
         let controller = UIHostingController(rootView: WebsiteRedirectsSettingsView())
         self.navigationController?.pushViewController(controller, animated: true)
       }, image: .init(systemName: "repeat"), accessory: .disclosureIndicator, cellClass: MultilineSubtitleCell.self)
     
-    general.rows.append(privacyReportRow)
+    general.rows.append(websiteRedirectsRow)
 
     return general
   }()

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -314,6 +314,15 @@ class SettingsViewController: TableViewController {
         option: Preferences.General.mediaAutoBackgrounding,
         image: UIImage(named: "background_play_settings_icon", in: .current, compatibleWith: nil)!.template),
     ])
+    
+    let privacyReportRow = Row(
+      text: Strings.urlRedirectsSettings,
+      selection: { [unowned self] in
+        let controller = UIHostingController(rootView: WebsiteRedirectsSettingsView())
+        self.navigationController?.pushViewController(controller, animated: true)
+      }, image: .init(systemName: "repeat"), accessory: .disclosureIndicator, cellClass: MultilineSubtitleCell.self)
+    
+    general.rows.append(privacyReportRow)
 
     return general
   }()

--- a/Client/Frontend/Settings/WebsiteRedirectsSettingsView.swift
+++ b/Client/Frontend/Settings/WebsiteRedirectsSettingsView.swift
@@ -13,22 +13,25 @@ struct WebsiteRedirectsSettingsView: View {
   
   var body: some View {
     List {
-      Section(footer: Text(Strings.redditRedirectFooter)) {
-        // Cell titles for websites do not have to be translated.
+      Section {
         Toggle(isOn: $reddit.value) {
           Text("reddit.com \(Image(systemName: "arrow.right")) old.reddit.com")
         }
         .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      } footer: {
+        Text(Strings.redditRedirectFooter)
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       
-      Section(footer: Text(Strings.nprRedirectFooter)) {
+      Section {
         Toggle(isOn: $npr.value) {
           Text("npr.org \(Image(systemName: "arrow.right")) text.npr.org")
         }
         .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      } footer: {
+        Text(Strings.nprRedirectFooter)
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(.insetGrouped)
     .navigationTitle(Strings.urlRedirectsSettings)

--- a/Client/Frontend/Settings/WebsiteRedirectsSettingsView.swift
+++ b/Client/Frontend/Settings/WebsiteRedirectsSettingsView.swift
@@ -1,0 +1,44 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Shared
+import BraveShared
+
+struct WebsiteRedirectsSettingsView: View {
+  @ObservedObject private var reddit = Preferences.WebsiteRedirects.reddit
+  @ObservedObject private var npr = Preferences.WebsiteRedirects.npr
+  
+  var body: some View {
+    List {
+      Section(footer: Text(Strings.redditRedirectFooter)) {
+        // Cell titles for websites do not have to be translated.
+        Toggle(isOn: $reddit.value) {
+          Text("reddit.com \(Image(systemName: "arrow.right")) old.reddit.com")
+        }
+        .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      
+      Section(footer: Text(Strings.nprRedirectFooter)) {
+        Toggle(isOn: $npr.value) {
+          Text("npr.org \(Image(systemName: "arrow.right")) text.npr.org")
+        }
+        .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    .listStyle(.insetGrouped)
+    .navigationTitle(Strings.urlRedirectsSettings)
+  }
+}
+
+#if DEBUG
+struct URLRedirectionSettingsView_Previews: PreviewProvider {
+  static var previews: some View {
+    WebsiteRedirectsSettingsView()
+  }
+}
+#endif

--- a/Client/WebFilters/WebsiteRedirects.swift
+++ b/Client/WebFilters/WebsiteRedirects.swift
@@ -1,0 +1,65 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import BraveShared
+
+struct WebsiteRedirects {
+  private enum Site: CaseIterable {
+    case reddit
+    case npr
+    
+    /// This is the host we want to redirect users to. All other parts of the url remain unchanged
+    var hostToRedirectTo: String {
+      switch self {
+      case .reddit: return "old.reddit.com"
+      case .npr: return "text.npr.org"
+      }
+    }
+    
+    /// What hosts should be redirected. Due to compat reasons not every host may be easily replaced.
+    var eligibleHosts: Set<String> {
+      switch self {
+      case .reddit: return ["reddit.com", "www.reddit.com", "np.reddit.com", "amp.reddit.com", "i.reddit.com"]
+      case .npr: return ["www.npr.org", "npr.org"]
+      }
+    }
+    
+    /// What hosts should not be redirected. It's either due to web compat reasons or to let user explicitely type a url to not override it.
+    /// Reddit is good example, regular reddit.com and new.reddit.com point to the same new user interface.
+    /// So we redirect all regular reddit.com link, but the user may explicitely go to new.reddit.com without having to disable the reddit redirect toggle.
+    var excludedHosts: Set<String> {
+      switch self {
+      case .reddit: return ["new.reddit.com"]
+      case .npr: return ["account.npr.org"]
+      }
+    }
+    
+    var isEnabled: Bool {
+      switch self {
+      case .reddit: return Preferences.WebsiteRedirects.reddit.value
+      case .npr: return Preferences.WebsiteRedirects.npr.value
+      }
+    }
+  }
+  
+  /// Decides whether a website the user is on should bre redirected to another website.
+  /// Returns nil if no redirection should happen.
+  static func websiteRedirect(for url: URL) -> URL? {
+    guard let host = url.host else { return nil }
+    
+    let foundMatch = Site.allCases
+      .filter { $0.isEnabled }
+      .filter { !$0.excludedHosts.contains(host) && host != $0.hostToRedirectTo }
+      .first(where: { $0.eligibleHosts.contains(host) })
+    
+    guard let redirect = foundMatch,
+          var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+    
+    components.host = redirect.hostToRedirectTo
+    return components.url
+  }
+}

--- a/Client/WebFilters/WebsiteRedirects.swift
+++ b/Client/WebFilters/WebsiteRedirects.swift
@@ -59,6 +59,9 @@ struct WebsiteRedirects {
     guard let redirect = foundMatch,
           var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
     
+    // For privacy reasons we do not redirect websites if username or password are present.
+    if components.user != nil || components.password != nil { return nil }
+    
     components.host = redirect.hostToRedirectTo
     return components.url
   }

--- a/Client/WebFilters/WebsiteRedirects.swift
+++ b/Client/WebFilters/WebsiteRedirects.swift
@@ -48,7 +48,7 @@ struct WebsiteRedirects {
   
   /// Decides whether a website the user is on should bre redirected to another website.
   /// Returns nil if no redirection should happen.
-  static func websiteRedirect(for url: URL) -> URL? {
+  static func redirect(for url: URL) -> URL? {
     guard let host = url.host else { return nil }
     
     let foundMatch = Site.allCases

--- a/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
+++ b/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
@@ -1,0 +1,85 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import Brave
+import Shared
+import BraveShared
+
+class WebsiteRedirectsTests: XCTestCase {
+  
+  override func setUpWithError() throws {
+    Preferences.WebsiteRedirects.reddit.value = true
+    Preferences.WebsiteRedirects.npr.value = true
+  }
+  
+  override func tearDownWithError() throws {
+    Preferences.WebsiteRedirects.reddit.reset()
+    Preferences.WebsiteRedirects.npr.reset()
+  }
+  
+  private func url(_ text: String) throws -> URL {
+    try XCTUnwrap(URL(string: text))
+  }
+  
+  func testBasicRedirect() throws {
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://npr.org/sample_article")), try url("https://text.npr.org/sample_article"))
+    
+    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://example.com")))
+  }
+  
+  func testExcludedHosts() throws {
+    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://new.reddit.com/r/brave")))
+    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://account.npr.org/login")))
+  }
+  
+  func testDisabledOptions() throws {
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    Preferences.WebsiteRedirects.reddit.value = false
+    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://reddit.com/r/brave")))
+    
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://npr.org/sample_article")), try url("https://text.npr.org/sample_article"))
+    Preferences.WebsiteRedirects.npr.value = false
+    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://npr.org/sample_article")))
+  }
+  
+  func testReddit() throws {
+    // Real life example
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for:
+        try url("https://reddit.com/r/brave_browser/comments/vtb6yr/whatsapp_web_is_not_working_on_brave/if6nce6/")),
+                   try url("https://old.reddit.com/r/brave_browser/comments/vtb6yr/whatsapp_web_is_not_working_on_brave/if6nce6/"))
+    
+    // Supported hosts
+    
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://i.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://amp.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://np.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://www.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+  }
+  
+  func testNpr() throws {
+    // Real life example
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://www.npr.org/2022/07/07/1107814440/researchers-can-now-explain-how-climate-change-is-affecting-your-weather")),
+                   try url("https://text.npr.org/2022/07/07/1107814440/researchers-can-now-explain-how-climate-change-is-affecting-your-weather"))
+  }
+}

--- a/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
+++ b/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
@@ -82,4 +82,16 @@ class WebsiteRedirectsTests: XCTestCase {
       for: try url("https://www.npr.org/2022/07/07/1107814440/researchers-can-now-explain-how-climate-change-is-affecting-your-weather")),
                    try url("https://text.npr.org/2022/07/07/1107814440/researchers-can-now-explain-how-climate-change-is-affecting-your-weather"))
   }
+  
+  func testSkipRedirectIfUserPasswordPresent() {
+    // Normal case no user/password
+    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+      for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    
+    // User:Password
+    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://username:password@reddit.com/r/brave")))
+    
+    // User only
+    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://username@reddit.com/r/brave")))
+  }
 }

--- a/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
+++ b/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
@@ -25,73 +25,73 @@ class WebsiteRedirectsTests: XCTestCase {
   }
   
   func testBasicRedirect() throws {
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
     
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://npr.org/sample_article")), try url("https://text.npr.org/sample_article"))
     
-    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://example.com")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://example.com")))
   }
   
   func testExcludedHosts() throws {
-    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://new.reddit.com/r/brave")))
-    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://account.npr.org/login")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://new.reddit.com/r/brave")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://account.npr.org/login")))
   }
   
   func testDisabledOptions() throws {
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
     Preferences.WebsiteRedirects.reddit.value = false
-    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://reddit.com/r/brave")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://reddit.com/r/brave")))
     
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://npr.org/sample_article")), try url("https://text.npr.org/sample_article"))
     Preferences.WebsiteRedirects.npr.value = false
-    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://npr.org/sample_article")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://npr.org/sample_article")))
   }
   
   func testReddit() throws {
     // Real life example
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for:
         try url("https://reddit.com/r/brave_browser/comments/vtb6yr/whatsapp_web_is_not_working_on_brave/if6nce6/")),
                    try url("https://old.reddit.com/r/brave_browser/comments/vtb6yr/whatsapp_web_is_not_working_on_brave/if6nce6/"))
     
     // Supported hosts
     
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://i.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
     
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://amp.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
     
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://np.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
     
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
     
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://www.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
   }
   
   func testNpr() throws {
     // Real life example
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://www.npr.org/2022/07/07/1107814440/researchers-can-now-explain-how-climate-change-is-affecting-your-weather")),
                    try url("https://text.npr.org/2022/07/07/1107814440/researchers-can-now-explain-how-climate-change-is-affecting-your-weather"))
   }
   
   func testSkipRedirectIfUserPasswordPresent() {
     // Normal case no user/password
-    XCTAssertEqual(WebsiteRedirects.websiteRedirect(
+    XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
     
     // User:Password
-    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://username:password@reddit.com/r/brave")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://username:password@reddit.com/r/brave")))
     
     // User only
-    XCTAssertNil(WebsiteRedirects.websiteRedirect(for: try url("https://username@reddit.com/r/brave")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://username@reddit.com/r/brave")))
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5657 

Security Review: https://github.com/brave/security/issues/946

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See for spec:
https://bravesoftware.slack.com/archives/CELA35G5S/p1656088022827869

Go to Brave Settings -> Website Redirects
Enable reddit or npr toggle.

Go to their websites and see if the website is automatically redirected.
For reddit, go to `new.reddit.com` when the toggle is enabled, make sure the new reddit interface is loaded

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="331" alt="Zrzut ekranu 2022-07-8 o 16 27 29" src="https://user-images.githubusercontent.com/6950387/178012114-0fb8ffd1-748d-4385-a055-ee6441abdbef.png">

<img width="333" alt="Zrzut ekranu 2022-07-8 o 16 27 35" src="https://user-images.githubusercontent.com/6950387/178012130-e2915e4c-bb01-478b-9eb7-5d779daa66d6.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
