### PR TITLE
Fix #5616: Close wallet panel when icon hidden/removed

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -9,6 +9,7 @@ import Data
 import BraveShared
 import BraveCore
 import BraveUI
+import BraveWallet
 
 private let log = Logger.browserLogger
 private let rewardsLog = Logger.braveCoreLogger
@@ -65,7 +66,16 @@ extension BrowserViewController: WKNavigationDelegate {
     }
     toolbarVisibilityViewModel.toolbarState = .expanded
 
-    tabManager.selectedTab?.isWalletIconVisible = false
+    if let selectedTab = tabManager.selectedTab,
+       selectedTab.url?.origin != webView.url?.origin {
+      // new site has a different origin, hide wallet icon.
+      tabManager.selectedTab?.isWalletIconVisible = false
+      // close wallet panel if it's open
+      if let popoverController = self.presentedViewController as? PopoverController,
+         popoverController.contentController is WalletPanelHostingController {
+        self.dismiss(animated: true)
+      }
+    }
 
     updateFindInPageVisibility(visible: false)
     displayPageZoom(visible: false)

--- a/Sources/BraveUI/Popover/PopoverController.swift
+++ b/Sources/BraveUI/Popover/PopoverController.swift
@@ -251,7 +251,7 @@ public class PopoverController: UIViewController {
 
   // MARK: - UI
 
-  private(set) var contentController: UIViewController & PopoverContentComponent
+  public private(set) var contentController: UIViewController & PopoverContentComponent
 
   private let containerView = ContainerView()
 


### PR DESCRIPTION
## Summary of Changes
- Update logic so we only remove the wallet icon from the url bar when the url origin changes. This is so a reload (which occurs during a network switch) or a dapp page change doesn't remove the wallet icon when not needed.
- Close wallet panel when wallet icon is removed

This pull request fixes #5616

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
The testplan from the ticket cannot be verified now because the icon is no longer hidden when the page reloads.
Instead, best we can verify is that the icon is no longer hidden during a page reload / network change:
1. Open any dapp and wait for wallet icon to show in url bar (you may have to tap 'connect wallet' on some dapp sites). [Uniswap link](https://app.uniswap.org/) has option to change network too.
2. Open the wallet panel and change the network.
3. Verify wallet icon is not hidden during page reload
4. Change the network from the dapp site itself, tapping 'Switch' on the Switch Network request modal should reload the page. 
5. Verify wallet icon is not hidden during page reload


## Screenshots:

https://user-images.githubusercontent.com/5314553/178053757-848e32a5-2896-49b2-b7eb-263842ee03f5.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
