### PR TITLE
Fix #5843, #5844: Wallet dapps show empty modal, account not selected after creating first account

### DIFF
--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -381,10 +381,10 @@ extension KeyringStore: BraveWalletKeyringServiceObserver {
         break
       }
       
-      if selectedAccount.coin.keyringId != keyringId {
+      let newKeyring = await keyringService.keyringInfo(keyringId)
+      if let newAccount = newKeyring.accountInfos.first {
         walletService.setSelectedCoin(coin)
-        let network = await rpcService.network(coin)
-        await rpcService.setNetwork(network.chainId, coin: network.coin)
+        await keyringService.setSelectedAccount(newAccount.address, coin: newAccount.coin)
       }
       updateKeyringInfo()
     }

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -155,6 +155,10 @@ public class KeyringStore: ObservableObject {
         if self.selectedAccount.address != selectedAccountAddress {
           if let selectedAccount = selectedAccountKeyring.accountInfos.first(where: { $0.address == selectedAccountAddress }) {
             self.selectedAccount = selectedAccount
+          } else if let firstAccount = selectedAccountKeyring.accountInfos.first {
+            // try and correct invalid state (no selected account for this coin type)
+            self.selectedAccount = firstAccount
+            await self.keyringService.setSelectedAccount(firstAccount.address, coin: firstAccount.coin)
           } // else selected account address does not exist in keyring (should not occur...)
         } // else `self.selectedAccount` is already the currently selected account
       } // else keyring for selected coin is unavailable (should not occur...)

--- a/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -158,7 +158,6 @@ public class KeyringStore: ObservableObject {
           } else if let firstAccount = selectedAccountKeyring.accountInfos.first {
             // try and correct invalid state (no selected account for this coin type)
             self.selectedAccount = firstAccount
-            await self.keyringService.setSelectedAccount(firstAccount.address, coin: firstAccount.coin)
           } // else selected account address does not exist in keyring (should not occur...)
         } // else `self.selectedAccount` is already the currently selected account
       } // else keyring for selected coin is unavailable (should not occur...)

--- a/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -55,11 +55,7 @@ public class NetworkStore: ObservableObject {
       // we don't need to call `setNetwork` on JsonRpcService
       self.selectedChainId = chain.chainId
       // update `isSwapSupported` for Buy/Send/Swap panel
-      if chain.coin == .eth {
-        self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
-      } else {
-        self.isSwapSupported = false
-      }
+      self.isSwapSupported = await swapService.isiOSSwapSupported(chainId: chain.chainId, coin: selectedCoin)
     }
   }
 
@@ -108,6 +104,7 @@ public class NetworkStore: ObservableObject {
       } else {
         let rpcServiceNetwork = await rpcService.network(network.coin)
         guard rpcServiceNetwork.chainId != network.chainId else {
+          self.isSwapSupported = await swapService.isiOSSwapSupported(chainId: network.chainId, coin: selectedCoin)
           return .chainAlreadySelected
         }
         let success = await rpcService.setNetwork(network.chainId, coin: network.coin)
@@ -209,11 +206,7 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
       // we don't need to call `setNetwork` on JsonRpcService
       selectedChainId = chainId
       
-      if coin == .eth {
-        isSwapSupported = await swapService.isSwapSupported(chainId)
-      } else {
-        isSwapSupported = false
-      }
+      isSwapSupported = await swapService.isiOSSwapSupported(chainId: chainId, coin: coin)
     }
   }
 }

--- a/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -744,12 +744,7 @@ extension SwapTokenStore: BraveWalletKeyringServiceObserver {
   public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
     Task { @MainActor in
       let network = await rpcService.network(coinType)
-      let isSwapSupported: Bool
-      if coinType == .eth {
-        isSwapSupported = await swapService.isSwapSupported(network.chainId)
-      } else {
-        isSwapSupported = false
-      }
+      let isSwapSupported = await swapService.isiOSSwapSupported(chainId: network.chainId, coin: coinType)
       guard isSwapSupported else { return }
       
       let keyringInfo = await keyringService.keyringInfo(coinType.keyringId)
@@ -767,12 +762,7 @@ extension SwapTokenStore: BraveWalletKeyringServiceObserver {
 extension SwapTokenStore: BraveWalletJsonRpcServiceObserver {
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
     Task { @MainActor in
-      let isSwapSupported: Bool
-      if coin == .eth {
-        isSwapSupported = await swapService.isSwapSupported(chainId)
-      } else {
-        isSwapSupported = false
-      }
+      let isSwapSupported = await swapService.isiOSSwapSupported(chainId: chainId, coin: coin)
       guard isSwapSupported, let accountInfo = accountInfo else { return }
       selectedFromToken = nil
       selectedToToken = nil

--- a/BraveWallet/Extensions/SwapServiceExtension.swift
+++ b/BraveWallet/Extensions/SwapServiceExtension.swift
@@ -1,0 +1,19 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+
+extension BraveWalletSwapService {
+  /// Helper function to determine if we support swaping for a given chainId & coin type
+  /// Swap may be supported by `swapService` prior to being supported on iOS.
+  func isiOSSwapSupported(chainId: String, coin: BraveWallet.CoinType) async -> Bool {
+    if coin == .eth {
+      return await isSwapSupported(chainId)
+    } else {
+      return false
+    }
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- When a new keyring is created, call `setSelectedAccount` on the account in that keyring
- Additionally, protect against having no selected account for a coin type by selecting the first account if this situation occurs.
- #5844 was caused by this bug. When switching networks in the panel, the `selectedAccount` returned from keyring service was nil because we did not select any account after creating the keyring.

This pull request fixes #5843, #5844.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Reset your wallet
2. Setup a new wallet
3. Open buy/send/swap. 
4. Verify Ethereum account shows as selected account in the top left.
5. Close buy/send/swap.
6. Switch to Solana network, create an account when prompted.
7. Open buy/send/swap. 
8. Verify Solana account shows as selected account in the top left
9. Close buy/send/swap, then close wallet
10. Open to `app.1inch.io`
11. Connect your wallet
12. Verify blank modal does not appear


## Screenshots:

https://user-images.githubusercontent.com/5314553/184379195-dee97ce1-14a1-4098-b5b0-ef137041f1de.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
