### PR TITLE
No Bug: Fix incorrect url bar focusing behaviour when opening blank tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1820,14 +1820,14 @@ public class BrowserViewController: UIViewController {
     // All private tabs closed and a new private tab is created
     if Preferences.Privacy.privateBrowsingOnly.value {
       tabManager.removeAll()
-      openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true, isExternal: true)
+      openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true, isExternal: true)
       popToBVC()
     } else {
       braveCore.historyAPI.deleteAll { [weak self] in
         guard let self = self else { return }
 
         self.tabManager.clearTabHistory() {
-          self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: false, isExternal: true)
+          self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: false, isExternal: true)
           self.popToBVC()
         }
       }
@@ -2306,7 +2306,7 @@ extension BrowserViewController: PresentingModalViewControllerDelegate {
 
 extension BrowserViewController: TabsBarViewControllerDelegate {
   func tabsBarDidSelectAddNewTab(_ isPrivate: Bool) {
-    openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: isPrivate)
+    openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: isPrivate)
   }
 
   func tabsBarDidSelectTab(_ tabsBarController: TabsBarViewController, _ tab: Tab) {
@@ -2811,7 +2811,7 @@ extension BrowserViewController: TabManagerDelegate {
         title: Strings.newPrivateTabTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
-          self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true)
+          self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
         })
 
       if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar?.view.isHidden == true) || (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {
@@ -2825,7 +2825,7 @@ extension BrowserViewController: TabManagerDelegate {
       title: PrivateBrowsingManager.shared.isPrivateBrowsing ? Strings.newPrivateTabTitle : Strings.newTabTitle,
       image: PrivateBrowsingManager.shared.isPrivateBrowsing ? UIImage(systemName: "plus.square.fill.on.square.fill") : UIImage(systemName: "plus.square.on.square"),
       handler: UIAction.deferredActionHandler { [unowned self] _ in
-        self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+        self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
       })
 
     if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar.view.isHidden) || (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -46,13 +46,13 @@ extension BrowserViewController {
   }
 
   @objc private func newTabKeyCommand() {
-    openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+    openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
   }
 
   @objc private func newPrivateTabKeyCommand() {
     // NOTE: We cannot and should not distinguish between "new-tab" and "new-private-tab"
     // when recording telemetry for key commands.
-    openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true)
+    openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
   }
 
   @objc private func closeTabKeyCommand() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -606,7 +606,7 @@ extension BrowserViewController: ToolbarDelegate {
   }
 
   func tabToolbarDidPressAddTab(_ tabToolbar: ToolbarProtocol, button: UIButton) {
-    self.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+    self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
   }
 
   func tabToolbarDidLongPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {

--- a/Client/Frontend/Browser/NavigationRouter.swift
+++ b/Client/Frontend/Browser/NavigationRouter.swift
@@ -88,7 +88,7 @@ public enum NavigationPath: Equatable {
       bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false, isExternal: true)
       bvc.popToBVC()
     } else {
-      bvc.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: isPrivate)
+      bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: isPrivate)
     }
   }
 
@@ -109,9 +109,9 @@ public enum NavigationPath: Equatable {
         bvc.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
       }
     case .newTab:
-      bvc.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
+      bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
     case .newPrivateTab:
-      bvc.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: true)
+      bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
     case .bookmarks:
       bvc.navigationHelper.openBookmarks()
     case .history:

--- a/Client/Frontend/Browser/QuickActions.swift
+++ b/Client/Frontend/Browser/QuickActions.swift
@@ -66,7 +66,7 @@ public class QuickActions: NSObject {
   }
 
   fileprivate func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController, isPrivate: Bool) {
-    bvc.openBlankNewTab(attemptLocationFieldFocus: true, isPrivate: isPrivate)
+    bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: isPrivate)
   }
 
   fileprivate func dismissAlertPopupView() {


### PR DESCRIPTION
As of #6150 merging, the `openBlankNewTab` was fixed to actually focus the URL bar when passing in `true` for the `attemptLocationFieldFocus` argument. However it turns out that we call this method with `true` all throughout the app even though we don't want the URL bar to focus in most of these scenarios.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Verify opening via search widget indeed focuses the URL bar
- Verify opening blank new tabs in all other scenarios do not focus the URL bar

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
