### PR TITLE
Fix #4672: Japan NTP tutorial page is being set as active tab when skipping on-boarding

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -36,14 +36,16 @@ extension BrowserViewController {
         profile: profile,
         rewards: rewards)
       onboardingController.modalPresentationStyle = .fullScreen
-      onboardingController.delegate = self
       parentController.present(onboardingController, animated: false)
       isOnboardingOrFullScreenCalloutPresented = true
     }
   }
 
   private func addNTPTutorialPage() {
-    if showNTPEducation().isEnabled, let url = showNTPEducation().url {
+    let basicOnboardingNotCompleted =
+      Preferences.General.basicOnboardingProgress.value != OnboardingProgress.newTabPage.rawValue
+    
+    if basicOnboardingNotCompleted, showNTPEducation().isEnabled, let url = showNTPEducation().url {
       tabManager.addTab(
         PrivilegedRequest(url: url) as URLRequest,
         afterTab: self.tabManager.selectedTab,
@@ -59,6 +61,7 @@ extension BrowserViewController {
       if !Preferences.FullScreenCallout.omniboxCalloutCompleted.value,
           Preferences.General.isNewRetentionUser.value == true {
         presentOmniBoxOnboarding()
+        addNTPTutorialPage()
       }
       
       if !Preferences.FullScreenCallout.ntpCalloutCompleted.value {
@@ -285,14 +288,6 @@ extension BrowserViewController {
   func completeOnboarding(_ controller: UIViewController) {
     Preferences.General.basicOnboardingCompleted.value = OnboardingState.completed.rawValue
     controller.dismiss(animated: true)
-  }
-}
-
-// MARK: WelcomeViewControllerDelegate
-
-extension BrowserViewController: WelcomeViewControllerDelegate {
-  func welcomeViewControllerDidShowNTPTutorialPage() {
-    addNTPTutorialPage()
   }
 }
 

--- a/Client/Frontend/Browser/Onboarding/OnboardingState.swift
+++ b/Client/Frontend/Browser/Onboarding/OnboardingState.swift
@@ -19,10 +19,8 @@ public enum OnboardingState: Int {
 public enum OnboardingProgress: Int {
   /// The user has never started any onboarding.
   case none
-  /// The user has completed the privacy consent
-  case privacyConsent
-  /// The user has completed the search engine onboarding.
-  case searchEngine
+  /// The user has seen new Tab Page
+  case newTabPage
   /// The user has completed the rewards onboarding.
   case rewards
 }

--- a/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Client/Frontend/Browser/Onboarding/Welcome/WelcomeViewController.swift
@@ -20,15 +20,10 @@ private enum WelcomeViewID: Int {
   case iconBackground = 8
 }
 
-protocol WelcomeViewControllerDelegate: AnyObject {
-  func welcomeViewControllerDidShowNTPTutorialPage()
-}
-
 class WelcomeViewController: UIViewController {
   private let profile: Profile?
   private let rewards: BraveRewards?
   private var state: WelcomeViewCalloutState?
-  weak var delegate: WelcomeViewControllerDelegate?
 
   convenience init(profile: Profile?, rewards: BraveRewards?) {
     self.init(
@@ -348,7 +343,6 @@ class WelcomeViewController: UIViewController {
           nextController.animateToDefaultSettingsState()
         },
         secondaryAction: {
-          self.delegate?.welcomeViewControllerDidShowNTPTutorialPage()
           self.close()
         }
       )
@@ -378,7 +372,6 @@ class WelcomeViewController: UIViewController {
       return
     }
     UIApplication.shared.open(settingsUrl)
-    self.delegate?.welcomeViewControllerDidShowNTPTutorialPage()
     self.close()
   }
 
@@ -403,6 +396,8 @@ class WelcomeViewController: UIViewController {
 
       break
     }
+    
+    Preferences.General.basicOnboardingProgress.value = OnboardingProgress.newTabPage.rawValue
     presenting.dismiss(animated: true, completion: nil)
   }
 }


### PR DESCRIPTION
Adding Japan NTP page load properly after onboarding. Currently no page is presented in new tab sequence.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4672

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Ensure Region/Language is set to Japan before launching Brave)
Skip the on-boarding and you'll notice that https://brave.com/ja/ntp-tutorial should be set as the non-active tab rather than active

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/186260709-4e43c09b-939d-4679-b341-bb64d8bde87a.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
