### PR TITLE
Fix #4502: Tab switching keyboard shortcut new tab (ctrl + tab)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -259,12 +259,17 @@ extension BrowserViewController {
       UIKeyCommand(title: Strings.shareWithTitle, action: #selector(shareWithKeyCommand), input: "s", modifierFlags: .command)
     ]
 
-    var keyCommandList = navigationCommands + tabNavigationCommands + bookmarkEditingCommands + shareCommands + findTextCommands
+    // Additional Commands which will have priority over system
+    let additionalPriorityCommandKeys = [
+      UIKeyCommand(input: "\t", modifierFlags: .control, action: #selector(newTabKeyCommand))
+    ]
+    
+    var keyCommandList = navigationCommands + tabNavigationCommands + bookmarkEditingCommands + shareCommands + findTextCommands + additionalPriorityCommandKeys
 
     // URL completion and Override Key commands
     let searchLocationCommands = [
       UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
-      UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
+      UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:)))
     ]
 
     // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
@@ -272,6 +277,7 @@ extension BrowserViewController {
       searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
       tabMovementCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
       tabNavigationKeyCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
+      additionalPriorityCommandKeys.forEach { $0.wantsPriorityOverSystemBehavior = true }
     }
 
     if topToolbar.inOverlayMode {


### PR DESCRIPTION
Adding ctrl+tab as new tab keyboard command for hardware keyboard and handle priority

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4502

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- open at least 2 tabs
- press ctrl + tab on a hardware keyboard

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
