### PR TITLE
Fix #6046: Wallet show solana account creation via dapp

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2534,6 +2534,11 @@ extension BrowserViewController: TabDelegate {
       topToolbar.updateWalletButtonState(.inactive)
     }
   }
+  
+  func updateWebpagePermissionRequest(_ request: WebpagePermissionRequest) {
+    guard let walletStore = self.walletStore ?? newWalletStore() else { return }
+    walletStore.cryptoStore?.latestPermissionRequest = request
+  }
 
   @MainActor
   private func isPendingRequestAvailable() async -> Bool {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2534,11 +2534,6 @@ extension BrowserViewController: TabDelegate {
       topToolbar.updateWalletButtonState(.inactive)
     }
   }
-  
-  func updateWebpagePermissionRequest(_ request: WebpagePermissionRequest) {
-    guard let walletStore = self.walletStore ?? newWalletStore() else { return }
-    walletStore.cryptoStore?.latestPermissionRequest = request
-  }
 
   @MainActor
   private func isPendingRequestAvailable() async -> Bool {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2720,7 +2720,7 @@ extension BrowserViewController: TabManagerDelegate {
     updateInContentHomePanel(selected?.url as URL?)
 
     notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
-    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
+    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.eth, .sol])
     WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
     updateURLBarWalletButton()
   }
@@ -3490,7 +3490,7 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.reset()
       tabManager.reloadSelectedTab()
       notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
-      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.eth])
+      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.eth])
       WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth])
       let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
       if let cryptoStore = CryptoStore.from(privateMode: privateMode) {
@@ -3501,7 +3501,7 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.reset()
       tabManager.reloadSelectedTab()
       notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
-      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.sol])
+      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.sol])
       WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.sol])
       let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
       if let cryptoStore = CryptoStore.from(privateMode: privateMode) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2546,6 +2546,9 @@ extension BrowserViewController: TabDelegate {
     if await cryptoStore.isPendingRequestAvailable() {
       return true
     } else if let selectedTabOrigin = tabManager.selectedTab?.url?.origin {
+      if WalletProviderAccountCreationRequestManager.shared.hasPendingRequest(for: selectedTabOrigin, coinType: .sol) {
+        return true
+      }
       return WalletProviderPermissionRequestsManager.shared.hasPendingRequest(for: selectedTabOrigin, coinType: .eth)
     }
     return false
@@ -2717,7 +2720,8 @@ extension BrowserViewController: TabManagerDelegate {
     updateInContentHomePanel(selected?.url as URL?)
 
     notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
-    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests()
+    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
+    WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
     updateURLBarWalletButton()
   }
 
@@ -3486,7 +3490,19 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.reset()
       tabManager.reloadSelectedTab()
       notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
-      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests()
+      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.eth])
+      WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth])
+      let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
+      if let cryptoStore = CryptoStore.from(privateMode: privateMode) {
+        cryptoStore.rejectAllPendingWebpageRequests()
+      }
+      updateURLBarWalletButton()
+    case Preferences.Wallet.defaultSolWallet.key:
+      tabManager.reset()
+      tabManager.reloadSelectedTab()
+      notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)
+      WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.sol])
+      WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.sol])
       let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
       if let cryptoStore = CryptoStore.from(privateMode: privateMode) {
         cryptoStore.rejectAllPendingWebpageRequests()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -235,7 +235,7 @@ extension Tab: BraveWalletProviderDelegate {
         self.tabDelegate?.updateURLBarWalletButton()
       })
 
-      tabDappStore.latestPermissionRequest = request
+      tabDappStore.latestPendingPermissionRequest = request
       self.tabDelegate?.showWalletNotification(self, origin: origin)
     }
   }
@@ -310,8 +310,8 @@ extension Tab: BraveWalletProviderDelegate {
   func showAccountCreation(_ type: BraveWallet.CoinType) {
     let origin = getOrigin()
     // store the account creation request
-    WalletProviderAccountCreationRequestManager.shared.beginRequest(for: origin, coinType: type) {
-      self.tabDelegate?.updateURLBarWalletButton()
+    WalletProviderAccountCreationRequestManager.shared.beginRequest(for: origin, coinType: type) { [weak self] in
+      self?.tabDelegate?.updateURLBarWalletButton()
     }
     // show wallet notification
     self.tabDelegate?.showWalletNotification(self, origin: origin)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -235,7 +235,7 @@ extension Tab: BraveWalletProviderDelegate {
         self.tabDelegate?.updateURLBarWalletButton()
       })
 
-      self.tabDelegate?.updateWebpagePermissionRequest(request)
+      tabDappStore.latestPermissionRequest = request
       self.tabDelegate?.showWalletNotification(self, origin: origin)
     }
   }
@@ -320,17 +320,21 @@ extension Tab: BraveWalletProviderDelegate {
   }
   
   func addSolanaConnectedAccount(_ account: String) {
-    tabDappStore.solConnectedAddresses.insert(account)
+    Task { @MainActor in
+      tabDappStore.solConnectedAddresses.insert(account)
+    }
   }
   
   func removeSolanaConnectedAccount(_ account: String) {
-    tabDappStore.solConnectedAddresses.remove(account)
+    Task { @MainActor in
+      tabDappStore.solConnectedAddresses.remove(account)
+    }
   }
   
   func clearSolanaConnectedAccounts() {
-    tabDappStore.solConnectedAddresses = .init()
-    Task {
-      await updateSolanaProperties()
+    Task { @MainActor in
+        tabDappStore.solConnectedAddresses = .init()
+        await updateSolanaProperties()
     }
   }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -310,7 +310,7 @@ extension Tab: BraveWalletProviderDelegate {
   func showAccountCreation(_ type: BraveWallet.CoinType) {
     let origin = getOrigin()
     // store the account creation request
-    WalletProviderAccountCreationRequestManager.shared.addRequest(or: origin, coinType: type)
+    WalletProviderAccountCreationRequestManager.shared.addRequest(for: origin, coinType: type)
     // show wallet notification
     self.tabDelegate?.showWalletNotification(self, origin: origin)
   }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -310,7 +310,9 @@ extension Tab: BraveWalletProviderDelegate {
   func showAccountCreation(_ type: BraveWallet.CoinType) {
     let origin = getOrigin()
     // store the account creation request
-    WalletProviderAccountCreationRequestManager.shared.addRequest(for: origin, coinType: type)
+    WalletProviderAccountCreationRequestManager.shared.beginRequest(for: origin, coinType: type) {
+      self.tabDelegate?.updateURLBarWalletButton()
+    }
     // show wallet notification
     self.tabDelegate?.showWalletNotification(self, origin: origin)
   }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -309,8 +309,14 @@ extension Tab: BraveWalletProviderDelegate {
   
   func showAccountCreation(_ type: BraveWallet.CoinType) {
     let origin = getOrigin()
+    let accountCreationRequestManager = WalletProviderAccountCreationRequestManager.shared
+    
+    // check if same account creation request exists
+    guard !accountCreationRequestManager.hasPendingRequest(for: origin, coinType: type)
+    else { return }
+    
     // store the account creation request
-    WalletProviderAccountCreationRequestManager.shared.beginRequest(for: origin, coinType: type) { [weak self] in
+    accountCreationRequestManager.beginRequest(for: origin, coinType: type) { [weak self] in
       self?.tabDelegate?.updateURLBarWalletButton()
     }
     // show wallet notification

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -225,7 +225,7 @@ extension Tab: BraveWalletProviderDelegate {
       }
       
       // add permission request to the queue
-      _ = permissionRequestManager.beginRequest(for: origin, coinType: coinType, providerHandler: completion, completion: { response in
+      let request = permissionRequestManager.beginRequest(for: origin, coinType: coinType, providerHandler: completion, completion: { response in
         switch response {
         case .granted(let accounts):
           completion(.none, accounts)
@@ -235,6 +235,7 @@ extension Tab: BraveWalletProviderDelegate {
         self.tabDelegate?.updateURLBarWalletButton()
       })
 
+      self.tabDelegate?.updateWebpagePermissionRequest(request)
       self.tabDelegate?.showWalletNotification(self, origin: origin)
     }
   }
@@ -307,7 +308,11 @@ extension Tab: BraveWalletProviderDelegate {
   }
   
   func showAccountCreation(_ type: BraveWallet.CoinType) {
-    // TODO: Issue #6046 - Show account creation for given coin type
+    let origin = getOrigin()
+    // store the account creation request
+    WalletProviderAccountCreationRequestManager.shared.addRequest(or: origin, coinType: type)
+    // show wallet notification
+    self.tabDelegate?.showWalletNotification(self, origin: origin)
   }
   
   func isSolanaAccountConnected(_ account: String) -> Bool {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -45,6 +45,7 @@ protocol TabDelegate {
   func stopMediaPlayback(_ tab: Tab)
   func showWalletNotification(_ tab: Tab, origin: URLOrigin)
   func updateURLBarWalletButton()
+  func updateWebpagePermissionRequest(_ request: WebpagePermissionRequest)
   func isTabVisible(_ tab: Tab) -> Bool
 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -45,7 +45,6 @@ protocol TabDelegate {
   func stopMediaPlayback(_ tab: Tab)
   func showWalletNotification(_ tab: Tab, origin: URLOrigin)
   func updateURLBarWalletButton()
-  func updateWebpagePermissionRequest(_ request: WebpagePermissionRequest)
   func isTabVisible(_ tab: Tab) -> Bool
 }
 

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -26,6 +26,8 @@ struct AddAccountView: View {
   private let maxIconSize: CGFloat = 80.0
   
   var preSelectedCoin: BraveWallet.CoinType?
+  var onCreate: (() -> Void)?
+  var onDismiss: (() -> Void)?
 
   private func addAccount(for coin: BraveWallet.CoinType) {
     if privateKey.isEmpty {
@@ -33,12 +35,14 @@ struct AddAccountView: View {
       let accountName = name.isEmpty ? defaultAccountName(for: coin, isPrimary: true) : name
       keyringStore.addPrimaryAccount(accountName, coin: coin) { success in
         if success {
+          onCreate?()
           presentationMode.dismiss()
         }
       }
     } else {
       let handler: (Bool, String) -> Void = { success, _ in
         if success {
+          onCreate?()
           presentationMode.dismiss()
         } else {
           failedToImport = true
@@ -80,7 +84,7 @@ struct AddAccountView: View {
     .listStyle(InsetGroupedListStyle())
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
-    .navigationTitle(Strings.Wallet.addAccountTitle)
+    .navigationTitle(String.localizedStringWithFormat(Strings.Wallet.addAccountTitle, preSelectedCoin?.localizedTitle ?? (selectedCoin?.localizedTitle ?? BraveWallet.CoinType.eth.localizedTitle)))
     .navigationBarItems(
       // Have to use this instead of toolbar placement to have a custom button style
       trailing: Button(action: {
@@ -151,6 +155,7 @@ struct AddAccountView: View {
     .toolbar {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: {
+          onDismiss?()
           presentationMode.dismiss()
         }) {
           Text(Strings.cancelButtonTitle)

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -73,6 +73,13 @@ struct AddAccountView: View {
     preSelectedCoin == nil && WalletConstants.supportedCoinTypes.count > 1
   }
   
+  private var navigationTitle: String {
+    if preSelectedCoin == nil, selectedCoin == nil {
+      return Strings.Wallet.addAccountTitle
+    }
+    return String.localizedStringWithFormat(Strings.Wallet.addAccountWithCoinTypeTitle, preSelectedCoin?.localizedTitle ?? (selectedCoin?.localizedTitle ?? BraveWallet.CoinType.eth.localizedTitle))
+  }
+  
   @ViewBuilder private var addAccountView: some View {
     List {
       accountNameSection
@@ -84,7 +91,7 @@ struct AddAccountView: View {
     .listStyle(InsetGroupedListStyle())
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
-    .navigationTitle(String.localizedStringWithFormat(Strings.Wallet.addAccountTitle, preSelectedCoin?.localizedTitle ?? (selectedCoin?.localizedTitle ?? BraveWallet.CoinType.eth.localizedTitle)))
+    .navigationTitle(navigationTitle)
     .navigationBarItems(
       // Have to use this instead of toolbar placement to have a custom button style
       trailing: Button(action: {

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -201,12 +201,12 @@ public struct CryptoView: View {
                   keyringStore: keyringStore,
                   preSelectedCoin: request.coinType,
                   onCreate: {
-                    // request is fullfilled. remove the stored request
-                    WalletProviderAccountCreationRequestManager.shared.removeRequest(for: request)
+                    // request is fullfilled.
+                    request.responseHandler(.created)
                   },
                   onDismiss: {
                     // request get declined by clicking `Cancel`
-                    WalletProviderAccountCreationRequestManager.shared.removeRequest(for: request)
+                    request.responseHandler(.rejected)
                   }
                 )
               }

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -195,6 +195,22 @@ public struct CryptoView: View {
                   dismissAction?()
                 }
               )
+            case .createAccount(let request):
+              NavigationView {
+                AddAccountView(
+                  keyringStore: keyringStore,
+                  preSelectedCoin: request.coinType,
+                  onCreate: {
+                    // request is fullfilled. remove the stored request
+                    WalletProviderAccountCreationRequestManager.shared.removeRequest(for: request)
+                  },
+                  onDismiss: {
+                    // request get declined by clicking `Cancel`
+                    WalletProviderAccountCreationRequestManager.shared.removeRequest(for: request)
+                  }
+                )
+              }
+              .navigationViewStyle(.stack)
             }
           }
           .transition(.asymmetric(insertion: .identity, removal: .opacity))

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -63,6 +63,7 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
+  @Published public var latestPermissionRequest: WebpagePermissionRequest?
   @Published private(set) var pendingRequest: PendingRequest?
   
   private let keyringService: BraveWalletKeyringService

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -381,7 +381,7 @@ extension CryptoStore: BraveWalletTxServiceObserver {
 
 extension CryptoStore: BraveWalletKeyringServiceObserver {
   public func keyringReset() {
-    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
+    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.eth, .sol])
     WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
     rejectAllPendingWebpageRequests()
   }

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -381,7 +381,8 @@ extension CryptoStore: BraveWalletTxServiceObserver {
 
 extension CryptoStore: BraveWalletKeyringServiceObserver {
   public func keyringReset() {
-    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests()
+    WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
+    WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth, .sol])
     rejectAllPendingWebpageRequests()
   }
   public func keyringCreated(_ keyringId: String) {

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -63,7 +63,6 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
-  @Published public var latestPermissionRequest: WebpagePermissionRequest?
   @Published private(set) var pendingRequest: PendingRequest?
   
   private let keyringService: BraveWalletKeyringService

--- a/Sources/BraveWallet/Crypto/Stores/TabDappStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TabDappStore.swift
@@ -9,6 +9,8 @@ import Foundation
 public class TabDappStore: ObservableObject {
   /// A set of solana account addresses that are currently connected to the dapp
   @Published public var solConnectedAddresses: Set<String> = .init()
+  /// The latest dapp permission request 
+  @Published public var latestPermissionRequest: WebpagePermissionRequest?
   
   public init() {}
 }

--- a/Sources/BraveWallet/Crypto/Stores/TabDappStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TabDappStore.swift
@@ -9,7 +9,9 @@ import Foundation
 public class TabDappStore: ObservableObject {
   /// A set of solana account addresses that are currently connected to the dapp
   @Published public var solConnectedAddresses: Set<String> = .init()
-  /// The latest pending dapp permission request 
+  /// The latest pending dapp permission request. A permission request will be created right after
+  /// the account creation request has been fullfilled. We store the request here for `WalletPanelView` observing
+  /// the change of this value.
   @Published public var latestPendingPermissionRequest: WebpagePermissionRequest?
   
   public init() {}

--- a/Sources/BraveWallet/Crypto/Stores/TabDappStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TabDappStore.swift
@@ -9,8 +9,8 @@ import Foundation
 public class TabDappStore: ObservableObject {
   /// A set of solana account addresses that are currently connected to the dapp
   @Published public var solConnectedAddresses: Set<String> = .init()
-  /// The latest dapp permission request 
-  @Published public var latestPermissionRequest: WebpagePermissionRequest?
+  /// The latest pending dapp permission request 
+  @Published public var latestPendingPermissionRequest: WebpagePermissionRequest?
   
   public init() {}
 }

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -511,7 +511,7 @@ struct WalletPanelView: View {
     .onChange(of: keyringStore.selectedAccount) { _ in
       isConnectHidden = isConnectButtonHidden()
     }
-    .onChange(of: tabDappStore.latestPermissionRequest) { newValue in
+    .onChange(of: tabDappStore.latestPendingPermissionRequest) { newValue in
       if let request = newValue, request.requestingOrigin == origin, request.coinType == keyringStore.selectedAccount.coin {
         presentWalletWithContext(.requestPermissions(request, onPermittedAccountsUpdated: { accounts in
           if request.coinType == .eth {
@@ -520,7 +520,7 @@ struct WalletPanelView: View {
             solConnectedAddresses = Set(accounts)
             isConnectHidden = false
           }
-          tabDappStore.latestPermissionRequest = nil
+          tabDappStore.latestPendingPermissionRequest = nil
         }))
       }
     }

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -511,7 +511,19 @@ struct WalletPanelView: View {
     .onChange(of: keyringStore.selectedAccount) { _ in
       isConnectHidden = isConnectButtonHidden()
     }
+    .onChange(of: cryptoStore.latestPermissionRequest) { newValue in
+      if let request = newValue, request.requestingOrigin == origin, request.coinType == keyringStore.selectedAccount.coin {
+        presentWalletWithContext(.requestEthererumPermissions(request, onPermittedAccountsUpdated: { accounts in
+          permittedAccounts = accounts
+        }))
+      }
+    }
     .onAppear {
+      if let accountCreationRequest = WalletProviderAccountCreationRequestManager.shared.firstPendingRequest(for: origin, coinTypes: Array(WalletConstants.supportedCoinTypes)) {
+        presentWalletWithContext(.createAccount(accountCreationRequest))
+        return
+      }
+      
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       if let request = permissionRequestManager.firstPendingRequest(for: origin, coinTypes: [.eth, .sol]) {
         presentWalletWithContext(.requestPermissions(request, onPermittedAccountsUpdated: { accounts in

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -511,10 +511,16 @@ struct WalletPanelView: View {
     .onChange(of: keyringStore.selectedAccount) { _ in
       isConnectHidden = isConnectButtonHidden()
     }
-    .onChange(of: cryptoStore.latestPermissionRequest) { newValue in
+    .onChange(of: tabDappStore.latestPermissionRequest) { newValue in
       if let request = newValue, request.requestingOrigin == origin, request.coinType == keyringStore.selectedAccount.coin {
         presentWalletWithContext(.requestEthererumPermissions(request, onPermittedAccountsUpdated: { accounts in
-          permittedAccounts = accounts
+          if request.coinType == .eth {
+            ethPermittedAccounts = accounts
+          } else if request.coinType == .sol {
+            solConnectedAddresses = Set(accounts)
+            isConnectHidden = false
+          }
+          tabDappStore.latestPermissionRequest = nil
         }))
       }
     }
@@ -530,6 +536,7 @@ struct WalletPanelView: View {
           if request.coinType == .eth {
             ethPermittedAccounts = accounts
           } else if request.coinType == .sol {
+            solConnectedAddresses = Set(accounts)
             isConnectHidden = false
           }
         }))

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -513,7 +513,7 @@ struct WalletPanelView: View {
     }
     .onChange(of: tabDappStore.latestPermissionRequest) { newValue in
       if let request = newValue, request.requestingOrigin == origin, request.coinType == keyringStore.selectedAccount.coin {
-        presentWalletWithContext(.requestEthererumPermissions(request, onPermittedAccountsUpdated: { accounts in
+        presentWalletWithContext(.requestPermissions(request, onPermittedAccountsUpdated: { accounts in
           if request.coinType == .eth {
             ethPermittedAccounts = accounts
           } else if request.coinType == .sol {

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -527,11 +527,7 @@ struct WalletPanelView: View {
     .onAppear {
       if let accountCreationRequest = WalletProviderAccountCreationRequestManager.shared.firstPendingRequest(for: origin, coinTypes: Array(WalletConstants.supportedCoinTypes)) {
         presentWalletWithContext(.createAccount(accountCreationRequest))
-        return
-      }
-      
-      let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
-      if let request = permissionRequestManager.firstPendingRequest(for: origin, coinTypes: [.eth, .sol]) {
+      } else if let request = WalletProviderPermissionRequestsManager.shared.firstPendingRequest(for: origin, coinTypes: [.eth, .sol]) {
         presentWalletWithContext(.requestPermissions(request, onPermittedAccountsUpdated: { accounts in
           if request.coinType == .eth {
             ethPermittedAccounts = accounts

--- a/Sources/BraveWallet/WalletHostingViewController.swift
+++ b/Sources/BraveWallet/WalletHostingViewController.swift
@@ -40,6 +40,8 @@ public enum PresentingContext {
   case settings
   /// Shows when the users want to edit connected account the the webpage
   case editSiteConnection(_ origin: URLOrigin, handler: (_ permittedAccounts: [String]) -> Void)
+  /// Shows account creation
+  case createAccount(_ request: WalletProviderAccountCreationRequest)
 }
 
 /// The initial wallet controller to present when the user wants to view their wallet

--- a/Sources/BraveWallet/WalletProviderAccountCreationManager.swift
+++ b/Sources/BraveWallet/WalletProviderAccountCreationManager.swift
@@ -1,0 +1,56 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+
+/// A permission request for a specific dapp
+public struct WalletProviderAccountCreationRequest: Equatable {
+  /// The origin that requested this permission
+  public let requestingOrigin: URLOrigin
+  /// The type of request
+  public let coinType: BraveWallet.CoinType
+  
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.requestingOrigin == rhs.requestingOrigin && lhs.coinType == rhs.coinType
+  }
+}
+
+public class WalletProviderAccountCreationRequestManager {
+  /// A shared instance of the account creation manager
+  public static let shared: WalletProviderAccountCreationRequestManager = .init()
+  
+  private var requests: [WalletProviderAccountCreationRequest] = []
+  
+  public func hasPendingRequest(for origin: URLOrigin, coinType: BraveWallet.CoinType) -> Bool {
+    requests.contains(where: { $0.requestingOrigin == origin && $0.coinType == coinType })
+  }
+  
+  /// Returns a list of pending requests waiting for a given origin and coin types
+  public func pendingRequests(for origin: URLOrigin, coinType: BraveWallet.CoinType) -> [WalletProviderAccountCreationRequest] {
+    requests.filter({ $0.requestingOrigin == origin && $0.coinType == coinType })
+  }
+  
+  public func removeRequest(for origin: URLOrigin, coinType: BraveWallet.CoinType) {
+    if let index = requests.firstIndex(where: { $0.requestingOrigin == origin && $0.coinType == coinType }) {
+      requests.remove(at: index)
+    }
+  }
+  
+  public func removeRequest(for request: WalletProviderAccountCreationRequest) {
+    if let index = requests.firstIndex(where: { $0 == request }) {
+      requests.remove(at: index)
+    }
+  }
+  
+  public func addRequest(or origin: URLOrigin, coinType: BraveWallet.CoinType) {
+    if !hasPendingRequest(for: origin, coinType: coinType) {
+      requests.append(WalletProviderAccountCreationRequest(requestingOrigin: origin, coinType: coinType))
+    }
+  }
+  
+  public func firstPendingRequest(for origin: URLOrigin, coinTypes: [BraveWallet.CoinType]) -> WalletProviderAccountCreationRequest? {
+    requests.filter { $0.requestingOrigin == origin && coinTypes.contains($0.coinType) }.first
+  }
+}

--- a/Sources/BraveWallet/WalletProviderAccountCreationManager.swift
+++ b/Sources/BraveWallet/WalletProviderAccountCreationManager.swift
@@ -44,7 +44,7 @@ public class WalletProviderAccountCreationRequestManager {
     }
   }
   
-  public func addRequest(or origin: URLOrigin, coinType: BraveWallet.CoinType) {
+  public func addRequest(for origin: URLOrigin, coinType: BraveWallet.CoinType) {
     if !hasPendingRequest(for: origin, coinType: coinType) {
       requests.append(WalletProviderAccountCreationRequest(requestingOrigin: origin, coinType: coinType))
     }

--- a/Sources/BraveWallet/WalletProviderAccountCreationManager.swift
+++ b/Sources/BraveWallet/WalletProviderAccountCreationManager.swift
@@ -7,10 +7,19 @@ import BraveCore
 
 /// A permission request for a specific dapp
 public struct WalletProviderAccountCreationRequest: Equatable {
+  /// A users response type
+  public enum Response {
+    /// The user rejected the prompt by dismissing the screen
+    case rejected
+    /// The user created a new account
+    case created
+  }
   /// The origin that requested this permission
-  public let requestingOrigin: URLOrigin
+  let requestingOrigin: URLOrigin
   /// The type of request
-  public let coinType: BraveWallet.CoinType
+  let coinType: BraveWallet.CoinType
+  /// A handler to be called when the user rejects to create a new account
+  let responseHandler: (Response) -> Void
   
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.requestingOrigin == rhs.requestingOrigin && lhs.coinType == rhs.coinType
@@ -44,13 +53,24 @@ public class WalletProviderAccountCreationRequestManager {
     }
   }
   
-  public func addRequest(for origin: URLOrigin, coinType: BraveWallet.CoinType) {
-    if !hasPendingRequest(for: origin, coinType: coinType) {
-      requests.append(WalletProviderAccountCreationRequest(requestingOrigin: origin, coinType: coinType))
+  public func beginRequest(
+    for origin: URLOrigin,
+    coinType: BraveWallet.CoinType,
+    completion: (() -> Void)? = nil
+  ) {
+    let request = WalletProviderAccountCreationRequest(requestingOrigin: origin, coinType: coinType) { [weak self] response in
+      guard let self = self else { return }
+      self.removeRequest(for: origin, coinType: coinType)
+      completion?()
     }
+    requests.append(request)
   }
   
   public func firstPendingRequest(for origin: URLOrigin, coinTypes: [BraveWallet.CoinType]) -> WalletProviderAccountCreationRequest? {
     requests.filter { $0.requestingOrigin == origin && coinTypes.contains($0.coinType) }.first
+  }
+  
+  public func cancelAllPendingRequests(coins: [BraveWallet.CoinType]) {
+    requests = requests.filter { !coins.contains($0.coinType) }
   }
 }

--- a/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
+++ b/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
@@ -91,7 +91,7 @@ public class WalletProviderPermissionRequestsManager {
   }
   
   /// Cancels all an in-flight requests without executing any decision
-  public func cancelAllPendingRequests() {
-    requests.removeAll()
+  public func cancelAllPendingRequests(coins: [BraveWallet.CoinType]) {
+    requests = requests.filter { !coins.contains($0.coinType) }
   }
 }

--- a/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
+++ b/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
@@ -91,7 +91,7 @@ public class WalletProviderPermissionRequestsManager {
   }
   
   /// Cancels all an in-flight requests without executing any decision
-  public func cancelAllPendingRequests(coins: [BraveWallet.CoinType]) {
+  public func cancelAllPendingRequests(for coins: [BraveWallet.CoinType]) {
     requests = requests.filter { !coins.contains($0.coinType) }
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -257,8 +257,8 @@ extension Strings {
       "wallet.addAccountTitle",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Add Account",
-      comment: "The title of the add account screen"
+      value: "Add %@ Account",
+      comment: "The title of the add account screen. '%@' will be placed with a coin type title. For example, 'Add Ethereum Account'. "
     )
     public static let add = NSLocalizedString(
       "wallet.addAccountAddButton",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -253,12 +253,19 @@ extension Strings {
       value: "Secondary Filecoin Account %lld",
       comment: "The default account name when adding a secondary account and not entering a custom name. '%lld' refers to a number (for example \"Secondary Filecoin Account 3\")"
     )
-    public static let addAccountTitle = NSLocalizedString(
+    public static let addAccountWithCoinTypeTitle = NSLocalizedString(
       "wallet.addAccountTitle",
       tableName: "BraveWallet",
       bundle: .strings,
       value: "Add %@ Account",
       comment: "The title of the add account screen. '%@' will be placed with a coin type title. For example, 'Add Ethereum Account'. "
+    )
+    public static let addAccountTitle = NSLocalizedString(
+      "wallet.addAccountTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Add Account",
+      comment: "The title of the add account screen."
     )
     public static let add = NSLocalizedString(
       "wallet.addAccountAddButton",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
solana provider delegate call back will trigger a solana account creation flow once the dapp is trying to connect to a brave wallet that does not have a solana account.
Once user has created the new solana account (which will be selected upon creation), a permission request will be received right after. app will prompt a permission panel for user to grant permission for connection as before.
The account creation request will be stored in the current session, same behaviour as the eth/solana permission request.

This pull request fixes #6046 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. Make sure your wallet does not have a solana account. For version with 1.44 and above, wallet creation will automatically create a solana account for you. If you need to create a new wallet with only an eth account, you would need to use an older build to do so.
2. go to a solana dapp (https://pwgoom.csb.app/) and try to connect wallet
3. a notification may appear on the top if wallet notification is not turned off in wallet settings.
4. click the notification 
5. a wallet unlock screen may appear if your wallet is locked
6. unlock your wallet
7. app will prompt an account creation screen
8. click add to create a solana account
9. app will prompt an permission screen right away
10. grant permission 
11. a. observe the wallet panel displayed the new solana account is selected, and it is connected. b. observe the dapp should display it has been connected to your wallet

1. Make sure your wallet does not have a solana account. For version with 1.44 and above, wallet creation will automatically create a solana account for you. If you need to create a new wallet with only an eth account, you would need to use an older build to do so.
2. go to a solana dapp (https://pwgoom.csb.app/) and try to connect wallet
3. a notification may appear on the top if wallet notification is not turned off in wallet settings.
4. click the notification 
5. a wallet unlock screen may appear if your wallet is locked
6. unlock your wallet
7. app will prompt an account creation screen
8. dismiss this screen by swiping down 
9. observe the wallet icon in url bar has a red badge indicates there is a pending request
10. dismiss the wallet panel 
11. click wallet icon in url bar to open wallet panel 
12. observe that the solana account creation screen shows up again
13. dismiss this screen by click cancel
14. observe the wallet icon in url bar has no red badge since user clicked `cancel` to not create a solana account
15. dismiss the wallet panel
16. click the wallet icon in url bar to open wallet panel
17. observe the create new account will not show up again


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
