### PR TITLE
Fix #6044: Fix possible infinite loop when restoring wallet

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -243,8 +243,6 @@ public class KeyringStore: ObservableObject {
         self.updateKeyringInfo()
         self.resetKeychainStoredPassword()
       }
-      self.walletService.setSelectedCoin(.eth)
-      self.rpcService.setNetwork(BraveWallet.MainnetChainId, coin: .eth, completion: { _ in })
       for coin in WalletConstants.supportedCoinTypes {
         Domain.clearAllWalletPermissions(for: coin)
       }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6044

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Restore a wallet from seed phrase
2. Verify app remains responsive & no longer has infinite loop.
3. Reset wallet & repeat from step 1. Loop does not occur every time.


## Screenshots:

https://user-images.githubusercontent.com/5314553/191567436-d7005942-2235-4bae-990e-7cfee27deaa7.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
