### PR TITLE
Fix #5692: Fix favicons not showing for .ico files

### DIFF
--- a/Client/Frontend/Browser/ImageCache/WebImageCache.swift
+++ b/Client/Frontend/Browser/ImageCache/WebImageCache.swift
@@ -82,7 +82,7 @@ final public class WebImageCache: ImageCacheProtocol {
     return imageOperation
   }
 
-  public func cacheImage(image: UIImage, data: Data, url: URL) {
+  public func cacheImage(image: UIImage, data: Data?, url: URL) {
     let key = self.webImageManager.cacheKey(for: url)
     webImageManager.imageCache.store(image, imageData: data, forKey: key, cacheType: .all)
   }


### PR DESCRIPTION
## Summary of Changes
- Sometimes icons can be decoded but SDWebImage will still return `nil for the `data` parameter
- This allows us to cache the image anyway (I don't know why this is a thing).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5692

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`

## Test Plan:
- Test `PancakeSwap.finance` or `app.uniswap.org`


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
