### PR TITLE
Fix #5874: Re-add widget intentdefinition to main iOS app target

### DIFF
--- a/App/BraveWidgets/ShortcutsWidget.swift
+++ b/App/BraveWidgets/ShortcutsWidget.swift
@@ -146,13 +146,13 @@ private extension WidgetShortcut {
     case .newPrivateTab:
       return shortcutsImage(with: "brave.shades")
     case .bookmarks:
-      return Image(uiImage: UIImage(named: "menu_bookmarks")!)
+      return Image(uiImage: UIImage(named: "menu_bookmarks")!.template)
     case .history:
-      return Image(uiImage: UIImage(named: "brave.history")!)
+      return Image(uiImage: UIImage(named: "brave.history")!.template)
     case .downloads:
-      return Image(uiImage: UIImage(named: "brave.downloads")!)
+      return Image(uiImage: UIImage(named: "brave.downloads")!.template)
     case .playlist:
-      return Image(uiImage: UIImage(named: "brave.playlist")!)
+      return Image(uiImage: UIImage(named: "brave.playlist")!.template)
     @unknown default:
       assertionFailure()
       return Image(systemName: "xmark.octagon")

--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		27AD20C426851C5400889AA7 /* BraveCore.xcframework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 27AD20C226851C5400889AA7 /* BraveCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		27B68DF025C48F39002D0826 /* MaterialComponents.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; };
 		27B68DF125C48F39002D0826 /* MaterialComponents.xcframework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 27B68DD625C48EE9002D0826 /* MaterialComponents.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		27BEDCCC28AD37CE0073425E /* BraveWidgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = CA0391E5271E1382000EB13C /* BraveWidgets.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		27D6761A282DA10700BCE16E /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 27D67619282DA10700BCE16E /* Icons.xcassets */; };
 		27D67623282DAD3700BCE16E /* BrowserIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 27D67621282DAD3700BCE16E /* BrowserIntents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		27F4439F2135E11200296C58 /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 27F443952135E11200296C58 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -1018,6 +1019,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
+				27BEDCCC28AD37CE0073425E /* BraveWidgets.intentdefinition in Sources */,
 				CAADEFE026E2707F0020DC4C /* SceneDelegate.swift in Sources */,
 				CAAE653D287C9FCF00FA44A3 /* CPTemplateApplicationSceneDelegate.swift in Sources */,
 			);


### PR DESCRIPTION
Also fixes up icon colours in dark mode

## Summary of Changes

This pull request fixes #5874 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

| Shortcuts | Single Stat |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-17 at 10 58 05](https://user-images.githubusercontent.com/529104/185173177-2499c3d0-920b-47e7-9a58-3c6e2710103d.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-17 at 11 02 10](https://user-images.githubusercontent.com/529104/185173998-150f5ed1-af8f-449d-8f43-da7402dc6a3b.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
