### PR TITLE
Fix #6135: Toggling sidebar will remove highlighting from the current video playing [iPad]

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -176,6 +176,8 @@ class PlaylistListViewController: UIViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
+    highlightActiveItem()
+    
     folderObserver = PlaylistManager.shared.onCurrentFolderDidChange
       .receive(on: DispatchQueue.main)
       .sink { [weak self] in
@@ -649,6 +651,15 @@ extension PlaylistListViewController {
 
     playerView.setControlsEnabled(!isExpired)
     activityIndicator.stopAnimating()
+  }
+  
+  func highlightActiveItem() {
+    let activeItemIndex = PlaylistCarplayManager.shared.currentlyPlayingItemIndex
+    
+    tableView.selectRow(
+      at: IndexPath(row: activeItemIndex, section: 0),
+      animated: false,
+      scrollPosition: .none)
   }
 }
 

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -382,7 +382,7 @@ class PlaylistViewController: UIViewController {
           videoTitle: item.pageTitle)
       }
       
-      self.highlightActiveItem()
+      self.listController.highlightActiveItem()
     }.store(in: &playerStateObservers)
 
     player.publisher(for: .pause).sink { [weak self] event in
@@ -758,7 +758,7 @@ extension PlaylistViewController: VideoViewDelegate {
     if index >= 0 {
       let indexPath = IndexPath(row: index, section: 0)
       
-      highlightActiveItem()
+      listController.highlightActiveItem()
       listController.prepareToPlayItem(at: indexPath) { [weak self] item in
         guard let self = self,
           let item = item
@@ -889,15 +889,6 @@ extension PlaylistViewController: VideoViewDelegate {
       let seekTime = CMTimeMakeWithSeconds(Float64(CGFloat(relativeOffset) * CGFloat(currentItem.asset.duration.value) / CGFloat(currentItem.asset.duration.timescale)), preferredTimescale: currentItem.currentTime().timescale)
       seek(videoView, to: seekTime.seconds)
     }
-  }
-
-  func highlightActiveItem() {
-    let activeItemIndex = PlaylistCarplayManager.shared.currentlyPlayingItemIndex
-    
-    listController.tableView.selectRow(
-      at: IndexPath(row: activeItemIndex, section: 0),
-      animated: false,
-      scrollPosition: .none)
   }
   
   func setPlaybackRate(_ videoView: VideoView, rate: Float) {


### PR DESCRIPTION
Moving highlight active item into list controller and activating when side panel changes visibility

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6135

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Add videos to playlist on iPad
- Open playlist, play video
- Tap on screen to dismiss the playlist
- Tap on the Icon to display the sidebar

## Screenshots:


https://user-images.githubusercontent.com/6643505/195200453-62666c35-ec2d-4a61-8bda-43c7292fbc81.mp4



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
