### PR TITLE
Fix #5898: Tab Mode changes does not preserve tab index

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -261,6 +261,10 @@ class TabTrayController: LoadingViewController {
   @objc func togglePrivateModeAction() {
     tabTraySearchController.isActive = false
 
+    if !privateMode {
+      tabManager.normalTabSelectedIndex = tabManager.selectedIndex
+    }
+    
     tabManager.willSwitchTabMode(leavingPBM: privateMode)
     privateMode.toggle()
     // When we switch from Private => Regular make sure we reset _selectedIndex, fix for bug #888
@@ -272,9 +276,9 @@ class TabTrayController: LoadingViewController {
       tabManager.addTabAndSelect(isPrivate: true)
     } else {
       tabTrayView.hidePrivateModeInfo()
-      // When you go back from private mode, a first tab is selected.
-      // So when you dismiss the modal, correct tab and url is showed.
-      tabManager.selectTab(tabManager.tabsForCurrentMode.first)
+      
+      tabManager.selectTab(tabManager.tabsForCurrentMode[safe: tabManager.normalTabSelectedIndex])
+      tabTrayView.collectionView.reloadData()
     }
 
     // Disable Search when Private mode info is on

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -261,6 +261,7 @@ class TabTrayController: LoadingViewController {
   @objc func togglePrivateModeAction() {
     tabTraySearchController.isActive = false
 
+    // Record the slected index before private mode navigation
     if !privateMode {
       tabManager.normalTabSelectedIndex = tabManager.selectedIndex
     }
@@ -277,6 +278,8 @@ class TabTrayController: LoadingViewController {
     } else {
       tabTrayView.hidePrivateModeInfo()
       
+      // When you go back from private mode, a previous current tab is selected
+      // Reloding the collection view in order to mark the selecte the tab
       tabManager.selectTab(tabManager.tabsForCurrentMode[safe: tabManager.normalTabSelectedIndex])
       tabTrayView.collectionView.reloadData()
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -82,7 +82,10 @@ class TabManager: NSObject {
   fileprivate let imageStore: DiskImageStore?
 
   fileprivate let prefs: Prefs
-  var selectedIndex: Int { return _selectedIndex }
+  var selectedIndex: Int {
+    return _selectedIndex
+  }
+  var normalTabSelectedIndex: Int = 0
   var tempTabs: [Tab]?
   private weak var rewards: BraveRewards?
   var makeWalletEthProvider: ((Tab) -> (BraveWalletEthereumProvider, js: String)?)?


### PR DESCRIPTION
Adding index checker for normal mode before changing to private mode and retrieve the index. After that reload the table to mark the selected index.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5898

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Open Tab -Tray in normal Mode when a any other tab is elected except the first one
Switch to Private Mode
Switch back to Normal Mode
The previously selected tab must be selected as current tab and marked with blue shadow

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/185707268-37bbc944-7495-4f8d-a7a8-725baaf3dd9e.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
