### PR TITLE
Fix #5829: Accounts list order changes

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -146,23 +146,7 @@ public class KeyringStore: ObservableObject {
     }
     Task { @MainActor in // fetch all KeyringInfo for all coin types
       let selectedCoin = await walletService.selectedCoin()
-      self.allKeyrings = await withTaskGroup(
-        of: BraveWallet.KeyringInfo.self,
-        returning: [BraveWallet.KeyringInfo].self,
-        body: { @MainActor [weak keyringService] group in
-          guard let keyringService = keyringService else { return [] }
-          for coin in WalletConstants.supportedCoinTypes {
-            group.addTask { @MainActor in
-              await keyringService.keyringInfo(coin.keyringId)
-            }
-          }
-          var allKeyrings: [BraveWallet.KeyringInfo] = []
-          for await keyring in group {
-            allKeyrings.append(keyring)
-          }
-          return allKeyrings
-        }
-      )
+      self.allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
       if let defaultKeyring = self.allKeyrings.first(where: { $0.id == BraveWallet.DefaultKeyringId }) {
         self.defaultKeyring = defaultKeyring
       }

--- a/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -165,6 +165,20 @@ extension BraveWallet.CoinType {
       return ""
     }
   }
+  
+  /// Sort order used when sorting by coin types
+  var sortOrder: Int {
+    switch self {
+    case .eth:
+      return 1
+    case .sol:
+      return 2
+    case .fil:
+      return 3
+    @unknown default:
+      return 10
+    }
+  }
 }
 
 extension BraveWallet.KeyringInfo {

--- a/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -23,11 +23,12 @@ extension BraveWalletKeyringService {
             await self.keyringInfo(coin.keyringId)
           }
         }
-        var allKeyrings: [BraveWallet.KeyringInfo] = []
-        for await keyring in group {
-          allKeyrings.append(keyring)
-        }
-        return allKeyrings
+        return await group.reduce([BraveWallet.KeyringInfo](), { partialResult, prior in
+          return partialResult + [prior]
+        })
+        .sorted(by: { lhs, rhs in
+          (lhs.coin ?? .eth).sortOrder < (rhs.coin ?? .eth).sortOrder
+        })
       }
     )
     return allKeyrings


### PR DESCRIPTION
## Summary of Changes
- KeyringStore was fetching all accounts for each coin type simultaneously. Depending on which call returned first, either Solana or Ethereum accounts could be listed first. Updated to sort the keyrings after fetching to resolve this undetermined order.

This pull request fixes #5829

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

See testplan, hard to reproduce as both of the calls to fetching keyring for coin type respond quick.


## Screenshots:



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
