### PR TITLE
Fix #5966: Edit visible token lists is not correct after a new solana account has been created and selected.

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -366,7 +366,7 @@ extension KeyringStore: BraveWalletKeyringServiceObserver {
     Task { @MainActor in
       let previouslySelectedCoin = await walletService.selectedCoin()
       walletService.setSelectedCoin(coinType)
-      if previouslySelectedCoin != coinType {
+      if previouslySelectedCoin != coinType || selectedAccount.coin != coinType {
         // update network here in case NetworkStore is closed.
         let network = await rpcService.network(coinType)
         await rpcService.setNetwork(network.chainId, coin: coinType)
@@ -377,21 +377,8 @@ extension KeyringStore: BraveWalletKeyringServiceObserver {
 
   public func keyringCreated(_ keyringId: String) {
     Task { @MainActor in
-      var coin: BraveWallet.CoinType = .eth
-      switch keyringId {
-      case BraveWallet.DefaultKeyringId:
-        coin = .eth
-      case BraveWallet.SolanaKeyringId:
-        coin = .sol
-      case BraveWallet.FilecoinKeyringId:
-        coin = .fil
-      default:
-        break
-      }
-      
       let newKeyring = await keyringService.keyringInfo(keyringId)
       if let newAccount = newKeyring.accountInfos.first {
-        walletService.setSelectedCoin(coin)
         await keyringService.setSelectedAccount(newAccount.address, coin: newAccount.coin)
       }
       updateKeyringInfo()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Correctly set network after a new keyring is created.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5966 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
