### PR TITLE
Fix #5739: Wallet dapp infinite reload loop

### DIFF
--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -77,10 +77,21 @@ public class NetworkStore: ObservableObject {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts
     } else {
-      guard self.selectedChainId != network.chainId else { return .chainAlreadySelected }
-      self.selectedChainId = network.chainId
-      let success = await rpcService.setNetwork(network.chainId, coin: network.coin)
-      return success ? nil : .unknown
+      let selectedCoin = await walletService.selectedCoin()
+      if self.selectedChainId != network.chainId {
+        self.selectedChainId = network.chainId
+      }
+      if selectedCoin != network.coin {
+        let success = await rpcService.setNetwork(network.chainId, coin: network.coin)
+        return success ? nil : .unknown
+      } else {
+        let rpcServiceNetwork = await rpcService.network(network.coin)
+        guard rpcServiceNetwork.chainId != network.chainId else {
+          return .chainAlreadySelected
+        }
+        let success = await rpcService.setNetwork(network.chainId, coin: network.coin)
+        return success ? nil : .unknown
+      }
     }
   }
 


### PR DESCRIPTION
## Summary of Changes
- Fix infinite loop when initializing a `NetworkStore` and setting the network. 
- `BrowserViewController.isPendingRequestAvailable()` was initializing a new `NetworkStore`, which calls `setNetwork` on `BraveWalletJsonRpcService`. This triggers the `func chainChangedEvent(_ chainId: String)` for `BraveWalletEventsListener` in `BrowserViewController+Wallet.swift` to be called repeatedly, which triggers an infinite page reload.

This pull request fixes #5739

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Tricky to reproduce, but persists after relaunch (tab restoration brings it back) until the tab is closed.
1. Visit [Metamask test dapp site](https://metamask.github.io/test-dapp/)
2. Open the wallet panel and change networks multiple times between Ethereum Mainnet, Ropsten test network and a Solana network. I've only noticed it on this test dapp site when connected to Ropsten.
3. Tab gets stuck in a reloading loop. Persists after relaunch until the tab is closed.


## Screenshots:

https://user-images.githubusercontent.com/5314553/180797888-404e9eb1-891f-415a-9553-a5a2d1488e75.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
