### PR TITLE
Fix #5692: Pull favicons from cache when necessary

### DIFF
--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -52,7 +52,7 @@ class FaviconHandler {
         FaviconMO.add(favicon, forSiteUrl: currentURL, persistent: !tab.isPrivate)
       }
       
-      let onCompletedSiteFavicon: ImageCacheCompletion = { image, data, _, _, url in
+      let onCompletedSiteFavicon: ImageCacheCompletion = { [weak tab] image, data, _, _, url in
         let favicon = Favicon(url: url.absoluteString, date: Date(), type: type)
         
         guard let image = image,
@@ -63,6 +63,10 @@ class FaviconHandler {
           
           onSuccess(favicon, data)
           return
+        }
+        
+        if let tab = tab, !tab.isPrivate {
+          webImageCache.cacheImage(image: image, data: data ?? Data(), url: url)
         }
         
         if let header = "%PDF".data(using: .utf8),
@@ -84,7 +88,7 @@ class FaviconHandler {
         onSuccess(favicon, data)
       }
       
-      let onCompletedPageFavicon: ImageCacheCompletion = { image, data, _, _, url in
+      let onCompletedPageFavicon: ImageCacheCompletion = { [weak tab] image, data, _, _, url in
         guard let image = image else {
           // If we failed to download a page-level icon, try getting the domain-level icon
           // instead before ultimately failing.
@@ -96,6 +100,10 @@ class FaviconHandler {
         let favicon = Favicon(url: url.absoluteString, date: Date(), type: type)
         favicon.width = Int(image.size.width)
         favicon.height = Int(image.size.height)
+        
+        if let tab = tab, !tab.isPrivate {
+          webImageCache.cacheImage(image: image, data: data ?? Data(), url: url)
+        }
         
         onSuccess(favicon, data)
       }

--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -66,7 +66,7 @@ class FaviconHandler {
         }
         
         if let tab = tab, !tab.isPrivate {
-          webImageCache.cacheImage(image: image, data: data ?? Data(), url: url)
+          webImageCache.cacheImage(image: image, data: imageData, url: url)
         }
         
         if let header = "%PDF".data(using: .utf8),
@@ -89,7 +89,7 @@ class FaviconHandler {
       }
       
       let onCompletedPageFavicon: ImageCacheCompletion = { [weak tab] image, data, _, _, url in
-        guard let image = image else {
+        guard let image = image, let data = data else {
           // If we failed to download a page-level icon, try getting the domain-level icon
           // instead before ultimately failing.
           let siteIconURL = currentURL.domainURL.appendingPathComponent("favicon.ico")
@@ -102,7 +102,7 @@ class FaviconHandler {
         favicon.height = Int(image.size.height)
         
         if let tab = tab, !tab.isPrivate {
-          webImageCache.cacheImage(image: image, data: data ?? Data(), url: url)
+          webImageCache.cacheImage(image: image, data: data, url: url)
         }
         
         onSuccess(favicon, data)

--- a/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
+++ b/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
@@ -292,18 +292,18 @@ public class FaviconFetcher {
           if !cache.isCached(url) {
             completion(self.url, self.monogramFavicon)
             return
-          } else {
-            cache.getCachedImage(for: url) { image in
-              if let image = image {
-                Self.isIconBackgroundTransparentAroundEdges(image) { isTransparent in
-                  completion(self.url, FaviconAttributes(image: image, includePadding: isTransparent))
-                }
-              } else {
-                completion(self.url, self.monogramFavicon)
-              }
-            }
-            return
           }
+          
+          cache.getCachedImage(for: url) { image in
+            if let image = image {
+              Self.isIconBackgroundTransparentAroundEdges(image) { isTransparent in
+                completion(self.url, FaviconAttributes(image: image, includePadding: isTransparent))
+              }
+            } else {
+              completion(self.url, self.monogramFavicon)
+            }
+          }
+          return
         }
 
         downloadIcon(url: url, addingToDatabase: false) { [weak self] image in

--- a/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
+++ b/Client/Frontend/Browser/Favicons/FaviconFetcher.swift
@@ -292,6 +292,17 @@ public class FaviconFetcher {
           if !cache.isCached(url) {
             completion(self.url, self.monogramFavicon)
             return
+          } else {
+            cache.getCachedImage(for: url) { image in
+              if let image = image {
+                Self.isIconBackgroundTransparentAroundEdges(image) { isTransparent in
+                  completion(self.url, FaviconAttributes(image: image, includePadding: isTransparent))
+                }
+              } else {
+                completion(self.url, self.monogramFavicon)
+              }
+            }
+            return
           }
         }
 

--- a/Client/Frontend/Browser/ImageCache/WebImageCache.swift
+++ b/Client/Frontend/Browser/ImageCache/WebImageCache.swift
@@ -87,6 +87,13 @@ final public class WebImageCache: ImageCacheProtocol {
     webImageManager.imageCache.store(image, imageData: data, forKey: key, cacheType: .all)
   }
 
+  public func getCachedImage(for url: URL, completion: @escaping (UIImage?) -> Void) {
+    let key = self.webImageManager.cacheKey(for: url)
+    webImageManager.imageCache.queryImage(forKey: key, options: [.fromCacheOnly, .queryMemoryData], context: nil, cacheType: .all) { image, _, _ in
+      completion(image)
+    }
+  }
+  
   public func isCached(_ url: URL) -> Bool {
     return webImageManager.cacheKey(for: url) != nil
   }

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -594,7 +594,7 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
         cell.imageView?.layer.borderColor = SearchViewControllerUX.iconBorderColor.cgColor
         cell.imageView?.layer.borderWidth = SearchViewControllerUX.iconBorderWidth
         cell.imageView?.image = UIImage()
-        cell.imageView?.loadFavicon(for: site.tileURL)
+        cell.imageView?.loadFavicon(for: site.tileURL, cachedOnly: true)
         cell.backgroundColor = .secondaryBraveBackground
       }
         


### PR DESCRIPTION
## Summary of Changes
- Pull favicons from cache only, when viewing History and Search Suggestions screens.
- Properly cache icons when they are fetched

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5692

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Check that the app does not make any requests for favicons when NOT viewing/visiting a page.

## Screenshots:
![image](https://user-images.githubusercontent.com/1530031/179082965-ec52059e-d4eb-4670-b4de-de5aa7fbd3a9.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
