### PR TITLE
Fix #5982: When playing next item automatically, item is not highlighted in playlist

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -381,6 +381,8 @@ class PlaylistViewController: UIViewController {
           videoDomain: item.pageSrc,
           videoTitle: item.pageTitle)
       }
+      
+      self.highlightActiveItem()
     }.store(in: &playerStateObservers)
 
     player.publisher(for: .pause).sink { [weak self] event in
@@ -752,6 +754,8 @@ extension PlaylistViewController: VideoViewDelegate {
 
     if index >= 0 {
       let indexPath = IndexPath(row: index, section: 0)
+      
+      highlightActiveItem()
       listController.prepareToPlayItem(at: indexPath) { [weak self] item in
         guard let self = self,
           let item = item
@@ -881,6 +885,15 @@ extension PlaylistViewController: VideoViewDelegate {
     }
   }
 
+  func highlightActiveItem() {
+    let activeItemIndex = PlaylistCarplayManager.shared.currentlyPlayingItemIndex
+    
+    listController.tableView.selectRow(
+      at: IndexPath(row: activeItemIndex, section: 0),
+      animated: false,
+      scrollPosition: .none)
+  }
+  
   func setPlaybackRate(_ videoView: VideoView, rate: Float) {
     player.setPlaybackRate(rate: rate)
   }


### PR DESCRIPTION
The active playing item is highlighted properly on the list.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5982

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Navigate to site with videos or audio
2. Add at least 2 items to playlist
3. Begin playing first item in playlist, then use gesture to scroll to right before the end of the recording. Allow the recording to run its course.
4. Next item should play automatically
5. Observe which item is highlight/selected

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/6643505/192047192-82874e4c-6cc8-4804-ae1b-52c61ad61e84.MP4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
