### PR TITLE
Fix #5863: Ensure the tab tray search bar fills the space on iOS 16

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -505,6 +505,7 @@ class TabTraySearchBar: UIView {
     self.searchBar = searchBar
     super.init(frame: .zero)
     addSubview(searchBar)
+    translatesAutoresizingMaskIntoConstraints = false
   }
 
   @available(*, unavailable)
@@ -528,10 +529,8 @@ class TabTraySearchBar: UIView {
     
     searchBar.frame = adjustedFrame
   }
-
-  override func sizeThatFits(_ size: CGSize) -> CGSize {
-    // This is done to adjust the frame of a UISearchBar inside of UISearchController
-    // Adjusting the bar frame directly doesnt work so had to create a custom view with UISearchBar
-    .init(width: size.width + 16, height: size.height)
+  
+  override var intrinsicContentSize: CGSize {
+    return UIView.layoutFittingExpandedSize
   }
 }


### PR DESCRIPTION
Unfortunately due to toolbar changes in iOS 16, it is no longer possible to make the bar have less horizontal padding, but on iOS 15 this solution still works the same as the prior one.

## Summary of Changes

This pull request fixes #5863

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

| iOS 15 | iOS 16 | 
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/529104/184672242-40c2b1b7-7a09-4ebf-9f68-d90819b99a17.png) | ![image](https://user-images.githubusercontent.com/529104/184672313-e8800aee-b971-4856-ba4f-9f7a496748a3.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
