### PR TITLE
Fix #6141: Fix testnets icon in iOS14 is not grey-out.

### DIFF
--- a/Sources/BraveWallet/Crypto/NetworkPicker.swift
+++ b/Sources/BraveWallet/Crypto/NetworkPicker.swift
@@ -107,6 +107,7 @@ struct NetworkPicker: View {
                 networkSelectionStore: networkSelectionStore
               )
             }
+            .accentColor(Color(.braveOrange))
             .navigationViewStyle(.stack)
           }
         }

--- a/Sources/BraveWallet/NetworkIcon.swift
+++ b/Sources/BraveWallet/NetworkIcon.swift
@@ -18,7 +18,7 @@ struct NetworkIcon: View {
         Image(iconName, bundle: .current)
           .resizable()
           .aspectRatio(contentMode: .fit)
-          .grayscale(grayscale ? 1 : 0)
+          .saturation(grayscale ? 0 : 1)
       } else if let urlString = network.iconUrls.first,
                 let url = URL(string: urlString) {
         WebImageReader(url: url) { image, isFinished in


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Using `saturation` instead of `grayscale`. `grayscale` seems not working properly in iOS14
Also fixed the back button text in `NetworkSelectionDetailView` with iOS 16 SDK

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6141

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Screen Shot 2022-10-11 at 12 09 11 PM](https://user-images.githubusercontent.com/1187676/195150148-0c5124f0-4c3f-4a0f-a463-0e451c3e74f3.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
