### PR TITLE
Fix #5783: Fix account import via json, disable Solana account import via json

### DIFF
--- a/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -155,6 +155,27 @@ struct AddAccountView: View {
         }
       }
     }
+    .sheet(isPresented: $isPresentingImport) {
+      DocumentOpenerView(allowedContentTypes: [.text, .json]) { urls in
+        guard let fileURL = urls.first else { return }
+        self.isLoadingFile = true
+        DispatchQueue.global(qos: .userInitiated).async {
+          do {
+            let data = try String(contentsOf: fileURL)
+            DispatchQueue.main.async {
+              self.privateKey = data
+              self.isLoadingFile = false
+            }
+          } catch {
+            DispatchQueue.main.async {
+              // Error: Couldn't load file
+              self.isLoadingFile = false
+            }
+          }
+        }
+      }
+    }
+    .animation(.default, value: isJSONImported)
   }
 
   private var accountNameSection: some View {

--- a/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -211,6 +211,11 @@ struct AddAccountView: View {
     }
     .listRowBackground(Color(.secondaryBraveGroupedBackground))
   }
+  
+  private var isJsonImportSupported: Bool {
+    // nil is possible if Solana is disabled
+    selectedCoin == nil || selectedCoin == .eth
+  }
 
   private var privateKeySection: some View {
     Section(
@@ -225,7 +230,7 @@ struct AddAccountView: View {
         .font(.system(.body, design: .monospaced))
         .frame(height: privateKeyFieldHeight)
         .background(
-          Text(Strings.Wallet.importAccountPlaceholder)
+          Text(isJsonImportSupported ? Strings.Wallet.importAccountPlaceholder : Strings.Wallet.importNonEthAccountPlaceholder)
             .padding(.vertical, 8)
             .padding(.horizontal, 4)  // To match the TextEditor's editing insets
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -238,7 +243,7 @@ struct AddAccountView: View {
           textView.smartQuotesType = .no
         }
         .accessibilityValue(privateKey.isEmpty ? Strings.Wallet.importAccountPlaceholder : privateKey)
-      if selectedCoin == nil || selectedCoin == .eth { // nil is possible if Solana is disabled
+      if isJsonImportSupported {
         Button(action: { isPresentingImport = true }) {
           HStack {
             Text(Strings.Wallet.importButtonTitle)

--- a/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -238,19 +238,21 @@ struct AddAccountView: View {
           textView.smartQuotesType = .no
         }
         .accessibilityValue(privateKey.isEmpty ? Strings.Wallet.importAccountPlaceholder : privateKey)
-      Button(action: { isPresentingImport = true }) {
-        HStack {
-          Text(Strings.Wallet.importButtonTitle)
-            .foregroundColor(.accentColor)
-            .font(.callout)
-          if isLoadingFile {
-            ProgressView()
-              .progressViewStyle(CircularProgressViewStyle())
+      if selectedCoin == nil || selectedCoin == .eth { // nil is possible if Solana is disabled
+        Button(action: { isPresentingImport = true }) {
+          HStack {
+            Text(Strings.Wallet.importButtonTitle)
+              .foregroundColor(.accentColor)
+              .font(.callout)
+            if isLoadingFile {
+              ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+            }
           }
+          .frame(maxWidth: .infinity)
         }
-        .frame(maxWidth: .infinity)
+        .disabled(isLoadingFile)
       }
-      .disabled(isLoadingFile)
     }
     .listRowBackground(Color(.secondaryBraveGroupedBackground))
   }

--- a/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -5,12 +5,13 @@
 
 import Foundation
 import BraveCore
+import OrderedCollections
 
 extension BraveWalletKeyringService {
   
   // Fetches all keyrings for all given coin types
   func keyrings(
-    for coins: Set<BraveWallet.CoinType>
+    for coins: OrderedSet<BraveWallet.CoinType>
   ) async -> [BraveWallet.KeyringInfo] {
     var allKeyrings: [BraveWallet.KeyringInfo] = []
     allKeyrings = await withTaskGroup(

--- a/BraveWallet/WalletConstants.swift
+++ b/BraveWallet/WalletConstants.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import BraveCore
+import OrderedCollections
 
 struct WalletConstants {
   /// The Brave swap fee as a % value
@@ -38,7 +39,7 @@ struct WalletConstants {
   ]
   
   /// The currently supported coin types.
-  static var supportedCoinTypes: Set<BraveWallet.CoinType> {
+  static var supportedCoinTypes: OrderedSet<BraveWallet.CoinType> {
     if WalletDebugFlags.isSolanaEnabled {
       return [.eth, .sol]
     }

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -316,6 +316,13 @@ extension Strings {
       value: "Enter, paste, or import your private key string file or JSON.",
       comment: "A placeholder on a text box for entering the users private key/json data to import accounts"
     )
+    public static let importNonEthAccountPlaceholder = NSLocalizedString(
+      "wallet.importNonEthAccountPlaceholder",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Enter or paste your private key.",
+      comment: "A placeholder on a text box for entering the users private key to import accounts"
+    )
     public static let importButtonTitle = NSLocalizedString(
       "wallet.importButtonTitle",
       tableName: "BraveWallet",

--- a/Package.swift
+++ b/Package.swift
@@ -279,6 +279,7 @@ let package = Package(
         "XCGLogger",
         .product(name: "BigNumber", package: "Swift-BigInt"),
         .product(name: "Algorithms", package: "swift-algorithms"),
+        .product(name: "Collections", package: "swift-collections"),
       ],
       path: "BraveWallet",
       plugins: ["CurrentBundleGenPlugin"]


### PR DESCRIPTION
## Summary of Changes
- Fix account import via json which regressed in https://github.com/brave/brave-ios/pull/5651 which removed the sheet presentation.
- Hide the 'Import...' button for non-ethereum account creation
- Update `WalletConstants.supportedCoinTypes` to be an `OrderedSet` instead of a regular `Set` so the order is consistent. Possible accounts list would show either Ethereum or Solana account first, and create account coin type selection had undetermined order for Ethereum / Solana coin types.

This pull request fixes #5783

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Ethereum account import via json:
1. Open Brave Wallet
2. Switch to 'Accounts' tab
3. Tap '+' to add account
4. Tap 'Ethereum' coin type
5. Tap 'Import...'
6. Verify document browser to select a json file to import is shown

Solana account import (removed json button)
1. Open Brave Wallet
2. Switch to 'Accounts' tab
3. Tap '+' to add account
4. Tap 'Solana' coin type
5. Verify 'Import...' button is no longer shown


## Screenshots:

https://user-images.githubusercontent.com/5314553/182934481-b97ba7c7-57f5-46af-b30d-a0dd4f491de8.mp4

https://user-images.githubusercontent.com/5314553/182934216-e42b509f-1de0-42d6-a366-34c1a9f3fb5b.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
