### PR TITLE
Fix #5979: iOS is not sending some URLs from History to Sync Engine

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -208,6 +208,8 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
 
   /// The currently open WalletStore
   weak var walletStore: WalletStore?
+  
+  var lastEnteredURLVisitType: VisitType = .unknown
 
   public init(
     profile: Profile,
@@ -1390,7 +1392,8 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
 
       tab.loadRequest(URLRequest(url: url))
 
-      recordNavigationInTab(url, visitType: visitType)
+      // Recording the last Visit Type for the url submitted
+      lastEnteredURLVisitType = visitType
       updateWebViewPageZoom(tab: tab)
     }
   }
@@ -2051,8 +2054,9 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
         if !tab.isPrivate, !url.isReaderModeURL {
           // The visitType is checked If it is "typed" or not to determine the History object we are adding
           // should be synced or not. This limitation exists on browser side so we are aligning with this
-          if let visitType = typedNavigation.first(where: { $0.key.typedDisplayString == url.typedDisplayString })?.value,
-            visitType == .typed {
+          if let visitType = typedNavigation.first(where: {
+            $0.key.typedDisplayString == url.typedDisplayString
+          })?.value, visitType == .typed {
             braveCore.historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date())
           } else {
             braveCore.historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date(), isURLTyped: false)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -467,6 +467,16 @@ extension BrowserViewController: WKNavigationDelegate {
     // If none of our helpers are responsible for handling this response,
     // just let the webview handle it as normal.
     decisionHandler(.allow)
+    
+    guard let url = responseURL, let tab = tab else {
+      return
+    }
+    
+    // Record the navigation visit type for the URL after navigation actions
+    // this is done in decidePolicyFor to handle all the cases like redirects etc.
+    if !url.isReaderModeURL, !url.isFileURL, url.isWebPage(), !tab.isPrivate {
+      recordNavigationInTab(url, visitType: lastEnteredURLVisitType)
+    }
   }
 
   public func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {


### PR DESCRIPTION
Handling record navigation in `decidePolicy` to get history URL properly.

By doing this and saving the visit type in record navigation. The list contains visit type can hold the real history URLs.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5979

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

History from iOS device to another device should be checked for urls that are visit type Typed.

- Enter url `google.com`
- Check history panel and see it is recorded as `https://www.google.com`
- Check synced device and observe the url is synced

- Enter url `brave.com/msupport`
- Check history panel and see it is recorded as `https://community.brave.com/c/support-and-troubleshooting/mobile-support/76`
- Check synced device and observe the url is synced

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
