### PR TITLE
No Bug: Removing the condition of compiling filter list data

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -532,13 +532,15 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
       
       // Load cached data
       // This is done first because compileResources and compilePendingResource need their results
-      await FilterListResourceDownloader.shared.loadCachedData()
-      await AdblockResourceDownloader.shared.loadCachedData()
-      
+      async let filterListCache: Void = await FilterListResourceDownloader.shared.loadCachedData()
+      async let adblockResourceCache: Void = await AdblockResourceDownloader.shared.loadCachedData()
+      _ = await (filterListCache, adblockResourceCache)
+
       // Compile some ad-block data
-      await AdBlockEngineManager.shared.compileResources()
-      await ContentBlockerManager.shared.compilePendingResources()
-      
+      async let compiledResourcesCompile: Void = await AdBlockEngineManager.shared.compileResources()
+      async let pendingResourcesCompile: Void = await ContentBlockerManager.shared.compilePendingResources()
+      _ = await (compiledResourcesCompile, pendingResourcesCompile)
+  
       FilterListResourceDownloader.shared.start(with: self.braveCore.adblockService)
       await AdblockResourceDownloader.shared.startFetching()
       ContentBlockerManager.shared.startTimer()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -162,7 +162,6 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
 
   let downloadQueue = DownloadQueue()
 
-  fileprivate var contentBlockListCompiled: Bool = false
   private var cancellables: Set<AnyCancellable> = []
 
   let rewards: BraveRewards
@@ -526,22 +525,19 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     updateWidgetFavoritesData()
     
     Task { @MainActor in
+      self.setupTabs()
+      
       await ContentBlockerManager.shared.loadBundledResources()
       await ContentBlockerManager.shared.loadCachedCompileResults()
       
       // Load cached data
       // This is done first because compileResources and compilePendingResource need their results
-      async let filterListCache: Void = await FilterListResourceDownloader.shared.loadCachedData()
-      async let adblockResourceCache: Void = await AdblockResourceDownloader.shared.loadCachedData()
-      _ = await (filterListCache, adblockResourceCache)
+      await FilterListResourceDownloader.shared.loadCachedData()
+      await AdblockResourceDownloader.shared.loadCachedData()
       
       // Compile some ad-block data
-      async let compiledResourcesCompile: Void = await AdBlockEngineManager.shared.compileResources()
-      async let pendingResourcesCompile: Void = await ContentBlockerManager.shared.compilePendingResources()
-      _ = await (compiledResourcesCompile, pendingResourcesCompile)
-      
-      self.contentBlockListCompiled = true
-      self.setupTabs()
+      await AdBlockEngineManager.shared.compileResources()
+      await ContentBlockerManager.shared.compilePendingResources()
       
       FilterListResourceDownloader.shared.start(with: self.braveCore.adblockService)
       await AdblockResourceDownloader.shared.startFetching()
@@ -991,7 +987,6 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
   }
 
   private func setupTabs() {
-    assert(contentBlockListCompiled, "Tabs should not be set up until after blocker lists are compiled")
     let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
     let noTabsAdded = self.tabManager.tabsForCurrentMode.isEmpty
     
@@ -1088,9 +1083,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     if crashedLastSession {
       showRestoreTabsAlert()
     } else {
-      if self.contentBlockListCompiled {
-        setupTabs()
-      }
+      setupTabs()
     }
     return {}
   }()
@@ -1102,9 +1095,7 @@ public class BrowserViewController: UIViewController, BrowserViewControllerDeleg
     }
     let alert = UIAlertController.restoreTabsAlert(
       okayCallback: { _ in
-        if self.contentBlockListCompiled {
-          self.setupTabs()
-        }
+        self.setupTabs()
       },
       noCallback: { _ in
         TabMO.deleteAll()


### PR DESCRIPTION
Removing the condition of compiling AdBlockEngineManager and ContentBlockerManager before setup tabs can start

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

- Load the app and check no delay 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->



https://user-images.githubusercontent.com/6643505/193896111-464c6bd4-b170-4f41-ac4a-74cc422d05c9.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
