### PR TITLE
Fix #5972: [Follow up to 4502] Switch to next tab keyboard shortcut (ctrl + tab)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -261,7 +261,7 @@ extension BrowserViewController {
 
     // Additional Commands which will have priority over system
     let additionalPriorityCommandKeys = [
-      UIKeyCommand(input: "\t", modifierFlags: .control, action: #selector(newTabKeyCommand))
+      UIKeyCommand(input: "\t", modifierFlags: .control, action: #selector(nextTabKeyCommand))
     ]
     
     var keyCommandList = navigationCommands + tabNavigationCommands + bookmarkEditingCommands + shareCommands + findTextCommands + additionalPriorityCommandKeys


### PR DESCRIPTION
New Tab Command changed with Next Tab Command

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5972

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Open at least 2 tabs

2. Press ctrl + tab on a hardware keyboard


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
