### PR TITLE
Ref #4002: Fix viewport of web view while scrolled & using bottom bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2304,8 +2304,8 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
       }
       return
     }
-    let headerHeight = toolbarVisibilityViewModel.transitionDistance
-    let footerHeight = footer.bounds.height + (isUsingBottomBar ? headerHeight - view.safeAreaInsets.bottom : 0)
+    let headerHeight = isUsingBottomBar ? 0 : toolbarVisibilityViewModel.transitionDistance
+    let footerHeight = footer.bounds.height + (isUsingBottomBar ? toolbarVisibilityViewModel.transitionDistance - view.safeAreaInsets.bottom : 0)
     // Changing the web view size while scrolling and a PDF is visible causes strange flickering, so only show
     // final expanded/collapsed states while a PDF is visible
     if let progress = progress, tab.mimeType != MIMEType.PDF {


### PR DESCRIPTION
## Summary of Changes

Fixes a bug reported by someone in the public beta where the top of web pages headers such as reddit.com were being cut off

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Turn on bottom bar
- Visit reddit.com
- Scroll down so that the url bar collapses
- Verify the header of the page is still at the top and not under the status bar

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
