### PR TITLE
Fix #5731: Transaction Parser Refactor

### DIFF
--- a/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -1,0 +1,140 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import Strings
+
+struct TransactionSummary: Equatable, Identifiable {
+  /// The transaction
+  let txInfo: BraveWallet.TransactionInfo
+  /// From address of the transaction
+  var fromAddress: String { txInfo.fromAddress }
+  /// Account name for the from address of the transaction
+  let namedFromAddress: String
+  /// To address of the transaction
+  var toAddress: String { txInfo.ethTxToAddress }
+  /// Account name for the to address of the transaction
+  let namedToAddress: String
+  /// The title for the transaction summary.
+  /// Ex. "Sent 1.0000 ETH ($1.00"',  "Swapped 2.0000 ETH ($2.00)" / "Approved 1.0000 DAI" /  "Sent ETH"
+  let title: String
+  /// The gas fee and fiat for the transaction
+  let gasFee: GasFee?
+  /// The network symbol for the transaction
+  let networkSymbol: String
+  
+  /// Transaction id
+  var id: String { txInfo.id }
+  /// The hash of the transaction
+  var txHash: String { txInfo.txHash }
+  /// Current status of the transaction
+  var txStatus: BraveWallet.TransactionStatus { txInfo.txStatus }
+  /// The time the transaction was created
+  var createdTime: Date { txInfo.createdTime }
+}
+
+extension TransactionParser {
+  
+  static func transactionSummary(
+    from transaction: BraveWallet.TransactionInfo,
+    network: BraveWallet.NetworkInfo,
+    accountInfos: [BraveWallet.AccountInfo],
+    visibleTokens: [BraveWallet.BlockchainToken],
+    allTokens: [BraveWallet.BlockchainToken],
+    assetRatios: [String: Double],
+    currencyFormatter: NumberFormatter
+  ) -> TransactionSummary {
+    guard let parsedTransaction = parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: visibleTokens,
+      allTokens: allTokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter,
+      decimalFormatStyle: .balance // use 4 digit precision for summary
+    ) else {
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
+        title: "",
+        gasFee: gasFee(
+          from: transaction,
+          network: network,
+          assetRatios: assetRatios,
+          currencyFormatter: currencyFormatter
+        ),
+        networkSymbol: network.symbol
+      )
+    }
+    switch parsedTransaction.details {
+    case let .ethSend(details):
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromTokenSymbol, details.fromFiat ?? "")
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: parsedTransaction.namedFromAddress,
+        namedToAddress: parsedTransaction.namedToAddress,
+        title: title,
+        gasFee: details.gasFee,
+        networkSymbol: details.fromTokenSymbol
+      )
+    case let .erc20Transfer(details):
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromTokenSymbol, details.fromFiat ?? "")
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: parsedTransaction.namedFromAddress,
+        namedToAddress: parsedTransaction.namedToAddress,
+        title: title,
+        gasFee: details.gasFee,
+        networkSymbol: parsedTransaction.networkSymbol
+      )
+    case let .ethSwap(details):
+      let fromAmount = details.fromAmount
+      let fromTokenSymbol = details.fromToken?.symbol ?? ""
+      let toAmount = details.minBuyAmount
+      let toTokenSymbol = details.toToken?.symbol ?? ""
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSwappedTitle, fromAmount, fromTokenSymbol, toAmount, toTokenSymbol)
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: parsedTransaction.namedFromAddress,
+        namedToAddress: parsedTransaction.namedToAddress,
+        title: title,
+        gasFee: details.gasFee,
+        networkSymbol: parsedTransaction.networkSymbol
+      )
+    case let .ethErc20Approve(details):
+      let title: String
+      if details.isUnlimited {
+        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, Strings.Wallet.editPermissionsApproveUnlimited, details.token.symbol)
+      } else {
+        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, details.approvalAmount, details.token.symbol)
+      }
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: parsedTransaction.namedFromAddress,
+        namedToAddress: parsedTransaction.namedToAddress,
+        title: title,
+        gasFee: details.gasFee,
+        networkSymbol: parsedTransaction.networkSymbol
+      )
+    case let .erc721Transfer(details):
+      let title: String
+      if let token = details.fromToken {
+        title = String.localizedStringWithFormat(Strings.Wallet.transactionUnknownSendTitle, token.symbol)
+      } else {
+        title = Strings.Wallet.send
+      }
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: parsedTransaction.namedFromAddress,
+        namedToAddress: parsedTransaction.namedToAddress,
+        title: title,
+        gasFee: nil,
+        networkSymbol: parsedTransaction.networkSymbol
+      )
+    }
+  }
+}

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -136,29 +136,33 @@ class TransactionParser {
             let minBuyAmountValue = transaction.txArgs[safe: 2] else {
         return nil
       }
-      let formattedSellAmount = formatter.decimalString(for: sellAmountValue.removingHexPrefix, radix: .hex, decimals: Int(network.decimals))?.trimmingTrailingZeros ?? ""
-      let formattedMinBuyAmount = formatter.decimalString(for: minBuyAmountValue.removingHexPrefix, radix: .hex, decimals: Int(network.decimals))?.trimmingTrailingZeros ?? ""
       
       let fillPathNoHexPrefix = fillPath.removingHexPrefix
       let fillPathLength = fillPathNoHexPrefix.count / 2
       let splitIndex = fillPathNoHexPrefix.index(fillPathNoHexPrefix.startIndex, offsetBy: fillPathLength)
-      let fromTokenAddress = String(fillPathNoHexPrefix[..<splitIndex])
-      let fromToken = token(for: fromTokenAddress.addingHexPrefix, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
-      let toTokenAddress = String(fillPathNoHexPrefix[splitIndex...])
-      let toToken = token(for: toTokenAddress.addingHexPrefix, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
-      /* Example:
-       ETH -> DAI
-       Sell Amount: 0.12345
+      let fromTokenAddress = String(fillPathNoHexPrefix[..<splitIndex]).addingHexPrefix
+      let toTokenAddress = String(fillPathNoHexPrefix[splitIndex...]).addingHexPrefix
       
-       fillPath="0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeead6d458402f60fd3bd25163575031acdce07538d"
-       sellAmountValue="0x1b6951ef585a000"
-       minBuyAmountValue="0x5c6f2d76e910358b"
-       formattedSellAmount="0.12345"
-       formattedMinBuyAmount="6.660592362643797387"
-       fromToken.symbol = "ETH"
-       fromTokenAddress = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-       toToken.symbol = "DAI"
+      let fromToken = token(for: fromTokenAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
+      let fromTokenDecimals = Int(fromToken?.decimals ?? network.decimals)
+      let toToken = token(for: toTokenAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
+      let toTokenDecimals = Int(toToken?.decimals ?? network.decimals)
+      
+      let formattedSellAmount = formatter.decimalString(for: sellAmountValue.removingHexPrefix, radix: .hex, decimals: fromTokenDecimals)?.trimmingTrailingZeros ?? ""
+      let formattedMinBuyAmount = formatter.decimalString(for: minBuyAmountValue.removingHexPrefix, radix: .hex, decimals: toTokenDecimals)?.trimmingTrailingZeros ?? ""
+      /* Example:
+       USDC -> DAI
+       Sell Amount: 1.5
+      
+       fillPath="0x07865c6e87b9f70255377e024ace6630c1eaa37fad6d458402f60fd3bd25163575031acdce07538d"
+       fromTokenAddress = "0x07865c6e87b9f70255377e024ace6630c1eaa37f"
+       fromToken.symbol = "USDC"
+       sellAmountValue="0x16e360"
+       formattedSellAmount="1.5"
        toTokenAddress = "0xad6d458402f60fd3bd25163575031acdce07538d"
+       toToken.symbol = "DAI"
+       minBuyAmountValue="0x1bd02ca9a7c244e"
+       formattedMinBuyAmount="0.125259433834718286"
        */
       return .init(
         transaction: transaction,

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -6,135 +6,16 @@
 import BraveCore
 import Strings
 
-struct TransactionSummary: Equatable, Identifiable {
-  struct GasFee: Equatable {
-    let fee: String
-    let fiat: String
-  }
-
-  /// The transaction
-  let txInfo: BraveWallet.TransactionInfo
-  /// From address of the transaction
-  var fromAddress: String { txInfo.fromAddress }
-  /// Account name for the from address of the transaction
-  let namedFromAddress: String
-  /// To address of the transaction
-  var toAddress: String { txInfo.ethTxToAddress }
-  /// Account name for the to address of the transaction
-  let namedToAddress: String
-  /// The title for the transaction summary.
-  /// Ex. "Sent 1.0000 ETH ($1.00"',  "Swapped 2.0000 ETH ($2.00)" / "Approved 1.0000 DAI" /  "Sent ETH"
-  let title: String
-  /// The gas fee and fiat for the transaction
-  let gasFee: GasFee?
-  /// The network symbol for the transaction
-  let networkSymbol: String
-  
-  /// Transaction id
-  var id: String { txInfo.id }
-  /// The hash of the transaction
-  var txHash: String { txInfo.txHash }
-  /// Current status of the transaction
-  var txStatus: BraveWallet.TransactionStatus { txInfo.txStatus }
-  /// The time the transaction was created
-  var createdTime: Date { txInfo.createdTime }
-}
-
 class TransactionParser {
   
   private init() {}
   
-  static func transactionSummary(
-    from transaction: BraveWallet.TransactionInfo,
-    network: BraveWallet.NetworkInfo,
-    accountInfos: [BraveWallet.AccountInfo],
-    visibleTokens: [BraveWallet.BlockchainToken],
-    allTokens: [BraveWallet.BlockchainToken],
-    assetRatios: [String: Double],
-    currencyFormatter: NumberFormatter
-  ) -> TransactionSummary {
-    TransactionSummary(
-      txInfo: transaction,
-      namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-      namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
-      title: title(
-        from: transaction,
-        network: network,
-        visibleTokens: visibleTokens,
-        allTokens: allTokens,
-        assetRatios: assetRatios,
-        currencyFormatter: currencyFormatter
-      ),
-      gasFee: gasFee(
-        from: transaction,
-        network: network,
-        assetRatios: assetRatios,
-        currencyFormatter: currencyFormatter
-      ),
-      networkSymbol: network.symbol
-    )
-  }
-  
-  private static func title(
-    from transaction: BraveWallet.TransactionInfo,
-    network: BraveWallet.NetworkInfo,
-    visibleTokens: [BraveWallet.BlockchainToken],
-    allTokens: [BraveWallet.BlockchainToken],
-    assetRatios: [String: Double],
-    currencyFormatter: NumberFormatter
-  ) -> String {
-    let formatter = WeiFormatter(decimalFormatStyle: .balance)
-    switch transaction.txType {
-    case .erc20Approve:
-      if let contractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
-          let value = transaction.txArgs[safe: 1],
-          let token = token(for: contractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) {
-        if value.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame {
-          return String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, Strings.Wallet.editPermissionsApproveUnlimited, token.symbol)
-        } else {
-          return String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? "", token.symbol)
-        }
-      } else {
-        return Strings.Wallet.transactionUnknownApprovalTitle
-      }
-    case .ethSend, .ethSwap, .other:
-      let amount = formatter.decimalString(for: transaction.ethTxValue.removingHexPrefix, radix: .hex, decimals: Int(network.decimals)) ?? ""
-      let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[network.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
-      if transaction.isSwap {
-        return String.localizedStringWithFormat(Strings.Wallet.transactionSwapTitle, amount, network.symbol, fiat)
-      } else {
-        return String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, amount, network.symbol, fiat)
-      }
-    case .erc20Transfer:
-      if let value = transaction.txArgs[safe: 1], let token = token(for: transaction.ethTxToAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) {
-        let amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
-        let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
-        return String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, amount, token.symbol, fiat)
-      } else {
-        return Strings.Wallet.send
-      }
-    case .erc721TransferFrom, .erc721SafeTransferFrom:
-      if let token = token(for: transaction.ethTxToAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) {
-        return String.localizedStringWithFormat(Strings.Wallet.transactionUnknownSendTitle, token.symbol)
-      } else {
-        return Strings.Wallet.send
-      }
-    case .solanaSystemTransfer,
-        .solanaSplTokenTransfer,
-        .solanaSplTokenTransferWithAssociatedTokenAccountCreation,
-        .erc1155SafeTransferFrom:
-      return ""
-    @unknown default:
-      return ""
-    }
-  }
-  
-  private static func gasFee(
+  static func gasFee(
     from transaction: BraveWallet.TransactionInfo,
     network: BraveWallet.NetworkInfo,
     assetRatios: [String: Double],
     currencyFormatter: NumberFormatter
-  ) -> TransactionSummary.GasFee? {
+  ) -> GasFee? {
     let isEIP1559Transaction = transaction.isEIP1559Transaction
     let limit = transaction.ethTxGasLimit
     let formatter = WeiFormatter(decimalFormatStyle: .gasFee(limit: limit.removingHexPrefix, radix: .hex))
@@ -149,7 +30,7 @@ class TransactionParser {
     return nil
   }
   
-  private static func token(
+  static func token(
     for contractAddress: String,
     network: BraveWallet.NetworkInfo,
     visibleTokens: [BraveWallet.BlockchainToken],
@@ -160,6 +41,330 @@ class TransactionParser {
     }
     return visibleTokens.first(where: findToken) ?? allTokens.first(where: findToken)
   }
+  
+  static func parseTransaction(
+    transaction: BraveWallet.TransactionInfo,
+    network: BraveWallet.NetworkInfo,
+    accountInfos: [BraveWallet.AccountInfo],
+    visibleTokens: [BraveWallet.BlockchainToken],
+    allTokens: [BraveWallet.BlockchainToken],
+    assetRatios: [String: Double],
+    currencyFormatter: NumberFormatter,
+    decimalFormatStyle: WeiFormatter.DecimalFormatStyle? = nil
+  ) -> ParsedTransaction? {
+    let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle ?? .decimals(precision: Int(network.decimals)))
+    switch transaction.txType {
+    case .ethSend, .other:
+      let fromTokenSymbol = network.symbol
+      let fromValue = transaction.ethTxValue
+      let fromValueFormatted = formatter.decimalString(for: fromValue.removingHexPrefix, radix: .hex, decimals: Int(network.decimals))?.trimmingTrailingZeros ?? ""
+      let fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[network.symbol.lowercased(), default: 0] * (Double(fromValueFormatted) ?? 0))) ?? "$0.00"
+      /* Example:
+       Send 0.1234 ETH
+       
+       fromAddress="0x882F5a2c1C429e6592D801486566D0753BC1dD04"
+       toAddress="0x4FC29eDF46859A67c5Bfa894C77a4E3C69353202"
+       fromTokenSymbol="ETH"
+       fromValue="0x1b667a56d488000"
+       fromValueFormatted="0.1234"
+       */
+      return .init(
+        transaction: transaction,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        fromAddress: transaction.fromAddress,
+        namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
+        toAddress: transaction.ethTxToAddress,
+        networkSymbol: network.symbol,
+        details: .ethSend(
+          .init(
+            fromTokenSymbol: fromTokenSymbol,
+            fromValue: fromValue,
+            fromAmount: fromValueFormatted,
+            fromFiat: fromFiat,
+            gasFee: gasFee(
+              from: transaction,
+              network: network,
+              assetRatios: assetRatios,
+              currencyFormatter: currencyFormatter
+            )
+          )
+        )
+      )
+    case .erc20Transfer:
+      guard let toAddress = transaction.txArgs[safe: 0],
+            let fromValue = transaction.txArgs[safe: 1],
+            let tokenContractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
+            let token = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
+        return nil
+      }
+      let fromAmount = formatter.decimalString(for: fromValue.removingHexPrefix, radix: .hex, decimals: Int(token.decimals))?.trimmingTrailingZeros ?? ""
+      let fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(fromAmount) ?? 0))) ?? "$0.00"
+      /*
+       fromAddress="0x882F5a2c1C429e6592D801486566D0753BC1dD04"
+       toAddress="0x7c24aed73d82c9d98a1b86bc2c8d2452c40419f8"
+       tokenContractAddress="0xaD6D458402F60fD3Bd25163575031ACDce07538D"
+       fromValue="0x5ff20a91f724000"
+       fromAmount="0.4321"
+       fromFiat="$0.43"
+       token.symbol="DAI"
+       */
+      return .init(
+        transaction: transaction,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        fromAddress: transaction.fromAddress,
+        namedToAddress: NamedAddresses.name(for: toAddress, accounts: accountInfos),
+        toAddress: toAddress,
+        networkSymbol: network.symbol,
+        details: .erc20Transfer(
+          .init(
+            fromTokenSymbol: token.symbol,
+            fromValue: fromValue,
+            fromAmount: fromAmount,
+            fromFiat: fromFiat,
+            gasFee: gasFee(
+              from: transaction,
+              network: network,
+              assetRatios: assetRatios,
+              currencyFormatter: currencyFormatter
+            )
+          )
+        )
+      )
+    case .ethSwap:
+      guard let fillPath = transaction.txArgs[safe: 0],
+            let sellAmountValue = transaction.txArgs[safe: 1],
+            let minBuyAmountValue = transaction.txArgs[safe: 2] else {
+        return nil
+      }
+      let formattedSellAmount = formatter.decimalString(for: sellAmountValue.removingHexPrefix, radix: .hex, decimals: Int(network.decimals))?.trimmingTrailingZeros ?? ""
+      let formattedMinBuyAmount = formatter.decimalString(for: minBuyAmountValue.removingHexPrefix, radix: .hex, decimals: Int(network.decimals))?.trimmingTrailingZeros ?? ""
+      
+      let fillPathNoHexPrefix = fillPath.removingHexPrefix
+      let fillPathLength = fillPathNoHexPrefix.count / 2
+      let splitIndex = fillPathNoHexPrefix.index(fillPathNoHexPrefix.startIndex, offsetBy: fillPathLength)
+      let fromTokenAddress = String(fillPathNoHexPrefix[..<splitIndex])
+      let fromToken = token(for: fromTokenAddress.addingHexPrefix, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
+      let toTokenAddress = String(fillPathNoHexPrefix[splitIndex...])
+      let toToken = token(for: toTokenAddress.addingHexPrefix, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
+      /* Example:
+       ETH -> DAI
+       Sell Amount: 0.12345
+      
+       fillPath="0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeead6d458402f60fd3bd25163575031acdce07538d"
+       sellAmountValue="0x1b6951ef585a000"
+       minBuyAmountValue="0x5c6f2d76e910358b"
+       formattedSellAmount="0.12345"
+       formattedMinBuyAmount="6.660592362643797387"
+       fromToken.symbol = "ETH"
+       fromTokenAddress = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+       toToken.symbol = "DAI"
+       toTokenAddress = "0xad6d458402f60fd3bd25163575031acdce07538d"
+       */
+      return .init(
+        transaction: transaction,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        fromAddress: transaction.fromAddress,
+        namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
+        toAddress: transaction.ethTxToAddress,
+        networkSymbol: network.symbol,
+        details: .ethSwap(
+          .init(
+            fromToken: fromToken,
+            fromValue: sellAmountValue,
+            fromAmount: formattedSellAmount,
+            toToken: toToken,
+            minBuyValue: minBuyAmountValue,
+            minBuyAmount: formattedMinBuyAmount,
+            gasFee: gasFee(
+              from: transaction,
+              network: network,
+              assetRatios: assetRatios,
+              currencyFormatter: currencyFormatter
+            )
+          )
+        )
+      )
+    case .erc20Approve:
+      guard let contractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
+            let value = transaction.txArgs[safe: 1],
+            let token = token(for: contractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
+        return nil
+      }
+      let isUnlimited = value.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame
+      let approvalAmount: String
+      if isUnlimited {
+        approvalAmount = Strings.Wallet.editPermissionsApproveUnlimited
+      } else {
+        approvalAmount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals))?.trimmingTrailingZeros ?? ""
+      }
+      /* Example:
+       Approve DAI
+       Proposed 0.1 DAI approval limit
+       
+       isUnlimited=false
+       fromAddress="0x7c24aED73D82c9D98a1B86Bc2C8d2452c40419F8"
+       token.symbol="DAI"
+       tokenContractAddress="0xaD6D458402F60fD3Bd25163575031ACDce07538D"
+       approvalValue="0x2386f26fc10000"
+       approvalAmount="0.01"
+       */
+      return .init(
+        transaction: transaction,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        fromAddress: transaction.fromAddress,
+        namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
+        toAddress: transaction.ethTxToAddress,
+        networkSymbol: network.symbol,
+        details: .ethErc20Approve(
+          .init(
+            token: token,
+            approvalValue: value,
+            approvalAmount: approvalAmount,
+            isUnlimited: isUnlimited,
+            gasFee: gasFee(
+              from: transaction,
+              network: network,
+              assetRatios: assetRatios,
+              currencyFormatter: currencyFormatter
+            )
+          )
+        )
+      )
+    case .erc721TransferFrom, .erc721SafeTransferFrom:
+      guard let owner = transaction.txArgs[safe: 0],
+            let toAddress = transaction.txArgs[safe: 1],
+            let tokenId = transaction.txArgs[safe: 2],
+            let tokenContractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
+            let token = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
+        return nil
+      }
+      return .init(
+        transaction: transaction,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        fromAddress: transaction.fromAddress, // The caller, which may not be the owner
+        namedToAddress: NamedAddresses.name(for: toAddress, accounts: accountInfos),
+        toAddress: toAddress,
+        networkSymbol: network.symbol,
+        details: .erc721Transfer(
+          .init(
+            fromToken: token,
+            fromValue: "1", // Can only send 1 erc721 at a time
+            fromAmount: "1",
+            owner: owner,
+            tokenId: tokenId
+          )
+        )
+      )
+    case .solanaSystemTransfer:
+      return nil
+    case .solanaSplTokenTransfer:
+      return nil
+    case .solanaSplTokenTransferWithAssociatedTokenAccountCreation:
+      return nil
+    case .erc1155SafeTransferFrom:
+      return nil
+    case .solanaDappSignAndSendTransaction:
+      return nil
+    case .solanaDappSignTransaction:
+      return nil
+    @unknown default:
+      return nil
+    }
+  }
 }
 
 extension BraveWallet.TransactionStatus: Equatable { }
+
+struct GasFee: Equatable {
+  let fee: String
+  let fiat: String
+}
+
+struct ParsedTransaction: Equatable {
+  enum Details: Equatable {
+    case ethSend(EthSendDetails)
+    case erc20Transfer(EthSendDetails)
+    case ethSwap(EthSwapDetails)
+    case ethErc20Approve(EthErc20ApproveDetails)
+    case erc721Transfer(Eth721TransferDetails)
+  }
+  
+  /// The transaction
+  let transaction: BraveWallet.TransactionInfo
+  
+  /// Account name for the from address of the transaction
+  let namedFromAddress: String
+  /// Address sending from
+  let fromAddress: String
+  
+  /// Account name for the to address of the transaction
+  let namedToAddress: String
+  /// Address sending to
+  let toAddress: String
+  
+  /// Network symbol of the transaction
+  let networkSymbol: String
+  
+  /// Details of the transaction
+  let details: Details
+}
+
+struct EthErc20ApproveDetails: Equatable {
+  /// Token being approved
+  let token: BraveWallet.BlockchainToken
+  /// Value being approved prior to formatting
+  let approvalValue: String
+  /// Value being approved formatted
+  let approvalAmount: String
+  /// If the value being approved is unlimited
+  let isUnlimited: Bool
+  /// Gas fee for the transaction
+  let gasFee: GasFee?
+}
+
+struct EthSendDetails: Equatable {
+  /// From token symbol
+  let fromTokenSymbol: String
+  /// From value prior to formatting
+  let fromValue: String
+  /// From amount formatted
+  let fromAmount: String
+  /// The amount formatted as currency
+  let fromFiat: String?
+  
+  /// Gas fee for the transaction
+  let gasFee: GasFee?
+}
+
+struct EthSwapDetails: Equatable {
+  /// Token being swapped from
+  let fromToken: BraveWallet.BlockchainToken?
+  /// From value prior to formatting
+  let fromValue: String
+  /// From amount formatted
+  let fromAmount: String
+  
+  /// Token being swapped to
+  let toToken: BraveWallet.BlockchainToken?
+  /// Min. buy value prior to formatting
+  let minBuyValue: String
+  /// Min. buy amount formatted
+  let minBuyAmount: String
+  
+  /// Gas fee for the transaction
+  let gasFee: GasFee?
+}
+
+struct Eth721TransferDetails: Equatable {
+  /// Token being swapped from
+  let fromToken: BraveWallet.BlockchainToken?
+  /// From value prior to formatting
+  let fromValue: String
+  /// From amount formatted
+  let fromAmount: String
+  
+  /// Owner (must not be confused with the caller (fromAddress)
+  let owner: String
+  /// The token id
+  let tokenId: String
+}

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -389,7 +389,8 @@ extension BraveWallet.TransactionInfo {
       visibleTokens: visibleTokens,
       allTokens: allTokens,
       assetRatios: assetRatios,
-      currencyFormatter: currencyFormatter
+      currencyFormatter: currencyFormatter,
+      decimalFormatStyle: decimalFormatStyle
     )
   }
 }

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -6,9 +6,7 @@
 import BraveCore
 import Strings
 
-class TransactionParser {
-  
-  private init() {}
+enum TransactionParser {
   
   static func gasFee(
     from transaction: BraveWallet.TransactionInfo,

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -370,3 +370,26 @@ struct Eth721TransferDetails: Equatable {
   /// The token id
   let tokenId: String
 }
+
+extension BraveWallet.TransactionInfo {
+  /// Use `TransactionParser` to build a `ParsedTransaction` model for this transaction.
+  func parsedTransaction(
+    network: BraveWallet.NetworkInfo,
+    accountInfos: [BraveWallet.AccountInfo],
+    visibleTokens: [BraveWallet.BlockchainToken],
+    allTokens: [BraveWallet.BlockchainToken],
+    assetRatios: [String: Double],
+    currencyFormatter: NumberFormatter,
+    decimalFormatStyle: WeiFormatter.DecimalFormatStyle? = nil
+  ) -> ParsedTransaction? {
+    TransactionParser.parseTransaction(
+      transaction: self,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: visibleTokens,
+      allTokens: allTokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter
+    )
+  }
+}

--- a/BraveWallet/Extensions/WeiFormatter.swift
+++ b/BraveWallet/Extensions/WeiFormatter.swift
@@ -150,3 +150,18 @@ struct WeiFormatter {
       .rounded().asString(radix: outputRadix.rawValue)
   }
 }
+
+extension String {
+  // Remove trailing zeros, including the decimal separator if necessary.
+  // Example: 1.0000000000 becomes 1, 1122.33440000000 becomes 1122.3344
+  var trimmingTrailingZeros: String {
+    do {
+      let regexPattern = "\\.0*$|(\\.\\d*[1-9])0+$"
+      let regex = try NSRegularExpression(pattern: regexPattern, options: .caseInsensitive)
+      let range = NSRange(location: 0, length: count)
+      return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "$1")
+    } catch {
+      return self
+    }
+  }
+}

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -39,6 +39,21 @@ extension BraveWallet.BlockchainToken {
     coin: .eth
   )
   
+  static let mockUSDCToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0x07865c6e87b9f70255377e024ace6630c1eaa37f",
+    name: "USDC",
+    logo: "",
+    isErc20: false,
+    isErc721: false,
+    symbol: "USDC",
+    decimals: 6,
+    visible: false,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: "",
+    coin: .eth
+  )
+  
   static let mockSolToken: BraveWallet.BlockchainToken = .init(
     contractAddress: "0x1111111111222222222233333333334444444444",
     name: "Solana",

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -1331,12 +1331,12 @@ extension Strings {
       value: "Approved",
       comment: "The title shown for ERC20 approvals when the user doesn't have the visible asset added"
     )
-    public static let transactionSwapTitle = NSLocalizedString(
-      "wallet.transactionSwapTitle",
+    public static let transactionSwappedTitle = NSLocalizedString(
+      "wallet.transactionSwappedTitle",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Swapped %@ %@ (%@)",
-      comment: "A title shown for a swap transaction. The first '%@' becomes the  amount, the second '%@' becomes the symbol for the cryptocurrency and the last '%@' becomes the fiat amount. For example: \"Swapped 0.0054 ETH ($22.44)\""
+      value: "Swapped %@ %@ to %@ %@",
+      comment: "A title shown for a swap transaction. The first '%@' becomes the from amount, the second '%@' becomes the symbol for the from currency, the third '%@' becomes the to amount, and the last '%@' becomes the to symbol. For example: \"Swapped 0.0054 ETH to 1.5 DAI\""
     )
     public static let transactionSendTitle = NSLocalizedString(
       "wallet.transactionSendTitle",

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -1,0 +1,499 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import BraveCore
+@testable import BraveWallet
+
+private extension BraveWallet.AccountInfo {
+  convenience init(
+    address: String,
+    name: String,
+    coin: BraveWallet.CoinType = .eth
+  ) {
+    self.init(
+      address: address,
+      name: name,
+      isImported: false,
+      hardware: nil,
+      coin: .eth
+    )
+  }
+}
+
+class TransactionParserTests: XCTestCase {
+  
+  private let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
+  private let accountInfos: [BraveWallet.AccountInfo] = [
+    .init(address: "0x1234567890123456789012345678901234567890", name: "Account 1"),
+    .init(address: "0x0987654321098765432109876543210987654321", name: "Account 2")
+  ]
+  private let tokens: [BraveWallet.BlockchainToken] = [.previewToken, .previewDaiToken]
+  let assetRatios: [String: Double] = ["eth": 1,
+                                       "dai": 2]
+  
+  func testEthSendTransaction() {
+    let network: BraveWallet.NetworkInfo = .mockMainnet
+    
+    let transactionData: BraveWallet.TxData1559 = .init(
+      baseData: .init(
+        nonce: "1",
+        gasPrice: "0x0",
+        gasLimit: "0x5208",
+        to: "0x0987654321098765432109876543210987654321",
+        value: "0x1b667a56d488000", // 0.1234
+        data: []
+      ),
+      chainId: network.chainId,
+      maxPriorityFeePerGas: "0x59672ead",
+      maxFeePerGas: "0x59672eb6",
+      gasEstimation: .init(
+        slowMaxPriorityFeePerGas: "0x0",
+        slowMaxFeePerGas: "0x9",
+        avgMaxPriorityFeePerGas: "0x59672ead",
+        avgMaxFeePerGas: "0x59672eb6",
+        fastMaxPriorityFeePerGas: "0x59682f00",
+        fastMaxFeePerGas: "0x59682f09",
+        baseFeePerGas: "0x9"
+      )
+    )
+    let transaction = BraveWallet.TransactionInfo(
+      id: "1",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: .init(ethTxData1559: transactionData),
+      txStatus: .confirmed,
+      txType: .ethSend,
+      txParams: [],
+      txArgs: [],
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil
+    )
+    
+    let expectedParsedTransaction = ParsedTransaction(
+      transaction: transaction,
+      namedFromAddress: "Account 1",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedToAddress: "Account 2",
+      toAddress: "0x0987654321098765432109876543210987654321",
+      networkSymbol: "ETH",
+      details: .ethSend(
+        .init(
+          fromTokenSymbol: "ETH",
+          fromValue: "0x1b667a56d488000",
+          fromAmount: "0.1234",
+          fromFiat: "$0.12",
+          gasFee: .init(
+            fee: "0.000031",
+            fiat: "$0.00"
+          )
+        )
+      )
+    )
+    
+    guard let parsedTransaction = TransactionParser.parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: tokens,
+      allTokens: tokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter
+    ) else {
+      XCTFail("Failed to parse ethSend transaction")
+      return
+    }
+    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+  
+  func testEthErc20TransferTransaction() {
+    let network: BraveWallet.NetworkInfo = .mockMainnet
+    
+    let transactionData: BraveWallet.TxData1559 = .init(
+      baseData: .init(
+        nonce: "1",
+        gasPrice: "0x0",
+        gasLimit: "0xca48",
+        to: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
+        value: "0x0",
+        data: []
+      ),
+      chainId: network.chainId,
+      maxPriorityFeePerGas: "0x59672ead",
+      maxFeePerGas: "0x59672eb6",
+      gasEstimation: .init(
+        slowMaxPriorityFeePerGas: "0x0",
+        slowMaxFeePerGas: "0x9",
+        avgMaxPriorityFeePerGas: "0x59672ead",
+        avgMaxFeePerGas: "0x59672eb6",
+        fastMaxPriorityFeePerGas: "0x59682f00",
+        fastMaxFeePerGas: "0x59682f09",
+        baseFeePerGas: "0x9"
+      )
+    )
+    let transaction = BraveWallet.TransactionInfo(
+      id: "2",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: .init(ethTxData1559: transactionData),
+      txStatus: .confirmed,
+      txType: .erc20Transfer,
+      txParams: [],
+      txArgs: ["0x0987654321098765432109876543210987654321", "0x5ff20a91f724000"], // toAddress, 0.4321
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil
+    )
+    
+    let expectedParsedTransaction = ParsedTransaction(
+      transaction: transaction,
+      namedFromAddress: "Account 1",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedToAddress: "Account 2",
+      toAddress: "0x0987654321098765432109876543210987654321",
+      networkSymbol: "ETH",
+      details: .erc20Transfer(
+        .init(
+          fromTokenSymbol: "DAI",
+          fromValue: "0x5ff20a91f724000",
+          fromAmount: "0.4321",
+          fromFiat: "$0.86",
+          gasFee: .init(
+            fee: "0.000078",
+            fiat: "$0.00"
+          )
+        )
+      )
+    )
+    
+    guard let parsedTransaction = TransactionParser.parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: tokens,
+      allTokens: tokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter
+    ) else {
+      XCTFail("Failed to parse erc20Transfer transaction")
+      return
+    }
+    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+  
+  func testEthSwapTransaction() {
+    let network: BraveWallet.NetworkInfo = .mockMainnet
+    
+    let transactionData: BraveWallet.TxData1559 = .init(
+      baseData: .init(
+        nonce: "1",
+        gasPrice: "0x0",
+        gasLimit: "0x4be75",
+        to: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF", // 0x exchange address
+        value: "0x1b6951ef585a000",
+        data: []
+      ),
+      chainId: network.chainId,
+      maxPriorityFeePerGas: "0x59682f00",
+      maxFeePerGas: "0x59682f09",
+      gasEstimation: .init(
+        slowMaxPriorityFeePerGas: "0x4ed3152b",
+        slowMaxFeePerGas: "0x4ed31534",
+        avgMaxPriorityFeePerGas: "0x59672ead",
+        avgMaxFeePerGas: "0x59672eb6",
+        fastMaxPriorityFeePerGas: "0x59682f00",
+        fastMaxFeePerGas: "0x59682f09",
+        baseFeePerGas: "0x9"
+      )
+    )
+    let transaction = BraveWallet.TransactionInfo(
+      id: "3",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: .init(ethTxData1559: transactionData),
+      txStatus: .confirmed,
+      txType: .ethSwap,
+      txParams: [],
+      txArgs: [
+        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeead6d458402f60fd3bd25163575031acdce07538d", // eth -> dai
+        "0x1b6951ef585a000", // 0.12345 eth
+        "0x5c6f2d76e910358b" // 6.660592362643797387 dai
+      ],
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil
+    )
+    
+    let expectedParsedTransaction = ParsedTransaction(
+      transaction: transaction,
+      namedFromAddress: "Account 1",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedToAddress: "0x Exchange Proxy",
+      toAddress: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
+      networkSymbol: "ETH",
+      details: .ethSwap(
+        .init(
+          fromToken: .previewToken,
+          fromValue: "0x1b6951ef585a000",
+          fromAmount: "0.12345",
+          toToken: .previewDaiToken,
+          minBuyValue: "0x5c6f2d76e910358b",
+          minBuyAmount: "6.660592362643797387",
+          gasFee: .init(
+            fee: "0.000466",
+            fiat: "$0.00"
+          )
+        )
+      )
+    )
+    
+    guard let parsedTransaction = TransactionParser.parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: tokens,
+      allTokens: tokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter
+    ) else {
+      XCTFail("Failed to parse ethSwap transaction")
+      return
+    }
+    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+  
+  func testErc20ApproveTransaction() {
+    let network: BraveWallet.NetworkInfo = .mockMainnet
+    
+    let transactionData: BraveWallet.TxData1559 = .init(
+      baseData: .init(
+        nonce: "1",
+        gasPrice: "0x0",
+        gasLimit: "0xb53f",
+        to: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
+        value: "0x0",
+        data: []
+      ),
+      chainId: network.chainId,
+      maxPriorityFeePerGas: "0x59682f00",
+      maxFeePerGas: "0x59682f09",
+      gasEstimation: .init(
+        slowMaxPriorityFeePerGas: "0x0",
+        slowMaxFeePerGas: "0x9",
+        avgMaxPriorityFeePerGas: "0x59672ead",
+        avgMaxFeePerGas: "0x59672eb6",
+        fastMaxPriorityFeePerGas: "0x59682f00",
+        fastMaxFeePerGas: "0x59682f09",
+        baseFeePerGas: "0x9"
+      )
+    )
+    let transaction = BraveWallet.TransactionInfo(
+      id: "4",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: .init(ethTxData1559: transactionData),
+      txStatus: .confirmed,
+      txType: .erc20Approve,
+      txParams: [],
+      txArgs: ["", "0x2386f26fc10000"], // 0.01
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil
+    )
+    
+    let expectedParsedTransaction = ParsedTransaction(
+      transaction: transaction,
+      namedFromAddress: "Account 1",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedToAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress.truncatedAddress,
+      toAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
+      networkSymbol: "ETH",
+      details: .ethErc20Approve(
+        .init(
+          token: .previewDaiToken,
+          approvalValue: "0x2386f26fc10000",
+          approvalAmount: "0.01",
+          isUnlimited: false,
+          gasFee: .init(
+            fee: "0.0000610",
+            fiat: "$0.00"
+          )
+        )
+      )
+    )
+    
+    guard let parsedTransaction = TransactionParser.parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: tokens,
+      allTokens: tokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter
+    ) else {
+      XCTFail("Failed to parse erc20Approve transaction")
+      return
+    }
+    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+  
+  func testErc20ApproveTransactionUnlimited() {
+    let network: BraveWallet.NetworkInfo = .mockMainnet
+    
+    let transactionData: BraveWallet.TxData1559 = .init(
+      baseData: .init(
+        nonce: "1",
+        gasPrice: "0x0",
+        gasLimit: "0xb53f",
+        to: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
+        value: "0x0",
+        data: []
+      ),
+      chainId: network.chainId,
+      maxPriorityFeePerGas: "0x59682f00",
+      maxFeePerGas: "0x59682f09",
+      gasEstimation: .init(
+        slowMaxPriorityFeePerGas: "0x0",
+        slowMaxFeePerGas: "0x9",
+        avgMaxPriorityFeePerGas: "0x59672ead",
+        avgMaxFeePerGas: "0x59672eb6",
+        fastMaxPriorityFeePerGas: "0x59682f00",
+        fastMaxFeePerGas: "0x59682f09",
+        baseFeePerGas: "0x9"
+      )
+    )
+    let transaction = BraveWallet.TransactionInfo(
+      id: "5",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: .init(ethTxData1559: transactionData),
+      txStatus: .confirmed,
+      txType: .erc20Approve,
+      txParams: [],
+      txArgs: ["", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"], // unlimited
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil
+    )
+    
+    let expectedParsedTransaction = ParsedTransaction(
+      transaction: transaction,
+      namedFromAddress: "Account 1",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedToAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress.truncatedAddress,
+      toAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
+      networkSymbol: "ETH",
+      details: .ethErc20Approve(
+        .init(
+          token: .previewDaiToken,
+          approvalValue: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          approvalAmount: "Unlimited",
+          isUnlimited: true,
+          gasFee: .init(
+            fee: "0.0000610",
+            fiat: "$0.00"
+          )
+        )
+      )
+    )
+    
+    guard let parsedTransaction = TransactionParser.parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: tokens,
+      allTokens: tokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter
+    ) else {
+      XCTFail("Failed to parse erc20Approve transaction")
+      return
+    }
+    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+  
+  func testErc721TransferFromTransaction() {
+    let network: BraveWallet.NetworkInfo = .mockMainnet
+    
+    let transactionData: BraveWallet.TxData1559 = .init(
+      baseData: .init(
+        nonce: "1",
+        gasPrice: "0x0",
+        gasLimit: "0x5208",
+        to: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
+        value: "0xde0b6b3a7640000", // 1
+        data: []
+      ),
+      chainId: network.chainId,
+      maxPriorityFeePerGas: "0x59672ead",
+      maxFeePerGas: "0x59672eb6",
+      gasEstimation: .init(
+        slowMaxPriorityFeePerGas: "0x0",
+        slowMaxFeePerGas: "0x9",
+        avgMaxPriorityFeePerGas: "0x59672ead",
+        avgMaxFeePerGas: "0x59672eb6",
+        fastMaxPriorityFeePerGas: "0x59682f00",
+        fastMaxFeePerGas: "0x59682f09",
+        baseFeePerGas: "0x9"
+      )
+    )
+    let transaction = BraveWallet.TransactionInfo(
+      id: "6",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: .init(ethTxData1559: transactionData),
+      txStatus: .confirmed,
+      txType: .erc721TransferFrom,
+      txParams: [],
+      txArgs: [
+        "0x1111111111aaaaaaaaaa2222222222bbbbbbbbbb", // owner
+        "0x0987654321098765432109876543210987654321", // toAddress
+        "token.id"
+      ],
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil
+    )
+    
+    let expectedParsedTransaction = ParsedTransaction(
+      transaction: transaction,
+      namedFromAddress: "Account 1",
+      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedToAddress: "Account 2",
+      toAddress: "0x0987654321098765432109876543210987654321",
+      networkSymbol: "ETH",
+      details: .erc721Transfer(
+        .init(
+          fromToken: .previewDaiToken,
+          fromValue: "1",
+          fromAmount: "1",
+          owner: "0x1111111111aaaaaaaaaa2222222222bbbbbbbbbb",
+          tokenId: "token.id"
+        )
+      )
+    )
+    
+    guard let parsedTransaction = TransactionParser.parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: tokens,
+      allTokens: tokens,
+      assetRatios: assetRatios,
+      currencyFormatter: currencyFormatter
+    ) else {
+      XCTFail("Failed to parse erc721TransferFrom transaction")
+      return
+    }
+    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+}

--- a/Tests/BraveWalletTests/WeiFormatterTests.swift
+++ b/Tests/BraveWalletTests/WeiFormatterTests.swift
@@ -46,4 +46,29 @@ class WeiFormatterTests: XCTestCase {
     // Hex
     XCTAssertEqual(try XCTUnwrap(formatter.weiString(from: 0.1, radix: .hex, decimals: 18)), "16345785d8a0000")
   }
+  
+  func testTrimmingTrailingZeros() {
+    typealias ValueExpected = (value: String, expected: String)
+    let testCases: [ValueExpected] = [
+      ValueExpected(value: "0", expected: "0"),
+      ValueExpected(value: "100", expected: "100"),
+      ValueExpected(value: "100001.1", expected: "100001.1"),
+      ValueExpected(value: "10001.1", expected: "10001.1"),
+      ValueExpected(value: "0.0000000000001", expected: "0.0000000000001"),
+      ValueExpected(value: "123456789.0", expected: "123456789"),
+      ValueExpected(value: "12345678.90", expected: "12345678.9"),
+      ValueExpected(value: "1234567.890", expected: "1234567.89"),
+      ValueExpected(value: "123456.7890", expected: "123456.789"),
+      ValueExpected(value: "12345.67890", expected: "12345.6789"),
+      ValueExpected(value: "0.000000000000000000", expected: "0"),
+      ValueExpected(value: "1.000000000000000000", expected: "1"),
+      ValueExpected(value: "0.112233440000000000", expected: "0.11223344"),
+      ValueExpected(value: "1122.33440000000000000", expected: "1122.3344"),
+      ValueExpected(value: "12345.112233440000000000", expected: "12345.11223344"),
+      ValueExpected(value: "12345.6789", expected: "12345.6789")
+    ]
+    testCases.forEach {
+      XCTAssertEqual($0.value.trimmingTrailingZeros, $0.expected)
+    }
+  }
 }


### PR DESCRIPTION
## Summary of Changes
- Refactored `TransactionParser` to generate a new `ParsedTransaction` model. `ParsedTransaction` model contains common properties like `fromAddress`, `toAddress` and named accounts and the network symbol. Additionally it holds an enum for specific transaction type details.

This pull request fixes #5731

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Create a few transactions on `development` branch:
    1. ETH send
    2. DAI send (or any non-ETH token)
    3. ERC 20 Approval
    4. Swap transaction ETH -> any non-ETH token
    5. Swap transaction from non-ETH token to a different non-ETH token
2. Verify display of these transactions in the transaction lists on Asset Detail, Account Detail and transaction history (from wallet panel). May help to take a screenshot for comparison.
3. Switch to `transaction-parser` branch
4. Verify display of the same transactions again, comparing against values from step 2.


## Screenshots:

![transactions on development](https://user-images.githubusercontent.com/5314553/180329198-a1ac2a94-fc53-404e-b516-8486cea0699c.png) | ![updated parsed transactions](https://user-images.githubusercontent.com/5314553/180329203-a5ccb3d3-f3e0-4f30-9a7e-8a1a98a01c25.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
