### PR TITLE
Fix #5773: fix error message didnt update after selected account changed.

### DIFF
--- a/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -233,6 +233,8 @@ public class SendTokenStore: ObservableObject {
           addressError = .notSolAddress
         } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
           addressError = .sameAsFromAddress
+        } else {
+          addressError = nil
         }
       }
     }


### PR DESCRIPTION

This pull request fixes #5773 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
please refer to the issue.

https://user-images.githubusercontent.com/1187676/182646942-18ae6e00-0717-466a-a268-82a9ef83f7ad.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
