### PR TITLE
Fix #5415: Use BraveWebView for link previews.

### DIFF
--- a/Client/Frontend/Browser/LinkPreviewViewController.swift
+++ b/Client/Frontend/Browser/LinkPreviewViewController.swift
@@ -24,7 +24,7 @@ class LinkPreviewViewController: UIViewController {
       $0.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
     }
 
-    let wk = WKWebView(frame: view.frame, configuration: configuration)
+    let wk = BraveWebView(frame: view.frame, configuration: configuration)
 
     let domain = Domain.getOrCreate(forUrl: url, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5415 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Open Private Browsing mode, go to wikipedia or some other website
- Long press on a link, it should show a website preview in the context menu
- Close the app or the private mode
- Go to Brave Shields settings -> Manage website data
- Verify that there's no cookie and cache for the link you previewed

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
