### PR TITLE
[No Bug]: Create shared directory in-case of a deletion

### DIFF
--- a/Client/Providers/Profile.swift
+++ b/Client/Providers/Profile.swift
@@ -29,6 +29,16 @@ class ProfileFileAccessor: FileAccessor {
     var rootPath: String
     let sharedContainerIdentifier = AppInfo.sharedContainerIdentifier
     if let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: sharedContainerIdentifier) {
+      var isDirectory: ObjCBool = false
+
+      if !FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+        do {
+          try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        } catch {
+          log.error("Unable to find the shared container directory and error while trying tpo create a new directory. ")
+        }
+      }
+      
       rootPath = url.path
     } else {
       log.error("Unable to find the shared container. Defaulting profile location to ~/Library/Application Support/ instead.")


### PR DESCRIPTION
Creating a shared container directory if somewhat the directory is removed.

This is added in case the shared directory will be deleted somehow, this should not be possible on a phone with no jailbreak applied.

Reported https://community.brave.com/t/ios-downloads-folder-gone/437019

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
N/A


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
