### PR TITLE
[No Bug]: Move shouldRequestBeOpenedAsPopup in URLExtension

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2913,15 +2913,13 @@ extension BrowserViewController: TabManagerDelegate {
   }
 }
 
-/// List of schemes that are allowed to be opened in new tabs.
-private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "about", "whatsapp"]
-
 extension BrowserViewController: WKUIDelegate {
   public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
     guard let parentTab = tabManager[webView] else { return nil }
 
     guard !navigationAction.isInternalUnprivileged,
-      shouldRequestBeOpenedAsPopup(navigationAction.request)
+          let navigationURL = navigationAction.request.url,
+          navigationURL.shouldRequestBeOpenedAsPopup()
     else {
       print("Denying popup from request: \(navigationAction.request)")
       return nil
@@ -2941,19 +2939,6 @@ extension BrowserViewController: WKUIDelegate {
     toolbarVisibilityViewModel.toolbarState = .expanded
 
     return newTab.webView
-  }
-
-  func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {
-    // Treat `window.open("")` the same as `window.open("about:blank")`.
-    if request.url?.absoluteString.isEmpty ?? false {
-      return true
-    }
-
-    if let scheme = request.url?.scheme?.lowercased(), schemesAllowedToBeOpenedAsPopups.contains(scheme) {
-      return true
-    }
-
-    return false
   }
 
   fileprivate func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {

--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -50,6 +50,22 @@ extension URL {
   public func lastComponentIsPrefixedBy(_ prefix: String) -> Bool {
     return (pathComponents.last?.hasPrefix(prefix) ?? false)
   }
+  
+  public func shouldRequestBeOpenedAsPopup() -> Bool {
+    /// List of schemes that are allowed to be opened in new tabs.
+    let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "about", "whatsapp"]
+    
+    // Treat `window.open("")` the same as `window.open("about:blank")`.
+    if absoluteString.isEmpty {
+      return true
+    }
+
+    if let scheme = scheme?.lowercased(), schemesAllowedToBeOpenedAsPopups.contains(scheme) {
+      return true
+    }
+
+    return false
+  }
 }
 
 // The list of permanent URI schemes has been taken from http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml

--- a/Tests/ClientTests/SchemePermissionTests.swift
+++ b/Tests/ClientTests/SchemePermissionTests.swift
@@ -51,44 +51,7 @@ class SchemePermissionTests: XCTestCase {
       }
     }
   }
-
-  // MARK: Lifecycle
   
-  static var braveCore: BraveCoreMain!
-
-  override func setUp() {
-    profile = BrowserProfile(localName: "mockProfile")
-
-    imageStore = try! DiskImageStore(files: MockFiles(), namespace: "MockTabManagerScreenshots", quality: 1)
-    
-    if Self.braveCore == nil {
-      Self.braveCore = BraveCoreMain(userAgent: "")
-      Self.braveCore.scheduleLowPriorityStartupTasks()
-    }
-
-    let migration = Migration(braveCore: Self.braveCore)
-
-    subject = BrowserViewController(
-      profile: profile,
-      diskImageStore: imageStore,
-      braveCore: Self.braveCore,
-      migration: migration,
-      crashedLastSession: false)
-  }
-
-  override func tearDown() {
-    subject = nil
-    profile = nil
-
-    Task { @MainActor in
-      await imageStore.clearExcluding(Set())
-      imageStore = nil
-    }
-    tabManager = nil
-
-    super.tearDown()
-  }
-
   // MARK: Internal
 
   func testShouldRequestOpenPopup() {
@@ -99,27 +62,23 @@ class SchemePermissionTests: XCTestCase {
     let urlRequestWhatsApp = urlRequestForScheme(.whatsapp)
 
     // Test Http URL Scheme
-    XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestHttp.request), urlRequestHttp.comment)
+    XCTAssertTrue(urlRequestHttp.request.url!.shouldRequestBeOpenedAsPopup(), urlRequestHttp.comment)
 
     // Test Https URL Scheme
-    XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestHttps.request), urlRequestHttps.comment)
+    XCTAssertTrue(urlRequestHttps.request.url!.shouldRequestBeOpenedAsPopup(), urlRequestHttps.comment)
 
     // Test Javascript URL Scheme
-    XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestJavascript.request), urlRequestJavascript.comment)
+    XCTAssertTrue(urlRequestJavascript.request.url!.shouldRequestBeOpenedAsPopup(), urlRequestJavascript.comment)
 
     // Test About URL Scheme
-    XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestAbout.request), urlRequestAbout.comment)
+    XCTAssertTrue(urlRequestAbout.request.url!.shouldRequestBeOpenedAsPopup(), urlRequestAbout.comment)
 
     // Test Whatapp URL Scheme
-    XCTAssertTrue(subject.shouldRequestBeOpenedAsPopup(urlRequestWhatsApp.request), urlRequestWhatsApp.comment)
+    XCTAssertTrue(urlRequestWhatsApp.request.url!.shouldRequestBeOpenedAsPopup(), urlRequestWhatsApp.comment)
   }
 
   private func urlRequestForScheme(_ type: SchemeTestType) -> (request: URLRequest, comment: String) {
     (request: URLRequest(url: URL(string: type.url)!), comment: type.description)
   }
 
-  private var subject: BrowserViewController!
-  private var profile: Profile!
-  private var tabManager: TabManager!
-  private var imageStore: DiskImageStore!
 }


### PR DESCRIPTION
Moving the shouldRequestBeOpenedAsPopup to a URLExtension and removing the browser dependency

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
