### PR TITLE
Fix #6218: Submit File:// URLs to the search engine like Chrome-iOS

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -208,10 +208,13 @@ extension BrowserViewController: TopToolbarDelegate {
 
   func processAddressBar(text: String, visitType: VisitType, isBraveSearchPromotion: Bool = false) {
     if let fixupURL = URIFixup.getURL(text), !isBraveSearchPromotion {
-      // The user entered a URL, so use it.
-      finishEditingAndSubmit(fixupURL, visitType: visitType)
-
-      return
+      // Do not allow users to enter URLs with the following schemes.
+      // Instead, submit them to the search engine like Chrome-iOS does.
+      if !["file"].contains(fixupURL.scheme) {
+        // The user entered a URL, so use it.
+        finishEditingAndSubmit(fixupURL, visitType: visitType)
+        return
+      }
     }
 
     // We couldn't build a URL, so pass it on to the search engine.


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1081

## Summary of Changes
- Submit `file://` URLs to the search engine like Chrome-iOS instead of cancelling the load request or allowing it to proceed.
- Users should not be able to enter local storage URLs in the Omnibox.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6218

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test submitting `file://www.verylongurl.gmail.accounts.google.com/` to the search bar/omni-box. The URL should be submitted to the search engine instead of trying to load that website.
- Test the hackerone ticket (same thing as typing in the URL above pretty much).


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
