### PR TITLE
Fix #5945: Add ability to manage dapp site connection based on coin type

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -177,7 +177,7 @@ extension Tab: BraveWalletProviderDelegate {
       // Check if eth permissions already exist for this origin and if they don't, ensure the user allows
       // ethereum/solana provider access
       let walletPermissions = origin.url.map { Domain.walletPermissions(forUrl: $0, coin: coinType) ?? [] } ?? []
-      if walletPermissions.isEmpty, !Preferences.Wallet.allowDappProviderAccountRequests.value {
+      if walletPermissions.isEmpty, !Preferences.Wallet.allowEthProviderAccess.value {
         completion(.internal, nil)
         return
       }

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -55,8 +55,9 @@ class CookiesAndCacheClearable: Clearable {
     UserDefaults.standard.synchronize()
     await BraveWebView.sharedNonPersistentStore().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: Date(timeIntervalSinceReferenceDate: 0))
     UserDefaults.standard.synchronize()
-    await Domain.clearAllWalletPermissions(for: .eth)
-    // TODO: will need to clear permission for `.sol` coin type once we support solana Dapps
+    for coin in [BraveWallet.CoinType.eth, BraveWallet.CoinType.sol] {
+      await Domain.clearAllWalletPermissions(for: coin)
+    }
   }
 }
 

--- a/Client/Migration/Migration.swift
+++ b/Client/Migration/Migration.swift
@@ -315,6 +315,9 @@ fileprivate extension Preferences {
 
     // BraveShared
     migrateBraveShared(keyPrefix: keyPrefix)
+    
+    // BraveWallet
+    migrate(key: "wallet.allow-eth-provider-account-requests", to: Preferences.Wallet.allowEthProviderAccess)
 
     // On 1.6 lastLaunchInfo is used to check if it's first app launch or not.
     // This needs to be translated to our new preference.

--- a/Client/Migration/Migration.swift
+++ b/Client/Migration/Migration.swift
@@ -248,8 +248,8 @@ fileprivate extension Preferences {
       key: "migration.cd-completed",
       default: Preferences.Migration.completed.value)
     /// A new preference key will be introduced in 1.44.x, indicates if Wallet Preferences migration has completed
-    static let walletCompleted =
-    Option<Bool>(key: "migration.wallet-completed", default: false)
+    static let walletProviderAccountRequestCompleted =
+    Option<Bool>(key: "migration.wallet-provider-account-request-completed", default: false)
   }
 
   /// Migrate the users preferences from prior versions of the app (<2.0)
@@ -330,11 +330,11 @@ fileprivate extension Preferences {
   
   /// Migrate Wallet Preferences from version <1.43
   class func migrateWalletPreferences() {
-    guard Preferences.Migration.walletCompleted.value != true else { return }
+    guard Preferences.Migration.walletProviderAccountRequestCompleted.value != true else { return }
     
     // Migrate `allowDappProviderAccountRequests` to `allowEthProviderAccess`
     migrate(keyPrefix: "", key: "wallet.allow-eth-provider-account-requests", to: Preferences.Wallet.allowEthProviderAccess)
     
-    Preferences.Migration.walletCompleted.value = true
+    Preferences.Migration.walletProviderAccountRequestCompleted.value = true
   }
 }

--- a/Client/Wallet/EthereumProviderHelper.swift
+++ b/Client/Wallet/EthereumProviderHelper.swift
@@ -7,6 +7,7 @@ import Foundation
 import WebKit
 import BraveCore
 import struct Shared.Logger
+import BraveShared
 
 private let log = Logger.browserLogger
 
@@ -83,6 +84,11 @@ class EthereumProviderHelper: TabContentScript {
     if message.webView?.url?.isLocal == false,
         message.webView?.hasOnlySecureContent == false { // prevent communication in mixed-content scenarios
       log.error("Failed ethereum provider communication security test")
+      return
+    }
+    
+    if !Preferences.Wallet.allowEthProviderAccess.value {
+      log.error("Ethereum provider access is disabled")
       return
     }
     

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -78,7 +78,7 @@ struct AccountDetailsView: View {
             .alert(isPresented: $isPresentingRemoveConfirmation) {
               Alert(
                 title: Text(Strings.Wallet.accountRemoveAlertConfirmation),
-                message: Text(Strings.Wallet.accountRemoveAlertConfirmationMessage),
+                message: Text(Strings.Wallet.warningAlertConfirmation),
                 primaryButton: .destructive(Text(Strings.yes), action: removeAccount),
                 secondaryButton: .cancel(Text(Strings.no))
               )

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -245,8 +245,9 @@ public class KeyringStore: ObservableObject {
       }
       self.walletService.setSelectedCoin(.eth)
       self.rpcService.setNetwork(BraveWallet.MainnetChainId, coin: .eth, completion: { _ in })
-      Domain.clearAllWalletPermissions(for: .eth)
-      // TODO: will need to clear permission for `.sol` coin type once we support solana Dapps
+      for coin in WalletConstants.supportedCoinTypes {
+        Domain.clearAllWalletPermissions(for: coin)
+      }
       completion?(isMnemonicValid)
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -64,10 +64,10 @@ public class SettingsStore: ObservableObject {
   func reset() {
     walletService.reset()
     keychain.resetPasswordInKeychain(key: KeyringStore.passwordKeychainKey)
-    Domain.clearAllWalletPermissions(for: .eth)
-    // TODO: will need to clear permission for `.sol` coin type once we support solana Dapps
-    Preferences.Wallet.defaultEthWallet.reset()
-    Preferences.Wallet.allowDappProviderAccountRequests.reset()
+    for coin in WalletConstants.supportedCoinTypes {
+      Domain.clearAllWalletPermissions(for: coin)
+      Preferences.Wallet.reset(for: coin)
+    }
     Preferences.Wallet.displayWeb3Notifications.reset()
   }
 

--- a/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -29,8 +29,9 @@ struct DappsSettings: View {
       self.defaultWallet = Preferences.Wallet.defaultSolWallet
       self.allowProviderAccess = Preferences.Wallet.allowSolProviderAccess
     default:
-      self.defaultWallet = Preferences.Option(key: "Unsupported-Coin-Default-Wallet", default: -1)
-      self.allowProviderAccess = Preferences.Option(key: "Unsupported-Coin-Allow-Access", default: false)
+      assertionFailure("Not supported coin type.")
+      self.defaultWallet = Preferences.Wallet.defaultEthWallet
+      self.allowProviderAccess = Preferences.Wallet.allowEthProviderAccess
     }
   }
   

--- a/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -3,58 +3,130 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import Foundation
-import BraveUI
 import SwiftUI
-import struct Shared.Strings
+import BraveShared
+import BraveCore
 
-struct ManageSiteConnectionsView: View {
-
+struct DappsSettings: View {
+  var coin: BraveWallet.CoinType
   @ObservedObject var siteConnectionStore: ManageSiteConnectionsStore
+  @ObservedObject var defaultWallet: Preferences.Option<Int>
+  @ObservedObject var allowProviderAccess: Preferences.Option<Bool>
   @State private var filterText: String = ""
   @State private var isShowingConfirmAlert: Bool = false
   
+  init(
+    coin: BraveWallet.CoinType,
+    siteConnectionStore: ManageSiteConnectionsStore
+  ) {
+    self.coin = coin
+    self.siteConnectionStore = siteConnectionStore
+    switch coin {
+    case .eth:
+      self.defaultWallet = Preferences.Wallet.defaultEthWallet
+      self.allowProviderAccess = Preferences.Wallet.allowEthProviderAccess
+    case .sol:
+      self.defaultWallet = Preferences.Wallet.defaultSolWallet
+      self.allowProviderAccess = Preferences.Wallet.allowSolProviderAccess
+    default:
+      self.defaultWallet = Preferences.Option(key: "Unsupported-Coin-Default-Wallet", default: -1)
+      self.allowProviderAccess = Preferences.Option(key: "Unsupported-Coin-Allow-Access", default: false)
+    }
+  }
+  
+  private var defaultWalletTitle: String {
+    switch coin {
+    case .eth:
+      return Strings.Wallet.web3PreferencesDefaultEthWallet
+    case .sol:
+      return Strings.Wallet.web3PreferencesDefaultSolWallet
+    default:
+      return ""
+    }
+  }
+  
+  private var allowProviderAccessTitle: String {
+    switch coin {
+    case .eth:
+      return Strings.Wallet.web3PreferencesAllowEthProviderAccess
+    case .sol:
+      return Strings.Wallet.web3PreferencesAllowSolProviderAccess
+    default:
+      return ""
+    }
+  }
+  
+  private var visibleSiteConnections: [SiteConnection] {
+    siteConnectionStore.siteConnections.filter(by: coin, text: filterText)
+  }
+  
   var body: some View {
     List {
-      ForEach(siteConnectionStore.siteConnections.filter(by: filterText)) { siteConnection in
-        NavigationLink(
-          destination: SiteConnectionDetailView(
-            siteConnection: siteConnection,
-            siteConnectionStore: siteConnectionStore
-          )
-        ) {
-          SiteRow(
-            siteConnection: siteConnection
-          )
-          .osAvailabilityModifiers { content in
-            if #available(iOS 15.0, *) {
-              content
-                .swipeActions(edge: .trailing) {
-                  Button(role: .destructive, action: {
-                    withAnimation {
-                      siteConnectionStore.removeAllPermissions(from: [siteConnection])
+      Section(header: Text(Strings.Wallet.dappsSettingsGeneralSectionTitle)
+        .foregroundColor(Color(.secondaryBraveLabel))
+      ) {
+        HStack {
+          Text(defaultWalletTitle)
+            .foregroundColor(Color(.braveLabel))
+          Spacer()
+          Menu {
+            Picker("", selection: $defaultWallet.value) {
+              ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
+                Text(walletType.name)
+                  .tag(walletType)
+              }
+            }
+            .pickerStyle(.inline)
+          } label: {
+            let wallet = Preferences.Wallet.WalletType(rawValue: defaultWallet.value) ?? .none
+            Text(wallet.name)
+              .foregroundColor(Color(.braveBlurpleTint))
+          }
+        }
+        Toggle(allowProviderAccessTitle, isOn: $allowProviderAccess.value)
+          .foregroundColor(Color(.braveLabel))
+          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+      }
+      Section(header: Text(Strings.Wallet.dappsSettingsConnectedSitesSectionTitle)) {
+        ForEach(siteConnectionStore.siteConnections.filter(by: coin, text: filterText)) { siteConnection in
+          NavigationLink(
+            destination: SiteConnectionDetailView(
+              siteConnection: siteConnection,
+              siteConnectionStore: siteConnectionStore
+            )
+          ) {
+            SiteRow(
+              siteConnection: siteConnection
+            )
+            .osAvailabilityModifiers { content in
+              if #available(iOS 15.0, *) {
+                content
+                  .swipeActions(edge: .trailing) {
+                    Button(role: .destructive, action: {
+                      withAnimation {
+                        siteConnectionStore.removeAllPermissions(from: [siteConnection])
+                      }
+                    }) {
+                      Label(Strings.Wallet.delete, systemImage: "trash")
                     }
-                  }) {
-                    Label(Strings.Wallet.delete, systemImage: "trash")
                   }
-                }
-            } else {
-              content
+              } else {
+                content
+              }
             }
           }
         }
-      }
-      .onDelete { indexes in
-        let visibleSiteConnections = siteConnectionStore.siteConnections.filter(by: filterText)
-        let siteConnectionsToRemove = indexes.map { visibleSiteConnections[$0] }
-        withAnimation {
-          siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
+        .onDelete { indexes in
+          let visibleSiteConnections = siteConnectionStore.siteConnections
+          let siteConnectionsToRemove = indexes.map { visibleSiteConnections[$0] }
+          withAnimation {
+            siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
+          }
         }
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .listStyle(.insetGrouped)
-    .navigationTitle(Strings.Wallet.web3PreferencesManageSiteConnections)
+    .listStyle(InsetGroupedListStyle())
+    .navigationTitle(String.localizedStringWithFormat(Strings.Wallet.dappsSettingsNavTitle, coin.localizedTitle))
     .navigationBarTitleDisplayMode(.inline)
     .filterable(text: $filterText, prompt: Strings.Wallet.manageSiteConnectionsFilterPlaceholder)
     .toolbar {
@@ -72,8 +144,8 @@ struct ManageSiteConnectionsView: View {
     .onAppear(perform: siteConnectionStore.fetchSiteConnections)
     .alert(isPresented: $isShowingConfirmAlert) {
       Alert(
-        title: Text(Strings.Wallet.manageSiteConnectionsConfirmAlertTitle),
-        message: Text(Strings.Wallet.manageSiteConnectionsConfirmAlertMessage),
+        title: Text(Strings.Wallet.warningAlertConfirmation),
+        message: Text(String.localizedStringWithFormat(Strings.Wallet.dappsSettingsRemoveAllWarning, visibleSiteConnections.count, visibleSiteConnections.count == 1 ? Strings.Wallet.dappsSettingsWebsiteSingular : Strings.Wallet.dappsSettingsWebsitePlural)),
         primaryButton: Alert.Button.destructive(
           Text(Strings.Wallet.manageSiteConnectionsConfirmAlertRemove),
           action: removeAll
@@ -84,16 +156,15 @@ struct ManageSiteConnectionsView: View {
   }
   
   func removeAll() {
-    let visibleSiteConnections = siteConnectionStore.siteConnections.filter(by: filterText)
     siteConnectionStore.removeAllPermissions(from: visibleSiteConnections)
     filterText = ""
   }
 }
- 
+
 private struct SiteRow: View {
-
+  
   let siteConnection: SiteConnection
-
+  
   private let maxBlockies = 3
   @ScaledMetric private var blockieSize = 16.0
   private let maxBlockieSize: CGFloat = 32
@@ -179,7 +250,7 @@ private struct SiteConnectionDetailView: View {
                     Button(role: .destructive, action: {
                       withAnimation(.default) {
                         if let url = URL(string: siteConnection.url) {
-                          siteConnectionStore.removePermissions(from: [address], url: url)
+                          siteConnectionStore.removePermissions(for: siteConnection.coin, from: [address], url: url)
                         }
                       }
                     }) {
@@ -195,7 +266,7 @@ private struct SiteConnectionDetailView: View {
           let addressesToRemove = indexSet.map({ siteConnection.connectedAddresses[$0] })
           withAnimation(.default) {
             if let url = URL(string: siteConnection.url) {
-              siteConnectionStore.removePermissions(from: addressesToRemove, url: url)
+              siteConnectionStore.removePermissions(for: siteConnection.coin, from: addressesToRemove, url: url)
               if #available(iOS 15, *) {
                 // iOS 15 will dismiss itself (and will use `.swipeActions` instead of `.onDelete`)
               } else if siteConnection.connectedAddresses.count == addressesToRemove.count {

--- a/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -87,40 +87,54 @@ struct DappsSettings: View {
           .foregroundColor(Color(.braveLabel))
           .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
       }
-      Section(header: Text(Strings.Wallet.dappsSettingsConnectedSitesSectionTitle)) {
-        ForEach(siteConnectionStore.siteConnections.filter(by: coin, text: filterText)) { siteConnection in
-          NavigationLink(
-            destination: SiteConnectionDetailView(
-              siteConnection: siteConnection,
-              siteConnectionStore: siteConnectionStore
-            )
-          ) {
-            SiteRow(
-              siteConnection: siteConnection
-            )
-            .osAvailabilityModifiers { content in
-              if #available(iOS 15.0, *) {
-                content
-                  .swipeActions(edge: .trailing) {
-                    Button(role: .destructive, action: {
-                      withAnimation {
-                        siteConnectionStore.removeAllPermissions(from: [siteConnection])
+      Section(
+        header: Text(Strings.Wallet.dappsSettingsConnectedSitesSectionTitle)
+      ) {
+        if visibleSiteConnections.isEmpty {
+          HStack {
+            Spacer()
+            Text(Strings.Wallet.dappsSettingsConnectedSitesSectionEmpty)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .font(.footnote)
+              .multilineTextAlignment(.center)
+            Spacer()
+          }
+          .padding(.vertical)
+        } else {
+          ForEach(visibleSiteConnections) { siteConnection in
+            NavigationLink(
+              destination: SiteConnectionDetailView(
+                siteConnection: siteConnection,
+                siteConnectionStore: siteConnectionStore
+              )
+            ) {
+              SiteRow(
+                siteConnection: siteConnection
+              )
+              .osAvailabilityModifiers { content in
+                if #available(iOS 15.0, *) {
+                  content
+                    .swipeActions(edge: .trailing) {
+                      Button(role: .destructive, action: {
+                        withAnimation {
+                          siteConnectionStore.removeAllPermissions(from: [siteConnection])
+                        }
+                      }) {
+                        Label(Strings.Wallet.delete, systemImage: "trash")
                       }
-                    }) {
-                      Label(Strings.Wallet.delete, systemImage: "trash")
                     }
-                  }
-              } else {
-                content
+                } else {
+                  content
+                }
               }
             }
           }
-        }
-        .onDelete { indexes in
-          let visibleSiteConnections = siteConnectionStore.siteConnections
-          let siteConnectionsToRemove = indexes.map { visibleSiteConnections[$0] }
-          withAnimation {
-            siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
+          .onDelete { indexes in
+            let visibleSiteConnections = siteConnectionStore.siteConnections
+            let siteConnectionsToRemove = indexes.map { visibleSiteConnections[$0] }
+            withAnimation {
+              siteConnectionStore.removeAllPermissions(from: siteConnectionsToRemove)
+            }
           }
         }
       }
@@ -240,7 +254,7 @@ private struct SiteConnectionDetailView: View {
   
   var body: some View {
     List {
-      Section(header: Text(Strings.Wallet.manageSiteConnectionsDetailHeader)) {
+      Section(header: Text(String.localizedStringWithFormat(Strings.Wallet.manageSiteConnectionsDetailHeader, siteConnection.coin.localizedTitle))) {
         ForEach(siteConnection.connectedAddresses, id: \.self) { address in
           AccountView(address: address, name: siteConnectionStore.accountInfo(for: address)?.name ?? "")
             .osAvailabilityModifiers { content in

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -12,9 +12,6 @@ public struct WalletSettingsView: View {
   @ObservedObject var settingsStore: SettingsStore
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var defaultEthWallet = Preferences.Wallet.defaultEthWallet
-  @ObservedObject var defaultSolWallet = Preferences.Wallet.defaultSolWallet
-  @ObservedObject var allowDappsRequestAccounts = Preferences.Wallet.allowDappProviderAccountRequests
   @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
 
   @State private var isShowingResetWalletAlert = false
@@ -105,61 +102,26 @@ public struct WalletSettingsView: View {
           .foregroundColor(Color(.secondaryBraveLabel))
       ) {
         Group {
-          HStack {
-            Text(Strings.Wallet.web3PreferencesDefaultEthWallet)
-              .foregroundColor(Color(.braveLabel))
-            Spacer()
-            Menu {
-              Picker("", selection: $defaultEthWallet.value) {
-                ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
-                  Text(walletType.name)
-                    .tag(walletType)
-                }
-              }
-              .pickerStyle(.inline)
-            } label: {
-              let wallet = Preferences.Wallet.WalletType(rawValue: defaultEthWallet.value) ?? .none
-              Text(wallet.name)
-                .foregroundColor(Color(.braveBlurpleTint))
-            }
-          }
-          if WalletDebugFlags.isSolanaDappsEnabled {
-            HStack {
-              Text(Strings.Wallet.web3PreferencesDefaultSolWallet)
-                .foregroundColor(Color(.braveLabel))
-              Spacer()
-              Menu {
-                Picker("", selection: $defaultSolWallet.value) {
-                  ForEach(Preferences.Wallet.WalletType.allCases) { walletType in
-                    Text(walletType.name)
-                      .tag(walletType)
+          ForEach(Array(WalletConstants.supportedCoinTypes)) { coin in
+            if coin != .sol || (coin == .sol && WalletDebugFlags.isSolanaDappsEnabled) {
+              NavigationLink(
+                destination:
+                  DappsSettings(
+                    coin: coin,
+                    siteConnectionStore: settingsStore.manageSiteConnectionsStore(keyringStore: keyringStore)
+                  )
+                  .onDisappear {
+                    settingsStore.closeManageSiteConnectionStore()
                   }
-                }
-                .pickerStyle(.inline)
-              } label: {
-                let wallet = Preferences.Wallet.WalletType(rawValue: defaultSolWallet.value) ?? .none
-                Text(wallet.name)
-                  .foregroundColor(Color(.braveBlurpleTint))
+              ) {
+                Text(coin.localizedTitle)
+                  .foregroundColor(Color(.braveLabel))
               }
             }
           }
-          Toggle(Strings.Wallet.web3PreferencesAllowSiteToRequestAccounts, isOn: $allowDappsRequestAccounts.value)
-            .foregroundColor(Color(.braveLabel))
-            .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
           Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
             .foregroundColor(Color(.braveLabel))
             .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-          NavigationLink(
-            destination: ManageSiteConnectionsView(
-              siteConnectionStore: settingsStore.manageSiteConnectionsStore(keyringStore: keyringStore)
-            )
-            .onDisappear {
-              settingsStore.closeManageSiteConnectionStore()
-            }
-          ) {
-            Text(Strings.Wallet.web3PreferencesManageSiteConnections)
-              .foregroundColor(Color(.braveLabel))
-          }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -5,6 +5,7 @@
 
 import BraveShared
 import struct Shared.Strings
+import BraveCore
 
 extension Preferences {
   public final class Wallet {
@@ -29,9 +30,14 @@ extension Preferences {
     public static let defaultEthWallet = Option<Int>(key: "wallet.default-wallet", default: WalletType.brave.rawValue)
     /// The default wallet to use for Solana to be communicate with web3
     public static let defaultSolWallet = Option<Int>(key: "wallet.default-sol-wallet", default: WalletType.brave.rawValue)
-    /// Whether or not webpages can use the Ethereum/Solana Provider API to communicate with users Ethereum/Solana wallet
-    public static let allowDappProviderAccountRequests: Option<Bool> = .init(
-      key: "wallet.allow-eth-provider-account-requests",
+    /// Whether or not webpages can use the Ethereum Provider API to communicate with users Ethereum wallet
+    public static let allowEthProviderAccess: Option<Bool> = .init(
+      key: "wallet.allow-eth-provider-access",
+      default: true
+    )
+    /// Whether or not webpages can use the Solana Provider API to communicate with users Solana wallet
+    public static let allowSolProviderAccess: Option<Bool> = .init(
+      key: "wallet.allow-sol-provider-access",
       default: true
     )
     /// The option to display web3 notification
@@ -40,5 +46,22 @@ extension Preferences {
     public static let showTestNetworks = Option<Bool>(key: "wallet.show-test-networks", default: false)
     /// The option for users to turn off aurora popup
     public static let showAuroraPopup = Option<Bool>(key: "wallet.show-aurora-popup", default: true)
+    
+    /// Reset Wallet Preferences based on coin type
+    public static func reset(for coin: BraveWallet.CoinType) {
+      switch coin {
+      case .eth:
+        Preferences.Wallet.defaultEthWallet.reset()
+        Preferences.Wallet.allowEthProviderAccess.reset()
+      case .sol:
+        Preferences.Wallet.defaultSolWallet.reset()
+        Preferences.Wallet.allowSolProviderAccess.reset()
+      case .fil:
+        // not supported
+        fallthrough
+      @unknown default:
+        return
+      }
+    }
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -162,12 +162,12 @@ extension Strings {
       value: "Remove this account?",
       comment: "The title of a confirmation dialog when attempting to remove an account"
     )
-    public static let accountRemoveAlertConfirmationMessage = NSLocalizedString(
-      "wallet.accountRemoveAlertConfirmationMessage",
+    public static let warningAlertConfirmation = NSLocalizedString(
+      "wallet.warningAlertConfirmation",
       tableName: "BraveWallet",
       bundle: .strings,
       value: "Are you sure?",
-      comment: "The message of a confirmation dialog when attempting to remove an account"
+      comment: "The message of a confirmation dialog when attempting to remove an account. Or the title of a confirmation dialog when attempting to remove all wallet connection for one or more websites"
     )
     public static let accountPrivateKeyDisplayWarning = NSLocalizedString(
       "wallet.accountPrivateKeyDisplayWarning",
@@ -2311,12 +2311,19 @@ extension Strings {
       value: "Default Solana Wallet",
       comment: "The title for the entry displaying the current preferred default Solana wallet is."
     )
-    public static let web3PreferencesAllowSiteToRequestAccounts = NSLocalizedString(
-      "wallet.web3PreferencesAllowSiteToRequestAccounts",
+    public static let web3PreferencesAllowEthProviderAccess = NSLocalizedString(
+      "wallet.web3PreferencesAllowEthProviderAccess",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Allow Sites to Request Accounts",
-      comment: "The title for the entry displaying the preferred option to allow web3 sites to rquest account's permission."
+      value: "Allow Sites to Access Ethereum Provider API",
+      comment: "The title for the entry displaying the preferred option to allow web3 sites to access the Ethereum provider API."
+    )
+    public static let web3PreferencesAllowSolProviderAccess = NSLocalizedString(
+      "wallet.web3PreferencesAllowSolProviderAccess",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Allow Sites to Access Solana Provider API",
+      comment: "The title for the entry displaying the preferred option to allow web3 sites to access the Solana provider API."
     )
     public static let web3PreferencesDisplayWeb3Notifications = NSLocalizedString(
       "wallet.web3PreferencesDisplayWeb3Notifications",
@@ -2336,7 +2343,7 @@ extension Strings {
       "wallet.manageSiteConnectionsFilterPlaceholder",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Filter",
+      value: "Filter Conneted Sites",
       comment: "The filter in the search bar for the screen to manage web3 sites account connections."
     )
     public static let manageSiteConnectionsRemoveAll = NSLocalizedString(
@@ -2709,6 +2716,48 @@ extension Strings {
       bundle: .strings,
       value: "Don't show again",
       comment: "A text button for user to click so this pop up will not show again."
+    )
+    public static let dappsSettingsNavTitle = NSLocalizedString(
+      "wallet.dappsSettingsNavTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "%@ Settings",
+      comment: "The navigation title of the settings screen for each Dapp. '%@' will be relpaced by the name of the coin type. For example, the title could 'Ethereum Settings', 'Solana Settings' etc."
+    )
+    public static let dappsSettingsRemoveAllWarning = NSLocalizedString(
+      "wallet.dappsSettingsRemoveAllWarning",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "This will remove all Wallet connection permissions for %d %@",
+      comment: "The warning message in a confirmation dialog when attempting to remove all wallet connection to a dapp."
+    )
+    public static let dappsSettingsWebsiteSingular = NSLocalizedString(
+      "wallet.dappsSettingsWebsiteSingular",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "website",
+      comment: "The singular word that will be used in `manageSiteConnectionsAccount`."
+    )
+    public static let dappsSettingsWebsitePlural = NSLocalizedString(
+      "wallet.dappsSettingsWebsitePlural",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "websites",
+      comment: "The plural word that will be used in `manageSiteConnectionsAccount`."
+    )
+    public static let dappsSettingsGeneralSectionTitle = NSLocalizedString(
+      "wallet.dappsSettingsGeneralSectionTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "General",
+      comment: "The title of the section that will display settings for default wallet and dapp provider api access permission"
+    )
+    public static let dappsSettingsConnectedSitesSectionTitle = NSLocalizedString(
+      "wallet.dappsSettingsConnectedSitesSectionTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Connected Sites",
+      comment: "The title of the section that will list all the permitted dapp connections"
     )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2315,14 +2315,14 @@ extension Strings {
       "wallet.web3PreferencesAllowEthProviderAccess",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Allow Sites to Access Ethereum Provider API",
+      value: "Allow Sites to Access the Ethereum Provider API",
       comment: "The title for the entry displaying the preferred option to allow web3 sites to access the Ethereum provider API."
     )
     public static let web3PreferencesAllowSolProviderAccess = NSLocalizedString(
       "wallet.web3PreferencesAllowSolProviderAccess",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Allow Sites to Access Solana Provider API",
+      value: "Allow Sites to Access the Solana Provider API",
       comment: "The title for the entry displaying the preferred option to allow web3 sites to access the Solana provider API."
     )
     public static let web3PreferencesDisplayWeb3Notifications = NSLocalizedString(
@@ -2343,7 +2343,7 @@ extension Strings {
       "wallet.manageSiteConnectionsFilterPlaceholder",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Filter Conneted Sites",
+      value: "Filter Connected DApps",
       comment: "The filter in the search bar for the screen to manage web3 sites account connections."
     )
     public static let manageSiteConnectionsRemoveAll = NSLocalizedString(
@@ -2406,8 +2406,8 @@ extension Strings {
       "wallet.manageSiteConnectionsDetailHeader",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Connected Ethereum Accounts",
-      comment: "The header shown above the list of connected accounts for a single website, shown after selecting/opening a website on the screen to manage web3 sites account connections."
+      value: "Connected %@ Accounts",
+      comment: "The header shown above the list of connected accounts for a single website, shown after selecting/opening a website on the screen to manage web3 sites account connections. '%@' will be replaced by a coin type title. For example, it could be 'Connected Ethereum Accounts' or 'Connected Solana Accounts' etc."
     )
     public static let walletTypeNone = NSLocalizedString(
       "wallet.walletTypeNone",
@@ -2756,8 +2756,15 @@ extension Strings {
       "wallet.dappsSettingsConnectedSitesSectionTitle",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Connected Sites",
+      value: "Connected DApps",
       comment: "The title of the section that will list all the permitted dapp connections"
+    )
+    public static let dappsSettingsConnectedSitesSectionEmpty = NSLocalizedString(
+      "wallet.dappsSettingsConnectedSitesSectionEmpty",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "DApps you connect to Brave Wallet will appear here",
+      comment: "A message that will be displayed under the section header when there is no dapps have been granted wallet connection."
     )
   }
 }

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -83,17 +83,32 @@ class SettingsStoreTests: XCTestCase {
 
     assert(
       Preferences.Wallet.WalletType.none.rawValue != Preferences.Wallet.defaultEthWallet.defaultValue,
-      "Test assumes default wallet value is not `none`") 
+      "Test assumes default wallet for eth value is not `none`")
     Preferences.Wallet.defaultEthWallet.value = Preferences.Wallet.WalletType.none.rawValue
     XCTAssertEqual(
       Preferences.Wallet.defaultEthWallet.value,
       Preferences.Wallet.WalletType.none.rawValue,
-      "Failed to update default wallet")
-    Preferences.Wallet.allowDappProviderAccountRequests.value = !Preferences.Wallet.allowDappProviderAccountRequests.defaultValue
+      "Failed to update default wallet for eth")
+    Preferences.Wallet.allowEthProviderAccess.value = !Preferences.Wallet.allowEthProviderAccess.defaultValue
     XCTAssertEqual(
-      Preferences.Wallet.allowDappProviderAccountRequests.value,
-      !Preferences.Wallet.allowDappProviderAccountRequests.defaultValue,
+      Preferences.Wallet.allowEthProviderAccess.value,
+      !Preferences.Wallet.allowEthProviderAccess.defaultValue,
       "Failed to update allow ethereum requests")
+    
+    assert(
+      Preferences.Wallet.WalletType.none.rawValue != Preferences.Wallet.defaultSolWallet.defaultValue,
+      "Test assumes default wallet for sol value is not `none`")
+    Preferences.Wallet.defaultSolWallet.value = Preferences.Wallet.WalletType.none.rawValue
+    XCTAssertEqual(
+      Preferences.Wallet.defaultSolWallet.value,
+      Preferences.Wallet.WalletType.none.rawValue,
+      "Failed to update default wallet for sol")
+    Preferences.Wallet.allowSolProviderAccess.value = !Preferences.Wallet.allowSolProviderAccess.defaultValue
+    XCTAssertEqual(
+      Preferences.Wallet.allowSolProviderAccess.value,
+      !Preferences.Wallet.allowSolProviderAccess.defaultValue,
+      "Failed to update allow solana requests")
+    
     Preferences.Wallet.displayWeb3Notifications.value = !Preferences.Wallet.displayWeb3Notifications.defaultValue
     XCTAssertEqual(
       Preferences.Wallet.displayWeb3Notifications.value,
@@ -129,11 +144,19 @@ class SettingsStoreTests: XCTestCase {
     XCTAssertEqual(
       Preferences.Wallet.defaultEthWallet.value,
       Preferences.Wallet.defaultEthWallet.defaultValue,
-      "Default Wallet was not reset to default")
+      "Default Wallet for eth was not reset to default")
     XCTAssertEqual(
-      Preferences.Wallet.allowDappProviderAccountRequests.value,
-      Preferences.Wallet.allowDappProviderAccountRequests.defaultValue,
+      Preferences.Wallet.allowEthProviderAccess.value,
+      Preferences.Wallet.allowEthProviderAccess.defaultValue,
       "Allow ethereum requests was not reset to default")
+    XCTAssertEqual(
+      Preferences.Wallet.defaultSolWallet.value,
+      Preferences.Wallet.defaultSolWallet.defaultValue,
+      "Default Wallet for sol was not reset to default")
+    XCTAssertEqual(
+      Preferences.Wallet.allowSolProviderAccess.value,
+      Preferences.Wallet.allowSolProviderAccess.defaultValue,
+      "Allow solana requests was not reset to default")
     XCTAssertEqual(
       Preferences.Wallet.displayWeb3Notifications.value,
       Preferences.Wallet.displayWeb3Notifications.defaultValue,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Web3 settings UI has been separated based on coin type.
Currently Solana is behind the feature flag. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5945 #6010 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Make sure manage ethereum dapp settings still working as before.
Solana dapp settings are still behind feature flag. Can be verified when Solana Dapps are fully supported. 


## Screenshots:

![simulator_screenshot_E3FD5800-DFFF-4BDA-890B-7B60BD1A5E9A](https://user-images.githubusercontent.com/1187676/189198267-2244db52-14de-4f48-a5be-cf859dfd3a16.png) | ![simulator_screenshot_C7B63B71-26C7-4E14-BC7E-9B0EF1547F16](https://user-images.githubusercontent.com/1187676/189198306-086d8b26-a30e-43dd-87ad-9a362b997b91.png)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
