### PR TITLE
Fix #5769: Display correct native asset icon

### DIFF
--- a/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -63,7 +63,7 @@ struct AccountActivityView: View {
         } else {
           ForEach(activityStore.assets) { asset in
             PortfolioAssetView(
-              image: AssetIconView(token: asset.token),
+              image: AssetIconView(token: asset.token, network: networkStore.selectedChain),
               title: asset.token.name,
               symbol: asset.token.symbol,
               amount: activityStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",

--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -67,7 +67,7 @@ struct AssetDetailHeaderView: View {
               }
             }
             HStack {
-              AssetIconView(token: assetDetailStore.token)
+              AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
               Text(assetDetailStore.token.name)
                 .fixedSize(horizontal: false, vertical: true)
                 .font(.title3.weight(.semibold))
@@ -76,7 +76,7 @@ struct AssetDetailHeaderView: View {
           .frame(maxWidth: .infinity, alignment: .leading)
         } else {
           HStack {
-            AssetIconView(token: assetDetailStore.token)
+            AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
             Text(assetDetailStore.token.name)
               .fixedSize(horizontal: false, vertical: true)
               .font(.title3.weight(.semibold))

--- a/BraveWallet/Crypto/AssetIconView.swift
+++ b/BraveWallet/Crypto/AssetIconView.swift
@@ -41,8 +41,8 @@ struct AssetIconView: View {
     
     if network.isNativeAsset(token) {
       // check bundled images
-      if UIImage(named: network.nativeTokenLogo, in: .current, with: nil) != nil {
-        return Image(network.nativeTokenLogo, bundle: .current)
+      if let uiImage = UIImage(named: network.nativeTokenLogo, in: .current, with: nil) {
+        return Image(uiImage: uiImage)
       }
     }
     

--- a/BraveWallet/Crypto/AssetIconView.swift
+++ b/BraveWallet/Crypto/AssetIconView.swift
@@ -39,9 +39,9 @@ struct AssetIconView: View {
       }
     }
     
-    if network.isNativeAsset(token) {
+    if network.isNativeAsset(token), let logo = network.nativeTokenLogo {
       // check bundled images
-      if let uiImage = UIImage(named: network.nativeTokenLogo, in: .current, with: nil) {
+      if let uiImage = UIImage(named: logo, in: .current, with: nil) {
         return Image(uiImage: uiImage)
       }
     }

--- a/BraveWallet/Crypto/AssetIconView.swift
+++ b/BraveWallet/Crypto/AssetIconView.swift
@@ -17,6 +17,7 @@ import BraveCore
 ///
 struct AssetIconView: View {
   var token: BraveWallet.BlockchainToken
+  var network: BraveWallet.NetworkInfo
   @ScaledMetric var length: CGFloat = 40
 
   private var fallbackMonogram: some View {
@@ -37,6 +38,14 @@ struct AssetIconView: View {
         return Image(uiImage: image)
       }
     }
+    
+    if network.isNativeAsset(token) {
+      // check bundled images
+      if UIImage(named: network.nativeTokenLogo, in: .current, with: nil) != nil {
+        return Image(network.nativeTokenLogo, bundle: .current)
+      }
+    }
+    
     return nil
   }
 
@@ -66,7 +75,7 @@ struct AssetIconView: View {
 #if DEBUG
 struct AssetIconView_Previews: PreviewProvider {
   static var previews: some View {
-    AssetIconView(token: .previewToken)
+    AssetIconView(token: .previewToken, network: .mockMainnet)
       .previewLayout(.sizeThatFits)
       .padding()
       .previewSizeCategories()
@@ -84,7 +93,8 @@ struct AssetIconView_Previews: PreviewProvider {
         coingeckoId: "",
         chainId: "",
         coin: .eth
-      )
+      ),
+      network: .mockMainnet
     )
     .previewLayout(.sizeThatFits)
     .padding()

--- a/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -37,10 +37,10 @@ struct BuyTokenView: View {
           Section(
             header: WalletListHeaderView(title: Text(Strings.Wallet.buy))
           ) {
-            NavigationLink(destination: BuyTokenSearchView(buyTokenStore: buyTokenStore)) {
+            NavigationLink(destination: BuyTokenSearchView(buyTokenStore: buyTokenStore, network: networkStore.selectedChain)) {
               HStack {
                 if let token = buyTokenStore.selectedBuyToken {
-                  AssetIconView(token: token, length: 26)
+                  AssetIconView(token: token, network: networkStore.selectedChain, length: 26)
                 }
                 Text(buyTokenStore.selectedBuyToken?.symbol ?? "BAT")
                   .font(.title3.weight(.semibold))

--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -64,7 +64,11 @@ struct SendTokenView: View {
           ) {
             HStack {
               if let token = sendTokenStore.selectedSendToken {
-                AssetIconView(token: token, length: 26)
+                AssetIconView(
+                  token: token,
+                  network: networkStore.selectedChain,
+                  length: 26
+                )
               }
               Text(sendTokenStore.selectedSendToken?.symbol ?? "")
                 .font(.title3.weight(.semibold))

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -235,7 +235,11 @@ struct SwapCryptoView: View {
       NavigationLink(destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .fromToken, network: networkStore.selectedChain)) {
         HStack {
           if let token = swapTokensStore.selectedFromToken {
-            AssetIconView(token: token, length: 26)
+            AssetIconView(
+              token: token,
+              network: networkStore.selectedChain,
+              length: 26
+            )
           }
           Text(swapTokensStore.selectedFromToken?.symbol ?? "")
             .font(.title3.weight(.semibold))
@@ -295,7 +299,11 @@ struct SwapCryptoView: View {
       ) {
         HStack {
           if let token = swapTokensStore.selectedToToken {
-            AssetIconView(token: token, length: 26)
+            AssetIconView(
+              token: token,
+              network: networkStore.selectedChain,
+              length: 26
+            )
           }
           Text(swapTokensStore.selectedToToken?.symbol ?? "")
             .font(.title3.weight(.semibold))

--- a/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -17,7 +17,7 @@ private struct EditTokenView: View {
       assetStore.isVisible.toggle()
     }) {
       HStack(spacing: 8) {
-        AssetIconView(token: assetStore.token)
+        AssetIconView(token: assetStore.token, network: assetStore.network)
         VStack(alignment: .leading) {
           Text(assetStore.token.name)
             .fontWeight(.semibold)

--- a/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
@@ -43,7 +43,7 @@ struct PortfolioAssetView: View {
 struct PortfolioAssetView_Previews: PreviewProvider {
   static var previews: some View {
     PortfolioAssetView(
-      image: AssetIconView(token: .previewToken),
+      image: AssetIconView(token: .previewToken, network: .mockMainnet),
       title: "Basic Attention Token",
       symbol: "BAT",
       amount: "$10,402.22",

--- a/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -78,7 +78,7 @@ struct PortfolioView: View {
             selectedToken = asset.token
           }) {
             PortfolioAssetView(
-              image: AssetIconView(token: asset.token),
+              image: AssetIconView(token: asset.token, network: networkStore.selectedChain),
               title: asset.token.name,
               symbol: asset.token.symbol,
               amount: portfolioStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",

--- a/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -29,7 +29,7 @@ struct AssetSearchView: View {
               cryptoStore.closeAssetDetailStore(for: token)
             }
         ) {
-          TokenView(token: token)
+          TokenView(token: token, network: cryptoStore.networkStore.selectedChain)
         }
       }
       .navigationTitle(Strings.Wallet.searchTitle.capitalized)

--- a/BraveWallet/Crypto/Search/BuyTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/BuyTokenSearchView.swift
@@ -9,6 +9,7 @@ import Strings
 
 struct BuyTokenSearchView: View {
   @ObservedObject var buyTokenStore: BuyTokenStore
+  var network: BraveWallet.NetworkInfo
 
   @Environment(\.presentationMode) @Binding private var presentationMode
 
@@ -18,7 +19,7 @@ struct BuyTokenSearchView: View {
         buyTokenStore.selectedBuyToken = token
         presentationMode.dismiss()
       }) {
-        TokenView(token: token)
+        TokenView(token: token, network: network)
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle.capitalized)

--- a/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -20,7 +20,7 @@ struct SendTokenSearchView: View {
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()
       }) {
-        TokenView(token: token)
+        TokenView(token: token, network: network)
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle)

--- a/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
+++ b/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
@@ -33,7 +33,7 @@ struct SwapTokenSearchView: View {
         }
         presentationMode.dismiss()
       }) {
-        TokenView(token: token)
+        TokenView(token: token, network: network)
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle)

--- a/BraveWallet/Crypto/Search/TokenView.swift
+++ b/BraveWallet/Crypto/Search/TokenView.swift
@@ -8,10 +8,11 @@ import BraveCore
 
 struct TokenView: View {
   var token: BraveWallet.BlockchainToken
-
+  var network: BraveWallet.NetworkInfo
+  
   var body: some View {
     HStack(spacing: 8) {
-      AssetIconView(token: token)
+      AssetIconView(token: token, network: network)
       VStack(alignment: .leading) {
         Text(token.name)
           .fontWeight(.semibold)
@@ -28,7 +29,7 @@ struct TokenView: View {
 #if DEBUG
 struct TokenView_Previews: PreviewProvider {
   static var previews: some View {
-    TokenView(token: MockBlockchainRegistry.testTokens.first!)
+    TokenView(token: MockBlockchainRegistry.testTokens.first!, network: .mockMainnet)
   }
 }
 #endif

--- a/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -24,20 +24,20 @@ public class AssetStore: ObservableObject, Equatable {
       }
     }
   }
+  var network: BraveWallet.NetworkInfo
 
   private let walletService: BraveWalletBraveWalletService
-  private var chainId: String
   private(set) var isCustomToken: Bool
 
   init(
     walletService: BraveWalletBraveWalletService,
-    chainId: String,
+    network: BraveWallet.NetworkInfo,
     token: BraveWallet.BlockchainToken,
     isCustomToken: Bool,
     isVisible: Bool
   ) {
     self.walletService = walletService
-    self.chainId = chainId
+    self.network = network
     self.token = token
     self.isCustomToken = isCustomToken
     self.isVisible = isVisible
@@ -82,7 +82,7 @@ public class UserAssetsStore: ObservableObject {
         assetStores = allTokens.union(userAssets, f: { $0.id }).map { token in
           AssetStore(
             walletService: walletService,
-            chainId: network.chainId,
+            network: network,
             token: token,
             isCustomToken: !allTokens.contains(where: {
               $0.contractAddress(in: network).caseInsensitiveCompare(token.contractAddress) == .orderedSame

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -29,7 +29,7 @@ extension BraveWallet.NetworkInfo: Identifiable {
     .init(
       contractAddress: "",
       name: symbolName,
-      logo: iconUrls.first ?? "",
+      logo: nativeTokenLogo,
       isErc20: false,
       isErc721: false,
       symbol: symbol,
@@ -40,6 +40,30 @@ extension BraveWallet.NetworkInfo: Identifiable {
       chainId: "",
       coin: coin
     )
+  }
+  
+  public var nativeTokenLogo: String {
+    if symbol.caseInsensitiveCompare("ETH") == .orderedSame {
+      return "eth-asset-icon"
+    } else if symbol.caseInsensitiveCompare("SOL") == .orderedSame {
+      return "sol-asset-icon"
+    } else if symbol.caseInsensitiveCompare("FIL") == .orderedSame {
+      return "filecoin-asset-icon"
+    } else if chainId.caseInsensitiveCompare(BraveWallet.PolygonMainnetChainId) == .orderedSame {
+      return "matic"
+    } else if chainId.caseInsensitiveCompare(BraveWallet.BinanceSmartChainMainnetChainId) == .orderedSame {
+      return "bnb-asset-icon"
+    } else if chainId.caseInsensitiveCompare(BraveWallet.CeloMainnetChainId) == .orderedSame {
+      return "celo"
+    } else if chainId.caseInsensitiveCompare(BraveWallet.AvalancheMainnetChainId) == .orderedSame {
+      return "avax"
+    } else if chainId.caseInsensitiveCompare(BraveWallet.FantomMainnetChainId) == .orderedSame {
+      return "fantom"
+    } else if chainId.caseInsensitiveCompare(BraveWallet.OptimismMainnetChainId) == .orderedSame {
+      return "optimism" // should never happen since OptimismMainnet's symbol is ETH
+    } else {
+      return iconUrls.first ?? ""
+    }
   }
   
   // Only Eth Mainnet or EVM has eip 1559

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -29,7 +29,7 @@ extension BraveWallet.NetworkInfo: Identifiable {
     .init(
       contractAddress: "",
       name: symbolName,
-      logo: nativeTokenLogo,
+      logo: nativeTokenLogo ?? "",
       isErc20: false,
       isErc721: false,
       symbol: symbol,
@@ -42,7 +42,7 @@ extension BraveWallet.NetworkInfo: Identifiable {
     )
   }
   
-  public var nativeTokenLogo: String {
+  public var nativeTokenLogo: String? {
     if symbol.caseInsensitiveCompare("ETH") == .orderedSame {
       return "eth-asset-icon"
     } else if symbol.caseInsensitiveCompare("SOL") == .orderedSame {
@@ -59,10 +59,8 @@ extension BraveWallet.NetworkInfo: Identifiable {
       return "avax"
     } else if chainId.caseInsensitiveCompare(BraveWallet.FantomMainnetChainId) == .orderedSame {
       return "fantom"
-    } else if chainId.caseInsensitiveCompare(BraveWallet.OptimismMainnetChainId) == .orderedSame {
-      return "optimism" // should never happen since OptimismMainnet's symbol is ETH
     } else {
-      return iconUrls.first ?? ""
+      return iconUrls.first
     }
   }
   

--- a/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -31,7 +31,7 @@ struct AddSuggestedTokenView: View {
         .padding(.top)
         VStack {
           VStack {
-            AssetIconView(token: token, length: 64)
+            AssetIconView(token: token, network: cryptoStore.networkStore.selectedChain, length: 64)
             Text(token.symbol)
               .font(.headline)
               .foregroundColor(Color(.bravePrimary))


### PR DESCRIPTION
Bundle some network's native assets' logos
For native token that is created by ourselves, we will insert the correct token logo.
For all token we will still try to load image using token's logo and token's symbol under `tokenLogoBaseURL`, if it fails we will use check if the token is native asset so we fetch the bundle native token icon. if it also fails, we will check if logo is a web image. if all fails, the monogram fallback image will be rendered. 

This pull request fixes #5769 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Switch between different networks to see if network's native asset's icon is being displayed. 


## Screenshots:
![Simulator Screen Shot - iPhone Xʀ - 2022-08-02 at 16 02 56](https://user-images.githubusercontent.com/1187676/182464258-0482a54d-d849-45bb-9995-7afcb7440010.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
