### PR TITLE
Fix #5904: Don't alter alpha of toolbar or expand on app foreground

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -674,7 +674,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     if let tab = tabManager.selectedTab, tab.isPrivate {
       webViewContainerBackdrop.alpha = 1
       webViewContainer.alpha = 0
-      topToolbar.locationContainer.alpha = 0
+      header.contentView.alpha = 0
       presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
       presentedViewController?.view.alpha = 0
     }
@@ -686,13 +686,16 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
   }
 
   @objc func appDidBecomeActiveNotification() {
+    guard let tab = tabManager.selectedTab, tab.isPrivate else {
+      return
+    }
     // Re-show any components that might have been hidden because they were being displayed
     // as part of a private mode tab
     UIView.animate(
       withDuration: 0.2, delay: 0, options: UIView.AnimationOptions(),
       animations: {
         self.webViewContainer.alpha = 1
-        self.topToolbar.locationContainer.alpha = 1
+        self.header.contentView.alpha = 1
         self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
         self.presentedViewController?.view.alpha = 1
         self.view.backgroundColor = .clear
@@ -700,9 +703,6 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
       completion: { _ in
         self.webViewContainerBackdrop.alpha = 0
       })
-
-    // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
-    toolbarVisibilityViewModel.toolbarState = .expanded
   }
 
   override public func viewDidLoad() {


### PR DESCRIPTION
This commit also fixes tab bars being visible while backgrounded in Private Mode

## Summary of Changes

This pull request fixes #5904 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
