### PR TITLE
Fix #6015: Use per-wallpaper logo overrides on NTP SI backgrounds

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
+++ b/Client/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
@@ -342,7 +342,8 @@ public class NTPDownloader {
   private func mapNTPWallpapersToFullPath(_ wallpapers: [NTPWallpaper], basePath: URL) -> [NTPWallpaper] {
     wallpapers.map {
       NTPWallpaper(
-        imageUrl: basePath.appendingPathComponent($0.imageUrl).path, logo: $0.logo,
+        imageUrl: basePath.appendingPathComponent($0.imageUrl).path,
+        logo: mapNTPLogoToFullPath($0.logo, basePath: basePath),
         focalPoint: $0.focalPoint, creativeInstanceId: $0.creativeInstanceId)
     }
   }

--- a/Client/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackground.swift
+++ b/Client/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackground.swift
@@ -32,6 +32,9 @@ class NewTabPageBackground: PreferencesObserver {
   }
   /// The sponsors logo if available
   var sponsorLogoImage: UIImage? {
+    if let logoOverrideImage = currentBackground?.wallpaper.logo?.image {
+      return logoOverrideImage
+    }
     if case .withBrandLogo(let logo) = currentBackground?.type {
       return logo?.image
     }

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -325,8 +325,8 @@ class NewTabPageViewController: UIViewController {
         } else {
           backgroundButtonsView.activeButton = .none
         }
-      case .withBrandLogo(let logo):
-        guard let logo = logo else { break }
+      case .withBrandLogo(let defaultLogo):
+        guard let logo = background.currentBackground?.wallpaper.logo ?? defaultLogo else { break }
         backgroundButtonsView.activeButton = .brandLogo(logo)
       case .withQRCode(_):
         backgroundButtonsView.activeButton = .QRCode


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6015

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
