### PR TITLE
Fix #5724: Integrate solana send transaction

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -35,10 +35,7 @@ struct SendTokenView: View {
       return true
     }
 
-    return sendAmount == 0
-      || sendAmount > balance
-      || sendTokenStore.sendAmount.isEmpty
-      || (sendTokenStore.addressError != nil && sendTokenStore.addressError != .missingChecksum)
+    return sendAmount == 0 || sendAmount > balance || sendTokenStore.sendAmount.isEmpty || sendTokenStore.sendAddress.isEmpty || (sendTokenStore.addressError != nil && sendTokenStore.addressError != .missingChecksum)
   }
 
   var body: some View {
@@ -157,7 +154,9 @@ struct SendTokenView: View {
             WalletLoadingButton(
               isLoading: sendTokenStore.isMakingTx,
               action: {
-                sendTokenStore.sendToken(amount: sendTokenStore.sendAmount) { success in
+                sendTokenStore.sendToken(
+                  amount: sendTokenStore.sendAmount
+                ) { success, _ in
                   isShowingError = !success
                   completion?(success)
                 }

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -18,7 +18,7 @@ struct AssetSearchView: View {
   
   var body: some View {
     NavigationView {
-      TokenList(tokens: allTokens.filter { !$0.isErc721 || $0.symbol == cryptoStore.networkStore.selectedChain.symbol }) { token in
+      TokenList(tokens: allTokens.filter { !$0.isErc721 || cryptoStore.networkStore.selectedChain.isNativeAsset($0) }) { token in
         NavigationLink(
           destination: AssetDetailView(
             assetDetailStore: cryptoStore.assetDetailStore(for: token),

--- a/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -15,7 +15,7 @@ struct SendTokenSearchView: View {
   var network: BraveWallet.NetworkInfo
   
   var body: some View {
-    TokenList(tokens: sendTokenStore.userAssets.filter { !$0.isErc721 || $0.symbol == network.symbol }) { token in
+    TokenList(tokens: sendTokenStore.userAssets.filter { !$0.isErc721 || network.isNativeAsset($0) }) { token in
       Button(action: {
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -16,6 +16,7 @@ public class SendTokenStore: ObservableObject {
   @Published var selectedSendToken: BraveWallet.BlockchainToken? {
     didSet {
       fetchAssetBalance()
+      validateSendAddress()
     }
   }
   /// The current selected token balance. Default with nil value.

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -44,6 +44,7 @@ public class SendTokenStore: ObservableObject {
     case notEthAddress
     case missingChecksum
     case invalidChecksum
+    case notSolAddress
 
     var errorDescription: String? {
       switch self {
@@ -57,6 +58,8 @@ public class SendTokenStore: ObservableObject {
         return Strings.Wallet.sendWarningAddressMissingChecksumInfo
       case .invalidChecksum:
         return Strings.Wallet.sendWarningAddressInvalidChecksum
+      case .notSolAddress:
+        return Strings.Wallet.sendWarningSolAddressNotValid
       }
     }
   }
@@ -67,6 +70,7 @@ public class SendTokenStore: ObservableObject {
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
+  private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   private var allTokens: [BraveWallet.BlockchainToken] = []
   private var currentAccountAddress: String?
   private var timer: Timer?
@@ -78,6 +82,7 @@ public class SendTokenStore: ObservableObject {
     txService: BraveWalletTxService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
     prefilledToken: BraveWallet.BlockchainToken?
   ) {
     self.keyringService = keyringService
@@ -86,6 +91,7 @@ public class SendTokenStore: ObservableObject {
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
     self.ethTxManagerProxy = ethTxManagerProxy
+    self.solTxManagerProxy = solTxManagerProxy
     self.selectedSendToken = prefilledToken
 
     self.keyringService.add(self)
@@ -179,43 +185,53 @@ public class SendTokenStore: ObservableObject {
     chainId: String,
     baseData: BraveWallet.TxData,
     from address: String,
-    completion: @escaping (_ success: Bool) -> Void
+    completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     let eip1559Data = BraveWallet.TxData1559(baseData: baseData, chainId: chainId, maxPriorityFeePerGas: "", maxFeePerGas: "", gasEstimation: nil)
     let txDataUnion = BraveWallet.TxDataUnion(ethTxData1559: eip1559Data)
     self.txService.addUnapprovedTransaction(txDataUnion, from: address, origin: nil) { success, txMetaId, errorMessage in
-      completion(success)
+      completion(success, errorMessage)
     }
   }
 
   private func validateSendAddress() {
-    guard !sendAddress.isEmpty else {
+    guard !sendAddress.isEmpty, let token = selectedSendToken else {
       addressError = nil
       return
     }
     let normalizedSendAddress = sendAddress.lowercased()
-    if !sendAddress.isETHAddress {
-      // 1. check if send address is a valid eth address
-      addressError = .notEthAddress
-    } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
-      // 2. check if send address is the same as the from address
-      addressError = .sameAsFromAddress
-    } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil)
-      || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil) {
-      // 3. check if send address is a contract address
-      addressError = .contractAddress
-    } else {
-      keyringService.checksumEthAddress(sendAddress) { [self] checksumAddress in
-        if sendAddress == checksumAddress {
-          // 4. check if send address is the same as the checksum address from the `KeyringService`
-          addressError = nil
-        } else if sendAddress.removingHexPrefix.lowercased() == sendAddress.removingHexPrefix || sendAddress.removingHexPrefix.uppercased() == sendAddress.removingHexPrefix {
-          // 5. check if send address has each of the alphabetic character as uppercase, or has each of
-          // the alphabeic character as lowercase
-          addressError = .missingChecksum
-        } else {
-          // 6. send address has mixed with uppercase and lowercase and does not match with the checksum address
-          addressError = .invalidChecksum
+    if token.coin == .eth {
+      if !sendAddress.isETHAddress {
+        // 1. check if send address is a valid eth address
+        addressError = .notEthAddress
+      } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
+        // 2. check if send address is the same as the from address
+        addressError = .sameAsFromAddress
+      } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil)
+                  || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil) {
+        // 3. check if send address is a contract address
+        addressError = .contractAddress
+      } else {
+        keyringService.checksumEthAddress(sendAddress) { [self] checksumAddress in
+          if sendAddress == checksumAddress {
+            // 4. check if send address is the same as the checksum address from the `KeyringService`
+            addressError = nil
+          } else if sendAddress.removingHexPrefix.lowercased() == sendAddress.removingHexPrefix || sendAddress.removingHexPrefix.uppercased() == sendAddress.removingHexPrefix {
+            // 5. check if send address has each of the alphabetic character as uppercase, or has each of
+            // the alphabeic character as lowercase
+            addressError = .missingChecksum
+          } else {
+            // 6. send address has mixed with uppercase and lowercase and does not match with the checksum address
+            addressError = .invalidChecksum
+          }
+        }
+      }
+    } else if token.coin == .sol {
+      walletService.isBase58EncodedSolanaPubkey(sendAddress) { [self] valid in
+        if !valid {
+          addressError = .notSolAddress
+        } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
+          addressError = .sameAsFromAddress
         }
       }
     }
@@ -223,7 +239,24 @@ public class SendTokenStore: ObservableObject {
 
   func sendToken(
     amount: String,
-    completion: @escaping (_ success: Bool) -> Void
+    completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
+  ) {
+    walletService.selectedCoin { [weak self] coin in
+      guard let self = self else { return }
+      switch coin {
+      case .eth:
+        self.sendTokenOnEth(amount: amount, completion: completion)
+      case .sol:
+        self.sendTokenOnSol(amount: amount, completion: completion)
+      default:
+        break
+      }
+    }
+  }
+
+  func sendTokenOnEth(
+    amount: String,
+    completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     guard
@@ -233,43 +266,86 @@ public class SendTokenStore: ObservableObject {
     else { return }
 
     isMakingTx = true
-    walletService.selectedCoin { [weak self] coin in
-      guard let self = self else { return }
-      self.rpcService.network(coin) { network in
-        if token.contractAddress.isEmpty {
-          let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: self.sendAddress, value: "0x\(weiHexString)", data: .init())
+    self.rpcService.network(.eth) { network in
+      if token.contractAddress.isEmpty {
+        let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: self.sendAddress, value: "0x\(weiHexString)", data: .init())
+        if network.isEip1559 {
+          self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success, errorMessage  in
+            self.isMakingTx = false
+            completion(success, errorMessage)
+          }
+        } else {
+          let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
+          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil) { success, txMetaId, errorMessage in
+            self.isMakingTx = false
+            completion(success, errorMessage)
+          }
+        }
+      } else {
+        self.ethTxManagerProxy.makeErc20TransferData(self.sendAddress, amount: "0x\(weiHexString)") { success, data in
+          guard success else {
+            completion(false, nil)
+            return
+          }
+          let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
           if network.isEip1559 {
-            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success in
+            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success, errorMessage  in
               self.isMakingTx = false
-              completion(success)
+              completion(success, errorMessage)
             }
           } else {
             let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
             self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil) { success, txMetaId, errorMessage in
               self.isMakingTx = false
-              completion(success)
+              completion(success, errorMessage)
             }
           }
-        } else {
-          self.ethTxManagerProxy.makeErc20TransferData(self.sendAddress, amount: "0x\(weiHexString)") { success, data in
-            guard success else {
-              completion(false)
-              return
-            }
-            let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data)
-            if network.isEip1559 {
-              self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success in
-                self.isMakingTx = false
-                completion(success)
-              }
-            } else {
-              let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-              self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil) { success, txMetaId, errorMessage in
-                self.isMakingTx = false
-                completion(success)
-              }
-            }
-          }
+        }
+      }
+    }
+  }
+  
+  private func sendTokenOnSol(
+    amount: String,
+    completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
+  ) {
+    guard let token = selectedSendToken,
+          let fromAddress = currentAccountAddress,
+          let lamports = WeiFormatter.decimalToLamports(amount)
+    else {
+      completion(false, "An Internal Error")
+      return
+    }
+    
+    if token.contractAddress.isEmpty {
+      solTxManagerProxy.makeSystemProgramTransferTxData(
+        fromAddress,
+        to: sendAddress,
+        lamports: lamports
+      ) { solTxData, error, errMsg in
+        guard let solanaTxData = solTxData else {
+          completion(false, errMsg)
+          return
+        }
+        let txDataUnion = BraveWallet.TxDataUnion(solanaTxData: solanaTxData)
+        self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil) { success, txMetaId, errMsg in
+          completion(success, errMsg)
+        }
+      }
+    } else {
+      solTxManagerProxy.makeTokenProgramTransferTxData(
+        token.contractAddress,
+        fromWalletAddress: fromAddress,
+        toWalletAddress: sendAddress,
+        amount: lamports
+      ) { solTxData, error, errMsg in
+        guard let solanaTxData = solTxData else {
+          completion(false, errMsg)
+          return
+        }
+        let txDataUnion = BraveWallet.TxDataUnion(solanaTxData: solanaTxData)
+        self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil) { success, txMetaId, errorMessage in
+          completion(success, errorMessage)
         }
       }
     }

--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -319,7 +319,7 @@ public class SendTokenStore: ObservableObject {
       return
     }
     
-    rpcService.network(.eth) { [weak self] network in
+    rpcService.network(.sol) { [weak self] network in
       guard let self = self else { return }
       if network.isNativeAsset(token) {
         self.solTxManagerProxy.makeSystemProgramTransferTxData(

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -289,13 +289,13 @@ public class TransactionConfirmationStore: ObservableObject {
   }
 
   func confirm(transaction: BraveWallet.TransactionInfo, completion: @escaping (_ error: String?) -> Void) {
-    txService.approveTransaction(.eth, txMetaId: transaction.id) { success, error, message in
+    txService.approveTransaction(transaction.coin, txMetaId: transaction.id) { success, error, message in
       completion(success ? nil : message)
     }
   }
 
   func reject(transaction: BraveWallet.TransactionInfo, completion: @escaping (Bool) -> Void) {
-    txService.rejectTransaction(.eth, txMetaId: transaction.id) { success in
+    txService.rejectTransaction(transaction.coin, txMetaId: transaction.id) { success in
       completion(success)
     }
   }

--- a/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -28,7 +28,8 @@ public class WalletStore {
     swapService: BraveWalletSwapService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
     txService: BraveWalletTxService,
-    ethTxManagerProxy: BraveWalletEthTxManagerProxy
+    ethTxManagerProxy: BraveWalletEthTxManagerProxy,
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   ) {
     self.keyringStore = .init(keyringService: keyringService, walletService: walletService, rpcService: rpcService)
     self.setUp(
@@ -39,7 +40,8 @@ public class WalletStore {
       swapService: swapService,
       blockchainRegistry: blockchainRegistry,
       txService: txService,
-      ethTxManagerProxy: ethTxManagerProxy
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy
     )
   }
 
@@ -51,7 +53,8 @@ public class WalletStore {
     swapService: BraveWalletSwapService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
     txService: BraveWalletTxService,
-    ethTxManagerProxy: BraveWalletEthTxManagerProxy
+    ethTxManagerProxy: BraveWalletEthTxManagerProxy,
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   ) {
     self.cancellable = self.keyringStore.$defaultKeyring
       .map(\.isKeyringCreated)
@@ -69,7 +72,8 @@ public class WalletStore {
             swapService: swapService,
             blockchainRegistry: blockchainRegistry,
             txService: txService,
-            ethTxManagerProxy: ethTxManagerProxy
+            ethTxManagerProxy: ethTxManagerProxy,
+            solTxManagerProxy: solTxManagerProxy
           )
           self.onPendingRequestCancellable = self.cryptoStore?.$pendingRequest
             .removeDuplicates()

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -67,6 +67,10 @@ struct TransactionConfirmationView: View {
         .joined(separator: "\n\n")
     }
   }
+  
+  private var isConfirmDisabled: Bool {
+    confirmationStore.activeTransaction.coin != networkStore.selectedChain.coin
+  }
 
   /// View showing the currently selected account with a blockie
   @ViewBuilder private var accountView: some View {
@@ -454,7 +458,7 @@ struct TransactionConfirmationView: View {
       Label(Strings.Wallet.confirm, systemImage: "checkmark.circle.fill")
     }
     .buttonStyle(BraveFilledButtonStyle(size: .large))
-    .disabled(!confirmationStore.state.isBalanceSufficient)
+    .disabled(!confirmationStore.state.isBalanceSufficient || isConfirmDisabled)
   }
 }
 

--- a/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -172,3 +172,15 @@ extension BraveWallet.KeyringInfo {
     accountInfos.first?.coin
   }
 }
+
+extension BraveWallet.TransactionInfo {
+  var coin: BraveWallet.CoinType {
+    if txDataUnion.solanaTxData != nil {
+      return .sol
+    } else if txDataUnion.filTxData != nil {
+      return .fil
+    } else {
+      return .eth
+    }
+  }
+}

--- a/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -184,3 +184,13 @@ extension BraveWallet.TransactionInfo {
     }
   }
 }
+
+extension BraveWallet.NetworkInfo {
+  func isNativeAsset(_ token: BraveWallet.BlockchainToken) -> Bool {
+    return nativeToken.contractAddress.caseInsensitiveCompare(token.contractAddress) == .orderedSame
+    && nativeToken.symbol.caseInsensitiveCompare(token.symbol) == .orderedSame
+    && symbol.caseInsensitiveCompare(token.symbol) == .orderedSame
+    && nativeToken.decimals == token.decimals
+    && coin == token.coin
+  }
+}

--- a/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -195,7 +195,7 @@ extension BraveWalletJsonRpcService {
     network: BraveWallet.NetworkInfo,
     completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
   ) {
-    if token.symbol == network.symbol {
+    if network.isNativeAsset(token) {
       balance(
         accountAddress,
         coin: .eth,

--- a/BraveWallet/Extensions/WeiFormatter.swift
+++ b/BraveWallet/Extensions/WeiFormatter.swift
@@ -149,6 +149,16 @@ struct WeiFormatter {
     return (gwei * (BDouble(10) ** 9))
       .rounded().asString(radix: outputRadix.rawValue)
   }
+  
+  static func decimalToLamports(_ decimalString: String) -> UInt64? {
+    guard isStringValid(decimalString, radix: .decimal),
+          let value = BDouble(decimalString, radix: Radix.decimal.rawValue)
+    else {
+      return nil
+    }
+    let stringValue = (value * (BDouble(10) ** 9)).rounded().description
+    return UInt64(stringValue)
+  }
 }
 
 extension String {

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -68,6 +68,21 @@ extension BraveWallet.BlockchainToken {
     chainId: "",
     coin: .sol
   )
+
+  static let mockSPLToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0x1111111111222222222233333333334444444445",
+    name: "Non-SOL",
+    logo: "",
+    isErc20: false,
+    isErc721: false,
+    symbol: "NONSOL",
+    decimals: 9,
+    visible: false,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: "",
+    coin: .sol
+  )
 }
 
 extension BraveWallet.AccountInfo {

--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -202,7 +202,7 @@ extension BraveWallet.NetworkInfo {
     rpcUrls: [],
     symbol: "SOL",
     symbolName: "Solana",
-    decimals: 18,
+    decimals: 9,
     coin: .sol,
     data: nil
   )

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -11,7 +11,15 @@ import BraveShared
 
 extension WalletStore {
   static var previewStore: WalletStore {
-    .init(
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._makeSystemProgramTransferTxData = { _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    
+    return .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: MockBraveWalletService(),
@@ -19,14 +27,23 @@ extension WalletStore {
       swapService: MockSwapService(),
       blockchainRegistry: MockBlockchainRegistry(),
       txService: MockTxService(),
-      ethTxManagerProxy: MockEthTxManagerProxy()
+      ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy
     )
   }
 }
 
 extension CryptoStore {
   static var previewStore: CryptoStore {
-    .init(
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._makeSystemProgramTransferTxData = { _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    
+    return .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: MockBraveWalletService(),
@@ -34,7 +51,8 @@ extension CryptoStore {
       swapService: MockSwapService(),
       blockchainRegistry: MockBlockchainRegistry(),
       txService: MockTxService(),
-      ethTxManagerProxy: MockEthTxManagerProxy()
+      ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy
     )
   }
 }
@@ -81,13 +99,22 @@ extension BuyTokenStore {
 
 extension SendTokenStore {
   static var previewStore: SendTokenStore {
-    .init(
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._makeSystemProgramTransferTxData = { _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    
+    return .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
   }

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -11,14 +11,6 @@ import BraveShared
 
 extension WalletStore {
   static var previewStore: WalletStore {
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    solTxManagerProxy._makeSystemProgramTransferTxData = { _, _, _, completion in
-      completion(.init(), .success, "")
-    }
-    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
-      completion(.init(), .success, "")
-    }
-    
     return .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
@@ -28,21 +20,13 @@ extension WalletStore {
       blockchainRegistry: MockBlockchainRegistry(),
       txService: MockTxService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
-      solTxManagerProxy: solTxManagerProxy
+      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy
     )
   }
 }
 
 extension CryptoStore {
   static var previewStore: CryptoStore {
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    solTxManagerProxy._makeSystemProgramTransferTxData = { _, _, _, completion in
-      completion(.init(), .success, "")
-    }
-    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
-      completion(.init(), .success, "")
-    }
-    
     return .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
@@ -52,7 +36,7 @@ extension CryptoStore {
       blockchainRegistry: MockBlockchainRegistry(),
       txService: MockTxService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
-      solTxManagerProxy: solTxManagerProxy
+      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy
     )
   }
 }
@@ -99,14 +83,6 @@ extension BuyTokenStore {
 
 extension SendTokenStore {
   static var previewStore: SendTokenStore {
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    solTxManagerProxy._makeSystemProgramTransferTxData = { _, _, _, completion in
-      completion(.init(), .success, "")
-    }
-    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
-      completion(.init(), .success, "")
-    }
-    
     return .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
@@ -114,7 +90,7 @@ extension SendTokenStore {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
-      solTxManagerProxy: solTxManagerProxy,
+      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
       prefilledToken: .previewToken
     )
   }
@@ -201,6 +177,21 @@ extension SettingsStore {
       txService: MockTxService(),
       keychain: TestableKeychain()
     )
+  }
+}
+
+extension BraveWallet.TestSolanaTxManagerProxy {
+  static var previewProxy: BraveWallet.TestSolanaTxManagerProxy {
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._makeSystemProgramTransferTxData = { _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    solTxManagerProxy._estimatedTxFee = { $1(UInt64(0), .success, "") }
+    
+    return solTxManagerProxy
   }
 }
 

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -11,7 +11,7 @@ import BraveShared
 
 extension WalletStore {
   static var previewStore: WalletStore {
-    return .init(
+    .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: MockBraveWalletService(),
@@ -27,7 +27,7 @@ extension WalletStore {
 
 extension CryptoStore {
   static var previewStore: CryptoStore {
-    return .init(
+    .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: MockBraveWalletService(),
@@ -83,7 +83,7 @@ extension BuyTokenStore {
 
 extension SendTokenStore {
   static var previewStore: SendTokenStore {
-    return .init(
+    .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: MockBraveWalletService(),

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1646,6 +1646,13 @@ extension Strings {
       value: "Address did not pass verification (invalid checksum). Please try again, replacing lowercase letters with uppercase.",
       comment: "A warning that appears below the send crypto address text field, when the input `To` address has invalid checksum."
     )
+    public static let sendWarningSolAddressNotValid = NSLocalizedString(
+      "wallet.sendWarningSolAddressNotValid",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Not a valid SOL address",
+      comment: "A warning that appears below the send crypto address text field, when the input `To` address is not a valid SOL address."
+    )
     public static let customNetworkChainIdTitle = NSLocalizedString(
       "wallet.customNetworkChainIdTitle",
       tableName: "BraveWallet",

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -25,7 +25,8 @@ extension WalletStore {
       let walletService = BraveWallet.ServiceFactory.get(privateMode: privateMode),
       let swapService = BraveWallet.SwapServiceFactory.get(privateMode: privateMode),
       let txService = BraveWallet.TxServiceFactory.get(privateMode: privateMode),
-      let ethTxManagerProxy = BraveWallet.EthTxManagerProxyFactory.get(privateMode: privateMode)
+      let ethTxManagerProxy = BraveWallet.EthTxManagerProxyFactory.get(privateMode: privateMode),
+      let solTxManagerProxy = BraveWallet.SolanaTxManagerProxyFactory.get(privateMode: privateMode)
     else {
       log.error("Failed to load wallet. One or more services were unavailable")
       return nil
@@ -38,7 +39,8 @@ extension WalletStore {
       swapService: swapService,
       blockchainRegistry: BraveCoreMain.blockchainRegistry,
       txService: txService,
-      ethTxManagerProxy: ethTxManagerProxy
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy
     )
   }
 }
@@ -53,7 +55,8 @@ extension CryptoStore {
       let walletService = BraveWallet.ServiceFactory.get(privateMode: privateMode),
       let swapService = BraveWallet.SwapServiceFactory.get(privateMode: privateMode),
       let txService = BraveWallet.TxServiceFactory.get(privateMode: privateMode),
-      let ethTxManagerProxy = BraveWallet.EthTxManagerProxyFactory.get(privateMode: privateMode)
+      let ethTxManagerProxy = BraveWallet.EthTxManagerProxyFactory.get(privateMode: privateMode),
+      let solTxManagerProxy = BraveWallet.SolanaTxManagerProxyFactory.get(privateMode: privateMode)
     else {
       log.error("Failed to load wallet. One or more services were unavailable")
       return nil
@@ -66,7 +69,8 @@ extension CryptoStore {
       swapService: swapService,
       blockchainRegistry: BraveCoreMain.blockchainRegistry,
       txService: txService,
-      ethTxManagerProxy: ethTxManagerProxy
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy
     )
   }
 }

--- a/Tests/BraveWalletTests/BraveWalletExtensionsTests.swift
+++ b/Tests/BraveWalletTests/BraveWalletExtensionsTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import BraveCore
+@testable import BraveWallet
+
+class BraveWalletExtensionsTests: XCTestCase {
+  
+  func testIsNativeAsset() {
+    let ethCoin: BraveWallet.BlockchainToken = .init(contractAddress: "", name: "Eth", logo: "", isErc20: false, isErc721: false, symbol: "Eth", decimals: 18, visible: true, tokenId: "", coingeckoId: "", chainId: "", coin: .eth)
+    let ethToken: BraveWallet.BlockchainToken = .init(contractAddress: "mock-eth-contract-address", name: "Eth Token", logo: "", isErc20: true, isErc721: false, symbol: "ETHTOKEN", decimals: 18, visible: false, tokenId: "", coingeckoId: "", chainId: "", coin: .eth)
+    let ethNetwork = BraveWallet.NetworkInfo.mockMainnet
+    
+    XCTAssertTrue(ethNetwork.isNativeAsset(ethCoin))
+    XCTAssertFalse(ethNetwork.isNativeAsset(ethToken))
+    
+    let solCoin: BraveWallet.BlockchainToken = .init(contractAddress: "", name: "Sol", logo: "", isErc20: false, isErc721: false, symbol: "SOL", decimals: 9, visible: true, tokenId: "", coingeckoId: "", chainId: "", coin: .sol)
+    let solToken: BraveWallet.BlockchainToken = .init(contractAddress: "mock-sol-contract-address", name: "Sol Token", logo: "", isErc20: true, isErc721: false, symbol: "SOLTOKEN", decimals: 9, visible: false, tokenId: "", coingeckoId: "", chainId: "", coin: .sol)
+    let solNetwork = BraveWallet.NetworkInfo.mockSolana
+    
+    XCTAssertTrue(solNetwork.isNativeAsset(solCoin))
+    XCTAssertFalse(solNetwork.isNativeAsset(solToken))
+  }
+}

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -117,7 +117,7 @@ class PortfolioStoreTests: XCTestCase {
     let mockAccountInfos: [BraveWallet.AccountInfo] = [.mockSolAccount]
     let network: BraveWallet.NetworkInfo = .mockSolana
     let chainId = network.chainId
-    let mockUserAssets: [BraveWallet.BlockchainToken] = [.mockSolToken.then { $0.visible = true }]
+    let mockUserAssets: [BraveWallet.BlockchainToken] = [BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true }]
     let mockLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL
     let mockDecimalBalance: Double = 3.8765 // rounded
     let mockSolAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "sol", toAsset: "usd", price: "200.00", assetTimeframeChange: "-57.23")

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -46,16 +46,16 @@ class SendTokenStoreTests: XCTestCase {
     rpcService._network = { $1(.mockRopsten) }
     rpcService._addObserver = { _ in }
     
-    let wallatService = BraveWallet.TestBraveWalletService()
-    wallatService._selectedCoin = { $0(.eth) }
-    wallatService._userAssets = { $2([.previewToken]) }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._selectedCoin = { $0(.eth) }
+    walletService._userAssets = { $2([.previewToken]) }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: rpcService,
-      walletService: wallatService,
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
@@ -81,16 +81,16 @@ class SendTokenStoreTests: XCTestCase {
   }
 
   func testMakeSendETHEIP1559Transaction() {
-    let wallatService = BraveWallet.TestBraveWalletService()
-    wallatService._selectedCoin = { $0(.eth) }
-    wallatService._userAssets = { $2([.previewToken]) }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._selectedCoin = { $0(.eth) }
+    walletService._userAssets = { $2([.previewToken]) }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
-      walletService: wallatService,
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
@@ -113,16 +113,16 @@ class SendTokenStoreTests: XCTestCase {
     rpcService._network = { $1(.mockRopsten) }
     rpcService._addObserver = { _ in }
     
-    let wallatService = BraveWallet.TestBraveWalletService()
-    wallatService._selectedCoin = { $0(.eth) }
-    wallatService._userAssets = { $2([.previewToken]) }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._selectedCoin = { $0(.eth) }
+    walletService._userAssets = { $2([.previewToken]) }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: rpcService,
-      walletService: wallatService,
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
@@ -142,16 +142,16 @@ class SendTokenStoreTests: XCTestCase {
   }
 
   func testMakeSendERC20EIP1559Transaction() {
-    let wallatService = BraveWallet.TestBraveWalletService()
-    wallatService._selectedCoin = { $0(.eth) }
-    wallatService._userAssets = { $2([.previewToken]) }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._selectedCoin = { $0(.eth) }
+    walletService._userAssets = { $2([.previewToken]) }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
-      walletService: wallatService,
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
@@ -177,8 +177,8 @@ class SendTokenStoreTests: XCTestCase {
     rpcService._network = { $1(.mockRopsten) }
     rpcService._addObserver = { _ in }
     
-    let wallatService = BraveWallet.TestBraveWalletService()
-    wallatService._selectedCoin = { $0(.eth) }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._selectedCoin = { $0(.eth) }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     
@@ -329,7 +329,7 @@ class SendTokenStoreTests: XCTestCase {
     keyringService._addObserver = { _ in }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
+    solTxManagerProxy._makeTokenProgramTransferTxData = { _, _, _, _, completion in
       completion(.init(), .success, "")
     }
     

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -14,6 +14,8 @@ class SendTokenStoreTests: XCTestCase {
   private let batSymbol = "BAT"
 
   func testPrefilledToken() {
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    
     var store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
@@ -21,6 +23,7 @@ class SendTokenStoreTests: XCTestCase {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil
     )
     XCTAssertNil(store.selectedSendToken)
@@ -32,20 +35,31 @@ class SendTokenStoreTests: XCTestCase {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
     XCTAssertEqual(store.selectedSendToken?.symbol.lowercased(), BraveWallet.BlockchainToken.previewToken.symbol.lowercased())
   }
 
   func testFetchAssets() {
-    let rpcService = MockJsonRpcService()
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._network = { $1(.mockRopsten) }
+    rpcService._addObserver = { _ in }
+    
+    let wallatService = BraveWallet.TestBraveWalletService()
+    wallatService._selectedCoin = { $0(.eth) }
+    wallatService._userAssets = { $2([.previewToken]) }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: rpcService,
-      walletService: MockBraveWalletService(),
+      walletService: wallatService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil
     )
     let ex = expectation(description: "fetch-assets")
@@ -67,18 +81,25 @@ class SendTokenStoreTests: XCTestCase {
   }
 
   func testMakeSendETHEIP1559Transaction() {
+    let wallatService = BraveWallet.TestBraveWalletService()
+    wallatService._selectedCoin = { $0(.eth) }
+    wallatService._userAssets = { $2([.previewToken]) }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
-      walletService: MockBraveWalletService(),
+      walletService: wallatService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
     store.setUpTest()
     let ex = expectation(description: "send-eth-eip1559-transaction")
-    store.sendToken(amount: "0.01") { success in
+    store.sendToken(amount: "0.01") { success, _ in
       defer { ex.fulfill() }
       XCTAssertTrue(success)
     }
@@ -88,25 +109,32 @@ class SendTokenStoreTests: XCTestCase {
   }
 
   func testMakeSendETHTransaction() {
-    let rpcService = MockJsonRpcService()
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._network = { $1(.mockRopsten) }
+    rpcService._addObserver = { _ in }
+    
+    let wallatService = BraveWallet.TestBraveWalletService()
+    wallatService._selectedCoin = { $0(.eth) }
+    wallatService._userAssets = { $2([.previewToken]) }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: rpcService,
-      walletService: MockBraveWalletService(),
+      walletService: wallatService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
     store.setUpTest()
 
     let ex = expectation(description: "send-eth-transaction")
-    rpcService.setNetwork(BraveWallet.RopstenChainId, coin: .eth) { success in
+    store.sendToken(amount: "0.01") { success, _ in
+      defer { ex.fulfill() }
       XCTAssertTrue(success)
-      store.sendToken(amount: "0.01") { success in
-        defer { ex.fulfill() }
-        XCTAssertTrue(success)
-      }
     }
     waitForExpectations(timeout: 3) { error in
       XCTAssertNil(error)
@@ -114,13 +142,20 @@ class SendTokenStoreTests: XCTestCase {
   }
 
   func testMakeSendERC20EIP1559Transaction() {
+    let wallatService = BraveWallet.TestBraveWalletService()
+    wallatService._selectedCoin = { $0(.eth) }
+    wallatService._userAssets = { $2([.previewToken]) }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
-      walletService: MockBraveWalletService(),
+      walletService: wallatService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil
     )
     let token: BraveWallet.BlockchainToken = .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, symbol: batSymbol, decimals: 18, visible: true, tokenId: "", coingeckoId: "", chainId: "", coin: .eth)
@@ -128,7 +163,7 @@ class SendTokenStoreTests: XCTestCase {
     store.setUpTest()
 
     let ex = expectation(description: "send-bat-eip1559-transaction")
-    store.sendToken(amount: "0.01") { success in
+    store.sendToken(amount: "0.01") { success, _ in
       defer { ex.fulfill() }
       XCTAssertTrue(success)
     }
@@ -138,7 +173,15 @@ class SendTokenStoreTests: XCTestCase {
   }
 
   func testMakeSendERC20Transaction() {
-    let rpcService = MockJsonRpcService()
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._network = { $1(.mockRopsten) }
+    rpcService._addObserver = { _ in }
+    
+    let wallatService = BraveWallet.TestBraveWalletService()
+    wallatService._selectedCoin = { $0(.eth) }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    
     let store = SendTokenStore(
       keyringService: MockKeyringService(),
       rpcService: rpcService,
@@ -146,17 +189,15 @@ class SendTokenStoreTests: XCTestCase {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
     store.setUpTest()
 
     let ex = expectation(description: "send-bat-transaction")
-    rpcService.setNetwork(BraveWallet.RopstenChainId, coin: .eth) { success in
+    store.sendToken(amount: "0.01") { success, _ in
+      defer { ex.fulfill() }
       XCTAssertTrue(success)
-      store.sendToken(amount: "0.01") { success in
-        defer { ex.fulfill() }
-        XCTAssertTrue(success)
-      }
     }
     waitForExpectations(timeout: 3) { error in
       XCTAssertNil(error)
@@ -184,6 +225,8 @@ class SendTokenStoreTests: XCTestCase {
     keyringService._selectedAccount = { $1("account-address") }
     keyringService._addObserver = { _ in }
     
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    
     let store = SendTokenStore(
       keyringService: keyringService,
       rpcService: rpcService,
@@ -191,6 +234,7 @@ class SendTokenStoreTests: XCTestCase {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
     store.setUpTest()
@@ -211,6 +255,102 @@ class SendTokenStoreTests: XCTestCase {
         sendFullBalanceEx.fulfill()
       }
       .store(in: &cancellables)
+    
+    waitForExpectations(timeout: 3) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  func testSolSendSystemProgramTransfer() {
+    let mockBalance = 47
+    
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockSolana.chainId) }
+    rpcService._network = { $1(BraveWallet.NetworkInfo.mockSolana)}
+    rpcService._solanaBalance = { _, _ , completion in
+      completion(UInt64(mockBalance), .success, "")
+    }
+    rpcService._addObserver = { _ in }
+    
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._userAssets = { $2([.previewToken]) }
+    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
+    
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._selectedAccount = { $1("account-address") }
+    keyringService._addObserver = { _ in }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._makeSystemProgramTransferTxData = {_, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: BraveWallet.NetworkInfo.mockSolana.nativeToken
+    )
+    
+    let ex = expectation(description: "send-sol-transaction")
+    store.sendToken(
+      amount: "0.01"
+    ) { success, errMsg in
+      defer { ex.fulfill() }
+      XCTAssertTrue(success)
+    }
+    
+    waitForExpectations(timeout: 3) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  func testSolSendTokenProgramTransfer() {
+    let mockBalance = 47
+    
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockSolana.chainId) }
+    rpcService._network = { $1(BraveWallet.NetworkInfo.mockSolana)}
+    rpcService._solanaBalance = { _, _ , completion in
+      completion(UInt64(mockBalance), .success, "")
+    }
+    rpcService._addObserver = { _ in }
+    
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._userAssets = { $2([.previewToken]) }
+    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
+    
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._selectedAccount = { $1("account-address") }
+    keyringService._addObserver = { _ in }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._makeTokenProgramTransferTxData = {_, _, _, _, completion in
+      completion(.init(), .success, "")
+    }
+    
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: .mockSPLToken
+    )
+    
+    let ex = expectation(description: "send-sol-transaction")
+    store.sendToken(
+      amount: "0.01"
+    ) { success, errMsg in
+      defer { ex.fulfill() }
+      XCTAssertTrue(success)
+    }
     
     waitForExpectations(timeout: 3) { error in
       XCTAssertNil(error)

--- a/Tests/BraveWalletTests/WeiFormatterTests.swift
+++ b/Tests/BraveWalletTests/WeiFormatterTests.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import XCTest
+import BigNumber
 @testable import BraveWallet
 
 class WeiFormatterTests: XCTestCase {
@@ -70,5 +71,15 @@ class WeiFormatterTests: XCTestCase {
     testCases.forEach {
       XCTAssertEqual($0.value.trimmingTrailingZeros, $0.expected)
     }
+  }
+  
+  func testDecimalToLamports() {
+    let decimalInputString = "1"
+    let lamportsValueString = "1000000000"
+    let lamports = WeiFormatter.decimalToLamports(decimalInputString)
+    
+    XCTAssertNotNil(UInt64(lamportsValueString))
+    XCTAssertNotNil(lamports)
+    XCTAssertEqual(UInt64(lamportsValueString)!, lamports!)
   }
 }


### PR DESCRIPTION
Changes include 
1. pulling all pending transaction for all accounts from all keyrings
2. integrate solana native coin sending transaction as well as other SPL tokens on solana
3. updated coin type for confirm and reject unapproved transactions.

This pull request fixes #5724 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
This can be verified when transaction parser #5723 is finished. 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
