### PR TITLE
Fix #5735: Update Transaction Details to use Transaction Parser

### DIFF
--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -15,7 +15,7 @@ struct AccountActivityView: View {
   @ObservedObject var networkStore: NetworkStore
 
   @State private var detailsPresentation: DetailsPresentation?
-  @State private var transactionDetails: BraveWallet.TransactionInfo?
+  @State private var transactionDetails: TransactionDetailsStore?
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
@@ -45,9 +45,6 @@ struct AccountActivityView: View {
   }
 
   var body: some View {
-    let assetRatios = activityStore.assets.reduce(into: [String: Double](), {
-      $0[$1.token.symbol.lowercased()] = Double($1.price)
-    })
     List {
       Section {
         AccountActivityHeaderView(account: accountInfo) { editMode in
@@ -83,7 +80,9 @@ struct AccountActivityView: View {
           emptyTextView(Strings.Wallet.noTransactions)
         } else {
           ForEach(activityStore.transactionSummaries) { txSummary in
-            Button(action: { self.transactionDetails = txSummary.txInfo }) {
+            Button(action: {
+              self.transactionDetails = activityStore.transactionDetailsStore(for: txSummary.txInfo)
+            }) {
               TransactionSummaryView(summary: txSummary)
             }
             .contextMenu {
@@ -116,16 +115,18 @@ struct AccountActivityView: View {
     )
     .background(
       Color.clear
-        .sheet(item: $transactionDetails) { tx in
-          TransactionDetailsView(
-            info: tx,
-            networkStore: networkStore,
-            keyringStore: keyringStore,
-            visibleTokens: activityStore.assets.map(\.token),
-            allTokens: activityStore.allTokens,
-            assetRatios: assetRatios,
-            currencyCode: activityStore.currencyCode
+        .sheet(
+          isPresented: Binding(
+            get: { self.transactionDetails != nil },
+            set: { if !$0 { self.transactionDetails = nil } }
           )
+        ) {
+          if let transactionDetailsStore = transactionDetails {
+            TransactionDetailsView(
+              transactionDetailsStore: transactionDetailsStore,
+              networkStore: networkStore
+            )
+          }
         }
     )
     .onReceive(keyringStore.$allKeyrings) { allKeyrings in

--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -148,6 +148,18 @@ class AccountActivityStore: ObservableObject {
       }
   }
   
+  func transactionDetailsStore(for transaction: BraveWallet.TransactionInfo) -> TransactionDetailsStore {
+    TransactionDetailsStore(
+      transaction: transaction,
+      keyringService: keyringService,
+      walletService: walletService,
+      rpcService: rpcService,
+      assetRatioService: assetRatioService,
+      blockchainRegistry: blockchainRegistry,
+      solanaTxManagerProxy: solTxManagerProxy
+    )
+  }
+  
   #if DEBUG
   func previewTransactions() {
     transactionSummaries = [.previewConfirmedSwap, .previewConfirmedSend, .previewConfirmedERC20Approve]

--- a/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -222,6 +222,18 @@ class AssetDetailStore: ObservableObject {
         )
       }
   }
+  
+  func transactionDetailsStore(for transaction: BraveWallet.TransactionInfo) -> TransactionDetailsStore {
+    TransactionDetailsStore(
+      transaction: transaction,
+      keyringService: keyringService,
+      walletService: walletService,
+      rpcService: rpcService,
+      assetRatioService: assetRatioService,
+      blockchainRegistry: blockchainRegistry,
+      solanaTxManagerProxy: solTxManagerProxy
+    )
+  }
 }
 
 extension AssetDetailStore: BraveWalletKeyringServiceObserver {

--- a/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -1,0 +1,134 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveCore
+
+class TransactionDetailsStore: ObservableObject {
+  
+  let transaction: BraveWallet.TransactionInfo
+  @Published private(set) var parsedTransaction: ParsedTransaction?
+  @Published private(set) var network: BraveWallet.NetworkInfo?
+  @Published private(set) var title: String?
+  @Published private(set) var value: String?
+  @Published private(set) var fiat: String?
+  @Published private(set) var gasFee: String?
+  @Published private(set) var marketPrice: String?
+  
+  @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
+    didSet {
+      currencyFormatter.currencyCode = currencyCode
+      update()
+    }
+  }
+  let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
+  
+  private let keyringService: BraveWalletKeyringService
+  private let walletService: BraveWalletBraveWalletService
+  private let rpcService: BraveWalletJsonRpcService
+  private let assetRatioService: BraveWalletAssetRatioService
+  private let blockchainRegistry: BraveWalletBlockchainRegistry
+  private let solanaTxManagerProxy: BraveWalletSolanaTxManagerProxy
+  
+  init(
+    transaction: BraveWallet.TransactionInfo,
+    keyringService: BraveWalletKeyringService,
+    walletService: BraveWalletBraveWalletService,
+    rpcService: BraveWalletJsonRpcService,
+    assetRatioService: BraveWalletAssetRatioService,
+    blockchainRegistry: BraveWalletBlockchainRegistry,
+    solanaTxManagerProxy: BraveWalletSolanaTxManagerProxy
+  ) {
+    self.transaction = transaction
+    self.keyringService = keyringService
+    self.walletService = walletService
+    self.rpcService = rpcService
+    self.assetRatioService = assetRatioService
+    self.blockchainRegistry = blockchainRegistry
+    self.solanaTxManagerProxy = solanaTxManagerProxy
+    
+    walletService.defaultBaseCurrency { [self] currencyCode in
+      self.currencyCode = currencyCode
+    }
+  }
+  
+  func update() {
+    Task { @MainActor in
+      let coin = transaction.coin
+      let network = await rpcService.network(coin)
+      self.network = network
+      let keyring = await keyringService.keyringInfo(coin.keyringId)
+      let allTokens: [BraveWallet.BlockchainToken] = await blockchainRegistry.allTokens(network.chainId, coin: network.coin)
+      let userVisibleTokens: [BraveWallet.BlockchainToken] = await walletService.userAssets(network.chainId, coin: network.coin)
+      let priceResult = await assetRatioService.priceWithIndividualRetry(
+        userVisibleTokens.map { $0.symbol.lowercased() },
+        toAssets: [currencyFormatter.currencyCode],
+        timeframe: .oneDay
+      )
+      let assetRatios = priceResult.assetPrices.reduce(into: [String: Double]()) {
+        $0[$1.fromAsset] = Double($1.price)
+      }
+      var solEstimatedTxFee: UInt64?
+      if transaction.coin == .sol {
+        (solEstimatedTxFee, _, _) = await solanaTxManagerProxy.estimatedTxFee(transaction.id)
+      }
+      guard let parsedTransaction = transaction.parsedTransaction(
+        network: network,
+        accountInfos: keyring.accountInfos,
+        visibleTokens: userVisibleTokens,
+        allTokens: allTokens,
+        assetRatios: assetRatios,
+        solEstimatedTxFee: solEstimatedTxFee,
+        currencyFormatter: currencyFormatter
+      ) else {
+        return
+      }
+      self.parsedTransaction = parsedTransaction
+      
+      switch parsedTransaction.details {
+      case let .ethSend(details),
+        let .erc20Transfer(details),
+        let .solSystemTransfer(details),
+        let .solSplTokenTransfer(details):
+        self.title = Strings.Wallet.sent
+        self.value = String(format: "%@ %@", details.fromAmount, details.fromToken.symbol)
+        self.fiat = details.fromFiat
+        if let tokenPrice = assetRatios[details.fromToken.symbol.lowercased()] {
+          self.marketPrice = currencyFormatter.string(from: NSNumber(value: tokenPrice)) ?? "$0.00"
+        }
+      case let .ethSwap(details):
+        self.title = Strings.Wallet.swap
+        if let fromToken = details.fromToken {
+          self.value = String(format: "%@ %@", details.fromAmount, fromToken.symbol)
+          if let tokenPrice = assetRatios[fromToken.symbol.lowercased()] {
+            self.marketPrice = currencyFormatter.string(from: NSNumber(value: tokenPrice)) ?? "$0.00"
+          }
+        } else {
+          self.value = details.fromAmount
+        }
+        self.fiat = details.fromFiat
+      case let .ethErc20Approve(details):
+        self.title = Strings.Wallet.approveNetworkButtonTitle
+        self.value = String(format: "%@ %@", details.approvalAmount, details.token.symbol)
+        if let tokenPrice = assetRatios[details.token.symbol.lowercased()] {
+          self.marketPrice = currencyFormatter.string(from: NSNumber(value: tokenPrice)) ?? "$0.00"
+        }
+      case let .erc721Transfer(details):
+        self.title = Strings.Wallet.swap
+        if let fromToken = details.fromToken {
+          self.value = String(format: "%@ %@", details.fromAmount, fromToken.symbol)
+          if let tokenPrice = assetRatios[fromToken.symbol.lowercased()] {
+            self.marketPrice = currencyFormatter.string(from: NSNumber(value: tokenPrice)) ?? "$0.00"
+          }
+        } else {
+          self.value = details.fromAmount
+        }
+      }
+      if let gasFee = parsedTransaction.gasFee {
+        self.gasFee = String(format: "%@ %@\n%@", gasFee.fee, parsedTransaction.networkSymbol, gasFee.fiat)
+      }
+    }
+  }
+}

--- a/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -26,7 +26,7 @@ class TransactionDetailsStore: ObservableObject {
   let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
     .then {
       $0.minimumFractionDigits = 2
-      $0.maximumFractionDigits = 10
+      $0.maximumFractionDigits = 6
     }
   
   private let keyringService: BraveWalletKeyringService

--- a/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -24,6 +24,10 @@ class TransactionDetailsStore: ObservableObject {
     }
   }
   let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
+    .then {
+      $0.minimumFractionDigits = 2
+      $0.maximumFractionDigits = 10
+    }
   
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
@@ -86,6 +90,7 @@ class TransactionDetailsStore: ObservableObject {
         return
       }
       self.parsedTransaction = parsedTransaction
+      self.currencyFormatter.maximumFractionDigits = 2 // use max. 2 digits for market price calculation
       
       switch parsedTransaction.details {
       case let .ethSend(details),

--- a/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -12,161 +12,34 @@ import Strings
 
 struct TransactionDetailsView: View {
   
-  var info: BraveWallet.TransactionInfo
+  @ObservedObject var transactionDetailsStore: TransactionDetailsStore
   @ObservedObject var networkStore: NetworkStore
-  @ObservedObject var keyringStore: KeyringStore
-  var visibleTokens: [BraveWallet.BlockchainToken]
-  var allTokens: [BraveWallet.BlockchainToken]
-  var assetRatios: [String: Double]
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
   
   init(
-    info: BraveWallet.TransactionInfo,
-    networkStore: NetworkStore,
-    keyringStore: KeyringStore,
-    visibleTokens: [BraveWallet.BlockchainToken],
-    allTokens: [BraveWallet.BlockchainToken],
-    assetRatios: [String: Double],
-    currencyCode: String
+    transactionDetailsStore: TransactionDetailsStore,
+    networkStore: NetworkStore
   ) {
-    self.info = info
+    self.transactionDetailsStore = transactionDetailsStore
     self.networkStore = networkStore
-    self.keyringStore = keyringStore
-    self.visibleTokens = visibleTokens
-    self.allTokens = allTokens
-    self.assetRatios = assetRatios
-    self.currencyFormatter.currencyCode = currencyCode
   }
   
   private let dateFormatter = DateFormatter().then {
     $0.dateFormat = "h:mm a - MMM d, yyyy"
   }
-  
-  private let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
-  
-  private func token(for contractAddress: String) -> BraveWallet.BlockchainToken? {
-    let findToken: (BraveWallet.BlockchainToken) -> Bool = { $0.contractAddress.caseInsensitiveCompare(contractAddress) == .orderedSame }
-    return visibleTokens.first(where: findToken) ?? allTokens.first(where: findToken)
-  }
-
-  /// The value of the transaction with symbol, ex. `"0.0100 ETH"`
-  private var value: String {
-    let formatter = WeiFormatter(decimalFormatStyle: .balance)
-    let amount: String
-    switch info.txType {
-    case .erc20Transfer:
-      amount = info.txArgs[safe: 0] ?? ""
-    case .erc721TransferFrom, .erc721SafeTransferFrom:
-      if let tokenID = info.txArgs[safe: 2],
-         let tokenIDValue = Int(tokenID.removingHexPrefix, radix: 16),
-         let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to,
-         let token = token(for: contractAddress) {
-        return String(format: "%@ %d", token.name, tokenIDValue)
-      } else {
-        return ""
-      }
-    case .erc20Approve:
-      if let contractAddress = info.txDataUnion.ethTxData1559?.baseData.to,
-         let value = info.txArgs[safe: 1],
-         let token = token(for: contractAddress) {
-        if value.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame {
-          amount = Strings.Wallet.editPermissionsApproveUnlimited
-        } else {
-          amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
-        }
-        return String(format: "%@ %@", amount, token.symbol)
-      } else {
-        return "0.0"
-      }
-    case .ethSend, .other:
-      amount = formatter.decimalString(for: info.ethTxValue.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) ?? ""
-    @unknown default:
-      amount = "0.0"
-    }
-    return String(format: "%@ %@", amount, networkStore.selectedChain.symbol)
-  }
-  
-  /// The fiat of the transaction, ex. `"$45.76"`
-  private var fiat: String? {
-    let formatter = WeiFormatter(decimalFormatStyle: .balance)
-    switch info.txType {
-    case .erc721TransferFrom, .erc721SafeTransferFrom, .erc20Approve:
-      return nil
-    case .ethSend, .other:
-      let amount = formatter.decimalString(for: info.ethTxValue.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) ?? ""
-      let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[networkStore.selectedChain.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
-      return fiat
-    case .erc20Transfer:
-      if let value = info.txArgs[safe: 1], let token = token(for: info.ethTxToAddress) {
-        let amount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals)) ?? ""
-        let fiat = currencyFormatter.string(from: NSNumber(value: assetRatios[token.symbol.lowercased(), default: 0] * (Double(amount) ?? 0))) ?? "$0.00"
-        return fiat
-      } else {
-        return "$0.00"
-      }
-    @unknown default:
-      return nil
-    }
-  }
-  
-  /// The gas fee including the fiat for the transaction, ex. `("0.003402 ETC", "$15.57")`
-  private var gasFee: (String, fiat: String)? {
-    let isEIP1559Transaction = info.isEIP1559Transaction
-    let limit = info.ethTxGasLimit
-    let formatter = WeiFormatter(decimalFormatStyle: .gasFee(limit: limit.removingHexPrefix, radix: .hex))
-    let hexFee = isEIP1559Transaction ? (info.txDataUnion.ethTxData1559?.maxFeePerGas ?? "") : info.ethTxGasPrice
-    if let value = formatter.decimalString(for: hexFee.removingHexPrefix, radix: .hex, decimals: Int(networkStore.selectedChain.decimals)) {
-      return (value, {
-        guard let doubleValue = Double(value), let assetRatio = assetRatios[networkStore.selectedChain.symbol.lowercased()] else {
-          return "$0.00"
-        }
-        return currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00"
-      }())
-    }
-    return nil
-  }
-  
-  /// The formatted transaction fee for the transaction, ex. `"0.003401\n$15.57"`
-  private var transactionFee: String? {
-    guard let (fee, fiat) = gasFee else {
-      return nil
-    }
-    let symbol = networkStore.selectedChain.symbol
-    return String(format: "%@ %@\n%@", fee, symbol, fiat)
-  }
-  
-  /// The market price for the asset
-  private var marketPrice: String {
-    let symbol = networkStore.selectedChain.symbol
-    let marketPrice = currencyFormatter.string(from: NSNumber(value: assetRatios[symbol.lowercased(), default: 0])) ?? "$0.00"
-    return marketPrice
-  }
-
-  private func namedAddress(for address: String) -> String {
-    NamedAddresses.name(for: address, accounts: keyringStore.allAccounts)
-  }
-
-  private var title: String {
-    switch info.txType {
-    case .erc20Approve:
-      return Strings.Wallet.transactionUnknownApprovalTitle
-    default:
-      return info.isSwap ? Strings.Wallet.swap : Strings.Wallet.sent
-    }
-  }
 
   private var header: some View {
     TransactionHeader(
-      fromAccountAddress: info.fromAddress,
-      fromAccountName: namedAddress(for: info.fromAddress),
-      toAccountAddress: info.ethTxToAddress,
-      toAccountName: namedAddress(for: info.ethTxToAddress),
-      originInfo: info.originInfo,
-      transactionType: title,
-      value: value,
-      fiat: fiat
+      fromAccountAddress: transactionDetailsStore.parsedTransaction?.fromAddress ?? "",
+      fromAccountName: transactionDetailsStore.parsedTransaction?.namedFromAddress ?? "",
+      toAccountAddress: transactionDetailsStore.parsedTransaction?.toAddress ?? "",
+      toAccountName: transactionDetailsStore.parsedTransaction?.namedToAddress ?? "",
+      originInfo: transactionDetailsStore.parsedTransaction?.transaction.originInfo,
+      transactionType: transactionDetailsStore.title ?? "",
+      value: transactionDetailsStore.value ?? "",
+      fiat: transactionDetailsStore.fiat
     )
       .frame(maxWidth: .infinity)
       .padding(.vertical, 30)
@@ -186,21 +59,23 @@ struct TransactionDetailsView: View {
               }
             }
         ) {
-          if let transactionFee = transactionFee {
+          if let transactionFee = transactionDetailsStore.gasFee {
             detailRow(title: Strings.Wallet.transactionDetailsTxFeeTitle, value: transactionFee)
           }
-          detailRow(title: Strings.Wallet.transactionDetailsMarketPriceTitle, value: marketPrice)
-          detailRow(title: Strings.Wallet.transactionDetailsDateTitle, value: dateFormatter.string(from: info.createdTime))
-          if !info.txHash.isEmpty {
+          if let marketPrice = transactionDetailsStore.marketPrice {
+            detailRow(title: Strings.Wallet.transactionDetailsMarketPriceTitle, value: marketPrice)
+          }
+          detailRow(title: Strings.Wallet.transactionDetailsDateTitle, value: dateFormatter.string(from: transactionDetailsStore.transaction.createdTime))
+          if !transactionDetailsStore.transaction.txHash.isEmpty {
             Button(action: {
               if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
-                 let url = baseURL?.appendingPathComponent("tx/\(info.txHash)") {
+                 let url = baseURL?.appendingPathComponent("tx/\(transactionDetailsStore.transaction.txHash)") {
                 openWalletURL?(url)
               }
             }) {
               detailRow(title: Strings.Wallet.transactionDetailsTxHashTitle) {
                 HStack {
-                  Text(info.txHash.truncatedHash)
+                  Text(transactionDetailsStore.transaction.txHash.truncatedHash)
                   Image(systemName: "arrow.up.forward.square")
                 }
                   .foregroundColor(Color(.braveBlurpleTint))
@@ -208,14 +83,16 @@ struct TransactionDetailsView: View {
             }
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
           }
-          detailRow(title: Strings.Wallet.transactionDetailsNetworkTitle, value: networkStore.selectedChain.chainName)
+          if let network = transactionDetailsStore.network {
+            detailRow(title: Strings.Wallet.transactionDetailsNetworkTitle, value: network.chainName)
+          }
           detailRow(title: Strings.Wallet.transactionDetailsStatusTitle) {
             HStack(spacing: 4) {
               Image(systemName: "circle.fill")
-                .foregroundColor(info.txStatus.color)
+                .foregroundColor(transactionDetailsStore.transaction.txStatus.color)
                 .imageScale(.small)
                 .accessibilityHidden(true)
-              Text(info.txStatus.localizedDescription)
+              Text(transactionDetailsStore.transaction.txStatus.localizedDescription)
                 .foregroundColor(Color(.braveLabel))
                 .multilineTextAlignment(.trailing)
             }
@@ -238,6 +115,7 @@ struct TransactionDetailsView: View {
           }
         }
       }
+      .onAppear(perform: transactionDetailsStore.update)
     }
   }
   
@@ -261,42 +139,3 @@ struct TransactionDetailsView: View {
     .listRowBackground(Color(.secondaryBraveGroupedBackground))
   }
 }
-
-#if DEBUG
-struct TransactionDetailsView_Previews: PreviewProvider {
-  static var previews: some View {
-    Group {
-      TransactionDetailsView(
-        info: .previewConfirmedSend,
-        networkStore: .previewStore,
-        keyringStore: .previewStore,
-        visibleTokens: [.previewToken],
-        allTokens: [],
-        assetRatios: ["eth": 4576.36],
-        currencyCode: CurrencyCode.usd.code
-      )
-        .previewColorSchemes()
-      TransactionDetailsView(
-        info: .previewConfirmedSwap,
-        networkStore: .previewStore,
-        keyringStore: .previewStore,
-        visibleTokens: [.previewToken],
-        allTokens: [],
-        assetRatios: ["eth": 4576.36],
-        currencyCode: CurrencyCode.usd.code
-      )
-        .previewColorSchemes()
-      TransactionDetailsView(
-        info: .previewConfirmedERC20Approve,
-        networkStore: .previewStore,
-        keyringStore: .previewStore,
-        visibleTokens: [.previewToken],
-        allTokens: [],
-        assetRatios: ["eth": 4576.36],
-        currencyCode: CurrencyCode.usd.code
-      )
-        .previewColorSchemes()
-    }
-  }
-}
-#endif

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -15,6 +15,12 @@ enum TransactionParser {
     solEstimatedTxFee: UInt64? = nil,
     currencyFormatter: NumberFormatter
   ) -> GasFee? {
+    var gasFee: GasFee?
+    let existingMinimumFractionDigits = currencyFormatter.minimumFractionDigits
+    let existingMaximumFractionDigits = currencyFormatter.maximumFractionDigits
+    // Show additional decimal places for gas fee calculations (Solana has low tx fees).
+    currencyFormatter.minimumFractionDigits = 2
+    currencyFormatter.maximumFractionDigits = 10
     switch network.coin {
     case .eth:
       let isEIP1559Transaction = transaction.isEIP1559Transaction
@@ -22,21 +28,25 @@ enum TransactionParser {
       let formatter = WeiFormatter(decimalFormatStyle: .gasFee(limit: limit.removingHexPrefix, radix: .hex))
       let hexFee = isEIP1559Transaction ? (transaction.txDataUnion.ethTxData1559?.maxFeePerGas ?? "") : transaction.ethTxGasPrice
       if let value = formatter.decimalString(for: hexFee.removingHexPrefix, radix: .hex, decimals: Int(network.decimals)) {
-        if let doubleValue = Double(value), let assetRatio = assetRatios[network.symbol.lowercased()] {
-          return .init(fee: value, fiat: currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00")
+        if let doubleValue = Double(value),
+            let assetRatio = assetRatios[network.symbol.lowercased()],
+            let fiat = currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) {
+          gasFee = .init(fee: value, fiat: fiat)
         } else {
-          return .init(fee: value, fiat: "$0.00")
+          gasFee = .init(fee: value, fiat: "$0.00")
         }
       }
     case .sol:
       guard let solEstimatedTxFee = solEstimatedTxFee else { return nil }
-      let gasFee = "\(solEstimatedTxFee)"
+      let estimatedTxFee = "\(solEstimatedTxFee)"
       let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: Int(network.decimals)))
-      if let value = formatter.decimalString(for: gasFee, radix: .decimal, decimals: Int(network.decimals))?.trimmingTrailingZeros {
-        if let doubleValue = Double(value), let assetRatio = assetRatios[network.symbol.lowercased()] {
-          return .init(fee: value, fiat: currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) ?? "$0.00")
+      if let value = formatter.decimalString(for: estimatedTxFee, radix: .decimal, decimals: Int(network.decimals))?.trimmingTrailingZeros {
+        if let doubleValue = Double(value),
+            let assetRatio = assetRatios[network.symbol.lowercased()],
+            let fiat = currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) {
+          gasFee = .init(fee: value, fiat: fiat)
         } else {
-          return .init(fee: value, fiat: "$0.00")
+          gasFee = .init(fee: value, fiat: "$0.00")
         }
       }
     case .fil:
@@ -44,7 +54,10 @@ enum TransactionParser {
     @unknown default:
       break
     }
-    return nil
+    // Restore previous fraction digits
+    currencyFormatter.minimumFractionDigits = existingMinimumFractionDigits
+    currencyFormatter.maximumFractionDigits = existingMaximumFractionDigits
+    return gasFee
   }
   
   static func token(

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -507,6 +507,7 @@ extension BraveWallet.TransactionInfo {
     assetRatios: [String: Double],
     solEstimatedTxFee: UInt64? = nil,
     currencyFormatter: NumberFormatter,
+    solEstimatedTxFee: UInt64? = nil,
     decimalFormatStyle: WeiFormatter.DecimalFormatStyle? = nil
   ) -> ParsedTransaction? {
     TransactionParser.parseTransaction(

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -507,7 +507,6 @@ extension BraveWallet.TransactionInfo {
     assetRatios: [String: Double],
     solEstimatedTxFee: UInt64? = nil,
     currencyFormatter: NumberFormatter,
-    solEstimatedTxFee: UInt64? = nil,
     decimalFormatStyle: WeiFormatter.DecimalFormatStyle? = nil
   ) -> ParsedTransaction? {
     TransactionParser.parseTransaction(

--- a/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -27,7 +27,7 @@ enum TransactionParser {
       let limit = transaction.ethTxGasLimit
       let formatter = WeiFormatter(decimalFormatStyle: .gasFee(limit: limit.removingHexPrefix, radix: .hex))
       let hexFee = isEIP1559Transaction ? (transaction.txDataUnion.ethTxData1559?.maxFeePerGas ?? "") : transaction.ethTxGasPrice
-      if let value = formatter.decimalString(for: hexFee.removingHexPrefix, radix: .hex, decimals: Int(network.decimals)) {
+      if let value = formatter.decimalString(for: hexFee.removingHexPrefix, radix: .hex, decimals: Int(network.decimals))?.trimmingTrailingZeros {
         if let doubleValue = Double(value),
             let assetRatio = assetRatios[network.symbol.lowercased()],
             let fiat = currencyFormatter.string(from: NSNumber(value: doubleValue * assetRatio)) {

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -71,21 +71,6 @@ extension BraveWallet.BlockchainToken {
   
   static let mockSpdToken: BraveWallet.BlockchainToken = .init(
     contractAddress: "0x1111111111222222222233333333334444444444",
-    name: "",
-    logo: "",
-    isErc20: false,
-    isErc721: false,
-    symbol: "SPD",
-    decimals: 6,
-    visible: false,
-    tokenId: "",
-    coingeckoId: "",
-    chainId: "",
-    coin: .sol
-  )
-  
-  static let mockSpdToken: BraveWallet.BlockchainToken = .init(
-    contractAddress: "0x1111111111222222222233333333334444444444",
     name: "Solpad",
     logo: "",
     isErc20: false,

--- a/BraveWallet/Preview Content/MockContent.swift
+++ b/BraveWallet/Preview Content/MockContent.swift
@@ -83,6 +83,21 @@ extension BraveWallet.BlockchainToken {
     chainId: "",
     coin: .sol
   )
+  
+  static let mockSpdToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0x1111111111222222222233333333334444444444",
+    name: "Solpad",
+    logo: "",
+    isErc20: false,
+    isErc721: false,
+    symbol: "SPD",
+    decimals: 6,
+    visible: false,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: "",
+    coin: .sol
+  )
 }
 
 extension BraveWallet.AccountInfo {

--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -220,4 +220,23 @@ extension BraveWallet.NetworkInfo {
   )
 }
 
+// TODO: Move to separate file
+class MockSolanaTxManagerProxy: BraveWalletSolanaTxManagerProxy {
+  func makeSystemProgramTransferTxData(_ from: String, to: String, lamports: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion(nil, .internalError, "Error message")
+  }
+  
+  func processSolanaHardwareSignature(_ txMetaId: String, signatureBytes: [NSNumber], completion: @escaping (Bool, BraveWallet.ProviderErrorUnion, String) -> Void) {
+    completion(false, .init(solanaProviderError: .internalError), "Error message")
+  }
+  
+  func makeTokenProgramTransferTxData(_ splTokenMintAddress: String, fromWalletAddress: String, toWalletAddress: String, amount: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion(nil, .internalError, "Error message")
+  }
+  
+  func estimatedTxFee(_ txMetaId: String, completion: @escaping (UInt64, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion(0, .internalError, "Error message")
+  }
+}
+
 #endif

--- a/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -220,23 +220,4 @@ extension BraveWallet.NetworkInfo {
   )
 }
 
-// TODO: Move to separate file
-class MockSolanaTxManagerProxy: BraveWalletSolanaTxManagerProxy {
-  func makeSystemProgramTransferTxData(_ from: String, to: String, lamports: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
-    completion(nil, .internalError, "Error message")
-  }
-  
-  func processSolanaHardwareSignature(_ txMetaId: String, signatureBytes: [NSNumber], completion: @escaping (Bool, BraveWallet.ProviderErrorUnion, String) -> Void) {
-    completion(false, .init(solanaProviderError: .internalError), "Error message")
-  }
-  
-  func makeTokenProgramTransferTxData(_ splTokenMintAddress: String, fromWalletAddress: String, toWalletAddress: String, amount: UInt64, completion: @escaping (BraveWallet.SolanaTxData?, BraveWallet.SolanaProviderError, String) -> Void) {
-    completion(nil, .internalError, "Error message")
-  }
-  
-  func estimatedTxFee(_ txMetaId: String, completion: @escaping (UInt64, BraveWallet.SolanaProviderError, String) -> Void) {
-    completion(0, .internalError, "Error message")
-  }
-}
-
 #endif

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -96,7 +96,7 @@ class TransactionParserTests: XCTestCase {
           fromFiat: "$0.12",
           gasFee: .init(
             fee: "0.000031",
-            fiat: "$0.00"
+            fiat: "$0.000031"
           )
         )
       )
@@ -186,7 +186,7 @@ class TransactionParserTests: XCTestCase {
           fromFiat: "$0.86",
           gasFee: .init(
             fee: "0.000078",
-            fiat: "$0.00"
+            fiat: "$0.000078"
           )
         )
       )
@@ -271,7 +271,7 @@ class TransactionParserTests: XCTestCase {
           minBuyAmountFiat: "$13.32",
           gasFee: .init(
             fee: "0.000466",
-            fiat: "$0.00"
+            fiat: "$0.000466"
           )
         )
       )
@@ -356,7 +356,7 @@ class TransactionParserTests: XCTestCase {
           minBuyAmountFiat: "$0.25",
           gasFee: .init(
             fee: "0.000466",
-            fiat: "$0.00"
+            fiat: "$0.000466"
           )
         )
       )
@@ -432,8 +432,8 @@ class TransactionParserTests: XCTestCase {
           approvalAmount: "0.01",
           isUnlimited: false,
           gasFee: .init(
-            fee: "0.0000610",
-            fiat: "$0.00"
+            fee: "0.000061",
+            fiat: "$0.000061"
           )
         )
       )
@@ -509,8 +509,8 @@ class TransactionParserTests: XCTestCase {
           approvalAmount: "Unlimited",
           isUnlimited: true,
           gasFee: .init(
-            fee: "0.0000610",
-            fiat: "$0.00"
+            fee: "0.000061",
+            fiat: "$0.000061"
           )
         )
       )
@@ -659,7 +659,10 @@ class TransactionParserTests: XCTestCase {
           fromValue: "100000000",
           fromAmount: "0.1",
           fromFiat: "$2.00",
-          gasFee: .init(fee: "0.00123", fiat: "$0.02")
+          gasFee: .init(
+            fee: "0.00123",
+            fiat: "$0.0246"
+          )
         )
       )
     )
@@ -743,7 +746,10 @@ class TransactionParserTests: XCTestCase {
           fromValue: "43210000",
           fromAmount: "43.21",
           fromFiat: "$648.15",
-          gasFee: .init(fee: "0.0123", fiat: "$0.25")
+          gasFee: .init(
+            fee: "0.0123",
+            fiat: "$0.246"
+          )
         )
       )
     )


### PR DESCRIPTION
## Summary of Changes
- Updates `TransactionDetailsView` to use the `TransactionParser` so transactions are formatted the same as the transaction summaries
- Add a `TransactionDetailsStore` to hold the services and populate the properties needed for transaction details

This pull request fixes #5735

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Create some SOL transactions, SPL token transactions, ETH send & swap transactions, etc.
2. Open Asset details from Portfolio screen
3. Tap on any transaction to open the transaction details
4. Verify transaction details shown correctly
5. Open Account activity / details from the Accounts screen
6. Tap on any transaction to open the transaction details
7. Verify transaction details shown correctly
8. Visit any dapp site and tap on the wallet icon to show the panel
9. Tap on transaction history to see transaction list
10. Tap on any transaction to open the transaction details
11. Verify transaction details shown correctly


## Screenshots:

![tx details - sol](https://user-images.githubusercontent.com/5314553/181016981-6aa7834d-cd5d-4ce3-8cad-825123cd172f.png) | ![tx details - eth](https://user-images.githubusercontent.com/5314553/181016986-a0fda8e7-06a2-457f-8a28-9d9e8a3320d6.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
