### PR TITLE
Fix #5940: Fixes last playback not working at all

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -187,6 +187,14 @@ class PlaylistListViewController: UIViewController {
 
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
+    
+    // Store the last played item's time-offset
+    if let playTime = delegate?.currentPlaylistItem?.currentTime(),
+      Preferences.Playlist.playbackLeftOff.value {
+      Preferences.Playlist.lastPlayedItemTime.value = playTime.seconds
+    } else {
+      Preferences.Playlist.lastPlayedItemTime.value = 0.0
+    }
 
     onCancelEditingItems()
   }
@@ -247,20 +255,37 @@ class PlaylistListViewController: UIViewController {
     }
     
     // Shared folders are loading
-    if PlaylistManager.shared.currentFolder == nil {
+    if PlaylistManager.shared.currentFolder?.isPersistent == false {
       autoPlayEnabled = true
       return
     }
 
     // Setup initial playback item and time-offset
+    var lastPlayedItemTime: Double = 0.0
+    
     let lastPlayedItemUrl = initialItem?.pageSrc ?? Preferences.Playlist.lastPlayedItemUrl.value
-    let lastPlayedItemTime = initialItem != nil ? initialItemOffset : Preferences.Playlist.lastPlayedItemTime.value
+    let lastPlayedItemId = PlaylistManager.shared.allItems.first(where: { $0.pageSrc == lastPlayedItemUrl })?.tagId
+    
+    // If the user is current viewing the same video as the last played item
+    // then we choose whichever time offset is more recent
+    if let pageSrc = initialItem?.pageSrc,
+       let lastPlayedItem = Preferences.Playlist.lastPlayedItemUrl.value,
+       pageSrc == lastPlayedItem {
+      
+      // User is current on the same page as the last played item
+      lastPlayedItemTime = initialItemOffset > Preferences.Playlist.lastPlayedItemTime.value ?
+                           initialItemOffset : Preferences.Playlist.lastPlayedItemTime.value
+    } else {
+      // Otherwise we choose the last played item offset from the page and fallback to the preference if none exists
+      lastPlayedItemTime = initialItem != nil ? initialItemOffset : Preferences.Playlist.lastPlayedItemTime.value
+    }
+    
     autoPlayEnabled = initialItem != nil ? true : Preferences.Playlist.firstLoadAutoPlay.value
 
     // If there is no last played item, then just select the first item in the playlist
     // which will play it if auto-play is enabled.
-    guard let lastPlayedItemUrl = lastPlayedItemUrl,
-      let index = PlaylistManager.shared.index(of: lastPlayedItemUrl)
+    guard let lastPlayedItemId = lastPlayedItemId,
+      let index = PlaylistManager.shared.index(of: lastPlayedItemId)
     else {
       tableView.delegate?.tableView?(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
       autoPlayEnabled = true
@@ -274,6 +299,7 @@ class PlaylistListViewController: UIViewController {
     }
 
     // Prepare the UI before playing the item
+    delegate?.showStaticImage(image: nil)
     let indexPath = IndexPath(row: index, section: 0)
     prepareToPlayItem(at: indexPath) { [weak self] item in
       guard let self = self,
@@ -324,7 +350,7 @@ class PlaylistListViewController: UIViewController {
           // Update the player position/time-offset of the last played item
           self.seekLastPlayedItem(
             at: indexPath,
-            lastPlayedItemUrl: lastPlayedItemUrl,
+            lastPlayedItemId: lastPlayedItemId,
             lastPlayedTime: lastPlayedItemTime)
 
           // Even if the item was NOT previously the last played item,
@@ -337,7 +363,7 @@ class PlaylistListViewController: UIViewController {
     autoPlayEnabled = true
   }
 
-  private func seekLastPlayedItem(at indexPath: IndexPath, lastPlayedItemUrl: String, lastPlayedTime: Double) {
+  private func seekLastPlayedItem(at indexPath: IndexPath, lastPlayedItemId: String, lastPlayedTime: Double) {
     // The item can be deleted at any time,
     // so we need to guard against it and make sure the index path matches up correctly
     // If it does, we check the last played time
@@ -345,7 +371,7 @@ class PlaylistListViewController: UIViewController {
     let item = PlaylistManager.shared.itemAtIndex(indexPath.row)
     guard let item = item else { return }
 
-    if item.pageSrc == lastPlayedItemUrl && lastPlayedTime > 0.0 && lastPlayedTime < delegate?.currentPlaylistAsset?.duration.seconds ?? 0.0 && Preferences.Playlist.playbackLeftOff.value {
+    if item.tagId == lastPlayedItemId && lastPlayedTime > 0.0 && lastPlayedTime < delegate?.currentPlaylistAsset?.duration.seconds ?? 0.0 && Preferences.Playlist.playbackLeftOff.value {
       self.playerView.seek(to: lastPlayedTime)
     }
   }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -272,9 +272,8 @@ class PlaylistListViewController: UIViewController {
        let lastPlayedItem = Preferences.Playlist.lastPlayedItemUrl.value,
        pageSrc == lastPlayedItem {
       
-      // User is current on the same page as the last played item
-      lastPlayedItemTime = initialItemOffset > Preferences.Playlist.lastPlayedItemTime.value ?
-                           initialItemOffset : Preferences.Playlist.lastPlayedItemTime.value
+      // User is current on the same page as the last played item]
+      lastPlayedItemTime = max(initialItemOffset, Preferences.Playlist.lastPlayedItemTime.value)
     } else {
       // Otherwise we choose the last played item offset from the page and fallback to the preference if none exists
       lastPlayedItemTime = initialItem != nil ? initialItemOffset : Preferences.Playlist.lastPlayedItemTime.value


### PR DESCRIPTION
## Summary of Changes
- Fix for last playback not working at all when leaving the current screen
- Fix for last playback not working at all due to shared folders refactor

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5940

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
