### PR TITLE
Fix #5804: Fixes crash when terminating Brave-Core

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -366,10 +366,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Clean up BraveCore
     braveCore.syncAPI.removeAllObservers()
-    if braveCore.responds(to: Selector(("onAppWillTerminate:"))) {
-      braveCore.perform(Selector(("onAppWillTerminate:")), with: nil)
-    }
-    
+
     log.debug("Cleanly Terminated the Application")
   }
 


### PR DESCRIPTION
## Summary of Changes
- Do not call brave-core's termination function.
- Depends on: https://github.com/brave/brave-core/pull/14562

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5804

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Kill the app many times to make sure it doesn't show crash report on next launch


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
