### PR TITLE
Fix #5786 : Update placeholder copy to remove url reference from to address field

### DIFF
--- a/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -129,7 +129,7 @@ struct SendTokenView: View {
           }
         ) {
           HStack(spacing: 14.0) {
-            TextField(Strings.Wallet.sendCryptoAddressPlaceholder, text: $sendTokenStore.sendAddress)
+            TextField(Strings.Wallet.sendToCryptoAddressPlaceholder, text: $sendTokenStore.sendAddress)
             Button(action: {
               if let string = UIPasteboard.general.string {
                 sendTokenStore.sendAddress = string

--- a/BraveWallet/WalletStrings.swift
+++ b/BraveWallet/WalletStrings.swift
@@ -974,11 +974,11 @@ extension Strings {
       value: "To",
       comment: "A title above the address you want to send to. For example this would appear over a cell that has the 'OxFCdf***DDee' with a clipboard icon and a qr-code icon on the right hand side"
     )
-    public static let sendCryptoAddressPlaceholder = NSLocalizedString(
-      "wallet.sendCryptoAddressPlaceholder",
+    public static let sendToCryptoAddressPlaceholder = NSLocalizedString(
+      "wallet.sendToCryptoAddressPlaceholder",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Enter address or url",
+      value: "Enter address",
       comment: "A placeholder of the address text field."
     )
     public static let scanQRCodeAccessibilityLabel = NSLocalizedString(


### PR DESCRIPTION
## Summary of Changes
- Copy update to remove reference to unsupported feature. Updated string name / key so copy is translations get updated.

This pull request fixes #5786

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Brave Wallet
2. Tap buy/send/swap button
3. Tap 'Send'
4. Verify to address field no longer references entering a `url`

## Screenshots:

![#5786](https://user-images.githubusercontent.com/5314553/182963597-05fc305c-f48b-457c-a45c-3dc3734878cc.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
