### PR TITLE
Fix #5947: Only show selected account for NewSiteConnectionView when coin type is solana

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -97,6 +97,9 @@ public class KeyringStore: ObservableObject {
   var allAccounts: [BraveWallet.AccountInfo] {
     allKeyrings.flatMap(\.accountInfos)
   }
+  
+  /// A list of default account with all support coin types
+  @Published var defaultAccounts: [BraveWallet.AccountInfo] = []
 
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
@@ -148,6 +151,7 @@ public class KeyringStore: ObservableObject {
       let selectedCoin = await walletService.selectedCoin()
       let selectedAccountAddress = await keyringService.selectedAccount(selectedCoin)
       self.allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
+      self.defaultAccounts = await keyringService.defaultAccounts(for: WalletConstants.supportedCoinTypes)
       if let defaultKeyring = allKeyrings.first(where: { $0.id == BraveWallet.DefaultKeyringId }) {
         self.defaultKeyring = defaultKeyring
       }

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -39,7 +39,14 @@ public struct NewSiteConnectionView: View {
   @State private var isConfirmationViewVisible: Bool = false
   
   private var accountInfos: [BraveWallet.AccountInfo] {
-    keyringStore.allKeyrings.first(where: { $0.coin == coin })?.accountInfos ?? []
+    if coin == .sol {
+      if let solanaDefaultAccount = keyringStore.defaultAccounts.first(where: { $0.coin == .sol }) {
+        return [solanaDefaultAccount]
+      } else {
+        return []
+      }
+    }
+    return keyringStore.allKeyrings.first(where: { $0.coin == coin })?.accountInfos ?? []
   }
   
   @ViewBuilder private func originAndFavicon(urlOrigin: URLOrigin) -> some View {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Since solana dapps connection will only established from the dapp side, we will only show the selected solana account for new connection request.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5947 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
