### PR TITLE
Fix #6173: Show correct Tabs Bar visibility state on iPad

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -333,7 +333,14 @@ class SettingsViewController: TableViewController {
     
     if UIDevice.current.userInterfaceIdiom == .pad {
       tabs.rows.append(
-        Row(text: Strings.showTabsBar, image: UIImage(named: "settings-show-tab-bar", in: .module, compatibleWith: nil)!.template, accessory: .switchToggle(value: Preferences.General.tabBarVisibility.value == TabBarVisibility.always.rawValue, { Preferences.General.tabBarVisibility.value = $0 ? TabBarVisibility.always.rawValue : TabBarVisibility.never.rawValue }), cellClass: MultilineValue1Cell.self)
+        Row(
+          text: Strings.showTabsBar,
+          image: UIImage(named: "settings-show-tab-bar", in: .module, compatibleWith: nil)!.template,
+          accessory: .switchToggle(value: Preferences.General.tabBarVisibility.value != TabBarVisibility.never.rawValue, {
+            Preferences.General.tabBarVisibility.value = $0 ? TabBarVisibility.always.rawValue : TabBarVisibility.never.rawValue
+          }),
+          cellClass: MultilineValue1Cell.self
+        )
       )
     } else {
       var row = Row(text: Strings.showTabsBar, detailText: TabBarVisibility(rawValue: Preferences.General.tabBarVisibility.value)?.displayString, image: UIImage(named: "settings-show-tab-bar", in: .module, compatibleWith: nil)!.template, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self)

--- a/Client/Migration/Migration.swift
+++ b/Client/Migration/Migration.swift
@@ -43,8 +43,10 @@ public class Migration {
     }
     
     if Preferences.General.isFirstLaunch.value {
-      // Default Value for preference of tab bar visibility for new users changed to landscape only
-      Preferences.General.tabBarVisibility.value = TabBarVisibility.landscapeOnly.rawValue
+      if UIDevice.current.userInterfaceIdiom == .phone {
+        // Default Value for preference of tab bar visibility for new users changed to landscape only
+        Preferences.General.tabBarVisibility.value = TabBarVisibility.landscapeOnly.rawValue
+      }
       // Default url bar location for new users is bottom
       Preferences.General.isUsingBottomBar.value = true
     }


### PR DESCRIPTION
- First launch now only sets tabs bar visibility to `landscapeOnly` on phones
- Settings is now a bit more lenient on showing Tabs Bar setting as on even if the pref is set to `landscapeOnly`

## Summary of Changes

This pull request fixes #6173 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
