### PR TITLE
Fix #6256: Duplicate symbol displayed for Solana Dapp transactions in tx confirmation

### DIFF
--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -411,22 +411,20 @@ enum TransactionParser {
             }
             
             if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
-               let instructionValueString = formatter.decimalString(for: instructionLamports, decimals: 9),
-               let instructionValue = BDouble(instructionValueString),
+               let instructionLamportsValue = BDouble(instructionLamports),
                let fromPubkey = instruction.accountMetas[safe: 0]?.pubkey,
                let toPubkey = instruction.accountMetas[safe: 1]?.pubkey,
                fromPubkey != toPubkey { // only show lamports as transfered if the amount is going to a different pubKey
-              valueFromInstructions += instructionValue
+              valueFromInstructions += instructionLamportsValue
             }
           case .withdrawNonceAccount:
             if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
-               let instructionValueString = formatter.decimalString(for: instructionLamports, decimals: 9),
-               let instructionValue = BDouble(instructionValueString) {
+               let instructionLamportsValue = BDouble(instructionLamports) {
               if let nonceAccount = instruction.accountMetas[safe: 0]?.pubkey,
                  nonceAccount == fromAddress {
-                valueFromInstructions += instructionValue
+                valueFromInstructions += instructionLamportsValue
               } else if let toPubkey = instruction.accountMetas[safe: 1]?.pubkey, toPubkey == fromAddress {
-                valueFromInstructions -= instructionValue
+                valueFromInstructions -= instructionLamportsValue
               }
             }
           case .createAccount, .createAccountWithSeed:
@@ -435,27 +433,26 @@ enum TransactionParser {
               toAddress = toPubkey
             }
             if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
-               let instructionValueString = formatter.decimalString(for: instructionLamports, decimals: 9),
-               let instructionValue = BDouble(instructionValueString) {
+               let instructionLamportsValue = BDouble(instructionLamports) {
               if let fromPubkey = instruction.accountMetas[safe: 0]?.pubkey,
                  fromPubkey == fromAddress {
-                valueFromInstructions += instructionValue
+                valueFromInstructions += instructionLamportsValue
               }
             }
           default:
             if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
-               let instructionValueString = formatter.decimalString(for: instructionLamports, decimals: 9),
-               let instructionValue = BDouble(instructionValueString) {
-              valueFromInstructions += instructionValue
+               let instructionLamportsValue = BDouble(instructionLamports) {
+              valueFromInstructions += instructionLamportsValue
             }
           }
-          // Add lamports from the instructions to the transaction lamports value
           if let transactionLamports = transactionLamports,
-             let transactionValueString = formatter.decimalString(for: "\(transactionLamports)", decimals: 9),
-             let transactionValue = BDouble(transactionValueString) {
-            fromValue = (transactionValue + valueFromInstructions).decimalExpansion(precisionAfterDecimalPoint: Int(network.decimals)).trimmingTrailingZeros
+              let transactionLamportsValue = BDouble(exactly: transactionLamports) {
+            let transactionTotal = transactionLamportsValue + valueFromInstructions
+            fromValue = transactionTotal.decimalExpansion(precisionAfterDecimalPoint: Int(network.decimals)).trimmingTrailingZeros
+            if let transactionTotalFormatted = formatter.decimalString(for: "\(transactionTotal)", decimals: 9)?.trimmingTrailingZeros {
+              fromAmount = transactionTotalFormatted
+            }
           }
-          fromAmount = "\(fromValue) SOL"
         }
       }
       


### PR DESCRIPTION
## Summary of Changes
- For `SolanaDappTxDetails` model in `TransactionParser`, the `fromValue` and `fromAmount` were both the formatted value. 
- This PR changes `TransactionParser` to calculate the sum of lamports from all of the instructions, and then format using the correct decimals after (previous behaviour formatted the value of each instruction then summed those values). This allows `fromValue` to contain the sum of all lamports from the instructions (and the transaction lamports), where the `fromAmount` is the formatted value using correct decimals.

This pull request fixes #6256

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit test dapp site https://fs749n.csb.app/
2. Connect and tap 'Sign and Send Transaction'
3. Verify `0.00000234 SOL` displayed

## Screenshots:

![#6256](https://user-images.githubusercontent.com/5314553/198093982-53f9ac80-2253-4e51-a3d5-3fbf6070ce1d.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
