### PR TITLE
Fix #5860: Add `window.caches` blocking when cookie blocking is enabled

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/CookieControl.js
+++ b/Client/Frontend/UserContent/UserScripts/CookieControl.js
@@ -39,3 +39,24 @@ if (Object.getOwnPropertyDescriptor(window, 'sessionStorage')) {
         },
     });
 }
+
+(() => {
+  // Access to caches should be denied when user has blocked all Cookies.
+  const makeFailingPromiseFunction = () => {
+    return function () {
+      return Promise.reject(
+        new DOMException('An attempt was made to break through the security policy of the user agent.')
+      )
+    }
+  }
+
+  // We need to check that window.caches is defined as this API was only added in iOS 15
+  // Later on we can probably remove this check.
+  if (window.caches !== undefined) {
+    window.CacheStorage.prototype.match = makeFailingPromiseFunction()
+    window.CacheStorage.prototype.has = makeFailingPromiseFunction()
+    window.CacheStorage.prototype.delete = makeFailingPromiseFunction()
+    window.CacheStorage.prototype.open = makeFailingPromiseFunction()
+    window.CacheStorage.prototype.keys = makeFailingPromiseFunction()
+  }
+})()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Block `window.caches` API when cookie blocking is enabled

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5860 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
You may use the the following test page: https://dev-pages.brave.software/storage/dom-storage.html
Note when cookie blocking is enabled, all frames should show "false"

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
