### PR TITLE
Add missing `isMetaMask` and `isBraveWallet` definitions on `window.e…

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/WalletEthereumProvider.js
+++ b/Client/Frontend/UserContent/UserScripts/WalletEthereumProvider.js
@@ -28,6 +28,8 @@ if (window.isSecureContext) {
       chainId: undefined,
       networkVersion: undefined,
       selectedAddress: undefined,
+      isMetaMask: true,
+      isBraveWallet: true,
       request: function (args) /* -> Promise<unknown> */  {
         return post('request', args)
       },


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6059

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open safari debugger
2. Check that both `isMetaMask` and `isBraveWallet` are now defined as true


## Screenshots:

<img width="246" alt="Screen Shot 2022-09-26 at 1 44 48 PM" src="https://user-images.githubusercontent.com/5314553/192344996-3f9bde6d-b8d1-47fd-bd3c-6d7fd8b22da7.png">

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
