### PR TITLE
Fix #6146: Add eTLD+1 check when debouncing

### DIFF
--- a/Client/WebFilters/DebouncingResourceDownloader.swift
+++ b/Client/WebFilters/DebouncingResourceDownloader.swift
@@ -360,16 +360,18 @@ public class DebouncingResourceDownloader {
     ///
     /// The following conditions must be met to redirect:
     /// 1. Must have a `MatcherRule` that satisifes this url
-    /// 2. Extracted URL  not be the same domain as the base URL
-    /// 3. Extracted URL must be a valid URL (Have valid scheme, have an `eTLD+1` or be an IP address etc.. )
-    /// 4. Extracted URL must have a `http` or `https` scheme
+    /// 2. Extracted URL must not have the same origin as that of the base URL
+    /// 3. Extracted URL must not have the same `eTLD+1` as that of the base URL (#6146)
+    /// 4. Extracted URL must be a valid URL (Have valid scheme, have an `eTLD+1` or be an IP address etc.. )
+    /// 5. Extracted URL must have a `http` or `https` scheme
     private func redirectURLOnce(from url: URL) throws -> (url: URL, rule: RedirectRule)? {
       guard let rule = matchingRedirectRule(for: url) else {
         return nil
       }
       
       guard let extractedURL = try rule.extractRedirectURL(from: url),
-            url.host != extractedURL.host,
+            url.origin != extractedURL.origin,
+            url.baseDomain != extractedURL.baseDomain,
             extractedURL.scheme == "http" || extractedURL.scheme == "https" else {
         return nil
       }

--- a/Tests/ClientTests/Resources/debouncing.json
+++ b/Tests/ClientTests/Resources/debouncing.json
@@ -246,6 +246,15 @@
   },
   {
     "include": [
+      "http://*.click.example/bounce?url=*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "url"
+  },
+  {
+    "include": [
       "*://brave-long-regex.example/*"
     ],
     "pref": "brave.de_amp.enabled",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6146 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
There are unit tests covering this scenario

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
