### PR TITLE
Fix #5749, #5567: Opening wallet panel on ethereum dapp causes page to reload

### DIFF
--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -45,7 +45,9 @@ public class NetworkStore: ObservableObject {
     Task { @MainActor in // fetch current selected network
       let selectedCoin = await walletService.selectedCoin()
       let chain = await rpcService.network(selectedCoin)
-      await setSelectedChain(chain)
+      // since we are fetch network from JsonRpcService,
+      // we don't need to call `setNetwork` on JsonRpcService
+      self.selectedChainId = chain.chainId
     }
   }
 
@@ -183,10 +185,9 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
   }
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
     walletService.setSelectedCoin(coin)
-    Task { @MainActor in
-      guard let chain = allChains.first(where: { $0.chainId == chainId && $0.coin == coin }) else {  return }
-      await setSelectedChain(chain)
-    }
+    // since JsonRpcService notify us of change,
+    // we don't need to call `setNetwork` on JsonRpcService
+    selectedChainId = chainId
   }
 }
 


### PR DESCRIPTION
## Summary of Changes
- Fixed an issue where we were calling `setNetwork` on Json Rpc Service when we were initializing `KeyringStore` or `NetworkStore`. This would occur when opening the wallet panel, opening main wallet, and when checking pending transactions to show badge on wallet icon.
    - `NetworkStore` was calling `setNetwork` in `init` when fetching the currently selected network so we can update our `selectedChain` value. Since the value is fetched from Json Rpc Service, we don't need to call `setNetwork` on Json Rpc Service after.
    - In `KeyringStore`, the first call to `updateKeyringInfo()` would assign to `selectedAccount`, which then was calling `setSelectedAccount` on Keyring Service. This then triggered `selectedAccountChanged()` observation to call `setNetwork` on Json Rpc Service.
- Fixed Portfolio race condition when switching accounts from one coin type to another. The account switch would trigger an `update()` call in `PortfolioStore` prior to us updating the selected coin type, then the account switch triggers a network switch which updates the selected coin type. This meant 2 calls to `update()` could be running at the same time but for different selected coin types, so depending on which completed first we could show the incorrect user assets.
- Additionally, while fixing `PortfolioStore` made a small change to the logic so we update the user visible tokens immediately (then update again once balances, prices and price history are fetched) to resolve #5567.

This pull request fixes #5749, #5567

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
**Wallet dapp reload bug:**

1. Open [Metamask test dapp site](https://metamask.github.io/test-dapp/)
2. Connect your account(s)
3. Open wallet panel via icon in URL bar
4. Verify page does not reload behind the panel
5. Close the panel
6. Tap `Get Encryption Key`. Click Provide on model get public encryption key request.
7. Enter some text in message box below `Get Encryption Key` box
8. Tap `Encrypt`, tap `Decrypt`
9. Tap 'Allow' on decrypt request.
The Get Public Encryption Key -> Encrypt -> Decrypt flow was broken due to the reloading.

**Portfolio race condition:**

0. Solana support must be enabled
1. Open main wallet, and open Send Transaction modal.
2. Tap selected account to switch accounts
3. Select an account of a different coin type (ex. if Ethereum account selected, select a Solana account)
4. Close Send Transaction modal
5. Verify Portfolio store shows correct user assets
6. Open Send Transaction modal
7. Select originally selected account (must be different coin type than current selection)
8. Close Send Transaction modal
9. Verify Portfolio store shows correct user assets


## Screenshots:
Ethereum dapp reload on panel open fixed:

https://user-images.githubusercontent.com/5314553/181783672-373d4362-439f-4c44-a616-39b6101b569b.mp4

Portfolio race condition (video from `development`), occurs frequently:

https://user-images.githubusercontent.com/5314553/181783484-758de79c-26f8-4580-b4c0-f3a3024c4a91.mp4

Portfolio race condition fixed (video from this branch):

https://user-images.githubusercontent.com/5314553/181784459-dfe3c005-73b4-4e60-a88e-5dec18e45253.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
