### PR TITLE
Fix #6027: When shields is expanded don't display large empty space

### DIFF
--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -196,7 +196,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
     // Ensure the a static width is given to the main view so we can calculate the height
     // correctly when we force a layout
     let height = visibleView.systemLayoutSizeFitting(
-      CGSize(width: width, height: UIScreen.main.bounds.height),
+      CGSize(width: width, height: 0),
       withHorizontalFittingPriority: .required,
       verticalFittingPriority: .fittingSizeLevel
     ).height


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6027 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![image](https://user-images.githubusercontent.com/529104/195402170-9013bd83-c916-4b0a-a1a5-7180d4c6edee.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
