### PR TITLE
Fix #6267: Fix animation when pushing account private key view

### DIFF
--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -78,7 +78,15 @@ struct PasswordEntryField: View {
         .textContentType(.password)
         .font(.subheadline)
         .introspectTextField(customize: { tf in
-          tf.becomeFirstResponder()
+          if #unavailable(iOS 15) {
+            // Fix for animation issue when pushing view onto
+            // navigation stack with this field on iOS 14 - #6267
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+              tf.becomeFirstResponder()
+            }
+          } else {
+            tf.becomeFirstResponder()
+          }
         })
         .textFieldStyle(BraveValidatedTextFieldStyle(error: error))
       if shouldShowBiometrics, keyringStore.isKeychainPasswordStored, let icon = biometricsIcon {


### PR DESCRIPTION
## Summary of Changes
- Add a delay before the password entry field becomes first responder on iOS 14

This pull request fixes #6267

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
I was only able to reproduce on device, not simulator
1. Open Wallet and navigate to Account details
2. Tap 'Private Key' row
3. Verify no more animation glitch when the private key view opens


## Screenshots:

https://user-images.githubusercontent.com/5314553/198376175-6fb820f3-76c1-4031-ac4a-1b945a22120d.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
