### PR TITLE
Fix #5878: Wallet section headers background when built with Xcode 14

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -32,8 +32,8 @@ struct AccountListView: View {
               }
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .listStyle(InsetGroupedListStyle())
       .navigationTitle(Strings.Wallet.selectAccountTitle)

--- a/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
@@ -29,31 +29,33 @@ struct AccountTransactionListView: View {
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
       ) {
-        if activityStore.transactionSummaries.isEmpty {
-          emptyTextView(Strings.Wallet.noTransactions)
-        } else {
-          ForEach(activityStore.transactionSummaries) { txSummary in
-            Button(action: {
-              self.transactionDetails = activityStore.transactionDetailsStore(for: txSummary.txInfo)
-            }) {
-              TransactionSummaryView(summary: txSummary)
-            }
-            .contextMenu {
-              if !txSummary.txHash.isEmpty {
-                Button(action: {
-                  if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
-                     let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                    openWalletURL?(url)
+        Group {
+          if activityStore.transactionSummaries.isEmpty {
+            emptyTextView(Strings.Wallet.noTransactions)
+          } else {
+            ForEach(activityStore.transactionSummaries) { txSummary in
+              Button(action: {
+                self.transactionDetails = activityStore.transactionDetailsStore(for: txSummary.txInfo)
+              }) {
+                TransactionSummaryView(summary: txSummary)
+              }
+              .contextMenu {
+                if !txSummary.txHash.isEmpty {
+                  Button(action: {
+                    if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+                       let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
+                      openWalletURL?(url)
+                    }
+                  }) {
+                    Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
                   }
-                }) {
-                  Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
                 }
               }
             }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
     .navigationTitle(Strings.Wallet.transactionsTitle)

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -48,34 +48,36 @@ struct AccountsView: View {
             }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(
           title: Text(Strings.Wallet.secondaryCryptoAccountsTitle),
           subtitle: Text(Strings.Wallet.secondaryCryptoAccountsSubtitle)
         )
       ) {
-        let accounts = secondaryAccounts
-        if accounts.isEmpty {
-          Text(Strings.Wallet.noSecondaryAccounts)
-            .foregroundColor(Color(.secondaryBraveLabel))
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
-            .font(.footnote.weight(.medium))
-        } else {
-          ForEach(accounts) { account in
-            Button {
-              selectedAccount = account
-            } label: {
-              AddressView(address: account.address) {
-                AccountView(address: account.address, name: account.name)
+        Group {
+          let accounts = secondaryAccounts
+          if accounts.isEmpty {
+            Text(Strings.Wallet.noSecondaryAccounts)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .multilineTextAlignment(.center)
+              .frame(maxWidth: .infinity)
+              .font(.footnote.weight(.medium))
+          } else {
+            ForEach(accounts) { account in
+              Button {
+                selectedAccount = account
+              } label: {
+                AddressView(address: account.address) {
+                  AccountView(address: account.address, name: account.name)
+                }
               }
             }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .background(
       NavigationLink(

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -58,49 +58,53 @@ struct AccountActivityView: View {
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.assetsTitle))
       ) {
-        if activityStore.assets.isEmpty {
-          emptyTextView(Strings.Wallet.noAssets)
-        } else {
-          ForEach(activityStore.assets) { asset in
-            PortfolioAssetView(
-              image: AssetIconView(token: asset.token, network: networkStore.selectedChain),
-              title: asset.token.name,
-              symbol: asset.token.symbol,
-              amount: activityStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
-              quantity: String(format: "%.04f", asset.decimalBalance)
-            )
+        Group {
+          if activityStore.assets.isEmpty {
+            emptyTextView(Strings.Wallet.noAssets)
+          } else {
+            ForEach(activityStore.assets) { asset in
+              PortfolioAssetView(
+                image: AssetIconView(token: asset.token, network: networkStore.selectedChain),
+                title: asset.token.name,
+                symbol: asset.token.symbol,
+                amount: activityStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
+                quantity: String(format: "%.04f", asset.decimalBalance)
+              )
+            }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
       ) {
-        if activityStore.transactionSummaries.isEmpty {
-          emptyTextView(Strings.Wallet.noTransactions)
-        } else {
-          ForEach(activityStore.transactionSummaries) { txSummary in
-            Button(action: {
-              self.transactionDetails = activityStore.transactionDetailsStore(for: txSummary.txInfo)
-            }) {
-              TransactionSummaryView(summary: txSummary)
-            }
-            .contextMenu {
-              if !txSummary.txHash.isEmpty {
-                Button(action: {
-                  if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
-                     let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                    openWalletURL?(url)
+        Group {
+          if activityStore.transactionSummaries.isEmpty {
+            emptyTextView(Strings.Wallet.noTransactions)
+          } else {
+            ForEach(activityStore.transactionSummaries) { txSummary in
+              Button(action: {
+                self.transactionDetails = activityStore.transactionDetailsStore(for: txSummary.txInfo)
+              }) {
+                TransactionSummaryView(summary: txSummary)
+              }
+              .contextMenu {
+                if !txSummary.txHash.isEmpty {
+                  Button(action: {
+                    if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+                       let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
+                      openWalletURL?(url)
+                    }
+                  }) {
+                    Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
                   }
-                }) {
-                  Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
                 }
               }
             }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
     .background(

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -209,8 +209,8 @@ struct AddAccountView: View {
       )
     ) {
       SecureField(Strings.Wallet.passwordPlaceholder, text: $originPassword)
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
   }
   
   private var isJsonImportSupported: Bool {
@@ -226,41 +226,43 @@ struct AddAccountView: View {
           .foregroundColor(Color(.bravePrimary))
       )
     ) {
-      TextEditor(text: $privateKey)
-        .autocapitalization(.none)
-        .font(.system(.body, design: .monospaced))
-        .frame(height: privateKeyFieldHeight)
-        .background(
-          Text(isJsonImportSupported ? Strings.Wallet.importAccountPlaceholder : Strings.Wallet.importNonEthAccountPlaceholder)
-            .padding(.vertical, 8)
-            .padding(.horizontal, 4)  // To match the TextEditor's editing insets
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .foregroundColor(Color(.placeholderText))
-            .opacity(privateKey.isEmpty ? 1 : 0)
-            .accessibilityHidden(true),
-          alignment: .top
-        )
-        .introspectTextView { textView in
-          textView.smartQuotesType = .no
-        }
-        .accessibilityValue(privateKey.isEmpty ? Strings.Wallet.importAccountPlaceholder : privateKey)
-      if isJsonImportSupported {
-        Button(action: { isPresentingImport = true }) {
-          HStack {
-            Text(Strings.Wallet.importButtonTitle)
-              .foregroundColor(.accentColor)
-              .font(.callout)
-            if isLoadingFile {
-              ProgressView()
-                .progressViewStyle(CircularProgressViewStyle())
-            }
+      Group {
+        TextEditor(text: $privateKey)
+          .autocapitalization(.none)
+          .font(.system(.body, design: .monospaced))
+          .frame(height: privateKeyFieldHeight)
+          .background(
+            Text(isJsonImportSupported ? Strings.Wallet.importAccountPlaceholder : Strings.Wallet.importNonEthAccountPlaceholder)
+              .padding(.vertical, 8)
+              .padding(.horizontal, 4)  // To match the TextEditor's editing insets
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .foregroundColor(Color(.placeholderText))
+              .opacity(privateKey.isEmpty ? 1 : 0)
+              .accessibilityHidden(true),
+            alignment: .top
+          )
+          .introspectTextView { textView in
+            textView.smartQuotesType = .no
           }
-          .frame(maxWidth: .infinity)
+          .accessibilityValue(privateKey.isEmpty ? Strings.Wallet.importAccountPlaceholder : privateKey)
+        if isJsonImportSupported {
+          Button(action: { isPresentingImport = true }) {
+            HStack {
+              Text(Strings.Wallet.importButtonTitle)
+                .foregroundColor(.accentColor)
+                .font(.callout)
+              if isLoadingFile {
+                ProgressView()
+                  .progressViewStyle(CircularProgressViewStyle())
+              }
+            }
+            .frame(maxWidth: .infinity)
+          }
+          .disabled(isLoadingFile)
         }
-        .disabled(isLoadingFile)
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
   }
   
   private func defaultAccountName(for coin: BraveWallet.CoinType, isPrimary: Bool) -> String {

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -59,14 +59,14 @@ struct AccountDetailsView: View {
                 isFieldFocused = tf.becomeFirstResponder()
               }
             }
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section {
           NavigationLink(destination: AccountPrivateKeyView(keyringStore: keyringStore, account: account)) {
             Text(Strings.Wallet.accountPrivateKey)
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         if account.isImported {
           Section {
             Button(action: { isPresentingRemoveConfirmation = true }) {
@@ -83,8 +83,8 @@ struct AccountDetailsView: View {
                 secondaryButton: .cancel(Text(Strings.no))
               )
             }
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
           }
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
       .listStyle(InsetGroupedListStyle())

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -48,63 +48,67 @@ struct AssetDetailView: View {
         .buttonStyle(BraveOutlineButtonStyle(size: .small))
         .padding(.vertical, 8)
       ) {
-        if assetDetailStore.accounts.isEmpty {
-          Text(Strings.Wallet.noAccounts)
-            .redacted(reason: assetDetailStore.isLoadingAccountBalances ? .placeholder : [])
-            .shimmer(assetDetailStore.isLoadingAccountBalances)
-            .font(.footnote)
-        } else {
-          ForEach(assetDetailStore.accounts) { viewModel in
-            HStack {
-              AddressView(address: viewModel.account.address) {
-                AccountView(address: viewModel.account.address, name: viewModel.account.name)
-              }
-              let showFiatPlaceholder = viewModel.fiatBalance.isEmpty && assetDetailStore.isLoadingPrice
-              let showBalancePlaceholder = viewModel.balance.isEmpty && assetDetailStore.isLoadingAccountBalances
-              VStack(alignment: .trailing) {
-                Text(showFiatPlaceholder ? "$0.00" : viewModel.fiatBalance)
-                  .redacted(reason: showFiatPlaceholder ? .placeholder : [])
-                  .shimmer(assetDetailStore.isLoadingPrice)
-                Text(showBalancePlaceholder ? "0.0000 \(assetDetailStore.token.symbol)" : "\(viewModel.balance) \(assetDetailStore.token.symbol)")
-                  .redacted(reason: showBalancePlaceholder ? .placeholder : [])
-                  .shimmer(assetDetailStore.isLoadingAccountBalances)
-              }
+        Group {
+          if assetDetailStore.accounts.isEmpty {
+            Text(Strings.Wallet.noAccounts)
+              .redacted(reason: assetDetailStore.isLoadingAccountBalances ? .placeholder : [])
+              .shimmer(assetDetailStore.isLoadingAccountBalances)
               .font(.footnote)
-              .foregroundColor(Color(.secondaryBraveLabel))
+          } else {
+            ForEach(assetDetailStore.accounts) { viewModel in
+              HStack {
+                AddressView(address: viewModel.account.address) {
+                  AccountView(address: viewModel.account.address, name: viewModel.account.name)
+                }
+                let showFiatPlaceholder = viewModel.fiatBalance.isEmpty && assetDetailStore.isLoadingPrice
+                let showBalancePlaceholder = viewModel.balance.isEmpty && assetDetailStore.isLoadingAccountBalances
+                VStack(alignment: .trailing) {
+                  Text(showFiatPlaceholder ? "$0.00" : viewModel.fiatBalance)
+                    .redacted(reason: showFiatPlaceholder ? .placeholder : [])
+                    .shimmer(assetDetailStore.isLoadingPrice)
+                  Text(showBalancePlaceholder ? "0.0000 \(assetDetailStore.token.symbol)" : "\(viewModel.balance) \(assetDetailStore.token.symbol)")
+                    .redacted(reason: showBalancePlaceholder ? .placeholder : [])
+                    .shimmer(assetDetailStore.isLoadingAccountBalances)
+                }
+                .font(.footnote)
+                .foregroundColor(Color(.secondaryBraveLabel))
+              }
             }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
       ) {
-        if assetDetailStore.transactionSummaries.isEmpty {
-          Text(Strings.Wallet.noTransactions)
-            .font(.footnote)
-        } else {
-          ForEach(assetDetailStore.transactionSummaries) { txSummary in
-            Button(action: {
-              self.transactionDetails = assetDetailStore.transactionDetailsStore(for: txSummary.txInfo)
-            }) {
-              TransactionSummaryView(summary: txSummary, displayAccountCreator: true)
-            }
-            .contextMenu {
-              if !txSummary.txHash.isEmpty {
-                Button(action: {
-                  if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
-                     let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                    openWalletURL?(url)
+        Group {
+          if assetDetailStore.transactionSummaries.isEmpty {
+            Text(Strings.Wallet.noTransactions)
+              .font(.footnote)
+          } else {
+            ForEach(assetDetailStore.transactionSummaries) { txSummary in
+              Button(action: {
+                self.transactionDetails = assetDetailStore.transactionDetailsStore(for: txSummary.txInfo)
+              }) {
+                TransactionSummaryView(summary: txSummary, displayAccountCreator: true)
+              }
+              .contextMenu {
+                if !txSummary.txHash.isEmpty {
+                  Button(action: {
+                    if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+                       let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
+                      openWalletURL?(url)
+                    }
+                  }) {
+                    Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
                   }
-                }) {
-                  Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")
                 }
               }
             }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section {
         EmptyView()
       } header: {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -62,8 +62,8 @@ struct BuyTokenView: View {
               TextField(String.localizedStringWithFormat(Strings.Wallet.amountInCurrency, "USD"), text: $amountInput)
                 .keyboardType(.decimalPad)
             }
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
           }
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
           Section(
             header: HStack {
               Button(action: {
@@ -87,7 +87,6 @@ struct BuyTokenView: View {
               .listRowBackground(Color(.clear))
           ) {
           }
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
       .navigationTitle(Strings.Wallet.buy)

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -80,8 +80,8 @@ struct SendTokenView: View {
             }
             .padding(.vertical, 8)
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
           header:
             WalletListHeaderView(
@@ -104,8 +104,8 @@ struct SendTokenView: View {
             text: $sendTokenStore.sendAmount
           )
           .keyboardType(.decimalPad)
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoToTitle)),
           footer: Group {
@@ -151,8 +151,8 @@ struct SendTokenView: View {
             }
             .buttonStyle(PlainButtonStyle())
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
           header:
             WalletLoadingButton(
@@ -176,7 +176,6 @@ struct SendTokenView: View {
             .listRowBackground(Color(.clear))
         ) {
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .alert(isPresented: $isShowingError) {
         Alert(

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -246,8 +246,8 @@ struct SwapCryptoView: View {
         }
         .padding(.vertical, 8)
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
     Section(
       header: WalletListHeaderView(
         title: Text(
@@ -284,8 +284,8 @@ struct SwapCryptoView: View {
         text: $swapTokensStore.sellAmount
       )
       .keyboardType(.decimalPad)
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
     Section(
       header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoToTitle))
     ) {
@@ -310,8 +310,8 @@ struct SwapCryptoView: View {
         }
         .padding(.vertical, 8)
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
     Section(
       header: WalletListHeaderView(
         title: Text(
@@ -327,8 +327,8 @@ struct SwapCryptoView: View {
         text: $swapTokensStore.buyAmount
       )
       .keyboardType(.decimalPad)
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
     Section(
       /*
        MVP only supports market price swap. Ref: https://github.com/brave/brave-browser/issues/18307
@@ -383,8 +383,8 @@ struct SwapCryptoView: View {
       .accessibilityLabel(Strings.Wallet.swapCryptoSlippageTitle)
       .accessibilityValue(formatSlippage)
       .accessibility(addTraits: .isButton)
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
     Section(
       header:
         VStack(spacing: 16) {

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -30,8 +30,8 @@ struct AddCustomAssetView: View {
               ProgressView()
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenContractAddress))
         ) {
@@ -54,8 +54,8 @@ struct AddCustomAssetView: View {
               }
             }
             .disabled(userAssetStore.isSearchingToken)
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenSymbol))
         ) {
@@ -66,8 +66,8 @@ struct AddCustomAssetView: View {
               ProgressView()
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.decimalsPrecision))
         ) {
@@ -79,8 +79,8 @@ struct AddCustomAssetView: View {
               ProgressView()
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .navigationTitle(Strings.Wallet.customTokenTitle)
       .navigationBarTitleDisplayMode(.inline)

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -86,45 +86,47 @@ struct EditUserAssetsView: View {
             }
           }
         ) {
-          let tokens = tokenStores
-          if tokens.isEmpty {
-            Text(Strings.Wallet.assetSearchEmpty)
-              .font(.footnote)
-              .foregroundColor(Color(.secondaryBraveLabel))
-              .multilineTextAlignment(.center)
-              .frame(maxWidth: .infinity)
-          } else {
-            ForEach(tokens, id: \.token.id) { store in
-              if store.isCustomToken {
-                EditTokenView(assetStore: store)
-                  .osAvailabilityModifiers { content in
-                    if #available(iOS 15.0, *) {
-                      content
-                        .swipeActions(edge: .trailing) {
-                          Button(role: .destructive, action: {
-                            removeCustomToken(store.token)
-                          }) {
-                            Label(Strings.Wallet.delete, systemImage: "trash")
+          Group {
+            let tokens = tokenStores
+            if tokens.isEmpty {
+              Text(Strings.Wallet.assetSearchEmpty)
+                .font(.footnote)
+                .foregroundColor(Color(.secondaryBraveLabel))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+            } else {
+              ForEach(tokens, id: \.token.id) { store in
+                if store.isCustomToken {
+                  EditTokenView(assetStore: store)
+                    .osAvailabilityModifiers { content in
+                      if #available(iOS 15.0, *) {
+                        content
+                          .swipeActions(edge: .trailing) {
+                            Button(role: .destructive, action: {
+                              removeCustomToken(store.token)
+                            }) {
+                              Label(Strings.Wallet.delete, systemImage: "trash")
+                            }
                           }
-                        }
-                    } else {
-                      content
-                        .contextMenu {
-                          Button {
-                            removeCustomToken(store.token)
-                          } label: {
-                            Label(Strings.Wallet.delete, systemImage: "trash")
+                      } else {
+                        content
+                          .contextMenu {
+                            Button {
+                              removeCustomToken(store.token)
+                            } label: {
+                              Label(Strings.Wallet.delete, systemImage: "trash")
+                            }
                           }
-                        }
+                      }
                     }
-                  }
-              } else {
-                EditTokenView(assetStore: store)
+                } else {
+                  EditTokenView(assetStore: store)
+                }
               }
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .animation(.default, value: tokenStores)
       .navigationTitle(Strings.Wallet.editVisibleAssetsButtonTitle)

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -73,33 +73,35 @@ struct PortfolioView: View {
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.assetsTitle))
       ) {
-        ForEach(portfolioStore.userVisibleAssets) { asset in
-          Button(action: {
-            selectedToken = asset.token
-          }) {
-            PortfolioAssetView(
-              image: AssetIconView(token: asset.token, network: networkStore.selectedChain),
-              title: asset.token.name,
-              symbol: asset.token.symbol,
-              amount: portfolioStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
-              quantity: String(format: "%.04f", asset.decimalBalance)
-            )
+        Group {
+          ForEach(portfolioStore.userVisibleAssets) { asset in
+            Button(action: {
+              selectedToken = asset.token
+            }) {
+              PortfolioAssetView(
+                image: AssetIconView(token: asset.token, network: networkStore.selectedChain),
+                title: asset.token.name,
+                symbol: asset.token.symbol,
+                amount: portfolioStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
+                quantity: String(format: "%.04f", asset.decimalBalance)
+              )
+            }
+          }
+          Button(action: { isPresentingEditUserAssets = true }) {
+            Text(Strings.Wallet.editVisibleAssetsButtonTitle)
+              .multilineTextAlignment(.center)
+              .font(.footnote.weight(.semibold))
+              .foregroundColor(Color(.bravePrimary))
+              .frame(maxWidth: .infinity)
+          }
+          .sheet(isPresented: $isPresentingEditUserAssets) {
+            EditUserAssetsView(userAssetsStore: portfolioStore.userAssetsStore) {
+              portfolioStore.update()
+            }
           }
         }
-        Button(action: { isPresentingEditUserAssets = true }) {
-          Text(Strings.Wallet.editVisibleAssetsButtonTitle)
-            .multilineTextAlignment(.center)
-            .font(.footnote.weight(.semibold))
-            .foregroundColor(Color(.bravePrimary))
-            .frame(maxWidth: .infinity)
-        }
-        .sheet(isPresented: $isPresentingEditUserAssets) {
-          EditUserAssetsView(userAssetsStore: portfolioStore.userAssetsStore) {
-            portfolioStore.update()
-          }
-        }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .background(
       NavigationLink(

--- a/Sources/BraveWallet/Crypto/Search/TokenList.swift
+++ b/Sources/BraveWallet/Crypto/Search/TokenList.swift
@@ -46,19 +46,21 @@ struct TokenList<Content: View>: View {
           }
         }
       ) {
-        if filteredTokens.isEmpty {
-          Text(Strings.Wallet.assetSearchEmpty)
-            .font(.footnote)
-            .foregroundColor(Color(.secondaryBraveLabel))
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
-        } else {
-          ForEach(filteredTokens) { token in
-            content(token)
+        Group {
+          if filteredTokens.isEmpty {
+            Text(Strings.Wallet.assetSearchEmpty)
+              .font(.footnote)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .multilineTextAlignment(.center)
+              .frame(maxWidth: .infinity)
+          } else {
+            ForEach(filteredTokens) { token in
+              content(token)
+            }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
     .animation(nil, value: query)

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
@@ -86,16 +86,16 @@ struct EditGasFeeView: View {
         TextField("", text: $perGasPrice)
           .keyboardType(.numberPad)
           .foregroundColor(Color(.braveLabel))
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.gasAmountLimit))
       ) {
         TextField("", text: $gasLimit)
           .keyboardType(.numberPad)
           .foregroundColor(Color(.braveLabel))
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section {
         Button(action: save) {
           Text(Strings.Wallet.saveButtonTitle)

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -181,8 +181,8 @@ struct EditPriorityFeeView: View {
         .accentColor(Color(.braveBlurpleTint))
         .pickerStyle(.inline)
         .foregroundColor(Color(.braveLabel))
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       if gasFeeKind == .custom {
         Section(
           header: VStack {
@@ -198,35 +198,37 @@ struct EditPriorityFeeView: View {
           .padding(.bottom, 12)
           .resetListHeaderStyle()
         ) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(Strings.Wallet.gasAmountLimit)
-              .foregroundColor(Color(.bravePrimary))
-              .font(.footnote.weight(.semibold))
-            TextField("", text: $gasLimit)
-              .keyboardType(.numberPad)
-              .foregroundColor(Color(.braveLabel))
+          Group {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(Strings.Wallet.gasAmountLimit)
+                .foregroundColor(Color(.bravePrimary))
+                .font(.footnote.weight(.semibold))
+              TextField("", text: $gasLimit)
+                .keyboardType(.numberPad)
+                .foregroundColor(Color(.braveLabel))
+            }
+            .padding(.vertical, 6)
+            VStack(alignment: .leading, spacing: 4) {
+              Text(Strings.Wallet.perGasTipLimit)
+                .font(.footnote.weight(.semibold))
+                .foregroundColor(Color(.bravePrimary))
+              TextField("", text: maximumPriorityFeeBinding)
+                .keyboardType(.numberPad)
+                .foregroundColor(Color(.braveLabel))
+            }
+            .padding(.vertical, 6)
+            VStack(alignment: .leading, spacing: 4) {
+              Text(Strings.Wallet.perGasPriceLimit)
+                .font(.footnote.weight(.semibold))
+                .foregroundColor(Color(.bravePrimary))
+              TextField("", text: $maximumGasPrice)
+                .keyboardType(.numberPad)
+                .foregroundColor(Color(.braveLabel))
+            }
+            .padding(.vertical, 6)
           }
-          .padding(.vertical, 6)
-          VStack(alignment: .leading, spacing: 4) {
-            Text(Strings.Wallet.perGasTipLimit)
-              .font(.footnote.weight(.semibold))
-              .foregroundColor(Color(.bravePrimary))
-            TextField("", text: maximumPriorityFeeBinding)
-              .keyboardType(.numberPad)
-              .foregroundColor(Color(.braveLabel))
-          }
-          .padding(.vertical, 6)
-          VStack(alignment: .leading, spacing: 4) {
-            Text(Strings.Wallet.perGasPriceLimit)
-              .font(.footnote.weight(.semibold))
-              .foregroundColor(Color(.bravePrimary))
-            TextField("", text: $maximumGasPrice)
-              .keyboardType(.numberPad)
-              .foregroundColor(Color(.braveLabel))
-          }
-          .padding(.vertical, 6)
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       Section {
         VStack {

--- a/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -166,40 +166,42 @@ struct SuggestedNetworkView: View {
   var body: some View {
     List {
       Section {
-        if let chain = chain {
-          VStack(alignment: .leading) {
-            Text(Strings.Wallet.networkNameTitle)
-              .fontWeight(.semibold)
-            Text(chain.chainName)
-          }
-          .padding(.vertical, 6)
-          .accessibilityElement(children: .combine)
-          if let networkURL = chain.rpcUrls.first {
+        Group {
+          if let chain = chain {
             VStack(alignment: .leading) {
-              Text(Strings.Wallet.networkURLTitle)
+              Text(Strings.Wallet.networkNameTitle)
                 .fontWeight(.semibold)
-              Text(URL(string: networkURL)?.absoluteDisplayString ?? networkURL)
+              Text(chain.chainName)
             }
             .padding(.vertical, 6)
-          }
-          Button {
-            isPresentingNetworkDetails = .init(from: chain, mode: .view)
-          } label: {
-            Text(Strings.Wallet.viewDetails)
-              .foregroundColor(Color(.braveBlurpleTint))
+            .accessibilityElement(children: .combine)
+            if let networkURL = chain.rpcUrls.first {
+              VStack(alignment: .leading) {
+                Text(Strings.Wallet.networkURLTitle)
+                  .fontWeight(.semibold)
+                Text(URL(string: networkURL)?.absoluteDisplayString ?? networkURL)
+              }
+              .padding(.vertical, 6)
+            }
+            Button {
+              isPresentingNetworkDetails = .init(from: chain, mode: .view)
+            } label: {
+              Text(Strings.Wallet.viewDetails)
+                .foregroundColor(Color(.braveBlurpleTint))
+            }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       } header: {
         headerView
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       .font(.footnote)
       
       Section {
         actionButtonContainer
           .frame(maxWidth: .infinity)
+          .listRowBackground(Color(.braveGroupedBackground))
       }
-      .listRowBackground(Color(.braveGroupedBackground))
       .listRowInsets(.zero)
       .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
       .accessibility(hidden: sizeCategory.isAccessibilityCategory)

--- a/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -142,6 +142,7 @@ struct EditSiteConnectionView: View {
               }
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         } header: {
           Group {
             if sizeCategory.isAccessibilityCategory {
@@ -158,7 +159,6 @@ struct EditSiteConnectionView: View {
           .resetListHeaderStyle()
           .padding(.vertical)
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .navigationTitle(Strings.Wallet.editSiteConnectionScreenTitle)
       .navigationBarTitleDisplayMode(.inline)

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -81,8 +81,8 @@ public struct NewSiteConnectionView: View {
       List {
         Section {
           headerView
+            .listRowBackground(Color(.braveGroupedBackground))
         }
-        .listRowBackground(Color(.braveGroupedBackground))
         Section {
           ForEach(keyringStore.defaultKeyring.accountInfos) { account in
             Button {
@@ -111,12 +111,12 @@ public struct NewSiteConnectionView: View {
               }
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         } header: {
           WalletListHeaderView(title: Text(Strings.Wallet.accountsPageTitle))
         } footer: {
           cautionFooterView
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Section {
           Button {
             isConfirmationViewVisible = true
@@ -135,8 +135,8 @@ public struct NewSiteConnectionView: View {
             })
             .hidden()
           )
+          .listRowBackground(Color(.braveGroupedBackground))
         }
-        .listRowBackground(Color(.braveGroupedBackground))
       }
       .listStyle(InsetGroupedListStyle())
       .navigationBarTitleDisplayMode(.inline)
@@ -183,8 +183,8 @@ public struct NewSiteConnectionView: View {
             .font(.footnote)
             .foregroundColor(Color(.braveLabel))
         }
+        .listRowBackground(Color(.braveGroupedBackground))
       }
-      .listRowBackground(Color(.braveGroupedBackground))
       Section {
         HStack(spacing: 12) {
           Image(braveSystemName: "brave.checkmark.circle.fill")
@@ -195,10 +195,10 @@ public struct NewSiteConnectionView: View {
         .foregroundColor(Color(.braveLabel))
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .combine)
+        .listRowBackground(Color(.braveGroupedBackground))
       } footer: {
         cautionFooterView
       }
-      .listRowBackground(Color(.braveGroupedBackground))
       Section {
         Button {
           let accounts = keyringStore.defaultKeyring.accountInfos
@@ -210,8 +210,8 @@ public struct NewSiteConnectionView: View {
         }
         .buttonStyle(BraveFilledButtonStyle(size: .large))
         .frame(maxWidth: .infinity)
+        .listRowBackground(Color(.braveGroupedBackground))
       }
-      .listRowBackground(Color(.braveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
     .navigationTitle(Strings.Wallet.newSiteConnectScreenTitle)

--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -298,8 +298,8 @@ struct CustomNetworkDetailsView: View {
         )
         .keyboardType(.numberPad)
         .disabled(model.mode.isEditMode)
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.customNetworkChainNameTitle))
       ) {
@@ -307,8 +307,8 @@ struct CustomNetworkDetailsView: View {
           placeholder: Strings.Wallet.customNetworkChainNamePlaceholder,
           item: $model.networkName
         )
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.customNetworkSymbolNameTitle))
       ) {
@@ -316,8 +316,8 @@ struct CustomNetworkDetailsView: View {
           placeholder: Strings.Wallet.customNetworkSymbolNamePlaceholder,
           item: $model.networkSymbolName
         )
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.customNetworkSymbolTitle))
       ) {
@@ -325,8 +325,8 @@ struct CustomNetworkDetailsView: View {
           placeholder: Strings.Wallet.customNetworkSymbolPlaceholder,
           item: $model.networkSymbol
         )
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.customNetworkCurrencyDecimalTitle))
       ) {
@@ -335,8 +335,8 @@ struct CustomNetworkDetailsView: View {
           item: $model.networkDecimals
         )
         .keyboardType(.numberPad)
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       if !model.rpcUrls.isEmpty {
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.customNetworkRpcUrlsTitle))
@@ -347,8 +347,8 @@ struct CustomNetworkDetailsView: View {
               item: $url
             )
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       if !model.iconUrls.isEmpty {
         Section(
@@ -360,8 +360,8 @@ struct CustomNetworkDetailsView: View {
               item: $url
             )
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       if !model.blockUrls.isEmpty {
         Section(
@@ -373,8 +373,8 @@ struct CustomNetworkDetailsView: View {
               item: $url
             )
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
     .navigationBarTitle(navigationTitle)

--- a/Sources/BraveWallet/Settings/ManageSiteConnectionsView.swift
+++ b/Sources/BraveWallet/Settings/ManageSiteConnectionsView.swift
@@ -204,8 +204,8 @@ private struct SiteConnectionDetailView: View {
             }
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(.insetGrouped)
     .navigationTitle(siteConnection.url)

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -58,8 +58,8 @@ public struct WalletSettingsView: View {
             .foregroundColor(Color(.braveLabel))
             .padding(.vertical, 4)
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section {
         Picker(selection: $settingsStore.currencyCode) {
           ForEach(CurrencyCode.allCurrencyCodes) { currencyCode in
@@ -72,8 +72,8 @@ public struct WalletSettingsView: View {
             .foregroundColor(Color(.braveLabel))
             .padding(.vertical, 4)
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       if settingsStore.isBiometricsAvailable, keyringStore.defaultKeyring.isKeyringCreated {
         Section(
           footer: Text(Strings.Wallet.settingsEnableBiometricsFooter)
@@ -86,8 +86,8 @@ public struct WalletSettingsView: View {
           )
             .foregroundColor(Color(.braveLabel))
             .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       Section(
         footer: Text(Strings.Wallet.networkFooter)
@@ -97,49 +97,51 @@ public struct WalletSettingsView: View {
           Text(Strings.Wallet.settingsNetworkButtonTitle)
             .foregroundColor(Color(.braveLabel))
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         header: Text(Strings.Wallet.web3PreferencesSectionTitle)
           .foregroundColor(Color(.secondaryBraveLabel))
       ) {
-        HStack {
-          Text(Strings.Wallet.web3PreferencesDefaultWallet)
-            .foregroundColor(Color(.braveLabel))
-          Spacer()
-          Menu {
-            Picker("", selection: $defaultWallet.value) {
-              ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
-                Text(walletType.name)
-                  .tag(walletType)
+        Group {
+          HStack {
+            Text(Strings.Wallet.web3PreferencesDefaultWallet)
+              .foregroundColor(Color(.braveLabel))
+            Spacer()
+            Menu {
+              Picker("", selection: $defaultWallet.value) {
+                ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
+                  Text(walletType.name)
+                    .tag(walletType)
+                }
               }
+              .pickerStyle(.inline)
+            } label: {
+              let wallet = Preferences.Wallet.WalletType(rawValue: defaultWallet.value) ?? .none
+              Text(wallet.name)
+                .foregroundColor(Color(.braveBlurpleTint))
             }
-            .pickerStyle(.inline)
-          } label: {
-            let wallet = Preferences.Wallet.WalletType(rawValue: defaultWallet.value) ?? .none
-            Text(wallet.name)
-              .foregroundColor(Color(.braveBlurpleTint))
           }
-        }
-        Toggle(Strings.Wallet.web3PreferencesAllowSiteToRequestAccounts, isOn: $allowDappsRequestAccounts.value)
-          .foregroundColor(Color(.braveLabel))
-          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-        Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
-          .foregroundColor(Color(.braveLabel))
-          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-        NavigationLink(
-          destination: ManageSiteConnectionsView(
-            siteConnectionStore: settingsStore.manageSiteConnectionsStore(keyringStore: keyringStore)
-          )
-          .onDisappear {
-            settingsStore.closeManageSiteConnectionStore()
-          }
-        ) {
-          Text(Strings.Wallet.web3PreferencesManageSiteConnections)
+          Toggle(Strings.Wallet.web3PreferencesAllowSiteToRequestAccounts, isOn: $allowDappsRequestAccounts.value)
             .foregroundColor(Color(.braveLabel))
+            .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+          Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
+            .foregroundColor(Color(.braveLabel))
+            .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+          NavigationLink(
+            destination: ManageSiteConnectionsView(
+              siteConnectionStore: settingsStore.manageSiteConnectionsStore(keyringStore: keyringStore)
+            )
+            .onDisappear {
+              settingsStore.closeManageSiteConnectionStore()
+            }
+          ) {
+            Text(Strings.Wallet.web3PreferencesManageSiteConnections)
+              .foregroundColor(Color(.braveLabel))
+          }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section(
         footer: Text(Strings.Wallet.settingsResetTransactionFooter)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -148,16 +150,15 @@ public struct WalletSettingsView: View {
           Text(Strings.Wallet.settingsResetTransactionTitle)
             .foregroundColor(Color(.braveBlurpleTint))
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section {
         Button(action: { isShowingResetWalletAlert = true }) {
           Text(Strings.Wallet.settingsResetButtonTitle)
             .foregroundColor(.red)
-        }
-        // iOS 15: .role(.destructive)
+        } // iOS 15: .role(.destructive)
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
     .navigationTitle(Strings.Wallet.braveWallet)


### PR DESCRIPTION
## Summary of Changes
- When built with Xcode 14 & iOS 16 SDK, there is a change in SwiftUI where you need to apply the `listRowBackground(_ color: Color)` modifier on a `Section`s content instead of on the `Section` itself, or the header/footer will have the `listRowBackground` modifier's Color applied.

This pull request fixes #5878

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Requires Xcode 14. Build the app with Xcode 14 & iOS 16 SDK.
2. Open all views in Brave Wallet, verify section headers no longer have background applied.


## Screenshots:
Wallet Settings Before | Wallet Settings After
--|--
![wallet-settings-ios16](https://user-images.githubusercontent.com/5314553/185220952-155c1268-32fa-4520-889f-2586f2b61814.png) | ![wallet-settings-ios16-fixed](https://user-images.githubusercontent.com/5314553/185221493-76f0b6d4-a84b-4d79-90c3-a45a15acc786.png)
Wallet Swap Before | Wallet Swap After
![wallet-swap-ios16](https://user-images.githubusercontent.com/5314553/185223948-abaa2449-76d8-4533-8423-1a7c5b26bb80.png) | ![wallet-swap-ios16-fixed](https://user-images.githubusercontent.com/5314553/185223959-774c39b3-6814-48c4-aa3b-af4fbac88f67.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
