### PR TITLE
Fix #5856: Logins & Passwords 'save login' toggle hidden behind search bar

### DIFF
--- a/Client/Frontend/Login/LoginListViewController.swift
+++ b/Client/Frontend/Login/LoginListViewController.swift
@@ -276,7 +276,7 @@ extension LoginListViewController {
   }
 
   override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-    if indexPath.section == Section.savedLogins.rawValue, let credentials = credentialList[safe: indexPath.row] {
+    if indexPath.section == Section.savedLogins.rawValue, let credentials = credentialList[safe: indexPath.row], !tableView.isEditing {
       let loginDetailsViewController = LoginInfoViewController(
         passwordAPI: passwordAPI,
         credentials: credentials,
@@ -292,8 +292,12 @@ extension LoginListViewController {
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     if indexPath.section == Section.savedLogins.rawValue {
-      fetchLoginInfo()
       searchController.isActive = false
+      
+      tableView.isEditing = false
+      setEditing(false, animated: false)
+      
+      fetchLoginInfo()
     }
   }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5856

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Open Settings -> Logins & Passwords
Tap edit in navigation bar
Tap a saved login
It should not open next screen

## Screenshots:

https://user-images.githubusercontent.com/6643505/194419380-6283f70c-bd5d-4c6a-abc0-072bda5be352.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
