### PR TITLE
Fix #5262: Search string is not updated if cursor is not at the end

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -81,7 +81,7 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
       0.1,
       action: {
         if self.isEditing {
-          self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.normalizeString(self.text ?? ""))
+          self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.text?.preferredSearchSuggestionText ?? "")
         }
       })
 
@@ -93,7 +93,7 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
           if text?.isEmpty == true && self.autocompleteTextLabel?.text?.isEmpty == false {
             text = self.autocompleteTextLabel?.text
           }
-          self.autocompleteDelegate?.autocompleteTextField(self, didDeleteAutoSelectedText: self.normalizeString(text ?? ""))
+          self.autocompleteDelegate?.autocompleteTextField(self, didDeleteAutoSelectedText: text?.preferredSearchSuggestionText ?? "")
         }
       })
   }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -280,13 +280,15 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
     hideCursor = autocompleteTextLabel != nil
     removeCompletion()
 
-    let isAtEnd = selectedTextRange?.start == endOfDocument
     let isKeyboardReplacingText = lastReplacement != nil
-    if isKeyboardReplacingText, isAtEnd, markedTextRange == nil {
-      notifyTextChanged?()
-    } else {
+    let noMarkedText = markedTextRange == nil // Should not add typed text before marked text is confirmed by user
+
+    guard isKeyboardReplacingText, noMarkedText  else {
       hideCursor = false
+      return
     }
+    
+    notifyTextChanged?()
   }
 
   // Reset the cursor to the end of the text field.

--- a/Sources/BraveShared/Extensions/StringExtensions.swift
+++ b/Sources/BraveShared/Extensions/StringExtensions.swift
@@ -33,4 +33,9 @@ extension String {
   public func toBase64() -> String {
     return Data(self.utf8).base64EncodedString()
   }
+  
+  /// Trim trailing and leading white space and new line characters to fetch better search suggestion text
+  public var preferredSearchSuggestionText: String {
+    return self.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+  }
 }

--- a/Tests/ClientTests/StringExtensionsTests.swift
+++ b/Tests/ClientTests/StringExtensionsTests.swift
@@ -13,6 +13,13 @@ class StringExtensionsTests: XCTestCase {
     XCTAssertEqual("foo456", "123foo456".stringByTrimmingLeadingCharactersInSet(.decimalDigits))
     XCTAssertEqual("", "123456".stringByTrimmingLeadingCharactersInSet(.decimalDigits))
   }
+  
+  func testPreferredSearchSuggestionText() {
+    XCTAssertEqual("brave", "   brave   ".preferredSearchSuggestionText)
+    XCTAssertEqual("bravesearch123", "bravesearch123".preferredSearchSuggestionText)
+    XCTAssertEqual("brave", "    brave".preferredSearchSuggestionText)
+    XCTAssertEqual("brave search talk- engine", "brave search talk- engine ".preferredSearchSuggestionText)
+  }
 
   func testPercentEscaping() {
     func roundtripTest(_ input: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
The criteria related with search text update is changed and also while submitting search suggestion trimming whitespaces is added to trailing and leading.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5262

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Type a string within the omnibox.
- Move the cursor back within the string.
- Type additional characters.


## Screenshots:


https://user-images.githubusercontent.com/6643505/184678797-9d3c0970-d07a-46b2-8490-0849a6c4f8e0.MP4




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
