### PR TITLE
Fix #6297: Show private key push animation

### DIFF
--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -78,13 +78,9 @@ struct PasswordEntryField: View {
         .textContentType(.password)
         .font(.subheadline)
         .introspectTextField(customize: { tf in
-          if #unavailable(iOS 15) {
-            // Fix for animation issue when pushing view onto
-            // navigation stack with this field on iOS 14 - #6267
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-              tf.becomeFirstResponder()
-            }
-          } else {
+          // Fix for animation issue when pushing SwiftUI view onto navigation
+          // stack when trying to show keyboard immediately #6267 / #6297
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             tf.becomeFirstResponder()
           }
         })


### PR DESCRIPTION
## Summary of Changes
- Apply fix from https://github.com/brave/brave-ios/issues/6267 to all iOS versions.

This pull request fixes #6297

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

On iOS 15 & 16, I had to test on device to reproduce the animation glitch.
1. Open account details
2. Tap 'Private Key' row
3. Verify no animation glitch anymore when view moves on screen


## Screenshots:




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
