### PR TITLE
Fix #6259: Update bottom bar view constraints when leaving overlay mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -255,6 +255,9 @@ extension BrowserViewController: TopToolbarDelegate {
     hideFavoritesController()
     updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
     updateTabsBarVisibility()
+    if isUsingBottomBar {
+      updateViewConstraints()
+    }
   }
 
   func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView) {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6259 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
