### PR TITLE
Fix #5776: Logic update for showing or hiding buy/send/swap options

### DIFF
--- a/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -148,8 +148,7 @@ struct AssetDetailHeaderView: View {
         .padding(.bottom)
       HStack {
         if assetDetailStore.isBuySupported
-            && !networkStore.isCustomChain(networkStore.selectedChain)
-            && networkStore.selectedChain.coin == .eth {
+            && WalletConstants.supportedBuyWithWyreNetworkChainIds.contains(networkStore.selectedChainId) {
           Button(
             action: {
               buySendSwapDestination = BuySendSwapDestination(
@@ -171,7 +170,7 @@ struct AssetDetailHeaderView: View {
         ) {
           Text(Strings.Wallet.send)
         }
-        if !networkStore.isCustomChain(networkStore.selectedChain) && networkStore.selectedChain.coin == .eth {
+        if networkStore.isSwapSupported {
           Button(
             action: {
               buySendSwapDestination = BuySendSwapDestination(

--- a/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
@@ -8,7 +8,7 @@ import BraveCore
 import Strings
 
 struct BuySendSwapView: View {
-  @ObservedObject var networkStore: NetworkStore
+  var networkStore: NetworkStore
   var action: (BuySendSwapDestination) -> Void
   var destinations: [BuySendSwapDestination] = []
 

--- a/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
@@ -8,25 +8,22 @@ import BraveCore
 import Strings
 
 struct BuySendSwapView: View {
-  var network: BraveWallet.NetworkInfo
+  @ObservedObject var networkStore: NetworkStore
   var action: (BuySendSwapDestination) -> Void
-  var destinations: [BuySendSwapDestination]
+  var destinations: [BuySendSwapDestination] = []
 
   init(
-    network: BraveWallet.NetworkInfo,
-    isCustomNetwork: Bool,
+    networkStore: NetworkStore,
     action: @escaping (BuySendSwapDestination) -> Void
   ) {
-    self.network = network
+    self.networkStore = networkStore
     self.action = action
-    if isCustomNetwork || network.coin != .eth {
-      destinations = [BuySendSwapDestination(kind: .send)]
-    } else {
-      destinations = [
-        BuySendSwapDestination(kind: .buy),
-        BuySendSwapDestination(kind: .send),
-        BuySendSwapDestination(kind: .swap),
-      ]
+    if WalletConstants.supportedBuyWithWyreNetworkChainIds.contains(networkStore.selectedChainId) {
+      self.destinations.append(BuySendSwapDestination(kind: .buy))
+    }
+    self.destinations.append(BuySendSwapDestination(kind: .send))
+    if networkStore.isSwapSupported {
+      self.destinations.append(BuySendSwapDestination(kind: .swap))
     }
   }
 
@@ -61,7 +58,7 @@ struct BuySendSwapView: View {
 #if DEBUG
 struct BuySendSwapView_Previews: PreviewProvider {
   static var previews: some View {
-    BuySendSwapView(network: .init(), isCustomNetwork: false, action: { _ in })
+    BuySendSwapView(networkStore: .previewStore, action: { _ in })
       .previewLayout(.sizeThatFits)
       //      .previewColorSchemes()
       .previewSizeCategories([.large, .accessibilityLarge])

--- a/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -223,11 +223,6 @@ struct SwapCryptoView: View {
     }
   }
 
-  private var isSwapEnabled: Bool {
-    let selectedChain = networkStore.selectedChainId
-    return selectedChain == BraveWallet.MainnetChainId || selectedChain == BraveWallet.RopstenChainId
-  }
-
   @ViewBuilder var swapFormSections: some View {
     Section(
       header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoFromTitle))
@@ -479,7 +474,7 @@ struct SwapCryptoView: View {
           .padding(.bottom, -16)  // Get it a bit closer
         ) {
         }
-        if isSwapEnabled {
+        if networkStore.isSwapSupported {
           swapFormSections
         } else {
           unsupportedSwapChainSection

--- a/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/BraveWallet/Crypto/CryptoPagesView.swift
@@ -223,8 +223,7 @@ private class CryptoPagesViewController: TabbedPageViewController {
   @objc private func tappedSwapButton() {
     let controller = FixedHeightHostingPanModalController(
       rootView: BuySendSwapView(
-        network: cryptoStore.networkStore.selectedChain,
-        isCustomNetwork: cryptoStore.networkStore.isCustomChain(cryptoStore.networkStore.selectedChain),
+        networkStore: cryptoStore.networkStore,
         action: { [weak self] destination in
           self?.dismiss(
             animated: true,

--- a/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -93,7 +93,8 @@ public class CryptoStore: ObservableObject {
     self.networkStore = .init(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     self.portfolioStore = .init(
       keyringService: keyringService,

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -649,6 +649,12 @@ public class SwapTokenStore: ObservableObject {
           } else {
             selectedToToken = allTokens.first(where: { $0.symbol.uppercased() == daiSymbol.uppercased() })
           }
+        } else {
+          if let fromToken = selectedFromToken {
+            selectedToToken = allTokens.first(where: { $0.symbol.uppercased() != fromToken.symbol.uppercased() })
+          } else {
+            selectedToToken = allTokens.first
+          }
         }
         completion?()
       }

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -745,13 +745,16 @@ extension SwapTokenStore: BraveWalletKeyringServiceObserver {
   }
 
   public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-    keyringService.keyringInfo(coinType.keyringId) { [self] keyringInfo in
+    Task { @MainActor in
+      let network = await rpcService.network(coinType)
+      guard await swapService.isSwapSupported(network.chainId) else { return }
+      
+      let keyringInfo = await keyringService.keyringInfo(coinType.keyringId)
       if !keyringInfo.accountInfos.isEmpty {
-        keyringService.selectedAccount(coinType) { [self] accountAddress in
-          let selectedAccountInfo = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!
-          prepare(with: selectedAccountInfo) { [self] in
-            fetchPriceQuote(base: .perSellAsset)
-          }
+        let accountAddress = await keyringService.selectedAccount(coinType)
+        let selectedAccountInfo = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!
+        prepare(with: selectedAccountInfo) { [self] in
+          fetchPriceQuote(base: .perSellAsset)
         }
       }
     }
@@ -760,14 +763,15 @@ extension SwapTokenStore: BraveWalletKeyringServiceObserver {
 
 extension SwapTokenStore: BraveWalletJsonRpcServiceObserver {
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
-    guard
-      let accountInfo = accountInfo,
-      chainId == BraveWallet.MainnetChainId || chainId == BraveWallet.RopstenChainId
-    else { return }
-    selectedFromToken = nil
-    selectedToToken = nil
-    prepare(with: accountInfo) { [self] in
-      fetchPriceQuote(base: .perSellAsset)
+    Task { @MainActor in
+      guard await swapService.isSwapSupported(chainId), let accountInfo = accountInfo else {
+        return
+      }
+      selectedFromToken = nil
+      selectedToToken = nil
+      prepare(with: accountInfo) { [self] in
+        fetchPriceQuote(base: .perSellAsset)
+      }
     }
   }
 

--- a/BraveWallet/Preview Content/MockStores.swift
+++ b/BraveWallet/Preview Content/MockStores.swift
@@ -46,7 +46,8 @@ extension NetworkStore {
     .init(
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
-      walletService: MockBraveWalletService()
+      walletService: MockBraveWalletService(),
+      swapService: MockSwapService()
     )
   }
   

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -52,7 +52,7 @@ struct WalletConstants {
   /// Supported networks for buying via Wyre
   // Not include Polygon Mainnet and Avalanche Mainnet due to core-side issue
   // https://github.com/brave/brave-browser/issues/24444
-  // Will bring back via https://github.com/brave/brave-ios/pull/5777
+  // Will bring back via https://github.com/brave/brave-ios/issues/5781
   static let supportedBuyWithWyreNetworkChainIds: [String] = [
     BraveWallet.MainnetChainId
   ]

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -51,9 +51,7 @@ struct WalletConstants {
   
   /// Supported networks for buying via Wyre
   static let supportedBuyWithWyreNetworkChainIds: [String] = [
-    BraveWallet.MainnetChainId,
-    BraveWallet.PolygonMainnetChainId,
-    BraveWallet.AvalancheMainnetChainId
+    BraveWallet.MainnetChainId
   ]
 }
 

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -50,6 +50,9 @@ struct WalletConstants {
   static let splTokenAccountCreationLink = URL(string: "https://support.brave.com/hc/en-us/articles/5546517853325")!
   
   /// Supported networks for buying via Wyre
+  // Not include Polygon Mainnet and Avalanche Mainnet due to core-side issue
+  // https://github.com/brave/brave-browser/issues/24444
+  // Will bring back via https://github.com/brave/brave-ios/pull/5777
   static let supportedBuyWithWyreNetworkChainIds: [String] = [
     BraveWallet.MainnetChainId
   ]

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -48,6 +48,13 @@ struct WalletConstants {
   
   /// The link for users to learn more about Solana SPL token account creation in transaction confirmation screen
   static let splTokenAccountCreationLink = URL(string: "https://support.brave.com/hc/en-us/articles/5546517853325")!
+  
+  /// Supported networks for buying via Wyre
+  static let supportedBuyWithWyreNetworkChainIds: [String] = [
+    BraveWallet.MainnetChainId,
+    BraveWallet.PolygonMainnetChainId,
+    BraveWallet.AvalancheMainnetChainId
+  ]
 }
 
 struct WalletDebugFlags {

--- a/BraveWallet/WalletPanelHostingController.swift
+++ b/BraveWallet/WalletPanelHostingController.swift
@@ -38,8 +38,7 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
       guard let self = self, let store = walletStore.cryptoStore else { return }
       let controller = FixedHeightHostingPanModalController(
         rootView: BuySendSwapView(
-          network: store.networkStore.selectedChain,
-          isCustomNetwork: store.networkStore.isCustomChain(store.networkStore.selectedChain),
+          networkStore: store.networkStore,
           action: { destination in
             self.dismiss(
               animated: true,

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -2661,5 +2661,12 @@ extension Strings {
       value: "View %@ test networks",
       comment: "A VoiceOver label that will be read out when a user focuses on the show test networks button in the network selection view. \"%@\" will be replaced with the network name such as \"Solana\" or \"Ethereum\""
     )
+    public static let networkNotSupportedForBuyToken = NSLocalizedString(
+      "wallet.networkNotSupportedForBuyToken",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Buy not supported for selected network",
+      comment: "A placeholder in Buy Screen, when user switched to a network that Brave currently doesn't support buy token with Wyre."
+    )
   }
 }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -932,27 +932,6 @@ extension Strings {
       value: "Continue to Wyre",
       comment: "The title of the button for users to click when they are ready to buy using Wyre payment"
     )
-    public static let buyTestTitle = NSLocalizedString(
-      "wallet.buyTestTitle",
-      tableName: "BraveWallet",
-      bundle: .strings,
-      value: "Test Faucet",
-      comment: "The title below account picker when user has selected a test network"
-    )
-    public static let buyTestDescription = NSLocalizedString(
-      "wallet.buyTestDescription",
-      tableName: "BraveWallet",
-      bundle: .strings,
-      value: "Get Ether from a faucet for %@",
-      comment: "The description of where user will go to once a test network has been picked in buy screen. '%@' will be replaced with a network such as 'Rinkeby' or 'Ropsten'"
-    )
-    public static let buyTestButtonTitle = NSLocalizedString(
-      "wallet.buyTestButtonTitle",
-      tableName: "BraveWallet",
-      bundle: .strings,
-      value: "Get Ether",
-      comment: "The title of the button for users to get ether if the test network has been chosen"
-    )
     public static let sendCryptoFromTitle = NSLocalizedString(
       "wallet.sendCryptoFromTitle",
       tableName: "BraveWallet",

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -151,6 +151,7 @@ extension BrowserViewController {
         let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
         let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
         let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        let swapService = BraveWallet.SwapServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
         
         if let keyringService = keyringService,
           let walletService = walletService,
@@ -164,11 +165,13 @@ extension BrowserViewController {
         var networkStore: NetworkStore?
         if let keyringService = keyringService,
            let rpcService = rpcService,
-           let walletService = walletService {
+           let walletService = walletService,
+           let swapService = swapService {
           networkStore = NetworkStore(
             keyringService: keyringService,
             rpcService: rpcService,
-            walletService: walletService
+            walletService: walletService,
+            swapService: swapService
           )
         }
         

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -23,7 +23,7 @@ import BraveShared
     WalletDebugFlags.isSolanaEnabled = true
   }
   
-  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService) {
+  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService) {
     let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let currentChainId = currentNetwork.chainId
     let currentSelectedCoin: BraveWallet.CoinType = .eth
@@ -59,18 +59,22 @@ import BraveShared
     walletService._addObserver = { _ in }
     walletService._selectedCoin = { $0(currentSelectedCoin) }
     
-    return (keyringService, rpcService, walletService)
+    let swapService = BraveWallet.TestSwapService()
+    swapService._isSwapSupported = { $1(true) }
+    
+    return (keyringService, rpcService, walletService, swapService)
   }
   
   func testUpdate() {
     Preferences.Wallet.showTestNetworks.value = false
 
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     // wait for all chains to populate in `NetworkStore`
@@ -103,12 +107,13 @@ import BraveShared
   func testUpdateTestNetworksEnabled() {
     Preferences.Wallet.showTestNetworks.value = true
     
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     // wait for all chains to populate in `NetworkStore`
@@ -139,12 +144,13 @@ import BraveShared
   }
   
   func testSetSelectedNetwork() async {
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)
@@ -154,12 +160,13 @@ import BraveShared
   }
   
   func testSetSelectedNetworkNoAccounts() async {
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)
@@ -170,12 +177,13 @@ import BraveShared
   }
   
   func testAlertResponseCreateAccount() {
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)
@@ -188,12 +196,13 @@ import BraveShared
   }
   
   func testAlertResponseDontCreateAccount() {
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -12,7 +12,7 @@ class NetworkStoreTests: XCTestCase {
   
   private var cancellables: Set<AnyCancellable> = .init()
   
-  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService) {
+  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService) {
     let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let currentChainId = currentNetwork.chainId
     let currentSelectedCoin: BraveWallet.CoinType = .eth
@@ -52,16 +52,20 @@ class NetworkStoreTests: XCTestCase {
     walletService._addObserver = { _ in }
     walletService._selectedCoin = { $0(currentSelectedCoin) }
     
-    return (keyringService, rpcService, walletService)
+    let swapService = BraveWallet.TestSwapService()
+    swapService._isSwapSupported = { $1(true) }
+    
+    return (keyringService, rpcService, walletService, swapService)
   }
   
   func testSetSelectedNetwork() async {
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let store = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let error = await store.setSelectedChain(.mockRopsten)
@@ -69,12 +73,13 @@ class NetworkStoreTests: XCTestCase {
   }
   
   func testSetSelectedNetworkSameNetwork() async {
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let store = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let error = await store.setSelectedChain(.mockMainnet)
@@ -82,12 +87,13 @@ class NetworkStoreTests: XCTestCase {
   }
   
   func testSetSelectedNetworkNoAccounts() async {
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let store = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let error = await store.setSelectedChain(.mockSolana)
@@ -96,12 +102,13 @@ class NetworkStoreTests: XCTestCase {
   
   func testUpdateChainList() {
     WalletDebugFlags.isSolanaEnabled = true
-    let (keyringService, rpcService, walletService) = setupServices()
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let store = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,
-      walletService: walletService
+      walletService: walletService,
+      swapService: swapService
     )
     
     let expectedAllChains: [BraveWallet.NetworkInfo] = [


### PR DESCRIPTION
## Description:
For Buy:
Mobile only support Buy with Wyre right now.

we need to fetch buyable tokens using correct chain id with Wyre provider
after compare with desktop, currently there are three networks support buy with Wyre. They are Eth Mainnet, EVM Polygon Mainnet and EVM Acalanche Mainnet
For Send:
No restriction

For Swap:
User api from BraveWalletSwapService.isSwapSupported to show or hide swap option.


This pull request fixes #5776 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Please refer to the issue.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
