### PR TITLE
Fix #5718: Solana Account Balances

### DIFF
--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -18,7 +18,7 @@ struct AssetSearchView: View {
   
   var body: some View {
     NavigationView {
-      TokenList(tokens: allTokens.filter({ $0.isErc20 || $0.symbol == cryptoStore.networkStore.selectedChain.symbol })) { token in
+      TokenList(tokens: allTokens.filter { !$0.isErc721 || $0.symbol == cryptoStore.networkStore.selectedChain.symbol }) { token in
         NavigationLink(
           destination: AssetDetailView(
             assetDetailStore: cryptoStore.assetDetailStore(for: token),

--- a/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -15,7 +15,7 @@ struct SendTokenSearchView: View {
   var network: BraveWallet.NetworkInfo
   
   var body: some View {
-    TokenList(tokens: sendTokenStore.userAssets.filter({ $0.isErc20 || $0.symbol == network.symbol })) { token in
+    TokenList(tokens: sendTokenStore.userAssets.filter { !$0.isErc721 || $0.symbol == network.symbol }) { token in
       Button(action: {
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -56,7 +56,7 @@ class AccountActivityStore: ObservableObject {
 
   func update() {
     Task { @MainActor in
-      let coin = await walletService.selectedCoin()
+      let coin = account.coin
       let network = await rpcService.network(coin)
       let keyring = await keyringService.keyringInfo(coin.keyringId)
       let allTokens: [BraveWallet.BlockchainToken] = await blockchainRegistry.allTokens(network.chainId, coin: network.coin)

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -83,12 +83,12 @@ class AccountActivityStore: ObservableObject {
       AssetViewModel(token: $0, decimalBalance: 0, price: "", history: [])
     }
     // fetch price for each asset
-    let (_, prices) = await assetRatioService.price(
+    let priceResult = await assetRatioService.priceWithIndividualRetry(
       userVisibleTokens.map { $0.symbol.lowercased() },
       toAssets: [currencyFormatter.currencyCode],
       timeframe: .oneDay
     )
-    for price in prices {
+    for price in priceResult.assetPrices {
       if let index = updatedAssets.firstIndex(where: {
         $0.token.symbol.caseInsensitiveCompare(price.fromAsset) == .orderedSame
       }) {

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -121,14 +121,12 @@ public class PortfolioStore: ObservableObject {
 
   /// Fetches the prices for a given list of symbols, giving a dictionary with the price for each symbol
   private func fetchPrices(for symbols: [String], completion: @escaping ([String: String]) -> Void) {
-    assetRatioService.price(
+    assetRatioService.priceWithIndividualRetry(
       symbols.map { $0.lowercased() },
       toAssets: [currencyFormatter.currencyCode],
       timeframe: timeframe
-    ) { success, assetPrices in
-      // `success` only refers to finding _all_ prices and if even 1 of N prices
-      // fail to fetch it will be false
-      let prices = Dictionary(uniqueKeysWithValues: assetPrices.map { ($0.fromAsset, $0.price) })
+    ) { priceResult in
+      let prices = Dictionary(uniqueKeysWithValues: priceResult.assetPrices.map { ($0.fromAsset, $0.price) })
       completion(prices)
     }
   }

--- a/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -103,19 +103,20 @@ public class UserAssetsStore: ObservableObject {
   ) {
     walletService.selectedCoin { [weak self] coinType in
       guard let self = self else { return }
+      // TODO: Add network selection picker to `AddCustomAssetView`: Issue #5725
       self.rpcService.network(coinType) { network in
         let token = BraveWallet.BlockchainToken(
           contractAddress: address,
           name: name,
           logo: "",
-          isErc20: true,
+          isErc20: coinType == .eth,
           isErc721: false,
           symbol: symbol,
           decimals: Int32(decimals),
           visible: true,
           tokenId: "",
           coingeckoId: "",
-          chainId: "",
+          chainId: network.chainId,
           coin: network.coin
         )
         self.walletService.addUserAsset(token) { success in

--- a/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
+++ b/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
@@ -1,0 +1,88 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+
+extension BraveWalletAssetRatioService {
+  typealias PricesResult = (assetPrices: [BraveWallet.AssetPrice], failureCount: Int)
+  
+  /// Fetch the price for a list of assets to a list of assets over a given timeframe.
+  /// If the main call for all asset prices fails, will fetch the price for each asset individually, so one failure will not result in a failure to fetch all assets.
+  func priceWithIndividualRetry(
+    _ fromAssets: [String],
+    toAssets: [String],
+    timeframe: BraveWallet.AssetPriceTimeframe
+  ) async -> PricesResult {
+    let (success, prices) = await self.price(fromAssets, toAssets: toAssets, timeframe: timeframe)
+    guard success else {
+      return await self.priceIndividually(fromAssets, toAssets: toAssets, timeframe: timeframe)
+    }
+    return PricesResult(prices, 0)
+  }
+  
+  /// Fetch the price for each asset in `fromAssets` individually, so one failure will not result in a failure to fetch all assets.
+  private func priceIndividually(
+    _ fromAssets: [String],
+    toAssets: [String],
+    timeframe: BraveWallet.AssetPriceTimeframe
+  ) async -> PricesResult {
+    await withTaskGroup(of: PricesResult.self) { group -> PricesResult in
+      fromAssets.forEach { asset in
+        group.addTask {
+          let (success, prices) = await self.price([asset], toAssets: toAssets, timeframe: timeframe)
+          return PricesResult(prices, success ? 0 : 1)
+        }
+      }
+      return await group.reduce(PricesResult([], 0), { prior, new in
+        return PricesResult(prior.assetPrices + new.assetPrices, prior.failureCount + new.failureCount)
+      })
+    }
+  }
+}
+
+extension BraveWalletAssetRatioService {
+  /// Fetch the price for a list of assets to a list of assets over a given timeframe.
+  /// If the main call for all asset prices fails, will fetch the price for each asset individually, so one failure will not result in a failure to fetch all assets.
+  func priceWithIndividualRetry(
+    _ fromAssets: [String],
+    toAssets: [String],
+    timeframe: BraveWallet.AssetPriceTimeframe,
+    completion: @escaping (PricesResult) -> Void
+  ) {
+    price(fromAssets, toAssets: toAssets, timeframe: timeframe) { [self] success, prices in
+      guard success else {
+        self.priceIndividually(fromAssets, toAssets: toAssets, timeframe: timeframe, completion: completion)
+        return
+      }
+      completion(PricesResult(prices, 0))
+    }
+  }
+  
+  /// Fetch the price for each asset in `fromAssets` individually, so one failure will not result in a failure to fetch all assets.
+  private func priceIndividually(
+    _ fromAssets: [String],
+    toAssets: [String],
+    timeframe: BraveWallet.AssetPriceTimeframe,
+    completion: @escaping (PricesResult) -> Void
+  ) {
+    var pricesResults: [PricesResult] = []
+    let dispatchGroup = DispatchGroup()
+    fromAssets.forEach { asset in
+      dispatchGroup.enter()
+      self.price([asset], toAssets: toAssets, timeframe: timeframe) { success, prices in
+        defer { dispatchGroup.leave() }
+        pricesResults.append(PricesResult(prices, success ? 0 : 1))
+      }
+    }
+    
+    dispatchGroup.notify(queue: .main) {
+      let priceResult = pricesResults.reduce(PricesResult([], 0), { prior, new in
+        return PricesResult(prior.assetPrices + new.assetPrices, prior.failureCount + new.failureCount)
+      })
+      completion(priceResult)
+    }
+  }
+}

--- a/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -43,20 +43,44 @@ extension BraveWalletJsonRpcService {
           }
         )
       case .sol:
-        solanaBalance(account.address, chainId: network.chainId) { lamports, status, errorMessage in
-          guard status == .success else {
-            completion(nil)
-            return
+        if token.symbol == network.nativeToken.symbol {
+          solanaBalance(account.address, chainId: network.chainId) { lamports, status, errorMessage in
+            guard status == .success else {
+              completion(nil)
+              return
+            }
+            let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+            if let valueString = formatter.decimalString(
+              for: "\(lamports)",
+              radix: .decimal,
+              decimals: Int(token.decimals)
+            ) {
+              completion(Double(valueString))
+            } else {
+              completion(nil)
+            }
           }
-          let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
-          if let valueString = formatter.decimalString(
-            for: "\(lamports)",
-            radix: .decimal,
-            decimals: Int(token.decimals)
-          ) {
-            completion(Double(valueString))
-          } else {
-            completion(nil)
+        } else {
+          // TODO: verify working
+          splTokenAccountBalance(
+            account.address,
+            tokenMintAddress: token.contractAddress,
+            chainId: network.chainId
+          ) { amount, lamports, uiAmountString, status, errorMessage in
+            guard status == .success else {
+              completion(nil)
+              return
+            }
+            let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+            if let valueString = formatter.decimalString(
+              for: "\(lamports)",
+              radix: .decimal,
+              decimals: Int(token.decimals)
+            ) {
+              completion(Double(valueString))
+            } else {
+              completion(nil)
+            }
           }
         }
       case .fil:
@@ -119,20 +143,44 @@ extension BraveWalletJsonRpcService {
           }
         )
       case .sol:
-        solanaBalance(accountAddress, chainId: network.chainId) { lamports, status, errorMessage in
-          guard status == .success else {
-            completion(nil)
-            return
+        if token.symbol == network.nativeToken.symbol {
+          solanaBalance(accountAddress, chainId: network.chainId) { lamports, status, errorMessage in
+            guard status == .success else {
+              completion(nil)
+              return
+            }
+            let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+            if let valueString = formatter.decimalString(
+              for: "\(lamports)",
+              radix: .decimal,
+              decimals: Int(token.decimals)
+            ) {
+              completion(BDouble(valueString))
+            } else {
+              completion(nil)
+            }
           }
-          let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
-          if let valueString = formatter.decimalString(
-            for: "\(lamports)",
-            radix: .decimal,
-            decimals: Int(token.decimals)
-          ) {
-            completion(BDouble(valueString))
-          } else {
-            completion(nil)
+        } else {
+          // TODO: verify working
+          splTokenAccountBalance(
+            accountAddress,
+            tokenMintAddress: token.contractAddress,
+            chainId: network.chainId
+          ) { amount, lamports, uiAmountString, status, errorMessage in
+            guard status == .success else {
+              completion(nil)
+              return
+            }
+            let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+            if let valueString = formatter.decimalString(
+              for: "\(lamports)",
+              radix: .decimal,
+              decimals: Int(token.decimals)
+            ) {
+              completion(BDouble(valueString))
+            } else {
+              completion(nil)
+            }
           }
         }
       case .fil:

--- a/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -61,7 +61,6 @@ extension BraveWalletJsonRpcService {
             }
           }
         } else {
-          // TODO: verify working
           splTokenAccountBalance(
             account.address,
             tokenMintAddress: token.contractAddress,
@@ -73,7 +72,7 @@ extension BraveWalletJsonRpcService {
             }
             let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
             if let valueString = formatter.decimalString(
-              for: "\(lamports)",
+              for: "\(amount)",
               radix: .decimal,
               decimals: Int(token.decimals)
             ) {
@@ -161,7 +160,6 @@ extension BraveWalletJsonRpcService {
             }
           }
         } else {
-          // TODO: verify working
           splTokenAccountBalance(
             accountAddress,
             tokenMintAddress: token.contractAddress,
@@ -173,7 +171,7 @@ extension BraveWalletJsonRpcService {
             }
             let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
             if let valueString = formatter.decimalString(
-              for: "\(lamports)",
+              for: "\(amount)",
               radix: .decimal,
               decimals: Int(token.decimals)
             ) {

--- a/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -217,6 +217,9 @@ extension BraveWalletJsonRpcService {
         chainId: network.chainId,
         completion: completion
       )
+    } else {
+      let errorMessage = "Unable to fetch ethereum balance for \(token.symbol) token in account address '\(accountAddress)'"
+      completion("", .internalError, errorMessage)
     }
   }
 }

--- a/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -65,7 +65,7 @@ extension BraveWalletJsonRpcService {
             account.address,
             tokenMintAddress: token.contractAddress,
             chainId: network.chainId
-          ) { amount, lamports, uiAmountString, status, errorMessage in
+          ) { amount, _, _, status, errorMessage in
             guard status == .success else {
               completion(nil)
               return
@@ -164,7 +164,7 @@ extension BraveWalletJsonRpcService {
             accountAddress,
             tokenMintAddress: token.contractAddress,
             chainId: network.chainId
-          ) { amount, lamports, uiAmountString, status, errorMessage in
+          ) { amount, _, _, status, errorMessage in
             guard status == .success else {
               completion(nil)
               return

--- a/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -15,42 +15,53 @@ extension BraveWalletJsonRpcService {
   func balance(
     for token: BraveWallet.BlockchainToken,
     in account: BraveWallet.AccountInfo,
+    decimalFormatStyle: WeiFormatter.DecimalFormatStyle = .balance,
     completion: @escaping (Double?) -> Void
   ) {
-    let convert: (String, BraveWallet.ProviderError, String) -> Void = { wei, status, _ in
-      guard status == .success && !wei.isEmpty else {
-        completion(nil)
-        return
-      }
-      let formatter = WeiFormatter(decimalFormatStyle: .balance)
-      if let valueString = formatter.decimalString(
-        for: wei.removingHexPrefix,
-        radix: .hex,
-        decimals: Int(token.decimals)
-      ) {
-        completion(Double(valueString))
-      } else {
-        completion(nil)
-      }
-    }
     network(account.coin) { [self] network in
-      if token.symbol == network.symbol {
-        balance(account.address, coin: account.coin, chainId: network.chainId, completion: convert)
-      } else if token.isErc20 {
-        erc20TokenBalance(
-          token.contractAddress(in: network),
-          address: account.address,
-          chainId: network.chainId,
-          completion: convert
+      switch account.coin {
+      case .eth:
+        ethBalance(
+          for: token,
+          in: account.address,
+          network: network,
+          completion: { wei, status, _ in
+            guard status == .success && !wei.isEmpty else {
+              completion(nil)
+              return
+            }
+            let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+            if let valueString = formatter.decimalString(
+              for: wei.removingHexPrefix,
+              radix: .hex,
+              decimals: Int(token.decimals)
+            ) {
+              completion(Double(valueString))
+            } else {
+              completion(nil)
+            }
+          }
         )
-      } else if token.isErc721 {
-        erc721TokenBalance(
-          token.contractAddress,
-          tokenId: token.tokenId,
-          accountAddress: account.address,
-          chainId: network.chainId,
-          completion: convert)
-      } else {
+      case .sol:
+        solanaBalance(account.address, chainId: network.chainId) { lamports, status, errorMessage in
+          guard status == .success else {
+            completion(nil)
+            return
+          }
+          let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+          if let valueString = formatter.decimalString(
+            for: "\(lamports)",
+            radix: .decimal,
+            decimals: Int(token.decimals)
+          ) {
+            completion(Double(valueString))
+          } else {
+            completion(nil)
+          }
+        }
+      case .fil:
+        completion(nil)
+      @unknown default:
         completion(nil)
       }
     }
@@ -83,42 +94,83 @@ extension BraveWalletJsonRpcService {
     decimalFormatStyle: WeiFormatter.DecimalFormatStyle,
     completion: @escaping (BDouble?) -> Void
   ) {
-    let convert: (String, BraveWallet.ProviderError, String) -> Void = { wei, status, _ in
-      guard status == .success && !wei.isEmpty else {
+    network(coin) { [self] network in
+      switch coin {
+      case .eth:
+        ethBalance(
+          for: token,
+          in: accountAddress,
+          network: network,
+          completion: { wei, status, _ in
+            guard status == .success && !wei.isEmpty else {
+              completion(nil)
+              return
+            }
+            let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+            if let valueString = formatter.decimalString(
+              for: wei.removingHexPrefix,
+              radix: .hex,
+              decimals: Int(token.decimals)
+            ) {
+              completion(BDouble(valueString))
+            } else {
+              completion(nil)
+            }
+          }
+        )
+      case .sol:
+        solanaBalance(accountAddress, chainId: network.chainId) { lamports, status, errorMessage in
+          guard status == .success else {
+            completion(nil)
+            return
+          }
+          let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+          if let valueString = formatter.decimalString(
+            for: "\(lamports)",
+            radix: .decimal,
+            decimals: Int(token.decimals)
+          ) {
+            completion(BDouble(valueString))
+          } else {
+            completion(nil)
+          }
+        }
+      case .fil:
         completion(nil)
-        return
-      }
-      let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
-      if let valueString = formatter.decimalString(
-        for: wei.removingHexPrefix,
-        radix: .hex,
-        decimals: Int(token.decimals)
-      ) {
-        completion(BDouble(valueString))
-      } else {
+      @unknown default:
         completion(nil)
       }
     }
-    network(coin) { [self] network in
-      if token.symbol == network.symbol {
-        balance(accountAddress, coin: coin, chainId: network.chainId, completion: convert)
-      } else if token.isErc20 {
-        erc20TokenBalance(
-          token.contractAddress(in: network),
-          address: accountAddress,
-          chainId: network.chainId,
-          completion: convert
-        )
-      } else if token.isErc721 {
-        erc721TokenBalance(
-          token.contractAddress,
-          tokenId: token.tokenId,
-          accountAddress: accountAddress,
-          chainId: network.chainId,
-          completion: convert)
-      } else {
-        completion(nil)
-      }
+  }
+  
+  private func ethBalance(
+    for token: BraveWallet.BlockchainToken,
+    in accountAddress: String,
+    network: BraveWallet.NetworkInfo,
+    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
+  ) {
+    if token.symbol == network.symbol {
+      balance(
+        accountAddress,
+        coin: .eth,
+        chainId: network.chainId,
+        completion: completion
+      )
+    } else if token.isErc20 {
+      erc20TokenBalance(
+        token.contractAddress(in: network),
+        address: accountAddress,
+        chainId: network.chainId,
+        completion: completion
+      )
+    } else if token.isErc721 {
+      erc721TokenBalance(
+        token.contractAddress,
+        tokenId: token.tokenId,
+        accountAddress: accountAddress,
+        chainId: network.chainId,
+        completion: completion
+      )
     }
   }
 }

--- a/BraveWallet/Extensions/WeiFormatter.swift
+++ b/BraveWallet/Extensions/WeiFormatter.swift
@@ -60,11 +60,11 @@ struct WeiFormatter {
     }
   }
 
-  /// Get a decimal representation of a Wei value given some decimal precision of said Wei
+  /// Get a decimal representation of a value string given some decimal precision of said value
   ///
   /// - parameters:
-  ///     - value: A wei string
-  ///     - radix: The radix of the wei string, defaults to 10
+  ///     - value: A string representation of the value, typically a wei value string.
+  ///     - radix: The radix of the value string, defaults to 10
   ///     - decimals: The number of decimal precision to convert to. For example, ETH and
   ///                 ERC20 tokens will have 18 decimals by default
   func decimalString(for value: String, radix: Radix = .decimal, decimals: Int) -> String? {

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -38,6 +38,21 @@ extension BraveWallet.BlockchainToken {
     chainId: "",
     coin: .eth
   )
+  
+  static let mockSolToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0x1111111111222222222233333333334444444444",
+    name: "Solana",
+    logo: "",
+    isErc20: false,
+    isErc721: false,
+    symbol: "SOL",
+    decimals: 9,
+    visible: false,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: "",
+    coin: .sol
+  )
 }
 
 extension BraveWallet.AccountInfo {

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -12,9 +12,9 @@ class PortfolioStoreTests: XCTestCase {
 
   private var cancellables: Set<AnyCancellable> = .init()
 
-  func testUpdate() {
+  func testUpdateEthereum() {
     // config test
-    let mockAccountInfos: [BraveWallet.AccountInfo] = [.previewAccount]
+    let mockAccountInfos: [BraveWallet.AccountInfo] = [.mockEthAccount]
     let chainId = BraveWallet.MainnetChainId
     let network: BraveWallet.NetworkInfo = .mockMainnet
     let mockUserAssets: [BraveWallet.BlockchainToken] = [.previewToken.then { $0.visible = true }]
@@ -91,6 +91,104 @@ class PortfolioStoreTests: XCTestCase {
       .sink { balance in
         defer { balanceException.fulfill() }
         XCTAssertEqual(balance, totalEthBalance)
+      }
+      .store(in: &cancellables)
+    // test that `update()` will update `isLoadingBalances` publisher
+    let isLoadingBalancesException = expectation(description: "update-isLoadingBalances")
+    store.$isLoadingBalances
+      .dropFirst()
+      .collect(2)
+      .first()
+      .sink { isLoadingUpdates in
+        defer { isLoadingBalancesException.fulfill() }
+        XCTAssertTrue(isLoadingUpdates[0])
+        XCTAssertFalse(isLoadingUpdates[1])
+      }
+      .store(in: &cancellables)
+    store.update()
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  func testUpdateSolana() {
+    WalletDebugFlags.isSolanaEnabled = true
+    // config test
+    let mockAccountInfos: [BraveWallet.AccountInfo] = [.mockSolAccount]
+    let network: BraveWallet.NetworkInfo = .mockSolana
+    let chainId = network.chainId
+    let mockUserAssets: [BraveWallet.BlockchainToken] = [.mockSolToken.then { $0.visible = true }]
+    let mockLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL
+    let mockDecimalBalance: Double = 3.8765 // rounded
+    let mockSolAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "sol", toAsset: "usd", price: "200.00", assetTimeframeChange: "-57.23")
+    let mockSolPriceHistory: [BraveWallet.AssetTimePrice] = [.init(date: Date(timeIntervalSinceNow: -1000), price: "$200.00"), .init(date: Date(), price: "250.00")]
+    let totalSolBalanceValue: Double = (Double(mockSolAssetPrice.price) ?? 0) * mockDecimalBalance
+    let currencyFormatter = NumberFormatter().then { $0.numberStyle = .currency }
+    let totalSolBalance = currencyFormatter.string(from: NSNumber(value: totalSolBalanceValue)) ?? ""
+
+    // setup test services
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._keyringInfo = { _, completion in
+      let keyring: BraveWallet.KeyringInfo = .init(
+        id: BraveWallet.DefaultKeyringId,
+        isKeyringCreated: true,
+        isLocked: false,
+        isBackedUp: true,
+        accountInfos: mockAccountInfos)
+      completion(keyring)
+    }
+    keyringService._addObserver = { _ in }
+    keyringService._isLocked = { $0(false) }
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._addObserver = { _ in }
+    rpcService._chainId = { $1(chainId) }
+    rpcService._network = { $1(network) }
+    rpcService._solanaBalance = { accountAddress, chainId, completion in
+      completion(mockLamportBalance, .success, "")
+    }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._userAssets = { _, _, completion in
+      completion(mockUserAssets)
+    }
+    walletService._addObserver = { _ in }
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
+    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
+    let assetRatioService = BraveWallet.TestAssetRatioService()
+    assetRatioService._price = { _, _, _, completion in
+      completion(true, [mockSolAssetPrice])
+    }
+    assetRatioService._priceHistory = { _, _, _, completion in
+      completion(true, mockSolPriceHistory)
+    }
+    // setup store
+    let store = PortfolioStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      assetRatioService: assetRatioService,
+      blockchainRegistry: BraveWallet.TestBlockchainRegistry()
+    )
+    // test that `update()` will assign new value to `userVisibleAssets` publisher
+    let userVisibleAssetsException = expectation(description: "update-userVisibleAssets")
+    XCTAssertTrue(store.userVisibleAssets.isEmpty)  // Initial state
+    store.$userVisibleAssets
+      .dropFirst()
+      .first()
+      .sink { userVisibleAssets in
+        defer { userVisibleAssetsException.fulfill() }
+        XCTAssertEqual(userVisibleAssets.count, 1)
+        XCTAssertEqual(userVisibleAssets[0].decimalBalance, mockDecimalBalance)
+        XCTAssertEqual(userVisibleAssets[0].price, mockSolAssetPrice.price)
+        XCTAssertEqual(userVisibleAssets[0].history, mockSolPriceHistory)
+      }.store(in: &cancellables)
+    // test that `update()` will assign new value to `balance` publisher
+    let balanceException = expectation(description: "update-balance")
+    store.$balance
+      .dropFirst()
+      .first()
+      .sink { balance in
+        defer { balanceException.fulfill() }
+        XCTAssertEqual(balance, totalSolBalance)
       }
       .store(in: &cancellables)
     // test that `update()` will update `isLoadingBalances` publisher


### PR DESCRIPTION
## Summary of Changes
- Update `BraveWalletJsonRpcService` extensions to support fetching Solana SOL balances and SPL Token balances.
- Add new `BraveWalletAssetRatioService` extension to fallback to fetching individual prices when the group fetch fails. The group fetch will fail if the price call fails for _just one_ of the token symbols. This is possible when you have a custom minted SPL Token.
- Fix adding a custom asset for Solana network. Currently it will add to the selected network. New issue created: #5725
- Fix account details view using currently selected network instead of account's coin type network. This caused Solana assets to show in Ethereum accounts when a Solana network was selected (and vice versa).

This pull request fixes #5718

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Switch to a Solana account with some balance on SOL and SPL tokens.
2. Verify balance updates correctly in Portfolio
3. Tap the SOL asset in Portfolio.
4. Verify balance displays correctly in Asset Details
5. Tap the SPL Token asset in Portfolio
6. Verify balance displays correctly in Asset Details
7. Tap back, and switch to Accounts tab
8. Select a Solana account
9. Verify balance displays correctly in Account Details
10. Switch back to an Ethereum account with some balance
10. Verify balance still displays correctly / as expected.


## Screenshots:

![#5718](https://user-images.githubusercontent.com/5314553/180088245-fdea0367-4f9d-4a03-9c34-528c71856ff9.png) | ![#5718 - 1](https://user-images.githubusercontent.com/5314553/180088253-d2bea8cb-c8af-4ad8-90de-b21388c705bf.png) | ![#5718 - 2](https://user-images.githubusercontent.com/5314553/180088261-c9d9128c-0667-4922-9ca1-9c1e80326cfb.png) | ![#5718 - 3](https://user-images.githubusercontent.com/5314553/180088272-07e0df31-10d3-43d9-b851-294c7a6a5ba2.png)
--|--|--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
