### PR TITLE
Fix #6086: Don't alter bottom bar when BVC is not visible/on top

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1214,7 +1214,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
 
     header.snp.remakeConstraints { make in
       if self.isUsingBottomBar {
-        if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view), keyboardHeight > 0 {
+        if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view), keyboardHeight > 0, presentedViewController == nil {
           var offset = -keyboardHeight
           if !topToolbar.inOverlayMode {
             // Showing collapsed URL bar while the keyboard is up

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Keyboard.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Keyboard.swift
@@ -10,7 +10,7 @@ import Shared
 extension BrowserViewController: KeyboardHelperDelegate {
   public func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
     keyboardState = state
-    if isUsingBottomBar && !topToolbar.inOverlayMode {
+    if isUsingBottomBar && !topToolbar.inOverlayMode && presentedViewController == nil {
       UIView.animate(withDuration: 0.1) { [self] in
         // We can't actually set the toolbar state to collapsed since bar collapsing/expanding is based on
         // many web view traits such as content size and such so we will just use the collapsed bar view
@@ -41,7 +41,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
   
   public func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
     keyboardState = nil
-    if isUsingBottomBar && !topToolbar.inOverlayMode {
+    if isUsingBottomBar && !topToolbar.inOverlayMode && presentedViewController == nil {
       UIView.animate(withDuration: 0.1) { [self] in
         // We can't actually set the toolbar state to expanded since bar collapsing/expanding is based on
         // many web view traits such as content size and such so we will just use the collapsed bar view


### PR DESCRIPTION
I couldn't actually reproduce the bug, but this change should fix keyboards appearing on presented controllers affecting the URL bar.

## Summary of Changes

This pull request fixes #6086 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Verify URL bar moves correctly when entering search
- Verify URL bar moves correctly and shows collapsed bar when tapping on a text field on a website
- Verify URL bar does not move when showing/hiding the keyboard on a presented screen (wallet, etc.)
  - Easiest way to notice this one is dismissing the wallet unlock screen while keyboard is up, you will no longer see the URL bar animating slightly downwards as wallet dismisses

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
