### PR TITLE
Fix #5744: Hide recovery phrase when app is backgrounded

### DIFF
--- a/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -59,7 +59,7 @@ struct BackupRecoveryPhraseView: View {
           .padding(.vertical)
         RecoveryPhraseGrid(data: recoveryWords, id: \.self) { word in
           Text(verbatim: "\(word.index + 1). \(word.value)")
-            .noCapture()
+            .customPrivacySensitive()
             .font(.footnote.bold())
             .padding(8)
             .frame(maxWidth: .infinity)

--- a/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
+++ b/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
@@ -56,7 +56,7 @@ struct VerifyRecoveryPhraseView: View {
             tappedWord(word)
           }) {
             Text(verbatim: word.value)
-              .noCapture()
+              .customPrivacySensitive()
               .font(.footnote.bold())
               .foregroundColor(.primary)
               .fixedSize(horizontal: false, vertical: true)
@@ -176,7 +176,7 @@ private struct SelectedWordsBox: View {
       case .word(let word, let index, let isCorrect):
         Button(action: { tappedWord(atIndex: index) }) {
           Text(verbatim: "\(index + 1). \(word)")
-            .noCapture()
+            .customPrivacySensitive()
             .padding(8)
             .frame(maxWidth: .infinity)
             .fixedSize(horizontal: false, vertical: true)

--- a/Sources/BraveUI/SwiftUI/CustomPrivacySensitiveModifier.swift
+++ b/Sources/BraveUI/SwiftUI/CustomPrivacySensitiveModifier.swift
@@ -1,0 +1,52 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// Custom modifier to behave similar to `.privacySensitive()`
+/// The `.privacySensitive()` doesn't work in sheets because the
+/// `redactedReasons` doesn't get passed through the environment in sheets.
+private struct CustomPrivacySensitiveModifier: ViewModifier {
+  
+  @State private var isBackgrounded: Bool = false
+  @State private var isCaptured: Bool = false
+  
+  func body(content: Content) -> some View {
+    Group {
+      if isBackgrounded || isCaptured {
+        content
+          .redacted(reason: .placeholder)
+      } else {
+        content
+      }
+    }
+    .onAppear {
+      isCaptured = UIScreen.main.isCaptured
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification, object: nil)
+    ) { notification in
+      isCaptured = (notification.object as? UIScreen)?.isCaptured ?? UIScreen.main.isCaptured
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
+    ) { _ in
+      isBackgrounded = true
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+    ) { _ in
+      isBackgrounded = false
+    }
+  }
+}
+
+extension View {
+  /// Redacts the given view if the app is backgrounded, or the system is actively
+  /// recording, mirroring, or using AirPlay to stream the contents of the screen.
+  public func customPrivacySensitive() -> some View {
+    modifier(CustomPrivacySensitiveModifier())
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Added new `CustomPrivacySensitiveModifier` that hides content using SwiftUI's `redacted(reason:)` api when the app is backgrounded or the screen is being recorded.

This pull request fixes #5744

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Setup a new wallet
2. On backup screen, background the app to the app switcher. Verify words are hidden.
3. Tap continue to verification screen and enter the first few words. Then background the app to the app switcher. Verify words are hidden.
4. Tap skip
5. Tap the backup warning banner at the top of portfolio
6. Start a screen recording via Control Center. Verify words are hidden in recording. 


## Screenshots:

![#5744 - backup](https://user-images.githubusercontent.com/5314553/181515006-27371494-df64-4ce7-86b5-c90748d052b8.png) | ![#5744 - verify](https://user-images.githubusercontent.com/5314553/181515015-a6c431d8-a8f2-4b5e-907b-9108554f1465.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
