### PR TITLE
Fix #4547: Moving bookmark down causes swap of position 

### DIFF
--- a/Client/Frontend/Sync/BraveCore/Bookmarks/BookmarkManager.swift
+++ b/Client/Frontend/Sync/BraveCore/Bookmarks/BookmarkManager.swift
@@ -217,12 +217,9 @@ class BookmarkManager {
     if let node = frc.object(at: sourceIndexPath)?.bookmarkNode,
       let parent = node.parent ?? bookmarksAPI.mobileNode {
 
-      // Moving to the very last index.. same as appending..
-      if destinationIndexPath.row == parent.children.count - 1 {
-        node.move(toParent: parent)
-      } else {
-        node.move(toParent: parent, index: UInt(destinationIndexPath.row))
-      }
+      // Moving down in the list the node destination index should be increased by 1
+      let destinationIndex = sourceIndexPath.row > destinationIndexPath.row ? destinationIndexPath.row : destinationIndexPath.row + 1
+      node.move(toParent: parent, index: UInt(destinationIndex))
 
       // Notify the delegate that items did move..
       // This is already done automatically in `Bookmarkv2Fetcher` listener.


### PR DESCRIPTION
Fixing destination index while moving the bookmark item in the list.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4547

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Navigate to a some Bookmarks Folder with some bookmark + Folders 
- Activate Edit mode and move a bookmark item up and down in the list 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/185464242-f1cc6826-c6e6-48b4-8bb8-a29780126b26.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
