### PR TITLE
Fix #5618: Move Account Picker to Section row instead of header

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -86,6 +86,7 @@ struct AccountPicker: View {
         }) {
           accountView
         }
+        .buttonStyle(.plain)
         // Context Menus are not supported inside `List`/`Form` section headers/footers so we must replace
         // this with a long press gesture + action sheet on iOS 14
         .simultaneousGesture(
@@ -113,6 +114,7 @@ struct AccountPicker: View {
       keyringStore: keyringStore,
       networkStore: networkStore
     )
+    .buttonStyle(.plain)
   }
 }
 

--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -26,16 +26,13 @@ struct BuyTokenView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section(
-          header: AccountPicker(
+        Section {
+          AccountPicker(
             keyringStore: keyringStore,
             networkStore: networkStore
           )
           .listRowBackground(Color.clear)
           .resetListHeaderStyle()
-          .padding(.top)
-          .padding(.bottom, -16)  // Get it a bit closer
-        ) {
         }
         if isBuySupported {
           Section(
@@ -89,6 +86,8 @@ struct BuyTokenView: View {
           }
         }
       }
+      .environment(\.defaultMinListHeaderHeight, 0)
+      .environment(\.defaultMinListRowHeight, 0)
       .navigationTitle(Strings.Wallet.buy)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -41,16 +41,13 @@ struct SendTokenView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section(
-          header: AccountPicker(
+        Section {
+          AccountPicker(
             keyringStore: keyringStore,
             networkStore: networkStore
           )
           .listRowBackground(Color.clear)
           .resetListHeaderStyle()
-          .padding(.top)
-          .padding(.bottom, -16)  // Get it a bit closer
-        ) {
         }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoFromTitle))
@@ -177,6 +174,8 @@ struct SendTokenView: View {
         ) {
         }
       }
+      .environment(\.defaultMinListHeaderHeight, 0)
+      .environment(\.defaultMinListRowHeight, 0)
       .alert(isPresented: $isShowingError) {
         Alert(
           title: Text(""),

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -225,7 +225,6 @@ struct SwapCryptoView: View {
 
   @ViewBuilder var swapFormSections: some View {
     Section(
-      header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoFromTitle))
     ) {
       NavigationLink(destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .fromToken, network: networkStore.selectedChain)) {
         HStack {
@@ -463,16 +462,13 @@ struct SwapCryptoView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section(
-          header: AccountPicker(
+        Section {
+          AccountPicker(
             keyringStore: keyringStore,
             networkStore: networkStore
           )
           .listRowBackground(Color.clear)
           .resetListHeaderStyle()
-          .padding(.top)
-          .padding(.bottom, -16)  // Get it a bit closer
-        ) {
         }
         if networkStore.isSwapSupported {
           swapFormSections
@@ -480,6 +476,8 @@ struct SwapCryptoView: View {
           unsupportedSwapChainSection
         }
       }
+      .environment(\.defaultMinListHeaderHeight, 0)
+      .environment(\.defaultMinListRowHeight, 0)
       .navigationTitle(Strings.Wallet.swap)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {


### PR DESCRIPTION
This fixes a bug in the iOS 16 SDK that doesn't allow these headers to be tapped.

Note: This commit is to be reverted once we start shipping with Xcode 14.1/iOS 16.1 SDK where the bug is fixed.

## Summary of Changes

This pull request fixes #5618 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
