### PR TITLE
Fix #6034: Show tabs bar by default for new users on iPad.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1322,7 +1322,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
       case .always:
         return tabCount > 1 || UIDevice.current.userInterfaceIdiom == .pad
       case .landscapeOnly:
-        return tabCount > 1 && UIDevice.current.orientation.isLandscape
+        return (tabCount > 1 && UIDevice.current.orientation.isLandscape) || UIDevice.current.userInterfaceIdiom == .pad
       case .never:
         return false
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
The 'show in landscape only' setting did not consider iPads.
Overall this setting option should not be present on iPads at all, but that's something to resolve as a separate item imo

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6034 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
