### PR TITLE
Fix #6081: Revert Shadow DOM for Content-Filters

### DIFF
--- a/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -147,22 +147,7 @@ extension AdblockEngine {
           style.appendChild(document.createTextNode(styles));
         }
 
-        const body = document.body || document.getElementsByTagName('body')[0];
-        if (!body) {
-          head.appendChild(style);
-        } else {
-          // Insert the element at a random position.
-          // This way pages cannot remove first or last element.
-          const min = 0;
-          const max = body.children.length;
-          const index = Math.floor(Math.random() * (max - min)) + min;
-      
-          const div = document.createElement('div');
-          body.insertBefore(div, body.children[index]);
-      
-          const shadow = div.attachShadow({ mode: 'closed' });
-          shadow.appendChild(style);
-        }
+        head.appendChild(style);
       })();
       """
     } else {


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1048

## Summary of Changes
- It only works for CosmeticFilters but something about the ContentFilters breaks it.
- Revert Shadow DOM for Content-Filters

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6081

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
