### PR TITLE
Fix #6228: Filtering out old Open Tabs Sessions ( +1 month old)

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -447,7 +447,17 @@ class TabTrayController: LoadingViewController {
   }
   
   private func fetchSyncedSessions(for query: String? = nil) -> [OpenDistantSession] {
-    let allSessions = braveCore.openTabsAPI.getSyncedSessions()
+    var allSessions = braveCore.openTabsAPI.getSyncedSessions()
+    
+    // Filter all the Open Tab Sessions older than 1 month
+    allSessions = allSessions.filter {
+      guard let modifiedTime = $0.modifiedTime else {
+        return true
+      }
+      
+      return Date() < modifiedTime.addingTimeInterval(30.days)
+    }
+    
     var queriedSessions = [OpenDistantSession]()
     
     if let query = query, !query.isEmpty {

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncContainerView.swift
@@ -64,9 +64,25 @@ extension TabTrayController {
       }
       
       tableView.tableHeaderView = headerView
+      
+      let tableFooterLabel = UILabel().then {
+        $0.textColor = .braveLabel
+        $0.textAlignment = .left
+        $0.numberOfLines = 0
+        $0.font = .preferredFont(forTextStyle: .subheadline)
+        $0.text = Strings.OpenTabs.openTabsListFooterTitle
+      }
+                 
+      let footerView = UIView(frame: .init(
+        width: tableView.frame.width, height: 60))
+      footerView.addSubview(tableFooterLabel)
 
-      // Set an empty footer to prevent empty cells from appearing in the list.
-      tableView.tableFooterView = UIView()
+      tableFooterLabel.snp.makeConstraints {
+        $0.leading.equalToSuperview().inset(16)
+        $0.top.bottom.trailing.equalToSuperview()
+      }
+      
+      tableView.tableFooterView = footerView
     }
     
     @available(*, unavailable)

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3197,6 +3197,13 @@ extension Strings {
         bundle: .strings,
         value: "Devices",
         comment: "The title displayed on table header for open tabs list from other devices")
+    public static let openTabsListFooterTitle =
+      NSLocalizedString(
+        "opentabs.openTabsListFooterTitle",
+        tableName: "BraveShared",
+        bundle: .strings,
+        value: "Open Tab Sessions older than 1 month will be filtered automatically.",
+        comment: "The title displayed on table footer for open tabs list from other devices indicating sessions older than a month is going to hidden")
   }
 }
 


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6228

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![1 1](https://user-images.githubusercontent.com/6643505/197286121-0c98588e-1010-4f1d-a94c-51980c8a246c.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
