### PR TITLE
Fix #6133: Not being able to add multiple items to playlist.

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
@@ -53,9 +53,9 @@ window.__firefox__.includeOnce("Playlist", function($) {
   function tagNode(node) {
     if (node) {
       if (!node.$<tagUUID>) {
-        node.$<tagUUID> = uuid_v4();
         node.addEventListener('webkitpresentationmodechanged', (e) => e.stopPropagation(), true);
       }
+      node.$<tagUUID> = uuid_v4();
     }
   }
   


### PR DESCRIPTION
Caused by not recreating node's uuid for every new media item.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6133 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
