### PR TITLE
Fix #4891: Can't dismiss/slide down the Quick Search settings menu

### DIFF
--- a/Client/Frontend/Settings/SearchQuickEnginesViewController.swift
+++ b/Client/Frontend/Settings/SearchQuickEnginesViewController.swift
@@ -49,7 +49,6 @@ class SearchQuickEnginesViewController: UITableViewController {
     navigationItem.title = Strings.quickSearchEngines
 
     tableView.do {
-      $0.isEditing = true
       $0.registerHeaderFooter(SettingsTableSectionHeaderFooterView.self)
       $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickSearchEngineRowIdentifier)
       #if swift(>=5.5)
@@ -58,6 +57,8 @@ class SearchQuickEnginesViewController: UITableViewController {
       }
       #endif
     }
+
+    navigationItem.rightBarButtonItem = editButtonItem
 
     let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: UX.headerHeight))
     tableView.tableFooterView = footer
@@ -99,7 +100,7 @@ class SearchQuickEnginesViewController: UITableViewController {
 
     let searchEngineCell = tableView.dequeueReusableCell(withIdentifier: Constants.quickSearchEngineRowIdentifier, for: indexPath).then {
       $0.showsReorderControl = true
-      $0.editingAccessoryView = toggle
+      $0.accessoryView = toggle
       $0.selectionStyle = .none
       $0.separatorInset = .zero
       $0.textLabel?.text = engine?.displayName
@@ -116,10 +117,6 @@ class SearchQuickEnginesViewController: UITableViewController {
 
   override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
     return UX.headerHeight
-  }
-
-  override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-    return true
   }
 
   override func tableView(_ tableView: UITableView, moveRowAt indexPath: IndexPath, to newIndexPath: IndexPath) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

The Quick Search Engines screen is always in edit mode which is not a right way using edit mode in tableview. The activation switch-toggle is place as an accessory view now and edit bar button is added in order to enable edit mode which will show ordering.

This also will provide swipe to bottom functionality on the screen when edit mode is disabled.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4891

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Install/launch Brave (doesn't matter which version as this is currently in the release)
- Go into Settings -> Search Engines -> Quick-Search Engines
- Attempt to dismiss the settings page by sliding the modal/page down 


## Screenshots:

https://user-images.githubusercontent.com/6643505/185219147-6f214a62-3fde-4659-a7bd-a0959bb6f07e.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
