### PR TITLE
Fix #5967: Password Protection for Secondary Account Removal

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -32,6 +32,7 @@ struct AccountActivityView: View {
     guard let info = keyringStore.allAccounts.first(where: { $0.address == activityStore.account.address }) else {
       // The account has been removed... User should technically never see this state because
       // `AccountsViewController` pops this view off the stack when the account is removed
+      presentationMode.dismiss()
       return activityStore.account
     }
     return info

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -25,10 +25,6 @@ struct AccountDetailsView: View {
 
   @Environment(\.presentationMode) @Binding private var presentationMode
 
-  private func removeAccount(password: String) {
-    keyringStore.removeSecondaryAccount(for: account, password: password)
-  }
-
   private func renameAccountAndDismiss() {
     if name.isEmpty {
       // Show error?
@@ -76,17 +72,12 @@ struct AccountDetailsView: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
             }
-            .alert(isPresented: $isPresentingRemoveConfirmation) {
-              Alert(
-                title: Text(Strings.Wallet.accountRemoveAlertConfirmation),
-                message: Text(Strings.Wallet.warningAlertConfirmation),
-                primaryButton: .destructive(Text(Strings.yes), action: {
-                  // TODO: Issue #5967 - Add password protection to view
-                  removeAccount(password: "")
-                }),
-                secondaryButton: .cancel(Text(Strings.no))
+            .sheet(isPresented: $isPresentingRemoveConfirmation, content: {
+              RemoveAccountConfirmationView(
+                account: account,
+                keyringStore: keyringStore
               )
-            }
+            })
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
           }
         }

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -150,11 +150,12 @@ public class KeyringStore: ObservableObject {
     Task { @MainActor in // fetch all KeyringInfo for all coin types
       let selectedCoin = await walletService.selectedCoin()
       let selectedAccountAddress = await keyringService.selectedAccount(selectedCoin)
-      self.allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
+      let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
       self.defaultAccounts = await keyringService.defaultAccounts(for: WalletConstants.supportedCoinTypes)
       if let defaultKeyring = allKeyrings.first(where: { $0.id == BraveWallet.DefaultKeyringId }) {
         self.defaultKeyring = defaultKeyring
       }
+      self.allKeyrings = allKeyrings
       if let selectedAccountKeyring = allKeyrings.first(where: { $0.coin == selectedCoin }) {
         if self.selectedAccount.address != selectedAccountAddress {
           if let selectedAccount = selectedAccountKeyring.accountInfos.first(where: { $0.address == selectedAccountAddress }) {

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -290,8 +290,10 @@ public class KeyringStore: ObservableObject {
 
   func removeSecondaryAccount(for account: BraveWallet.AccountInfo, password: String, completion: ((Bool) -> Void)? = nil) {
     keyringService.removeImportedAccount(account.address, password: password, coin: account.coin) { success in
-      self.updateKeyringInfo()
       completion?(success)
+      if success {
+        self.updateKeyringInfo()
+      }
     }
   }
 

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -16,6 +16,92 @@ struct PasswordEntryError: LocalizedError, Equatable {
   static let incorrectPassword = Self(message: Strings.Wallet.incorrectPasswordErrorMessage)
 }
 
+/// Field for entering wallet password, with optional biometrics support
+struct PasswordEntryField: View {
+  
+  /// The password being entered
+  @Binding var password: String
+  /// The error displayed under the password field
+  @Binding var error: PasswordEntryError?
+  /// If we should show the biometrics icon to allow biometics unlock (if available & password stored in keychain)
+  let shouldShowBiometrics: Bool
+  let keyringStore: KeyringStore
+  let onCommit: () -> Void
+  
+  @State private var attemptedBiometricsUnlock: Bool = false
+  
+  init(
+    password: Binding<String>,
+    error: Binding<PasswordEntryError?>,
+    shouldShowBiometrics: Bool,
+    keyringStore: KeyringStore,
+    onCommit: @escaping () -> Void
+  ) {
+    self._password = password
+    self._error = error
+    self.shouldShowBiometrics = shouldShowBiometrics
+    self.onCommit = onCommit
+    self.keyringStore = keyringStore
+  }
+  
+  private var biometricsIcon: Image? {
+    let context = LAContext()
+    if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
+      switch context.biometryType {
+      case .faceID:
+        return Image(systemName: "faceid")
+      case .touchID:
+        return Image(systemName: "touchid")
+      case .none:
+        return nil
+      @unknown default:
+        return nil
+      }
+    }
+    return nil
+  }
+  
+  private func fillPasswordFromKeychain() {
+    if let password = keyringStore.retrievePasswordFromKeychain() {
+      self.password = password
+      onCommit()
+    }
+  }
+  
+  var body: some View {
+    HStack {
+      SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: onCommit)
+        .textContentType(.password)
+        .font(.subheadline)
+        .introspectTextField(customize: { tf in
+          tf.becomeFirstResponder()
+        })
+        .textFieldStyle(BraveValidatedTextFieldStyle(error: error))
+      if shouldShowBiometrics, keyringStore.isKeychainPasswordStored, let icon = biometricsIcon {
+        Button(action: fillPasswordFromKeychain) {
+          icon
+            .imageScale(.large)
+            .font(.headline)
+        }
+      }
+    }
+  }
+}
+
+#if DEBUG
+struct PasswordEntryField_Previews: PreviewProvider {
+  static var previews: some View {
+    PasswordEntryField(
+      password: Binding(get: { "" }, set: { _ in }),
+      error: Binding(get: { nil }, set: { _ in }),
+      shouldShowBiometrics: false,
+      keyringStore: .previewStore,
+      onCommit: {})
+  }
+}
+#endif
+
+/// View for entering a password with an title and message displayed, and optional biometrics
 struct PasswordEntryView: View {
   
   let keyringStore: KeyringStore
@@ -40,35 +126,10 @@ struct PasswordEntryView: View {
   
   @State private var password = ""
   @State private var error: PasswordEntryError?
-  @State private var attemptedBiometricsUnlock: Bool = false
   @Environment(\.presentationMode) @Binding private var presentationMode
   
   private var isPasswordValid: Bool {
     !password.isEmpty
-  }
-  
-  private var biometricsIcon: Image? {
-    let context = LAContext()
-    if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
-      switch context.biometryType {
-      case .faceID:
-        return Image(systemName: "faceid")
-      case .touchID:
-        return Image(systemName: "touchid")
-      case .none:
-        return nil
-      @unknown default:
-        return nil
-      }
-    }
-    return nil
-  }
-  
-  private func fillPasswordFromKeychain() {
-    if let password = keyringStore.retrievePasswordFromKeychain() {
-      self.password = password
-      validate()
-    }
   }
   
   private func validate() {
@@ -88,7 +149,7 @@ struct PasswordEntryView: View {
     NavigationView {
       ScrollView(.vertical) {
         VStack(spacing: 36) {
-          Image("graphic-lock", bundle: .current)
+          Image("graphic-lock", bundle: .module)
             .accessibilityHidden(true)
           VStack {
             Text(message)
@@ -96,22 +157,13 @@ struct PasswordEntryView: View {
               .padding(.bottom)
               .multilineTextAlignment(.center)
               .fixedSize(horizontal: false, vertical: true)
-            HStack {
-              SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: validate)
-                .textContentType(.password)
-                .font(.subheadline)
-                .introspectTextField(customize: { tf in
-                  tf.becomeFirstResponder()
-                })
-                .textFieldStyle(BraveValidatedTextFieldStyle(error: error))
-              if shouldShowBiometrics, keyringStore.isKeychainPasswordStored, let icon = biometricsIcon {
-                Button(action: fillPasswordFromKeychain) {
-                  icon
-                    .imageScale(.large)
-                    .font(.headline)
-                }
-              }
-            }
+            PasswordEntryField(
+              password: $password,
+              error: $error,
+              shouldShowBiometrics: shouldShowBiometrics,
+              keyringStore: keyringStore,
+              onCommit: validate
+            )
             .padding(.horizontal, 48)
           }
           Button(action: validate) {
@@ -128,14 +180,19 @@ struct PasswordEntryView: View {
         .navigationTitle(title)
       }
     }
-    .onAppear {
-      guard shouldShowBiometrics else { return }
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [self] in
-        if !attemptedBiometricsUnlock && UIApplication.shared.isProtectedDataAvailable {
-          attemptedBiometricsUnlock = true
-          fillPasswordFromKeychain()
-        }
-      }
-    }
   }
 }
+
+#if DEBUG
+struct PasswordEntryView_Previews: PreviewProvider {
+  static var previews: some View {
+    PasswordEntryView(
+      keyringStore: .previewStore,
+      message: String.localizedStringWithFormat(
+        Strings.Wallet.removeAccountConfirmationMessage,
+        "Account 1"
+      ),
+      action: { _, _ in })
+  }
+}
+#endif

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -186,6 +186,7 @@ struct PasswordEntryView: View {
         }
       }
     }
+    .navigationViewStyle(.stack)
   }
 }
 

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -1,0 +1,139 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import DesignSystem
+import Strings
+import SwiftUI
+import BraveCore
+import LocalAuthentication
+
+struct PasswordEntryView: View {
+  
+  struct EntryError: LocalizedError, Equatable {
+    let message: String
+    var errorDescription: String? { message }
+  }
+  
+  let keyringStore: KeyringStore
+  let title: String
+  let message: String
+  let shouldShowBiometrics: Bool
+  let action: (_ password: String, _ completion: @escaping (EntryError?) -> Void) -> Void
+  
+  init(
+    keyringStore: KeyringStore,
+    title: String = Strings.Wallet.verifyPasswordTitle,
+    message: String,
+    shouldShowBiometrics: Bool = true,
+    action: @escaping (_ password: String, _ completion: @escaping (EntryError?) -> Void) -> Void
+  ) {
+    self.keyringStore = keyringStore
+    self.title = title
+    self.message = message
+    self.shouldShowBiometrics = shouldShowBiometrics
+    self.action = action
+  }
+  
+  @State private var password = ""
+  @State private var error: EntryError?
+  @State private var attemptedBiometricsUnlock: Bool = false
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
+  private var isPasswordValid: Bool {
+    !password.isEmpty
+  }
+  
+  private var biometricsIcon: Image? {
+    let context = LAContext()
+    if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
+      switch context.biometryType {
+      case .faceID:
+        return Image(systemName: "faceid")
+      case .touchID:
+        return Image(systemName: "touchid")
+      case .none:
+        return nil
+      @unknown default:
+        return nil
+      }
+    }
+    return nil
+  }
+  
+  private func fillPasswordFromKeychain() {
+    if let password = keyringStore.retrievePasswordFromKeychain() {
+      self.password = password
+      validate()
+    }
+  }
+  
+  private func validate() {
+    action(password) { entryError in
+      DispatchQueue.main.async {
+        if let entryError = entryError {
+          self.error = entryError
+          UIImpactFeedbackGenerator(style: .medium).bzzt()
+        } else {
+          presentationMode.dismiss()
+        }
+      }
+    }
+  }
+  
+  var body: some View {
+    NavigationView {
+      ScrollView(.vertical) {
+        VStack(spacing: 36) {
+          Image("graphic-lock", bundle: .current)
+            .accessibilityHidden(true)
+          VStack {
+            Text(message)
+              .font(.headline)
+              .padding(.bottom)
+              .multilineTextAlignment(.center)
+              .fixedSize(horizontal: false, vertical: true)
+            HStack {
+              SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: validate)
+                .textContentType(.password)
+                .font(.subheadline)
+                .introspectTextField(customize: { tf in
+                  tf.becomeFirstResponder()
+                })
+                .textFieldStyle(BraveValidatedTextFieldStyle(error: error))
+              if shouldShowBiometrics, keyringStore.isKeychainPasswordStored, let icon = biometricsIcon {
+                Button(action: fillPasswordFromKeychain) {
+                  icon
+                    .imageScale(.large)
+                    .font(.headline)
+                }
+              }
+            }
+            .padding(.horizontal, 48)
+          }
+          Button(action: validate) {
+            Text(Strings.Wallet.confirm)
+          }
+          .buttonStyle(BraveFilledButtonStyle(size: .normal))
+          .disabled(!isPasswordValid)
+          .frame(maxWidth: .infinity)
+          .listRowInsets(.zero)
+        }
+        .padding()
+        .padding(.vertical)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(title)
+      }
+    }
+    .onAppear {
+      guard shouldShowBiometrics else { return }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [self] in
+        if !attemptedBiometricsUnlock && UIApplication.shared.isProtectedDataAvailable {
+          attemptedBiometricsUnlock = true
+          fillPasswordFromKeychain()
+        }
+      }
+    }
+  }
+}

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -171,13 +171,19 @@ struct PasswordEntryView: View {
           }
           .buttonStyle(BraveFilledButtonStyle(size: .normal))
           .disabled(!isPasswordValid)
-          .frame(maxWidth: .infinity)
-          .listRowInsets(.zero)
         }
         .padding()
         .padding(.vertical)
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(title)
+        .toolbar {
+          ToolbarItemGroup(placement: .cancellationAction) {
+            Button(action: { presentationMode.dismiss() }) {
+              Text(Strings.cancelButtonTitle)
+                .foregroundColor(Color(.braveOrange))
+            }
+          }
+        }
       }
     }
   }

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -9,25 +9,27 @@ import SwiftUI
 import BraveCore
 import LocalAuthentication
 
-struct PasswordEntryView: View {
+struct PasswordEntryError: LocalizedError, Equatable {
+  let message: String
+  var errorDescription: String? { message }
   
-  struct EntryError: LocalizedError, Equatable {
-    let message: String
-    var errorDescription: String? { message }
-  }
+  static let incorrectPassword = Self(message: Strings.Wallet.incorrectPasswordErrorMessage)
+}
+
+struct PasswordEntryView: View {
   
   let keyringStore: KeyringStore
   let title: String
   let message: String
   let shouldShowBiometrics: Bool
-  let action: (_ password: String, _ completion: @escaping (EntryError?) -> Void) -> Void
+  let action: (_ password: String, _ completion: @escaping (PasswordEntryError?) -> Void) -> Void
   
   init(
     keyringStore: KeyringStore,
-    title: String = Strings.Wallet.verifyPasswordTitle,
+    title: String = Strings.Wallet.confirmPasswordTitle,
     message: String,
     shouldShowBiometrics: Bool = true,
-    action: @escaping (_ password: String, _ completion: @escaping (EntryError?) -> Void) -> Void
+    action: @escaping (_ password: String, _ completion: @escaping (PasswordEntryError?) -> Void) -> Void
   ) {
     self.keyringStore = keyringStore
     self.title = title
@@ -37,7 +39,7 @@ struct PasswordEntryView: View {
   }
   
   @State private var password = ""
-  @State private var error: EntryError?
+  @State private var error: PasswordEntryError?
   @State private var attemptedBiometricsUnlock: Bool = false
   @Environment(\.presentationMode) @Binding private var presentationMode
   

--- a/Sources/BraveWallet/RemoveAccountConfirmationView.swift
+++ b/Sources/BraveWallet/RemoveAccountConfirmationView.swift
@@ -1,0 +1,41 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import DesignSystem
+import Strings
+import SwiftUI
+import BraveCore
+
+struct RemoveAccountConfirmationView: View {
+
+  let account: BraveWallet.AccountInfo
+  var keyringStore: KeyringStore
+
+  var body: some View {
+    PasswordEntryView(
+      keyringStore: keyringStore,
+      message: String.localizedStringWithFormat(Strings.Wallet.removeAccountConfirmationMessage, account.name),
+      action: { password, completion in
+        keyringStore.removeSecondaryAccount(
+          for: account,
+          password: password,
+          completion: { success in
+            completion(success ? nil : .incorrectPassword)
+          }
+        )
+      })
+  }
+}
+
+#if DEBUG
+struct RemoveAccountConfirmationView_Previews: PreviewProvider {
+  static var previews: some View {
+    RemoveAccountConfirmationView(
+      account: .previewAccount,
+      keyringStore: .previewStore
+    )
+  }
+}
+#endif

--- a/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
+++ b/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
@@ -11,92 +11,31 @@ struct BiometricsPasscodeEntryView: View {
   
   @ObservedObject var keyringStore: KeyringStore
   
-  private enum UnlockError: LocalizedError {
-    case incorrectPassword
-    
-    var errorDescription: String? {
-      switch self {
-      case .incorrectPassword:
-        return Strings.Wallet.incorrectPasswordErrorMessage
-      }
-    }
-  }
-  
-  @State private var password: String = ""
-  /// Error occured when user entered their password
-  @State private var unlockError: UnlockError?
-  /// Flag used to determine if we should show an error alert because we failed to store the password in the keychain
-  @State private var isShowingKeychainError: Bool = false
-  @Environment(\.presentationMode) @Binding private var presentationMode
-  
-  private var isPasswordValid: Bool {
-    !password.isEmpty
-  }
-  
-  private func unlock() {
-    keyringStore.validate(password: password) { isValid in
-      if isValid {
-        // store password in keychain
-        if case let status = keyringStore.storePasswordInKeychain(password),
-           status != errSecSuccess {
-          self.isShowingKeychainError = true
-        } else {
-          // password stored in keychain, dismiss modal
-          presentationMode.dismiss()
-        }
-      } else {
-        // Conflict with the keyboard submit/dismissal that causes a bug
-        // with SwiftUI animating the screen away...
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-          unlockError = .incorrectPassword
-          UIImpactFeedbackGenerator(style: .medium).bzzt()
-        }
-      }
-    }
-  }
-  
   var body: some View {
-    NavigationView {
-      ScrollView(.vertical) {
-        VStack(spacing: 36) {
-          Image("graphic-lock", bundle: .module)
-            .accessibilityHidden(true)
-          VStack {
-            Text(Strings.Wallet.enterPasswordForBiometricsTitle)
-              .font(.headline)
-              .padding(.bottom)
-              .multilineTextAlignment(.center)
-              .fixedSize(horizontal: false, vertical: true)
-            SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: unlock)
-              .textContentType(.password)
-              .font(.subheadline)
-              .introspectTextField(customize: { tf in
-                tf.becomeFirstResponder()
-              })
-              .textFieldStyle(BraveValidatedTextFieldStyle(error: unlockError))
-              .padding(.horizontal, 48)
+    PasswordEntryView(
+      keyringStore: keyringStore,
+      title: Strings.Wallet.enterPasswordForBiometricsNavTitle,
+      message: Strings.Wallet.enterPasswordForBiometricsTitle,
+      action: { password, completion in
+        keyringStore.validate(password: password) { isValid in
+          if isValid {
+            // store password in keychain
+            if case let status = keyringStore.storePasswordInKeychain(password),
+               status != errSecSuccess {
+              completion(.init(message: Strings.Wallet.biometricsSetupErrorMessage))
+            } else {
+              // password stored in keychain
+              completion(nil)
+            }
+          } else {
+            // Conflict with the keyboard submit/dismissal that causes a bug
+            // with SwiftUI animating the screen away...
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+              completion(.init(message: Strings.Wallet.incorrectPasswordErrorMessage))
+            }
           }
-          Button(action: unlock) {
-            Text(Strings.Wallet.saveButtonTitle)
-          }
-          .buttonStyle(BraveFilledButtonStyle(size: .normal))
-          .disabled(!isPasswordValid)
-          .frame(maxWidth: .infinity)
-          .listRowInsets(.zero)
         }
-        .padding()
-        .padding(.vertical)
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(Strings.Wallet.enterPasswordForBiometricsNavTitle)
-        .alert(isPresented: $isShowingKeychainError) {
-          Alert(
-            title: Text(Strings.Wallet.biometricsSetupErrorTitle),
-            message: Text(Strings.Wallet.biometricsSetupErrorMessage),
-            dismissButton: .default(Text(Strings.OKString))
-          )
-        }
-      }
-    }
+      })
   }
 }
 

--- a/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
+++ b/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
@@ -22,7 +22,7 @@ struct BiometricsPasscodeEntryView: View {
             // store password in keychain
             if case let status = keyringStore.storePasswordInKeychain(password),
                status != errSecSuccess {
-              completion(.init(message: Strings.Wallet.biometricsSetupErrorMessage))
+              completion(.incorrectPassword)
             } else {
               // password stored in keychain
               completion(nil)

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2780,12 +2780,26 @@ extension Strings {
       value: "DApps you connect to Brave Wallet will appear here",
       comment: "A message that will be displayed under the section header when there is no dapps have been granted wallet connection."
     )
-    public static let verifyPasswordTitle = NSLocalizedString(
-      "wallet.verifyPasswordTitle",
+    public static let confirmPasswordTitle = NSLocalizedString(
+      "wallet.confirmPasswordTitle",
       tableName: "BraveWallet",
       bundle: .strings,
-      value: "Verify Password",
+      value: "Confirm Password",
       comment: "The title displayed in the navigation of the confirmation view where a user tries to remove a secondary account."
+    )
+    public static let removeAccountConfirmationMessage = NSLocalizedString(
+      "wallet.removeAccountConfirmationMessage",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Are you sure you want to remove \"%@\"?",
+      comment: "A message that will be displayed above the password entry field when the user tries to remove a secondary account. '%@' will be replaced with the account's name"
+    )
+    public static let removeAccountErrorMessage = NSLocalizedString(
+      "wallet.removeAccountErrorMessage",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Invalid Password",
+      comment: "A message that will be displayed under the password entry field when the user enters an incorrect password and their secondary account is not removed."
     )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2780,5 +2780,12 @@ extension Strings {
       value: "DApps you connect to Brave Wallet will appear here",
       comment: "A message that will be displayed under the section header when there is no dapps have been granted wallet connection."
     )
+    public static let verifyPasswordTitle = NSLocalizedString(
+      "wallet.verifyPasswordTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Verify Password",
+      comment: "The title displayed in the navigation of the confirmation view where a user tries to remove a secondary account."
+    )
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Add password confirmation view which requires user to enter their password prior to removing any secondary account.
- Refactored the existing `BiometricsPasscodeEntryView` to extract out the view logic for re-use.

This pull request fixes #5967

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Add a secondary account
2. Open account details for secondary account
3. Tap 'Remove Account'
4. Tap biometrics button (face id / touch id) on device, confirm password is auto-filled if available
5. Tap 'Confirm' button to confirm account is removed. Verify modals and detail views are dismissed back to `Accounts` tab.

Since biometrics password entry view was refactored, a quick test of that view:
1. Open wallet settings on a biometrics capable device
2. Toggle 'Allow Biometric Unlock' switch to disabled if it is not currently
3. Toggle 'Allow Biometric Unlock' switch to enabled and confirm flow still works as expected


## Screenshots:

<img width="488" alt="account removal" src="https://user-images.githubusercontent.com/5314553/195152864-e5ea9a82-0423-4dfa-bf38-4457226b6f7f.png">



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
