### PR TITLE
Fix #6174: Send to your device flow modals too large in landscape view

### DIFF
--- a/Client/Frontend/Browser/SendTab/SendTabProcessController.swift
+++ b/Client/Frontend/Browser/SendTab/SendTabProcessController.swift
@@ -35,6 +35,8 @@ class SendTabProcessController: SendTabTransitioningController {
   
   struct UX {
     static let contentInset = 20.0
+    static let maxTabletWidth = 400
+    static let maxPhoneWidth = 300
   }
   
   private let processTypeImageView = UIImageView().then {
@@ -102,7 +104,15 @@ class SendTabProcessController: SendTabTransitioningController {
     
     containerView.snp.makeConstraints {
       $0.centerX.centerY.equalToSuperview()
-      $0.width.equalToSuperview().multipliedBy(0.75)
+      if traitCollection.verticalSizeClass == .compact {
+        $0.width.greaterThanOrEqualTo(UX.maxPhoneWidth)
+      } else {
+        if traitCollection.horizontalSizeClass == .regular {
+          $0.width.greaterThanOrEqualTo(UX.maxTabletWidth)
+        } else {
+          $0.width.equalToSuperview().multipliedBy(0.75)
+        }
+      }
       $0.height.equalTo(containerView.snp.width)
     }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Send Tab Progress/Process pop over adjustment

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6174

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Connect to sync chain
2. Open a webpage
3. Change device to landscape view
4. Select menu > Send to your devices from the shared menu
5. Select recipient device in the first modal, tap send
6. Observe sending... and sent modals

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


![devicesizes](https://user-images.githubusercontent.com/6643505/197041224-80ad7085-cd0b-471f-bef9-4843352ece3b.png)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
