### PR TITLE
Fix #6023: URLBar not updating after restore for Dynamic History Pages

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -403,6 +403,7 @@ class Tab: NSObject {
         let request = PrivilegedRequest(url: restoreURL) as URLRequest
         webView.load(request)
         lastRequest = request
+        restoring = false
       }
     } else if let request = lastRequest {
       webView.load(request)


### PR DESCRIPTION
## Summary of Changes
- Set `tab.restore = false` to correctly identify that a tab is no longer restoring session.
- This in turn causes the URLBar to trigger an update of its UI and URL.
- Bug has existed as far back as 1.3.x

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6023

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
