### PR TITLE
Fix #6013: Device with PB only mode causes the main device to show onboarding message on Tabs sync

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -32,6 +32,15 @@ class TabTrayController: LoadingViewController {
     case local
     case sync
   }
+  
+  // MARK: SyncActionState
+  
+  enum SyncActionState {
+    case noSyncChain
+    case openTabsDisabled
+    case noSyncedSessions
+    case activeSessions
+  }
 
   let tabManager: TabManager
   private let braveCore: BraveCoreMain
@@ -39,6 +48,24 @@ class TabTrayController: LoadingViewController {
   
   weak var delegate: TabTrayDelegate?
   weak var toolbarUrlActionsDelegate: ToolbarUrlActionsDelegate?
+  
+  private var emptyPanelState: SyncActionState {
+    get {
+      if Preferences.Chromium.syncEnabled.value {
+        if !Preferences.Chromium.syncOpenTabsEnabled.value {
+          return .openTabsDisabled
+        }
+      } else {
+        return .noSyncChain
+      }
+      
+      if sessionList.count > 0 {
+        return .activeSessions
+      }
+      
+      return .noSyncedSessions
+    }
+  }
 
   private(set) lazy var dataSource =
     DataSource(
@@ -412,7 +439,7 @@ class TabTrayController: LoadingViewController {
     
     tabSyncView.do {
       $0.tableView.reloadData()
-      $0.updateNoSyncPanelState(isHidden: sessionList.count > 0)
+      $0.updateNoSyncPanelState(actionType: emptyPanelState)
     }
     
     updateEmptyPanelState(isHidden: !(isTabTrayBeingSearched && sessionList.isEmpty && !(query?.isEmpty ?? true)))
@@ -531,7 +558,7 @@ class TabTrayController: LoadingViewController {
     applySnapshot()
   }
   
-  private func presentSyncSettings(status: TabSyncContainerView.SyncActionType) {
+  private func presentSyncSettings(status: SyncActionState) {
     switch status {
       case .noSyncChain:
         openInsideSettingsNavigation(
@@ -539,7 +566,7 @@ class TabTrayController: LoadingViewController {
             syncAPI: braveCore.syncAPI,
             syncProfileServices: braveCore.syncProfileService,
             tabManager: tabManager))
-      case .openTabsDisabled:
+      case .openTabsDisabled, .noSyncedSessions:
         if !DeviceInfo.hasConnectivity() {
           present(SyncAlerts.noConnection, animated: true)
           return
@@ -550,6 +577,8 @@ class TabTrayController: LoadingViewController {
             syncAPI: braveCore.syncAPI,
             syncProfileService: braveCore.syncProfileService,
             tabManager: tabManager))
+      default:
+        return
     }
   }
   

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -33,9 +33,9 @@ class TabTrayController: LoadingViewController {
     case sync
   }
   
-  // MARK: SyncActionState
+  // MARK: SyncStatusState
   
-  enum SyncActionState {
+  enum SyncStatusState {
     case noSyncChain
     case openTabsDisabled
     case noSyncedSessions
@@ -49,7 +49,7 @@ class TabTrayController: LoadingViewController {
   weak var delegate: TabTrayDelegate?
   weak var toolbarUrlActionsDelegate: ToolbarUrlActionsDelegate?
   
-  private var emptyPanelState: SyncActionState {
+  private var emptyPanelState: SyncStatusState {
     get {
       if Preferences.Chromium.syncEnabled.value {
         if !Preferences.Chromium.syncOpenTabsEnabled.value {
@@ -439,7 +439,7 @@ class TabTrayController: LoadingViewController {
     
     tabSyncView.do {
       $0.tableView.reloadData()
-      $0.updateNoSyncPanelState(actionType: emptyPanelState)
+      $0.updateSyncStatusPanel(for: emptyPanelState)
     }
     
     updateEmptyPanelState(isHidden: !(isTabTrayBeingSearched && sessionList.isEmpty && !(query?.isEmpty ?? true)))
@@ -558,7 +558,7 @@ class TabTrayController: LoadingViewController {
     applySnapshot()
   }
   
-  private func presentSyncSettings(status: SyncActionState) {
+  private func presentSyncSettings(status: SyncStatusState) {
     switch status {
       case .noSyncChain:
         openInsideSettingsNavigation(

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
@@ -87,7 +87,7 @@ extension TabTrayController {
       case .openTabsDisabled:
         let disabledOpenTabsEmptyStateView = EmptyStateOverlayView(
           title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
-          description: Strings.OpenTabs.noSyncSessionPlaceHolderViewDescription,
+          description: Strings.OpenTabs.enableOpenTabsPlaceHolderViewDescription,
           icon: UIImage(named: "sync-settings", in: .current, compatibleWith: nil),
           buttonText: Strings.OpenTabs.tabSyncEnableButtonTitle,
           action: { [weak self] in
@@ -99,9 +99,9 @@ extension TabTrayController {
       default:
         let noSessionsEmptyStateView = EmptyStateOverlayView(
           title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
-          description: "There are no active sessions to show from your other devices.",
+          description: Strings.OpenTabs.noSyncSessionPlaceHolderViewDescription,
           icon: UIImage(named: "sync-settings", in: .current, compatibleWith: nil),
-          buttonText: "Show Sync Settings",
+          buttonText: Strings.OpenTabs.showSettingsSyncButtonTitle,
           action: { [weak self] in
             self?.actionHandler?(.noSyncedSessions)
           },

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
@@ -20,7 +20,7 @@ extension TabTrayController {
     
     private(set) var tableView = UITableView(frame: .zero, style: .insetGrouped)
 
-    var actionHandler: ((SyncActionState) -> Void)?
+    var actionHandler: ((SyncStatusState) -> Void)?
     
     private var noSyncTabsOverlayView = EmptyStateOverlayView()
     
@@ -71,8 +71,8 @@ extension TabTrayController {
     @available(*, unavailable)
     required init(coder: NSCoder) { fatalError() }
     
-    private func createNewEmptyStateView(for actionType: SyncActionState) -> EmptyStateOverlayView {
-      switch actionType {
+    private func createNewEmptyStateView(for state: SyncStatusState) -> EmptyStateOverlayView {
+      switch state {
       case .noSyncChain:
         let noSyncChainEmptyStateView = EmptyStateOverlayView(
           title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
@@ -114,12 +114,12 @@ extension TabTrayController {
     /// Update visibility of view shown when no synced session exists
     /// This view contains information about  how to join sync chain and enable open tabs
     /// - Parameter isHidden: Boolean to set isHidden
-    func updateNoSyncPanelState(actionType: SyncActionState) {
+    func updateSyncStatusPanel(for state: SyncStatusState) {
       noSyncTabsOverlayView.removeFromSuperview()
       
-      if actionType != .activeSessions {
+      if state != .activeSessions {
         noSyncTabsOverlayView.removeFromSuperview()
-        noSyncTabsOverlayView = createNewEmptyStateView(for: actionType)
+        noSyncTabsOverlayView = createNewEmptyStateView(for: state)
         
         if noSyncTabsOverlayView.superview == nil {
           addSubview(noSyncTabsOverlayView)

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3098,13 +3098,20 @@ extension Strings {
         bundle: .strings,
         value: "To get started, set up a sync chain and toggle \"Open Tabs\" in Sync Settings.",
         comment: "The description of the view explaining user should join a sync chain.")
+    public static let enableOpenTabsPlaceHolderViewDescription =
+      NSLocalizedString(
+        "opentabs.enableOpenTabsPlaceHolderViewDescription",
+        tableName: "BraveShared",
+        bundle: .strings,
+        value: "Enable tab syncing to see tabs from your other devices.",
+        comment: "The description of the view describing tab syncing should be enabled.")
     public static let noSyncSessionPlaceHolderViewDescription =
       NSLocalizedString(
         "opentabs.noSyncSessionPlaceHolderViewDescription",
         tableName: "BraveShared",
         bundle: .strings,
-        value: "Enable tab syncing to see tabs from your other devices.",
-        comment: "The description of the view describing tab syncing should be enabled.")
+        value: "There are no active sessions to show from your other devices.",
+        comment: "The description of the view describing no other sessions are active in sync.")
     public static let syncChainStartButtonTitle =
       NSLocalizedString(
         "opentabs.startASyncChainButtonTitle",
@@ -3119,6 +3126,13 @@ extension Strings {
         bundle: .strings,
         value: "Enable tab syncing",
         comment: "The button which navigates to screen where Tab Sync functionality toggle can be adjusted")
+    public static let showSettingsSyncButtonTitle =
+      NSLocalizedString(
+        "opentabs.showSettingsSyncButtonTitle",
+        tableName: "BraveShared",
+        bundle: .strings,
+        value: "Show Sync Settings",
+        comment: "The button which navigates to screen where user can view sync settings")
     public static let noSyncSessionPlaceHolderViewAdditionalDescription =
       NSLocalizedString(
         "opentabs.noSyncSessionPlaceHolderViewAdditionalDescription",


### PR DESCRIPTION
Adding no synced session state to empty state view list of synced tabs.

The PR fixes showing wrong empty state panel when user 

- Has successfully joined the sync chain
- Has enabled the open tabs as sync type
- But - has no synced sessions from other devices from the chain (this encapsulates the case there is only one device in sync chain)

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6013

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Test 1: 

- Fresh install
- Go Tab Tray switch to Session from other tabs part with segmented control
- Check empty panel is shown with setup chain button and description about.
- Press "setup a Sync Chain" button and create a new sync chain but do not enable open tabs
- Dismiss the modal and check empty state panel is changed indicating Open Tabs sync type is not enabled
- Press "Enable Tab Sync" button and enable Open Tabs type
- Dismiss the modal and check the empty stater panel is changed and have description indicating there are no active sessions

Test 2: 

- Add browsing history on device 1
- Create a sync chain on the device and enable all sync switches
- Add device 2 to the sync chain and enable all sync switches
- Device 1 shows onboarding message in sync tabs in tab tray
- Device 2 shows all the history from device 1 sync'd under device name
- Go back to device 1 and click on Start a sync chain , takes onboarding to create a new sync chain but its already created and has the device linked

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/190703402-b86d3e81-1417-45ae-abbf-dbc40ad2525b.MP4


![open1 11](https://user-images.githubusercontent.com/6643505/190703527-491b91f9-8b0b-45c8-a156-6c4dbe63e6c0.png)



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
