### PR TITLE
Fix #5834: Restoring wallet on Solana network retains Solana as selected network

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -237,6 +237,8 @@ public class KeyringStore: ObservableObject {
         self.updateKeyringInfo()
         self.resetKeychainStoredPassword()
       }
+      self.walletService.setSelectedCoin(.eth)
+      self.rpcService.setNetwork(BraveWallet.MainnetChainId, coin: .eth, completion: { _ in })
       Domain.clearAllEthereumPermissions()
       completion?(isMnemonicValid)
     }


### PR DESCRIPTION
## Summary of Changes
- Fixed by setting the selected coin type back to ethereum when the wallet is restored.

This pull request fixes #5834

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Select Solana as your selected network in the wallet
2. Lock the wallet
3. Tap restore and restore your wallet
4. Verify selected network shows as Ethereum after wallet is restored


## Screenshots:


https://user-images.githubusercontent.com/5314553/184145750-a3033021-b6ca-42d5-abbf-cac8fc6217f9.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
