### PR TITLE
Fix #5816: Fix some tokens not displaying price history in asset details 

### DIFF
--- a/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -196,8 +196,19 @@ extension BraveWallet.NetworkInfo {
 }
 
 extension BraveWallet.BlockchainToken {
-  /// The id to fetch price and price history. Use `coingeckoId` when it's not empty, otherwise use `symbol`
   var assetRatioId: String {
-    coingeckoId.isEmpty ? symbol : coingeckoId
+    if !coingeckoId.isEmpty {
+      return coingeckoId
+    }
+    
+    if chainId != BraveWallet.MainnetChainId {
+      return symbol
+    }
+    
+    if contractAddress.isEmpty {
+      return symbol
+    }
+    
+    return contractAddress
   }
 }

--- a/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -196,16 +196,13 @@ extension BraveWallet.NetworkInfo {
 }
 
 extension BraveWallet.BlockchainToken {
+  /// The id to fetch price and price history.
   var assetRatioId: String {
     if !coingeckoId.isEmpty {
       return coingeckoId
     }
     
-    if chainId != BraveWallet.MainnetChainId {
-      return symbol
-    }
-    
-    if contractAddress.isEmpty {
+    if chainId != BraveWallet.MainnetChainId || contractAddress.isEmpty {
       return symbol
     }
     


### PR DESCRIPTION
## Summary of Changes
Return correct `assetRatioId` 

This pull request fixes #5816

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
on mainnet, 1nch, aave, etc don't have price history.

## Screenshots:

![simulator_screenshot_872F21E4-A7C5-415A-A6DF-9F0F3674E0D2](https://user-images.githubusercontent.com/1187676/183668965-d9b40518-cc16-43f4-87f6-9acb65b06443.png) | ![simulator_screenshot_AA68E442-D83A-4F18-91DB-31673A405BD0](https://user-images.githubusercontent.com/1187676/183669009-d11dd77b-073a-482b-a9be-a1b3834f2b6a.png)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
