### PR TITLE
Fix #5812: Fix infinite de-amp loop during server side redirect

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/DeAMP.js
+++ b/Client/Frontend/UserContent/UserScripts/DeAMP.js
@@ -9,12 +9,13 @@ window.braveDeAmp = (args) => {
   const W = window
   const D = W.document
   const securityToken = args.securityToken
-
+  const messageHandler = webkit.messageHandlers[args.handlerName]
+  
   let timesToCheck = 20
   let intervalId
   
   const sendMessage = (destURL) => {
-    return webkit.messageHandlers[args.handlerName].postMessage({
+    return messageHandler.postMessage({
       securityToken: securityToken,
       destURL: destURL.href
     })


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5812 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
