### PR TITLE
Fix #5695: Allow tapping empty bottom area to expand toolbars

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -42,6 +42,7 @@ private let KVOs: [KVOConstants] = [
 
 private struct BrowserViewControllerUX {
   fileprivate static let showHeaderTapAreaHeight: CGFloat = 32
+  fileprivate static let showFooterTapAreaHeight: CGFloat = 44
   fileprivate static let bookmarkStarAnimationDuration: Double = 0.5
   fileprivate static let bookmarkStarAnimationOffset: CGFloat = 80
 }
@@ -111,6 +112,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
   let header = HeaderContainerView()
   var footer: UIView!
   fileprivate var topTouchArea: UIButton!
+  fileprivate let bottomTouchArea = UIButton()
 
   // These constraints allow to show/hide tabs bar
   var webViewContainerTopOffset: Constraint?
@@ -750,6 +752,10 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     topTouchArea.addTarget(self, action: #selector(tappedTopArea), for: .touchUpInside)
     view.addSubview(topTouchArea)
 
+    bottomTouchArea.isAccessibilityElement = false
+    bottomTouchArea.addTarget(self, action: #selector(tappedTopArea), for: .touchUpInside)
+    view.addSubview(bottomTouchArea)
+    
     // Setup the URL bar, wrapped in a view to get transparency effect
     topToolbar = TopToolbarView()
     topToolbar.translatesAutoresizingMaskIntoConstraints = false
@@ -964,6 +970,10 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
       make.height.equalTo(BrowserViewControllerUX.showHeaderTapAreaHeight)
     }
 
+    bottomTouchArea.snp.makeConstraints { make in
+      make.bottom.left.right.equalTo(self.view)
+      make.height.equalTo(BrowserViewControllerUX.showFooterTapAreaHeight)
+    }
   }
 
   override public func viewDidLayoutSubviews() {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5695 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
