### PR TITLE
Fix #5862: Extending size of click target  for search suggestion populate button

### DIFF
--- a/Client/Frontend/Browser/Search/SearchSuggestionCell.swift
+++ b/Client/Frontend/Browser/Search/SearchSuggestionCell.swift
@@ -24,8 +24,9 @@ class SuggestionCell: UITableViewCell {
     $0.lineBreakMode = .byTruncatingMiddle
   }
 
-  private let openButton = UIButton().then {
-    $0.setImage(UIImage(named: "recent-search-arrow", in: .current, compatibleWith: nil)!, for: .normal)
+  private let openButton = BraveButton().then {
+    $0.setImage(UIImage(named: "recent-search-arrow", in: .current, compatibleWith: nil), for: .normal)
+    $0.hitTestSlop = UIEdgeInsets(equalInset: -20)
     $0.setContentHuggingPriority(.required, for: .horizontal)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
   }


### PR DESCRIPTION
Adding Extra inset to search suggestion populate button hitTest

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5862

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Open Brave
- Click on the top search bar
- Search something to get suggestions
- Click arrow to populate new search text in url bar
- Test if it is convenient to test after changes

## Screenshots:

https://user-images.githubusercontent.com/6643505/186215455-e22d9d7c-6d79-42ee-bb3c-07a2b912b26c.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
