### PR TITLE
No bug: Solana dapps setup refactor

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -404,7 +404,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     screenshotHelper = ScreenshotHelper(tabManager: tabManager)
     tabManager.addDelegate(self)
     tabManager.addNavigationDelegate(self)
-    tabManager.makeWalletProvider = { [weak self] tab in
+    tabManager.makeWalletEthProvider = { [weak self] tab in
       guard let self = self,
             let provider = self.braveCore.ethereumProvider(with: tab, isPrivateBrowsing: tab.isPrivate) else {
         return nil
@@ -444,7 +444,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     Preferences.Playlist.webMediaSourceCompatibility.observe(from: self)
     Preferences.PrivacyReports.captureShieldsData.observe(from: self)
     Preferences.PrivacyReports.captureVPNAlerts.observe(from: self)
-    Preferences.Wallet.defaultWallet.observe(from: self)
+    Preferences.Wallet.defaultEthWallet.observe(from: self)
     
     // Lists need to be compiled before attempting tab restoration
     
@@ -3479,7 +3479,7 @@ extension BrowserViewController: PreferencesObserver {
       PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.buildChannel.isPublic)
     case Preferences.PrivacyReports.captureVPNAlerts.key:
       PrivacyReportsManager.scheduleVPNAlertsTask()
-    case Preferences.Wallet.defaultWallet.key:
+    case Preferences.Wallet.defaultEthWallet.key:
       tabManager.reset()
       tabManager.reloadSelectedTab()
       notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -567,7 +567,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
       tabsBar.reloadDataAndRestoreSelectedTab()
       
-      if tab.walletProvider != nil {
+      if tab.walletEthProvider != nil {
         tab.emitEthereumEvent(.connect)
       }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -162,12 +162,12 @@ extension Tab: BraveWalletProviderDelegate {
     return origin
   }
 
-  public func requestPermissions(_ type: BraveWallet.CoinType, accounts: [String], completion: @escaping RequestPermissionsCallback) {
+  public func requestPermissions(_ coinType: BraveWallet.CoinType, accounts: [String], completion: @escaping RequestPermissionsCallback) {
     Task { @MainActor in
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       let origin = getOrigin()
       
-      if permissionRequestManager.hasPendingRequest(for: origin, coinType: type) {
+      if permissionRequestManager.hasPendingRequest(for: origin, coinType: coinType) {
         completion(.requestInProgress, nil)
         return
       }
@@ -186,7 +186,7 @@ extension Tab: BraveWalletProviderDelegate {
         completion(.internal, nil)
         return
       }
-      let (success, accounts) = await allowedAccounts(type, accounts: accounts)
+      let (success, accounts) = await allowedAccounts(coinType, accounts: accounts)
       if !success {
         completion(.internal, [])
         return
@@ -197,7 +197,7 @@ extension Tab: BraveWalletProviderDelegate {
       }
       
       // add permission request to the queue
-      _ = permissionRequestManager.beginRequest(for: origin, coinType: .eth, providerHandler: completion, completion: { response in
+      _ = permissionRequestManager.beginRequest(for: origin, coinType: coinType, providerHandler: completion, completion: { response in
         switch response {
         case .granted(let accounts):
           completion(.none, accounts)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -68,8 +68,8 @@ class Tab: NSObject {
 
   var secureContentState: TabSecureContentState = .unknown
 
-  var walletProvider: BraveWalletEthereumProvider?
-  var walletProviderJS: String?
+  var walletEthProvider: BraveWalletEthereumProvider?
+  var walletEthProviderJS: String?
   var isWalletIconVisible: Bool = false {
     didSet {
       tabDelegate?.updateURLBarWalletButton()
@@ -333,7 +333,7 @@ class Tab: NSObject {
         isMediaBackgroundPlaybackEnabled: Preferences.General.mediaAutoBackgrounding.value,
         isNightModeEnabled: Preferences.General.nightModeEnabled.value,
         isDeAMPEnabled: Preferences.Shields.autoRedirectAMPPages.value,
-        walletProviderJS: walletProviderJS
+        walletEthProviderJS: walletEthProviderJS
       )
       tabDelegate?.tab(self, didCreateWebView: webView)
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -85,7 +85,7 @@ class TabManager: NSObject {
   var selectedIndex: Int { return _selectedIndex }
   var tempTabs: [Tab]?
   private weak var rewards: BraveRewards?
-  var makeWalletProvider: ((Tab) -> (BraveWalletEthereumProvider, js: String)?)?
+  var makeWalletEthProvider: ((Tab) -> (BraveWalletEthereumProvider, js: String)?)?
   private var domainFrc = Domain.frc()
 
   init(prefs: Prefs, imageStore: DiskImageStore?, rewards: BraveRewards?) {
@@ -450,10 +450,10 @@ class TabManager: NSObject {
       tab.id = id ?? TabMO.create()
     }
 
-    if let (provider, js) = makeWalletProvider?(tab) {
-      tab.walletProvider = provider
-      tab.walletProvider?.`init`(tab)
-      tab.walletProviderJS = js
+    if let (provider, js) = makeWalletEthProvider?(tab) {
+      tab.walletEthProvider = provider
+      tab.walletEthProvider?.`init`(tab)
+      tab.walletEthProviderJS = js
     }
     
     delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }

--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -118,7 +118,7 @@ class UserScriptManager {
     isMediaBackgroundPlaybackEnabled: Bool,
     isNightModeEnabled: Bool,
     isDeAMPEnabled: Bool,
-    walletProviderJS: String?
+    walletEthProviderJS: String?
   ) {
     self.tab = tab
     self.isCookieBlockingEnabled = isCookieBlockingEnabled
@@ -129,7 +129,7 @@ class UserScriptManager {
     self.isNightModeEnabled = isNightModeEnabled
     self.isDeAMPEnabled = isDeAMPEnabled
     self.userScriptTypes = []
-    self.walletProviderJS = walletProviderJS
+    self.walletEthProviderJS = walletEthProviderJS
     self.isRequestBlockingEnabled = true
     
     reloadUserScripts()
@@ -428,7 +428,7 @@ class UserScriptManager {
       in: .page)
   }()
 
-  private let walletProviderScript: WKUserScript? = {
+  private let walletEthProviderScript: WKUserScript? = {
     guard let path = Bundle.current.path(forResource: "WalletEthereumProvider", ofType: "js"),
           let source = try? String(contentsOfFile: path) else {
       return nil
@@ -451,7 +451,7 @@ class UserScriptManager {
                         in: .page)
   }()
 
-  private var walletProviderJS: String?
+  private var walletEthProviderJS: String?
     
   private func reloadUserScripts() {
     tab?.webView?.configuration.userContentController.do {
@@ -514,11 +514,11 @@ class UserScriptManager {
         }
       }
 
-      if let script = walletProviderScript,
+      if let script = walletEthProviderScript,
          tab?.isPrivate == false,
-         Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultWallet.value) == .brave {
+         Preferences.Wallet.WalletType(rawValue: Preferences.Wallet.defaultEthWallet.value) == .brave {
         $0.addUserScript(script)
-        if var providerJS = walletProviderJS {
+        if var providerJS = walletEthProviderJS {
           providerJS = """
             (function() {
               if (window.isSecureContext) {

--- a/Client/Wallet/EthereumProviderHelper.swift
+++ b/Client/Wallet/EthereumProviderHelper.swift
@@ -68,7 +68,7 @@ class EthereumProviderHelper: TabContentScript {
   ) {
     guard let tab = tab,
           !tab.isPrivate,
-          let provider = tab.walletProvider,
+          let provider = tab.walletEthProvider,
           !message.frameInfo.securityOrigin.host.isEmpty, // Fail if there is no last committed URL yet
           message.frameInfo.isMainFrame, // Fail the request came from 3p origin
           JSONSerialization.isValidJSONObject(message.body),

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -65,8 +65,8 @@ public class SettingsStore: ObservableObject {
     walletService.reset()
     keychain.resetPasswordInKeychain(key: KeyringStore.passwordKeychainKey)
     Domain.clearAllEthereumPermissions()
-    Preferences.Wallet.defaultWallet.reset()
-    Preferences.Wallet.allowEthereumProviderAccountRequests.reset()
+    Preferences.Wallet.defaultEthWallet.reset()
+    Preferences.Wallet.allowDappProviderAccountRequests.reset()
     Preferences.Wallet.displayWeb3Notifications.reset()
   }
 

--- a/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -97,7 +97,7 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
   func add(_ observer: BraveWalletBraveWalletServiceObserver) {
   }
 
-  func setDefaultWallet(_ defaultWallet: BraveWallet.DefaultWallet) {
+  func setDefaultWallet(_ defaultEthWallet: BraveWallet.DefaultWallet) {
   }
 
   func notifySignMessageRequestProcessed(_ approved: Bool, id: Int32, signature: BraveWallet.ByteArrayStringUnion?, error: String?) {
@@ -203,10 +203,10 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
     completion(.braveWallet)
   }
   
-  func setDefaultEthereumWallet(_ defaultWallet: BraveWallet.DefaultWallet) {
+  func setDefaultEthereumWallet(_ defaultEthWallet: BraveWallet.DefaultWallet) {
   }
   
-  func setDefaultSolanaWallet(_ defaultWallet: BraveWallet.DefaultWallet) {
+  func setDefaultSolanaWallet(_ defaultEthWallet: BraveWallet.DefaultWallet) {
   }
 }
 #endif

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -12,8 +12,8 @@ public struct WalletSettingsView: View {
   @ObservedObject var settingsStore: SettingsStore
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var defaultWallet = Preferences.Wallet.defaultWallet
-  @ObservedObject var allowDappsRequestAccounts = Preferences.Wallet.allowEthereumProviderAccountRequests
+  @ObservedObject var defaultEthWallet = Preferences.Wallet.defaultEthWallet
+  @ObservedObject var allowDappsRequestAccounts = Preferences.Wallet.allowDappProviderAccountRequests
   @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
 
   @State private var isShowingResetWalletAlert = false
@@ -105,11 +105,11 @@ public struct WalletSettingsView: View {
       ) {
         Group {
           HStack {
-            Text(Strings.Wallet.web3PreferencesDefaultWallet)
+            Text(Strings.Wallet.web3PreferencesDefaultEthWallet)
               .foregroundColor(Color(.braveLabel))
             Spacer()
             Menu {
-              Picker("", selection: $defaultWallet.value) {
+              Picker("", selection: $defaultEthWallet.value) {
                 ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
                   Text(walletType.name)
                     .tag(walletType)
@@ -117,7 +117,7 @@ public struct WalletSettingsView: View {
               }
               .pickerStyle(.inline)
             } label: {
-              let wallet = Preferences.Wallet.WalletType(rawValue: defaultWallet.value) ?? .none
+              let wallet = Preferences.Wallet.WalletType(rawValue: defaultEthWallet.value) ?? .none
               Text(wallet.name)
                 .foregroundColor(Color(.braveBlurpleTint))
             }

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -13,6 +13,7 @@ public struct WalletSettingsView: View {
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var defaultEthWallet = Preferences.Wallet.defaultEthWallet
+  @ObservedObject var defaultSolWallet = Preferences.Wallet.defaultSolWallet
   @ObservedObject var allowDappsRequestAccounts = Preferences.Wallet.allowDappProviderAccountRequests
   @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
 
@@ -120,6 +121,26 @@ public struct WalletSettingsView: View {
               let wallet = Preferences.Wallet.WalletType(rawValue: defaultEthWallet.value) ?? .none
               Text(wallet.name)
                 .foregroundColor(Color(.braveBlurpleTint))
+            }
+          }
+          if WalletDebugFlags.isSolanaDappsEnabled {
+            HStack {
+              Text(Strings.Wallet.web3PreferencesDefaultSolWallet)
+                .foregroundColor(Color(.braveLabel))
+              Spacer()
+              Menu {
+                Picker("", selection: $defaultSolWallet.value) {
+                  ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
+                    Text(walletType.name)
+                      .tag(walletType)
+                  }
+                }
+                .pickerStyle(.inline)
+              } label: {
+                let wallet = Preferences.Wallet.WalletType(rawValue: defaultSolWallet.value) ?? .none
+                Text(wallet.name)
+                  .foregroundColor(Color(.braveBlurpleTint))
+              }
             }
           }
           Toggle(Strings.Wallet.web3PreferencesAllowSiteToRequestAccounts, isOn: $allowDappsRequestAccounts.value)

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -54,3 +54,7 @@ struct WalletConstants {
     BraveWallet.MainnetChainId
   ]
 }
+
+struct WalletDebugFlags {
+  static var isSolanaDappsEnabled: Bool = false
+}

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -25,10 +25,10 @@ extension Preferences {
         }
       }
     }
-    /// The options of wallet to be communicate with web3
-    public static let defaultWallet = Option<Int>(key: "wallet.default-wallet", default: WalletType.brave.rawValue)
-    /// Whether or not webpages can use the Ethereum Provider API to communicate with users ethereum wallet
-    public static let allowEthereumProviderAccountRequests: Option<Bool> = .init(
+    /// The default wallet to use for Ethereum to be communicate with web3
+    public static let defaultEthWallet = Option<Int>(key: "wallet.default-wallet", default: WalletType.brave.rawValue)
+    /// Whether or not webpages can use the Ethereum/Solana Provider API to communicate with users Ethereum/Solana wallet
+    public static let allowDappProviderAccountRequests: Option<Bool> = .init(
       key: "wallet.allow-eth-provider-account-requests",
       default: true
     )

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -27,6 +27,8 @@ extension Preferences {
     }
     /// The default wallet to use for Ethereum to be communicate with web3
     public static let defaultEthWallet = Option<Int>(key: "wallet.default-wallet", default: WalletType.brave.rawValue)
+    /// The default wallet to use for Solana to be communicate with web3
+    public static let defaultSolWallet = Option<Int>(key: "wallet.default-sol-wallet", default: WalletType.brave.rawValue)
     /// Whether or not webpages can use the Ethereum/Solana Provider API to communicate with users Ethereum/Solana wallet
     public static let allowDappProviderAccountRequests: Option<Bool> = .init(
       key: "wallet.allow-eth-provider-account-requests",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2297,12 +2297,12 @@ extension Strings {
       value: "Web3 preferences",
       comment: "The section title for users to set up preferences for interation with web3 sites."
     )
-    public static let web3PreferencesDefaultWallet = NSLocalizedString(
-      "wallet.web3PreferencesDefaultWallet",
+    public static let web3PreferencesDefaultEthWallet = NSLocalizedString(
+      "wallet.web3PreferencesDefaultEthWallet",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Default Wallet",
-      comment: "The title for the entry displaying the current preferred default wallet is."
+      value: "Default Ethereum Wallet",
+      comment: "The title for the entry displaying the current preferred default Ethereum wallet is."
     )
     public static let web3PreferencesAllowSiteToRequestAccounts = NSLocalizedString(
       "wallet.web3PreferencesAllowSiteToRequestAccounts",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2304,6 +2304,13 @@ extension Strings {
       value: "Default Ethereum Wallet",
       comment: "The title for the entry displaying the current preferred default Ethereum wallet is."
     )
+    public static let web3PreferencesDefaultSolWallet = NSLocalizedString(
+      "wallet.web3PreferencesDefaultSolWallet",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Default Solana Wallet",
+      comment: "The title for the entry displaying the current preferred default Solana wallet is."
+    )
     public static let web3PreferencesAllowSiteToRequestAccounts = NSLocalizedString(
       "wallet.web3PreferencesAllowSiteToRequestAccounts",
       tableName: "BraveWallet",

--- a/Sources/Data/models/Domain.swift
+++ b/Sources/Data/models/Domain.swift
@@ -366,13 +366,14 @@ extension Domain {
         let domain = Domain.getOrCreateInternal(
           url, context: context,
           saveStrategy: .persistentStore)
-        domain.setWalletDappPermission(account: account, grant: grant, context: context)
+        domain.setWalletEthDappPermission(account: account, grant: grant, context: context)
       }
     }
   }
   
-  private func setWalletDappPermission(
-    account: String, grant: Bool,
+  private func setWalletEthDappPermission(
+    account: String,
+    grant: Bool,
     context: NSManagedObjectContext
   ) {
     if grant {

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -82,11 +82,11 @@ class SettingsStoreTests: XCTestCase {
     }
 
     assert(
-      Preferences.Wallet.WalletType.none.rawValue != Preferences.Wallet.defaultWallet.defaultValue,
+      Preferences.Wallet.WalletType.none.rawValue != Preferences.Wallet.defaultEthWallet.defaultValue,
       "Test assumes default wallet value is not `none`") 
-    Preferences.Wallet.defaultWallet.value = Preferences.Wallet.WalletType.none.rawValue
+    Preferences.Wallet.defaultEthWallet.value = Preferences.Wallet.WalletType.none.rawValue
     XCTAssertEqual(
-      Preferences.Wallet.defaultWallet.value,
+      Preferences.Wallet.defaultEthWallet.value,
       Preferences.Wallet.WalletType.none.rawValue,
       "Failed to update default wallet")
     Preferences.Wallet.allowEthereumProviderAccountRequests.value = !Preferences.Wallet.allowEthereumProviderAccountRequests.defaultValue
@@ -127,8 +127,8 @@ class SettingsStoreTests: XCTestCase {
       walletServiceResetCalled,
       "WalletService reset() not called")
     XCTAssertEqual(
-      Preferences.Wallet.defaultWallet.value,
-      Preferences.Wallet.defaultWallet.defaultValue,
+      Preferences.Wallet.defaultEthWallet.value,
+      Preferences.Wallet.defaultEthWallet.defaultValue,
       "Default Wallet was not reset to default")
     XCTAssertEqual(
       Preferences.Wallet.allowEthereumProviderAccountRequests.value,

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -89,10 +89,10 @@ class SettingsStoreTests: XCTestCase {
       Preferences.Wallet.defaultEthWallet.value,
       Preferences.Wallet.WalletType.none.rawValue,
       "Failed to update default wallet")
-    Preferences.Wallet.allowEthereumProviderAccountRequests.value = !Preferences.Wallet.allowEthereumProviderAccountRequests.defaultValue
+    Preferences.Wallet.allowDappProviderAccountRequests.value = !Preferences.Wallet.allowDappProviderAccountRequests.defaultValue
     XCTAssertEqual(
-      Preferences.Wallet.allowEthereumProviderAccountRequests.value,
-      !Preferences.Wallet.allowEthereumProviderAccountRequests.defaultValue,
+      Preferences.Wallet.allowDappProviderAccountRequests.value,
+      !Preferences.Wallet.allowDappProviderAccountRequests.defaultValue,
       "Failed to update allow ethereum requests")
     Preferences.Wallet.displayWeb3Notifications.value = !Preferences.Wallet.displayWeb3Notifications.defaultValue
     XCTAssertEqual(
@@ -131,8 +131,8 @@ class SettingsStoreTests: XCTestCase {
       Preferences.Wallet.defaultEthWallet.defaultValue,
       "Default Wallet was not reset to default")
     XCTAssertEqual(
-      Preferences.Wallet.allowEthereumProviderAccountRequests.value,
-      Preferences.Wallet.allowEthereumProviderAccountRequests.defaultValue,
+      Preferences.Wallet.allowDappProviderAccountRequests.value,
+      Preferences.Wallet.allowDappProviderAccountRequests.defaultValue,
       "Allow ethereum requests was not reset to default")
     XCTAssertEqual(
       Preferences.Wallet.displayWeb3Notifications.value,


### PR DESCRIPTION
## Summary of Changes
- Rename existing ethereum dapp related properties to include Ethereum reference.
- Add `WalletDebugFlags.isSolanaDappsEnabled` flag
- Add Default Solana Wallet preference to wallet settings (when debug flag enabled), change copy for initial 'Default Wallet` preference to 'Default Ethereum Wallet'

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Code refactor for Solana dapps work to begin. 
Verify Default Solana Wallet preference only shows when debug flag is enabled?


## Screenshots:

![Default Solana Wallet](https://user-images.githubusercontent.com/5314553/185637441-d8b5961e-01b7-4c07-ad73-5cc2691ab479.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
