### PR TITLE
Fix #5987: Remove edit option from search settings with no custom SE 

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -128,8 +128,6 @@ class SearchSettingsTableViewController: UITableViewController {
         UIBarButtonItem(title: Strings.settingsSearchDoneButton, style: .done, target: self, action: #selector(dismissAnimated))
     }
 
-    self.navigationItem.rightBarButtonItem = editButtonItem
-
     let footer = SettingsTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width, height: UX.headerHeight))
     tableView.tableFooterView = footer
   }
@@ -137,6 +135,7 @@ class SearchSettingsTableViewController: UITableViewController {
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
+    updateTableEditModeVisibility()
     tableView.reloadData()
   }
 
@@ -175,6 +174,16 @@ class SearchSettingsTableViewController: UITableViewController {
     }
 
     return cell
+  }
+  
+  private func updateTableEditModeVisibility() {
+    tableView.endEditing(true)
+    
+    if customSearchEngines.isEmpty {
+      navigationItem.rightBarButtonItem = nil
+    } else {
+      navigationItem.rightBarButtonItem = editButtonItem
+    }
   }
 
   // MARK: TableViewDataSource - TableViewDelegate
@@ -318,6 +327,7 @@ class SearchSettingsTableViewController: UITableViewController {
           try searchEngines.deleteCustomEngine(engine)
           tableView.deleteRows(at: [indexPath], with: .right)
           tableView.reloadData()
+          updateTableEditModeVisibility()
         } catch {
           log.error("Search Engine Error while deleting")
         }


### PR DESCRIPTION
Hiding Search Engine Edit Button when there is no custom engine

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5987

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Test visibility of Edit button with different scenarios which are

- Enter the screen with no custom search engine

- Enter the screen with custom search engines

-Delete custom engine and check edit button disappears 

## Screenshots:

https://user-images.githubusercontent.com/6643505/189183929-0cf58106-d938-4ebe-aa37-608f8fc2afd0.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
