### PR TITLE
Fix #5849: Fix for playlist showing ads in videos

### DIFF
--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -664,7 +664,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
         let domainForShields = Domain.getOrCreate(forUrl: mainDocumentURL, persistent: false)
 
         // Force adblocking on
-        domainForShields.shield_allOff = 1
+        domainForShields.shield_allOff = 0
         domainForShields.shield_adblockAndTp = true
 
         let (on, off) = BlocklistName.blocklists(forDomain: domainForShields)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Enable all shields for playlist and not just adblock shields

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5849

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
