### PR TITLE
Fix #5827: Fix Swap is available after user creates first solana account

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -367,21 +367,26 @@ extension KeyringStore: BraveWalletKeyringServiceObserver {
   }
 
   public func keyringCreated(_ keyringId: String) {
-    var coin: BraveWallet.CoinType = .eth
-    switch keyringId {
-    case BraveWallet.DefaultKeyringId:
-      coin = .eth
-    case BraveWallet.SolanaKeyringId:
-      coin = .sol
-    case BraveWallet.FilecoinKeyringId:
-      coin = .fil
-    default:
-      break
+    Task { @MainActor in
+      var coin: BraveWallet.CoinType = .eth
+      switch keyringId {
+      case BraveWallet.DefaultKeyringId:
+        coin = .eth
+      case BraveWallet.SolanaKeyringId:
+        coin = .sol
+      case BraveWallet.FilecoinKeyringId:
+        coin = .fil
+      default:
+        break
+      }
+      
+      if selectedAccount.coin.keyringId != keyringId {
+        walletService.setSelectedCoin(coin)
+        let network = await rpcService.network(coin)
+        await rpcService.setNetwork(network.chainId, coin: network.coin)
+      }
+      updateKeyringInfo()
     }
-    if selectedAccount.coin.keyringId != keyringId {
-      walletService.setSelectedCoin(coin)
-    }
-    updateKeyringInfo()
   }
 
   public func keyringRestored(_ keyringId: String) {

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -55,7 +55,11 @@ public class NetworkStore: ObservableObject {
       // we don't need to call `setNetwork` on JsonRpcService
       self.selectedChainId = chain.chainId
       // update `isSwapSupported` for Buy/Send/Swap panel
-      self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
+      if chain.coin == .eth {
+        self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
+      } else {
+        self.isSwapSupported = false
+      }
     }
   }
 
@@ -205,7 +209,11 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
       // we don't need to call `setNetwork` on JsonRpcService
       selectedChainId = chainId
       
-      isSwapSupported = await swapService.isSwapSupported(chainId)
+      if coin == .eth {
+        isSwapSupported = await swapService.isSwapSupported(chainId)
+      } else {
+        isSwapSupported = false
+      }
     }
   }
 }


### PR DESCRIPTION

This pull request fixes #5827

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. make sure you dont have a solana account
2. go to wallet make sure you are on a network that support swap (e.x ETH)
3. create your first solana account
4. after you create solana account check if swap is still available 

Note: For verifying this on a local build please make sure you are on top of `release` branch.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
