### PR TITLE
No Bug: Bump BraveCore to 1.45.108

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -38,18 +38,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   var window: UIWindow?
   lazy var braveCore: BraveCoreMain = {
-    var switches: [BraveCoreSwitch: String] = [:]
+    var switches: [BraveCoreSwitch] = []
     if !AppConstants.buildChannel.isPublic {
       // Check prefs for additional switches
       let activeSwitches = Preferences.BraveCore.activeSwitches.value
       let switchValues = Preferences.BraveCore.switchValues.value
       for activeSwitch in activeSwitches {
         if let value = switchValues[activeSwitch], !value.isEmpty {
-          switches[BraveCoreSwitch(rawValue: activeSwitch)] = value
+          switches.append(.init(key: .init(rawValue: activeSwitch), value: value))
         }
       }
     }
-    switches[.rewardsFlags] = BraveRewards.Configuration.current().flags
+    switches.append(.init(key: .rewardsFlags, value: BraveRewards.Configuration.current().flags))
     return BraveCoreMain(userAgent: UserAgent.mobile, additionalSwitches: switches)
   }()
   

--- a/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
+++ b/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
@@ -8,7 +8,7 @@ import BraveShared
 import BraveCore
 import BraveUI
 
-extension BraveCoreSwitch {
+extension BraveCoreSwitchKey {
   fileprivate var displayString: String {
     switch self {
     case .vModule:
@@ -34,7 +34,7 @@ private struct BasicStringInputView: View {
   @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
   @Environment(\.presentationMode) @Binding private var presentationMode
 
-  var coreSwitch: BraveCoreSwitch
+  var coreSwitch: BraveCoreSwitchKey
   var hint: String?
 
   @State private var text: String = ""
@@ -87,7 +87,7 @@ private struct BasicPickerInputView: View {
   @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
   @Environment(\.presentationMode) @Binding private var presentationMode
 
-  var coreSwitch: BraveCoreSwitch
+  var coreSwitch: BraveCoreSwitchKey
   var options: [String]
 
   @State private var selectedItem: String = ""
@@ -143,9 +143,9 @@ struct BraveCoreDebugSwitchesView: View {
     @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
     @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
 
-    var coreSwitch: BraveCoreSwitch
+    var coreSwitch: BraveCoreSwitchKey
 
-    init(_ coreSwitch: BraveCoreSwitch) {
+    init(_ coreSwitch: BraveCoreSwitchKey) {
       self.coreSwitch = coreSwitch
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.108/brave-core-ios-1.45.108.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.91",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
-      "integrity": "sha512-IuKDCOs3PiZEdu7vm+i3nGRAuwpbZEGBZBYtNk3j1m41qUNXIprJEG2L4zXc2YFTmbqSHkoMfxRN+mtmxmAA8A==",
+      "version": "1.45.108",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.108/brave-core-ios-1.45.108.tgz",
+      "integrity": "sha512-aoWf971qyYCHX9pXbW0VTfWW/hzYNz/N4HN0xh081X8EQMVsDq0rcuaUMt521mAvOLH2yt/BNWEyuM5V83sqiA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
-      "integrity": "sha512-IuKDCOs3PiZEdu7vm+i3nGRAuwpbZEGBZBYtNk3j1m41qUNXIprJEG2L4zXc2YFTmbqSHkoMfxRN+mtmxmAA8A=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.108/brave-core-ios-1.45.108.tgz",
+      "integrity": "sha512-aoWf971qyYCHX9pXbW0VTfWW/hzYNz/N4HN0xh081X8EQMVsDq0rcuaUMt521mAvOLH2yt/BNWEyuM5V83sqiA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.91/brave-core-ios-1.45.91.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.108/brave-core-ios-1.45.108.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
Fixes refactor around Brave Core switches

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
