### PR TITLE
Fix #5835: Fix wallet crash caused by same coinGeckoId

### DIFF
--- a/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -112,7 +112,7 @@ class AccountActivityStore: ObservableObject {
     // update assets with balance
     for tokenBalance in tokenBalances {
       if let value = tokenBalance.balance, let index = updatedAssets.firstIndex(where: {
-        $0.token.symbol.caseInsensitiveCompare(tokenBalance.token.symbol) == .orderedSame
+        $0.token.assetBalanceId.caseInsensitiveCompare(tokenBalance.token.assetBalanceId) == .orderedSame
       }) {
         updatedAssets[index].decimalBalance = value
       }

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -213,7 +213,7 @@ public class PortfolioStore: ObservableObject {
   @MainActor func fetchPriceHistory(
     for priceIds: [String]
   ) async -> [String: [BraveWallet.AssetTimePrice]] {
-    let uniquePriceIds = Array(Set(priceIds))
+    let uniquePriceIds = Set(priceIds)
     let priceHistories = await withTaskGroup(of: [String: [BraveWallet.AssetTimePrice]].self) { @MainActor group -> [String: [BraveWallet.AssetTimePrice]] in
       for priceId in uniquePriceIds {
         let priceId = priceId.lowercased()

--- a/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -123,7 +123,7 @@ public class PortfolioStore: ObservableObject {
       let balances = await fetchBalances(for: userAssets, accounts: keyring.accountInfos)
       guard !Task.isCancelled else { return } // limit network request(s) if cancelled
       let nonZeroBalanceTokens = balances.filter { $1 > 0 }.map { $0.key }
-      let nonZeroBalanceTokensPriceIds = userAssets.filter({ nonZeroBalanceTokens.contains($0.symbol.lowercased())}).map { $0.assetRatioId }
+      let nonZeroBalanceTokensPriceIds = userAssets.filter({ nonZeroBalanceTokens.contains($0.assetBalanceId.lowercased())}).map { $0.assetRatioId }
       let priceHistories = await fetchPriceHistory(for: nonZeroBalanceTokensPriceIds)
       guard !Task.isCancelled else { return } // limit network request(s) if cancelled
       let visibleTokens = userAssets.filter(\.visible).map { $0.assetRatioId.lowercased() }
@@ -134,11 +134,11 @@ public class PortfolioStore: ObservableObject {
       
       // build our userVisibleAssets
       userVisibleAssets = userAssets.map { token in
-        let symbol = token.symbol.lowercased()
+        let balanceId = token.assetBalanceId.lowercased()
         let priceId = token.assetRatioId.lowercased()
         return AssetViewModel(
           token: token,
-          decimalBalance: balances[symbol] ?? 0.0,
+          decimalBalance: balances[balanceId] ?? 0.0,
           price: prices[priceId] ?? "",
           history: priceHistories[priceId] ?? []
         )
@@ -182,8 +182,8 @@ public class PortfolioStore: ObservableObject {
             guard let balance = await self.rpcService.balance(for: token, in: account) else {
               return [:]
             }
-            let symbol = token.symbol.lowercased()
-            return [symbol: balance]
+            let balanceId = token.assetBalanceId.lowercased()
+            return [balanceId: balance]
           }
         }
       }
@@ -213,8 +213,9 @@ public class PortfolioStore: ObservableObject {
   @MainActor func fetchPriceHistory(
     for priceIds: [String]
   ) async -> [String: [BraveWallet.AssetTimePrice]] {
+    let uniquePriceIds = Array(Set(priceIds))
     let priceHistories = await withTaskGroup(of: [String: [BraveWallet.AssetTimePrice]].self) { @MainActor group -> [String: [BraveWallet.AssetTimePrice]] in
-      for priceId in priceIds {
+      for priceId in uniquePriceIds {
         let priceId = priceId.lowercased()
         group.addTask { @MainActor in
           let (success, history) = await self.assetRatioService.priceHistory(

--- a/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
+++ b/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
@@ -16,7 +16,9 @@ extension BraveWalletAssetRatioService {
     toAssets: [String],
     timeframe: BraveWallet.AssetPriceTimeframe
   ) async -> PricesResult {
-    let (success, prices) = await self.price(fromAssets, toAssets: toAssets, timeframe: timeframe)
+    // make sure there is no duplicate priceId
+    let uniquePriceIds = Array(Set(fromAssets))
+    let (success, prices) = await self.price(uniquePriceIds, toAssets: toAssets, timeframe: timeframe)
     guard success else {
       return await self.priceIndividually(fromAssets, toAssets: toAssets, timeframe: timeframe)
     }
@@ -29,8 +31,10 @@ extension BraveWalletAssetRatioService {
     toAssets: [String],
     timeframe: BraveWallet.AssetPriceTimeframe
   ) async -> PricesResult {
-    await withTaskGroup(of: PricesResult.self) { @MainActor group -> PricesResult in
-      fromAssets.forEach { asset in
+    // make sure there is no duplicate priceId
+    let uniquePriceIds = Array(Set(fromAssets))
+    return await withTaskGroup(of: PricesResult.self) { @MainActor group -> PricesResult in
+      uniquePriceIds.forEach { asset in
         group.addTask { @MainActor in
           let (success, prices) = await self.price([asset], toAssets: toAssets, timeframe: timeframe)
           return PricesResult(prices, success ? 0 : 1)
@@ -52,7 +56,9 @@ extension BraveWalletAssetRatioService {
     timeframe: BraveWallet.AssetPriceTimeframe,
     completion: @escaping (PricesResult) -> Void
   ) {
-    price(fromAssets, toAssets: toAssets, timeframe: timeframe) { [self] success, prices in
+    // make sure there is no duplicate priceId
+    let uniquePriceIds = Array(Set(fromAssets))
+    price(uniquePriceIds, toAssets: toAssets, timeframe: timeframe) { [self] success, prices in
       guard success else {
         self.priceIndividually(fromAssets, toAssets: toAssets, timeframe: timeframe, completion: completion)
         return
@@ -68,9 +74,11 @@ extension BraveWalletAssetRatioService {
     timeframe: BraveWallet.AssetPriceTimeframe,
     completion: @escaping (PricesResult) -> Void
   ) {
+    // make sure there is no duplicate priceId
+    let uniquePriceIds = Array(Set(fromAssets))
     var pricesResults: [PricesResult] = []
     let dispatchGroup = DispatchGroup()
-    fromAssets.forEach { asset in
+    uniquePriceIds.forEach { asset in
       dispatchGroup.enter()
       self.price([asset], toAssets: toAssets, timeframe: timeframe) { success, prices in
         defer { dispatchGroup.leave() }

--- a/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
+++ b/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
@@ -32,7 +32,7 @@ extension BraveWalletAssetRatioService {
     timeframe: BraveWallet.AssetPriceTimeframe
   ) async -> PricesResult {
     // make sure there is no duplicate priceId
-    let uniquePriceIds = Array(Set(fromAssets))
+    let uniquePriceIds = Set(fromAssets)
     return await withTaskGroup(of: PricesResult.self) { @MainActor group -> PricesResult in
       uniquePriceIds.forEach { asset in
         group.addTask { @MainActor in
@@ -75,7 +75,7 @@ extension BraveWalletAssetRatioService {
     completion: @escaping (PricesResult) -> Void
   ) {
     // make sure there is no duplicate priceId
-    let uniquePriceIds = Array(Set(fromAssets))
+    let uniquePriceIds = Set(fromAssets)
     var pricesResults: [PricesResult] = []
     let dispatchGroup = DispatchGroup()
     uniquePriceIds.forEach { asset in

--- a/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -222,4 +222,9 @@ extension BraveWallet.BlockchainToken {
     
     return contractAddress
   }
+  
+  /// The id to map with the return balance from RPCService
+  var assetBalanceId: String {
+    "\(contractAddress)+\(symbol)"
+  }
 }

--- a/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -91,7 +91,7 @@ extension BraveWallet.SignMessageRequest {
 
 extension BraveWallet.BlockchainToken: Identifiable {
   public var id: String {
-    symbol.lowercased()
+    contractAddress.lowercased()
   }
 
   public func contractAddress(in network: BraveWallet.NetworkInfo) -> String {

--- a/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -43,7 +43,7 @@ extension BraveWalletJsonRpcService {
           }
         )
       case .sol:
-        if token.symbol == network.nativeToken.symbol {
+        if network.isNativeAsset(token) {
           solanaBalance(account.address, chainId: network.chainId) { lamports, status, errorMessage in
             guard status == .success else {
               completion(nil)
@@ -142,7 +142,7 @@ extension BraveWalletJsonRpcService {
           }
         )
       case .sol:
-        if token.symbol == network.nativeToken.symbol {
+        if network.isNativeAsset(token) {
           solanaBalance(accountAddress, chainId: network.chainId) { lamports, status, errorMessage in
             guard status == .success else {
               completion(nil)

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -273,7 +273,7 @@ class SendTokenStoreTests: XCTestCase {
     rpcService._addObserver = { _ in }
     
     let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { $2([.previewToken]) }
+    walletService._userAssets = { $2([.mockSolToken]) }
     walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
     
     let keyringService = BraveWallet.TestKeyringService()
@@ -310,18 +310,16 @@ class SendTokenStoreTests: XCTestCase {
   }
   
   func testSolSendTokenProgramTransfer() {
-    let mockBalance = 47
-    
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockSolana.chainId) }
     rpcService._network = { $1(BraveWallet.NetworkInfo.mockSolana)}
-    rpcService._solanaBalance = { _, _ , completion in
-      completion(UInt64(mockBalance), .success, "")
+    rpcService._splTokenAccountBalance = {_, _, _, completion in
+      completion("1000000", UInt8(6), "1", .success, "")
     }
     rpcService._addObserver = { _ in }
     
     let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { $2([.previewToken]) }
+    walletService._userAssets = { $2([.mockSpdToken]) }
     walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
     
     let keyringService = BraveWallet.TestKeyringService()


### PR DESCRIPTION
## Summary of Changes
fix duplicate id for fetching price and price history. set up balance mapping with unique id

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5835 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. create a solana account
2. add two or more tokens that have the same coinGeckoId (bat portal and bat wormhole) to your visible assets
3. observe if crash happens 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
