### PR TITLE
Ref #6015: Use wallpaper logo override URLs as well as images

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -745,8 +745,8 @@ class NewTabPageViewController: UIViewController {
     switch background.type {
     case .regular:
       presentImageCredit(sender)
-    case .withBrandLogo(let logo):
-      guard let logo = logo else { break }
+    case .withBrandLogo(let defaultLogo):
+      guard let logo = background.wallpaper.logo ?? defaultLogo else { break }
       tappedSponsorButton(logo)
     case .withQRCode(let code):
       tappedQRCode(code)


### PR DESCRIPTION
## Summary of Changes

Fixes the missed destination URL override

This pull request refs #6015 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
