### PR TITLE
Fix #5966: Wallet edit visible assets with new solana account creation

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -137,11 +137,8 @@ struct AddCustomAssetView: View {
 struct AddCustomAssetView_Previews: PreviewProvider {
   static var previews: some View {
     AddCustomAssetView(
-      userAssetStore: UserAssetsStore(
-        walletService: MockBraveWalletService(),
-        blockchainRegistry: MockBlockchainRegistry(),
-        rpcService: MockJsonRpcService(),
-        assetRatioService: MockAssetRatioService()))
+      userAssetStore: .previewStore
+    )
   }
 }
 #endif

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -58,6 +58,7 @@ public class PortfolioStore: ObservableObject {
     walletService: self.walletService,
     blockchainRegistry: self.blockchainRegistry,
     rpcService: self.rpcService,
+    keyringService: self.keyringService,
     assetRatioService: self.assetRatioService
   )
   

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -196,9 +196,7 @@ extension UserAssetsStore: BraveWalletJsonRpcServiceObserver {
 
 extension UserAssetsStore: BraveWalletKeyringServiceObserver {
   public func keyringCreated(_ keyringId: String) {
-    Task { @MainActor in
-      self.fetchVisibleAssets()
-    }
+    fetchVisibleAssets()
   }
   
   public func keyringRestored(_ keyringId: String) {

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -55,6 +55,7 @@ public class UserAssetsStore: ObservableObject {
   private let walletService: BraveWalletBraveWalletService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
   private let rpcService: BraveWalletJsonRpcService
+  private let keyringService: BraveWalletKeyringService
   private let assetRatioService: BraveWalletAssetRatioService
   private var allTokens: [BraveWallet.BlockchainToken] = []
   private var timer: Timer?
@@ -63,13 +64,16 @@ public class UserAssetsStore: ObservableObject {
     walletService: BraveWalletBraveWalletService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
     rpcService: BraveWalletJsonRpcService,
+    keyringService: BraveWalletKeyringService,
     assetRatioService: BraveWalletAssetRatioService
   ) {
     self.walletService = walletService
     self.blockchainRegistry = blockchainRegistry
     self.rpcService = rpcService
+    self.keyringService = keyringService
     self.assetRatioService = assetRatioService
     self.rpcService.add(self)
+    self.keyringService.add(self)
 
     fetchVisibleAssets()
   }
@@ -187,5 +191,37 @@ extension UserAssetsStore: BraveWalletJsonRpcServiceObserver {
   public func onAddEthereumChainRequestCompleted(_ chainId: String, error: String) {
   }
   public func onIsEip1559Changed(_ chainId: String, isEip1559: Bool) {
+  }
+}
+
+extension UserAssetsStore: BraveWalletKeyringServiceObserver {
+  public func keyringCreated(_ keyringId: String) {
+    Task { @MainActor in
+      self.fetchVisibleAssets()
+    }
+  }
+  
+  public func keyringRestored(_ keyringId: String) {
+  }
+  
+  public func keyringReset() {
+  }
+  
+  public func locked() {
+  }
+  
+  public func unlocked() {
+  }
+  
+  public func backedUp() {
+  }
+  
+  public func accountsChanged() {
+  }
+  
+  public func autoLockMinutesChanged() {
+  }
+  
+  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
   }
 }

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -147,6 +147,7 @@ extension UserAssetsStore {
       walletService: MockBraveWalletService(),
       blockchainRegistry: MockBlockchainRegistry(),
       rpcService: MockJsonRpcService(),
+      keyringService: MockKeyringService(),
       assetRatioService: MockAssetRatioService()
     )
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Second attempt fixing #5966 
Once solana keyring has been created, selected coin will automatically set to .sol which will result front end has no need to set network. 
`UserAssetStore` was only listening to network change in order to refresh the asset list. 
The new fix is now make `UserAssetStore` to listen to keyringCreated, so that any new keyring created will force this store to refresh the asset list.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5966

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. Download a build that is older than 1.44.x to set up a wallet with only eth accounts
2. upgrade the build to 1.44 or later.
3. Observe the selected account is an eth account
4. change network to solana
5. observe wallet is asking user to make a new solana account
6. tap `Edit Visible Assets`
7. observe that the asset list contains tokens from eth network.
8. accept all the prompts in order to proceed to create a solana account
9. observe now network is now selected to solana and selected account is a solana account
10. tap `Edit Visible Assets`
11. observe now the asset list contains tokens from solana network. 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
