### PR TITLE
Fix #6285: Don't show edit menu on URL bar upon entering overlay mode

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -133,6 +133,7 @@ class TabLocationView: UIView {
     urlTextField.backgroundColor = .clear
     urlTextField.clipsToBounds = true
     urlTextField.textColor = .braveLabel
+    urlTextField.isEnabled = false
     // Remove the default drop interaction from the URL text field so that our
     // custom drop interaction on the BVC can accept dropped URLs.
     if let dropInteraction = urlTextField.textDropInteraction {


### PR DESCRIPTION
For some reason on iOS 16 the new `UIEditMenuInteraction` is shown when entering overlay mode on the `DisplayTextField` despite it not being the first responder.

## Summary of Changes

This pull request fixes #6285

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
