### PR TITLE
No Bug: Update App Store Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Brave for iOS 🦁
 ===============
 
-Download on the [App Store](https://itunes.apple.com/app/brave-web-browser/id1052879175?mt=8).
+Download on the [App Store](https://apps.apple.com/app/brave-web-browser/id1052879175).
 
 This branch (development)
 -----------


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5762 by updating the App Store Links, from the older itunes.apple.com to the newer apps.apple.com. 

## Submitter Checklist:

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
