### PR TITLE
Fix #1358: Issue with no cosmetic filter scripts after an HTTPS upgrade

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -416,6 +416,14 @@ extension BrowserViewController: WKNavigationDelegate {
     let response = navigationResponse.response
     let responseURL = response.url
     let tab = tab(for: webView)
+    
+    /// Check if we upgraded to https and if so we need to update the url of frame evaluations
+    if let url = responseURL, var components = URLComponents(url: url, resolvingAgainstBaseURL: false), components.scheme == "https" {
+      components.scheme = "http"
+      if tab?.frameEvaluations[url] == nil, let downgradedURL = components.url {
+        tab?.frameEvaluations[url] = tab?.frameEvaluations[downgradedURL]
+      }
+    }
 
     if let tab = tab,
       let responseURL = responseURL,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Detect when we did an https upgrade and update all pending script evaluations accordingly.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6107

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
