### PR TITLE
Fix #6219: Do not open external links in child tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -179,7 +179,11 @@ extension BrowserViewController: WKNavigationDelegate {
     // First special case are some schemes that are about Calling. We prompt the user to confirm this action. This
     // gives us the exact same behaviour as Safari.
     if ["sms", "tel", "facetime", "facetime-audio"].contains(url.scheme) {
-      handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      
+      // Do not allow opening external URLs from child tabs
+      if (webView as? TabWebView)?.tab?.parent == nil {
+        handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      }
       decisionHandler(.cancel, preferences)
       return
     }
@@ -189,20 +193,29 @@ extension BrowserViewController: WKNavigationDelegate {
     // iOS will always say yes. TODO Is this the same as isWhitelisted?
 
     if isAppleMapsURL(url) {
-      handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      // Do not allow opening external URLs from child tabs
+      if (webView as? TabWebView)?.tab?.parent == nil {
+        handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      }
       decisionHandler(.cancel, preferences)
       return
     }
 
     if isStoreURL(url) {
-      handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      // Do not allow opening external URLs from child tabs
+      if (webView as? TabWebView)?.tab?.parent == nil {
+        handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      }
       decisionHandler(.cancel, preferences)
       return
     }
 
     // Handles custom mailto URL schemes.
     if url.scheme == "mailto" {
-      handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      // Do not allow opening external URLs from child tabs
+      if (webView as? TabWebView)?.tab?.parent == nil {
+        handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+      }
       decisionHandler(.cancel, preferences)
       return
     }
@@ -407,13 +420,16 @@ extension BrowserViewController: WKNavigationDelegate {
     // This check handles custom app schemes to open external apps.
     // Our own 'brave' scheme does not require the switch-app prompt.
     if url.scheme?.contains("brave") == false {
-      handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true) { didOpenURL in
-        // Do not show error message for JS navigated links or redirect
-        // as it's not the result of a user action.
-        if !didOpenURL, navigationAction.navigationType == .linkActivated {
-          let alert = UIAlertController(title: Strings.unableToOpenURLErrorTitle, message: Strings.unableToOpenURLError, preferredStyle: .alert)
-          alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
-          self.present(alert, animated: true, completion: nil)
+      // Do not allow opening external URLs from child tabs
+      if (webView as? TabWebView)?.tab?.parent == nil {
+        handleExternalURL(url, isMainFrame: navigationAction.targetFrame?.isMainFrame == true) { didOpenURL in
+          // Do not show error message for JS navigated links or redirect
+          // as it's not the result of a user action.
+          if !didOpenURL, navigationAction.navigationType == .linkActivated {
+            let alert = UIAlertController(title: Strings.unableToOpenURLErrorTitle, message: Strings.unableToOpenURLError, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+            self.present(alert, animated: true, completion: nil)
+          }
         }
       }
     }


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1082

## Summary of Changes
- Changes the code to check if an external link such as `tel:` is opening in a child tab, and block it so it.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6219

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test the hacker one ticket and make sure external links such as `tel:` does not prompt the user from a second tab (child tab)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
