### PR TITLE
Fix #6224: Alternative Delete logic for Playlist

### DIFF
--- a/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
+++ b/Client/Frontend/Browser/Playlist/BrowserViewController+Playlist.swift
@@ -64,7 +64,7 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate, PlaylistFolderSh
           self.dismiss(animated: true)
 
           DispatchQueue.main.async {
-            if PlaylistManager.shared.delete(itemId: item.tagId) {
+            if PlaylistManager.shared.delete(item: item) {
               self.updatePlaylistURLBar(tab: tab, state: .newItem, item: item)
             }
           }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
@@ -296,9 +296,7 @@ extension PlaylistListViewController: UITableViewDataSource {
         
         let deleteOfflineAction = UIAction(title: Strings.PlaylistFolderSharing.deleteOfflineDataMenuTitle, image: UIImage(braveSystemNamed: "brave.cloud.slash")?.template) { [unowned self] _ in
           folder.playlistItems?.forEach {
-            if let itemId = $0.uuid {
-              PlaylistManager.shared.deleteCache(itemId: itemId)
-            }
+            PlaylistManager.shared.deleteCache(item: PlaylistInfo(item: $0))
           }
           
           self.tableView.reloadData()

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -63,7 +63,7 @@ private extension PlaylistListViewController {
         UIAlertAction(
           title: Strings.PlayList.removeActionButtonTitle, style: .destructive,
           handler: { [unowned self] _ in
-            _ = PlaylistManager.shared.deleteCache(itemId: item.tagId)
+            _ = PlaylistManager.shared.deleteCache(item: item)
             self.tableView.reloadRows(at: [indexPath], with: .automatic)
           }))
 

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -612,7 +612,11 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
   }
 
   func deleteItem(itemId: String, at index: Int) {
-    PlaylistManager.shared.delete(itemId: itemId)
+    guard let item = PlaylistItem.getItem(uuid: itemId) else {
+      return
+    }
+    
+    PlaylistManager.shared.delete(item: PlaylistInfo(item: item))
 
     if PlaylistCarplayManager.shared.currentlyPlayingItemIndex == index || PlaylistManager.shared.numberOfAssets == 0 {
       stopPlaying()

--- a/Sources/Data/models/PlaylistItem.swift
+++ b/Sources/Data/models/PlaylistItem.swift
@@ -298,8 +298,25 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
   }
 
   public static func removeItems(_ items: [PlaylistInfo], completion: (() -> Void)? = nil) {
-    let uuids = items.map({ $0.tagId })
+    var uuids = [String]()
+    var mediaSrcs = [String]()
+    
+    items.forEach({
+      if $0.tagId.isEmpty {
+        mediaSrcs.append($0.src)
+      } else {
+        uuids.append($0.tagId)
+      }
+    })
+    
     PlaylistItem.deleteAll(predicate: NSPredicate(format: "uuid IN %@", uuids), context: .new(inMemory: false), includesPropertyValues: false, completion: completion)
+    
+    if !mediaSrcs.isEmpty {
+      // As a backup, we delete by media source (not page source)
+      // This is more unique than pageSrc.
+      // This is because you can add multiple items per page but they'd each have a different media source.
+      PlaylistItem.deleteAll(predicate: NSPredicate(format: "mediaSrc IN %@", mediaSrcs), context: .new(inMemory: false), includesPropertyValues: false, completion: completion)
+    }
   }
 
   public static func moveItems(items: [NSManagedObjectID], to folderUUID: String?) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- If deleting an item fails by UUID, try to delete it by its media source url which should be unique enough to delete only that item.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6224

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test deleting playlist items
- Test deleting playlist items in different folders
- Test deleting folders with items
- Test deleting folders without items
- Test attempting to delete items in SharedFolders
- Test deleting items on different OS versions (14, 15, 16)
- Test all of the above on iPad as well.
- Test adding folders in older versions of Brave, then upgrading to a newer version, and deleting the items in those folders.


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
