### PR TITLE
Fix #5577: Solana/Filecoin network switch

### DIFF
--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -54,8 +54,7 @@ struct AssetDetailHeaderView: View {
             HStack {
               NetworkPicker(
                 keyringStore: keyringStore,
-                networkStore: networkStore,
-                selectedNetwork: networkStore.selectedChainBinding
+                networkStore: networkStore
               )
               if horizontalSizeClass == .regular {
                 Spacer()
@@ -83,8 +82,7 @@ struct AssetDetailHeaderView: View {
               .font(.title3.weight(.semibold))
             NetworkPicker(
               keyringStore: keyringStore,
-              networkStore: networkStore,
-              selectedNetwork: networkStore.selectedChainBinding
+              networkStore: networkStore
             )
             if horizontalSizeClass == .regular {
               Spacer()

--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -53,6 +53,7 @@ struct AssetDetailHeaderView: View {
           VStack(alignment: .leading) {
             HStack {
               NetworkPicker(
+                keyringStore: keyringStore,
                 networkStore: networkStore,
                 selectedNetwork: networkStore.selectedChainBinding
               )
@@ -81,6 +82,7 @@ struct AssetDetailHeaderView: View {
               .fixedSize(horizontal: false, vertical: true)
               .font(.title3.weight(.semibold))
             NetworkPicker(
+              keyringStore: keyringStore,
               networkStore: networkStore,
               selectedNetwork: networkStore.selectedChainBinding
             )

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -111,8 +111,7 @@ struct AccountPicker: View {
   private var networkPickerView: some View {
     NetworkPicker(
       keyringStore: keyringStore,
-      networkStore: networkStore,
-      selectedNetwork: networkStore.selectedChainBinding
+      networkStore: networkStore
     )
   }
 }

--- a/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -110,6 +110,7 @@ struct AccountPicker: View {
 
   private var networkPickerView: some View {
     NetworkPicker(
+      keyringStore: keyringStore,
       networkStore: networkStore,
       selectedNetwork: networkStore.selectedChainBinding
     )

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -163,7 +163,7 @@ struct MarketPriceView: View {
 
 struct SwapCryptoView: View {
   @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var ethNetworkStore: NetworkStore
+  @ObservedObject var networkStore: NetworkStore
   @ObservedObject var swapTokensStore: SwapTokenStore
 
   @State private var orderType: OrderType = .market
@@ -180,7 +180,7 @@ struct SwapCryptoView: View {
       VStack(alignment: .leading, spacing: 4.0) {
         Text(Strings.Wallet.swapCryptoUnsupportNetworkTitle)
           .font(.headline)
-        Text(String.localizedStringWithFormat(Strings.Wallet.swapCryptoUnsupportNetworkDescription, ethNetworkStore.selectedChain.chainName))
+        Text(String.localizedStringWithFormat(Strings.Wallet.swapCryptoUnsupportNetworkDescription, networkStore.selectedChain.chainName))
           .font(.subheadline)
           .foregroundColor(Color(.secondaryBraveLabel))
       }
@@ -224,7 +224,7 @@ struct SwapCryptoView: View {
   }
 
   private var isSwapEnabled: Bool {
-    let selectedChain = ethNetworkStore.selectedChainId
+    let selectedChain = networkStore.selectedChainId
     return selectedChain == BraveWallet.MainnetChainId || selectedChain == BraveWallet.RopstenChainId
   }
 
@@ -232,7 +232,7 @@ struct SwapCryptoView: View {
     Section(
       header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoFromTitle))
     ) {
-      NavigationLink(destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .fromToken, network: ethNetworkStore.selectedChain)) {
+      NavigationLink(destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .fromToken, network: networkStore.selectedChain)) {
         HStack {
           if let token = swapTokensStore.selectedFromToken {
             AssetIconView(token: token, length: 26)
@@ -291,7 +291,7 @@ struct SwapCryptoView: View {
       header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoToTitle))
     ) {
       NavigationLink(
-        destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .toToken, network: ethNetworkStore.selectedChain)
+        destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .toToken, network: networkStore.selectedChain)
       ) {
         HStack {
           if let token = swapTokensStore.selectedToToken {
@@ -463,7 +463,7 @@ struct SwapCryptoView: View {
         Section(
           header: AccountPicker(
             keyringStore: keyringStore,
-            networkStore: ethNetworkStore
+            networkStore: networkStore
           )
           .listRowBackground(Color.clear)
           .resetListHeaderStyle()
@@ -502,7 +502,7 @@ struct SwapCryptoView_Previews: PreviewProvider {
   static var previews: some View {
     SwapCryptoView(
       keyringStore: .previewStore,
-      ethNetworkStore: .previewStore,
+      networkStore: .previewStore,
       swapTokensStore: .previewStore,
       onDismiss: {}
     )

--- a/BraveWallet/Crypto/CryptoView.swift
+++ b/BraveWallet/Crypto/CryptoView.swift
@@ -158,7 +158,7 @@ public struct CryptoView: View {
               case .swap:
                 SwapCryptoView(
                   keyringStore: keyringStore,
-                  ethNetworkStore: store.networkStore,
+                  networkStore: store.networkStore,
                   swapTokensStore: store.openSwapTokenStore(destination.initialToken),
                   completion: { success in
                     if success {
@@ -269,7 +269,7 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
           case .swap:
             SwapCryptoView(
               keyringStore: keyringStore,
-              ethNetworkStore: cryptoStore.networkStore,
+              networkStore: cryptoStore.networkStore,
               swapTokensStore: cryptoStore.openSwapTokenStore(action.initialToken),
               onDismiss: { cryptoStore.buySendSwapDestination = nil }
             )

--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -143,12 +143,9 @@ struct NetworkPicker: View {
         AddAccountView(keyringStore: keyringStore, preSelectedCoin: nextNetwork?.coin)
       }
       .onDisappear {
-        Task { @MainActor in
-          guard let nextNetwork = nextNetwork else { return }
-          // if it errors it's due to no accounts and we don't want to switch to nextNetwork
-          await networkStore.setSelectedChain(nextNetwork)
-          self.nextNetwork = nil
-        }
+        // User either created an account, or cancelled. If account created,
+        // `NetworkStore`s `keyringCreated` observation will switch to the new account
+        self.nextNetwork = nil
       }
     }
   }

--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -140,7 +140,7 @@ struct NetworkPicker: View {
       isPresented: $isPresentingAddAccount
     ) {
       NavigationView {
-        AddAccountView(keyringStore: keyringStore) // TODO: pass `nextNetwork.coin` to account creation
+        AddAccountView(keyringStore: keyringStore, preSelectedCoin: nextNetwork?.coin)
       }
       .onDisappear {
         Task { @MainActor in

--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -145,7 +145,7 @@ struct NetworkPicker: View {
       .onDisappear {
         Task { @MainActor in
           guard let nextNetwork = nextNetwork else { return }
-          // iff it errors it's due to no accounts and we don't want to switch to nextNetwork
+          // if it errors it's due to no accounts and we don't want to switch to nextNetwork
           await networkStore.setSelectedChain(nextNetwork)
           self.nextNetwork = nil
         }

--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -44,7 +44,7 @@ struct NetworkPicker: View {
   }
   
   private var availableChains: [BraveWallet.NetworkInfo] {
-    networkStore.ethereumChains.filter { chain in
+    networkStore.allChains.filter { chain in
       if !Preferences.Wallet.showTestNetworks.value {
         var testNetworkChainIdsToRemove = WalletConstants.supportedTestNetworkChainIds
         // Don't remove selected network (possible if selected then disabled showing test networks)

--- a/BraveWallet/Crypto/NetworkPicker.swift
+++ b/BraveWallet/Crypto/NetworkPicker.swift
@@ -114,8 +114,8 @@ struct NetworkPicker: View {
       )
     ) {
       Alert(
-        title: Text("You don't have a \(selectedNetwork.shortChainName) account"),
-        message: Text("Create one now?"),
+        title: Text(String.localizedStringWithFormat(Strings.Wallet.createAccountAlertTitle, selectedNetwork.shortChainName)),
+        message: Text(Strings.Wallet.createAccountAlertMessage),
         primaryButton: .default(Text(Strings.yes), action: {
           // show create account for `networkStore.selectedChain.coin`
           self.isPresentingAddAccount = true

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -50,6 +50,7 @@ struct PortfolioView: View {
         balance: portfolioStore.balance,
         historicalBalances: portfolioStore.historicalBalances,
         isLoading: portfolioStore.isLoadingBalances,
+        keyringStore: keyringStore,
         networkStore: networkStore,
         selectedDateRange: $portfolioStore.timeframe
       )
@@ -136,6 +137,7 @@ struct BalanceHeaderView: View {
   var balance: String
   var historicalBalances: [BalanceTimePrice]
   var isLoading: Bool
+  var keyringStore: KeyringStore
   @ObservedObject var networkStore: NetworkStore
   @Binding var selectedDateRange: BraveWallet.AssetPriceTimeframe
 
@@ -150,6 +152,7 @@ struct BalanceHeaderView: View {
         if sizeCategory.isAccessibilityCategory {
           VStack(alignment: .leading) {
             NetworkPicker(
+              keyringStore: keyringStore,
               networkStore: networkStore,
               selectedNetwork: networkStore.selectedChainBinding
             )
@@ -161,6 +164,7 @@ struct BalanceHeaderView: View {
             Text(verbatim: balance)
               .font(.largeTitle.bold())
             NetworkPicker(
+              keyringStore: keyringStore,
               networkStore: networkStore,
               selectedNetwork: networkStore.selectedChainBinding
             )

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -153,8 +153,7 @@ struct BalanceHeaderView: View {
           VStack(alignment: .leading) {
             NetworkPicker(
               keyringStore: keyringStore,
-              networkStore: networkStore,
-              selectedNetwork: networkStore.selectedChainBinding
+              networkStore: networkStore
             )
             Text(verbatim: balance)
               .font(.largeTitle.bold())
@@ -165,8 +164,7 @@ struct BalanceHeaderView: View {
               .font(.largeTitle.bold())
             NetworkPicker(
               keyringStore: keyringStore,
-              networkStore: networkStore,
-              selectedNetwork: networkStore.selectedChainBinding
+              networkStore: networkStore
             )
             Spacer()
           }

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -48,7 +48,7 @@ struct AssetSearchView: View {
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
       cryptoStore.blockchainRegistry.allTokens(
-        cryptoStore.networkStore.selectedChainId,
+        cryptoStore.networkStore.selectedChain.chainId,
         coin: cryptoStore.networkStore.selectedChain.coin
       ) { tokens in
         self.allTokens = ([cryptoStore.networkStore.selectedChain.nativeToken] + tokens).sorted(by: { $0.symbol < $1.symbol })

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -48,7 +48,7 @@ struct AssetSearchView: View {
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
       cryptoStore.blockchainRegistry.allTokens(
-        cryptoStore.networkStore.selectedChain.chainId,
+        cryptoStore.networkStore.selectedChainId,
         coin: cryptoStore.networkStore.selectedChain.coin
       ) { tokens in
         self.allTokens = ([cryptoStore.networkStore.selectedChain.nativeToken] + tokens).sorted(by: { $0.symbol < $1.symbol })

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -87,7 +87,11 @@ public class CryptoStore: ObservableObject {
     self.txService = txService
     self.ethTxManagerProxy = ethTxManagerProxy
     
-    self.networkStore = .init(rpcService: rpcService, walletService: walletService)
+    self.networkStore = .init(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService
+    )
     self.portfolioStore = .init(
       keyringService: keyringService,
       rpcService: rpcService,

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -189,6 +189,12 @@ extension NetworkStore: BraveWalletKeyringServiceObserver {
   }
   
   public func keyringCreated(_ keyringId: String) {
+    Task { @MainActor in
+      // select the newly created account
+      let keyring = await keyringService.keyringInfo(keyringId)
+      guard let newAccount = keyring.accountInfos.first else { return }
+      await keyringService.setSelectedAccount(newAccount.address, coin: newAccount.coin)
+    }
   }
   
   public func keyringRestored(_ keyringId: String) {

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -84,8 +84,8 @@ public class NetworkStore: ObservableObject {
     Task { @MainActor in
       let keyringId = network.coin.keyringId
       let keyringInfo = await keyringService.keyringInfo(keyringId)
-        // Need to prompt user to create new account via alert
-        self.currentNetworkNeedsAccount = keyringInfo.accountInfos.isEmpty
+      // Need to prompt user to create new account via alert
+      self.currentNetworkNeedsAccount = keyringInfo.accountInfos.isEmpty
     }
     guard self.selectedChainId != network.chainId else { return }
     self.previousNetworkChainId = selectedChainId

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -47,7 +47,7 @@ public class NetworkStore: ObservableObject {
     self.updateChainList()
     rpcService.add(self)
     
-    Task { // fetch current selected network
+    Task { @MainActor in // fetch current selected network
       let selectedCoin = await walletService.selectedCoin()
       let chainIdForCoin = await rpcService.chainId(selectedCoin)
       let allNetworksForCoin = await rpcService.allNetworks(selectedCoin)
@@ -60,7 +60,7 @@ public class NetworkStore: ObservableObject {
   }
 
   private func updateChainList() {
-    Task { // fetch all networks for all coin types
+    Task { @MainActor in // fetch all networks for all coin types
       self.allChains = await withTaskGroup(of: [BraveWallet.NetworkInfo].self) { [weak rpcService] group -> [BraveWallet.NetworkInfo] in
         guard let rpcService = rpcService else { return [] }
         for coinType in WalletConstants.supportedCoinTypes {

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -43,9 +43,7 @@ public class NetworkStore: ObservableObject {
     
     Task { @MainActor in // fetch current selected network
       let selectedCoin = await walletService.selectedCoin()
-      let chainIdForCoin = await rpcService.chainId(selectedCoin)
-      let allNetworksForCoin = await rpcService.allNetworks(selectedCoin)
-      guard let chain = allNetworksForCoin.first(where: { $0.chainId == chainIdForCoin }) else { return }
+      let chain = await rpcService.network(selectedCoin)
       await setSelectedChain(chain)
     }
   }

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -174,6 +174,7 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
     updateChainList()
   }
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
+    walletService.setSelectedCoin(coin)
     Task { @MainActor in
       guard let chain = allChains.first(where: { $0.chainId == chainId && $0.coin == coin }) else {  return }
       await setSelectedChain(chain)

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -90,6 +90,7 @@ public class NetworkStore: ObservableObject {
     guard self.selectedChainId != network.chainId else { return }
     self.previousNetworkChainId = selectedChainId
     self.selectedChainId = network.chainId
+    self.rpcService.setNetwork(network.chainId, coin: network.coin) { _ in }
   }
   
   func returnToPreviousChainIfAccountNotCreated() {

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -119,6 +119,7 @@ extension BraveWallet.NetworkInfo: Identifiable {
   public var isCustom: Bool {
     /// Will be able to get known/custom networks after
     /// https://github.com/brave/brave-ios/issues/5489
+    // brave-core/components/brave_wallet/browser/brave_wallet_utils.cc
     let knownEthNetworks = [
       BraveWallet.MainnetChainId,
       BraveWallet.RinkebyChainId,
@@ -133,7 +134,19 @@ extension BraveWallet.NetworkInfo: Identifiable {
       BraveWallet.FantomMainnetChainId,
       BraveWallet.OptimismMainnetChainId
     ]
-    return !knownEthNetworks.contains(id)
+    let knownSolNetworks = [
+      BraveWallet.SolanaMainnet,
+      BraveWallet.SolanaTestnet,
+      BraveWallet.SolanaDevnet,
+      BraveWallet.LocalhostChainId
+    ]
+    let knownFilNetworks = [
+      BraveWallet.FilecoinMainnet,
+      BraveWallet.FilecoinTestnet,
+      BraveWallet.LocalhostChainId
+    ]
+    let knownNetworks = knownEthNetworks + knownSolNetworks + knownFilNetworks
+    return !knownNetworks.contains(id)
   }
   
   // Only Eth Mainnet or EVM has eip 1559

--- a/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -56,7 +56,7 @@ struct SuggestedNetworkView: View {
     case let .addNetwork(chain):
       return chain
     case let .switchNetworks(chainId):
-      return networkStore.ethereumChains.first(where: { $0.chainId == chainId })
+      return networkStore.allChains.first(where: { $0.chainId == chainId })
     }
   }
   

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -214,6 +214,7 @@ struct WalletPanelView: View {
   private var networkPickerButton: some View {
     NetworkPicker(
       style: .init(textColor: .white, borderColor: .white),
+      keyringStore: keyringStore,
       networkStore: networkStore,
       selectedNetwork: networkStore.selectedChainBinding
     )

--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -215,8 +215,7 @@ struct WalletPanelView: View {
     NetworkPicker(
       style: .init(textColor: .white, borderColor: .white),
       keyringStore: keyringStore,
-      networkStore: networkStore,
-      selectedNetwork: networkStore.selectedChainBinding
+      networkStore: networkStore
     )
   }
   

--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -182,6 +182,18 @@ extension BraveWallet.NetworkInfo {
     coin: .eth,
     data: .init(ethData: .init(isEip1559: true))
   )
+  static let mockSolana: BraveWallet.NetworkInfo = .init(
+    chainId: BraveWallet.SolanaMainnet,
+    chainName: "Solana Mainnet",
+    blockExplorerUrls: [""],
+    iconUrls: [],
+    rpcUrls: [],
+    symbol: "SOL",
+    symbolName: "Solana",
+    decimals: 18,
+    coin: .sol,
+    data: nil
+  )
 }
 
 #endif

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -42,6 +42,7 @@ extension CryptoStore {
 extension NetworkStore {
   static var previewStore: NetworkStore {
     .init(
+      keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: MockBraveWalletService()
     )

--- a/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -470,7 +470,7 @@ struct CustomNetworkDetailsView: View {
     }
     // Check if input chain id already existed for non-edit mode
     if !model.mode.isEditMode,
-      networkStore.ethereumChains.contains(where: { $0.id == chainIdInHex }) {
+      networkStore.allChains.contains(where: { $0.id == chainIdInHex }) {
       customNetworkError = .duplicateId
       return
     }

--- a/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/BraveWallet/Settings/CustomNetworkListView.swift
@@ -28,7 +28,7 @@ struct CustomNetworkListView: View {
   }
   
   private var customNetworks: [BraveWallet.NetworkInfo] {
-    networkStore.ethereumChains.filter { $0.isCustom }
+    networkStore.allChains.filter { $0.isCustom }
   }
   
   @ViewBuilder private var customNetworksList: some View {

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -31,5 +31,5 @@ struct WalletConstants {
   ]
   
   /// The currently supported coin types.
-  static let supportedCoinTypes: [BraveWallet.CoinType] = [.eth, .sol, .fil]
+  static let supportedCoinTypes: [BraveWallet.CoinType] = [.eth]
 }

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -30,6 +30,6 @@ struct WalletConstants {
     BraveWallet.FilecoinTestnet
   ]
   
-  /// The supported coin types for wallet acount creation
-  static let supportedCoinTypes: [BraveWallet.CoinType] = [.eth]
+  /// The currently supported coin types.
+  static let supportedCoinTypes: [BraveWallet.CoinType] = [.eth, .sol, .fil]
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2556,5 +2556,19 @@ extension Strings {
       value: "Select one of the following account types",
       comment: "A header displayed above coin types selection."
     )
+    public static let createAccountAlertTitle = NSLocalizedString(
+      "wallet.createAccountAlertTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "You don't have a %@ account",
+      comment: "The title of the alert shown when a user switches to a network they do not have an account for yet. '%@' will be replaced with a network name such as 'Solana' or 'Filecoin'."
+    )
+    public static let createAccountAlertMessage = NSLocalizedString(
+      "wallet.createAccountAlertMessage",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Create one now?",
+      comment: "The message of the alert shown when a user switches to a network they do not have an account for yet."
+    )
   }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -148,8 +148,10 @@ extension BrowserViewController {
       }
       MenuItemButton(icon: UIImage(named: "menu-settings", in: .current, compatibleWith: nil)!.template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
         var settingsStore: SettingsStore?
-        if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-          let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+        let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        if let keyringService = keyringService,
+          let walletService = walletService,
           let txService = BraveWallet.TxServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
           settingsStore = SettingsStore(
             keyringService: keyringService,
@@ -158,14 +160,19 @@ extension BrowserViewController {
           )
         }
         var networkStore: NetworkStore?
-        if let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-           let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
-          networkStore = NetworkStore(rpcService: rpcService, walletService: walletService)
+        if let keyringService = keyringService,
+           let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
+           let walletService = walletService {
+          networkStore = NetworkStore(
+            keyringService: keyringService,
+            rpcService: rpcService,
+            walletService: walletService
+          )
         }
         
         var keyringStore: KeyringStore?
-        if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing),
-           let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
+        if let keyringService = keyringService,
+           let walletService = walletService {
             keyringStore = KeyringStore(keyringService: keyringService, walletService: walletService)
         }
 

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -1,0 +1,93 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Combine
+import BraveCore
+@testable import BraveWallet
+
+class NetworkStoreTests: XCTestCase {
+  
+  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService) {
+    let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
+    let currentChainId = currentNetwork.chainId
+    let currentSelectedCoin: BraveWallet.CoinType = .eth
+    let allNetworks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
+      .eth: [.mockMainnet, .mockRinkeby, .mockRopsten],
+      .sol: [.mockSolana]
+    ]
+    
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._keyringInfo = { keyringId, completion in
+      let isEthereumKeyringId = keyringId == BraveWallet.CoinType.eth.keyringId
+      let keyring: BraveWallet.KeyringInfo = .init(
+        id: BraveWallet.DefaultKeyringId,
+        isKeyringCreated: true,
+        isLocked: false,
+        isBackedUp: true,
+        accountInfos: isEthereumKeyringId ? [.previewAccount] : []
+      )
+      completion(keyring)
+    }
+    keyringService._addObserver = { _ in }
+    keyringService._isLocked = { $0(false) }
+    
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._addObserver = { _ in }
+    rpcService._chainId = { $1(currentChainId) }
+    rpcService._network = { $1(currentNetwork) }
+    rpcService._allNetworks = { coinType, completion in
+      completion(allNetworks[coinType, default: []])
+    }
+    rpcService._setNetwork = { _, _, completion in
+      completion(true)
+    }
+    
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._addObserver = { _ in }
+    walletService._selectedCoin = { $0(currentSelectedCoin) }
+    
+    return (keyringService, rpcService, walletService)
+  }
+  
+  func testSetSelectedNetwork() async {
+    let (keyringService, rpcService, walletService) = setupServices()
+    
+    let store = NetworkStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService
+    )
+    
+    let error = await store.setSelectedChain(.mockRopsten)
+    XCTAssertNil(error, "Expected success, accounts exist for ethereum")
+  }
+  
+  func testSetSelectedNetworkSameNetwork() async {
+    let (keyringService, rpcService, walletService) = setupServices()
+    
+    let store = NetworkStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService
+    )
+    
+    let error = await store.setSelectedChain(.mockMainnet)
+    XCTAssertEqual(error, .chainAlreadySelected, "Expected chain already selected error")
+  }
+  
+  func testSetSelectedNetworkNoAccounts() async {
+    let (keyringService, rpcService, walletService) = setupServices()
+    
+    let store = NetworkStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService
+    )
+    
+    let error = await store.setSelectedChain(.mockSolana)
+    XCTAssertEqual(error, .selectedChainHasNoAccounts, "Expected chain has no accounts error")
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Add support for switching to Solana and Filecoin networks

This pull request fixes #5577 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
0. Until Solana support work is ready, need to add `.sol` and/or `.fil` to `supportedCoinTypes` in `WalletConstants.swift`.
1. Switch network to a Solana network.
2. Verify prompted via alert to create a Solana account.
3. Tap 'No'
4. Verify network remains on previous Ethereum network.
5. Switch network to a Solana network
6. Tap 'Yes' on create account alert
7. Verify Add Account modal shows up, and does not show the coin selection view (we know coin type from selected network).
    -  NOTE: Actually creating a Solana / Filecoin account is not supported yet. Add account dismissal will check for accounts > 0 for that coin type. If none exist, you will remain on previous network.
8. Dismiss Add Account modal
9. Verify network remains on previous Ethereum network.


## Screenshots:

https://user-images.githubusercontent.com/5314553/179073380-9feb80c8-3b64-467c-8285-25aefaffa026.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
