### PR TITLE
Ref #6072: Add missing iOS 16 background colors to buy/send/swap

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -174,6 +174,7 @@ struct SendTokenView: View {
         ) {
         }
       }
+      .listBackgroundColor(Color(.braveGroupedBackground))
       .environment(\.defaultMinListHeaderHeight, 0)
       .environment(\.defaultMinListRowHeight, 0)
       .alert(isPresented: $isShowingError) {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -476,6 +476,7 @@ struct SwapCryptoView: View {
           unsupportedSwapChainSection
         }
       }
+      .listBackgroundColor(Color(.braveGroupedBackground))
       .environment(\.defaultMinListHeaderHeight, 0)
       .environment(\.defaultMinListRowHeight, 0)
       .navigationTitle(Strings.Wallet.swap)


### PR DESCRIPTION
## Summary of Changes

Somehow missed these in https://github.com/brave/brave-ios/pull/6101

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
