### PR TITLE
Fix #4684: Race condition allows on-screen keyboard to pre-empt while showing Privacy Education

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -134,17 +134,22 @@ extension BrowserViewController {
     
     controller.buttonText = Strings.PrivacyHub.onboardingButtonTitle
 
+    topToolbar.isURLBarEnabled = false
+
     presentPopoverContent(
       using: controller,
       with: frame, cornerRadius: 12.0,
-      didDismiss: {
+      didDismiss: { [weak self] in
+        self?.topToolbar.isURLBarEnabled = true
         Preferences.PrivacyReports.ntpOnboardingCompleted.value = true
       },
-      didClickBorderedArea: {
+      didClickBorderedArea: { [weak self] in
+        self?.topToolbar.isURLBarEnabled = true
         Preferences.PrivacyReports.ntpOnboardingCompleted.value = true
       },
       didButtonClick: { [weak self] in
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+          self?.topToolbar.isURLBarEnabled = true
           self?.openPrivacyReport()
         }
       }

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -170,6 +170,14 @@ class TopToolbarView: UIView, ToolbarProtocol {
       self.shareButton, self.tabsButton, self.bookmarkButton,
       self.forwardButton, self.backButton, self.menuButton,
     ].compactMap { $0 }
+  
+  var isURLBarEnabled = true {
+    didSet {
+      if oldValue == isURLBarEnabled { return }
+      
+      locationTextField?.isUserInteractionEnabled = isURLBarEnabled
+    }
+  }
 
   /// Update the shields icon based on whether or not shields are enabled for this site
   func refreshShieldsStatus() {


### PR DESCRIPTION
Adding url bar interaction while showing privacy onboarding.

## Summary of Changes

After original ticket created Onboarding is totally changed so the steps to produce this ticket is changed with it.

Right now the Privacy Hub NTP alert is being shown on a different time but same can be produced when alert is shown on the screen.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4684

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Satisfy the conditions for Privacy Onboarding including (20 tracker blocked on debug build)
Next 2 steps are same with older ticket
- (timing on this is pretty difficult) now, tap on the URL bar, to bring up the on-screen keyboard
- look at the screen

## Screenshots:

![1](https://user-images.githubusercontent.com/6643505/186236394-22c6bd8d-f18f-4b9e-b91c-17acf4eb406b.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
