### PR TITLE
Fix #6005: Wallet solana sign transactions

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -290,7 +290,9 @@ class SolanaProviderScriptHandler: TabContentScript {
     guard status == .success else {
       return (nil, buildErrorJson(status: status, errorMessage: errorMessage))
     }
-    guard let encodedSerializedTxs = JSONSerialization.jsObject(withNative: serializedTxs) else {
+    let encodedSerializedTxs = serializedTxs.compactMap {  JSONSerialization.jsObject(withNative: $0)
+    }
+    if encodedSerializedTxs.isEmpty {
       return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
     }
     return (encodedSerializedTxs, nil)

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -261,7 +261,7 @@ class SolanaProviderScriptHandler: TabContentScript {
     guard status == .success else {
       return (nil, buildErrorJson(status: status, errorMessage: errorMessage))
     }
-    let listMojoInt = serializedTx.map({ MojoBase.Value(intValue: $0.int32Value) })
+    let listMojoInt = serializedTx.map { MojoBase.Value(intValue: $0.int32Value) }
     guard let encodedSerializedTx = MojoBase.Value(listValue: listMojoInt).jsonObject else {
       return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
     }

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -261,7 +261,8 @@ class SolanaProviderScriptHandler: TabContentScript {
     guard status == .success else {
       return (nil, buildErrorJson(status: status, errorMessage: errorMessage))
     }
-    guard let encodedSerializedTx = JSONSerialization.jsObject(withNative: serializedTx) else {
+    let listMojoInt = serializedTx.map({ MojoBase.Value(intValue: $0.int32Value) })
+    guard let encodedSerializedTx = MojoBase.Value(listValue: listMojoInt).jsonObject else {
       return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
     }
     return (encodedSerializedTx, nil)
@@ -290,9 +291,13 @@ class SolanaProviderScriptHandler: TabContentScript {
     guard status == .success else {
       return (nil, buildErrorJson(status: status, errorMessage: errorMessage))
     }
-    let encodedSerializedTxs = serializedTxs.compactMap {  JSONSerialization.jsObject(withNative: $0)
+    let encodedSerializedTxs = serializedTxs.compactMap {
+      let listMojoInt = $0.map { number in
+        MojoBase.Value(intValue: number.int32Value)
+      }
+      return MojoBase.Value(listValue: listMojoInt).jsonObject
     }
-    if encodedSerializedTxs.isEmpty {
+    guard !encodedSerializedTxs.isEmpty else {
       return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
     }
     return (encodedSerializedTxs, nil)

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -40,8 +40,8 @@ enum WebpageRequestResponse: Equatable {
   case signMessage(approved: Bool, id: Int32)
   case getEncryptionPublicKey(approved: Bool, originInfo: BraveWallet.OriginInfo)
   case decrypt(approved: Bool, originInfo: BraveWallet.OriginInfo)
-  case signTransaction(approved: Bool, id: Int32, signature: BraveWallet.ByteArrayStringUnion?, error: String?)
-  case signAllTransactions(approved: Bool, id: Int32, signatures: [BraveWallet.ByteArrayStringUnion]?, error: String?)
+  case signTransaction(approved: Bool, id: Int32)
+  case signAllTransactions(approved: Bool, id: Int32)
 }
 
 public class CryptoStore: ObservableObject {
@@ -330,10 +330,10 @@ public class CryptoStore: ObservableObject {
       walletService.notifyGetPublicKeyRequestProcessed(approved, origin: originInfo.origin)
     case let .decrypt(approved, originInfo):
       walletService.notifyDecryptRequestProcessed(approved, origin: originInfo.origin)
-    case let .signTransaction(approved, id, signature, error):
-      walletService.notifySignTransactionRequestProcessed(approved, id: id, signature: signature, error: error)
-    case let .signAllTransactions(approved, id, signatures, error):
-      walletService.notifySignAllTransactionsRequestProcessed(approved, id: id, signatures: signatures, error: error)
+    case let .signTransaction(approved, id):
+      walletService.notifySignTransactionRequestProcessed(approved, id: id, signature: nil, error: nil)
+    case let .signAllTransactions(approved, id):
+      walletService.notifySignAllTransactionsRequestProcessed(approved, id: id, signatures: nil, error: nil)
     }
     pendingRequest = nil
   }

--- a/Sources/BraveWallet/Panels/RequestContainerView.swift
+++ b/Sources/BraveWallet/Panels/RequestContainerView.swift
@@ -76,15 +76,19 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               networkStore: cryptoStore.networkStore,
               onDismiss: onDismiss
             )
-          case let .signTransaction(request):
+          case let .signTransaction(requests):
             SignTransactionView(
-              request: .signTransaction(request),
+              keyringStore: keyringStore,
+              networkStore: cryptoStore.networkStore,
+              request: .signTransaction(requests),
               cryptoStore: cryptoStore,
               onDismiss: onDismiss
             )
-          case let .signAllTransactions(request):
+          case let .signAllTransactions(requests):
             SignTransactionView(
-              request: .signAllTransactions(request),
+              keyringStore: keyringStore,
+              networkStore: cryptoStore.networkStore,
+              request: .signAllTransactions(requests),
               cryptoStore: cryptoStore,
               onDismiss: onDismiss
             )

--- a/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
+++ b/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
@@ -7,27 +7,85 @@ import BraveCore
 import DesignSystem
 import SwiftUI
 
+class SignTransactionRequestUnion {
+  let id: Int32
+  let originInfo: BraveWallet.OriginInfo
+  let fromAddress: String
+  let txDatas: [BraveWallet.TxDataUnion]
+  let rawMessage: [BraveWallet.ByteArrayStringUnion]
+  
+  init(
+    id: Int32,
+    originInfo: BraveWallet.OriginInfo,
+    fromAddress: String,
+    txDatas: [BraveWallet.TxDataUnion],
+    rawMessage: [BraveWallet.ByteArrayStringUnion]
+  ) {
+    self.id = id
+    self.originInfo = originInfo
+    self.fromAddress = fromAddress
+    self.txDatas = txDatas
+    self.rawMessage = rawMessage
+  }
+}
+
 struct SignTransactionView: View {
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var networkStore: NetworkStore
+  
   enum Request {
-    case signTransaction(BraveWallet.SignTransactionRequest)
-    case signAllTransactions(BraveWallet.SignAllTransactionsRequest)
-    
-    var instructions: [[BraveWallet.SolanaInstruction]] {
-      switch self {
-      case let .signTransaction(request):
-        if let instructions = request.txData.solanaTxData?.instructions {
-          return [instructions]
-        }
-        return []
-      case let .signAllTransactions(request):
-        return request.txDatas.map { $0.solanaTxData?.instructions ?? [] }
-      }
-    }
+    case signTransaction([BraveWallet.SignTransactionRequest])
+    case signAllTransactions([BraveWallet.SignAllTransactionsRequest])
   }
   
   var request: Request
   var cryptoStore: CryptoStore
   var onDismiss: () -> Void
+  
+  @State private var txIndex: Int = 0
+  @State private var showWarning: Bool = true
+  @Environment(\.sizeCategory) private var sizeCategory
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.openWalletURLAction) private var openWalletURL
+  @ScaledMetric private var blockieSize = 54
+  private let maxBlockieSize: CGFloat = 108
+  private let normalizedRequests: [SignTransactionRequestUnion]
+  
+  init(
+    keyringStore: KeyringStore,
+    networkStore: NetworkStore,
+    request: Request,
+    cryptoStore: CryptoStore,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.keyringStore = keyringStore
+    self.networkStore = networkStore
+    self.request = request
+    self.cryptoStore = cryptoStore
+    self.onDismiss = onDismiss
+    switch self.request {
+    case .signTransaction(let requests):
+      self.normalizedRequests = requests.map {
+        SignTransactionRequestUnion(
+          id: $0.id,
+          originInfo: $0.originInfo,
+          fromAddress: $0.fromAddress,
+          txDatas: [$0.txData],
+          rawMessage: [$0.rawMessage]
+        )
+      }
+    case .signAllTransactions(let requests):
+      self.normalizedRequests = requests.map {
+        SignTransactionRequestUnion(
+          id: $0.id,
+          originInfo: $0.originInfo,
+          fromAddress: $0.fromAddress,
+          txDatas: $0.txDatas,
+          rawMessage: $0.rawMessages
+        )
+      }
+    }
+  }
   
   var navigationTitle: String {
     switch request {
@@ -38,44 +96,241 @@ struct SignTransactionView: View {
     }
   }
   
-  private func instructionsDisplayString() -> String {
-    request.instructions
-      .map { instructionsForOneTx in
-        instructionsForOneTx
-          .map { TransactionParser.parseSolanaInstruction($0).toString }
-          .joined(separator: "\n\n") // separator between each instruction
-      }
-      .joined(separator: "\n\n\n\n") // separator between each transaction
+  private var currentRequest: SignTransactionRequestUnion {
+    normalizedRequests[txIndex]
   }
   
-  var body: some View { // TODO: Issue #6005 - SignTransaction / SignAllTransactions panel
-    VStack {
-      StaticTextView(text: instructionsDisplayString(), isMonospaced: false)
-        .frame(maxWidth: .infinity)
-        .frame(height: 200)
-        .background(Color(.tertiaryBraveGroupedBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-        .padding()
-        .background(Color(.secondaryBraveGroupedBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-      Button(action: {
-        switch request {
-        case let .signTransaction(request):
-          cryptoStore.handleWebpageRequestResponse(
-            .signTransaction(approved: false, id: request.id, signature: nil, error: "User rejected the request")
-          )
-        case let .signAllTransactions(request):
-          cryptoStore.handleWebpageRequestResponse(
-            .signAllTransactions(approved: false, id: request.id, signatures: nil, error: "User rejected the request")
-          )
+  private var instructions: [[BraveWallet.SolanaInstruction]] {
+    return currentRequest.txDatas.map { $0.solanaTxData?.instructions ?? [] }
+    //      switch self {
+    //      case let .signTransaction(request):
+    //        if let instructions = request.txData.solanaTxData?.instructions {
+    //          return [instructions]
+    //        }
+    //        return []
+    //      case let .signAllTransactions(request):
+    //        return request.txDatas.map { $0.solanaTxData?.instructions ?? [] }
+    //      }
+  }
+
+  private func instructionsDisplayString() -> String {
+    instructions
+     .map { instructionsForOneTx in
+       instructionsForOneTx
+         .map { TransactionParser.parseSolanaInstruction($0).toString }
+         .joined(separator: "\n\n") // separator between each instruction
+     }
+     .joined(separator: "\n\n\n\n") // separator between each transaction
+  }
+
+  private var account: BraveWallet.AccountInfo {
+    keyringStore.allAccounts.first(where: { $0.address == currentRequest.fromAddress }) ?? keyringStore.selectedAccount
+  }
+  
+  var body: some View {
+    ScrollView(.vertical) {
+      VStack {
+        VStack(spacing: 12) {
+          HStack {
+            Text(networkStore.selectedChain.chainName)
+              .font(.subheadline)
+              .foregroundColor(Color(.braveLabel))
+            Spacer()
+            if normalizedRequests.count > 1 {
+              HStack {
+                Spacer()
+                Text(String.localizedStringWithFormat(Strings.Wallet.transactionCount, txIndex + 1, normalizedRequests.count))
+                  .fontWeight(.semibold)
+                Button(action: next) {
+                  Text(Strings.Wallet.next)
+                    .fontWeight(.semibold)
+                    .foregroundColor(Color(.braveBlurpleTint))
+                }
+              }
+            }
+          }
+          VStack(spacing: 12) {
+            Blockie(address: account.address)
+              .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
+            Text(urlOrigin: currentRequest.originInfo.origin)
+              .font(.caption)
+              .foregroundColor(Color(.braveLabel))
+              .multilineTextAlignment(.center)
+            AddressView(address: account.address) {
+              VStack(spacing: 4) {
+                Text(account.name)
+                  .font(.subheadline.weight(.semibold))
+                  .foregroundColor(Color(.braveLabel))
+              }
+            }
+          }
+          .accessibilityElement(children: .combine)
+          Text(Strings.Wallet.signatureRequestSubtitle)
+            .font(.title3.weight(.semibold))
+            .foregroundColor(Color(.bravePrimary))
+            .multilineTextAlignment(.center)
         }
-        onDismiss()
-      }) {
-        Text(Strings.Wallet.rejectTransactionButtonTitle)
+        .padding(.vertical, 16)
+        .padding(.horizontal, 8)
+        if showWarning {
+          warningView
+            .padding(.vertical, 12)
+            .padding(.horizontal, 20)
+        } else {
+          divider
+            .padding(.top, 8)
+          StaticTextView(text: instructionsDisplayString(), isMonospaced: false)
+            .frame(maxWidth: .infinity)
+            .frame(height: 200)
+            .background(Color(.tertiaryBraveGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            .padding()
+            .background(
+              Color(.secondaryBraveGroupedBackground)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        buttonsContainer
+          .padding(.top)
+          .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
+          .accessibility(hidden: sizeCategory.isAccessibilityCategory)
       }
-        .buttonStyle(BraveFilledButtonStyle(size: .large))
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(Text(navigationTitle))
     }
-    .navigationBarTitleDisplayMode(.inline)
-    .navigationTitle(Text(navigationTitle))
+  }
+  
+  @ViewBuilder private var buttonsContainer: some View {
+    if sizeCategory.isAccessibilityCategory {
+      VStack {
+        buttons
+      }
+    } else {
+      HStack {
+        buttons
+      }
+    }
+  }
+  
+  @ViewBuilder private var buttons: some View {
+    if showWarning {
+      Button(action: { // cancel
+        switch request {
+        case .signTransaction(_):
+          cryptoStore.handleWebpageRequestResponse(.signTransaction(approved: false, id: currentRequest.id, signature: nil, error: nil))
+          onDismiss()
+        case .signAllTransactions(_):
+          cryptoStore.handleWebpageRequestResponse(.signAllTransactions(approved: false, id: currentRequest.id, signatures: nil, error: nil))
+        }
+      }) {
+        Text(Strings.cancelButtonTitle)
+      }
+      .buttonStyle(BraveOutlineButtonStyle(size: .large))
+      Button(action: { // Continue
+        showWarning = false
+      }) {
+        Text(Strings.Wallet.continueButtonTitle)
+          .imageScale(.large)
+      }
+      .buttonStyle(BraveFilledButtonStyle(size: .large))
+    } else {
+      Button(action: { // cancel
+        switch request {
+        case .signTransaction(_):
+          cryptoStore.handleWebpageRequestResponse(.signTransaction(approved: false, id: currentRequest.id, signature: nil, error: nil))
+          onDismiss()
+        case .signAllTransactions(_):
+          cryptoStore.handleWebpageRequestResponse(.signAllTransactions(approved: false, id: currentRequest.id, signatures: nil, error: nil))
+        }
+      }) {
+        Text(Strings.cancelButtonTitle)
+      }
+      .buttonStyle(BraveOutlineButtonStyle(size: .large))
+      //    .disabled(isButtonsDisabled)
+      Button(action: { // approve
+        switch request {
+        case .signTransaction(_):
+          cryptoStore.handleWebpageRequestResponse(.signTransaction(approved: true, id: currentRequest.id, signature: nil, error: nil))
+          onDismiss()
+        case .signAllTransactions(_):
+          cryptoStore.handleWebpageRequestResponse(.signAllTransactions(approved: true, id: currentRequest.id, signatures: nil, error: nil))
+        }
+      }) {
+        Label(Strings.Wallet.sign, braveSystemImage: "brave.key")
+          .imageScale(.large)
+      }
+      .buttonStyle(BraveFilledButtonStyle(size: .large))
+      //    .disabled(isButtonsDisabled)
+    }
+  }
+  
+  @ViewBuilder private var divider: some View {
+    VStack {
+      Text("Details")
+        .font(.subheadline.weight(.semibold))
+        .foregroundColor(Color(.bravePrimary))
+      HStack {
+        LinearGradient(braveGradient: colorScheme == .dark ? .darkGradient02 : .lightGradient02)
+      }
+      .frame(height: 4)
+      .padding(.horizontal, 20)
+    }
+  }
+  
+  @ViewBuilder private var warningView: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Group {
+        Label("Sign at your own risk", systemImage: "exclamationmark.triangle")
+          .font(.subheadline.weight(.semibold))
+          .foregroundColor(Color(.braveErrorLabel))
+          .padding(.top, 12)
+        Text("Note that Brave can’t verify what will happen if you sign. A signature could authorize nearly any operation in your account or on your behalf, including (but not limited to) giving total control of your account and crypto assets to the site making the request. Only sign if you’re sure you want to take this action, and trust the requesting site.")
+          .font(.subheadline)
+          .foregroundColor(Color(.braveErrorLabel))
+        Button(action: {
+          openWalletURL?(WalletConstants.signTransactionRiskLink)
+        }) {
+          Text(Strings.Wallet.learnMoreButton)
+            .font(.subheadline)
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+        .padding(.bottom, 12)
+      }
+      .padding(.horizontal, 12)
+    }
+    .background(
+      Color(.braveErrorBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    )
+  }
+  
+  private func next() {
+    if txIndex + 1 < normalizedRequests.count {
+      txIndex += 1
+    } else {
+      txIndex = 0
+    }
   }
 }
+
+#if DEBUG
+struct SignTransaction_Previews: PreviewProvider {
+  static var previews: some View {
+    SignTransactionView(
+      keyringStore: .previewStore,
+      networkStore: .previewStore,
+      request: .signTransaction([BraveWallet.SignTransactionRequest(
+        originInfo: .init(),
+        id: 0,
+        fromAddress: "2xyURwxRjuLZh89YGjywEJauh2fxnkbtUEyAU9pdvHA1",
+        txData: .init(),
+        rawMessage: .init(),
+        coin: .sol
+      )]),
+      cryptoStore: .previewStore,
+      onDismiss: {}
+    )
+    .previewColorSchemes()
+  }
+}
+#endif

--- a/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
+++ b/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
@@ -104,9 +104,9 @@ struct SignTransactionView: View {
     currentRequest.txDatas
       .map { $0.solanaTxData?.instructions ?? [] }
       .map { instructionsForOneTx in
-       instructionsForOneTx
-         .map { TransactionParser.parseSolanaInstruction($0).toString }
-         .joined(separator: "\n\n") // separator between each instruction
+        instructionsForOneTx
+          .map { TransactionParser.parseSolanaInstruction($0).toString }
+          .joined(separator: "\n\n") // separator between each instruction
       }
       .joined(separator: "\n\n\n\n") // separator between each transaction
   }
@@ -121,7 +121,7 @@ struct SignTransactionView: View {
         VStack(spacing: 12) {
           HStack {
             Text(networkStore.selectedChain.chainName)
-              .font(.subheadline)
+              .font(.callout)
               .foregroundColor(Color(.braveLabel))
             Spacer()
             if normalizedRequests.count > 1 {
@@ -140,25 +140,21 @@ struct SignTransactionView: View {
           VStack(spacing: 12) {
             Blockie(address: account.address)
               .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-            Text(urlOrigin: currentRequest.originInfo.origin)
-              .font(.caption)
-              .foregroundColor(Color(.braveLabel))
-              .multilineTextAlignment(.center)
             AddressView(address: account.address) {
-              VStack(spacing: 4) {
-                Text(account.name)
-                  .font(.subheadline.weight(.semibold))
-                  .foregroundColor(Color(.braveLabel))
-              }
+              Text(account.name)
             }
+            .foregroundColor(Color(.bravePrimary))
+            .font(.callout)
+            Text(urlOrigin: currentRequest.originInfo.origin)
+              .foregroundColor(Color(.braveLabel))
+              .font(.subheadline)
+              .multilineTextAlignment(.center)
           }
           .accessibilityElement(children: .combine)
           Text(Strings.Wallet.signatureRequestSubtitle)
             .font(.title3.weight(.semibold))
             .foregroundColor(Color(.bravePrimary))
-            .multilineTextAlignment(.center)
         }
-        .padding(.vertical, 16)
         .padding(.horizontal, 8)
         if showWarning {
           warningView
@@ -166,26 +162,30 @@ struct SignTransactionView: View {
             .padding(.horizontal, 20)
         } else {
           divider
-            .padding(.top, 8)
-          StaticTextView(text: instructionsDisplayString(), isMonospaced: true)
-            .frame(maxWidth: .infinity)
-            .frame(height: 200)
-            .background(Color(.tertiaryBraveGroupedBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-            .padding()
-            .background(
-              Color(.secondaryBraveGroupedBackground)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .padding(.vertical, 8)
+          VStack(alignment: .leading) {
+            StaticTextView(text: instructionsDisplayString())
+              .frame(maxWidth: .infinity)
+              .frame(height: 200)
+              .background(Color(.tertiaryBraveGroupedBackground))
+              .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+              .padding()
+          }
+          .background(
+            Color(.secondaryBraveGroupedBackground)
+          )
+          .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         buttonsContainer
           .padding(.top)
           .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
           .accessibility(hidden: sizeCategory.isAccessibilityCategory)
       }
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(Text(navigationTitle))
+      .padding()
     }
+    .navigationBarTitleDisplayMode(.inline)
+    .navigationTitle(Text(navigationTitle))
+    .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
   }
   
   @ViewBuilder private var buttonsContainer: some View {
@@ -202,20 +202,7 @@ struct SignTransactionView: View {
   
   @ViewBuilder private var buttons: some View {
     if showWarning {
-      Button(action: { // cancel
-        switch request {
-        case .signTransaction(_):
-          cryptoStore.handleWebpageRequestResponse(.signTransaction(approved: false, id: currentRequest.id))
-        case .signAllTransactions(_):
-          cryptoStore.handleWebpageRequestResponse(.signAllTransactions(approved: false, id: currentRequest.id))
-        }
-        if normalizedRequests.count == 1 {
-          onDismiss()
-        }
-      }) {
-        Text(Strings.cancelButtonTitle)
-      }
-      .buttonStyle(BraveOutlineButtonStyle(size: .large))
+      cancelButton
       Button(action: { // Continue
         showWarning = false
       }) {
@@ -225,20 +212,7 @@ struct SignTransactionView: View {
       .buttonStyle(BraveFilledButtonStyle(size: .large))
       .disabled(txIndex != 0)
     } else {
-      Button(action: { // cancel
-        switch request {
-        case .signTransaction(_):
-          cryptoStore.handleWebpageRequestResponse(.signTransaction(approved: false, id: currentRequest.id))
-        case .signAllTransactions(_):
-          cryptoStore.handleWebpageRequestResponse(.signAllTransactions(approved: false, id: currentRequest.id))
-        }
-        if normalizedRequests.count == 1 {
-          onDismiss()
-        }
-      }) {
-        Text(Strings.cancelButtonTitle)
-      }
-      .buttonStyle(BraveOutlineButtonStyle(size: .large))
+      cancelButton
       Button(action: { // approve
         switch request {
         case .signTransaction(_):
@@ -259,6 +233,23 @@ struct SignTransactionView: View {
     }
   }
   
+  @ViewBuilder private var cancelButton: some View {
+    Button(action: { // cancel
+      switch request {
+      case .signTransaction(_):
+        cryptoStore.handleWebpageRequestResponse(.signTransaction(approved: false, id: currentRequest.id))
+      case .signAllTransactions(_):
+        cryptoStore.handleWebpageRequestResponse(.signAllTransactions(approved: false, id: currentRequest.id))
+      }
+      if normalizedRequests.count == 1 {
+        onDismiss()
+      }
+    }) {
+      Text(Strings.cancelButtonTitle)
+    }
+    .buttonStyle(BraveOutlineButtonStyle(size: .large))
+  }
+  
   @ViewBuilder private var divider: some View {
     VStack {
       Text(Strings.Wallet.solanaSignTransactionDetails)
@@ -268,7 +259,6 @@ struct SignTransactionView: View {
         LinearGradient(braveGradient: colorScheme == .dark ? .darkGradient02 : .lightGradient02)
       }
       .frame(height: 4)
-      .padding(.horizontal, 20)
     }
   }
   
@@ -317,7 +307,7 @@ struct SignTransaction_Previews: PreviewProvider {
       request: .signTransaction([BraveWallet.SignTransactionRequest(
         originInfo: .init(),
         id: 0,
-        fromAddress: "2xyURwxRjuLZh89YGjywEJauh2fxnkbtUEyAU9pdvHA1",
+        fromAddress: BraveWallet.AccountInfo.previewAccount.address,
         txData: .init(),
         rawMessage: .init(),
         coin: .sol

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -91,6 +91,9 @@ struct WalletConstants {
   
   /// The link for users to open Aurora site
   static let auroraBridgeLink: URL? = URL(string: "https://rainbowbridge.app")
+  
+  /// The link for for users to learn more about sign transactions
+  static let signTransactionRiskLink: URL = URL(string: "https://support.brave.com/hc/en-us/articles/4409513799693")!
 }
 
 public struct WalletDebugFlags {

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3210,14 +3210,14 @@ extension Strings {
     public static let solanaSignTransactionWarning = NSLocalizedString(
       "wallet.solanaSignTransactionWarning",
       tableName: "BraveWallet",
-      bundle: .strings,
+      bundle: .module,
       value: "Note that Brave can’t verify what will happen if you sign. A signature could authorize nearly any operation in your account or on your behalf, including (but not limited to) giving total control of your account and crypto assets to the site making the request. Only sign if you’re sure you want to take this action, and trust the requesting site.",
       comment: "The warning message to let users understand the risk of using Brave Wallet to sign any transaction."
     )
     public static let solanaSignTransactionDetails = NSLocalizedString(
       "wallet.solanaSignTransactionDetails",
       tableName: "BraveWallet",
-      bundle: .strings,
+      bundle: .module,
       value: "Details",
       comment: "The title on top of a separater, and the transaction details will be displayed below the separater."
     )

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3207,5 +3207,19 @@ extension Strings {
       value: "Data",
       comment: "The label displayed beside the Data for an instruction type we don't support decoding. Ex. \"Data: [1, 20, 3, 5, 50]]\""
     )
+    public static let solanaSignTransactionWarning = NSLocalizedString(
+      "wallet.solanaSignTransactionWarning",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Note that Brave can’t verify what will happen if you sign. A signature could authorize nearly any operation in your account or on your behalf, including (but not limited to) giving total control of your account and crypto assets to the site making the request. Only sign if you’re sure you want to take this action, and trust the requesting site.",
+      comment: "The warning message to let users understand the risk of using Brave Wallet to sign any transaction."
+    )
+    public static let solanaSignTransactionDetails = NSLocalizedString(
+      "wallet.solanaSignTransactionDetails",
+      tableName: "BraveWallet",
+      bundle: .strings,
+      value: "Details",
+      comment: "The title on top of a separater, and the transaction details will be displayed below the separater."
+    )
   }
 }

--- a/Tests/ClientTests/SolanaProviderScriptHandlerTests.swift
+++ b/Tests/ClientTests/SolanaProviderScriptHandlerTests.swift
@@ -343,10 +343,11 @@ import XCTest
     
     let (result, error) = await solProviderHelper.signTransaction(args: args)
     XCTAssertNil(error)
-    guard let result = result as? String, let serializedTx = MojoBase.Value(jsonString: result)?.listValue?.compactMap({ $0.intValue }) else {
+    guard let result = result as? [NSNumber] else {
       XCTFail("Unexpected result to signTransaction request")
       return
     }
+    let serializedTx = result.compactMap({ Int32($0.intValue) })
     XCTAssertEqual(serializedTx, kSerializedTx)
   }
   
@@ -410,11 +411,11 @@ import XCTest
     
     let (result, error) = await solProviderHelper.signAllTransactions(args: args)
     XCTAssertNil(error)
-    guard let result = result as? String,
-          let serializedTxs = MojoBase.Value(jsonString: result)?.listValue?.compactMap({ $0.listValue?.compactMap({ $0.intValue }) }) else {
+    guard let result = result as? [[NSNumber]] else {
       XCTFail("Unexpected result to signAllTransactions request")
       return
     }
+    let serializedTxs = result.compactMap({ $0.compactMap({ Int32($0.intValue) }) })
     XCTAssertEqual(serializedTxs, [kSerializedTx])
   }
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Sign Solana Transaction and All Transactions requested from Solana Dapps.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6005

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. Go to https://pwgoom.csb.app/
2. connect the dapp with brave wallet
3. click Sign Transaction 
4. observe the wallet notification will show up
5. click to open wallet (unlock wallet if it's locked)
6. observe a sign transaction panel will show up
7. check 
   a. network 
   b. dapp's origin 
   c. account 
   d. check warning message has been shown e. check CTA are cancel (cancel to sign transaction) and continue(continue to pass this warning message)
9. click cancel
10. observe the test dapp log displaying user has rejected this request
11. repeat step 3 to 6
12. click continue 
13. observe the transaction details shows up and new CTA sign shows up 
14. click sign
15. observe request panel dismissed and test dapp prints out `signTransaction` object with no error

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Repeat the above steps but for `sign all transactions`

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Test multiple requests:
1. Go to https://pwgoom.csb.app/
2. connect the dapp with brave wallet
3. click sign transaction
4. click notification and unlock wallet if its locked
5. observe a sign transaction request panel will show up 
6. dimiss it by swipe it down
7. click sign transaction again
8. observe a sign transaction request panel show up again but this time with `1 of x` Next on the top right (x will be the times you creates sign transaction request, in this case would be 2)
9. click next to see if it loops though the queue correctly 
10. observe that if the current request is not the very first one `Continue` button will be disabled
11. click Continue to pass the warning message
12. click next button on top right to see if it looks though the queue correcly
13. observe that if the current request is not the very first one `Sign` button will be disabled. 

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Repeat the above steps but for `sign all transactions`


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-10-26 at 13 25 29](https://user-images.githubusercontent.com/1187676/198094778-00a2937c-53f2-4ab7-9778-a985f639af55.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-10-26 at 13 25 31](https://user-images.githubusercontent.com/1187676/198094781-163fa416-0f40-41c9-8a23-25707484b8a2.png)
-- | --

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
