### PR TITLE
No Bug: Remove cancel button from signature request view

### DIFF
--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -128,14 +128,6 @@ struct SignatureRequestView: View {
     .navigationBarTitleDisplayMode(.inline)
     .foregroundColor(Color(.braveLabel))
     .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
-    .toolbar {
-      ToolbarItemGroup(placement: .cancellationAction) {
-        Button(action: { presentationMode.dismiss() }) {
-          Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveOrange))
-        }
-      }
-    }
   }
   
   private var isButtonsDisabled: Bool {


### PR DESCRIPTION
## Summary of Changes
- Since building with Xcode 14 we have an unneeded cancel button on signature request view (they is a down chevron beside it). This PR removes it

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit [MetaMask test dapp site](https://metamask.github.io/test-dapp/)
2. Connect to the dapp
3. Tap 'Sign' under the 'Eth Sign' section


## Screenshots:

Before | After
--|--
![before](https://user-images.githubusercontent.com/5314553/198065437-0f938646-43ed-4f7e-8d4b-828b22a7b9c0.png) | ![after](https://user-images.githubusercontent.com/5314553/198065442-d700a97c-60b6-48df-bc9a-beda94991d86.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
