### PR TITLE
Re-Fix #5863: Ensure the tab tray search bar fills the space on iOS 16

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/Views/TabTraySearchView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabTraySearchView.swift
@@ -3,7 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 import UIKit
 
 class TabTraySearchBar: UIView {
@@ -13,6 +12,7 @@ class TabTraySearchBar: UIView {
     self.searchBar = searchBar
     super.init(frame: .zero)
     addSubview(searchBar)
+    translatesAutoresizingMaskIntoConstraints = false
   }
 
   @available(*, unavailable)
@@ -37,10 +37,8 @@ class TabTraySearchBar: UIView {
     searchBar.frame = adjustedFrame
   }
 
-  override func sizeThatFits(_ size: CGSize) -> CGSize {
-    // This is done to adjust the frame of a UISearchBar inside of UISearchController
-    // Adjusting the bar frame directly doesnt work so had to create a custom view with UISearchBar
-    .init(width: size.width + 16, height: size.height)
+  override var intrinsicContentSize: CGSize {
+    return UIView.layoutFittingExpandedSize
   }
 }
 


### PR DESCRIPTION
Repeat of https://github.com/brave/brave-ios/pull/5871 

Code was accidentally reverted due to a rebase mistake in tab sync