### PR TITLE
Fix #6072: Set List/Form background colours on iOS 16

### DIFF
--- a/Client/Frontend/Browser/Certificate Viewer/CertificateViewController.swift
+++ b/Client/Frontend/Browser/Certificate Viewer/CertificateViewController.swift
@@ -108,6 +108,7 @@ private struct CertificateView: View {
         content
       }
       .listStyle(InsetGroupedListStyle())
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     }
   }
 

--- a/Client/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
+++ b/Client/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
@@ -8,6 +8,7 @@ import Shared
 import BraveShared
 import Data
 import CoreData
+import BraveUI
 
 extension Domain: Identifiable {
   public var id: String {
@@ -111,6 +112,7 @@ struct PageZoomSettingsView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(Strings.PageZoom.settingsTitle)
     .navigationBarTitleDisplayMode(.inline)
     .listStyle(.insetGrouped)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistEditFolderView.swift
@@ -8,6 +8,7 @@ import Data
 import CoreData
 import Shared
 import BraveShared
+import BraveUI
 
 struct PlaylistEditFolderView: View {
   @State private var folderName: String
@@ -35,6 +36,7 @@ struct PlaylistEditFolderView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .listStyle(.insetGrouped)
       .navigationTitle(Strings.PlaylistFolders.playlistEditFolderScreenTitle)
       .navigationBarTitleDisplayMode(.inline)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
@@ -9,6 +9,7 @@ import Data
 import CoreData
 import Shared
 import BraveShared
+import BraveUI
 
 private struct PlaylistFolderImage: View {
   let item: PlaylistItem
@@ -221,6 +222,7 @@ struct PlaylistMoveFolderView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       .listStyle(.insetGrouped)
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.PlaylistFolders.playlistFolderMoveFolderScreenTitle)
       .navigationBarTitleDisplayMode(.inline)
       .navigationViewStyle(.stack)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
@@ -9,6 +9,7 @@ import Data
 import CoreData
 import Shared
 import BraveShared
+import BraveUI
 
 class PlaylistFolderImageLoader: ObservableObject {
   @Published var image: UIImage?
@@ -205,6 +206,7 @@ struct PlaylistNewFolderView: View {
         }
       }
       .listStyle(.insetGrouped)
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.PlaylistFolders.playlistNewFolderScreenTitle)
       .navigationBarTitleDisplayMode(.inline)
       .navigationViewStyle(.stack)

--- a/Client/Frontend/Browser/PrivacyHub/AllVPNAlertsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/AllVPNAlertsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 import Shared
 import BraveShared
 import Data
+import BraveUI
 
 extension PrivacyReportsView {
   struct AllVPNAlertsView: View {
@@ -115,6 +116,7 @@ extension PrivacyReportsView {
             }
           }
           .listStyle(.insetGrouped)
+          .listBackgroundColor(Color(UIColor.braveGroupedBackground))
           
           Spacer()
         } else {

--- a/Client/Frontend/Browser/PrivacyHub/PrivacyReportAllTimeListsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/PrivacyReportAllTimeListsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 import Shared
 import BraveShared
 import Data
+import BraveUI
 
 private struct FaviconImage: View {
   let url: URL?
@@ -146,6 +147,7 @@ struct PrivacyReportAllTimeListsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
   
   private var websitesList: some View {
@@ -169,6 +171,7 @@ struct PrivacyReportAllTimeListsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
   
   var body: some View {

--- a/Client/Frontend/Settings/Brave Search/BraveSearchDebugMenu.swift
+++ b/Client/Frontend/Settings/Brave Search/BraveSearchDebugMenu.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import SwiftUI
+import BraveUI
 
 struct BraveSearchDebugMenu: View {
 
@@ -34,6 +35,7 @@ struct BraveSearchDebugMenu: View {
         }
       }
     }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
 
   private func formattedDate(_ date: Date) -> String {

--- a/Client/Frontend/Settings/Brave Search/BraveSearchDebugMenuDetail.swift
+++ b/Client/Frontend/Settings/Brave Search/BraveSearchDebugMenuDetail.swift
@@ -37,6 +37,7 @@ struct BraveSearchDebugMenuDetail: View {
         )
       }
     }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
 
   private var cookieNames: String {

--- a/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
+++ b/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveShared
 import BraveCore
+import BraveUI
 
 extension BraveCoreSwitch {
   fileprivate var displayString: String {
@@ -51,6 +52,7 @@ private struct BasicStringInputView: View {
       }
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(coreSwitch.displayString)
     .onAppear {
       // SwiftUI bug, has to wait a bit
@@ -103,6 +105,7 @@ private struct BasicPickerInputView: View {
       .pickerStyle(.inline)
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(coreSwitch.displayString)
     .onAppear {
       // SwiftUI bug, has to wait a bit
@@ -225,6 +228,7 @@ struct BraveCoreDebugSwitchesView: View {
       }
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitle("BraveCore Switches")
   }
 }

--- a/Client/Frontend/Settings/FilterListsView.swift
+++ b/Client/Frontend/Settings/FilterListsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import Strings
 import Data
 import DesignSystem
+import BraveUI
 
 /// A view showing enabled and disabled community filter lists
 struct FilterListsView: View {
@@ -32,7 +33,9 @@ struct FilterListsView: View {
           .textCase(.none)
       }
       
-    }.navigationTitle(Strings.filterLists)
+    }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
+    .navigationTitle(Strings.filterLists)
   }
 }
 

--- a/Client/Frontend/Settings/ManageWebsiteDataView.swift
+++ b/Client/Frontend/Settings/ManageWebsiteDataView.swift
@@ -141,6 +141,7 @@ struct ManageWebsiteDataView: View {
         .listRowBackground(Color(.braveBackground))
       }
       .listStyle(.plain)
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .environment(\.editMode, $editMode)
       .overlay(
         Group {

--- a/Client/Frontend/Settings/PrivacyReportSettingsView.swift
+++ b/Client/Frontend/Settings/PrivacyReportSettingsView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import Shared
 import BraveShared
+import BraveUI
 
 struct PrivacyReportSettingsView: View {
   
@@ -73,6 +74,7 @@ struct PrivacyReportSettingsView: View {
       }
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
 }
 

--- a/Client/Frontend/Settings/SandboxInspectorView.swift
+++ b/Client/Frontend/Settings/SandboxInspectorView.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import SwiftUI
+import BraveUI
 
 /// A small file browser that lets you inspect the contents of the apps sandbox.
 ///
@@ -125,6 +126,7 @@ struct SandboxInspectorView: View {
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle("Sandbox Inspector")
     .navigationBarTitleDisplayMode(.inline)
     .onAppear(perform: getNodes)

--- a/Client/Frontend/Settings/WebsiteRedirectsSettingsView.swift
+++ b/Client/Frontend/Settings/WebsiteRedirectsSettingsView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import Shared
 import BraveShared
+import BraveUI
 
 struct WebsiteRedirectsSettingsView: View {
   @ObservedObject private var reddit = Preferences.WebsiteRedirects.reddit
@@ -34,6 +35,7 @@ struct WebsiteRedirectsSettingsView: View {
       }
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(Strings.urlRedirectsSettings)
   }
 }

--- a/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -6,6 +6,7 @@
 import UIKit
 import SwiftUI
 import BraveShared
+import BraveUI
 
 extension FeedDataSource.Environment {
   fileprivate var name: String {
@@ -118,6 +119,7 @@ public struct BraveNewsDebugSettingsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle("Brave News QA Settings")
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
@@ -191,6 +193,7 @@ private struct LanguagePicker: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .onAppear {
       if !FeedDataSource.supportedLanguages.contains(languageCode) {
         // SwiftUI bug needs to be set a bit after

--- a/Sources/BraveUI/SwiftUI/ListBackground.swift
+++ b/Sources/BraveUI/SwiftUI/ListBackground.swift
@@ -1,0 +1,20 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SwiftUI
+
+extension View {
+  /// Sets the background color of a List when using iOS 16 which is no longer backed by `UITableView`, thus
+  /// not respecting `UIAppearance` overrides
+  @available(iOS, introduced: 14.0, deprecated: 16.0, message: "Use `scrollContentBackground` and `background` directly")
+  public func listBackgroundColor(_ color: Color) -> some View {
+    if #available(iOS 16.0, *) {
+      return self.scrollContentBackground(.hidden).background(color)
+    } else {
+      return self
+    }
+  }
+}

--- a/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveCore
 import struct Shared.Strings
+import BraveUI
 
 struct AccountListView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -36,6 +37,7 @@ struct AccountListView: View {
         }
       }
       .listStyle(InsetGroupedListStyle())
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.Wallet.selectAccountTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveCore
 import struct Shared.Strings
+import BraveUI
 
 struct AccountTransactionListView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -58,6 +59,7 @@ struct AccountTransactionListView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(Strings.Wallet.transactionsTitle)
     .navigationBarTitleDisplayMode(.inline)
     .sheet(

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -102,6 +102,7 @@ struct AccountsView: View {
         })
     )
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -8,6 +8,7 @@ import BraveCore
 import SwiftUI
 import Strings
 import DesignSystem
+import BraveUI
 
 struct AccountActivityView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -107,6 +108,7 @@ struct AccountActivityView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .background(
       Color.clear
         .sheet(item: $detailsPresentation) {

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -78,6 +78,7 @@ struct AddAccountView: View {
       privateKeySection
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.addAccountTitle)
     .navigationBarItems(
@@ -134,6 +135,7 @@ struct AddAccountView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.addAccountTitle)
   }

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -12,6 +12,7 @@ import CoreImage
 import CoreImage.CIFilterBuiltins
 import Strings
 import BraveShared
+import BraveUI
 
 struct AccountDetailsView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -88,6 +89,7 @@ struct AccountDetailsView: View {
         }
       }
       .listStyle(InsetGroupedListStyle())
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.Wallet.accountDetailsTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -10,6 +10,7 @@ import BraveCore
 import DesignSystem
 import Strings
 import BraveShared
+import BraveUI
 
 struct AssetDetailView: View {
   @ObservedObject var assetDetailStore: AssetDetailStore
@@ -125,6 +126,7 @@ struct AssetDetailView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(assetDetailStore.token.name)
     .navigationBarTitleDisplayMode(.inline)
     .onAppear {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import DesignSystem
 import BraveCore
 import Strings
+import BraveUI
 
 struct BuyTokenView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -88,6 +89,7 @@ struct BuyTokenView: View {
       }
       .environment(\.defaultMinListHeaderHeight, 0)
       .environment(\.defaultMinListRowHeight, 0)
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.Wallet.buy)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -6,6 +6,7 @@
 import BraveCore
 import DesignSystem
 import SwiftUI
+import BraveUI
 
 struct NetworkSelectionView: View {
   
@@ -53,6 +54,7 @@ struct NetworkSelectionView: View {
       })
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(Strings.Wallet.networkSelectionTitle)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
@@ -259,6 +261,7 @@ private struct NetworkSelectionDetailView: View {
       }
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(networks.first?.shortChainName ?? Strings.Wallet.networkSelectionTitle)
     .navigationBarTitleDisplayMode(.inline)
   }

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveCore
 import Strings
+import BraveUI
 
 struct AddCustomAssetView: View {
   @ObservedObject var userAssetStore: UserAssetsStore
@@ -82,6 +83,7 @@ struct AddCustomAssetView: View {
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.Wallet.customTokenTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import Strings
 import BraveShared
 import BraveCore
+import BraveUI
 
 private struct EditTokenView: View {
   @ObservedObject var assetStore: AssetStore
@@ -128,6 +129,7 @@ struct EditUserAssetsView: View {
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .animation(.default, value: tokenStores)
       .navigationTitle(Strings.Wallet.editVisibleAssetsButtonTitle)
       .navigationBarTitleDisplayMode(.inline)

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -10,6 +10,7 @@ import SnapKit
 import Introspect
 import Strings
 import DesignSystem
+import BraveUI
 
 struct PortfolioView: View {
   var cryptoStore: CryptoStore
@@ -127,6 +128,7 @@ struct PortfolioView: View {
     )
     .animation(.default, value: portfolioStore.userVisibleAssets)
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .introspectTableView { tableView in
       withAnimation(nil) {
         tableInset = -tableView.layoutMargins.left

--- a/Sources/BraveWallet/Crypto/Search/TokenList.swift
+++ b/Sources/BraveWallet/Crypto/Search/TokenList.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveCore
 import Strings
+import BraveUI
 
 struct TokenList<Content: View>: View {
   var tokens: [BraveWallet.BlockchainToken]
@@ -63,6 +64,7 @@ struct TokenList<Content: View>: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .animation(nil, value: query)
     .filterable(text: $query)
   }

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditGasFeeView.swift
@@ -9,6 +9,7 @@ import DesignSystem
 import SwiftUI
 import Strings
 import BigNumber
+import BraveUI
 
 /// Allows the user to edit the gas fee structure of an regular transaction before confirming it
 ///
@@ -108,6 +109,7 @@ struct EditGasFeeView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.editGasTitle)
     .alert(isPresented: $isShowingAlert) {

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import DesignSystem
 import BraveCore
 import Strings
+import BraveUI
 
 struct EditNonceView: View {
   var confirmationStore: TransactionConfirmationStore
@@ -52,6 +53,7 @@ struct EditNonceView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.advancedSettingsTransaction)
     .alert(isPresented: $isShowingAlert) {

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -7,6 +7,7 @@ import BraveCore
 import DesignSystem
 import Strings
 import SwiftUI
+import BraveUI
 
 struct EditPermissionsView: View {
   
@@ -129,6 +130,7 @@ struct EditPermissionsView: View {
       .listRowBackground(Color(.braveGroupedBackground))
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.editPermissionsTitle)
     .alert(isPresented: $isShowingAlert) {

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -8,6 +8,7 @@ import BraveCore
 import DesignSystem
 import Strings
 import BigNumber
+import BraveUI
 
 /// Allows the user to edit the gas fee structure of an EIP-1559 transaction before confirming it
 ///
@@ -255,6 +256,7 @@ struct EditPriorityFeeView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.maxPriorityFeeTitle)
     .alert(isPresented: $isShowingAlert) {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -103,6 +103,7 @@ struct TransactionDetailsView: View {
         .listRowInsets(.zero)
       }
       .listStyle(.insetGrouped)
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
       .navigationTitle(Strings.Wallet.transactionDetailsTitle)
       .navigationBarTitleDisplayMode(.inline)

--- a/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -207,6 +207,7 @@ struct SuggestedNetworkView: View {
       .accessibility(hidden: sizeCategory.isAccessibilityCategory)
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .overlay(

--- a/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -9,6 +9,7 @@ import Strings
 import BraveShared
 import BraveUI
 import Data
+import BraveUI
 
 struct EditSiteConnectionView: View {
   @ObservedObject var keyringStore: KeyringStore
@@ -176,6 +177,7 @@ struct EditSiteConnectionView: View {
           .padding(.vertical)
         }
       }
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.Wallet.editSiteConnectionScreenTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -8,6 +8,7 @@ import Strings
 import BraveShared
 import DesignSystem
 import BraveCore
+import BraveUI
 
 /// A view to display to a user to allow them to setup a connection to a dApp for the first time.
 public struct NewSiteConnectionView: View {
@@ -153,6 +154,7 @@ public struct NewSiteConnectionView: View {
         }
       }
       .listStyle(InsetGroupedListStyle())
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationBarTitleDisplayMode(.inline)
       .navigationTitle(Strings.Wallet.newSiteConnectScreenTitle)
       .toolbar {
@@ -228,6 +230,7 @@ public struct NewSiteConnectionView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(Strings.Wallet.newSiteConnectScreenTitle)
     .navigationBarTitleDisplayMode(.inline)
   }

--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import BraveCore
 import Shared
 import Strings
+import BraveUI
 
 struct NetworkInputItem: Identifiable {
   var input: String
@@ -377,6 +378,7 @@ struct CustomNetworkDetailsView: View {
         }
       }
     }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {

--- a/Sources/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkListView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import BraveShared
 import BraveCore
 import Strings
+import BraveUI
 
 struct CustomNetworkListView: View {
   @ObservedObject var networkStore: NetworkStore
@@ -110,6 +111,7 @@ struct CustomNetworkListView: View {
       }
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .overlay(
       Group {
         if customNetworks.isEmpty {

--- a/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveShared
 import BraveCore
+import BraveUI
 
 struct DappsSettings: View {
   var coin: BraveWallet.CoinType
@@ -141,6 +142,7 @@ struct DappsSettings: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(String.localizedStringWithFormat(Strings.Wallet.dappsSettingsNavTitle, coin.localizedTitle))
     .navigationBarTitleDisplayMode(.inline)
     .filterable(text: $filterText, prompt: Strings.Wallet.manageSiteConnectionsFilterPlaceholder)
@@ -294,6 +296,7 @@ private struct SiteConnectionDetailView: View {
       }
     }
     .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(siteConnection.url)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -144,6 +144,7 @@ public struct WalletSettingsView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationTitle(Strings.Wallet.braveWallet)
     .navigationBarTitleDisplayMode(.inline)
     .background(


### PR DESCRIPTION
Note: This requires Xcode 14 CI and will fail otherwise

## Summary of Changes

This pull request fixes #6072 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
