### PR TITLE
Fix #6187: Use correct message handler name for playlist web loader

### DIFF
--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -350,7 +350,7 @@ class PlaylistWebLoader: UIView {
       "$<PlaylistDetector>": "PlaylistDetector_\(token)",
       "$<security_token>": "\(token)",
       "$<sendMessage>": "playlistDetector_sendMessage_\(token)",
-      "$<handler>": "playlistCacheLoader_\(UserScriptManager.securityToken)",
+      "$<handler>": PlaylistWebLoaderContentHelper.messageHandlerName,
       "$<notify>": "notify_\(token)",
       "$<onLongPressActivated>": "onLongPressActivated_\(token)",
       "$<setupLongPress>": "setupLongPress_\(token)",


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6187

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
