### PR TITLE
Fix #5963:  Close All Tabs action should close Tabs for current Tab Mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2864,7 +2864,7 @@ extension BrowserViewController: TabManagerDelegate {
           let cancelAction = UIAlertAction(title: Strings.CancelString, style: .cancel)
           let closedTabsTitle = String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count)
           let closeAllAction = UIAlertAction(title: closedTabsTitle, style: .destructive) { _ in
-            tabManager.removeAll()
+            tabManager.removeAllForCurrentMode()
           }
           alert.addAction(closeAllAction)
           alert.addAction(cancelAction)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -110,7 +110,7 @@ extension BrowserViewController {
   }
 
   @objc private func closeAllTabsKeyCommand() {
-    tabManager.removeAll()
+    tabManager.removeAllForCurrentMode()
   }
 
   @objc private func addBookmarkCommand() {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -818,6 +818,10 @@ class TabManager: NSObject {
   func removeAll() {
     removeTabs(self.allTabs)
   }
+  
+  func removeAllForCurrentMode() {
+    removeTabs(tabsForCurrentMode)
+  }
 
   func getIndex(_ tab: Tab) -> Int? {
     assert(Thread.isMainThread)


### PR DESCRIPTION
Close All # Tabs action should close all the tabs for the current Tab Mode (Normal / Private).

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5963

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

- Start Browser in Normal Mode
- Open some random tabs
- Navigate Tab Tray and change viewing mode to Private
- Open 4 (could be any number) tabs in private mode
- Close Tab Tray and long press tab icon on bottom bar
- Choose action Close All Tabs
- Check Tabs in Private Mode is closed
- Change viewing mode to normal
- Check Tabs opened in normal mode is not closed

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/188171275-9bcb0a6e-ee4e-4f26-88bc-dee1e4e116b8.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
