### PR TITLE
Fix #6223: Playlist detection can only apply to pages and not video nodes

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
@@ -53,9 +53,15 @@ window.__firefox__.includeOnce("Playlist", function($) {
   function tagNode(node) {
     if (node) {
       if (!node.$<tagUUID>) {
-        node.$<tagUUID> = uuid_v4();
         node.addEventListener('webkitpresentationmodechanged', (e) => e.stopPropagation(), true);
       }
+      
+      // This is awful on dynamic websites.
+      // Some websites are now using the re-using video tag even if the page itself, and the history changes.
+      // I no longer have a proper way to detect if a video was already detected.
+      // IE: If a page has TWO videos on it, there is no way to display which was already added, as we have to now rely on PageURL
+      // or video src (or <source> tag)
+      node.$<tagUUID> = uuid_v4();
     }
   }
   


### PR DESCRIPTION
## Summary of Changes
- Revert change to node UUID. We can no longer detect UNIQUE videos on a page due to popular sites like Youtube "re-using" the exact same video tag. Previously, it would re-create the page itself dynamically, this meant discarding the video tag. But now it doesn't even do that, and just re-uses the same tags, and modifies only the <source> tags and "src" attributes.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6223

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test adding multiple videos and playing them. Make sure that playing two different videos does NOT play the same video over and over.
- Test deleting a single video and make sure only that video gets deleted, and nothing else.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
