### PR TITLE
Fix #6277 Detect unknown unicode in sign message requests and some improvement for misleading message 

### DIFF
--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -17,7 +17,10 @@ struct SignatureRequestView: View {
   var onDismiss: () -> Void
 
   @State private var requestIndex: Int = 0
+  /// A map between request index and a boolean value indicates this request message needs pilcrow formating
   @State private var needPilcrowFormatted: [Int: Bool] = [0: false]
+  /// A map between request index and a boolean value indicates this request message is displayed as
+  /// its original content
   @State private var showOrignalMessage: [Int: Bool] = [0: true]
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.presentationMode) @Binding private var presentationMode

--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -17,10 +17,11 @@ struct SignatureRequestView: View {
   var onDismiss: () -> Void
 
   @State private var requestIndex: Int = 0
-  @State private var renderUnknownUnicodes: Bool = false
-  @State private var needPilcrowFormatted: Bool = false
+  @State private var needPilcrowFormatted: [Int: Bool] = [0: false]
+  @State private var showOrignalMessage: [Int: Bool] = [0: true]
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.pixelLength) private var pixelLength
   @ScaledMetric private var blockieSize = 54
   private let maxBlockieSize: CGFloat = 108
   private let staticTextViewHeight: CGFloat = 200
@@ -34,56 +35,26 @@ struct SignatureRequestView: View {
   }
   
   private var requestMessage: String {
-    var result = currentRequest.message
-    
-    if needPilcrowFormatted {
-      var copy = currentRequest.message
-      while copy.range(of: "\\n{2,}", options: .regularExpression) != nil {
-        if let range = copy.range(of: "\\n{2,}", options: .regularExpression) {
-          let newlines = String(copy[range])
-          result.replaceSubrange(range, with: "\n\u{00B6} <\(newlines.count)>\n")
-          copy.replaceSubrange(range, with: "\n\u{00B6} <\(newlines.count)>\n")
+    if showOrignalMessage[requestIndex] == true {
+      return currentRequest.message
+    } else {
+      let uuid = UUID()
+      var result = currentRequest.message
+      if needPilcrowFormatted[requestIndex] == true {
+        var copy = currentRequest.message
+        while copy.range(of: "\\n{2,}", options: .regularExpression) != nil {
+          if let range = copy.range(of: "\\n{2,}", options: .regularExpression) {
+            let newlines = String(copy[range])
+            result.replaceSubrange(range, with: "\n\(uuid.uuidString) <\(newlines.count)>\n")
+            copy.replaceSubrange(range, with: "\n\(uuid.uuidString) <\(newlines.count)>\n")
+          }
         }
       }
-    }
-    
-    if renderUnknownUnicodes {
-      result = result.printableWithUnknownUnicode
-    }
-    
-    return result
-  }
-  
-  private struct WarningView<Button: View>: View {
-    var warningMsg: String
-    var button: () -> Button
-    
-    @Environment(\.pixelLength) private var pixelLength
-    
-    init(
-      warningMsg: String,
-      @ViewBuilder button: @escaping () -> Button
-    ) {
-      self.warningMsg = warningMsg
-      self.button = button
-    }
-    
-    var body: some View {
-      VStack(alignment: .leading, spacing: 8) {
-        Text("\(Image(systemName: "exclamationmark.triangle.fill"))  \(warningMsg)")
-          .font(.subheadline.weight(.medium))
-          .foregroundColor(Color(.braveLabel))
-        button()
+      if currentRequest.message.hasUnknownUnicode {
+        result = result.printableWithUnknownUnicode
       }
-      .padding(12)
-      .background(
-        Color(.braveWarningBackground)
-          .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-              .strokeBorder(Color(.braveWarningBorder), style: StrokeStyle(lineWidth: pixelLength))
-          )
-          .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-      )
+      
+      return result.replacingOccurrences(of: uuid.uuidString, with: "\u{00B6}")
     }
   }
   
@@ -138,21 +109,39 @@ struct SignatureRequestView: View {
           Text(Strings.Wallet.signatureRequestSubtitle)
             .font(.headline)
             .foregroundColor(Color(.bravePrimary))
-          VStack(alignment: .leading, spacing: 8) {
-            if needPilcrowFormatted {
-              WarningView(warningMsg: Strings.Wallet.signMessageConsecutiveNewlineWarning) {}
-            }
-            if currentRequest.message.hasUnknownUnicode {
-              WarningView(warningMsg: Strings.Wallet.signMessageRequestUnknownUnicodeWarning) {
-                Button {
-                  renderUnknownUnicodes.toggle()
-                } label: {
-                  Text(renderUnknownUnicodes ? Strings.Wallet.signMessageShowOriginalMessage : Strings.Wallet.signMessageShowUnknownUnicode)
-                    .font(.subheadline)
-                    .foregroundColor(Color(.braveBlurple))
-                }
+          if needPilcrowFormatted[requestIndex] == true || currentRequest.message.hasUnknownUnicode == true {
+            VStack(spacing: 8) {
+              if needPilcrowFormatted[requestIndex] == true {
+                Text("\(Image(systemName: "exclamationmark.triangle.fill")) \(Strings.Wallet.signMessageConsecutiveNewlineWarning)")
+                  .font(.subheadline.weight(.medium))
+                  .foregroundColor(Color(.braveLabel))
+                  .multilineTextAlignment(.center)
+              }
+              if currentRequest.message.hasUnknownUnicode == true {
+                Text("\(Image(systemName: "exclamationmark.triangle.fill"))  \(Strings.Wallet.signMessageRequestUnknownUnicodeWarning)")
+                  .font(.subheadline.weight(.medium))
+                  .foregroundColor(Color(.braveLabel))
+                  .multilineTextAlignment(.center)
+              }
+              Button {
+                let value = showOrignalMessage[requestIndex] ?? false
+                showOrignalMessage[requestIndex] = !value
+              } label: {
+                Text(showOrignalMessage[requestIndex] == true ? Strings.Wallet.signMessageShowUnknownUnicode : Strings.Wallet.signMessageShowOriginalMessage)
+                  .font(.subheadline)
+                  .foregroundColor(Color(.braveBlurple))
               }
             }
+            .padding(12)
+            .frame(maxWidth: .infinity)
+            .background(
+              Color(.braveWarningBackground)
+                .overlay(
+                  RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(Color(.braveWarningBorder), style: StrokeStyle(lineWidth: pixelLength))
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            )
           }
         }
         .padding(.vertical, 32)
@@ -162,10 +151,10 @@ struct SignatureRequestView: View {
           .background(Color(.tertiaryBraveGroupedBackground))
           .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
           .padding()
-        .background(
-          Color(.secondaryBraveGroupedBackground)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+          .background(
+            Color(.secondaryBraveGroupedBackground)
+          )
+          .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         buttonsContainer
           .padding(.top)
           .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
@@ -203,9 +192,13 @@ struct SignatureRequestView: View {
     .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
     .introspectTextView { textView in
       // A flash to show users message is overflowing the text view (related to issue https://github.com/brave/brave-ios/issues/6277)
-      textView.flashScrollIndicators()
-      if textView.contentSize.height > staticTextViewHeight && requestMessage.hasConsecutiveNewLines {
-        needPilcrowFormatted = true
+      if showOrignalMessage[requestIndex] == true {
+        if textView.contentSize.height > staticTextViewHeight && currentRequest.message.hasConsecutiveNewLines {
+          needPilcrowFormatted[requestIndex] = true
+          textView.flashScrollIndicators()
+        } else {
+          needPilcrowFormatted[requestIndex] = false
+        }
       }
     }
   }
@@ -253,7 +246,11 @@ struct SignatureRequestView: View {
   
   private func next() {
     if requestIndex + 1 < requests.count {
-      requestIndex += 1
+      let value = requestIndex + 1
+      if showOrignalMessage[value] == nil {
+        showOrignalMessage[value] = true
+      }
+      requestIndex = value
     } else {
       requestIndex = 0
     }
@@ -284,8 +281,6 @@ extension String {
       if let unicodeScalar = Unicode.Scalar(ci) {
         if ci == 10 { // will keep newline char as it is
           result += "\n"
-        } else if ci == 182 {
-          result += unicodeScalar.escaped(asASCII: false) // will display pilcrow sign
         } else {
           // ascii char will be displayed as it is
           // unknown (> 127) will be displayed as hex-encoded

--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -222,6 +222,7 @@ struct SignatureRequestView: View {
   @ViewBuilder private var buttons: some View {
     Button(action: { // cancel
       cryptoStore.handleWebpageRequestResponse(.signMessage(approved: false, id: currentRequest.id))
+      updateState()
       if requests.count == 1 {
         onDismiss()
       }
@@ -233,6 +234,7 @@ struct SignatureRequestView: View {
     .disabled(isButtonsDisabled)
     Button(action: { // approve
       cryptoStore.handleWebpageRequestResponse(.signMessage(approved: true, id: currentRequest.id))
+      updateState()
       if requests.count == 1 {
         onDismiss()
       }
@@ -242,6 +244,24 @@ struct SignatureRequestView: View {
     }
     .buttonStyle(BraveFilledButtonStyle(size: .large))
     .disabled(isButtonsDisabled)
+  }
+  
+  private func updateState() {
+    var newShowOrignalMessage: [Int: Bool] = [:]
+    showOrignalMessage.forEach { key, value in
+      if key != 0 {
+        newShowOrignalMessage[key - 1] = value
+      }
+    }
+    showOrignalMessage = newShowOrignalMessage
+    
+    var newNeedPilcrowFormatted: [Int: Bool] = [:]
+    needPilcrowFormatted.forEach { key, value in
+      if key != 0 {
+        newNeedPilcrowFormatted[key - 1] = value
+      }
+    }
+    needPilcrowFormatted = newNeedPilcrowFormatted
   }
   
   private func next() {

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3232,14 +3232,14 @@ extension Strings {
       "wallet.signMessageRequestUnknownUnicodeWarning",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Multiple consecutive new-line characters detected! Replaced with Pilcrow Sign(s).",
+      value: "Consecutive newline characters detected!",
       comment: "A warning message to tell users that the sign request message contains consecutive new-line characters."
     )
     public static let signMessageShowUnknownUnicode = NSLocalizedString(
       "wallet.signMessageRequestUnknownUnicodeWarning",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "View message in ASCII encoding",
+      value: "Show encoded message",
       comment: "The title of the button that users can click to display the sign request message in ASCII encoding."
     )
     public static let signMessageShowOriginalMessage = NSLocalizedString(

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3221,5 +3221,33 @@ extension Strings {
       value: "Details",
       comment: "The title on top of a separater, and the transaction details will be displayed below the separater."
     )
+    public static let signMessageRequestUnknownUnicodeWarning = NSLocalizedString(
+      "wallet.signMessageRequestUnknownUnicodeWarning",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Non-ASCII characters detected!",
+      comment: "A warning message to tell users that the sign request message contains non-ascii characters."
+    )
+    public static let signMessageConsecutiveNewlineWarning = NSLocalizedString(
+      "wallet.signMessageRequestUnknownUnicodeWarning",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Multiple consecutive new-line characters detected! Replaced with Pilcrow Sign(s).",
+      comment: "A warning message to tell users that the sign request message contains consecutive new-line characters."
+    )
+    public static let signMessageShowUnknownUnicode = NSLocalizedString(
+      "wallet.signMessageRequestUnknownUnicodeWarning",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "View message in ASCII encoding",
+      comment: "The title of the button that users can click to display the sign request message in ASCII encoding."
+    )
+    public static let signMessageShowOriginalMessage = NSLocalizedString(
+      "wallet.signMessageRequestUnknownUnicodeWarning",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "View original message",
+      comment: "The title of the button that users can click to display the sign request message as its original content."
+    )
   }
 }

--- a/Tests/BraveWalletTests/WalletStringExtensionTests.swift
+++ b/Tests/BraveWalletTests/WalletStringExtensionTests.swift
@@ -1,0 +1,36 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import BraveWallet
+
+import Foundation
+
+class WalletStringExtensionTests: XCTestCase {
+  func testHasUnknownUnicode() {
+    let stringHasOnlyKnownUnicode = "hello this is message is in ascii chars only"
+    XCTAssertFalse(stringHasOnlyKnownUnicode.hasUnknownUnicode)
+    
+   let stringsHasUnknownUnicode = "\u{202E} EVIL"
+    XCTAssertTrue(stringsHasUnknownUnicode.hasUnknownUnicode)
+  }
+  
+  func testHasConsecutiveNewlines() {
+    let stringHasNoNewlines = "Here is one sentence."
+    XCTAssertFalse(stringHasNoNewlines.hasConsecutiveNewLines)
+    
+    let stringsHasNewlineButNoConsecutiveNewlines = "Here is one sentence.\nAnd here is another."
+    XCTAssertFalse(stringsHasNewlineButNoConsecutiveNewlines.hasConsecutiveNewLines)
+    
+    let stringHasConsecutiveNewlines = "Main Message\n\n\n\n\nEvil payload is below"
+    XCTAssertTrue(stringHasConsecutiveNewlines.hasConsecutiveNewLines)
+  }
+  
+  func testPrintableWithUnknownUnicode() {
+    let string = "Main Message\nEvil payload is below \n¶\npaylod still loooks good\nNew Line\n¶\n\u{202E} EVIL"
+    let printable = "Main Message\nEvil payload is below \n\u{00B6}\npaylod still loooks good\nNew Line\n\u{00B6}\n\\u{202E} EVIL"
+    XCTAssertEqual(string.printableWithUnknownUnicode, printable)
+  }
+}

--- a/Tests/BraveWalletTests/WalletStringExtensionTests.swift
+++ b/Tests/BraveWalletTests/WalletStringExtensionTests.swift
@@ -30,7 +30,7 @@ class WalletStringExtensionTests: XCTestCase {
   
   func testPrintableWithUnknownUnicode() {
     let string = "Main Message\nEvil payload is below \n¶\npaylod still loooks good\nNew Line\n¶\n\u{202E} EVIL"
-    let printable = "Main Message\nEvil payload is below \n\u{00B6}\npaylod still loooks good\nNew Line\n\u{00B6}\n\\u{202E} EVIL"
+    let printable = "Main Message\nEvil payload is below \n\\u{00B6}\npaylod still loooks good\nNew Line\n\\u{00B6}\n\\u{202E} EVIL"
     XCTAssertEqual(string.printableWithUnknownUnicode, printable)
   }
 }


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
We will detect unknown unicode in sign request message. (any unicode that is no inside [0, 127] would be considered as unknown)
When unknown unicode is detected, a corresponding warning will show up with a cta button that users can switch between original message and message in ascii-encoding.
We will also detect consecutive newline characters (2 or more consecutive newline characters). 
If those consecutive newline characters will push textview content size overflowing the textview frame size, another warning will show up and the message consecutive newline characters will be replaced with pilcrow sign with a number right after indicates how many newline characters are detected. 
When message contains both unknown characters and consecutive newline characters that will make message overflow the textbox, two warnings will show up. 
Note: the CTA button that to show message unknown unicodes will escape the pilcrow sign. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6277

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. Test message has unknown unicode (check warning message and CTA)
2. Test message has multiple consecutive newline characters that will overflow the textbox (check warning message and the pilcrow signs)
3. Test message has multiple consecutive newline characters that will NOT overflow the textbox (check there should not be a warning or pilcrow formatted)
4. Test message has both unknown unicode and consecutive newline characters that will overflow the textbox (check two warning messages; check the pilcrow sign; check warning CTA display correct message)
5. Test message has unknown unicode and consecutive newline characters that will NOT overflow the textbox (check one warning message and CTA)
6. Test a regular message (check no warning message)


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/1187676/199269806-136751e4-9ef4-4212-8144-fc19ca67857e.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
