### PR TITLE
Fix #6124: Force a NTP relayout when updating tabs bar visiblity

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1376,6 +1376,11 @@ public class BrowserViewController: UIViewController {
   func updateTabsBarVisibility() {
     defer {
       toolbar?.line.isHidden = isUsingBottomBar
+      if isUsingBottomBar {
+        // Ensure NTP relayout occurs
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+      }
     }
     
     header.expandedBarStackView.removeArrangedSubview(tabsBar.view)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #6124 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
