### PR TITLE
Fix #5889: allow users to input decimal value with other locale's decimal separator

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -22,7 +22,7 @@ struct SendTokenView: View {
   var onDismiss: () -> Void
 
   private var isSendDisabled: Bool {
-    guard let sendAmount = BDouble(sendTokenStore.sendAmount),
+    guard let sendAmount = BDouble(sendTokenStore.sendAmount.normalizedDecimals),
       let balance = sendTokenStore.selectedSendTokenBalance,
       let token = sendTokenStore.selectedSendToken,
       !sendTokenStore.isMakingTx
@@ -31,7 +31,7 @@ struct SendTokenView: View {
     }
 
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: Int(token.decimals)))
-    if weiFormatter.weiString(from: sendTokenStore.sendAmount, radix: .decimal, decimals: Int(token.decimals)) == nil {
+    if weiFormatter.weiString(from: sendTokenStore.sendAmount.normalizedDecimals, radix: .decimal, decimals: Int(token.decimals)) == nil {
       return true
     }
 

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -264,7 +264,7 @@ public class SendTokenStore: ObservableObject {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     guard
       let token = selectedSendToken,
-      let weiHexString = weiFormatter.weiString(from: amount, radix: .hex, decimals: Int(token.decimals)),
+      let weiHexString = weiFormatter.weiString(from: amount.normalizedDecimals, radix: .hex, decimals: Int(token.decimals)),
       let fromAddress = currentAccountAddress
     else { return }
 
@@ -315,7 +315,7 @@ public class SendTokenStore: ObservableObject {
   ) {
     guard let token = selectedSendToken,
           let fromAddress = currentAccountAddress,
-          let amount = WeiFormatter.decimalToAmount(amount, tokenDecimals: Int(token.decimals))
+          let amount = WeiFormatter.decimalToAmount(amount.normalizedDecimals, tokenDecimals: Int(token.decimals))
     else {
       completion(false, "An Internal Error")
       return

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -49,7 +49,7 @@ public class SwapTokenStore: ObservableObject {
   /// The sell amount in this swap
   @Published var sellAmount = "" {
     didSet {
-      guard !sellAmount.isEmpty, BDouble(sellAmount) != nil else {
+      guard !sellAmount.isEmpty, BDouble(sellAmount.normalizedDecimals) != nil else {
         state = .idle
         return
       }
@@ -66,7 +66,7 @@ public class SwapTokenStore: ObservableObject {
   /// The buy amount in this swap
   @Published var buyAmount = "" {
     didSet {
-      guard !buyAmount.isEmpty, BDouble(buyAmount) != nil else {
+      guard !buyAmount.isEmpty, BDouble(buyAmount.normalizedDecimals) != nil else {
         state = .idle
         return
       }
@@ -205,18 +205,18 @@ public class SwapTokenStore: ObservableObject {
     case .perSellAsset:
       // make sure the base value should not be zero, otherwise, it will always return insufficient liquidity error.
       // following desktop to make a idle state
-      if let sellAmountValue = BDouble(sellAmount), sellAmountValue == 0 {
+      if let sellAmountValue = BDouble(sellAmount.normalizedDecimals), sellAmountValue == 0 {
         return nil
       }
-      sellAmountInWei = weiFormatter.weiString(from: sellAmount, radix: .decimal, decimals: Int(sellToken.decimals)) ?? "0"
+      sellAmountInWei = weiFormatter.weiString(from: sellAmount.normalizedDecimals, radix: .decimal, decimals: Int(sellToken.decimals)) ?? "0"
       buyAmountInWei = ""
     case .perBuyAsset:
       // same as sell amount. make sure base value should not be zero
-      if let buyAmountValue = BDouble(buyAmount), buyAmountValue == 0 {
+      if let buyAmountValue = BDouble(buyAmount.normalizedDecimals), buyAmountValue == 0 {
         return nil
       }
       sellAmountInWei = ""
-      buyAmountInWei = weiFormatter.weiString(from: buyAmount, radix: .decimal, decimals: Int(buyToken.decimals)) ?? "0"
+      buyAmountInWei = weiFormatter.weiString(from: buyAmount.normalizedDecimals, radix: .decimal, decimals: Int(buyToken.decimals)) ?? "0"
     }
     let swapParams = BraveWallet.SwapParams(
       takerAddress: accountInfo.address,
@@ -478,7 +478,7 @@ public class SwapTokenStore: ObservableObject {
   private func checkBalanceShowError(swapResponse: BraveWallet.SwapResponse) {
     guard
       let accountInfo = accountInfo,
-      let sellAmountValue = BDouble(sellAmount),
+      let sellAmountValue = BDouble(sellAmount.normalizedDecimals),
       let gasLimit = BDouble(swapResponse.estimatedGas),
       let gasPrice = BDouble(swapResponse.gasPrice, over: "1000000000000000000"),
       let fromToken = selectedFromToken,
@@ -599,7 +599,7 @@ public class SwapTokenStore: ObservableObject {
             
             // check balance first because error can cause by insufficient balance
             if let sellTokenBalance = self.selectedFromTokenBalance,
-               let sellAmountValue = BDouble(self.sellAmount),
+               let sellAmountValue = BDouble(self.sellAmount.normalizedDecimals),
                sellTokenBalance < sellAmountValue {
               self.state = .error(Strings.Wallet.insufficientBalance)
               return

--- a/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
+++ b/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 The Brave Authors. All rights reserved.
+// Copyright 2022 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
+++ b/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
@@ -6,12 +6,19 @@
 import Foundation
 
 extension String {
-  static let numberFormatter = NumberFormatter().then {
+  static let numberFormatterWithCurrentLocale = NumberFormatter().then {
     $0.numberStyle = .decimal
     $0.locale = Locale.current
   }
   
+  static let numberFormatterUsLocale = NumberFormatter().then {
+    $0.numberStyle = .decimal
+    $0.locale = .init(identifier: "en_US")
+  }
+  
   var normalizedDecimals: String {
-    return self.replacingOccurrences(of: String.numberFormatter.decimalSeparator, with: ".")
+    guard String.numberFormatterUsLocale.locale != String.numberFormatterWithCurrentLocale.locale else { return self }
+    guard let number = String.numberFormatterWithCurrentLocale.number(from: self) else { return self }
+    return  String.numberFormatterUsLocale.string(from: number) ?? self
   }
 }

--- a/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
+++ b/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
@@ -6,18 +6,19 @@
 import Foundation
 
 extension String {
-  static let numberFormatterWithCurrentLocale = NumberFormatter().then {
+  private static let numberFormatterWithCurrentLocale = NumberFormatter().then {
     $0.numberStyle = .decimal
     $0.locale = Locale.current
   }
   
-  static let numberFormatterUsLocale = NumberFormatter().then {
+  private static let numberFormatterUsLocale = NumberFormatter().then {
     $0.numberStyle = .decimal
     $0.locale = .init(identifier: "en_US")
   }
   
+  /// This will convert decimal string to use `en_US` locale decimal separator
   var normalizedDecimals: String {
-    guard String.numberFormatterUsLocale.locale != String.numberFormatterWithCurrentLocale.locale else { return self }
+    guard String.numberFormatterUsLocale.decimalSeparator != String.numberFormatterWithCurrentLocale.decimalSeparator else { return self }
     guard let number = String.numberFormatterWithCurrentLocale.number(from: self) else { return self }
     return  String.numberFormatterUsLocale.string(from: number) ?? self
   }

--- a/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
+++ b/Sources/BraveWallet/Extensions/String+NumberFormatter.swift
@@ -1,0 +1,17 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+extension String {
+  static let numberFormatter = NumberFormatter().then {
+    $0.numberStyle = .decimal
+    $0.locale = Locale.current
+  }
+  
+  var normalizedDecimals: String {
+    return self.replacingOccurrences(of: String.numberFormatter.decimalSeparator, with: ".")
+  }
+}


### PR DESCRIPTION
Unfortunately we cannot force the keyboard to use en_US locale in SwiftUI, so users can input decimal value with a decimal separator that is not a dot. This will cause Big Number construction failure since this library only expecting dot as the decimal separator. 
This solution will convert any decimal input that is not using a dot as the decimal separator to use dot.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5889

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
please refer to the issue

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
