### PR TITLE
Fix #5841: Dismiss network picker modal after creating an account for new network

### DIFF
--- a/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -114,7 +114,9 @@ struct NetworkSelectionView: View {
           .navigationViewStyle(.stack)
           .onDisappear {
             Task { @MainActor in
-              await store.handleDismissAddAccount()
+              if await store.handleDismissAddAccount() {
+                presentationMode.dismiss()
+              }
             }
           }
         }

--- a/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
+++ b/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
@@ -116,10 +116,12 @@ class NetworkSelectionStore: ObservableObject {
     }
   }
   
-  @MainActor func handleDismissAddAccount() async {
-    guard let nextNetwork = nextNetwork else { return }
+  /// Should be called after dismissing create account. Returns true if an account was created and we switched networks.
+  @MainActor func handleDismissAddAccount() async -> Bool {
+    guard let nextNetwork = nextNetwork else { return false }
     // if it errors it's due to no accounts and we don't want to switch to nextNetwork
-    await networkStore.setSelectedChain(nextNetwork)
+    let result = await networkStore.setSelectedChain(nextNetwork)
     self.nextNetwork = nil
+    return result != .selectedChainHasNoAccounts
   }
 }


### PR DESCRIPTION
## Summary of Changes
- When switching to a network that the user does not have any accounts for, the user is prompted to create an account. After creating the account for that network, we now dismiss the network picker.
- Added unit tests to `NetworkStoreTests` for the `handleDismissAddAccount()` function.

This pull request fixes #5841

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Setup a new wallet / use a wallet without a Solana account
2. Open network picker and select Solana
3. Tap 'Yes' on the alert to create an account
4. Tap 'Add' on the modal to create the account
5. Verify network picker modal is dismissed

## Screenshots:

https://user-images.githubusercontent.com/5314553/184403509-a71d5439-c5f2-46c8-879c-3d38cd9bc32d.mp4


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
