### PR TITLE
Fix #5846: Disable bottom expand button when no bottom toolbar exists

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -582,6 +582,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     toolbar?.removeFromSuperview()
     toolbar?.tabToolbarDelegate = nil
     toolbar = nil
+    bottomTouchArea.isEnabled = showToolbar
 
     if showToolbar {
       toolbar = BottomToolbarView()


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5846 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
