### PR TITLE
Fix #5894: Enable partial support for toolbar collapsing on PDF pages

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2129,7 +2129,6 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
   ) {
     guard
       let tab = tabManager.selectedTab,
-      tab.mimeType != MIMEType.PDF, // Constraint-based animation is causing PDF docs to flicker.
       let webView = tab.webView,
       !webView.isLoading else {
       
@@ -2152,7 +2151,9 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     }
     let headerHeight = toolbarVisibilityViewModel.transitionDistance
     let footerHeight = footer.bounds.height
-    if let progress = progress {
+    // Changing the web view size while scrolling and a PDF is visible causes strange flickering, so only show
+    // final expanded/collapsed states while a PDF is visible
+    if let progress = progress, tab.mimeType != MIMEType.PDF {
       switch state {
       case .expanded:
         toolbarTopConstraint?.update(offset: -min(headerHeight, max(0, headerHeight * progress)))


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #5894 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
