### PR TITLE
No Bug: Move MaterialComponents fix to bootstrap

### DIFF
--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -729,7 +729,6 @@
 				F84B21BC1A090F8100AAB793 /* Resources */,
 				28CE83DE1A1D1E7C00576538 /* Frameworks */,
 				F84B22531A0920C600AAB793 /* Embed App Extensions */,
-				27C2856425D5CDEF00429881 /* Fix MaterialComponents Info.plist */,
 				272FC6BF25DC19A0000F2EFC /* Fix Embedded Frameworks Signing */,
 			);
 			buildRules = (
@@ -935,24 +934,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"${SRCROOT}/..\"\nsh swiftlint.sh\n\n";
-		};
-		27C2856425D5CDEF00429881 /* Fix MaterialComponents Info.plist */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Fix MaterialComponents Info.plist";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# MaterialComponents.framework doesn't seem to have a `CFBundleShortVersionString`\n/usr/libexec/PlistBuddy -c 'Add :CFBundleShortVersionString string 1.0' \"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MaterialComponents.framework/Info.plist\" || echo \"CFBundleShortVersionString already set\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,6 +33,8 @@ fi
 echo "${COLOR_ORANGE}Signing BraveCore frameworks…${COLOR_NONE}"
 find "node_modules/brave-core-ios" -name '*.framework' -print0 | while read -d $'\0' framework
 do
+  # MaterialComponents.framework doesn't seem to have a `CFBundleShortVersionString`
+  /usr/libexec/PlistBuddy -c 'Add :CFBundleShortVersionString string 1.0' "${framework}/Info.plist" || true
   codesign --force --deep --sign "-" --preserve-metadata=identifier,entitlements --timestamp=none "${framework}"
 done
 


### PR DESCRIPTION
## Summary of Changes

Make sure to run bootstrap before making next build

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Verify after bootstrap that Info.plist's for all frameworks in `node_modules/brave-core-ios` have `CFBundleShortVersionString` set to `1.0`

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
