### PR TITLE
Fix #6160: UI Issues with tab sync flow in landscape

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -164,7 +164,8 @@ class TabTrayController: LoadingViewController {
   private var searchBarView: TabTraySearchBar?
   let tabTraySearchController = UISearchController(searchResultsController: nil)
 
-  private lazy var emptyStateOverlayView: UIView = EmptyStateOverlayView(title: Strings.noSearchResultsfound)
+  private lazy var emptyStateOverlayView: UIView = EmptyStateOverlayView(
+    overlayDetails: EmptyOverlayStateDetails(title: Strings.noSearchResultsfound))
 
   override var preferredStatusBarStyle: UIStatusBarStyle {
     if PrivateBrowsingManager.shared.isPrivateBrowsing {
@@ -279,6 +280,13 @@ class TabTrayController: LoadingViewController {
       })
   
     reloadOpenTabsSession()
+  }
+  
+  override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransition(to: size, with: coordinator)
+    
+      tabSyncView.setNeedsLayout()
+      tabSyncView.layoutIfNeeded()
   }
   
   override func loadView() {

--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -282,13 +282,6 @@ class TabTrayController: LoadingViewController {
     reloadOpenTabsSession()
   }
   
-  override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-    super.viewWillTransition(to: size, with: coordinator)
-    
-      tabSyncView.setNeedsLayout()
-      tabSyncView.layoutIfNeeded()
-  }
-  
   override func loadView() {
     createTypeSelectorItems()
     layoutTabTray()

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
@@ -22,7 +22,8 @@ extension TabTrayController {
 
     var actionHandler: ((SyncStatusState) -> Void)?
     
-    private var noSyncTabsOverlayView = EmptyStateOverlayView()
+    private var noSyncTabsOverlayView = EmptyStateOverlayView(
+      overlayDetails: EmptyOverlayStateDetails())
     
     override init(frame: CGRect) {
       super.init(frame: frame)
@@ -75,37 +76,43 @@ extension TabTrayController {
       switch state {
       case .noSyncChain:
         let noSyncChainEmptyStateView = EmptyStateOverlayView(
-          title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
-          description: Strings.OpenTabs.noSyncChainPlaceHolderViewDescription,
-          icon: UIImage(named: "sync-settings", in: .module, compatibleWith: nil),
-          buttonText: "\(Strings.OpenTabs.syncChainStartButtonTitle) →",
-          action: { [weak self] in
-            self?.actionHandler?(.noSyncChain)
-          })
+          overlayDetails: EmptyOverlayStateDetails(
+            title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
+            description: Strings.OpenTabs.noSyncChainPlaceHolderViewDescription,
+            icon: UIImage(named: "sync-settings", in: .module, compatibleWith: nil),
+            buttonText: "\(Strings.OpenTabs.syncChainStartButtonTitle) →",
+            action: { [weak self] in
+              self?.actionHandler?(.noSyncChain)
+            })
+          )
         
         return noSyncChainEmptyStateView
       case .openTabsDisabled:
         let disabledOpenTabsEmptyStateView = EmptyStateOverlayView(
-          title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
-          description: Strings.OpenTabs.enableOpenTabsPlaceHolderViewDescription,
-          icon: UIImage(named: "sync-settings", in: .module, compatibleWith: nil),
-          buttonText: Strings.OpenTabs.tabSyncEnableButtonTitle,
-          action: { [weak self] in
-            self?.actionHandler?(.openTabsDisabled)
-          },
-          actionDescription: Strings.OpenTabs.noSyncSessionPlaceHolderViewAdditionalDescription)
+          overlayDetails: EmptyOverlayStateDetails(
+            title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
+            description: Strings.OpenTabs.enableOpenTabsPlaceHolderViewDescription,
+            icon: UIImage(named: "sync-settings", in: .module, compatibleWith: nil),
+            buttonText: Strings.OpenTabs.tabSyncEnableButtonTitle,
+            action: { [weak self] in
+              self?.actionHandler?(.openTabsDisabled)
+            },
+            actionDescription: Strings.OpenTabs.noSyncSessionPlaceHolderViewAdditionalDescription)
+          )
         
         return disabledOpenTabsEmptyStateView
       default:
         let noSessionsEmptyStateView = EmptyStateOverlayView(
-          title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
-          description: Strings.OpenTabs.noSyncSessionPlaceHolderViewDescription,
-          icon: UIImage(named: "sync-settings", in: .module, compatibleWith: nil),
-          buttonText: Strings.OpenTabs.showSettingsSyncButtonTitle,
-          action: { [weak self] in
-            self?.actionHandler?(.noSyncedSessions)
-          },
-          actionDescription: Strings.OpenTabs.noSyncSessionPlaceHolderViewAdditionalDescription)
+          overlayDetails: EmptyOverlayStateDetails(
+            title: Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle,
+            description: Strings.OpenTabs.noSyncSessionPlaceHolderViewDescription,
+            icon: UIImage(named: "sync-settings", in: .module, compatibleWith: nil),
+            buttonText: Strings.OpenTabs.showSettingsSyncButtonTitle,
+            action: { [weak self] in
+              self?.actionHandler?(.noSyncedSessions)
+            },
+            actionDescription: Strings.OpenTabs.noSyncSessionPlaceHolderViewAdditionalDescription)
+          )
         
         return noSessionsEmptyStateView
       }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -76,7 +76,8 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
   private var isBookmarksBeingSearched = false
   private let bookmarksSearchController = UISearchController(searchResultsController: nil)
   private var bookmarksSearchQuery = ""
-  private lazy var noSearchResultOverlayView = EmptyStateOverlayView(title: Strings.noSearchResultsfound)
+  private lazy var noSearchResultOverlayView = EmptyStateOverlayView(
+    overlayDetails: EmptyOverlayStateDetails(title: Strings.noSearchResultsfound))
 
   // MARK: Lifecycle
 

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -97,15 +97,24 @@ class EmptyStateOverlayView: UIView {
     super.layoutSubviews()
     
     doLayout(details: overlayDetails)
+    
+    let heightOffset = traitCollection.verticalSizeClass == .compact ? 0 : -50
+    
+    containerView.snp.remakeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.centerY.equalToSuperview().offset(heightOffset)
+    }
   }
   
   private func doLayout(details: EmptyOverlayStateDetails) {
     backgroundColor = .secondaryBraveBackground
+    
+    let heightOffset = traitCollection.verticalSizeClass == .compact ? 0 : -50
 
     addSubview(containerView)
     containerView.snp.makeConstraints {
       $0.centerX.equalToSuperview()
-      $0.centerY.equalToSuperview().offset(traitCollection.verticalSizeClass == .compact ? 0 : -50)
+      $0.centerY.equalToSuperview().offset(heightOffset)
       $0.width.equalToSuperview().multipliedBy(0.75)
       $0.size.lessThanOrEqualToSuperview()
     }
@@ -115,22 +124,22 @@ class EmptyStateOverlayView: UIView {
       containerView.addArrangedSubview(iconImageView)
       
       iconImageView.snp.makeConstraints {
-        $0.size.equalTo(traitCollection.verticalSizeClass == .compact ? 40 : 60)
+        $0.size.equalTo(45)
        }
       
-      containerView.setCustomSpacing(35, after: iconImageView)
+      containerView.setCustomSpacing(25, after: iconImageView)
     }
     
     if let title = details.title {
       informationLabel.text = title
       containerView.addArrangedSubview(informationLabel)
-      containerView.setCustomSpacing(25, after: informationLabel)
+      containerView.setCustomSpacing(20, after: informationLabel)
     }
     
     if let description = details.description {
       descriptionLabel.text = description
       containerView.addArrangedSubview(descriptionLabel)
-      containerView.setCustomSpacing(45, after: descriptionLabel)
+      containerView.setCustomSpacing(35, after: descriptionLabel)
     }
     
     if let buttonText = details.buttonText {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -115,7 +115,7 @@ class EmptyStateOverlayView: UIView {
       containerView.addArrangedSubview(iconImageView)
       
       iconImageView.snp.makeConstraints {
-        $0.size.equalTo(60)
+        $0.size.equalTo(traitCollection.verticalSizeClass == .compact ? 40 : 60)
        }
       
       containerView.setCustomSpacing(35, after: iconImageView)

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -7,6 +7,15 @@ import Foundation
 import Shared
 import UIKit
 
+struct EmptyOverlayStateDetails {
+  var title: String?
+  var description: String?
+  var icon: UIImage?
+  var buttonText: String?
+  var action: (() -> Void)?
+  var actionDescription: String?
+}
+
 class EmptyStateOverlayView: UIView {
   
   private struct UX {
@@ -50,70 +59,25 @@ class EmptyStateOverlayView: UIView {
   private let containerView = UIStackView().then {
     $0.axis = .vertical
     $0.alignment = .center
+    $0.layer.masksToBounds = true
     $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
     $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
   }
   
   private var actionHandler: (() -> Void)?
+  private var overlayDetails: EmptyOverlayStateDetails
 
-  required init(
-    title: String? = nil,
-    description: String? = nil,
-    icon: UIImage? = nil,
-    buttonText: String? = nil,
-    action: (() -> Void)? = nil,
-    actionDescription: String? = nil) {
+  required init(overlayDetails: EmptyOverlayStateDetails) {
+    self.overlayDetails = overlayDetails
+    
     super.init(frame: .zero)
 
-    backgroundColor = .secondaryBraveBackground
-    
-    addSubview(containerView)
-    containerView.snp.makeConstraints {
-      $0.centerX.equalToSuperview()
-      $0.centerY.equalToSuperview().offset(-50)
-      $0.width.equalToSuperview().multipliedBy(0.75)
-      $0.size.lessThanOrEqualToSuperview()
-    }
-    
-    if let icon = icon {
-      iconImageView.image = icon
-      containerView.addArrangedSubview(iconImageView)
-      
-      iconImageView.snp.makeConstraints {
-        $0.size.equalTo(60)
-       }
-      
-      containerView.setCustomSpacing(35, after: iconImageView)
-    }
-    
-    if let title = title {
-      informationLabel.text = title
-      containerView.addArrangedSubview(informationLabel)
-      containerView.setCustomSpacing(25, after: informationLabel)
-    }
-    
-    if let description = description {
-      descriptionLabel.text = description
-      containerView.addArrangedSubview(descriptionLabel)
-      containerView.setCustomSpacing(45, after: descriptionLabel)
-    }
-    
-    if let buttonText = buttonText {
-      actionButton.setTitle(buttonText, for: .normal)
-      actionButton.addTarget(self, action: #selector(tappedActionButton), for: .touchUpInside)
-      containerView.addArrangedSubview(actionButton)
-      containerView.setCustomSpacing(25, after: actionButton)
-    }
-    
-    if let actionDescription = actionDescription {
-      actionDescriptionLabel.text = actionDescription
-      containerView.addArrangedSubview(actionDescriptionLabel)
-    }
-    
-    if let action = action {
+    if let action = overlayDetails.action {
       actionHandler = action
     }
-    
+      
+    doLayout(details: overlayDetails)
+             
     updateFont()
   }
 
@@ -125,7 +89,61 @@ class EmptyStateOverlayView: UIView {
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
     
+    doLayout(details: overlayDetails)
     updateFont()
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    doLayout(details: overlayDetails)
+  }
+  
+  private func doLayout(details: EmptyOverlayStateDetails) {
+    backgroundColor = .secondaryBraveBackground
+
+    addSubview(containerView)
+    containerView.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.centerY.equalToSuperview().offset(traitCollection.verticalSizeClass == .compact ? 0 : -50)
+      $0.width.equalToSuperview().multipliedBy(0.75)
+      $0.size.lessThanOrEqualToSuperview()
+    }
+    
+    if let icon = details.icon {
+      iconImageView.image = icon
+      containerView.addArrangedSubview(iconImageView)
+      
+      iconImageView.snp.makeConstraints {
+        $0.size.equalTo(60)
+       }
+      
+      containerView.setCustomSpacing(35, after: iconImageView)
+    }
+    
+    if let title = details.title {
+      informationLabel.text = title
+      containerView.addArrangedSubview(informationLabel)
+      containerView.setCustomSpacing(25, after: informationLabel)
+    }
+    
+    if let description = details.description {
+      descriptionLabel.text = description
+      containerView.addArrangedSubview(descriptionLabel)
+      containerView.setCustomSpacing(45, after: descriptionLabel)
+    }
+    
+    if let buttonText = details.buttonText {
+      actionButton.setTitle(buttonText, for: .normal)
+      actionButton.addTarget(self, action: #selector(tappedActionButton), for: .touchUpInside)
+      containerView.addArrangedSubview(actionButton)
+      containerView.setCustomSpacing(25, after: actionButton)
+    }
+    
+    if let actionDescription = details.actionDescription {
+      actionDescriptionLabel.text = actionDescription
+      containerView.addArrangedSubview(actionDescriptionLabel)
+    }
   }
   
   private func updateFont() {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -17,11 +17,12 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
   weak var toolbarUrlActionsDelegate: ToolbarUrlActionsDelegate?
 
   private lazy var emptyStateOverlayView = EmptyStateOverlayView(
-    title: Preferences.Privacy.privateBrowsingOnly.value
-      ? Strings.History.historyPrivateModeOnlyStateTitle
-      : Strings.History.historyEmptyStateTitle,
-    icon: UIImage(named: "emptyHistory", in: .module, compatibleWith: nil)!)
-
+    overlayDetails: EmptyOverlayStateDetails(
+      title: Preferences.Privacy.privateBrowsingOnly.value
+        ? Strings.History.historyPrivateModeOnlyStateTitle
+        : Strings.History.historyEmptyStateTitle,
+      icon: UIImage(named: "emptyHistory", in: .module, compatibleWith: nil)))
+  
   private let historyAPI: BraveHistoryAPI
   private let tabManager: TabManager
 

--- a/Client/Frontend/Login/LoginListViewController.swift
+++ b/Client/Frontend/Login/LoginListViewController.swift
@@ -44,7 +44,8 @@ class LoginListViewController: LoginAuthViewController {
   private var searchLoginTimer: Timer?
   private var isCredentialsBeingSearched = false
   private let searchController = UISearchController(searchResultsController: nil)
-  private let emptyLoginView = EmptyStateOverlayView(title: Strings.Login.loginListEmptyScreenTitle)
+  private let emptyStateOverlayView = EmptyStateOverlayView(
+    overlayDetails: EmptyOverlayStateDetails(title: Strings.Login.loginListEmptyScreenTitle))
 
   // MARK: Lifecycle
 
@@ -181,7 +182,7 @@ class LoginListViewController: LoginAuthViewController {
 extension LoginListViewController {
 
   override func numberOfSections(in tableView: UITableView) -> Int {
-    tableView.backgroundView = credentialList.isEmpty ? emptyLoginView : nil
+    tableView.backgroundView = credentialList.isEmpty ? emptyStateOverlayView : nil
 
     return Section.allCases.count
   }

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -132,11 +132,12 @@ class SyncSettingsTableViewController: UIViewController, UITableViewDelegate, UI
   
   private var tableView = UITableView(frame: .zero, style: .grouped)
 
-  private lazy var noSyncedDevicesOverlayView = EmptyStateOverlayView(
-    title: Strings.OpenTabs.noDevicesSyncChainPlaceholderViewTitle,
-    description: Strings.OpenTabs.noDevicesSyncChainPlaceholderViewDescription,
-    icon: UIImage(systemName: "exclamationmark.arrow.triangle.2.circlepath"))
-
+  private lazy var emptyStateOverlayView = EmptyStateOverlayView(
+    overlayDetails: EmptyOverlayStateDetails(
+      title: Strings.OpenTabs.noDevicesSyncChainPlaceholderViewTitle,
+      description: Strings.OpenTabs.noDevicesSyncChainPlaceholderViewDescription,
+      icon: UIImage(systemName: "exclamationmark.arrow.triangle.2.circlepath")))
+  
   // MARK: Actions
 
   @objc
@@ -221,13 +222,13 @@ class SyncSettingsTableViewController: UIViewController, UITableViewDelegate, UI
   /// - Parameter isHidden: Boolean to set isHidden
   private func updateNoSyncedDevicesState(isHidden: Bool) {
     if isHidden {
-      noSyncedDevicesOverlayView.removeFromSuperview()
+      emptyStateOverlayView.removeFromSuperview()
     } else {
-      if noSyncedDevicesOverlayView.superview == nil {
-        view.addSubview(noSyncedDevicesOverlayView)
-        view.bringSubviewToFront(noSyncedDevicesOverlayView)
+      if emptyStateOverlayView.superview == nil {
+        view.addSubview(emptyStateOverlayView)
+        view.bringSubviewToFront(emptyStateOverlayView)
         
-        noSyncedDevicesOverlayView.snp.makeConstraints {
+        emptyStateOverlayView.snp.makeConstraints {
           $0.edges.equalTo(tableView)
         }
       }


### PR DESCRIPTION
This pull request  fixes the problems and consolidates creation of empty overlay view that is being used in many controllers.
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Clean install 1.44
- Open tab tray
- Switch to tabs from other devices segmented tab
- Rotate device to landscape
- Observe

## Screenshots:

https://user-images.githubusercontent.com/6643505/195943448-31c3f694-e54c-4903-9d81-5b6b1fdbe65c.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
