### PR TITLE
Fix #6243: Adding shared playlist multiple times might not succeed 

### DIFF
--- a/Sources/Data/models/PlaylistFolder.swift
+++ b/Sources/Data/models/PlaylistFolder.swift
@@ -119,6 +119,10 @@ final public class PlaylistFolder: NSManagedObject, CRUD, Identifiable {
       
       PlaylistFolder.reorderItems(context: context)
       
+      // Issue #6243 The policy change is added to prevent merge conflicts
+      // Occasionally saving context will give error
+      // Fatal error: Error saving DB: Error Domain=NSCocoaErrorDomain Code=133020 "Could not merge changes."
+      // Merge policy should change be changed to mergeByPropertyObjectTrumpMergePolicyType to prevent this
       let policy = context.mergePolicy
       context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
       PlaylistFolder.saveContext(context)

--- a/Sources/Data/models/PlaylistFolder.swift
+++ b/Sources/Data/models/PlaylistFolder.swift
@@ -118,13 +118,23 @@ final public class PlaylistFolder: NSManagedObject, CRUD, Identifiable {
       playlistFolder.creatorLink = folder.creatorLink
       
       PlaylistFolder.reorderItems(context: context)
+      
+      let policy = context.mergePolicy
+      context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
       PlaylistFolder.saveContext(context)
+      context.mergePolicy = policy
       
       DispatchQueue.main.async {
         completion?(folderId)
       }
     }
   }
+  
+  public static func clearMemoryContext() {
+      DataController.perform(context: .existing(DataController.viewContextInMemory), save: true) { context in
+        context.reset()
+      }
+    }
 
   public static func getOtherFoldersCount() -> Int {
     PlaylistFolder.count(predicate: NSPredicate(format: "uuid != %@", PlaylistFolder.savedFolderUUID)) ?? 0

--- a/Sources/Data/models/PlaylistFolder.swift
+++ b/Sources/Data/models/PlaylistFolder.swift
@@ -129,12 +129,6 @@ final public class PlaylistFolder: NSManagedObject, CRUD, Identifiable {
       }
     }
   }
-  
-  public static func clearMemoryContext() {
-      DataController.perform(context: .existing(DataController.viewContextInMemory), save: true) { context in
-        context.reset()
-      }
-    }
 
   public static func getOtherFoldersCount() -> Int {
     PlaylistFolder.count(predicate: NSPredicate(format: "uuid != %@", PlaylistFolder.savedFolderUUID)) ?? 0

--- a/Sources/Data/models/PlaylistItem.swift
+++ b/Sources/Data/models/PlaylistItem.swift
@@ -152,6 +152,10 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
 
       PlaylistItem.reorderItems(context: context)
 
+      // Issue #6243 The policy change is added to prevent merge conflicts
+      // Occasionally saving context will give error
+      // Fatal error: Error saving DB: Error Domain=NSCocoaErrorDomain Code=133020 "Could not merge changes."
+      // Merge policy should change be changed to mergeByPropertyObjectTrumpMergePolicyType to prevent this
       let policy = context.mergePolicy
       context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
       PlaylistItem.saveContext(context)

--- a/Sources/Data/models/PlaylistItem.swift
+++ b/Sources/Data/models/PlaylistItem.swift
@@ -151,8 +151,12 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
       })
 
       PlaylistItem.reorderItems(context: context)
-      PlaylistItem.saveContext(context)
 
+      let policy = context.mergePolicy
+      context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
+      PlaylistItem.saveContext(context)
+      context.mergePolicy = policy
+      
       DispatchQueue.main.async {
         completion?()
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->
Changing merge policy while saving folder and item after re-ordering

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6243

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
