### PR TITLE
Fix #5924: Problem with Tab Display Title including "localhost"

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -466,10 +466,9 @@ class Tab: NSObject {
   }
 
   var displayTitle: String {
-    if let title = webView?.title, !title.isEmpty {
-      let displayTitle = title.contains("localhost") ? "" : title
-      syncTab?.setTitle(displayTitle)
-      return displayTitle
+    if let displayTabTitle = fetchDisplayTitle(using: url, title: title) {
+      syncTab?.setTitle(displayTabTitle)
+      return displayTabTitle
     }
 
     // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
@@ -545,6 +544,24 @@ class Tab: NSObject {
           return url
         }
       }
+    }
+    
+    return nil
+  }
+  
+  func fetchDisplayTitle(using url: URL?, title: String?) -> String? {
+    if let tabTitle = title, !tabTitle.isEmpty {
+      var displayTitle = tabTitle
+      
+      // Checking host is "localhost" || host == "127.0.0.1"
+      // or hostless URL (iOS forwards hostless URLs (e.g., http://:6571) to localhost.)
+      // DisplayURL will retrieve original URL even it is redirected to Error Page
+      if let isLocal = url?.displayURL?.isLocal, isLocal {
+        displayTitle = ""
+      }
+
+      syncTab?.setTitle(displayTitle)
+      return displayTitle
     }
     
     return nil

--- a/Tests/ClientTests/TabEventHandlerTests.swift
+++ b/Tests/ClientTests/TabEventHandlerTests.swift
@@ -55,6 +55,29 @@ class TabEventHandlerTests: XCTestCase {
 
     handler.unregister(tabObservers)
   }
+  
+  func testOnlyRegisteredForEvents111() {
+    let tab = Tab(configuration: WKWebViewConfiguration(), type: .private)
+    
+    let urlTest1 = URL(string: "https://www.brave.com")
+    let urlTest2 = URL(string: "http://localhost:8080")
+    let urlTest3 = URL(string: "https://127.0.0.1:8080")
+    let urlTest4 = URL(string: "https://locallhost.com")
+    
+    let titleTest1 = "Brave"
+    let wrongTestTitle = "Wrong Title"
+    let localHostTitle = "localhost"
+    
+    let displaytitle1 = tab.fetchDisplayTitle(using: urlTest1, title: titleTest1)
+    let displaytitle2 = tab.fetchDisplayTitle(using: urlTest2, title: wrongTestTitle)
+    let displaytitle3 = tab.fetchDisplayTitle(using: urlTest3, title: wrongTestTitle)
+    let displaytitle4 = tab.fetchDisplayTitle(using: urlTest4, title: localHostTitle)
+
+    XCTAssertEqual(displaytitle1, titleTest1)
+    XCTAssertEqual(displaytitle2, "")
+    XCTAssertEqual(displaytitle3, "")
+    XCTAssertEqual(displaytitle4, localHostTitle)
+  }
 }
 
 class DummyHandler: TabEventHandler {


### PR DESCRIPTION
Handling localhost site and omitting the title without breaking other website that has title of localhost

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5924

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

- Enter http://localhost:8080 and check title not existing
- Enter http://127.0.0.1:8080 and check title not existing
- Enter https://en.m.wikipedia.org/wiki/Localhost and check title is localhost- Wikipedia

## Screenshots:


https://user-images.githubusercontent.com/6643505/194167380-6cc3a041-50a8-4a89-a911-5961c2de5726.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
