### PR TITLE
Fix #6287: Dismissing wallet to show rating request

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -109,9 +109,16 @@ extension WalletPanelHostingController: PopoverContentComponent {}
 
 extension BrowserViewController: BraveWalletDelegate {
   public func requestAppReview() {
-    // Handle App Rating
-    // User is either finished sending/swapping a crypto token or added an account to wallet.
-    AppReviewManager.shared.handleAppReview(for: self)
+    // wait for any dismissals, ex after adding an account/sending crypto/swapping crypto
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+      var topMostViewController: UIViewController = self
+      while let presentedViewController = topMostViewController.presentedViewController {
+        topMostViewController = presentedViewController
+      }
+      // Handle App Rating
+      // User is either finished sending/swapping a crypto token or added an account to wallet.
+      AppReviewManager.shared.handleAppReview(for: topMostViewController)
+    }
   }
   
   public func openWalletURL(_ destinationURL: URL) {

--- a/Sources/BraveWallet/WalletHostingViewController.swift
+++ b/Sources/BraveWallet/WalletHostingViewController.swift
@@ -79,9 +79,7 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
       }
     }
     rootView.appRatingRequestAction = { [unowned self] in
-      (presentingViewController ?? self).dismiss(animated: true) {
-        self.delegate?.requestAppReview()
-      }
+      self.delegate?.requestAppReview()
     }
     cancellable = walletStore.keyringStore.$defaultKeyring
       .dropFirst() // Drop initial value


### PR DESCRIPTION
## Summary of Changes
- Remove dismissal and instead attempt to show rating request over the top most view controller

This pull request fixes #6287

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Verify adding an account does not dismiss wallet, but shows rating alert over wallet
- Verify sending crypto does not dismiss wallet, but shows rating alert over wallet
- Verify swapping crypto does not dismiss wallet, but shows rating alert over wallet


## Screenshots:

https://user-images.githubusercontent.com/5314553/198730564-e96062b3-bbe2-4374-85cb-0d46b7da7651.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
