### PR TITLE
Fix #5941: support coin type in EditSiteConnectionView

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -189,6 +189,7 @@ public struct CryptoView: View {
               EditSiteConnectionView(
                 keyringStore: keyringStore,
                 origin: origin,
+                coin: .eth, // TODO: switch to dynamic coin type once we support Solona Dapps
                 onDismiss: { accounts in
                   handler(accounts)
                   dismissAction?()

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2479,6 +2479,20 @@ extension Strings {
       value: "Switch",
       comment: "The title of the button for users to click so that they disconnect wallet account to the dapp site(also permission removed). It will be displayed at the right hand side of each account option in edit site connection screen."
     )
+    public static let editSiteConnectionAccountActionTrust = NSLocalizedString(
+      "wallet.editSiteConnectionAccountActionTrust",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Trust",
+      comment: "The title of the button for users to click so that they grant wallet account permission for the Solana Dapp. It will be displayed at the right hand side of each account option in edit site connection screen."
+    )
+    public static let editSiteConnectionAccountActionRevoke = NSLocalizedString(
+      "wallet.editSiteConnectionAccountActionRevoke",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Revoke",
+      comment: "The title of the button for users to click so that they remove wallet account permission from the Solana Dapp. It will be displayed at the right hand side of each account option in edit site connection screen"
+    )
     public static let walletPanelConnected = NSLocalizedString(
       "wallet.walletPanelConnected",
       tableName: "BraveWallet",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
EditSiteConnectionView is now supporting coin type.
However, currently, we will only pass `.eth` since solana dapps will not be supported til 1.45.x

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5941

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
