### PR TITLE
Fix #5005: Update Show Tab Bar default setting to landscape only

### DIFF
--- a/Client/Migration/Migration.swift
+++ b/Client/Migration/Migration.swift
@@ -40,6 +40,11 @@ public class Migration {
     if !Preferences.Migration.playlistV1FileSettingsLocationCompleted.value {
       movePlaylistV1Items()
     }
+    
+    // Default Value for preference of tab bar visibility for new users changed to landscape only
+    if Preferences.General.isFirstLaunch.value {
+      Preferences.General.tabBarVisibility.value = TabBarVisibility.landscapeOnly.rawValue
+    }
 
     // Adding Observer to enable sync types
 


### PR DESCRIPTION
Changing the default value for Tab Bar Visual Preference to landscape only choice

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5005

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Check if the preference value is not changed for existing user and it works as expected
2. Check the default value changed to landscape only for fresh user and check if it works as expected


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/185671484-c6d1dd8f-625c-41a3-bda5-cd396189aee6.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
