### PR TITLE
Ref #5645: Don't expand toolbars on trait collection change

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -625,7 +625,6 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     displayedPopoverController?.dismiss(animated: true, completion: nil)
     coordinator.animate(
       alongsideTransition: { context in
-        self.toolbarVisibilityViewModel.toolbarState = .expanded
         if self.isViewLoaded {
           self.statusBarOverlay.backgroundColor = self.topToolbar.backgroundColor
           self.setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
This fixes an animation glitch where changing the appearance from light mode to dark mode, increasing font sizes, etc. would cause the toolbar to jump a bit.  Showing toolbars here was originally to handle zoom changes when rotating but the KVO observation of content size will catch this anyways so is no longer needed at all.

## Summary of Changes

Follow up of #5645

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
