### PR TITLE
Fix #6271: Race condition when removing a secondary account

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -89,7 +89,10 @@ struct AccountsView: View {
           if let account = selectedAccount {
             AccountActivityView(
               keyringStore: keyringStore,
-              activityStore: cryptoStore.accountActivityStore(for: account),
+              activityStore: cryptoStore.accountActivityStore(
+                for: account,
+                isSelectedAccount: false
+              ),
               networkStore: cryptoStore.networkStore
             )
             .onDisappear {

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -91,7 +91,7 @@ struct AccountsView: View {
               keyringStore: keyringStore,
               activityStore: cryptoStore.accountActivityStore(
                 for: account,
-                isSelectedAccount: false
+                observeAccountUpdates: false
               ),
               networkStore: cryptoStore.networkStore
             )

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -123,7 +123,10 @@ public struct CryptoView: View {
               NavigationView {
                 AccountTransactionListView(
                   keyringStore: walletStore.keyringStore,
-                  activityStore: store.accountActivityStore(for: walletStore.keyringStore.selectedAccount),
+                  activityStore: store.accountActivityStore(
+                    for: walletStore.keyringStore.selectedAccount,
+                    isSelectedAccount: true
+                  ),
                   networkStore: store.networkStore
                 )
                 .toolbar {

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -125,7 +125,7 @@ public struct CryptoView: View {
                   keyringStore: walletStore.keyringStore,
                   activityStore: store.accountActivityStore(
                     for: walletStore.keyringStore.selectedAccount,
-                    isSelectedAccount: true
+                    observeAccountUpdates: true
                   ),
                   networkStore: store.networkStore
                 )

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -7,6 +7,10 @@ import Foundation
 import BraveCore
 
 class AccountActivityStore: ObservableObject {
+  /// If we are displaying the selected account (ex. in `WalletPanelView`).
+  /// In some cases, we do not want to update the current account displayed
+  /// when the selected account changes (ex. when removing an account)
+  let isSelectedAccount: Bool
   private(set) var account: BraveWallet.AccountInfo
   @Published private(set) var assets: [AssetViewModel] = []
   @Published var transactionSummaries: [TransactionSummary] = []
@@ -30,6 +34,7 @@ class AccountActivityStore: ObservableObject {
 
   init(
     account: BraveWallet.AccountInfo,
+    isSelectedAccount: Bool,
     keyringService: BraveWalletKeyringService,
     walletService: BraveWalletBraveWalletService,
     rpcService: BraveWalletJsonRpcService,
@@ -39,6 +44,7 @@ class AccountActivityStore: ObservableObject {
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   ) {
     self.account = account
+    self.isSelectedAccount = isSelectedAccount
     self.keyringService = keyringService
     self.walletService = walletService
     self.rpcService = rpcService
@@ -193,6 +199,7 @@ extension AccountActivityStore: BraveWalletKeyringServiceObserver {
   }
   
   func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+    guard isSelectedAccount else { return }
     keyringService.keyringInfo(coin.keyringId) { [self] keyringInfo in
       keyringService.selectedAccount(coin) { [self] accountAddress in
         account = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -7,10 +7,10 @@ import Foundation
 import BraveCore
 
 class AccountActivityStore: ObservableObject {
-  /// If we are displaying the selected account (ex. in `WalletPanelView`).
-  /// In some cases, we do not want to update the current account displayed
-  /// when the selected account changes (ex. when removing an account)
-  let isSelectedAccount: Bool
+  /// If we want to observe selected account changes (ex. in `WalletPanelView`).
+  /// In some cases, we do not want to update the account displayed when the
+  /// selected account changes (ex. when removing an account).
+  let observeAccountUpdates: Bool
   private(set) var account: BraveWallet.AccountInfo
   @Published private(set) var assets: [AssetViewModel] = []
   @Published var transactionSummaries: [TransactionSummary] = []
@@ -34,7 +34,7 @@ class AccountActivityStore: ObservableObject {
 
   init(
     account: BraveWallet.AccountInfo,
-    isSelectedAccount: Bool,
+    observeAccountUpdates: Bool,
     keyringService: BraveWalletKeyringService,
     walletService: BraveWalletBraveWalletService,
     rpcService: BraveWalletJsonRpcService,
@@ -44,7 +44,7 @@ class AccountActivityStore: ObservableObject {
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   ) {
     self.account = account
-    self.isSelectedAccount = isSelectedAccount
+    self.observeAccountUpdates = observeAccountUpdates
     self.keyringService = keyringService
     self.walletService = walletService
     self.rpcService = rpcService
@@ -199,7 +199,7 @@ extension AccountActivityStore: BraveWalletKeyringServiceObserver {
   }
   
   func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-    guard isSelectedAccount else { return }
+    guard observeAccountUpdates else { return }
     keyringService.keyringInfo(coin.keyringId) { [self] keyringInfo in
       keyringService.selectedAccount(coin) { [self] accountAddress in
         account = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -195,12 +195,18 @@ public class CryptoStore: ObservableObject {
   }
   
   private var accountActivityStore: AccountActivityStore?
-  func accountActivityStore(for account: BraveWallet.AccountInfo) -> AccountActivityStore {
-    if let store = accountActivityStore, store.account.address == account.address {
+  func accountActivityStore(
+    for account: BraveWallet.AccountInfo,
+    isSelectedAccount: Bool
+  ) -> AccountActivityStore {
+    if let store = accountActivityStore,
+       store.account.address == account.address,
+       store.isSelectedAccount == isSelectedAccount {
       return store
     }
     let store = AccountActivityStore(
       account: account,
+      isSelectedAccount: isSelectedAccount,
       keyringService: keyringService,
       walletService: walletService,
       rpcService: rpcService,

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -197,16 +197,16 @@ public class CryptoStore: ObservableObject {
   private var accountActivityStore: AccountActivityStore?
   func accountActivityStore(
     for account: BraveWallet.AccountInfo,
-    isSelectedAccount: Bool
+    observeAccountUpdates: Bool
   ) -> AccountActivityStore {
     if let store = accountActivityStore,
        store.account.address == account.address,
-       store.isSelectedAccount == isSelectedAccount {
+       store.observeAccountUpdates == observeAccountUpdates {
       return store
     }
     let store = AccountActivityStore(
       account: account,
-      isSelectedAccount: isSelectedAccount,
+      observeAccountUpdates: observeAccountUpdates,
       keyringService: keyringService,
       walletService: walletService,
       rpcService: rpcService,

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -119,7 +119,10 @@ public struct WalletPanelContainerView: View {
             keyringStore: keyringStore,
             cryptoStore: cryptoStore,
             networkStore: cryptoStore.networkStore,
-            accountActivityStore: cryptoStore.accountActivityStore(for: keyringStore.selectedAccount),
+            accountActivityStore: cryptoStore.accountActivityStore(
+              for: keyringStore.selectedAccount,
+              isSelectedAccount: true
+            ),
             tabDappStore: tabDappStore,
             origin: origin,
             presentWalletWithContext: { context in

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -121,7 +121,7 @@ public struct WalletPanelContainerView: View {
             networkStore: cryptoStore.networkStore,
             accountActivityStore: cryptoStore.accountActivityStore(
               for: keyringStore.selectedAccount,
-              isSelectedAccount: true
+              observeAccountUpdates: true
             ),
             tabDappStore: tabDappStore,
             origin: origin,

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -159,6 +159,7 @@ extension AccountActivityStore {
   static var previewStore: AccountActivityStore {
     .init(
       account: .previewAccount,
+      isSelectedAccount: false,
       keyringService: MockKeyringService(),
       walletService: MockBraveWalletService(),
       rpcService: MockJsonRpcService(),

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -159,7 +159,7 @@ extension AccountActivityStore {
   static var previewStore: AccountActivityStore {
     .init(
       account: .previewAccount,
-      isSelectedAccount: false,
+      observeAccountUpdates: false,
       keyringService: MockKeyringService(),
       walletService: MockBraveWalletService(),
       rpcService: MockJsonRpcService(),


### PR DESCRIPTION
## Summary of Changes
- Fix race condition that could cause Account Details modal to fail to dismiss after removing an account. 'Cancel' / 'Done' buttons would not dismiss either, requiring a swipe to dismiss.
- Race condition: 
    - When integrating the Wallet Panel for dapps, `AccountActivityStore` was updated to change it's account to the selected account when the selected account changes, so that it would fetch the new info for the current account on display in the panel.
    - `AccountActivityView` is observing the `KeyringStore`s `allKeyrings` property to handle account deletion [here](https://github.com/brave/brave-ios/blob/development/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift#L139-L146). When the account on display no longer exists in the keyring, we dismiss account details and pop back to the 'Accounts' tab.
    - The race condition can occur when the `AccountActivityStore` account updates _before_ the `AccountActivityView` observation of the keyring used for dismissing Account Details. `AccountActivityStore` account would update to the _selected_ account, no longer referencing the _removed_ account and thus the condition to dismiss Account Details modal would fail and we would not dismiss.

This pull request fixes #6271

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
I was able to reproduce this easiest on iOS 15, however it's possible on all versions.
1. Add a secondary account
2. Make sure this secondary account is selected account (buy/send/swap will show selected account)
3. Open account details for the secondary account
4. Tap 'Remove Account'
5. Enter wallet password to remove the account
6. Verify the account details modal is dismissed as expected, back to 'Accounts' tab.
7. Repeat from step 1 at least twice, given the issue was a race condition


## Screenshots:

iOS 14.5 | iOS 15.5 | iOS 16 | iPadOS 14.5 | iPadOS 15.5 | iPadOS 16
-- | -- | -- | -- | -- | --
<video src=https://user-images.githubusercontent.com/5314553/199066739-c262b2ed-860c-43b6-90c9-e47d702baa77.mp4> | <video src=https://user-images.githubusercontent.com/5314553/199066776-0e2fcac6-c114-47f3-a612-5d19148e7e26.mp4> | <video src=https://user-images.githubusercontent.com/5314553/199066797-e4ead8a1-ee76-43eb-9254-3641c0b7fb6f.mp4> | <video src=https://user-images.githubusercontent.com/5314553/199066938-1dbcc496-56d1-4fae-a293-0a4cd4a81efc.mp4> | <video src=https://user-images.githubusercontent.com/5314553/199067011-83684236-c949-4938-af05-cd6590428ef9.mp4> | <video src=https://user-images.githubusercontent.com/5314553/199067073-342312ab-d682-4d52-a8b3-45df4a7cf543.mp4>


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
