### PR TITLE
Fix #5906: Update `NewSiteConnectionView` to support non-Ethereum account types

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -94,6 +94,7 @@ public struct CryptoView: View {
             case .requestEthererumPermissions(let request, let onPermittedAccountsUpdated):
               NewSiteConnectionView(
                 origin: request.requestingOrigin,
+                coin: request.coinType,
                 keyringStore: keyringStore,
                 onConnect: {
                   request.decisionHandler(.granted(accounts: $0))


### PR DESCRIPTION
## Summary of Changes
- Update `NewSiteConnectionView` to take in a `BraveWallet.CoinType` and display those accounts from the `KeyringStore`

This pull request fixes #5906

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1.  Verify connection to an ethereum dapp site will still show Ethereum accounts.
2. Modify `CryptoView` to pass in `.sol` instead of `request.coinType` to `NewSiteConnectionView`.
3. Visit a ethereum dapp that is not yet connected (or remove connection via Wallet Settings), and initiate a permissions request
4. Verify only your Solana accounts are shown.
5. NOTE: You will not want to try and connect these accounts, as they will have invalid Ethereum addresses.


## Screenshots:

![#5906](https://user-images.githubusercontent.com/5314553/185982540-9107118d-d056-435a-bad6-1ead55f420ac.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
