### PR TITLE
Fix Norwegian translation (#6155)

### DIFF
--- a/App/l10n/Resources/nb.lproj/BraveShared.strings
+++ b/App/l10n/Resources/nb.lproj/BraveShared.strings
@@ -1370,7 +1370,7 @@
 "pagezoom.settings.emptyWebsitesTitle" = "Ingen nettsider lagt til";
 
 /* Title of the Web-Page Zoom settings menu */
-"pagezoom.settings.menu-title" = "Sidezoon";
+"pagezoom.settings.menu-title" = "Sidezoom";
 
 /* Title for the section for the Web-Page zoom level of other websites */
 "pagezoom.settings.otherWebsitesZoomLevelSectionTitle" = "Alle andre nettsider";
@@ -1388,7 +1388,7 @@
 "pagezoom.settings.title" = "Sidezoom-innstillinger";
 
 /* Title for the web-page zoom level view */
-"pagezoom.zoomView.text" = "Sidezoon";
+"pagezoom.zoomView.text" = "Sidezoom";
 
 /* Sync pair device settings section title */
 "Pair" = "Par";


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6155. There was a typo in Norsk Bokmål translation: "Sidezoo**n**" -> "Sidezoo**m**".

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
0. Set Norsk Bokmål as a system language.
1. Open main menu, while any site is open.
2. Check that there's an option "Sidezoom" instead of "Sidezoon" (this is a page zoom).

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![image](https://user-images.githubusercontent.com/14852335/196722769-0701df70-f7a5-4eb8-ac59-0440563529f7.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
