### PR TITLE
Fix #5824: Bump Brave-Core to 1.42.91

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.43.58/brave-core-ios-1.43.58.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.42.91/brave-core-ios-1.42.91.tgz",
         "page-metadata-parser": "^1.1.3",
         "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
         "webpack-cli": "^4.8.0"
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.43.58",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.43.58/brave-core-ios-1.43.58.tgz",
-      "integrity": "sha512-syChk/xUdbj93Jpw87uKx9B0HIBy3VlMpSHAKJo2XWwudXgWB7O+ZrQmBawydZPqjvTrox2IqQ5nWFc37fGrdg==",
+      "version": "1.42.91",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.42.91/brave-core-ios-1.42.91.tgz",
+      "integrity": "sha512-TIw12TfaVqqMg+5qBexJGByvRSp5TpnBnX8p/Ro4eGNro5x9Qt0EZKqZI9ZIaHq9sER/0iy72aS+aCuQO1h/zg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1727,8 +1727,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.43.58/brave-core-ios-1.43.58.tgz",
-      "integrity": "sha512-syChk/xUdbj93Jpw87uKx9B0HIBy3VlMpSHAKJo2XWwudXgWB7O+ZrQmBawydZPqjvTrox2IqQ5nWFc37fGrdg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.42.91/brave-core-ios-1.42.91.tgz",
+      "integrity": "sha512-TIw12TfaVqqMg+5qBexJGByvRSp5TpnBnX8p/Ro4eGNro5x9Qt0EZKqZI9ZIaHq9sER/0iy72aS+aCuQO1h/zg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.43.58/brave-core-ios-1.43.58.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.42.91/brave-core-ios-1.42.91.tgz",
     "page-metadata-parser": "^1.1.3",
     "readability": "git+https://github.com/mozilla/readability.git#b9f47bcc8d3c223cabe2dec6a42eeb3bd778d85c",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Bump Brave-Core to 1.42.91

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5824

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
