### PR TITLE
Fix #5723: Solana transaction support in Transaction Parser

### DIFF
--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -26,6 +26,7 @@ class AccountActivityStore: ObservableObject {
   private let assetRatioService: BraveWalletAssetRatioService
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
+  private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
 
   init(
     account: BraveWallet.AccountInfo,
@@ -34,7 +35,8 @@ class AccountActivityStore: ObservableObject {
     rpcService: BraveWalletJsonRpcService,
     assetRatioService: BraveWalletAssetRatioService,
     txService: BraveWalletTxService,
-    blockchainRegistry: BraveWalletBlockchainRegistry
+    blockchainRegistry: BraveWalletBlockchainRegistry,
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   ) {
     self.account = account
     self.keyringService = keyringService
@@ -43,6 +45,7 @@ class AccountActivityStore: ObservableObject {
     self.assetRatioService = assetRatioService
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
+    self.solTxManagerProxy = solTxManagerProxy
     
     self.keyringService.add(self)
     self.rpcService.add(self)
@@ -124,7 +127,12 @@ class AccountActivityStore: ObservableObject {
     allTokens: [BraveWallet.BlockchainToken],
     assetRatios: [String: Double]
   ) async -> [TransactionSummary] {
-    await txService.allTransactionInfo(.eth, from: account.address)
+    let transactions = await txService.allTransactionInfo(account.coin, from: account.address)
+    var solEstimatedTxFees: [String: UInt64] = [:]
+    if network.coin == .sol {
+      solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(for: transactions.map(\.id))
+    }
+    return transactions
       .sorted(by: { $0.createdTime > $1.createdTime })
       .map { transaction in
         TransactionParser.transactionSummary(
@@ -134,6 +142,7 @@ class AccountActivityStore: ObservableObject {
           visibleTokens: userVisibleTokens,
           allTokens: allTokens,
           assetRatios: assetRatios,
+          solEstimatedTxFee: solEstimatedTxFees[transaction.id],
           currencyFormatter: currencyFormatter
         )
       }

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -129,7 +129,7 @@ class AccountActivityStore: ObservableObject {
   ) async -> [TransactionSummary] {
     let transactions = await txService.allTransactionInfo(account.coin, from: account.address)
     var solEstimatedTxFees: [String: UInt64] = [:]
-    if network.coin == .sol {
+    if account.coin == .sol {
       solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(for: transactions.map(\.id))
     }
     return transactions

--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -55,6 +55,7 @@ class AssetDetailStore: ObservableObject {
   private let rpcService: BraveWalletJsonRpcService
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
+  private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
 
   let token: BraveWallet.BlockchainToken
 
@@ -65,6 +66,7 @@ class AssetDetailStore: ObservableObject {
     walletService: BraveWalletBraveWalletService,
     txService: BraveWalletTxService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
     token: BraveWallet.BlockchainToken
   ) {
     self.assetRatioService = assetRatioService
@@ -73,6 +75,7 @@ class AssetDetailStore: ObservableObject {
     self.walletService = walletService
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
+    self.solTxManagerProxy = solTxManagerProxy
     self.token = token
 
     self.keyringService.add(self)
@@ -164,25 +167,41 @@ class AssetDetailStore: ObservableObject {
     keyring: BraveWallet.KeyringInfo,
     assetRatios: [String: Double]
   ) async -> [TransactionSummary] {
-    let network = await rpcService.network(.eth)
+    let coin = token.coin
+    let network = await rpcService.network(coin)
     let allTransactions = await withTaskGroup(of: [BraveWallet.TransactionInfo].self) { group -> [BraveWallet.TransactionInfo] in
       for account in keyring.accountInfos {
         group.addTask {
-          await self.txService.allTransactionInfo(.eth, from: account.address)
+          await self.txService.allTransactionInfo(coin, from: account.address)
         }
       }
       return await group.reduce([BraveWallet.TransactionInfo](), { partialResult, prior in
         return partialResult + prior
       })
     }
+    var solEstimatedTxFees: [String: UInt64] = [:]
+    if network.coin == .sol {
+      solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(for: allTransactions.map(\.id))
+    }
     return allTransactions
       .filter { tx in
         switch tx.txType {
         case .erc20Approve, .erc20Transfer:
-          let toAddress = tx.txDataUnion.ethTxData1559?.baseData.to
-          return toAddress == self.token.contractAddress
+          guard let tokenContractAddress = tx.txDataUnion.ethTxData1559?.baseData.to else {
+            return false
+          }
+          return tokenContractAddress.caseInsensitiveCompare(self.token.contractAddress) == .orderedSame
         case .ethSend, .ethSwap, .other, .erc721TransferFrom, .erc721SafeTransferFrom:
           return network.symbol.caseInsensitiveCompare(self.token.symbol) == .orderedSame
+        case .solanaSystemTransfer:
+          return network.symbol.caseInsensitiveCompare(self.token.symbol) == .orderedSame
+        case .solanaSplTokenTransfer, .solanaSplTokenTransferWithAssociatedTokenAccountCreation:
+          guard let tokenContractAddress = tx.txDataUnion.solanaTxData?.splTokenMintAddress else {
+            return false
+          }
+          return tokenContractAddress.caseInsensitiveCompare(self.token.contractAddress) == .orderedSame
+        case .erc1155SafeTransferFrom, .solanaDappSignTransaction, .solanaDappSignAndSendTransaction:
+          return false
         @unknown default:
           return false
         }
@@ -196,6 +215,7 @@ class AssetDetailStore: ObservableObject {
           visibleTokens: [token],
           allTokens: [],
           assetRatios: assetRatios,
+          solEstimatedTxFee: solEstimatedTxFees[transaction.id],
           currencyFormatter: self.currencyFormatter
         )
       }

--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -169,6 +169,8 @@ class AssetDetailStore: ObservableObject {
   ) async -> [TransactionSummary] {
     let coin = token.coin
     let network = await rpcService.network(coin)
+    let userVisibleAssets = await walletService.userAssets(network.chainId, coin: coin)
+    let allTokens = await blockchainRegistry.allTokens(network.chainId, coin: coin)
     let allTransactions = await withTaskGroup(of: [BraveWallet.TransactionInfo].self) { group -> [BraveWallet.TransactionInfo] in
       for account in keyring.accountInfos {
         group.addTask {
@@ -212,8 +214,8 @@ class AssetDetailStore: ObservableObject {
           from: transaction,
           network: network,
           accountInfos: keyring.accountInfos,
-          visibleTokens: [token],
-          allTokens: [],
+          visibleTokens: userVisibleAssets,
+          allTokens: allTokens,
           assetRatios: assetRatios,
           solEstimatedTxFee: solEstimatedTxFees[transaction.id],
           currencyFormatter: self.currencyFormatter

--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -180,7 +180,7 @@ class AssetDetailStore: ObservableObject {
       })
     }
     var solEstimatedTxFees: [String: UInt64] = [:]
-    if network.coin == .sol {
+    if token.coin == .sol {
       solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(for: allTransactions.map(\.id))
     }
     return allTransactions

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -172,6 +172,7 @@ public class CryptoStore: ObservableObject {
       walletService: walletService,
       txService: txService,
       blockchainRegistry: blockchainRegistry,
+      solTxManagerProxy: solTxManagerProxy,
       token: token
     )
     assetDetailStore = store
@@ -196,7 +197,8 @@ public class CryptoStore: ObservableObject {
       rpcService: rpcService,
       assetRatioService: assetRatioService,
       txService: txService,
-      blockchainRegistry: blockchainRegistry
+      blockchainRegistry: blockchainRegistry,
+      solTxManagerProxy: solTxManagerProxy
     )
     accountActivityStore = store
     return store

--- a/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -44,6 +44,7 @@ extension TransactionParser {
     visibleTokens: [BraveWallet.BlockchainToken],
     allTokens: [BraveWallet.BlockchainToken],
     assetRatios: [String: Double],
+    solEstimatedTxFee: UInt64?,
     currencyFormatter: NumberFormatter
   ) -> TransactionSummary {
     guard let parsedTransaction = parseTransaction(
@@ -53,6 +54,7 @@ extension TransactionParser {
       visibleTokens: visibleTokens,
       allTokens: allTokens,
       assetRatios: assetRatios,
+      solEstimatedTxFee: solEstimatedTxFee,
       currencyFormatter: currencyFormatter,
       decimalFormatStyle: .balance // use 4 digit precision for summary
     ) else {
@@ -72,17 +74,17 @@ extension TransactionParser {
     }
     switch parsedTransaction.details {
     case let .ethSend(details):
-      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromTokenSymbol, details.fromFiat ?? "")
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "")
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: details.gasFee,
-        networkSymbol: details.fromTokenSymbol
+        networkSymbol: parsedTransaction.networkSymbol
       )
     case let .erc20Transfer(details):
-      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromTokenSymbol, details.fromFiat ?? "")
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "")
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
@@ -133,6 +135,16 @@ extension TransactionParser {
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: nil,
+        networkSymbol: parsedTransaction.networkSymbol
+      )
+    case let .solSystemTransfer(details), let .solSplTokenTransfer(details):
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "")
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: parsedTransaction.namedFromAddress,
+        namedToAddress: parsedTransaction.namedToAddress,
+        title: title,
+        gasFee: details.gasFee,
         networkSymbol: parsedTransaction.networkSymbol
       )
     }

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -167,19 +167,24 @@ enum TransactionParser {
       
       let formattedSellAmount = formatter.decimalString(for: sellAmountValue.removingHexPrefix, radix: .hex, decimals: fromTokenDecimals)?.trimmingTrailingZeros ?? ""
       let formattedMinBuyAmount = formatter.decimalString(for: minBuyAmountValue.removingHexPrefix, radix: .hex, decimals: toTokenDecimals)?.trimmingTrailingZeros ?? ""
+      
+      let fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[fromToken?.symbol.lowercased() ?? "", default: 0] * (Double(formattedSellAmount) ?? 0))) ?? "$0.00"
+      let minBuyAmountFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[toToken?.symbol.lowercased() ?? "", default: 0] * (Double(formattedMinBuyAmount) ?? 0))) ?? "$0.00"
       /* Example:
        USDC -> DAI
        Sell Amount: 1.5
       
-       fillPath="0x07865c6e87b9f70255377e024ace6630c1eaa37fad6d458402f60fd3bd25163575031acdce07538d"
+       fillPath = "0x07865c6e87b9f70255377e024ace6630c1eaa37fad6d458402f60fd3bd25163575031acdce07538d"
        fromTokenAddress = "0x07865c6e87b9f70255377e024ace6630c1eaa37f"
        fromToken.symbol = "USDC"
-       sellAmountValue="0x16e360"
-       formattedSellAmount="1.5"
+       sellAmountValue = "0x16e360"
+       formattedSellAmount = "1.5"
+       fromFiat = "$187.37"
        toTokenAddress = "0xad6d458402f60fd3bd25163575031acdce07538d"
        toToken.symbol = "DAI"
-       minBuyAmountValue="0x1bd02ca9a7c244e"
-       formattedMinBuyAmount="0.125259433834718286"
+       minBuyAmountValue = "0x1bd02ca9a7c244e"
+       formattedMinBuyAmount = "0.125259433834718286"
+       minBuyAmountFiat = "$6.67"
        */
       return .init(
         transaction: transaction,
@@ -193,9 +198,11 @@ enum TransactionParser {
             fromToken: fromToken,
             fromValue: sellAmountValue,
             fromAmount: formattedSellAmount,
+            fromFiat: fromFiat,
             toToken: toToken,
             minBuyValue: minBuyAmountValue,
             minBuyAmount: formattedMinBuyAmount,
+            minBuyAmountFiat: minBuyAmountFiat,
             gasFee: gasFee(
               from: transaction,
               network: network,
@@ -443,6 +450,8 @@ struct EthSwapDetails: Equatable {
   let fromValue: String
   /// From amount formatted
   let fromAmount: String
+  /// The amount formatted as currency
+  let fromFiat: String?
   
   /// Token being swapped to
   let toToken: BraveWallet.BlockchainToken?
@@ -450,6 +459,8 @@ struct EthSwapDetails: Equatable {
   let minBuyValue: String
   /// Min. buy amount formatted
   let minBuyAmount: String
+  /// The amount formatted as currency
+  let minBuyAmountFiat: String?
   
   /// Gas fee for the transaction
   let gasFee: GasFee?

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -414,6 +414,23 @@ struct ParsedTransaction: Equatable {
   
   /// Details of the transaction
   let details: Details
+  
+  /// Gas fee for the transaction if available
+  var gasFee: GasFee? {
+    switch details {
+    case let .ethSend(details),
+      let .erc20Transfer(details),
+      let .solSystemTransfer(details),
+      let .solSplTokenTransfer(details):
+      return details.gasFee
+    case let .ethSwap(details):
+      return details.gasFee
+    case let .ethErc20Approve(details):
+      return details.gasFee
+    case .erc721Transfer:
+      return nil
+    }
+  }
 }
 
 struct EthErc20ApproveDetails: Equatable {
@@ -488,8 +505,8 @@ extension BraveWallet.TransactionInfo {
     visibleTokens: [BraveWallet.BlockchainToken],
     allTokens: [BraveWallet.BlockchainToken],
     assetRatios: [String: Double],
-    currencyFormatter: NumberFormatter,
     solEstimatedTxFee: UInt64? = nil,
+    currencyFormatter: NumberFormatter,
     decimalFormatStyle: WeiFormatter.DecimalFormatStyle? = nil
   ) -> ParsedTransaction? {
     TransactionParser.parseTransaction(

--- a/BraveWallet/Extensions/SolanaTxManagerProxyExtensions.swift
+++ b/BraveWallet/Extensions/SolanaTxManagerProxyExtensions.swift
@@ -1,0 +1,39 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+
+extension BraveWalletSolanaTxManagerProxy {
+  
+  /// Fetches the estimatedTxFee for an array of transaction meta ids.
+  func estimatedTxFees(
+    for transactionMetaIds: [String],
+    completion: @escaping ([String: UInt64]) -> Void
+  ) {
+    var estimatedTxFees: [String: UInt64] = [:]
+    let dispatchGroup = DispatchGroup()
+    transactionMetaIds.forEach { txMetaId in
+      dispatchGroup.enter()
+      estimatedTxFee(txMetaId) { fee, _, _ in
+        defer { dispatchGroup.leave() }
+        estimatedTxFees[txMetaId] = fee
+      }
+    }
+    dispatchGroup.notify(queue: .main) {
+      completion(estimatedTxFees)
+    }
+  }
+  
+  /// Fetches the estimatedTxFee for an array of transaction meta ids.
+  @MainActor func estimatedTxFees(
+    for transactionMetaIds: [String]
+  ) async -> [String: UInt64] {
+    await withCheckedContinuation { continuation in
+      estimatedTxFees(for: transactionMetaIds) { fees in
+        continuation.resume(returning: fees)
+      }
+    }
+  }
+}

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -212,6 +212,7 @@ extension TransactionSummary {
       visibleTokens: [.previewToken, .previewDaiToken],
       allTokens: [],
       assetRatios: [BraveWallet.BlockchainToken.previewToken.symbol.lowercased(): 1],
+      solEstimatedTxFee: nil,
       currencyFormatter: .usdCurrencyFormatter
     )
   }

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -68,25 +68,10 @@ extension BraveWallet.BlockchainToken {
     chainId: "",
     coin: .sol
   )
-
-  static let mockSPLToken: BraveWallet.BlockchainToken = .init(
-    contractAddress: "0x1111111111222222222233333333334444444445",
-    name: "Non-SOL",
-    logo: "",
-    isErc20: false,
-    isErc721: false,
-    symbol: "NONSOL",
-    decimals: 9,
-    visible: false,
-    tokenId: "",
-    coingeckoId: "",
-    chainId: "",
-    coin: .sol
-  )
   
   static let mockSpdToken: BraveWallet.BlockchainToken = .init(
     contractAddress: "0x1111111111222222222233333333334444444444",
-    name: "Solpad",
+    name: "",
     logo: "",
     isErc20: false,
     isErc721: false,

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -55,7 +55,7 @@ extension BraveWallet.BlockchainToken {
   )
   
   static let mockSolToken: BraveWallet.BlockchainToken = .init(
-    contractAddress: "0x1111111111222222222233333333334444444444",
+    contractAddress: "",
     name: "Solana",
     logo: "",
     isErc20: false,
@@ -77,6 +77,21 @@ extension BraveWallet.BlockchainToken {
     isErc721: false,
     symbol: "NONSOL",
     decimals: 9,
+    visible: false,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: "",
+    coin: .sol
+  )
+  
+  static let mockSpdToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0x1111111111222222222233333333334444444444",
+    name: "Solpad",
+    logo: "",
+    isErc20: false,
+    isErc721: false,
+    symbol: "SPD",
+    decimals: 6,
     visible: false,
     tokenId: "",
     coingeckoId: "",

--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -220,4 +220,23 @@ extension BraveWallet.NetworkInfo {
   )
 }
 
+// TODO: Move to separate file
+class MockSolanaTxManagerProxy: BraveWalletSolanaTxManagerProxy {
+  func makeSystemProgramTransferTxData(_ from: String, to: String, lamports: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion(nil, .internalError, "Error message")
+  }
+  
+  func processSolanaHardwareSignature(_ txMetaId: String, signatureBytes: [NSNumber], completion: @escaping (Bool, BraveWallet.ProviderErrorUnion, String) -> Void) {
+    completion(false, .init(solanaProviderError: .internalError), "Error message")
+  }
+  
+  func makeTokenProgramTransferTxData(_ splTokenMintAddress: String, fromWalletAddress: String, toWalletAddress: String, amount: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion(nil, .internalError, "Error message")
+  }
+  
+  func estimatedTxFee(_ txMetaId: String, completion: @escaping (UInt64, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion(0, .internalError, "Error message")
+  }
+}
+
 #endif

--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -220,23 +220,4 @@ extension BraveWallet.NetworkInfo {
   )
 }
 
-// TODO: Move to separate file
-class MockSolanaTxManagerProxy: BraveWalletSolanaTxManagerProxy {
-  func makeSystemProgramTransferTxData(_ from: String, to: String, lamports: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
-    completion(nil, .internalError, "Error message")
-  }
-  
-  func processSolanaHardwareSignature(_ txMetaId: String, signatureBytes: [NSNumber], completion: @escaping (Bool, BraveWallet.ProviderErrorUnion, String) -> Void) {
-    completion(false, .init(solanaProviderError: .internalError), "Error message")
-  }
-  
-  func makeTokenProgramTransferTxData(_ splTokenMintAddress: String, fromWalletAddress: String, toWalletAddress: String, amount: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
-    completion(nil, .internalError, "Error message")
-  }
-  
-  func estimatedTxFee(_ txMetaId: String, completion: @escaping (UInt64, BraveWallet.SolanaProviderError, String) -> Void) {
-    completion(0, .internalError, "Error message")
-  }
-}
-
 #endif

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -105,6 +105,7 @@ extension AssetDetailStore {
       walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
       token: .previewToken
     )
   }
@@ -146,7 +147,8 @@ extension AccountActivityStore {
       rpcService: MockJsonRpcService(),
       assetRatioService: MockAssetRatioService(),
       txService: MockTxService(),
-      blockchainRegistry: MockBlockchainRegistry()
+      blockchainRegistry: MockBlockchainRegistry(),
+      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy
     )
   }
 }

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -341,7 +341,7 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .mockSPLToken
+      prefilledToken: .mockSpdToken
     )
     
     let ex = expectation(description: "send-sol-transaction")

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -669,7 +669,7 @@ class TransactionParserTests: XCTestCase {
       solEstimatedTxFee: 123000000000,
       currencyFormatter: currencyFormatter
     ) else {
-      XCTFail("Failed to parse ethSend transaction")
+      XCTFail("Failed to parse solanaSystemTransfer transaction")
       return
     }
     
@@ -753,7 +753,7 @@ class TransactionParserTests: XCTestCase {
       solEstimatedTxFee: 123000000000,
       currencyFormatter: currencyFormatter
     ) else {
-      XCTFail("Failed to parse ethSend transaction")
+      XCTFail("Failed to parse solanaSplTokenTransfer transaction")
       return
     }
     

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -614,7 +614,7 @@ class TransactionParserTests: XCTestCase {
       feePayer: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
       toWalletAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
       splTokenMintAddress: "",
-      lamports: 100000000000000000,
+      lamports: 100000000,
       amount: 0,
       txType: .solanaSystemTransfer,
       instructions: [
@@ -651,10 +651,10 @@ class TransactionParserTests: XCTestCase {
       details: .solSystemTransfer(
         .init(
           fromToken: .mockSolToken,
-          fromValue: "100000000000000000",
+          fromValue: "100000000",
           fromAmount: "0.1",
           fromFiat: "$2.00",
-          gasFee: .init(fee: "0.000000123", fiat: "$0.00")
+          gasFee: .init(fee: "0.00123", fiat: "$0.02")
         )
       )
     )
@@ -666,7 +666,7 @@ class TransactionParserTests: XCTestCase {
       visibleTokens: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
-      solEstimatedTxFee: 123000000000,
+      solEstimatedTxFee: 1230000,
       currencyFormatter: currencyFormatter
     ) else {
       XCTFail("Failed to parse solanaSystemTransfer transaction")
@@ -738,7 +738,7 @@ class TransactionParserTests: XCTestCase {
           fromValue: "43210000",
           fromAmount: "43.21",
           fromFiat: "$648.15",
-          gasFee: .init(fee: "0.000000123", fiat: "$0.00")
+          gasFee: .init(fee: "0.0123", fiat: "$0.25")
         )
       )
     )
@@ -750,7 +750,7 @@ class TransactionParserTests: XCTestCase {
       visibleTokens: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
-      solEstimatedTxFee: 123000000000,
+      solEstimatedTxFee: 12300000,
       currencyFormatter: currencyFormatter
     ) else {
       XCTFail("Failed to parse solanaSplTokenTransfer transaction")

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -37,6 +37,7 @@ class TransactionParserTests: XCTestCase {
   ]
   let assetRatios: [String: Double] = ["eth": 1,
                                        "dai": 2,
+                                       "usdc": 3,
                                        "sol": 20,
                                        "spd": 15]
   
@@ -263,9 +264,11 @@ class TransactionParserTests: XCTestCase {
           fromToken: .previewToken,
           fromValue: "0x1b6951ef585a000",
           fromAmount: "0.12345",
+          fromFiat: "$0.12",
           toToken: .previewDaiToken,
           minBuyValue: "0x5c6f2d76e910358b",
           minBuyAmount: "6.660592362643797387",
+          minBuyAmountFiat: "$13.32",
           gasFee: .init(
             fee: "0.000466",
             fiat: "$0.00"
@@ -346,9 +349,11 @@ class TransactionParserTests: XCTestCase {
           fromToken: .mockUSDCToken,
           fromValue: "0x16e360",
           fromAmount: "1.5",
+          fromFiat: "$4.50",
           toToken: .previewDaiToken,
           minBuyValue: "0x1bd02ca9a7c244e",
           minBuyAmount: "0.125259433834718286",
+          minBuyAmountFiat: "$0.25",
           gasFee: .init(
             fee: "0.000466",
             fiat: "$0.00"


### PR DESCRIPTION
## Summary of Changes
- Support the 3 Solana transaction types in the `TransctionParser`
- Fix `AccountActivityStore` using hardcoded `.eth` coin type, causing issues when connected to other networks / viewing Solana accounts
- Fix `AssetDetailStore` using hardcoded `.eth` coin type, causing issues displaying transactions

This pull request fixes #5723

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create a send transaction for SOL token
2. Create a send transaction for any non-SOL token on Solana (Spl Token)
3. Verify transactions show up in account detail / account activity for the respective account that made the transaction
4. Verify transactions show up in the asset detail for the respective tokens (SOL and the non-SOL token)

You can use [Solana explorer](https://explorer.solana.com/) to verify transaction display.

## Screenshots:

![#5723 - account details](https://user-images.githubusercontent.com/5314553/180493319-114c6776-4e13-47bc-ab20-371dc7e0e76e.png) | ![#5723 - asset details SOL](https://user-images.githubusercontent.com/5314553/180493533-1e109e17-91c5-46fb-b572-9521eaceab62.png) | ![#5723 - asset details STEPHEN](https://user-images.githubusercontent.com/5314553/180493339-58b68ac5-f854-4c7c-8bba-43b247acc6be.png)
--|--|--

[SOL send transaction on explorer](https://explorer.solana.com/tx/5BV3TMCuAKgw5NfGDdQMvThfETsN62fpJhhSkGHXA3FnBGyXp98A9D3EDZPZjfEo3LqTJzqnEujJ6rQdAGSgkyAL?cluster=devnet)
[STEPHEN send transaction on explorer](https://explorer.solana.com/tx/4S8er1q5PsbKyhQrXFt1E7Y1VUJZVKDVVvQatXYrnz96ZuZ9T2QZsdV7fsudgxmYK7FGD2AiyQtwmRTDGHnf4miU?cluster=devnet)
(transactions from screenshots)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
