### PR TITLE
Fix #6118: Find in Page Problems

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1161,7 +1161,9 @@ public class BrowserViewController: UIViewController {
 
     header.snp.remakeConstraints { make in
       if self.isUsingBottomBar {
-        if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view), keyboardHeight > 0, presentedViewController == nil {
+        // Need to check Find In Page Bar is enabled in order to aligh it properly when bottom-bar is enabled
+        if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view), keyboardHeight > 0,
+           (presentedViewController == nil || findInPageBar != nil) {
           var offset = -keyboardHeight
           if !topToolbar.inOverlayMode {
             // Showing collapsed URL bar while the keyboard is up
@@ -2014,43 +2016,6 @@ public class BrowserViewController: UIViewController {
     displayedPopoverController = nil
     updateDisplayedPopoverProperties = nil
   }
-
-  func updateFindInPageVisibility(visible: Bool, tab: Tab? = nil) {
-    if visible {
-      if findInPageBar == nil {
-        let findInPageBar = FindInPageBar()
-        self.findInPageBar = findInPageBar
-        findInPageBar.delegate = self
-        
-        displayPageZoom(visible: false)
-        alertStackView.addArrangedSubview(findInPageBar)
-
-        findInPageBar.snp.makeConstraints { make in
-          make.height.equalTo(UIConstants.toolbarHeight)
-          make.edges.equalTo(alertStackView)
-        }
-
-        updateViewConstraints()
-
-        // We make the find-in-page bar the first responder below, causing the keyboard delegates
-        // to fire. This, in turn, will animate the Find in Page container since we use the same
-        // delegate to slide the bar up and down with the keyboard. We don't want to animate the
-        // constraints added above, however, so force a layout now to prevent these constraints
-        // from being lumped in with the keyboard animation.
-        findInPageBar.layoutIfNeeded()
-      }
-
-      self.findInPageBar?.becomeFirstResponder()
-    } else if let findInPageBar = self.findInPageBar {
-      findInPageBar.endEditing(true)
-      let tab = tab ?? tabManager.selectedTab
-      guard let webView = tab?.webView else { return }
-      webView.evaluateSafeJavaScript(functionName: "__firefox__.findDone", contentWorld: FindInPageScriptHandler.scriptSandbox)
-      findInPageBar.removeFromSuperview()
-      self.findInPageBar = nil
-      updateViewConstraints()
-    }
-  }
   
   func displayPageZoom(visible: Bool) {
     if !visible || pageZoomBar != nil {     
@@ -2077,6 +2042,7 @@ public class BrowserViewController: UIViewController {
     }
     
     if let findInPageBar = findInPageBar {
+      updateFindInPageVisibility(visible: false)
       findInPageBar.endEditing(true)
       findInPageBar.removeFromSuperview()
       self.findInPageBar = nil
@@ -2316,6 +2282,8 @@ extension BrowserViewController: TabsBarViewControllerDelegate {
   func tabsBarDidSelectTab(_ tabsBarController: TabsBarViewController, _ tab: Tab) {
     if tab == tabManager.selectedTab { return }
     topToolbar.leaveOverlayMode(didCancel: true)
+    updateFindInPageVisibility(visible: false)
+    
     tabManager.selectTab(tab)
   }
 
@@ -3261,55 +3229,6 @@ extension BrowserViewController: TabTrayDelegate {
   }
 }
 
-extension BrowserViewController: FindInPageBarDelegate, FindInPageScriptHandlerDelegate {
-  func findInPage(_ findInPage: FindInPageBar, didTextChange text: String) {
-    find(text, function: "find")
-  }
-
-  func findInPage(_ findInPage: FindInPageBar, didFindNextWithText text: String) {
-    findInPageBar?.endEditing(true)
-    find(text, function: "findNext")
-  }
-
-  func findInPage(_ findInPage: FindInPageBar, didFindPreviousWithText text: String) {
-    findInPageBar?.endEditing(true)
-    find(text, function: "findPrevious")
-  }
-
-  func findInPageDidPressClose(_ findInPage: FindInPageBar) {
-    updateFindInPageVisibility(visible: false)
-  }
-
-  fileprivate func find(_ text: String, function: String) {
-    guard let webView = tabManager.selectedTab?.webView else { return }
-
-    if let delegate = webView.findInPageDelegate {
-      let backwards = function == TextSearchDirection.previous.rawValue
-
-      delegate.find(string: text, backwards: backwards) { [weak self] index, total in
-        guard let self = self else { return }
-        self.findInPageBar?.totalResults = Int(total)
-        self.findInPageBar?.currentResult = index
-      }
-    } else {
-      webView.evaluateSafeJavaScript(functionName: "__firefox__.\(function)", args: [text], contentWorld: FindInPageScriptHandler.scriptSandbox)
-    }
-  }
-
-  func findInPageHelper(_ findInPageHelper: FindInPageScriptHandler, didUpdateCurrentResult currentResult: Int) {
-    findInPageBar?.currentResult = currentResult
-  }
-
-  func findInPageHelper(_ findInPageHelper: FindInPageScriptHandler, didUpdateTotalResults totalResults: Int) {
-    findInPageBar?.totalResults = totalResults
-  }
-
-  func findTextInPage(_ direction: TextSearchDirection) {
-    guard let seachText = findInPageBar?.text else { return }
-
-    find(seachText, function: direction.rawValue)
-  }
-}
 
 extension BrowserViewController: JSPromptAlertControllerDelegate {
   func promptAlertControllerDidDismiss(_ alertController: JSPromptAlertController) {


### PR DESCRIPTION
Fixing Cant select text after closing the bar and Editing issues related with new actions.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6118 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
De-activation Problem:

- Open a webpage in Brave IOS browser
- Find text on page
- Use the x button to dismiss the find in page bottom bar / Change the tab using Tab Bar / Open a new tab using BottomBar / Open TabTray using BottomBar
- And Find-In Page deactivates properly

Presentation Problem:

- Open a webpage in Brave IOS browser
- Activate URL Bottom Bar
- Find text on page
- Bar is presented on top keyboard

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/194400556-1de38779-7c84-417b-8706-cab8fb3a7539.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
