### PR TITLE
Fix #6221: Allow url bar state reset after orientation change & keyboard

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Keyboard.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Keyboard.swift
@@ -41,7 +41,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
   
   public func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
     keyboardState = nil
-    if isUsingBottomBar && !topToolbar.inOverlayMode && (presentedViewController == nil || collapsedURLBarView.isKeyboardVisible) {
+    if isUsingBottomBar && !topToolbar.inOverlayMode &&
+        (presentedViewController == nil || collapsedURLBarView.isKeyboardVisible) /* Always reset things if collapsed url bar is visible */ ||
+        !toolbarVisibilityViewModel.isEnabled /* Always reset things after orientation change that may change bottom bar */ {
       UIView.animate(withDuration: 0.1) { [self] in
         // We can't actually set the toolbar state to expanded since bar collapsing/expanding is based on
         // many web view traits such as content size and such so we will just use the collapsed bar view


### PR DESCRIPTION
When orientation changes to landscape while the keyboard is visible `isUsingBottomBar` is no longer true, thus we don't reset the changes we've made the toolbars. This adds a check to see if we've disabled the toolbar visibility handler even without being in bottom bar mode

## Summary of Changes

This pull request fixes #6221

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
