### PR TITLE
Ref #5643: Bump BraveCore to 1.41.91 beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.41.74/brave-core-ios-1.41.74.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.41.91/brave-core-ios-1.41.91.tgz",
         "page-metadata-parser": "^1.1.3",
         "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
         "webpack-cli": "^4.8.0"
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.41.74",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.41.74/brave-core-ios-1.41.74.tgz",
-      "integrity": "sha512-RH45G6pk2Qkn+4UaqhR5sVgmMnu73ziPv3uKb1B9HvWEiQs7cOFg+29RI/EUr8g7gzUutCZPoX4ptnI4ft0mJg==",
+      "version": "1.41.91",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.41.91/brave-core-ios-1.41.91.tgz",
+      "integrity": "sha512-zi8CP7pN3ftD1QikjsiQbGfU50rK0J9Mco2vz2EdUBkkkHDWVAaduZ5uDrTSziLbVD1DXB/5xXXAbz3yWHsdAw==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1639,8 +1639,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.41.47/brave-core-ios-1.41.47.tgz",
-      "integrity": "sha512-PykFr2yH9PXxAPyknKrJ1L7dZHinzqkyBt2LxoBTsh8Xxh+QQstaF1oWh/d4q4l1zrvWRSU1TVmhp/jhPJa2TQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.41.91/brave-core-ios-1.41.91.tgz",
+      "integrity": "sha512-zi8CP7pN3ftD1QikjsiQbGfU50rK0J9Mco2vz2EdUBkkkHDWVAaduZ5uDrTSziLbVD1DXB/5xXXAbz3yWHsdAw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.41.74/brave-core-ios-1.41.74.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.41.91/brave-core-ios-1.41.91.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
Bump Brave Core 1.41.91 - No changes required over develop (1.41.74)
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #5643

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
