### PR TITLE
Fix #5881: Password Protection for Account Private Key

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -101,6 +101,7 @@ struct AccountDetailsView: View {
         }
       }
     }
+    .accentColor(Color(.braveOrange)) // needed for navigation bar back button(s)
     .onAppear {
       if name.isEmpty {
         // Wait until next runloop pass to fix bug where body isn't recomputed based on state change

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
@@ -19,8 +19,12 @@ struct AccountPrivateKeyView: View {
 
   @Environment(\.pixelLength) private var pixelLength
   
-  private var isPasswordValid: Bool {
-    !password.isEmpty
+  private var isShowHideButtonDisabled: Bool {
+    if key != nil {
+      return false
+    } else {
+      return password.isEmpty
+    }
   }
   
   private func validateAndShowPrivateKey() {
@@ -82,7 +86,7 @@ struct AccountPrivateKeyView: View {
           Text(isKeyVisible ? Strings.Wallet.hidePrivateKeyButtonTitle : Strings.Wallet.showPrivateKeyButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
-        .disabled(!isPasswordValid)
+        .disabled(isShowHideButtonDisabled)
       }
       .padding()
     }

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountPrivateKeyView.swift
@@ -11,11 +11,31 @@ import Strings
 struct AccountPrivateKeyView: View {
   @ObservedObject var keyringStore: KeyringStore
   var account: BraveWallet.AccountInfo
-
-  @State private var key: String = ""
-  @State private var isKeyVisible: Bool = false
+  
+  @State private var password = ""
+  @State private var error: PasswordEntryError?
+  @State private var key: String?
+  private var isKeyVisible: Bool { key != nil }
 
   @Environment(\.pixelLength) private var pixelLength
+  
+  private var isPasswordValid: Bool {
+    !password.isEmpty
+  }
+  
+  private func validateAndShowPrivateKey() {
+    keyringStore.privateKey(for: account, password: password) { key in
+      if let key = key {
+        withAnimation(nil) {
+          self.key = key
+          self.password = ""
+        }
+      } else {
+        self.error = .incorrectPassword
+        UIImpactFeedbackGenerator(style: .medium).bzzt()
+      }
+    }
+  }
 
   var body: some View {
     ScrollView(.vertical) {
@@ -32,34 +52,45 @@ struct AccountPrivateKeyView: View {
               )
               .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
           )
-        SensitiveTextView(text: key, isShowingText: $isKeyVisible)
-          .multilineTextAlignment(.center)
-          .font(.system(.body, design: .monospaced))
-          .padding(40)
-
+        if let key = key {
+          SensitiveTextView(text: key, isShowingText: Binding<Bool>(
+            get: { self.key != nil },
+            set: { if !$0 { self.key = nil } }
+          ))
+            .multilineTextAlignment(.center)
+            .font(.system(.body, design: .monospaced))
+            .padding(40)
+        } else {
+          PasswordEntryField(
+            password: $password,
+            error: $error,
+            shouldShowBiometrics: true,
+            keyringStore: keyringStore,
+            onCommit: validateAndShowPrivateKey
+          )
+            .padding(40)
+        }
         Button(action: {
-          withAnimation {
-            isKeyVisible.toggle()
+          withAnimation(nil) {
+            if isKeyVisible {
+              self.key = nil
+            } else {
+              validateAndShowPrivateKey()
+            }
           }
         }) {
           Text(isKeyVisible ? Strings.Wallet.hidePrivateKeyButtonTitle : Strings.Wallet.showPrivateKeyButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
-        .animation(nil, value: isKeyVisible)
+        .disabled(!isPasswordValid)
       }
       .padding()
-      .onAppear {
-        // TODO: Issue #5881 - Add password protection to view
-        keyringStore.privateKey(for: account, password: "") { key in
-          self.key = key ?? ""
-        }
-      }
     }
     .background(Color(.braveBackground))
     .navigationTitle(Strings.Wallet.accountPrivateKey)
     .navigationBarTitleDisplayMode(.inline)
     .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
-      isKeyVisible = false
+      self.key = nil
     }
     .alertOnScreenshot {
       Alert(

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -82,6 +82,7 @@ struct PasswordEntryField: View {
           icon
             .imageScale(.large)
             .font(.headline)
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }


### PR DESCRIPTION
## Summary of Changes
- Add password protection to view an account's private key
- This PR depends on refactor in https://github.com/brave/brave-ios/pull/6149

This pull request fixes #5881

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open account details
2. Tap 'Private Key'
3. Tap biometrics button (face id / touch id) on device, confirm password is auto-filled if available
4. Tap 'Show private key' button to reveal the private key
5. Tap 'Hide private key' button to hide the private key


## Screenshots:

![private key](https://user-images.githubusercontent.com/5314553/195160525-ef9b61c3-a97a-481f-9eb5-7b6f5e1c21ea.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
