### PR TITLE
Fix #6097: Make sure the widget data stat is displayed in one line

### DIFF
--- a/App/BraveWidgets/StatsWidget.swift
+++ b/App/BraveWidgets/StatsWidget.swift
@@ -82,8 +82,8 @@ private struct StatsView: View {
                 Text(verbatim: placeholderOrPrivacyRedaction ? "-" : data.value)
                   .font(.system(size: 32.0))
                   .foregroundColor(Color(data.color))
-                  .multilineTextAlignment(.center)
                   .minimumScaleFactor(0.5)
+                  .lineLimit(1)
                   .unredacted()
                 Text(verbatim: data.name)
                   .font(.system(size: 10, weight: .semibold))
@@ -113,8 +113,17 @@ struct StatsWidget_Previews: PreviewProvider {
     let kinds: [StatKind] = [.adsBlocked, .dataSaved, .timeSaved]
     return kinds.map { StatData(name: $0.name, value: $0.displayString, color: $0.valueColor) }
   }
+  
+  static var fullStats: [StatData] {
+    let ads = StatData(name: StatKind.adsBlocked.name, value: "113K", color: StatKind.adsBlocked.valueColor)
+    let data = StatData(name: StatKind.dataSaved.name, value: "3,47GB", color: StatKind.dataSaved.valueColor)
+    let time = StatData(name: StatKind.timeSaved.name, value: "1h", color: StatKind.timeSaved.valueColor)
+    return [ads, data, time]
+  }
 
   static var previews: some View {
+    StatsView(entry: StatsEntry(date: Date(), statData: fullStats))
+      .previewContext(WidgetPreviewContext(family: .systemMedium))
     StatsView(entry: StatsEntry(date: Date(), statData: stats))
       .previewContext(WidgetPreviewContext(family: .systemMedium))
     StatsView(entry: StatsEntry(date: Date(), statData: stats))


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
I can't reproduce it, blind fix

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6097 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
