### PR TITLE
Fix #6122: Bump BraveCore to 1.45.91

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -487,11 +487,11 @@ class TabManager: NSObject {
 
     if let (provider, js) = makeWalletEthProvider?(tab) {
       let providerJS = """
-      (function() {
+      window.__firefox__.execute(function($, $Object) {
         if (window.isSecureContext) {
           \(js)
         }
-      })();
+      });
       """
       
       tab.walletEthProvider = provider

--- a/Client/WebFilters/AdblockServicePublisher.swift
+++ b/Client/WebFilters/AdblockServicePublisher.swift
@@ -71,7 +71,7 @@ class AdblockServicePublisher {
     return adBlockService
   }
   
-  private func filterList(forUUID uuid: String) throws -> AdblockFilterList {
+  private func filterList(forUUID uuid: String) throws -> AdblockFilterListCatalogEntry {
     guard let filterList = adBlockService?.regionalFilterLists?.first(where: { $0.uuid == uuid }) else {
       throw AdblockServiceError.uuidNotFound(uuid)
     }

--- a/Client/WebFilters/FilterList.swift
+++ b/Client/WebFilters/FilterList.swift
@@ -22,7 +22,7 @@ struct FilterList: Decodable, Identifiable {
   
   var id: String { return uuid }
   
-  init(from filterList: AdblockFilterList, isEnabled: Bool) {
+  init(from filterList: AdblockFilterListCatalogEntry, isEnabled: Bool) {
     self.uuid = filterList.uuid
     self.title = filterList.title
     self.description = filterList.desc

--- a/Client/WebFilters/FilterListResourceDownloader.swift
+++ b/Client/WebFilters/FilterListResourceDownloader.swift
@@ -247,7 +247,7 @@ public class FilterListResourceDownloader: ObservableObject {
   /// Invoked when shield components are loaded
   ///
   /// This function will start fetching data and subscribe publishers once if it hasn't already done so.
-  private func didUpdateShieldComponent(folderPath: String, adBlockFilterLists: [AdblockFilterList]) {
+  private func didUpdateShieldComponent(folderPath: String, adBlockFilterLists: [AdblockFilterListCatalogEntry]) {
     if !startedFetching && !adBlockFilterLists.isEmpty {
       startedFetching = true
       let filterLists = loadFilterLists(from: adBlockFilterLists, filterListSettings: settingsManager.allFilterListSettings)
@@ -296,7 +296,7 @@ public class FilterListResourceDownloader: ObservableObject {
   }
   
   /// Load filter lists from the ad block service
-  private func loadFilterLists(from regionalFilterLists: [AdblockFilterList], filterListSettings: [FilterListSetting]) -> [FilterList] {
+  private func loadFilterLists(from regionalFilterLists: [AdblockFilterListCatalogEntry], filterListSettings: [FilterListSetting]) -> [FilterList] {
     return regionalFilterLists.map { adBlockFilterList in
       let setting = filterListSettings.first(where: { $0.uuid == adBlockFilterList.uuid })
       return FilterList(from: adBlockFilterList,

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -24,8 +24,8 @@ struct AccountDetailsView: View {
 
   @Environment(\.presentationMode) @Binding private var presentationMode
 
-  private func removeAccount() {
-    keyringStore.removeSecondaryAccount(for: account)
+  private func removeAccount(password: String) {
+    keyringStore.removeSecondaryAccount(for: account, password: password)
   }
 
   private func renameAccountAndDismiss() {
@@ -79,7 +79,10 @@ struct AccountDetailsView: View {
               Alert(
                 title: Text(Strings.Wallet.accountRemoveAlertConfirmation),
                 message: Text(Strings.Wallet.warningAlertConfirmation),
-                primaryButton: .destructive(Text(Strings.yes), action: removeAccount),
+                primaryButton: .destructive(Text(Strings.yes), action: {
+                  // TODO: Issue #5967 - Add password protection to view
+                  removeAccount(password: "")
+                }),
                 secondaryButton: .cancel(Text(Strings.no))
               )
             }

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
@@ -49,7 +49,8 @@ struct AccountPrivateKeyView: View {
       }
       .padding()
       .onAppear {
-        keyringStore.privateKey(for: account) { key in
+        // TODO: Issue #5881 - Add password protection to view
+        keyringStore.privateKey(for: account, password: "") { key in
           self.key = key ?? ""
         }
       }

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -11,8 +11,17 @@ import Strings
 struct BackupRecoveryPhraseView: View {
   @ObservedObject var keyringStore: KeyringStore
 
+  private var password: String?
   @State private var confirmedPhraseBackup: Bool = false
   @State private var recoveryWords: [RecoveryWord] = []
+  
+  init(
+    password: String? = nil,
+    keyringStore: KeyringStore
+  ) {
+    self.password = password
+    self.keyringStore = keyringStore
+  }
 
   private var warningView: some View {
     HStack(alignment: .firstTextBaseline) {
@@ -80,7 +89,12 @@ struct BackupRecoveryPhraseView: View {
           .font(.footnote)
           .padding(.vertical, 30)
           .padding(.horizontal, 20)
-        NavigationLink(destination: VerifyRecoveryPhraseView(keyringStore: keyringStore)) {
+        NavigationLink(
+          destination: VerifyRecoveryPhraseView(
+            recoveryWords: recoveryWords,
+            keyringStore: keyringStore
+          )
+        ) {
           Text(Strings.Wallet.continueButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
@@ -98,8 +112,12 @@ struct BackupRecoveryPhraseView: View {
       .padding()
     }
     .onAppear {
-      keyringStore.recoveryPhrase { words in
-        recoveryWords = words
+      if let password = password {
+        keyringStore.recoveryPhrase(password: password) { words in
+          recoveryWords = words
+        }
+      } else {
+        // TODO: Issue #5882 - Add password protection to view (not in Onboarding flow) 
       }
     }
     .modifier(ToolbarModifier(isShowingCancel: !keyringStore.isOnboardingVisible))

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -10,7 +10,16 @@ import Strings
 
 struct BackupWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
+  private var password: String
   @State private var acknowledgedWarning: Bool = false
+  
+  init(
+    password: String,
+    keyringStore: KeyringStore
+  ) {
+    self.password = password
+    self.keyringStore = keyringStore
+  }
 
   var body: some View {
     ScrollView(.vertical) {
@@ -31,7 +40,12 @@ struct BackupWalletView: View {
           .foregroundColor(.secondary)
           .font(.footnote)
         VStack(spacing: 12) {
-          NavigationLink(destination: BackupRecoveryPhraseView(keyringStore: keyringStore)) {
+          NavigationLink(
+            destination: BackupRecoveryPhraseView(
+              password: password,
+              keyringStore: keyringStore
+            )
+          ) {
             Text(Strings.Wallet.continueButtonTitle)
           }
           .buttonStyle(BraveFilledButtonStyle(size: .normal))
@@ -63,7 +77,10 @@ struct BackupWalletView: View {
 struct BackupWalletView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      BackupWalletView(keyringStore: .previewStore)
+      BackupWalletView(
+        password: "",
+        keyringStore: .previewStore
+      )
     }
     .previewLayout(.sizeThatFits)
     .previewColorSchemes()

--- a/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -147,7 +147,12 @@ private struct CreateWalletView: View {
               navController?.presentedViewController?.present(alert, animated: true)
               return false
             }
-            let controller = UIHostingController(rootView: BackupWalletView(keyringStore: keyringStore))
+            let controller = UIHostingController(
+              rootView: BackupWalletView(
+                password: password,
+                keyringStore: keyringStore
+              )
+            )
             navController?.pushViewController(controller, animated: true)
             return true
           },
@@ -169,7 +174,7 @@ private struct CreateWalletView: View {
       )
       .background(
         NavigationLink(
-          destination: BackupWalletView(keyringStore: keyringStore),
+          destination: BackupWalletView(password: password, keyringStore: keyringStore),
           isActive: $isSkippingBiometricsPrompt
         ) {
           EmptyView()

--- a/Sources/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
@@ -11,11 +11,20 @@ import Strings
 struct VerifyRecoveryPhraseView: View {
   @ObservedObject var keyringStore: KeyringStore
 
-  @State private var recoveryWords: [RecoveryWord] = []
-  @State private var randomizedWords: [RecoveryWord] = []
+  @State private var recoveryWords: [RecoveryWord]
+  @State private var randomizedWords: [RecoveryWord]
   @State private var selectedWords: [RecoveryWord] = []
 
   @Environment(\.modalPresentationMode) @Binding private var modalPresentationMode
+  
+  init(
+    recoveryWords: [RecoveryWord],
+    keyringStore: KeyringStore
+  ) {
+    self.recoveryWords = recoveryWords
+    self.randomizedWords = recoveryWords.shuffled()
+    self.keyringStore = keyringStore
+  }
 
   private var wordsSelectedInCorrectOrder: Bool {
     recoveryWords == selectedWords
@@ -98,12 +107,6 @@ struct VerifyRecoveryPhraseView: View {
         }
       }
       .padding()
-    }
-    .onAppear {
-      keyringStore.recoveryPhrase { words in
-        recoveryWords = words
-        randomizedWords = words.shuffled()
-      }
     }
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
     .navigationTitle(Strings.Wallet.cryptoTitle)
@@ -219,7 +222,14 @@ private struct SelectedWordsBox: View {
 struct VerifyRecoveryPhraseView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      VerifyRecoveryPhraseView(keyringStore: .previewStore)
+      VerifyRecoveryPhraseView(
+        recoveryWords: [
+          .init(value: "First", index: 0),
+          .init(value: "Second", index: 1),
+          .init(value: "Third", index: 2)
+        ],
+        keyringStore: .previewStore
+      )
     }
     .previewLayout(.sizeThatFits)
     .previewColorSchemes()

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -215,10 +215,9 @@ public class KeyringStore: ObservableObject {
     }
   }
 
-  func recoveryPhrase(_ completion: @escaping ([RecoveryWord]) -> Void) {
-    keyringService.mnemonic { phrase in
-      let words =
-        phrase
+  func recoveryPhrase(password: String, completion: @escaping ([RecoveryWord]) -> Void) {
+    keyringService.mnemonic(forDefaultKeyring: password) { phrase in
+      let words = phrase
         .split(separator: " ")
         .enumerated()
         .map { RecoveryWord(value: String($0.element), index: $0.offset) }
@@ -289,8 +288,8 @@ public class KeyringStore: ObservableObject {
     }
   }
 
-  func removeSecondaryAccount(for account: BraveWallet.AccountInfo, completion: ((Bool) -> Void)? = nil) {
-    keyringService.removeImportedAccount(account.address, coin: account.coin) { success in
+  func removeSecondaryAccount(for account: BraveWallet.AccountInfo, password: String, completion: ((Bool) -> Void)? = nil) {
+    keyringService.removeImportedAccount(account.address, password: password, coin: account.coin) { success in
       self.updateKeyringInfo()
       completion?(success)
     }
@@ -308,8 +307,8 @@ public class KeyringStore: ObservableObject {
     }
   }
 
-  func privateKey(for account: BraveWallet.AccountInfo, completion: @escaping (String?) -> Void) {
-    keyringService.privateKey(forKeyringAccount: account.address, coin: account.coin) { success, key in
+  func privateKey(for account: BraveWallet.AccountInfo, password: String, completion: @escaping (String?) -> Void) {
+    keyringService.privateKey(forKeyringAccount: account.address, password: password, coin: account.coin) { success, key in
       completion(success ? key : nil)
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -122,7 +122,7 @@ public class NetworkStore: ObservableObject {
     completion: @escaping (_ accepted: Bool, _ errMsg: String) -> Void
   ) {
     func add(network: BraveWallet.NetworkInfo, completion: @escaping (_ accepted: Bool, _ errMsg: String) -> Void) {
-      rpcService.addEthereumChain(network) { [self] chainId, status, message in
+      rpcService.addChain(network) { [self] chainId, status, message in
         if status == .success {
           // Update `ethereumChains` by api calling
           updateChainList()
@@ -132,7 +132,7 @@ public class NetworkStore: ObservableObject {
           // meaning add custom network failed for some reason.
           // Also add the the old network back on rpc service
           if let oldNetwork = allChains.filter({ $0.coin == .eth }).first(where: { $0.id.lowercased() == network.id.lowercased() }) {
-            rpcService.addEthereumChain(oldNetwork) { _, _, _ in
+            rpcService.addChain(oldNetwork) { _, _, _ in
               // Update `ethereumChains` by api calling
               self.updateChainList()
               self.isAddingNewNetwork = false
@@ -166,9 +166,7 @@ public class NetworkStore: ObservableObject {
     _ network: BraveWallet.NetworkInfo,
     completion: @escaping (_ success: Bool) -> Void
   ) {
-    rpcService.removeEthereumChain(network.id) { success in
-      completion(success)
-    }
+    rpcService.removeChain(network.id, coin: network.coin, completion: completion)
   }
 
   public func removeCustomNetwork(
@@ -179,7 +177,7 @@ public class NetworkStore: ObservableObject {
       completion(false)
       return
     }
-    rpcService.removeEthereumChain(network.id) { [self] success in
+    rpcService.removeChain(network.chainId, coin: network.coin) { [self] success in
       if success {
         // check if its the current network, set mainnet the active net
         if network.id.lowercased() == selectedChainId.lowercased() {

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -93,7 +93,7 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
     completion([])
   }
   
-  func removeEthereumChain(_ chainId: String, completion: @escaping (Bool) -> Void) {
+  func removeChain(_ chainId: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
     if let index = networks.firstIndex(where: { $0.chainId == chainId }) {
       networks.remove(at: index)
       completion(true)
@@ -102,7 +102,7 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
     }
   }
   
-  func addEthereumChain(_ chain: BraveWallet.NetworkInfo, completion: @escaping (String, BraveWallet.ProviderError, String) -> Void) {
+  func addChain(_ chain: BraveWallet.NetworkInfo, completion: @escaping (String, BraveWallet.ProviderError, String) -> Void) {
     networks.append(chain)
     completion("", .success, "")
   }

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -103,7 +103,7 @@ class MockKeyringService: BraveWalletKeyringService {
     completion(defaultKeyring.isBackedUp)
   }
 
-  func mnemonic(forDefaultKeyring completion: @escaping (String) -> Void) {
+  func mnemonic(forDefaultKeyring password: String, completion: @escaping (String) -> Void) {
     completion(mnemonic)
   }
 
@@ -204,7 +204,7 @@ class MockKeyringService: BraveWalletKeyringService {
     completion(false, "")
   }
 
-  func privateKey(forKeyringAccount address: String, coin: BraveWallet.CoinType, completion: @escaping (Bool, String) -> Void) {
+  func privateKey(forKeyringAccount address: String, password: String, coin: BraveWallet.CoinType, completion: @escaping (Bool, String) -> Void) {
     completion(true, "807df4db569fab37cdf475a4bda779897f0f3dd9c5d90a2cb953c88ef762fd96")
   }
 
@@ -216,7 +216,7 @@ class MockKeyringService: BraveWalletKeyringService {
     }
   }
 
-  func removeImportedAccount(_ address: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
+  func removeImportedAccount(_ address: String, password: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
     guard let index = defaultKeyring.accountInfos.firstIndex(where: { $0.address == address }) else {
       completion(false)
       return
@@ -341,7 +341,7 @@ class MockKeyringService: BraveWalletKeyringService {
     completion(true)
   }
 
-  func removeHardwareAccount(_ address: String, coin: BraveWallet.CoinType) {
+  func removeHardwareAccount(_ address: String, password: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
   }
 
   func notifyUserInteraction() {

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -636,7 +636,8 @@ class TransactionParserTests: XCTestCase {
         .init(
           programId: "",
           accountMetas: [.init(pubkey: "", isSigner: false, isWritable: false)],
-          data: [])
+          data: [],
+          decodedData: nil)
       ],
       send: .init(maxRetries: .init(maxRetries: 1), preflightCommitment: nil, skipPreflight: nil),
       signTransactionParam: nil
@@ -724,7 +725,8 @@ class TransactionParserTests: XCTestCase {
         .init(
           programId: "",
           accountMetas: [.init(pubkey: "", isSigner: false, isWritable: false)],
-          data: [])
+          data: [],
+          decodedData: nil)
       ],
       send: .init(maxRetries: .init(maxRetries: 1), preflightCommitment: nil, skipPreflight: nil),
       signTransactionParam: nil

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.68",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
-      "integrity": "sha512-N544LUlzoNaQOEYY2K0GcVuF8dH877kafobJ5q5Q05EtkdEiYUr/AxRjJg+MqD7vjVvgEYLbRTD9UXTr8DWYYg==",
+      "version": "1.45.71",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
+      "integrity": "sha512-tvclybwYgtFNoSY+kCf8ekghQE+Yo31sy6gJ6R8O3U9dgQGZZmw80POtIl6Mj4010dmORvpCnBj2nM7tGz0ppA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
-      "integrity": "sha512-N544LUlzoNaQOEYY2K0GcVuF8dH877kafobJ5q5Q05EtkdEiYUr/AxRjJg+MqD7vjVvgEYLbRTD9UXTr8DWYYg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
+      "integrity": "sha512-tvclybwYgtFNoSY+kCf8ekghQE+Yo31sy6gJ6R8O3U9dgQGZZmw80POtIl6Mj4010dmORvpCnBj2nM7tGz0ppA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.88",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
-      "integrity": "sha512-Foh7Swmr7SG6sdW7jexVs41mxk3wFpdoXE1cQS0soJKHrJiaQnno+ucgyboLOjdjs4vPPJF0883yl2Rfa/ZDKw==",
+      "version": "1.45.91",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
+      "integrity": "sha512-IuKDCOs3PiZEdu7vm+i3nGRAuwpbZEGBZBYtNk3j1m41qUNXIprJEG2L4zXc2YFTmbqSHkoMfxRN+mtmxmAA8A==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
-      "integrity": "sha512-Foh7Swmr7SG6sdW7jexVs41mxk3wFpdoXE1cQS0soJKHrJiaQnno+ucgyboLOjdjs4vPPJF0883yl2Rfa/ZDKw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
+      "integrity": "sha512-IuKDCOs3PiZEdu7vm+i3nGRAuwpbZEGBZBYtNk3j1m41qUNXIprJEG2L4zXc2YFTmbqSHkoMfxRN+mtmxmAA8A=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.26",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
-      "integrity": "sha512-wpIc5LP5Q2zfeFKlAAG8dtp5PtndkBEzu3BqVwAbbCaEElr62pXt7D3Dd0dSNoYpgeD1jF9WChA6BtStTCsgcA==",
+      "version": "1.45.41",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
+      "integrity": "sha512-l3SwpTJpKB0qghxydGdtyjXO9uCjwhErZwyDGRazXvAiB5LRusSo6N4Dfvq6uOl0Xr1LRw19w484lXY4IPt4pQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
-      "integrity": "sha512-wpIc5LP5Q2zfeFKlAAG8dtp5PtndkBEzu3BqVwAbbCaEElr62pXt7D3Dd0dSNoYpgeD1jF9WChA6BtStTCsgcA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
+      "integrity": "sha512-l3SwpTJpKB0qghxydGdtyjXO9uCjwhErZwyDGRazXvAiB5LRusSo6N4Dfvq6uOl0Xr1LRw19w484lXY4IPt4pQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.71",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
-      "integrity": "sha512-tvclybwYgtFNoSY+kCf8ekghQE+Yo31sy6gJ6R8O3U9dgQGZZmw80POtIl6Mj4010dmORvpCnBj2nM7tGz0ppA==",
+      "version": "1.45.88",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
+      "integrity": "sha512-Foh7Swmr7SG6sdW7jexVs41mxk3wFpdoXE1cQS0soJKHrJiaQnno+ucgyboLOjdjs4vPPJF0883yl2Rfa/ZDKw==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
-      "integrity": "sha512-tvclybwYgtFNoSY+kCf8ekghQE+Yo31sy6gJ6R8O3U9dgQGZZmw80POtIl6Mj4010dmORvpCnBj2nM7tGz0ppA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
+      "integrity": "sha512-Foh7Swmr7SG6sdW7jexVs41mxk3wFpdoXE1cQS0soJKHrJiaQnno+ucgyboLOjdjs4vPPJF0883yl2Rfa/ZDKw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.48",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
-      "integrity": "sha512-dgRlXkP71eMERyUROma/OdsnRsG3s5MaVbB6uckRwGU15NtYCpgSC+MQLN/Mws3LqM8lr2wBMFjs0U7M2OqccQ==",
+      "version": "1.45.55",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
+      "integrity": "sha512-LLuexweRlzwCXUxI6MF2jxeNFECCQiuxamhL2CylhwsbVFNXyT3Yg0UQTtpUE4dPt1yvxtvt5elDfwFZE+iiSQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
-      "integrity": "sha512-dgRlXkP71eMERyUROma/OdsnRsG3s5MaVbB6uckRwGU15NtYCpgSC+MQLN/Mws3LqM8lr2wBMFjs0U7M2OqccQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
+      "integrity": "sha512-LLuexweRlzwCXUxI6MF2jxeNFECCQiuxamhL2CylhwsbVFNXyT3Yg0UQTtpUE4dPt1yvxtvt5elDfwFZE+iiSQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.55",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
-      "integrity": "sha512-LLuexweRlzwCXUxI6MF2jxeNFECCQiuxamhL2CylhwsbVFNXyT3Yg0UQTtpUE4dPt1yvxtvt5elDfwFZE+iiSQ==",
+      "version": "1.45.68",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
+      "integrity": "sha512-N544LUlzoNaQOEYY2K0GcVuF8dH877kafobJ5q5Q05EtkdEiYUr/AxRjJg+MqD7vjVvgEYLbRTD9UXTr8DWYYg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
-      "integrity": "sha512-LLuexweRlzwCXUxI6MF2jxeNFECCQiuxamhL2CylhwsbVFNXyT3Yg0UQTtpUE4dPt1yvxtvt5elDfwFZE+iiSQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
+      "integrity": "sha512-N544LUlzoNaQOEYY2K0GcVuF8dH877kafobJ5q5Q05EtkdEiYUr/AxRjJg+MqD7vjVvgEYLbRTD9UXTr8DWYYg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.41",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
-      "integrity": "sha512-l3SwpTJpKB0qghxydGdtyjXO9uCjwhErZwyDGRazXvAiB5LRusSo6N4Dfvq6uOl0Xr1LRw19w484lXY4IPt4pQ==",
+      "version": "1.45.44",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
+      "integrity": "sha512-51RqgDeE01PSokadQi7mUTJ+4/Q2tlCQFhSP4hqVxcMsw41jsuvVHjhW7+NTM2dKY6C1TasXMZ8BKuRkLfEYrA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
-      "integrity": "sha512-l3SwpTJpKB0qghxydGdtyjXO9uCjwhErZwyDGRazXvAiB5LRusSo6N4Dfvq6uOl0Xr1LRw19w484lXY4IPt4pQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
+      "integrity": "sha512-51RqgDeE01PSokadQi7mUTJ+4/Q2tlCQFhSP4hqVxcMsw41jsuvVHjhW7+NTM2dKY6C1TasXMZ8BKuRkLfEYrA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.44.109/brave-core-ios-1.44.109.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.44.109",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.44.109/brave-core-ios-1.44.109.tgz",
-      "integrity": "sha512-uB0cPFrabp1aN58GrwAjbBdhoUQIuqy2IwtHP3cSVjV2at0TcMJOjlyJAJaIP0MDhAdZGzm1/66XazzlMQlJJw==",
+      "version": "1.45.26",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
+      "integrity": "sha512-wpIc5LP5Q2zfeFKlAAG8dtp5PtndkBEzu3BqVwAbbCaEElr62pXt7D3Dd0dSNoYpgeD1jF9WChA6BtStTCsgcA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.44.109/brave-core-ios-1.44.109.tgz",
-      "integrity": "sha512-uB0cPFrabp1aN58GrwAjbBdhoUQIuqy2IwtHP3cSVjV2at0TcMJOjlyJAJaIP0MDhAdZGzm1/66XazzlMQlJJw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
+      "integrity": "sha512-wpIc5LP5Q2zfeFKlAAG8dtp5PtndkBEzu3BqVwAbbCaEElr62pXt7D3Dd0dSNoYpgeD1jF9WChA6BtStTCsgcA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.44",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
-      "integrity": "sha512-51RqgDeE01PSokadQi7mUTJ+4/Q2tlCQFhSP4hqVxcMsw41jsuvVHjhW7+NTM2dKY6C1TasXMZ8BKuRkLfEYrA==",
+      "version": "1.45.48",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
+      "integrity": "sha512-dgRlXkP71eMERyUROma/OdsnRsG3s5MaVbB6uckRwGU15NtYCpgSC+MQLN/Mws3LqM8lr2wBMFjs0U7M2OqccQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
-      "integrity": "sha512-51RqgDeE01PSokadQi7mUTJ+4/Q2tlCQFhSP4hqVxcMsw41jsuvVHjhW7+NTM2dKY6C1TasXMZ8BKuRkLfEYrA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
+      "integrity": "sha512-dgRlXkP71eMERyUROma/OdsnRsG3s5MaVbB6uckRwGU15NtYCpgSC+MQLN/Mws3LqM8lr2wBMFjs0U7M2OqccQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.44.109/brave-core-ios-1.44.109.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.26/brave-core-ios-1.45.26.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.48/brave-core-ios-1.45.48.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.41/brave-core-ios-1.45.41.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.44/brave-core-ios-1.45.44.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.71/brave-core-ios-1.45.71.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.88/brave-core-ios-1.45.88.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.55/brave-core-ios-1.45.55.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.68/brave-core-ios-1.45.68.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Bumps BraveCore to v1.45.91
- 3 TODOS that are required for v1.45 release from wallet team are in progress right now.

This pull request fixes #6122

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
