### PR TITLE
Fix #5415: Private tab Link-Previews

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3168,8 +3168,11 @@ extension BrowserViewController: WKUIDelegate {
       return UIMenu(title: url.absoluteString.truncate(length: 100), children: actions)
     }
 
-    let linkPreview: UIContextMenuContentPreviewProvider = {
-      return LinkPreviewViewController(url: url)
+    let linkPreview: UIContextMenuContentPreviewProvider? = { [unowned self] in
+      if let tab = tabManager.tabForWebView(webView) {
+        return LinkPreviewViewController(url: url, for: tab, browserController: self)
+      }
+      return nil
     }
 
     let linkPreviewProvider = Preferences.General.enableLinkPreview.value ? linkPreview : nil

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -39,6 +39,10 @@ extension URL {
 }
 
 extension BrowserViewController {
+  private func tab(for webView: WKWebView) -> Tab? {
+    tabManager[webView] ?? (webView as? TabWebView)?.tab
+  }
+  
   fileprivate func handleExternalURL(_ url: URL, openedURLCompletionHandler: ((Bool) -> Void)? = nil) {
     self.view.endEditing(true)
     let popup = AlertPopupView(
@@ -198,7 +202,7 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
-    let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab
+    let tab = tab(for: webView)
 
     let domainForRequestURL = Domain.getOrCreate(
       forUrl: url,
@@ -393,7 +397,7 @@ extension BrowserViewController: WKNavigationDelegate {
   public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
     let response = navigationResponse.response
     let responseURL = response.url
-    let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab
+    let tab = tab(for: webView)
 
     if let tab = tab,
       let responseURL = responseURL,
@@ -480,7 +484,7 @@ extension BrowserViewController: WKNavigationDelegate {
     guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic ||
           challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest ||
           challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM,
-          let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab
+          let tab = tab(for: webView)
     else {
       completionHandler(.performDefaultHandling, nil)
       return
@@ -507,7 +511,7 @@ extension BrowserViewController: WKNavigationDelegate {
   }
 
   public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
-    guard let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab else { return }
+    guard let tab = tab(for: webView) else { return }
     // Set the committed url which will also set tab.url
     tab.committedURL = webView.url
     
@@ -606,7 +610,7 @@ extension BrowserViewController: WKNavigationDelegate {
   }
 
   public func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
-    guard let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab, let url = webView.url, rewards.isEnabled else { return }
+    guard let tab = tab(for: webView), let url = webView.url, rewards.isEnabled else { return }
     tab.redirectURLs.append(url)
   }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -198,7 +198,7 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
-    let tab = tabManager[webView]
+    let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab
 
     let domainForRequestURL = Domain.getOrCreate(
       forUrl: url,
@@ -305,7 +305,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
     if ["http", "https", "data", "blob", "file"].contains(url.scheme) {
       if navigationAction.targetFrame?.isMainFrame == true {
-        tabManager[webView]?.updateUserAgent(webView, newURL: url)
+        tab?.updateUserAgent(webView, newURL: url)
       }
 
       pendingRequests[url.absoluteString] = navigationAction.request
@@ -352,7 +352,7 @@ extension BrowserViewController: WKNavigationDelegate {
       }
 
       // Cookie Blocking code below
-      if let tab = tabManager[webView] {
+      if let tab = tab {
         tab.userScriptManager?.isCookieBlockingEnabled = Preferences.Privacy.blockAllCookies.value
       }
 
@@ -393,8 +393,9 @@ extension BrowserViewController: WKNavigationDelegate {
   public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
     let response = navigationResponse.response
     let responseURL = response.url
+    let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab
 
-    if let tab = tabManager[webView],
+    if let tab = tab,
       let responseURL = responseURL,
       InternalURL(responseURL)?.isSessionRestore == true {
       tab.shouldClassifyLoadsForAds = false
@@ -414,8 +415,8 @@ extension BrowserViewController: WKNavigationDelegate {
       // If an upgraded https load happens with a host which was upgraded, increase the stats
       if url.scheme == "https", let _ = pendingHTTPUpgrades.removeValue(forKey: urlHost) {
         BraveGlobalShieldStats.shared.httpse += 1
-        if let stats = self.tabManager[webView]?.contentBlocker.stats {
-          self.tabManager[webView]?.contentBlocker.stats = stats.adding(httpsCount: 1)
+        if let stats = tab?.contentBlocker.stats {
+          tab?.contentBlocker.stats = stats.adding(httpsCount: 1)
         }
       }
     }
@@ -449,7 +450,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
     // If the content type is not HTML, create a temporary document so it can be downloaded and
     // shared to external applications later. Otherwise, clear the old temporary document.
-    if let tab = tabManager[webView], navigationResponse.isForMainFrame {
+    if let tab = tab, navigationResponse.isForMainFrame {
       if response.mimeType?.isKindOfHTML == false, let request = request {
         tab.temporaryDocument = TemporaryDocument(preflightResponse: response, request: request, tab: tab)
       } else {
@@ -476,8 +477,10 @@ extension BrowserViewController: WKNavigationDelegate {
       return
     }
 
-    guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM,
-      let tab = tabManager[webView]
+    guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic ||
+          challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest ||
+          challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM,
+          let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab
     else {
       completionHandler(.performDefaultHandling, nil)
       return
@@ -504,7 +507,7 @@ extension BrowserViewController: WKNavigationDelegate {
   }
 
   public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
-    guard let tab = tabManager[webView] else { return }
+    guard let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab else { return }
     // Set the committed url which will also set tab.url
     tab.committedURL = webView.url
     
@@ -603,7 +606,7 @@ extension BrowserViewController: WKNavigationDelegate {
   }
 
   public func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
-    guard let tab = tabManager[webView], let url = webView.url, rewards.isEnabled else { return }
+    guard let tab = tabManager[webView] ?? (webView as? TabWebView)?.tab, let url = webView.url, rewards.isEnabled else { return }
     tab.redirectURLs.append(url)
   }
 }

--- a/Client/Frontend/Browser/LinkPreviewViewController.swift
+++ b/Client/Frontend/Browser/LinkPreviewViewController.swift
@@ -9,10 +9,15 @@ import Shared
 
 class LinkPreviewViewController: UIViewController {
 
-  let url: URL
+  private let url: URL
+  private weak var parentTab: Tab?
+  private var currentTab: Tab?
+  private weak var browserController: BrowserViewController?
 
-  init(url: URL) {
+  init(url: URL, for tab: Tab, browserController: BrowserViewController) {
     self.url = url
+    self.parentTab = tab
+    self.browserController = browserController
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -20,22 +25,33 @@ class LinkPreviewViewController: UIViewController {
   required init?(coder aDecoder: NSCoder) { fatalError() }
 
   override func viewDidLoad() {
-    let configuration = WKWebViewConfiguration().then {
-      $0.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
+    guard let parentTab = parentTab,
+          let tabWebView = parentTab.webView else {
+      return
     }
-
-    let wk = WKWebView(frame: view.frame, configuration: configuration)
-
-    let domain = Domain.getOrCreate(forUrl: url, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
-
-    BlocklistName.blocklists(forDomain: domain).on.forEach {
-      ContentBlockerHelper.ruleStore.lookUpContentRuleList(forIdentifier: $0.filename) { rule, _ in
-        guard let rule = rule else { return }
-        wk.configuration.userContentController.add(rule)
-      }
+    
+    currentTab = Tab(configuration: tabWebView.configuration,
+                     type: .private,
+                     tabGeneratorAPI: nil).then {
+      $0.tabDelegate = browserController
+      $0.navigationDelegate = browserController
+      $0.createWebview()
+      $0.webView?.scrollView.layer.masksToBounds = true
     }
-
-    view.addSubview(wk)
-    wk.load(URLRequest(url: url))
+    
+    guard let currentTab = currentTab,
+          let webView = currentTab.webView else {
+      return
+    }
+    
+    webView.frame = view.bounds
+    view.addSubview(webView)
+    
+    webView.load(URLRequest(url: url))
+  }
+  
+  deinit {
+    self.currentTab?.navigationDelegate = nil
+    self.currentTab = nil
   }
 }

--- a/Client/Frontend/Browser/LinkPreviewViewController.swift
+++ b/Client/Frontend/Browser/LinkPreviewViewController.swift
@@ -31,7 +31,7 @@ class LinkPreviewViewController: UIViewController {
     }
     
     currentTab = Tab(configuration: tabWebView.configuration,
-                     type: .private,
+                     type: parentTab.isPrivate ? .private : .regular,
                      tabGeneratorAPI: nil).then {
       $0.tabDelegate = browserController
       $0.navigationDelegate = browserController

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -315,7 +315,7 @@ class Tab: NSObject {
       if configuration!.urlSchemeHandler(forURLScheme: InternalURL.scheme) == nil {
         configuration!.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
       }
-      let webView = TabWebView(frame: .zero, configuration: configuration!, isPrivate: isPrivate)
+      let webView = TabWebView(frame: .zero, tab: self, configuration: configuration!, isPrivate: isPrivate)
       webView.delegate = self
       configuration = nil
 
@@ -839,6 +839,12 @@ private protocol TabWebViewDelegate: AnyObject {
 
 class TabWebView: BraveWebView, MenuHelperInterface {
   fileprivate weak var delegate: TabWebViewDelegate?
+  private(set) weak var tab: Tab?
+  
+  init(frame: CGRect, tab: Tab, configuration: WKWebViewConfiguration = WKWebViewConfiguration(), isPrivate: Bool = true) {
+    self.tab = tab
+    super.init(frame: frame, configuration: configuration, isPrivate: isPrivate)
+  }
 
   override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
     if action == MenuHelper.selectorForcePaste {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix private tabs Link Previews to not store History.
- Fix private tabs Link Previews to use the same delegates as all other tabs, so it automatically gets ad-block, fingerprint protection, etc...

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5415

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- In the Ticket

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
