### PR TITLE
No Bug: Improve incremental build times

### DIFF
--- a/Plugins/CurrentBundleGenPlugin/CurrentBundleGenPlugin.swift
+++ b/Plugins/CurrentBundleGenPlugin/CurrentBundleGenPlugin.swift
@@ -59,11 +59,14 @@ struct CurrentBundleGenPlugin: BuildToolPlugin {
       private class BundleFinder {}
     }
     """
-    try source.write(
-      toFile: outputDirectory.appending("current_bundle_accessor.swift").string,
-      atomically: true,
-      encoding: .utf8
-    )
+    let filePath = outputDirectory.appending("current_bundle_accessor.swift")
+    if !FileManager.default.fileExists(atPath: filePath.string) {
+      try source.write(
+        toFile: filePath.string,
+        atomically: true,
+        encoding: .utf8
+      )
+    }
     // TODO: Generate the above file in an `executableTarget` when SPM supports building Mac tools while targetting iOS
     return [
       .buildCommand(
@@ -71,7 +74,7 @@ struct CurrentBundleGenPlugin: BuildToolPlugin {
         executable: Path("/bin/zsh"),
         arguments: [],
         inputFiles: [],
-        outputFiles: [outputDirectory.appending("current_bundle_accessor.swift")]
+        outputFiles: [filePath]
       )
     ]
   }


### PR DESCRIPTION
Every build the CurrentBundleGen plugin would write a file to the output directory, thus touching it and requiring anything that used `.current` in that module to be recompiled.

Given this plugin's lifetime is short (to be removed when we move to Xcode 14), we can optimize this by only allowing it to write once. Since the contents of this file shouldn't change we should be OK to only check for file existence and not contents

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
