### PR TITLE
Fix #5770: Pending transactions not refreshed on network change

### DIFF
--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -105,6 +105,7 @@ public class CryptoStore: ObservableObject {
     
     self.keyringService.add(self)
     self.txService.add(self)
+    self.rpcService.add(self)
   }
   
   private var buyTokenStore: BuyTokenStore?
@@ -383,5 +384,17 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
   public func autoLockMinutesChanged() {
   }
   public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
+  }
+}
+
+extension CryptoStore: BraveWalletJsonRpcServiceObserver {
+  public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
+    prepare()
+  }
+  
+  public func onAddEthereumChainRequestCompleted(_ chainId: String, error: String) {
+  }
+  
+  public func onIsEip1559Changed(_ chainId: String, isEip1559: Bool) {
   }
 }

--- a/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -15,8 +15,8 @@ public class TransactionConfirmationStore: ObservableObject {
   @Published var symbol: String = ""
   /// The fiat value of `value`
   @Published var fiat: String = ""
-  /// The network short name that this transaction is made on
-  @Published var networkShortChainName: String = ""
+  /// The network name that this transaction is made on
+  @Published var networkChainName: String = ""
   /// The gas value for this transaction
   @Published var gasValue: String = ""
   /// The symbol of the gas token for this transaction
@@ -274,7 +274,7 @@ public class TransactionConfirmationStore: ObservableObject {
   ) async {
     originInfo = activeParsedTransaction.transaction.originInfo
     transactionDetails = activeTransactionDetails
-    networkShortChainName = network.shortChainName
+    networkChainName = network.chainName
     
     switch activeParsedTransaction.details {
     case let .ethSend(details),

--- a/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -213,7 +213,7 @@ struct TransactionConfirmationView: View {
         VStack {
           // Header
           HStack(alignment: .top) {
-            Text(confirmationStore.networkShortChainName)
+            Text(confirmationStore.networkChainName)
             Spacer()
             VStack(alignment: .trailing) {
               transactionsButton


### PR DESCRIPTION
## Summary of Changes
- Fix `CryptoStore` not refreshing transactions on network switch, causing pending transactions for the last selected network to be seen with missing transaction details / broken UI.
- Show full network chain name on transaction confirmation

This pull request fixes #5770

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Don't close the wallet modal during this flow:
  1. Switch to Solana Devnet
  2. Create a transaction on Solana Devnet
  3. Don't approve/reject the transaction, dismiss the modal
  4. Switch to Solana Testnet
  5. Verify pending transaction button is hidden / removed
  6. Switch back to Solana Devnet
  7. Verify pending transaction button is visible. 
  8. Open pending transaction, verify transaction details are shown


## Screenshots:

https://user-images.githubusercontent.com/5314553/182463914-1b6423d8-1bd4-40b8-bc0c-5b3888bfa369.mov



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
