### PR TITLE
Fix #5858: fix logic that determines correct visible screen state.

### DIFF
--- a/BraveWallet/Panels/WalletPanelView.swift
+++ b/BraveWallet/Panels/WalletPanelView.swift
@@ -35,13 +35,20 @@ public struct WalletPanelContainerView: View {
 
   private var visibleScreen: VisibleScreen {
     let keyring = keyringStore.defaultKeyring
-    if keyringStore.defaultKeyring.id.isEmpty || keyringStore.selectedAccount.address.isEmpty {
+    // check if we are still fetching the `defaultKeyring`
+    if keyringStore.defaultKeyring.id.isEmpty {
       return .loading
     }
+    // keyring fetched, check if user has created a wallet
     if !keyring.isKeyringCreated || keyringStore.isOnboardingVisible {
       return .onboarding
     }
-    if keyring.isLocked || keyringStore.isRestoreFromUnlockBiometricsPromptVisible {
+    // keyring fetched & wallet setup, but selected account not fetched
+    if keyringStore.selectedAccount.address.isEmpty {
+      return .loading
+    }
+    // keyring fetched & wallet setup, wallet is locked
+    if keyring.isLocked || keyringStore.isRestoreFromUnlockBiometricsPromptVisible { // wallet is locked
       return .unlock
     }
     return .panel


### PR DESCRIPTION

This pull request fixes #5858

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Please refer to the issue


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
