### PR TITLE
Fix #5882: Password Protection Backup Seed Phrase

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -38,6 +38,7 @@ struct AccountsHeaderView: View {
             }
             .navigationViewStyle(StackNavigationViewStyle())
             .environment(\.modalPresentationMode, $isPresentingBackup)
+            .accentColor(Color(.braveOrange))
           }
       )
       Spacer()

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -31,7 +31,10 @@ struct AccountsHeaderView: View {
         Color.clear
           .sheet(isPresented: $isPresentingBackup) {
             NavigationView {
-              BackupRecoveryPhraseView(keyringStore: keyringStore)
+              BackupWalletView(
+                password: nil,
+                keyringStore: keyringStore
+              )
             }
             .navigationViewStyle(StackNavigationViewStyle())
             .environment(\.modalPresentationMode, $isPresentingBackup)

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -11,15 +11,14 @@ import Strings
 struct BackupRecoveryPhraseView: View {
   @ObservedObject var keyringStore: KeyringStore
 
-  private var password: String?
   @State private var confirmedPhraseBackup: Bool = false
-  @State private var recoveryWords: [RecoveryWord] = []
+  @State private var recoveryWords: [RecoveryWord]
   
   init(
-    password: String? = nil,
+    recoveryWords: [RecoveryWord],
     keyringStore: KeyringStore
   ) {
-    self.password = password
+    self.recoveryWords = recoveryWords
     self.keyringStore = keyringStore
   }
 
@@ -111,16 +110,6 @@ struct BackupRecoveryPhraseView: View {
       }
       .padding()
     }
-    .onAppear {
-      if let password = password {
-        keyringStore.recoveryPhrase(password: password) { words in
-          recoveryWords = words
-        }
-      } else {
-        // TODO: Issue #5882 - Add password protection to view (not in Onboarding flow) 
-      }
-    }
-    .modifier(ToolbarModifier(isShowingCancel: !keyringStore.isOnboardingVisible))
     .navigationTitle(Strings.Wallet.cryptoTitle)
     .navigationBarTitleDisplayMode(.inline)
     .introspectViewController { vc in
@@ -136,37 +125,16 @@ struct BackupRecoveryPhraseView: View {
       )
     }
   }
-
-  struct ToolbarModifier: ViewModifier {
-    var isShowingCancel: Bool
-
-    @Environment(\.presentationMode) @Binding private var presentationMode
-
-    func body(content: Content) -> some View {
-      if isShowingCancel {
-        content
-          .toolbar {
-            ToolbarItemGroup(placement: .cancellationAction) {
-              Button(action: {
-                presentationMode.dismiss()
-              }) {
-                Text(Strings.cancelButtonTitle)
-                  .foregroundColor(Color(.braveOrange))
-              }
-            }
-          }
-      } else {
-        content
-      }
-    }
-  }
 }
 
 #if DEBUG
 struct BackupRecoveryPhraseView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      BackupRecoveryPhraseView(keyringStore: .previewStore)
+      BackupRecoveryPhraseView(
+        recoveryWords: [],
+        keyringStore: .previewStore
+      )
     }
     .previewLayout(.sizeThatFits)
     .previewColorSchemes()

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -108,7 +108,6 @@ struct BackupWalletView: View {
         label: {
           EmptyView()
         })
-      .accentColor(Color(.braveOrange))
     )
   }
   

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -10,57 +10,79 @@ import Strings
 
 struct BackupWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
-  private var password: String
+  @State private var password: String
+  @State private var passwordError: PasswordEntryError?
   @State private var acknowledgedWarning: Bool = false
+  @State private var recoveryWords: [RecoveryWord] = []
+  private let requirePasswordEntry: Bool
   
   init(
-    password: String,
+    password: String?,
     keyringStore: KeyringStore
   ) {
-    self.password = password
+    self.requirePasswordEntry = password == nil
+    self.password = password ?? ""
     self.keyringStore = keyringStore
+  }
+  
+  private var isContinueButtonDisabled: Bool {
+    !acknowledgedWarning || password.isEmpty
+  }
+  
+  private func continueToBackupPhrase() {
+    guard acknowledgedWarning else {
+      // user can press return in field to execute when continue button is disabled
+      return
+    }
+    keyringStore.recoveryPhrase(password: password) { words in
+      if words.isEmpty {
+        passwordError = .incorrectPassword
+      } else {
+        recoveryWords = words
+      }
+    }
   }
 
   var body: some View {
     ScrollView(.vertical) {
-      VStack(spacing: 46) {
+      VStack(spacing: 24) {
         Image("graphic-save", bundle: .module)
-          .padding(.top)
+        
         VStack(spacing: 14) {
           Text(Strings.Wallet.backupWalletTitle)
             .font(.headline)
-            .foregroundColor(.primary)
+            .foregroundColor(Color(.bravePrimary))
           Text(Strings.Wallet.backupWalletSubtitle)
             .font(.subheadline)
-            .foregroundColor(.secondary)
+            .foregroundColor(Color(.braveLabel))
         }
-        .fixedSize(horizontal: false, vertical: true)
         .multilineTextAlignment(.center)
+        
         Toggle(Strings.Wallet.backupWalletDisclaimer, isOn: $acknowledgedWarning)
-          .foregroundColor(.secondary)
           .font(.footnote)
-        VStack(spacing: 12) {
-          NavigationLink(
-            destination: BackupRecoveryPhraseView(
-              password: password,
-              keyringStore: keyringStore
-            )
-          ) {
-            Text(Strings.Wallet.continueButtonTitle)
-          }
-          .buttonStyle(BraveFilledButtonStyle(size: .normal))
-          .disabled(!acknowledgedWarning)
-          Button(action: {
-            keyringStore.markOnboardingCompleted()
-          }) {
-            Text(Strings.Wallet.skipButtonTitle)
-              .font(Font.subheadline.weight(.medium))
-              .foregroundColor(Color(.braveLabel))
-          }
+          .foregroundColor(Color(.braveLabel))
+          .padding(.horizontal, 20)
+          .padding(.vertical, 10)
+        
+        if requirePasswordEntry {
+          PasswordEntryField(
+            password: $password,
+            error: $passwordError,
+            placeholder: Strings.Wallet.backupWalletPasswordPlaceholder,
+            shouldShowBiometrics: true,
+            keyringStore: keyringStore,
+            onCommit: continueToBackupPhrase
+          )
         }
+        
+        Button(action: continueToBackupPhrase) {
+          Text(Strings.Wallet.continueButtonTitle)
+        }
+        .buttonStyle(BraveFilledButtonStyle(size: .normal))
+        .disabled(isContinueButtonDisabled)
       }
-      .padding(.horizontal, 30)
-      .padding(.vertical)
+      .padding()
+      .padding()
     }
     .navigationBarBackButtonHidden(true)
     .navigationTitle(Strings.Wallet.cryptoTitle)
@@ -69,7 +91,49 @@ struct BackupWalletView: View {
       vc.navigationItem.backButtonTitle = Strings.Wallet.backupWalletBackButtonTitle
       vc.navigationItem.backButtonDisplayMode = .minimal
     }
+    .modifier(ToolbarModifier(isShowingCancel: !keyringStore.isOnboardingVisible))
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
+    .background(
+      NavigationLink(
+        isActive: Binding(
+          get: { !recoveryWords.isEmpty },
+          set: { if !$0 { recoveryWords = [] } }
+        ),
+        destination: {
+          BackupRecoveryPhraseView(
+            recoveryWords: recoveryWords,
+            keyringStore: keyringStore
+          )
+        },
+        label: {
+          EmptyView()
+        })
+      .accentColor(Color(.braveOrange))
+    )
+  }
+  
+  struct ToolbarModifier: ViewModifier {
+    var isShowingCancel: Bool
+
+    @Environment(\.presentationMode) @Binding private var presentationMode
+
+    func body(content: Content) -> some View {
+      if isShowingCancel {
+        content
+          .toolbar {
+            ToolbarItemGroup(placement: .cancellationAction) {
+              Button(action: {
+                presentationMode.dismiss()
+              }) {
+                Text(Strings.cancelButtonTitle)
+                  .foregroundColor(Color(.braveOrange))
+              }
+            }
+          }
+      } else {
+        content
+      }
+    }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -80,6 +80,16 @@ struct BackupWalletView: View {
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
         .disabled(isContinueButtonDisabled)
+        
+        if keyringStore.isOnboardingVisible {
+          Button(action: {
+            keyringStore.markOnboardingCompleted()
+          }) {
+            Text(Strings.Wallet.skipButtonTitle)
+              .font(Font.subheadline.weight(.medium))
+              .foregroundColor(Color(.braveLabel))
+          }
+        }
       }
       .padding()
       .padding()

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -48,6 +48,7 @@ struct PortfolioView: View {
             )
           }
           .environment(\.modalPresentationMode, $isPresentingBackup)
+          .accentColor(Color(.braveOrange))
         }
       }
       BalanceHeaderView(

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -42,7 +42,10 @@ struct PortfolioView: View {
         .padding([.top, .leading, .trailing], 12)
         .sheet(isPresented: $isPresentingBackup) {
           NavigationView {
-            BackupRecoveryPhraseView(keyringStore: keyringStore)
+            BackupWalletView(
+              password: nil,
+              keyringStore: keyringStore
+            )
           }
           .environment(\.modalPresentationMode, $isPresentingBackup)
         }

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -23,6 +23,8 @@ struct PasswordEntryField: View {
   @Binding var password: String
   /// The error displayed under the password field
   @Binding var error: PasswordEntryError?
+  /// Password field placeholder
+  let placeholder: String
   /// If we should show the biometrics icon to allow biometics unlock (if available & password stored in keychain)
   let shouldShowBiometrics: Bool
   let keyringStore: KeyringStore
@@ -33,12 +35,14 @@ struct PasswordEntryField: View {
   init(
     password: Binding<String>,
     error: Binding<PasswordEntryError?>,
+    placeholder: String = Strings.Wallet.passwordPlaceholder,
     shouldShowBiometrics: Bool,
     keyringStore: KeyringStore,
     onCommit: @escaping () -> Void
   ) {
     self._password = password
     self._error = error
+    self.placeholder = placeholder
     self.shouldShowBiometrics = shouldShowBiometrics
     self.onCommit = onCommit
     self.keyringStore = keyringStore
@@ -70,7 +74,7 @@ struct PasswordEntryField: View {
   
   var body: some View {
     HStack {
-      SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: onCommit)
+      SecureField(placeholder, text: $password, onCommit: onCommit)
         .textContentType(.password)
         .font(.subheadline)
         .introspectTextField(customize: { tf in

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -86,6 +86,7 @@ struct PasswordEntryField: View {
           icon
             .imageScale(.large)
             .font(.headline)
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -505,6 +505,13 @@ extension Strings {
       value: "I understand that if I lose my recovery phrase, I won’t be able to access my crypto wallet.",
       comment: "The label next to a toggle which the user must acknowledge"
     )
+    public static let backupWalletPasswordPlaceholder = NSLocalizedString(
+      "wallet.backupWalletPasswordPlaceholder",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Enter password to backup wallet",
+      comment: "The placeholder for the password entry field when a user tries to backup their wallet."
+    )
     public static let continueButtonTitle = NSLocalizedString(
       "wallet.continueButtonTitle",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Add optional password property to `BackupWalletView`. When nil, will require a password to move to next step.
- Instead of displaying `BackupRecoveryPhraseView` from Portfolio & Accounts tabs backup buttons, we show `BackupWalletView` with the password field.

This pull request fixes #5882

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
3 spots to test against: Onboarding, Portfolio backup banner, Accounts backup button.

Onboarding:
1. Reset your Brave Wallet
2. Open Brave Wallet
3. Tap 'Get Started'
4. Enter wallet password
5. Verify password field is not shown on 'Backup Wallet' step (user just entered their password on prior step)
6. Continue to next step & verify backup seed phrase / recovery words are shown

Portfolio:
1. Reset your Brave Wallet
2. Open Brave Wallet
3. Tap 'Get Started'
4. Enter wallet password
5. Tap skip on backup wallet step
6. On 'Portfolio' tab, tap the banner at the top to backup your wallet
7. Verify password field is shown and is required
8. Continue to next step & verify backup seed phrase / recovery words are shown

Accounts 'Backup' button:
1. Reset your Brave Wallet
2. Open Brave Wallet
3. Tap 'Get Started'
4. Enter wallet password
5. Tap skip on backup wallet step
6. On 'Portfolio' tab, tap the banner at the top to backup your wallet
7. Verify password field is shown and is required
8. Continue to next step & verify backup seed phrase / recovery words are shown


## Screenshots:

Onboarding | Portfolio backup banner | Accounts backup button | Backup Wallet w/ password
--|--|--|--
![backup wallet step](https://user-images.githubusercontent.com/5314553/195441041-265076c0-6888-49de-8680-f7ea00c598bb.png) | ![portfolio backup banner](https://user-images.githubusercontent.com/5314553/195440983-d535f8de-ee42-4c8f-b686-2a6e4600a3b5.png) | ![accounts backup button](https://user-images.githubusercontent.com/5314553/195441006-bb7b8b9b-5298-47c1-b9bd-fb5a0217dd92.png) | ![backup wallet step - password](https://user-images.githubusercontent.com/5314553/195441036-b8ec5aa9-0cfd-4474-a5a2-c457e89ef7eb.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
