### PR TITLE
Fix #5952: Improve hit area of top toolbar buttons

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -263,8 +263,6 @@ class TabLocationView: UIView {
 
     let subviews = [lockImageView, urlTextField, tabOptionsStackView]
     contentView = UIStackView(arrangedSubviews: subviews)
-    contentView.distribution = .fill
-    contentView.alignment = .center
     contentView.layoutMargins = UIEdgeInsets(top: 2, left: TabLocationViewUX.spacing, bottom: 2, right: 0)
     contentView.isLayoutMarginsRelativeArrangement = true
     contentView.insetsLayoutMarginsFromSafeArea = false

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -279,7 +279,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
   }
 
   private let mainStackView = UIStackView().then {
-    $0.alignment = .center
     $0.spacing = 8
     $0.isLayoutMarginsRelativeArrangement = true
     $0.insetsLayoutMarginsFromSafeArea = false
@@ -293,7 +292,6 @@ class TopToolbarView: UIView, ToolbarProtocol {
   
   private let trailingItemsStackView = UIStackView().then {
     $0.distribution = .fillEqually
-    $0.alignment = .center
     $0.spacing = 8
   }
 


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5952 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
