### PR TITLE
Fix #6004: Solana instruction parsing for transaction confirmation

### DIFF
--- a/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -99,6 +99,15 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump.git",
+      "state" : {
+        "revision" : "819d9d370cd721c9d87671e29d947279292e4541",
+        "version" : "0.6.0"
+      }
+    },
+    {
       "identity" : "swift-markdown",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-markdown",
@@ -149,6 +158,15 @@
       "state" : {
         "revision" : "e421a7b3440a271834337694e6050133a3958bc7",
         "version" : "2.7.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "16e6409ee82e1b81390bdffbf217b9c08ab32784",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-markdown", revision: "4f0c76fcd29fea648915f41e2aa896d47608087a"),
     .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.7.2"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(name: "Static", path: "ThirdParty/Static"),
     .package(name: "JitsiMeet", path: "ThirdParty/JitsiMeet"),
   ],
@@ -359,7 +360,14 @@ let package = Package(
         .copy("Certificates/certviewer/github.com.cer"),
       ]
     ),
-    .testTarget(name: "BraveWalletTests", dependencies: ["BraveWallet", "DataTestsUtils"]),
+    .testTarget(
+      name: "BraveWalletTests",
+      dependencies: [
+        "BraveWallet",
+        "DataTestsUtils",
+        .product(name: "CustomDump", package: "swift-custom-dump")
+      ]
+    ),
     .testTarget(name: "StorageTests", dependencies: ["Storage", "BraveSharedTestUtils"], resources: [.copy("fixtures/v33.db"), .copy("testcert1.pem"), .copy("testcert2.pem")]),
     .testTarget(name: "DataTests", dependencies: ["Data", "DataTestsUtils"]),
     .testTarget(name: "SPMLibrariesTests", dependencies: ["GCDWebServers"]),

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -376,7 +376,7 @@ public class TransactionConfirmationStore: ObservableObject {
       symbol = ""
       value = details.fromAmount
       transactionDetails = details.instructions
-        .map { TransactionParser.solanaInstructionFormatted($0) }
+        .map(\.toString)
         .joined(separator: "\n\n") // separator between each instruction
       
       if let gasFee = details.gasFee {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -373,7 +373,7 @@ public class TransactionConfirmationStore: ObservableObject {
       symbol = details.fromToken?.symbol ?? ""
       value = details.fromAmount
     case let .solDappTransaction(details):
-      symbol = ""
+      symbol = details.symbol ?? ""
       value = details.fromAmount
       transactionDetails = details.instructions
         .map(\.toString)

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -377,8 +377,6 @@ public class TransactionConfirmationStore: ObservableObject {
       value = details.fromAmount
       transactionDetails = details.instructions
         .map { TransactionParser.solanaInstructionFormatted($0) }
-        .enumerated()
-        .map { (index, formattedInstruction) in "Instruction #\(index + 1)\n\(formattedInstruction)" }
         .joined(separator: "\n\n") // separator between each instruction
       
       if let gasFee = details.gasFee {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -130,8 +130,9 @@ class TransactionDetailsStore: ObservableObject {
         } else {
           self.value = details.fromAmount
         }
-      case .solDappTransaction:
-        break
+      case let .solDappTransaction(details):
+        self.title = Strings.Wallet.solanaDappTransactionTitle
+        self.value = details.fromAmount
       case .other:
         break
       }

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -416,19 +416,11 @@ struct TransactionConfirmationView: View {
       .navigationBarTitleDisplayMode(.inline)
       .foregroundColor(Color(.braveLabel))
       .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
-      .toolbar {
-        ToolbarItemGroup(placement: .cancellationAction) {
-          Button(action: { presentationMode.dismiss() }) {
-            Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
-          }
+      .onAppear {
+        Task { @MainActor in
+          await confirmationStore.prepare()
         }
       }
-    .onAppear {
-      Task { @MainActor in
-        await confirmationStore.prepare()
-      }
-    }
   }
 
   @ViewBuilder private var rejectConfirmContainer: some View {

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -417,7 +417,7 @@ struct TransactionConfirmationView: View {
       .foregroundColor(Color(.braveLabel))
       .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
       .onAppear {
-        Task { @MainActor in
+        Task {
           await confirmationStore.prepare()
         }
       }

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -38,7 +38,14 @@ struct TransactionConfirmationView: View {
     if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
       return Strings.Wallet.transactionTypeApprove
     }
-    return confirmationStore.activeParsedTransaction.transaction.isSwap ? Strings.Wallet.swap : Strings.Wallet.send
+    switch confirmationStore.activeParsedTransaction.transaction.txType {
+    case .erc20Approve:
+      return Strings.Wallet.transactionTypeApprove
+    case .solanaDappSignTransaction, .solanaDappSignAndSendTransaction:
+      return Strings.Wallet.solanaDappTransactionTitle
+    default:
+      return confirmationStore.activeParsedTransaction.transaction.isSwap ? Strings.Wallet.swap : Strings.Wallet.send
+    }
   }
 
   /// View showing the currently selected account with a blockie

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -19,13 +19,15 @@ struct TransactionHeader: View {
   let fiat: String?
   
   @Environment(\.sizeCategory) private var sizeCategory
+  @ScaledMetric private var blockieSize = 48
+  private let maxBlockieSize: CGFloat = 96
   
   var body: some View {
     VStack(spacing: 8) {
       VStack(spacing: 8) {
         if fromAccountAddress == toAccountAddress {
           Blockie(address: fromAccountAddress)
-            .frame(width: 48, height: 48)
+            .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
           AddressView(address: fromAccountAddress) {
             Text(fromAccountName)
           }
@@ -33,7 +35,7 @@ struct TransactionHeader: View {
           BlockieGroup(
             fromAddress: fromAccountAddress,
             toAddress: toAccountAddress,
-            size: 48
+            size: min(blockieSize, maxBlockieSize)
           )
           Group {
             if sizeCategory.isAccessibilityCategory {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -23,36 +23,44 @@ struct TransactionHeader: View {
   var body: some View {
     VStack(spacing: 8) {
       VStack(spacing: 8) {
-        BlockieGroup(
-          fromAddress: fromAccountAddress,
-          toAddress: toAccountAddress,
-          size: 48
-        )
-        Group {
-          if sizeCategory.isAccessibilityCategory {
-            VStack {
-              AddressView(address: fromAccountAddress) {
-                Text(fromAccountName)
+        if fromAccountAddress == toAccountAddress {
+          Blockie(address: fromAccountAddress)
+            .frame(width: 48, height: 48)
+          AddressView(address: fromAccountAddress) {
+            Text(fromAccountName)
+          }
+        } else {
+          BlockieGroup(
+            fromAddress: fromAccountAddress,
+            toAddress: toAccountAddress,
+            size: 48
+          )
+          Group {
+            if sizeCategory.isAccessibilityCategory {
+              VStack {
+                AddressView(address: fromAccountAddress) {
+                  Text(fromAccountName)
+                }
+                Image(systemName: "arrow.down")
+                AddressView(address: toAccountAddress) {
+                  Text(toAccountName)
+                }
               }
-              Image(systemName: "arrow.down")
-              AddressView(address: toAccountAddress) {
-                Text(toAccountName)
-              }
-            }
-          } else {
-            HStack {
-              AddressView(address: fromAccountAddress) {
-                Text(fromAccountName)
-              }
-              Image(systemName: "arrow.right")
-              AddressView(address: toAccountAddress) {
-                Text(toAccountName)
+            } else {
+              HStack {
+                AddressView(address: fromAccountAddress) {
+                  Text(fromAccountName)
+                }
+                Image(systemName: "arrow.right")
+                AddressView(address: toAccountAddress) {
+                  Text(toAccountName)
+                }
               }
             }
           }
+          .foregroundColor(Color(.bravePrimary))
+          .font(.callout)
         }
-        .foregroundColor(Color(.bravePrimary))
-        .font(.callout)
       }
       .accessibilityElement()
       .accessibility(addTraits: .isStaticText)

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -152,8 +152,8 @@ extension TransactionParser {
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
         namedToAddress: parsedTransaction.namedToAddress,
-        title: "",
-        gasFee: nil,
+        title: Strings.Wallet.solanaDappTransactionTitle,
+        gasFee: parsedTransaction.gasFee,
         networkSymbol: parsedTransaction.networkSymbol
       )
     case .other:

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -489,14 +489,14 @@ enum TransactionParser {
     _ instruction: BraveWallet.SolanaInstruction
   ) -> SolanaDappTxDetails.ParsedSolanaInstruction {
     guard let decodedData = instruction.decodedData else {
-      let title = "Unknown"
+      let title = Strings.Wallet.solanaUnknownInstructionName
       let programId = SolanaDappTxDetails.ParsedSolanaInstruction.KeyValue(
-        key: "Program Id", value: instruction.programId)
+        key: Strings.Wallet.solanaInstructionProgramId, value: instruction.programId)
       let accountPubkeys = instruction.accountMetas.map(\.pubkey)
       let accounts = SolanaDappTxDetails.ParsedSolanaInstruction.KeyValue(
-        key: "Accounts", value: accountPubkeys.isEmpty ? "[]" : accountPubkeys.joined(separator: "\n"))
+        key: Strings.Wallet.solanaInstructionAccounts, value: accountPubkeys.isEmpty ? "[]" : accountPubkeys.joined(separator: "\n"))
       let data = SolanaDappTxDetails.ParsedSolanaInstruction.KeyValue(
-        key: "Data", value: "\(instruction.data)")
+        key: Strings.Wallet.solanaInstructionData, value: "\(instruction.data)")
       return .init(name: title, details: [programId, accounts, data], instruction: instruction)
     }
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
@@ -514,11 +514,10 @@ enum TransactionParser {
       
       if let lamportsParam = decodedData.paramFor(.lamports),
          let lamportsValue = formatter.decimalString(for: lamportsParam.value, radix: .decimal, decimals: 9)?.trimmingTrailingZeros {
-        details.append(.init(key: lamportsParam.localizedName, value: "\(lamportsValue) SOL"))
+        details.append(.init(key: Strings.Wallet.solanaAmount, value: "\(lamportsValue) SOL"))
       }
       
       let params = decodedData.params
-        .filter { $0.name != BraveWallet.DecodedSolanaInstructionData.ParamKey.lamports.rawValue } // shown above
       if !params.isEmpty {
         let params = params.map { param in
           SolanaDappTxDetails.ParsedSolanaInstruction.KeyValue(key: param.localizedName, value: param.value)
@@ -550,14 +549,10 @@ enum TransactionParser {
          let decimalsParam = decodedData.paramFor(.decimals),
          let decimals = Int(decimalsParam.value),
          let amountValue = formatter.decimalString(for: amountParam.value, radix: .decimal, decimals: decimals)?.trimmingTrailingZeros {
-        details.append(.init(key: amountParam.localizedName, value: amountValue))
+        details.append(.init(key: Strings.Wallet.solanaAmount, value: amountValue))
       }
       
       let params = decodedData.params
-        .filter {
-          $0.name != BraveWallet.DecodedSolanaInstructionData.ParamKey.amount.rawValue // shown above
-          && $0.name != BraveWallet.DecodedSolanaInstructionData.ParamKey.decimals.rawValue // shown above
-        }
       if !params.isEmpty {
         let params = params.map { param in
           SolanaDappTxDetails.ParsedSolanaInstruction.KeyValue(key: param.localizedName, value: param.value)

--- a/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
+++ b/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
@@ -25,17 +25,17 @@ extension BraveWallet.SolanaInstruction {
   
   var instructionName: String {
     guard let decodedData = self.decodedData else {
-      return "Unknown"
+      return Strings.Wallet.solanaUnknownInstructionName
     }
     if isSystemProgram,
        let instructionType = BraveWallet.SolanaSystemInstruction(rawValue: Int(decodedData.instructionType)) {
       let name = instructionType.name
-      return "System Program - \(name)"
+      return String.localizedStringWithFormat(Strings.Wallet.solanaSystemProgramName, name)
     } else if isTokenProgram, let instructionType = BraveWallet.SolanaTokenInstruction(rawValue: Int(decodedData.instructionType)) {
       let name = instructionType.name
-      return "Token Program - \(name)"
+      return String.localizedStringWithFormat(Strings.Wallet.solanaTokenProgramName, name)
     }
-    return "Unknown"
+    return Strings.Wallet.solanaUnknownInstructionName
   }
 }
 
@@ -43,33 +43,33 @@ extension BraveWallet.SolanaSystemInstruction {
   var name: String {
     switch self {
     case .transfer:
-      return "Transfer"
+      return Strings.Wallet.solanaTransferInstructionName
     case .transferWithSeed:
-      return "TransferWithSeed"
+      return Strings.Wallet.solanaTransferWithSeedInstructionName
     case .withdrawNonceAccount:
-      return "WithdrawNonceAccount"
+      return Strings.Wallet.solanaWithdrawNonceAccountInstructionName
     case .createAccount:
-      return "CreateAccount"
+      return Strings.Wallet.solanaCreateAccountInstructionName
     case .createAccountWithSeed:
-      return "CreateAccountWithSeed"
+      return Strings.Wallet.solanaCreateAccountWithSeedInstructionName
     case .assign:
-      return "Assign"
+      return Strings.Wallet.solanaAssignInstructionName
     case .assignWithSeed:
-      return "AssignWithSeed"
+      return Strings.Wallet.solanaAssignWithSeedInstructionName
     case .allocate:
-      return "Allocate"
+      return Strings.Wallet.solanaAllocateInstructionName
     case .allocateWithSeed:
-      return "AllocateWithSeed"
+      return Strings.Wallet.solanaAllocateWithSeedInstructionName
     case .advanceNonceAccount:
-      return "AdvanceNonceAccount"
+      return Strings.Wallet.solanaAdvanceNonceAccountInstructionName
     case .initializeNonceAccount:
-      return "InitializeNonceAccount"
+      return Strings.Wallet.solanaInitializeNonceAccountInstructionName
     case .authorizeNonceAccount:
-      return "AuthorizeNonceAccount"
+      return Strings.Wallet.solanaAuthorizeNonceAccountInstructionName
     case .upgradeNonceAccount:
-      return "UpgradeNonceAccount"
+      return Strings.Wallet.solanaUpgradeNonceAccountInstructionName
     default:
-      return "Unknown"
+      return Strings.Wallet.solanaUnknownInstructionName
     }
   }
 }
@@ -78,49 +78,49 @@ extension BraveWallet.SolanaTokenInstruction {
   var name: String {
     switch self {
     case .initializeMint:
-      return "InitializeMint"
+      return Strings.Wallet.solanaInitializeMintInstructionName
     case .initializeMint2:
-      return "InitializeMint2"
+      return Strings.Wallet.solanaInitializeMint2InstructionName
     case .initializeAccount:
-      return "InitializeAccount"
+      return Strings.Wallet.solanaInitializeAccountInstructionName
     case .initializeAccount2:
-      return "InitializeAccount2"
+      return Strings.Wallet.solanaInitializeAccount2InstructionName
     case .initializeAccount3:
-      return "InitializeAccount3"
+      return Strings.Wallet.solanaInitializeAccount3InstructionName
     case .initializeMultisig:
-      return "InitializeMultisig"
+      return Strings.Wallet.solanaInitializeMultisigInstructionName
     case .initializeMultisig2:
-      return "InitializeMultisig2"
+      return Strings.Wallet.solanaInitializeMultisig2InstructionName
     case .approve:
-      return "Approve"
+      return Strings.Wallet.solanaApproveInstructionName
     case .transfer:
-      return "Transfer"
+      return Strings.Wallet.solanaTransferInstructionName
     case .revoke:
-      return "Revoke"
+      return Strings.Wallet.solanaRevokeInstructionName
     case .setAuthority:
-      return "SetAuthority"
+      return Strings.Wallet.solanaSetAuthorityInstructionName
     case .mintTo:
-      return "MintTo"
+      return Strings.Wallet.solanaMintToInstructionName
     case .burn:
-      return "Burn"
+      return Strings.Wallet.solanaBurnInstructionName
     case .closeAccount:
-      return "CloseAccount"
+      return Strings.Wallet.solanaCloseAccountInstructionName
     case .freezeAccount:
-      return "FreezeAccount"
+      return Strings.Wallet.solanaFreezeAccountInstructionName
     case .thawAccount:
-      return "ThawAccount"
+      return Strings.Wallet.solanaThawAccountInstructionName
     case .approveChecked:
-      return "ApproveChecked"
+      return Strings.Wallet.solanaApproveCheckedInstructionName
     case .transferChecked:
-      return "TransferChecked"
+      return Strings.Wallet.solanaTransferCheckedInstructionName
     case .mintToChecked:
-      return "MintToChecked"
+      return Strings.Wallet.solanaMintToInstructionName
     case .burnChecked:
-      return "BurnChecked"
+      return Strings.Wallet.solanaBurnCheckedInstructionName
     case .syncNative:
-      return "SyncNative"
+      return Strings.Wallet.solanaSyncNativeInstructionName
     @unknown default:
-      return "Unknown"
+      return Strings.Wallet.solanaUnknownInstructionName
     }
   }
 }
@@ -142,7 +142,6 @@ extension BraveWallet.DecodedSolanaInstructionData {
     case seed
     case fromSeed = "from_seed"
     case fromOwner = "from_owner"
-    /// should be moved to `accountMetas`, not available in params
     case nonceAccount = "nonce_account"
     case authorityType = "authority_type"
     case newAuthority = "new_authority"

--- a/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
+++ b/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
@@ -1,0 +1,153 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+
+extension BraveWallet.SolanaInstruction {
+  
+  var isSystemProgram: Bool {
+    programId == BraveWallet.SolanaSystemProgramId
+  }
+  
+  var isTokenProgram: Bool {
+    programId == BraveWallet.SolanaTokenProgramId
+  }
+  
+  var isAssociatedTokenProgram: Bool {
+    programId == BraveWallet.SolanaAssociatedTokenProgramId
+  }
+  
+  var isSysvarRentProgram: Bool {
+    programId == BraveWallet.SolanaSysvarRentProgramId
+  }
+  
+  var instructionName: String {
+    guard let decodedData = self.decodedData else {
+      return "Unknown"
+    }
+    if isSystemProgram,
+       let instructionType = BraveWallet.SolanaSystemInstruction(rawValue: Int(decodedData.instructionType)) {
+      let name = instructionType.name
+      return "System Program - \(name)"
+    } else if isTokenProgram, let instructionType = BraveWallet.SolanaTokenInstruction(rawValue: Int(decodedData.instructionType)) {
+      let name = instructionType.name
+      return "Token Program - \(name)"
+    }
+    return "Unknown"
+  }
+}
+
+extension BraveWallet.SolanaSystemInstruction {
+  var name: String {
+    switch self {
+    case .transfer:
+      return "Transfer"
+    case .transferWithSeed:
+      return "TransferWithSeed"
+    case .withdrawNonceAccount:
+      return "WithdrawNonceAccount"
+    case .createAccount:
+      return "CreateAccount"
+    case .createAccountWithSeed:
+      return "CreateAccountWithSeed"
+    case .assign:
+      return "Assign"
+    case .assignWithSeed:
+      return "AssignWithSeed"
+    case .allocate:
+      return "Allocate"
+    case .allocateWithSeed:
+      return "AllocateWithSeed"
+    case .advanceNonceAccount:
+      return "AdvanceNonceAccount"
+    case .initializeNonceAccount:
+      return "InitializeNonceAccount"
+    case .authorizeNonceAccount:
+      return "AuthorizeNonceAccount"
+    case .upgradeNonceAccount:
+      return "UpgradeNonceAccount"
+    default:
+      return "Unknown"
+    }
+  }
+}
+
+extension BraveWallet.SolanaTokenInstruction {
+  var name: String {
+    switch self {
+    case .initializeMint:
+      return "InitializeMint"
+    case .initializeMint2:
+      return "InitializeMint2"
+    case .initializeAccount:
+      return "InitializeAccount"
+    case .initializeAccount2:
+      return "InitializeAccount2"
+    case .initializeAccount3:
+      return "InitializeAccount3"
+    case .initializeMultisig:
+      return "InitializeMultisig"
+    case .initializeMultisig2:
+      return "InitializeMultisig2"
+    case .approve:
+      return "Approve"
+    case .transfer:
+      return "Transfer"
+    case .revoke:
+      return "Revoke"
+    case .setAuthority:
+      return "SetAuthority"
+    case .mintTo:
+      return "MintTo"
+    case .burn:
+      return "Burn"
+    case .closeAccount:
+      return "CloseAccount"
+    case .freezeAccount:
+      return "FreezeAccount"
+    case .thawAccount:
+      return "ThawAccount"
+    case .approveChecked:
+      return "ApproveChecked"
+    case .transferChecked:
+      return "TransferChecked"
+    case .mintToChecked:
+      return "MintToChecked"
+    case .burnChecked:
+      return "BurnChecked"
+    case .syncNative:
+      return "SyncNative"
+    @unknown default:
+      return "Unknown"
+    }
+  }
+}
+
+extension BraveWallet.DecodedSolanaInstructionData {
+  func paramFor(_ paramKey: ParamKey) -> BraveWallet.SolanaInstructionParam? {
+    params.first(where: { $0.name == paramKey.rawValue })
+  }
+  
+  // brave-core/components/brave_wallet/browser/solana_instruction_data_decoder.cc
+  // GetSystemInstructionParams() / GetTokenInstructionParams()
+  enum ParamKey: String {
+    case lamports
+    case amount
+    case decimals
+    case space
+    case owner
+    case base
+    case seed
+    case fromSeed = "from_seed"
+    case fromOwner = "from_owner"
+    /// should be moved to `accountMetas`, not available in params
+    case nonceAccount = "nonce_account"
+    case authorityType = "authority_type"
+    case newAuthority = "new_authority"
+    case mintAuthority = "mint_authority"
+    case freezeAuthority = "freeze_authority"
+    case numOfSigners = "num_of_signers"
+  }
+}

--- a/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
+++ b/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
@@ -42,13 +42,9 @@ struct SignTransactionView: View {
     request.instructions
       .map { instructionsForOneTx in
         instructionsForOneTx
-          .map { TransactionParser.solanaInstructionFormatted($0) }
-          .enumerated()
-          .map { (index, formattedInstruction) in "Instruction #\(index + 1)\n\(formattedInstruction)" }
+          .map { TransactionParser.parseSolanaInstruction($0).toString }
           .joined(separator: "\n\n") // separator between each instruction
       }
-      .enumerated()
-      .map { (index, formattedTxInstructions) in "Transaction #\(index + 1)\n\(formattedTxInstructions)" }
       .joined(separator: "\n\n\n\n") // separator between each transaction
   }
   

--- a/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
+++ b/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
@@ -11,6 +11,18 @@ struct SignTransactionView: View {
   enum Request {
     case signTransaction(BraveWallet.SignTransactionRequest)
     case signAllTransactions(BraveWallet.SignAllTransactionsRequest)
+    
+    var instructions: [[BraveWallet.SolanaInstruction]] {
+      switch self {
+      case let .signTransaction(request):
+        if let instructions = request.txData.solanaTxData?.instructions {
+          return [instructions]
+        }
+        return []
+      case let .signAllTransactions(request):
+        return request.txDatas.map { $0.solanaTxData?.instructions ?? [] }
+      }
+    }
   }
   
   var request: Request
@@ -26,27 +38,48 @@ struct SignTransactionView: View {
     }
   }
   
+  private func instructionsDisplayString() -> String {
+    request.instructions
+      .map { instructionsForOneTx in
+        instructionsForOneTx
+          .map { TransactionParser.solanaInstructionFormatted($0) }
+          .enumerated()
+          .map { (index, formattedInstruction) in "Instruction #\(index + 1)\n\(formattedInstruction)" }
+          .joined(separator: "\n\n") // separator between each instruction
+      }
+      .enumerated()
+      .map { (index, formattedTxInstructions) in "Transaction #\(index + 1)\n\(formattedTxInstructions)" }
+      .joined(separator: "\n\n\n\n") // separator between each transaction
+  }
+  
   var body: some View { // TODO: Issue #6005 - SignTransaction / SignAllTransactions panel
-    Color.gray
-      .overlay(
-        Button(action: {
-          switch request {
-          case let .signTransaction(request):
-            cryptoStore.handleWebpageRequestResponse(
-              .signTransaction(approved: false, id: request.id, signature: nil, error: "User rejected the request")
-            )
-          case let .signAllTransactions(request):
-            cryptoStore.handleWebpageRequestResponse(
-              .signAllTransactions(approved: false, id: request.id, signatures: nil, error: "User rejected the request")
-            )
-          }
-          onDismiss()
-        }) {
-          Text(Strings.Wallet.rejectTransactionButtonTitle)
+    VStack {
+      StaticTextView(text: instructionsDisplayString(), isMonospaced: false)
+        .frame(maxWidth: .infinity)
+        .frame(height: 200)
+        .background(Color(.tertiaryBraveGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+        .padding()
+        .background(Color(.secondaryBraveGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+      Button(action: {
+        switch request {
+        case let .signTransaction(request):
+          cryptoStore.handleWebpageRequestResponse(
+            .signTransaction(approved: false, id: request.id, signature: nil, error: "User rejected the request")
+          )
+        case let .signAllTransactions(request):
+          cryptoStore.handleWebpageRequestResponse(
+            .signAllTransactions(approved: false, id: request.id, signatures: nil, error: "User rejected the request")
+          )
         }
-          .buttonStyle(BraveFilledButtonStyle(size: .large))
-      )
-      .navigationBarTitleDisplayMode(.inline)
-      .navigationTitle(Text(navigationTitle))
+        onDismiss()
+      }) {
+        Text(Strings.Wallet.rejectTransactionButtonTitle)
+      }
+        .buttonStyle(BraveFilledButtonStyle(size: .large))
+    }
+    .navigationBarTitleDisplayMode(.inline)
+    .navigationTitle(Text(navigationTitle))
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2920,5 +2920,12 @@ extension Strings {
       value: "Buy crypto with Visa or Mastercard.",
       comment: "The description of one of the 'Wyre' provider."
     )
+    public static let solanaDappTransactionTitle = NSLocalizedString(
+      "wallet.solanaDappTransactionTitle",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Approve Transaction",
+      comment: "The title displayed above the value of a Solana dapp transaction in transaction confirmation view, transaction details view and transaction summary rows."
+    )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2927,5 +2927,285 @@ extension Strings {
       value: "Approve Transaction",
       comment: "The title displayed above the value of a Solana dapp transaction in transaction confirmation view, transaction details view and transaction summary rows."
     )
+    public static let solanaSystemProgramName = NSLocalizedString(
+      "wallet.solanaSystemProgramName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "System Program - %@",
+      comment: "The title displayed beside the name of any Solana System Program instruction type. '%@' will be replaced with the instruction's name, ex. \"System Program - Transfer\""
+    )
+    public static let solanaTransferInstructionName = NSLocalizedString(
+      "wallet.solanaTransferInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Transfer",
+      comment: "The title displayed above the System Program & Token Program Transfer instruction type for Solana Instruction details."
+    )
+    public static let solanaTransferWithSeedInstructionName = NSLocalizedString(
+      "wallet.solanaTransferWithSeedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Transfer With Seed",
+      comment: "The title displayed above the System Program TransferWithSeed instruction type for Solana Instruction details."
+    )
+    public static let solanaWithdrawNonceAccountInstructionName = NSLocalizedString(
+      "wallet.solanaWithdrawNonceAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Withdraw Nonce Account",
+      comment: "The title displayed above the System Program WithdrawNonceAccount instruction type for Solana Instruction details."
+    )
+    public static let solanaCreateAccountInstructionName = NSLocalizedString(
+      "wallet.solanaCreateAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Create Account",
+      comment: "The title displayed above the System Program CreateAccount instruction type for Solana Instruction details."
+    )
+    public static let solanaCreateAccountWithSeedInstructionName = NSLocalizedString(
+      "wallet.solanaCreateAccountWithSeedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Create Account With Seed",
+      comment: "The title displayed above the System Program CreateAccountWithSeed instruction type for Solana Instruction details."
+    )
+    public static let solanaAssignInstructionName = NSLocalizedString(
+      "wallet.solanaAssignInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Assign",
+      comment: "The title displayed above the System Program Assign instruction type for Solana Instruction details."
+    )
+    public static let solanaAssignWithSeedInstructionName = NSLocalizedString(
+      "wallet.solanaAssignWithSeedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Assign With Seed",
+      comment: "The title displayed above the System Program AssignWithSeed instruction type for Solana Instruction details."
+    )
+    public static let solanaAllocateInstructionName = NSLocalizedString(
+      "wallet.solanaAllocateInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Allocate",
+      comment: "The title displayed above the System Program Allocate instruction type for Solana Instruction details."
+    )
+    public static let solanaAllocateWithSeedInstructionName = NSLocalizedString(
+      "wallet.solanaAllocateWithSeedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Allocate With Seed",
+      comment: "The title displayed above the System Program AllocateWithSeed instruction type for Solana Instruction details."
+    )
+    public static let solanaAdvanceNonceAccountInstructionName = NSLocalizedString(
+      "wallet.solanaAdvanceNonceAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Advance Nonce Account",
+      comment: "The title displayed above the System Program AdvanceNonceAccount instruction type for Solana Instruction details."
+    )
+    public static let solanaInitializeNonceAccountInstructionName = NSLocalizedString(
+      "wallet.solanaInitializeNonceAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Nonce Account",
+      comment: "The title displayed above the System Program InitializeNonceAccount instruction type for Solana Instruction details."
+    )
+    public static let solanaAuthorizeNonceAccountInstructionName = NSLocalizedString(
+      "wallet.solanaAuthorizeNonceAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Authorize Nonce Account",
+      comment: "The title displayed above the System Program AuthorizeNonceAccount instruction type for Solana Instruction details."
+    )
+    public static let solanaUpgradeNonceAccountInstructionName = NSLocalizedString(
+      "wallet.solanaUpgradeNonceAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Upgrade Nonce Account",
+      comment: "The title displayed above the System Program UpgradeNonceAccount instruction type for Solana Instruction details."
+    )
+    public static let solanaTokenProgramName = NSLocalizedString(
+      "wallet.solanaTokenProgramName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Token Program - %@",
+      comment: "The title displayed beside the name of any Solana Token Program instruction type. '%@' will be replaced with the instruction's name, ex. \"Token Program - Initialize Mint\""
+    )
+    public static let solanaInitializeMintInstructionName = NSLocalizedString(
+      "wallet.solanaInitializeMintInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Mint",
+      comment: "The title displayed above the Token Program InitializeMint instruction type for Solana Instruction details."
+    )
+    public static let solanaInitializeMint2InstructionName = NSLocalizedString(
+      "wallet.solanaInitializeMint2InstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Mint 2",
+      comment: "The title displayed above the Token Program InitializeMint2 instruction type for Solana Instruction details."
+    )
+    public static let solanaInitializeAccountInstructionName = NSLocalizedString(
+      "wallet.solanaInitializeAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Account",
+      comment: "The title displayed above the Token Program InitializeAccount instruction type for Solana Instruction details."
+    )
+    public static let solanaInitializeAccount2InstructionName = NSLocalizedString(
+      "wallet.solanaInitializeAccount2InstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Account 2",
+      comment: "The title displayed above the Token Program InitializeAccount2 instruction type for Solana Instruction details."
+    )
+    public static let solanaInitializeAccount3InstructionName = NSLocalizedString(
+      "wallet.solanaInitializeAccount3InstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Account 3",
+      comment: "The title displayed above the Token Program InitializeAccount3 instruction type for Solana Instruction details."
+    )
+    public static let solanaInitializeMultisigInstructionName = NSLocalizedString(
+      "wallet.solanaInitializeMultisigInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Multisig",
+      comment: "The title displayed above the Token Program InitializeMultisig instruction type for Solana Instruction details."
+    )
+    public static let solanaInitializeMultisig2InstructionName = NSLocalizedString(
+      "wallet.solanaInitializeMultisig2InstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Initialize Multisig 2",
+      comment: "The title displayed above the Token Program InitializeMultisig2 instruction type for Solana Instruction details."
+    )
+    public static let solanaApproveInstructionName = NSLocalizedString(
+      "wallet.solanaApproveInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Approve",
+      comment: "The title displayed above the Token Program Approve instruction type for Solana Instruction details."
+    )
+    public static let solanaRevokeInstructionName = NSLocalizedString(
+      "wallet.solanaRevokeInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Revoke",
+      comment: "The title displayed above the Token Program Revoke instruction type for Solana Instruction details."
+    )
+    public static let solanaSetAuthorityInstructionName = NSLocalizedString(
+      "wallet.solanaSetAuthorityInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Set Authority",
+      comment: "The title displayed above the Token Program Set Authority instruction type for Solana Instruction details."
+    )
+    public static let solanaMintToInstructionName = NSLocalizedString(
+      "wallet.solanaMintToInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Mint To",
+      comment: "The title displayed above the Token Program Mint To instruction type for Solana Instruction details."
+    )
+    public static let solanaBurnInstructionName = NSLocalizedString(
+      "wallet.solanaBurnInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Burn",
+      comment: "The title displayed above the Token Program Burn instruction type for Solana Instruction details."
+    )
+    public static let solanaCloseAccountInstructionName = NSLocalizedString(
+      "wallet.solanaCloseAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Close Account",
+      comment: "The title displayed above the Token Program Close Account instruction type for Solana Instruction details."
+    )
+    public static let solanaFreezeAccountInstructionName = NSLocalizedString(
+      "wallet.solanaFreezeAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Freeze Account",
+      comment: "The title displayed above the Token Program Freeze Account instruction type for Solana Instruction details."
+    )
+    public static let solanaThawAccountInstructionName = NSLocalizedString(
+      "wallet.solanaThawAccountInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Thaw Account",
+      comment: "The title displayed above the Token Program Thaw Account instruction type for Solana Instruction details."
+    )
+    public static let solanaApproveCheckedInstructionName = NSLocalizedString(
+      "wallet.solanaApproveCheckedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Approve Checked",
+      comment: "The title displayed above the Token Program Approved Checked instruction type for Solana Instruction details."
+    )
+    public static let solanaTransferCheckedInstructionName = NSLocalizedString(
+      "wallet.solanaTransferCheckedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Transfer Checked",
+      comment: "The title displayed above the Token Program Transfer Checked instruction type for Solana Instruction details."
+    )
+    public static let solanaMintToCheckedInstructionName = NSLocalizedString(
+      "wallet.solanaMintToCheckedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Mint To Checked",
+      comment: "The title displayed above the Token Program Mint To Checked instruction type for Solana Instruction details."
+    )
+    public static let solanaBurnCheckedInstructionName = NSLocalizedString(
+      "wallet.solanaBurnCheckedInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Burn Checked",
+      comment: "The title displayed above the Token Program Burn Checked instruction type for Solana Instruction details."
+    )
+    public static let solanaSyncNativeInstructionName = NSLocalizedString(
+      "wallet.solanaSyncNativeInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Sync Native",
+      comment: "The title displayed above the Token Program Sync Native instruction type for Solana Instruction details."
+    )
+    public static let solanaAmount = NSLocalizedString(
+      "wallet.solanaAmount",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Amount",
+      comment: "The label displayed beside the formatted amount of an instruction type. Ex. \"Amount: 0.1 SOL\""
+    )
+    public static let solanaUnknownInstructionName = NSLocalizedString(
+      "wallet.solanaUnknownInstructionName",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Unknown Instruction Type",
+      comment: "The title displayed above an unknown instruction type for Solana Instruction details."
+    )
+    public static let solanaInstructionProgramId = NSLocalizedString(
+      "wallet.solanaInstructionProgramId",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Program Id",
+      comment: "The label displayed beside the Program Id for an instruction type we don't support decoding. Ex. \"Program Id: 1111223344aabbccd\""
+    )
+    public static let solanaInstructionAccounts = NSLocalizedString(
+      "wallet.solanaInstructionAccounts",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Program Id",
+      comment: "The label displayed beside the Accounts for an instruction type we don't support decoding. Ex. \"Accounts: <solana_public_key>\""
+    )
+    public static let solanaInstructionData = NSLocalizedString(
+      "wallet.solanaInstructionData",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Data",
+      comment: "The label displayed beside the Data for an instruction type we don't support decoding. Ex. \"Data: [1, 20, 3, 5, 50]]\""
+    )
   }
 }

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -6,6 +6,7 @@
 import XCTest
 import BraveCore
 @testable import BraveWallet
+import CustomDump
 
 private extension BraveWallet.AccountInfo {
   convenience init(
@@ -783,5 +784,143 @@ class TransactionParserTests: XCTestCase {
     }
     
     XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+  
+  func testParseSolanaInstruction() {
+    let fromPubkey = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeee"
+    let toPubkey = "zzzzzzzzzzyyyyyyyyyyxxxxxxxxxxwwwwwwwwwwvvvv"
+    let transferInstruction = BraveWallet.SolanaInstruction(
+      programId: BraveWallet.SolanaSystemProgramId,
+      accountMetas: [
+        .init(pubkey: fromPubkey, isSigner: false, isWritable: false),
+        .init(pubkey: toPubkey, isSigner: false, isWritable: false)
+      ],
+      data: [],
+      decodedData: .init(
+        instructionType: UInt32(BraveWallet.SolanaSystemInstruction.transfer.rawValue),
+        accountParams: [
+          .init(name: "from_account", localizedName: "From Account"),
+          .init(name: "to_account", localizedName: "To Account"),],
+        params: [.init(name: "lamports", localizedName: "Lamports", value: "10000")]
+      )
+    )
+    let expectedParsedTransfer = SolanaDappTxDetails.ParsedSolanaInstruction(
+      name: "System Program - Transfer",
+      details: [
+        .init(key: "From Account", value: fromPubkey),
+        .init(key: "To Account", value: toPubkey),
+        .init(key: "Lamports", value: "0.00001 SOL")
+      ],
+      instruction: transferInstruction
+    )
+    XCTAssertNoDifference(expectedParsedTransfer, TransactionParser.parseSolanaInstruction(transferInstruction))
+    
+    let withdrawNonceAccountInstruction = BraveWallet.SolanaInstruction(
+      programId: BraveWallet.SolanaSystemProgramId,
+      accountMetas: [
+        .init(pubkey: fromPubkey, isSigner: false, isWritable: false),
+        .init(pubkey: toPubkey, isSigner: false, isWritable: false),
+        .init(pubkey: "SysvarRecentB1ockHashes11111111111111111111", isSigner: false, isWritable: false),
+        .init(pubkey: "SysvarRent111111111111111111111111111111111", isSigner: false, isWritable: false),
+        .init(pubkey: toPubkey, isSigner: false, isWritable: false),
+      ],
+      data: [],
+      decodedData: .init(
+        instructionType: UInt32(BraveWallet.SolanaSystemInstruction.withdrawNonceAccount.rawValue),
+        accountParams: [
+          .init(name: "nonce_account", localizedName: "Nonce Account"),
+          .init(name: "to_account", localizedName: "To Account"),
+          .init(name: "recentblockhashes_sysvar", localizedName: "RecentBlockhashes sysvar"),
+          .init(name: "rent_sysvar", localizedName: "Rent sysvar"),
+          .init(name: "nonce_authority", localizedName: "Nonce Authority")
+        ],
+        params: [
+          .init(name: "lamports", localizedName: "Lamports", value: "40")
+        ]
+      )
+    )
+    let expectedParsedWithdrawNonceAccount = SolanaDappTxDetails.ParsedSolanaInstruction(
+      name: "System Program - WithdrawNonceAccount",
+      details: [
+        .init(key: "Nonce Account", value: fromPubkey),
+        .init(key: "To Account", value: toPubkey),
+        .init(key: "RecentBlockhashes sysvar", value: "SysvarRecentB1ockHashes11111111111111111111"),
+        .init(key: "Rent sysvar", value: "SysvarRent111111111111111111111111111111111"),
+        .init(key: "Nonce Authority", value: toPubkey),
+        .init(key: "Lamports", value: "0.00000004 SOL")
+      ],
+      instruction: withdrawNonceAccountInstruction
+    )
+    XCTAssertNoDifference(expectedParsedWithdrawNonceAccount, TransactionParser.parseSolanaInstruction(withdrawNonceAccountInstruction))
+    
+    let createAccountInstruction = BraveWallet.SolanaInstruction(
+      programId: BraveWallet.SolanaSystemProgramId,
+      accountMetas: [
+        .init(pubkey: fromPubkey, isSigner: false, isWritable: false),
+        .init(pubkey: toPubkey, isSigner: false, isWritable: false),
+      ],
+      data: [],
+      decodedData: .init(
+        instructionType: UInt32(BraveWallet.SolanaSystemInstruction.createAccount.rawValue),
+        accountParams: [
+          .init(name: "from_account", localizedName: "From Account"),
+          .init(name: "new_account", localizedName: "New Account"),
+        ],
+        params: [
+          .init(name: "lamports", localizedName: "Lamports", value: "2000"),
+          .init(name: "space", localizedName: "Space", value: "1"),
+          .init(name: "owner_program", localizedName: "Owner Program", value: toPubkey)
+        ]
+      )
+    )
+    let expectedParsedCreateAccount = SolanaDappTxDetails.ParsedSolanaInstruction(
+      name: "System Program - CreateAccount",
+      details: [
+        .init(key: "From Account", value: fromPubkey),
+        .init(key: "New Account", value: toPubkey),
+        .init(key: "Lamports", value: "0.000002 SOL"),
+        .init(key: "Space", value: "1"),
+        .init(key: "Owner Program", value: toPubkey)
+      ],
+      instruction: createAccountInstruction
+    )
+    XCTAssertNoDifference(expectedParsedCreateAccount, TransactionParser.parseSolanaInstruction(createAccountInstruction))
+    
+    let createAccountWithSeedInstruction = BraveWallet.SolanaInstruction(
+      programId: BraveWallet.SolanaSystemProgramId,
+      accountMetas: [
+        .init(pubkey: fromPubkey, isSigner: false, isWritable: false),
+        .init(pubkey: toPubkey, isSigner: false, isWritable: false),
+      ],
+      data: [],
+      decodedData: .init(
+        instructionType: UInt32(BraveWallet.SolanaSystemInstruction.createAccountWithSeed.rawValue),
+        accountParams: [
+          .init(name: "from_account", localizedName: "From Account"),
+          .init(name: "created_account", localizedName: "Created Account"),
+        ],
+        params: [
+          .init(name: "lamports", localizedName: "Lamports", value: "300"),
+          .init(name: "base", localizedName: "Base", value: toPubkey),
+          .init(name: "seed", localizedName: "Seed", value: ""),
+          .init(name: "space", localizedName: "Space", value: "1"),
+          .init(name: "owner_program", localizedName: "Owner Program", value: toPubkey)
+        ]
+      )
+    )
+    let expectedParsedCreateAccountWithSeed = SolanaDappTxDetails.ParsedSolanaInstruction(
+      name: "System Program - CreateAccountWithSeed",
+      details: [
+        .init(key: "From Account", value: fromPubkey),
+        .init(key: "Created Account", value: toPubkey),
+        .init(key: "Lamports", value: "0.0000003 SOL"),
+        .init(key: "Base", value: toPubkey),
+        .init(key: "Seed", value: ""),
+        .init(key: "Space", value: "1"),
+        .init(key: "Owner Program", value: toPubkey)
+      ],
+      instruction: createAccountWithSeedInstruction
+    )
+    XCTAssertNoDifference(expectedParsedCreateAccountWithSeed, TransactionParser.parseSolanaInstruction(createAccountWithSeedInstruction))
   }
 }

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -809,7 +809,8 @@ class TransactionParserTests: XCTestCase {
       details: [
         .init(key: "From Account", value: fromPubkey),
         .init(key: "To Account", value: toPubkey),
-        .init(key: "Lamports", value: "0.00001 SOL")
+        .init(key: "Amount", value: "0.00001 SOL"),
+        .init(key: "Lamports", value: "10000")
       ],
       instruction: transferInstruction
     )
@@ -840,14 +841,15 @@ class TransactionParserTests: XCTestCase {
       )
     )
     let expectedParsedWithdrawNonceAccount = SolanaDappTxDetails.ParsedSolanaInstruction(
-      name: "System Program - WithdrawNonceAccount",
+      name: "System Program - Withdraw Nonce Account",
       details: [
         .init(key: "Nonce Account", value: fromPubkey),
         .init(key: "To Account", value: toPubkey),
         .init(key: "RecentBlockhashes sysvar", value: "SysvarRecentB1ockHashes11111111111111111111"),
         .init(key: "Rent sysvar", value: "SysvarRent111111111111111111111111111111111"),
         .init(key: "Nonce Authority", value: toPubkey),
-        .init(key: "Lamports", value: "0.00000004 SOL")
+        .init(key: "Amount", value: "0.00000004 SOL"),
+        .init(key: "Lamports", value: "40")
       ],
       instruction: withdrawNonceAccountInstruction
     )
@@ -874,11 +876,12 @@ class TransactionParserTests: XCTestCase {
       )
     )
     let expectedParsedCreateAccount = SolanaDappTxDetails.ParsedSolanaInstruction(
-      name: "System Program - CreateAccount",
+      name: "System Program - Create Account",
       details: [
         .init(key: "From Account", value: fromPubkey),
         .init(key: "New Account", value: toPubkey),
-        .init(key: "Lamports", value: "0.000002 SOL"),
+        .init(key: "Amount", value: "0.000002 SOL"),
+        .init(key: "Lamports", value: "2000"),
         .init(key: "Space", value: "1"),
         .init(key: "Owner Program", value: toPubkey)
       ],
@@ -909,11 +912,12 @@ class TransactionParserTests: XCTestCase {
       )
     )
     let expectedParsedCreateAccountWithSeed = SolanaDappTxDetails.ParsedSolanaInstruction(
-      name: "System Program - CreateAccountWithSeed",
+      name: "System Program - Create Account With Seed",
       details: [
         .init(key: "From Account", value: fromPubkey),
         .init(key: "Created Account", value: toPubkey),
-        .init(key: "Lamports", value: "0.0000003 SOL"),
+        .init(key: "Amount", value: "0.0000003 SOL"),
+        .init(key: "Lamports", value: "300"),
         .init(key: "Base", value: toPubkey),
         .init(key: "Seed", value: ""),
         .init(key: "Space", value: "1"),


### PR DESCRIPTION
## Summary of Changes
- Add support for parsing `SolanaInstruction` from a Solana transaction for displaying instructions for Solana dapp sign and send transactions, sign transaction / sign all transaction requests.
- `TransactionParser.parseSolanaInstruction(_ instruction: BraveWallet.SolanaInstruction) -> SolanaDappTxDetails.ParsedSolanaInstruction` can be used on it's own for sign transaction / sign all transactions request

This pull request fixes #6004

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
0. Enable Solana Dapps feature flag
1. Open test solana dapp site in code sandbox: https://codesandbox.io/s/github/darkdh/solana-provider-test
2. Edit values of transactions to test different Solana Instructions
3. Tap 'open in a new window' in the site preview window
4. Tap 'Connect' to connect to the test dapp site
5. Use the 'Sign and Send Transaction' / 'Sign and Send SPL Token Transaction' buttons to create Solana dapp transactions
6. Compare Solana Dapp Transactions vs desktop; the instructions are shown in the 'details' box of Transaction Confirmation View

## Screenshots:

https://user-images.githubusercontent.com/5314553/196849040-de84e225-a8fa-48fb-9197-57fda6bd75ef.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
