### PR TITLE
Ref #5948: iOS 16 UIMenu Paste prompt avoidance  

### DIFF
--- a/Client/Extensions/UIActionExtensions.swift
+++ b/Client/Extensions/UIActionExtensions.swift
@@ -22,3 +22,20 @@ extension UIAction {
     }
   }
 }
+
+extension UIAction.Identifier {
+  static var backportedPasteAndGo: UIAction.Identifier? {
+    if #available(iOS 15.0, *) {
+      return .pasteAndGo
+    } else {
+      return nil
+    }
+  }
+  static var backportedPaste: UIAction.Identifier? {
+    if #available(iOS 15.0, *) {
+      return .paste
+    } else {
+      return nil
+    }
+  }
+}

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -642,24 +642,52 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
     return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] _ in
       var actionMenuChildren: [UIAction] = []
 
-      let pasteGoAction = UIAction(
-        title: Strings.pasteAndGoTitle,
-        image: UIImage(systemName: "doc.on.clipboard.fill"),
-        handler: UIAction.deferredActionHandler { _ in
-          if let pasteboardContents = UIPasteboard.general.string {
-            self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
-          }
-        })
+      var pasteGoAction: UIAction?
+      var pasteAction: UIAction?
+      
+      if #available(iOS 15.0, *) {
+        pasteGoAction = UIAction(
+          title: Strings.pasteAndGoTitle,
+          image: UIImage(systemName: "doc.on.clipboard.fill"),
+          identifier: .pasteAndGo,
+          handler: UIAction.deferredActionHandler { _ in
+            if let pasteboardContents = UIPasteboard.general.string {
+              self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
+            }
+          })
+      } else {
+        pasteGoAction = UIAction(
+          title: Strings.pasteAndGoTitle,
+          image: UIImage(systemName: "doc.on.clipboard.fill"),
+          handler: UIAction.deferredActionHandler { _ in
+            if let pasteboardContents = UIPasteboard.general.string {
+              self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
+            }
+          })
+      }
 
-      let pasteAction = UIAction(
-        title: Strings.pasteTitle,
-        image: UIImage(systemName: "doc.on.clipboard"),
-        handler: UIAction.deferredActionHandler { _ in
-          if let pasteboardContents = UIPasteboard.general.string {
-            // Enter overlay mode and make the search controller appear.
-            self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
-          }
-        })
+      if #available(iOS 15.0, *) {
+        pasteAction = UIAction(
+          title: Strings.pasteTitle,
+          image: UIImage(systemName: "doc.on.clipboard"),
+          identifier: .paste,
+          handler: UIAction.deferredActionHandler { _ in
+            if let pasteboardContents = UIPasteboard.general.string {
+              // Enter overlay mode and make the search controller appear.
+              self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+            }
+          })
+      } else {
+        pasteAction = UIAction(
+          title: Strings.pasteTitle,
+          image: UIImage(systemName: "doc.on.clipboard"),
+          handler: UIAction.deferredActionHandler { _ in
+            if let pasteboardContents = UIPasteboard.general.string {
+              // Enter overlay mode and make the search controller appear.
+              self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+            }
+          })
+      }
 
       let copyAction = UIAction(
         title: Strings.copyAddressTitle,
@@ -671,7 +699,15 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         })
 
       if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
-        actionMenuChildren = [pasteGoAction, pasteAction, copyAction]
+        if let pasteGoAction = pasteGoAction {
+          actionMenuChildren.append(pasteGoAction)
+        }
+        
+        if let pasteAction = pasteAction {
+          actionMenuChildren.append(pasteAction)
+        }
+        
+        actionMenuChildren.append(copyAction)
       } else {
         actionMenuChildren = [copyAction]
       }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -642,52 +642,26 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
     return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] _ in
       var actionMenuChildren: [UIAction] = []
 
-      var pasteGoAction: UIAction?
-      var pasteAction: UIAction?
-      
-      if #available(iOS 15.0, *) {
-        pasteGoAction = UIAction(
-          title: Strings.pasteAndGoTitle,
-          image: UIImage(systemName: "doc.on.clipboard.fill"),
-          identifier: .pasteAndGo,
-          handler: UIAction.deferredActionHandler { _ in
-            if let pasteboardContents = UIPasteboard.general.string {
-              self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
-            }
-          })
-      } else {
-        pasteGoAction = UIAction(
-          title: Strings.pasteAndGoTitle,
-          image: UIImage(systemName: "doc.on.clipboard.fill"),
-          handler: UIAction.deferredActionHandler { _ in
-            if let pasteboardContents = UIPasteboard.general.string {
-              self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
-            }
-          })
-      }
+      let pasteGoAction = UIAction(
+        title: Strings.pasteAndGoTitle,
+        image: UIImage(systemName: "doc.on.clipboard.fill"),
+        identifier: .backportedPasteAndGo,
+        handler: UIAction.deferredActionHandler { _ in
+          if let pasteboardContents = UIPasteboard.general.string {
+            self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
+          }
+        })
 
-      if #available(iOS 15.0, *) {
-        pasteAction = UIAction(
-          title: Strings.pasteTitle,
-          image: UIImage(systemName: "doc.on.clipboard"),
-          identifier: .paste,
-          handler: UIAction.deferredActionHandler { _ in
-            if let pasteboardContents = UIPasteboard.general.string {
-              // Enter overlay mode and make the search controller appear.
-              self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
-            }
-          })
-      } else {
-        pasteAction = UIAction(
-          title: Strings.pasteTitle,
-          image: UIImage(systemName: "doc.on.clipboard"),
-          handler: UIAction.deferredActionHandler { _ in
-            if let pasteboardContents = UIPasteboard.general.string {
-              // Enter overlay mode and make the search controller appear.
-              self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
-            }
-          })
-      }
+      let pasteAction = UIAction(
+        title: Strings.pasteTitle,
+        image: UIImage(systemName: "doc.on.clipboard"),
+        identifier: .backportedPaste,
+        handler: UIAction.deferredActionHandler { _ in
+          if let pasteboardContents = UIPasteboard.general.string {
+            // Enter overlay mode and make the search controller appear.
+            self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+          }
+        })
 
       let copyAction = UIAction(
         title: Strings.copyAddressTitle,
@@ -699,15 +673,7 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         })
 
       if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
-        if let pasteGoAction = pasteGoAction {
-          actionMenuChildren.append(pasteGoAction)
-        }
-        
-        if let pasteAction = pasteAction {
-          actionMenuChildren.append(pasteAction)
-        }
-        
-        actionMenuChildren.append(copyAction)
+        actionMenuChildren = [pasteGoAction, pasteAction, copyAction]
       } else {
         actionMenuChildren = [copyAction]
       }


### PR DESCRIPTION

This is the first part of avoiding clipboard prompt for iOS 16.

Adding identifier to paste and go - paste action for avoiding paste confirmation prompt. This will allow us to copy from UIMenu actions without any prompt. 

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #5948

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Long Press URL Bar
- Paste - Paste & Go actions should not trigger prompt on iOS16

## Screenshots:


![test1 1](https://user-images.githubusercontent.com/6643505/188712473-aaa00f53-2b76-45d9-b218-d91b97ac3585.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
