### PR TITLE
Fix #5848: Remove pending request indicator (badge) from the wallet icon in URL bar once wallet has been reset

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -147,33 +147,10 @@ extension BrowserViewController {
         }
       }
       MenuItemButton(icon: UIImage(named: "menu-settings", in: .current, compatibleWith: nil)!.template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
-        var settingsStore: SettingsStore?
-        let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        let walletService = BraveWallet.ServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        let swapService = BraveWallet.SwapServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing)
-        
-        if let keyringService = keyringService,
-          let walletService = walletService,
-          let txService = BraveWallet.TxServiceFactory.get(privateMode: PrivateBrowsingManager.shared.isPrivateBrowsing) {
-          settingsStore = SettingsStore(
-            keyringService: keyringService,
-            walletService: walletService,
-            txService: txService
-          )
-        }
-        var networkStore: NetworkStore?
-        if let keyringService = keyringService,
-           let rpcService = rpcService,
-           let walletService = walletService,
-           let swapService = swapService {
-          networkStore = NetworkStore(
-            keyringService: keyringService,
-            rpcService: rpcService,
-            walletService: walletService,
-            swapService: swapService
-          )
-        }
+        let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
+        let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode)
+        let walletService = BraveWallet.ServiceFactory.get(privateMode: privateMode)
+        let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: privateMode)
         
         var keyringStore: KeyringStore?
         if let keyringService = keyringService,
@@ -185,6 +162,8 @@ extension BrowserViewController {
             rpcService: rpcService
           )
         }
+        
+        let cryptoStore = CryptoStore.from(privateMode: privateMode)
 
         let vc = SettingsViewController(
           profile: self.profile,
@@ -194,9 +173,9 @@ extension BrowserViewController {
           legacyWallet: self.legacyWallet,
           windowProtection: self.windowProtection,
           braveCore: self.braveCore,
-          walletSettingsStore: settingsStore,
-          walletNetworkStore: networkStore,
-          keyringStore: keyringStore)
+          keyringStore: keyringStore,
+          cryptoStore: cryptoStore
+        )
         vc.settingsDelegate = self
         menuController.pushInnerMenu(vc)
       }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -147,10 +147,10 @@ extension BrowserViewController {
         }
       }
       MenuItemButton(icon: UIImage(named: "menu-settings", in: .current, compatibleWith: nil)!.template, title: Strings.settingsMenuItem) { [unowned self, unowned menuController] in
-        let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-        let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode)
-        let walletService = BraveWallet.ServiceFactory.get(privateMode: privateMode)
-        let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: privateMode)
+        let isPrivateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
+        let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: isPrivateMode)
+        let walletService = BraveWallet.ServiceFactory.get(privateMode: isPrivateMode)
+        let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: isPrivateMode)
         
         var keyringStore: KeyringStore?
         if let keyringService = keyringService,
@@ -163,7 +163,7 @@ extension BrowserViewController {
           )
         }
         
-        let cryptoStore = CryptoStore.from(privateMode: privateMode)
+        let cryptoStore = CryptoStore.from(privateMode: isPrivateMode)
 
         let vc = SettingsViewController(
           profile: self.profile,

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -45,9 +45,8 @@ class SettingsViewController: TableViewController {
   private let passwordAPI: BravePasswordAPI
   private let syncAPI: BraveSyncAPI
   private let syncProfileServices: BraveSyncProfileServiceIOS
-  private let walletSettingsStore: SettingsStore?
-  private let walletNetworkStore: NetworkStore?
   private let keyringStore: KeyringStore?
+  private let cryptoStore: CryptoStore?
   private let windowProtection: WindowProtection?
 
   private let featureSectionUUID: UUID = .init()
@@ -61,9 +60,8 @@ class SettingsViewController: TableViewController {
     legacyWallet: BraveLedger? = nil,
     windowProtection: WindowProtection?,
     braveCore: BraveCoreMain,
-    walletSettingsStore: SettingsStore? = nil,
-    walletNetworkStore: NetworkStore? = nil,
-    keyringStore: KeyringStore? = nil
+    keyringStore: KeyringStore? = nil,
+    cryptoStore: CryptoStore? = nil
   ) {
     self.profile = profile
     self.tabManager = tabManager
@@ -75,9 +73,8 @@ class SettingsViewController: TableViewController {
     self.passwordAPI = braveCore.passwordAPI
     self.syncAPI = braveCore.syncAPI
     self.syncProfileServices = braveCore.syncProfileService
-    self.walletSettingsStore = walletSettingsStore
-    self.walletNetworkStore = walletNetworkStore
     self.keyringStore = keyringStore
+    self.cryptoStore = cryptoStore
 
     super.init(style: .insetGrouped)
   }
@@ -676,7 +673,8 @@ class SettingsViewController: TableViewController {
   }()
 
   private func setUpSections() {
-    if let settingsStore = walletSettingsStore, let networkStore = walletNetworkStore, let keyringStore = keyringStore {
+    if let cryptoStore = cryptoStore, let keyringStore = keyringStore {
+      let settingsStore = cryptoStore.settingsStore
       settingsStore.isDefaultKeyringCreated { [weak self] created in
         guard let self = self else { return }
         var copyOfSections = self.sections
@@ -694,7 +692,7 @@ class SettingsViewController: TableViewController {
                 selection: { [unowned self] in
                   let walletSettingsView = WalletSettingsView(
                     settingsStore: settingsStore,
-                    networkStore: networkStore,
+                    networkStore: cryptoStore.networkStore,
                     keyringStore: keyringStore
                   )
                   let vc = UIHostingController(rootView: walletSettingsView)
@@ -710,6 +708,8 @@ class SettingsViewController: TableViewController {
         }
         self.dataSource.sections = copyOfSections
       }
+    } else {
+      self.dataSource.sections = sections
     }
   }
 

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -236,7 +236,7 @@ public class CryptoStore: ObservableObject {
     return store
   }
   
-  private(set) lazy var settingsStore = SettingsStore(
+  public private(set) lazy var settingsStore = SettingsStore(
     keyringService: keyringService,
     walletService: walletService,
     txService: txService
@@ -367,6 +367,8 @@ extension CryptoStore: BraveWalletTxServiceObserver {
 
 extension CryptoStore: BraveWalletKeyringServiceObserver {
   public func keyringReset() {
+    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests()
+    rejectAllPendingWebpageRequests()
   }
   public func keyringCreated(_ keyringId: String) {
   }


### PR DESCRIPTION
## Summary of Changes
Cancel all pending request once wallet has been reset

This pull request fixes #5848 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Please refer to the issue.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
