### PR TITLE
Fix #5861: Broken header in add account screen iOS14

### DIFF
--- a/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -77,6 +77,7 @@ struct AddAccountView: View {
       }
       privateKeySection
     }
+    .listStyle(InsetGroupedListStyle())
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.addAccountTitle)
     .navigationBarItems(


### PR DESCRIPTION
This pull request fixes #5861

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
please refer to the issue.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
