### PR TITLE
Fix #6208: Incorrect Solana account can be shown in permission request view

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -225,15 +225,21 @@ extension Tab: BraveWalletProviderDelegate {
       }
       
       // add permission request to the queue
-      let request = permissionRequestManager.beginRequest(for: origin, coinType: coinType, providerHandler: completion, completion: { response in
-        switch response {
-        case .granted(let accounts):
-          completion(.none, accounts)
-        case .rejected:
-          completion(.none, [])
+      let request = permissionRequestManager.beginRequest(
+        for: origin,
+        accounts: accounts,
+        coinType: coinType,
+        providerHandler: completion,
+        completion: { response in
+          switch response {
+          case .granted(let accounts):
+            completion(.none, accounts)
+          case .rejected:
+            completion(.none, [])
+          }
+          self.tabDelegate?.updateURLBarWalletButton()
         }
-        self.tabDelegate?.updateURLBarWalletButton()
-      })
+      )
 
       tabDappStore.latestPendingPermissionRequest = request
       self.tabDelegate?.showWalletNotification(self, origin: origin)

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -94,6 +94,7 @@ public struct CryptoView: View {
             case .requestPermissions(let request, let onPermittedAccountsUpdated):
               NewSiteConnectionView(
                 origin: request.requestingOrigin,
+                accounts: request.requestingAccounts,
                 coin: request.coinType,
                 keyringStore: keyringStore,
                 onConnect: {

--- a/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
+++ b/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
@@ -18,6 +18,8 @@ public struct WebpagePermissionRequest: Equatable {
   }
   /// The origin that requested this permission
   let requestingOrigin: URLOrigin
+  /// The accounts being requested to connect
+  let requestingAccounts: [String]
   /// The type of request
   let coinType: BraveWallet.CoinType
   /// A handler to be called when the user either approves or rejects the connection request
@@ -49,11 +51,16 @@ public class WalletProviderPermissionRequestsManager {
   /// users response by providing a closure
   public func beginRequest(
     for origin: URLOrigin,
+    accounts: [String],
     coinType: BraveWallet.CoinType,
     providerHandler: RequestPermissionsCallback?,
     completion: ((WebpagePermissionRequest.Response) -> Void)? = nil
   ) -> WebpagePermissionRequest {
-    var request = WebpagePermissionRequest(requestingOrigin: origin, coinType: coinType) { [weak self] decision in
+    var request = WebpagePermissionRequest(
+      requestingOrigin: origin,
+      requestingAccounts: accounts,
+      coinType: coinType
+    ) { [weak self] decision in
       guard let self = self, let originURL = origin.url else { return }
       if case .granted(let accounts) = decision {
         Domain.setWalletPermissions(


### PR DESCRIPTION
## Summary of Changes
- Store the accounts being requested in the `WebpagePermissionRequest`
- Display the accounts from the request in the `NewSiteConnectionView`

This pull request fixes #6208

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Have 2 Solana accounts
  2. Select account 1
  3. Visit a Solana dapp you have not connected to (or remove permissions from the dapp in Wallet Settings), ex. https://jup.ag/
  4. Click 'Connect Wallet'
  5. Observe account 1 is shown in the `NewSiteConnectionView` modal
  6. Swipe to dismiss this modal (do not click cancel)
  7. On wallet panel, change selected account to Solana account 2
  8. Close wallet panel and then re-open it
  9. Observe account 1 is still shown in the `NewSiteConnectionView` modal

Verify Ethereum dapp connection requests will still show all accounts in the permission requests.


## Screenshots:

https://user-images.githubusercontent.com/5314553/196764423-e5f00fd6-4f3c-4c35-9fae-946f46b657e7.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
