### PR TITLE
No Bug: Add empty translations for all new widget intent strings

### DIFF
--- a/App/BraveWidgets/de.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/de.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Nur, um sicherzugehen, Sie suchten nach „Neuer privater Tab“?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/es.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/es.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Solo para confirmar: ¿querías decir \"Nueva pestaña privada\"?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/fr.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/fr.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Vouliez-vous dire « Nouvel onglet privé » ?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/id-ID.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/id-ID.lproj/BraveWidgets.strings
@@ -169,3 +169,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Hanya untuk mengonfirmasi, Anda ingin 'Tab Privat baru'?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/it.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/it.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Solo per conferma, volevi “Nuova scheda privata”?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/ja.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/ja.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "確認ですが、'新しいプライベートタブ' を探していましたか？";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/ko-KR.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/ko-KR.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "'새 비공개 탭'을 찾고 계신가요?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/ms.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/ms.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Sebagai pengesahan, betulkah anda inginkan 'Tab Peribadi Baharu'?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/nb.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/nb.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Bare som en bekreftelse – du ville ha 'Ny privat fane'?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/pl.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/pl.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Czy na pewno masz na myśli „Nowa karta w trybie prywatnym”?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/pt-BR.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/pt-BR.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Só para confirmar: você queria a opção \"Nova guia privada\"?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/ru.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/ru.lproj/BraveWidgets.strings
@@ -169,3 +169,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Показать результаты по запросу «Новая вкладка инкогнито»?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/sv.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/sv.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Var det ”Ny privat flik” du sökte efter?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/tr.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/tr.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Sadece onaylamak için soruyorum, \"Yeni Gizli Sekme\" bölümünü mü istediniz?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/uk.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/uk.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "Ви мали на увазі «Нова приватна вкладка»?";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/zh-TW.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/zh-TW.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "您要的是「新隱私分頁」，對嗎？";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";

--- a/App/BraveWidgets/zh.lproj/BraveWidgets.strings
+++ b/App/BraveWidgets/zh.lproj/BraveWidgets.strings
@@ -172,3 +172,17 @@
 /* (No Comment) */
 "YQiQuz-vs094F" = "您要的是“新隐私标签页”，对吗？";
 
+/* (No Comment) */
+"ziTvSZ" = "Shortcuts Widget Configuration";
+
+/* (No Comment) */
+"hssb67" = "Shortcut Widget Configuration";
+
+/* (No Comment) */
+"XkwBGY" = "Lock Screen Shortcut Configuration";
+
+/* (No Comment) */
+"8pcZ6L" = "Lock Screen Favorite Widget";
+
+/* (No Comment) */
+"7Ds8rk" = "Lock Screen Favorite Configuration";


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Suppresses the warnings we get about untranslated strings

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
