### PR TITLE
Fix #6083: Reject PostMessage requests from invalid frames

### DIFF
--- a/Client/Frontend/Browser/Tab+TabContentScript.swift
+++ b/Client/Frontend/Browser/Tab+TabContentScript.swift
@@ -33,6 +33,10 @@ extension TabContentScriptLoader {
   }
   
   static func secureScript(handlerNamesMap: [String: String], securityToken: String, script: String) -> String {
+    guard !script.isEmpty else {
+      return script
+    }
+    
     var script = script
     for (obfuscatedHandlerName, actualHandlerName) in handlerNamesMap {
       script = script.replacingOccurrences(of: obfuscatedHandlerName, with: actualHandlerName)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -334,6 +334,7 @@ class Tab: NSObject {
 
       self.webView = webView
       self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
+      tabDelegate?.tab(self, didCreateWebView: webView)
       
       let scriptPreferences: [UserScriptManager.ScriptType: Bool] = [
         .cookieBlocking: Preferences.Privacy.blockAllCookies.value,
@@ -345,7 +346,6 @@ class Tab: NSObject {
       
       userScripts = Set(scriptPreferences.filter({ $0.value }).map({ $0.key }))
       self.updateInjectedScripts()
-      tabDelegate?.tab(self, didCreateWebView: webView)
       nightMode = Preferences.General.nightModeEnabled.value
     }
   }

--- a/Client/Frontend/UserContent/UserScripts/__firefox__.js
+++ b/Client/Frontend/UserContent/UserScripts/__firefox__.js
@@ -29,10 +29,10 @@ if (!window.__firefox__) {
   let $Reflect = secureCopy(Reflect);
   let $Array = secureCopy(Array);
   let $webkit = window.webkit;
-  let $messageHandlers = $webkit.messageHandlers;
+  let $MessageHandlers = $webkit.messageHandlers;
   
   secureCopy = undefined;
-  let secureObjects = [$Object, $Function, $Reflect, $Array];
+  let secureObjects = [$Object, $Function, $Reflect, $Array, $MessageHandlers];
   
   /*
    *  Prevent recursive calls if a page overrides these.
@@ -131,11 +131,16 @@ if (!window.__firefox__) {
   };
     
   $.postNativeMessage = function(messageHandlerName, message) {
+    if (!window.webkit || !window.webkit.messageHandlers) {
+      return Promise.reject(new TypeError("undefined is not an object (evaluating 'webkit.messageHandlers')"));
+    }
+    
     let webkit = window.webkit;
-    delete window.webkit;
+    delete window.webkit.messageHandlers[messageHandlerName].postMessage;
+    delete window.webkit.messageHandlers[messageHandlerName];
     delete window.webkit.messageHandlers;
-    delete $messageHandlers[messageHandlerName].postMessage;
-    let result = $messageHandlers[messageHandlerName].postMessage(message);
+    delete window.webkit;
+    let result = $MessageHandlers[messageHandlerName].postMessage(message);
     window.webkit = webkit;
     return result;
   }


### PR DESCRIPTION
## Summary of Changes
- Change order of deleting webkit message handlers before posting messages.
- Guard against injecting empty scripts (they do no harm but would be annoying debugging and see no code)
- Discovered invalid frame `postMessage` while testing Wallet on `https://jup.ag/` only :(
- Related (ticket filed with WebKit): https://github.com/brave/internal/issues/914

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6083

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
