### PR TITLE
Fix #6087: Address QR code prefix

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -185,7 +185,10 @@ struct SendTokenView: View {
         )
       }
       .sheet(isPresented: $isShowingScanner) {
-        AddressQRCodeScannerView(address: $sendTokenStore.sendAddress)
+        AddressQRCodeScannerView(
+          coin: sendTokenStore.selectedSendToken?.coin ?? .eth,
+          address: $sendTokenStore.sendAddress
+        )
       }
       .navigationTitle(Strings.Wallet.send)
       .navigationBarTitleDisplayMode(.inline)

--- a/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
+++ b/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
@@ -260,19 +260,3 @@ extension AddressQRCodeScannerViewController: AVCaptureMetadataOutputObjectsDele
     isFinishScanning = false
   }
 }
-
-private extension String {
-  /// Strip prefix if it exists, ex. 'ethereum:'
-  var strippedETHAddress: String {
-    guard !isETHAddress else { return self }
-    if !starts(with: "0x"),
-       contains("0x"),
-       let range = range(of: "0x"),
-       case let updatedAddressSubstring = self[range.lowerBound...],
-       case let updatedAddress = String(updatedAddressSubstring),
-       updatedAddress.isETHAddress {
-      return updatedAddress
-    }
-    return self
-  }
-}

--- a/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
+++ b/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
@@ -7,8 +7,10 @@ import SwiftUI
 import AVFoundation
 import SnapKit
 import Strings
+import BraveCore
 
 struct AddressQRCodeScannerView: View {
+  var coin: BraveWallet.CoinType
   @Binding var address: String
   @State private var isErrorPresented: Bool = false
   @State private var permissionDenied: Bool = false
@@ -41,6 +43,7 @@ struct AddressQRCodeScannerView: View {
       .ignoresSafeArea()
       #else
       _AddressQRCodeScannerView(
+        coin: coin,
         address: $address,
         isErrorPresented: $isErrorPresented,
         isPermissionDenied: $permissionDenied,
@@ -93,6 +96,7 @@ struct AddressQRCodeScannerView: View {
 
 private struct _AddressQRCodeScannerView: UIViewControllerRepresentable {
   typealias UIViewControllerType = AddressQRCodeScannerViewController
+  var coin: BraveWallet.CoinType
   @Binding var address: String
   @Binding var isErrorPresented: Bool
   @Binding var isPermissionDenied: Bool
@@ -100,6 +104,7 @@ private struct _AddressQRCodeScannerView: UIViewControllerRepresentable {
 
   func makeUIViewController(context: Context) -> UIViewControllerType {
     AddressQRCodeScannerViewController(
+      coin: coin,
       address: _address,
       isErrorPresented: _isErrorPresented,
       isPermissionDenied: _isPermissionDenied,
@@ -112,6 +117,7 @@ private struct _AddressQRCodeScannerView: UIViewControllerRepresentable {
 }
 
 private class AddressQRCodeScannerViewController: UIViewController {
+  var coin: BraveWallet.CoinType
   @Binding private var address: String
   @Binding private var isErrorPresented: Bool
   @Binding private var isPermissionDenied: Bool
@@ -127,11 +133,13 @@ private class AddressQRCodeScannerViewController: UIViewController {
   var dismiss: () -> Void
 
   init(
+    coin: BraveWallet.CoinType,
     address: Binding<String>,
     isErrorPresented: Binding<Bool>,
     isPermissionDenied: Binding<Bool>,
     dismiss: @escaping () -> Void
   ) {
+    self.coin = coin
     self._address = address
     self._isErrorPresented = isErrorPresented
     self._isPermissionDenied = isPermissionDenied
@@ -221,20 +229,50 @@ private class AddressQRCodeScannerViewController: UIViewController {
     previewLayer = videoPreviewLayer
     captureSession.startRunning()
   }
+  
+  private func foundAddress(_ address: String) {
+    self.address = address
+    dismiss()
+  }
 }
 
 extension AddressQRCodeScannerViewController: AVCaptureMetadataOutputObjectsDelegate {
   func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
-    if let stringValue = (metadataObjects.first as? AVMetadataMachineReadableCodeObject)?.stringValue, stringValue.isETHAddress {
-      address = stringValue
-      dismiss()
-    } else {
-      isErrorPresented = true
+    guard let stringValue = (metadataObjects.first as? AVMetadataMachineReadableCodeObject)?.stringValue else {
+      return
+    }
+    switch coin {
+    case .eth:
+      if stringValue.isETHAddress {
+        foundAddress(stringValue)
+      } else if stringValue.strippedETHAddress.isETHAddress {
+        foundAddress(stringValue.strippedETHAddress)
+      } else {
+        isErrorPresented = true
+      }
+    default:
+      foundAddress(stringValue)
     }
     isFinishScanning = true
   }
 
   func resetCamera() {
     isFinishScanning = false
+  }
+}
+
+private extension String {
+  /// Strip prefix if it exists, ex. 'ethereum:'
+  var strippedETHAddress: String {
+    guard !isETHAddress else { return self }
+    if !starts(with: "0x"),
+       contains("0x"),
+       let range = range(of: "0x"),
+       case let updatedAddressSubstring = self[range.lowerBound...],
+       case let updatedAddress = String(updatedAddressSubstring),
+       updatedAddress.isETHAddress {
+      return updatedAddress
+    }
+    return self
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/Address.swift
+++ b/Sources/BraveWallet/Crypto/Stores/Address.swift
@@ -43,6 +43,20 @@ extension String {
     return hex.count == 40 && hex.allSatisfy(\.isHexDigit)
   }
   
+  /// Strip prefix if it exists, ex. 'ethereum:'
+  var strippedETHAddress: String {
+    guard !isETHAddress else { return self }
+    if !starts(with: "0x"),
+       contains("0x"),
+       let range = range(of: "0x"),
+       case let updatedAddressSubstring = self[range.lowerBound...],
+       case let updatedAddress = String(updatedAddressSubstring),
+       updatedAddress.isETHAddress {
+      return updatedAddress
+    }
+    return self
+  }
+  
   /// Insert zero-width space every character inside this string
   var zwspOutput: String {
     return map {

--- a/Tests/BraveWalletTests/AddressTests.swift
+++ b/Tests/BraveWalletTests/AddressTests.swift
@@ -40,6 +40,30 @@ class AddressTests: XCTestCase {
     XCTAssertFalse(isAddressFalseNoHexDigits.isETHAddress)
   }
   
+  func testStrippedETHAddress() {
+    let address = "0x0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
+    XCTAssertEqual(address, address.strippedETHAddress)
+    
+    let addressEthereumPrefix = "ethereum:0x0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
+    let addressEthereumPrefixStripped = addressEthereumPrefix.strippedETHAddress
+    XCTAssertNotEqual(addressEthereumPrefix, addressEthereumPrefixStripped)
+    XCTAssertEqual(addressEthereumPrefixStripped, address)
+    
+    let addressEthereumPrefix2 = "Ethereum:0x0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
+    let addressEthereumPrefix2Stripped = addressEthereumPrefix2.strippedETHAddress
+    XCTAssertNotEqual(addressEthereumPrefix2, addressEthereumPrefix2Stripped)
+    XCTAssertEqual(addressEthereumPrefix2Stripped, address)
+    
+    let addressEthPrefix = "eth:0x0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
+    let addressEthPrefixStripped = addressEthPrefix.strippedETHAddress
+    XCTAssertNotEqual(addressEthPrefix, addressEthPrefixStripped)
+    XCTAssertEqual(addressEthPrefixStripped, address)
+    
+    let addressFalseWrongPrefix = "0c84cD05f2Bc2AfD7f29d4E71346d17697C353b7"
+    let addressFalseWrongPrefixStripped = addressFalseWrongPrefix.strippedETHAddress
+    XCTAssertEqual(addressFalseWrongPrefix, addressFalseWrongPrefixStripped)
+  }
+  
   func testZwspOutput() {
     let address = "0x1bBE4E6EF7294c99358377abAd15A6d9E98127A2"
     let zwspAddress = "0\u{200b}x\u{200b}1\u{200b}b\u{200b}B\u{200b}E\u{200b}4\u{200b}E\u{200b}6\u{200b}E\u{200b}F\u{200b}7\u{200b}2\u{200b}9\u{200b}4\u{200b}c\u{200b}9\u{200b}9\u{200b}3\u{200b}5\u{200b}8\u{200b}3\u{200b}7\u{200b}7\u{200b}a\u{200b}b\u{200b}A\u{200b}d\u{200b}1\u{200b}5\u{200b}A\u{200b}6\u{200b}d\u{200b}9\u{200b}E\u{200b}9\u{200b}8\u{200b}1\u{200b}2\u{200b}7\u{200b}A\u{200b}2\u{200b}"


### PR DESCRIPTION
## Summary of Changes
- When reading an address via QR code, strip prefix before `0x` if there is a prefix. Ex. `ethereum:`
- Don't validate address as ethereum address for non-ethereum coin types

This pull request fixes #6087

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Ethereum:
1. Install MetaMask extension on desktop.
2. Select Ethereum network
3. Open send crypto view and tap QR code button in the 'To' address field
4. Scan the QR code
5. Verify the address populates in the 'To' field, and does not contain `ethereum:` prefix

Solana:
1. Generate a text QR code for a Solana address ([QR code generator](https://www.qr-code-generator.com/))
2. Select Solana network
3. Open send crypto view and tap QR code button in the 'To' address field
4. Scan the QR code
5. Verify the address populates in the 'To' field


## Screenshots:

https://user-images.githubusercontent.com/5314553/193308151-5475a6e5-1c08-4b9c-be97-a3d65e3e2753.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
