### PR TITLE
No bug: Match buy option selection list background colour with list background colour in portfolio

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyProviderSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyProviderSelectionView.swift
@@ -68,6 +68,7 @@ struct BuyProviderSelectionView: View {
       }
     }
     .listStyle(InsetGroupedListStyle())
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.providerSelectionScreenTitle)
   }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyProviderSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyProviderSelectionView.swift
@@ -64,10 +64,10 @@ struct BuyProviderSelectionView: View {
           }
           .padding(.vertical, 10)
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
     .listStyle(InsetGroupedListStyle())
-    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .navigationBarTitleDisplayMode(.inline)
     .navigationTitle(Strings.Wallet.providerSelectionScreenTitle)
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
Old | Updated
--|--
![IMG_1924](https://user-images.githubusercontent.com/1187676/198354842-8efecba5-e3e8-40c9-94c7-f062ee1c24fe.png) | ![simulator_screenshot_19811B5D-BFFC-4628-9FE3-61EE0E8F4BE8](https://user-images.githubusercontent.com/1187676/198356065-69413a6a-0fab-486c-b8eb-c498e0b5741a.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
