### PR TITLE
Fix #6157: Tab restores with a light grey / disabled close button

### DIFF
--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -135,6 +135,12 @@ class TabsBarViewController: UIViewController {
       }
       .store(in: &cancellables)
   }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    
+    updateOverflowIndicatorsLayout(addButtonIncluded: true)
+  }
 
   private var privateModeCancellable: AnyCancellable?
   private func updateColors(_ isPrivateBrowsing: Bool) {
@@ -269,13 +275,16 @@ class TabsBarViewController: UIViewController {
     return max(overflow, 0)
   }
 
-  private func updateOverflowIndicatorsLayout() {
+  private func updateOverflowIndicatorsLayout(addButtonIncluded: Bool = false) {
     let offset = Float(collectionView.contentOffset.x)
     let startFade = Float(30)
     leftOverflowIndicator.opacity = min(1, offset / startFade)
 
     // all the way scrolled right
-    let offsetFromRight = collectionView.contentSize.width - CGFloat(offset) - collectionView.frame.width
+    var offsetFromRight = collectionView.contentSize.width - CGFloat(offset) - collectionView.frame.width
+    if addButtonIncluded {
+      offsetFromRight -= plusButton.frame.width
+    }
     rightOverflowIndicator.opacity = min(1, Float(offsetFromRight) / startFade)
   }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->
Adding Plus button case for iPad TabsBar overflow

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6157

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Open some website on iPad
- Fully close the app via app switcher
- Re-open Brave, observe light grey close button on the tab

## Screenshots:


https://user-images.githubusercontent.com/6643505/197254008-7f4ab78c-e03f-4c8e-90cb-a17cb506b650.mov



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
