### PR TITLE
No Bug: Set correct path for BraveStrings file for translations.

### DIFF
--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -246,7 +246,7 @@
 		27FDB77C284FDB9D00ACEB16 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "Shortcuts/zh-TW.lproj/BrowserIntents.strings"; sourceTree = "<group>"; };
 		27FDCE512835AE0800E78FAD /* l10n.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = l10n.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		27FDCED72835B3D300E78FAD /* SharedStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SharedStrings.swift; path = ../Sources/Shared/SharedStrings.swift; sourceTree = SOURCE_ROOT; };
-		27FDCED92835B5AA00E78FAD /* BraveStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BraveStrings.swift; path = ../BraveShared/BraveStrings.swift; sourceTree = SOURCE_ROOT; };
+		27FDCED92835B5AA00E78FAD /* BraveStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BraveStrings.swift; path = ../Sources/BraveShared/BraveStrings.swift; sourceTree = SOURCE_ROOT; };
 		27FDCEDB2835B66D00E78FAD /* WalletStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WalletStrings.swift; path = ../BraveWallet/WalletStrings.swift; sourceTree = SOURCE_ROOT; };
 		2F6931B4260CFB3700ECEB38 /* BrowserIntents.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BrowserIntents.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F6931B6260CFB3700ECEB38 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Followup to https://github.com/brave/brave-ios/pull/5743
Without this our l10n were unable to pick up changes.

This required reapproving all BraveShared translations in transifex as well due to path change.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
