### PR TITLE
Hold first tab load until sheilds are ready

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -138,7 +138,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       return true
     }
 
-    BrowserViewController.isFirstLaunch = Preferences.General.isFirstLaunch.value
     migration = Migration(braveCore: braveCore)
 
     // TODO: Downgrade to 14.5 once api becomes available.

--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -138,6 +138,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       return true
     }
 
+    BrowserViewController.isFirstLaunch = Preferences.General.isFirstLaunch.value
     migration = Migration(braveCore: braveCore)
 
     // TODO: Downgrade to 14.5 once api becomes available.

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -33,19 +33,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
     guard let windowScene = (scene as? UIWindowScene) else { return }
-
-    sceneInfo = (UIApplication.shared.delegate as? AppDelegate)?.sceneInfo(for: session)
-    guard let sceneInfo = sceneInfo else {
+    
+    // Create a browser instance
+    // There has to be an application delegate
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+      fatalError("Failed to create browser instance")
+    }
+    
+    guard let sceneInfo = appDelegate.sceneInfo(for: session) else {
       return
     }
+
+    self.sceneInfo = sceneInfo
 
     // We have to wait until pre1.12 migration is done until we proceed with database
     // initialization. This is because Database container may change. See bugs #3416, #3377.
     DataController.shared.initializeOnce()
     Migration.postCoreDataInitMigrations()
-    
-    let appDelegate = UIApplication.shared.delegate as? AppDelegate
-    assert(appDelegate != nil, "Should not be nil!")
 
     Preferences.General.themeNormalMode.objectWillChange
       .receive(on: RunLoop.main)
@@ -68,17 +72,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self?.updateTheme()
       }
       .store(in: &cancellables)
-
-    // Create a browser instance
-    guard
-      let browserViewController = createBrowserWindow(
-        scene: windowScene,
-        profile: sceneInfo.profile,
-        diskImageStore: sceneInfo.diskImageStore,
-        migration: sceneInfo.migration)
-    else {
-      fatalError("Failed to create browser instance")
-    }
+    
+    let browserViewController = createBrowserWindow(
+      scene: windowScene,
+      braveCore: appDelegate.braveCore,
+      profile: sceneInfo.profile,
+      diskImageStore: sceneInfo.diskImageStore,
+      migration: sceneInfo.migration)
 
     if SceneDelegate.shouldHandleUrpLookup {
       // TODO: Find a better way to do this when multiple windows are involved.
@@ -102,13 +102,47 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     PlaylistCarplayManager.shared.do {
       $0.browserController = browserViewController
     }
+    
+    Task { @MainActor in
+      // Load cached data
+      // This is done first because compileResources and loadCachedRuleLists need their results
+      async let loadBundledResources: Void = await ContentBlockerManager.shared.loadBundledResources()
+      async let filterListCache: Void = await FilterListResourceDownloader.shared.loadCachedData()
+      async let adblockResourceCache: Void = await AdblockResourceDownloader.shared.loadCachedData()
+      _ = await (loadBundledResources, filterListCache, adblockResourceCache)
 
+      // Compile some engines and load cached rule lists
+      async let compiledResourcesCompile: Void = await AdBlockEngineManager.shared.compileResources()
+      async let cachedRuleListLoad: Void = await ContentBlockerManager.shared.loadCachedRuleLists()
+      _ = await (compiledResourcesCompile, cachedRuleListLoad)
+      
+      self.present(
+        browserViewController: browserViewController,
+        windowScene: windowScene,
+        connectionOptions: connectionOptions
+      )
+      
+      await ContentBlockerManager.shared.cleanupDeadRuleLists()
+      await ContentBlockerManager.shared.compilePendingResources()
+      FilterListResourceDownloader.shared.start(with: appDelegate.braveCore.adblockService)
+      await AdblockResourceDownloader.shared.startFetching()
+      ContentBlockerManager.shared.startTimer()
+      await AdBlockEngineManager.shared.startTimer()
+    }
+        
+    PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.buildChannel.isPublic)
+    PrivacyReportsManager.consolidateData()
+    PrivacyReportsManager.scheduleProcessingBlockedRequests()
+    PrivacyReportsManager.scheduleVPNAlertsTask()
+  }
+  
+  private func present(browserViewController: BrowserViewController, windowScene: UIWindowScene, connectionOptions: UIScene.ConnectionOptions) {
     // Assign each browser a navigation controller
     let navigationController = UINavigationController(rootViewController: browserViewController).then {
       $0.isNavigationBarHidden = true
       $0.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
     }
-
+    
     // Assign each browser a window of its own
     let window = UIWindow(windowScene: windowScene).then {
       $0.backgroundColor = .black
@@ -119,10 +153,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         return .braveBlurple
       }
-
+      
       $0.rootViewController = navigationController
     }
-
+    
     self.window = window
 
     // TODO: Refactor to accept a UIWindowScene
@@ -130,7 +164,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // As each instance should have its own protection?
     self.windowProtection = WindowProtection(window: window)
     window.makeKeyAndVisible()
-
+    
     // Open shared URLs on launch if there are any
     if !connectionOptions.urlContexts.isEmpty {
       self.scene(windowScene, openURLContexts: connectionOptions.urlContexts)
@@ -151,11 +185,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         browserViewController.openPrivacyReport()
       }
     }
-        
-    PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.buildChannel.isPublic)
-    PrivacyReportsManager.consolidateData()
-    PrivacyReportsManager.scheduleProcessingBlockedRequests()
-    PrivacyReportsManager.scheduleVPNAlertsTask()
   }
 
   func sceneDidDisconnect(_ scene: UIScene) {
@@ -388,12 +417,7 @@ extension SceneDelegate {
 }
 
 extension SceneDelegate {
-  private func createBrowserWindow(scene: UIWindowScene, profile: Profile, diskImageStore: DiskImageStore?, migration: Migration?) -> BrowserViewController? {
-    // There has to be an application delegate
-    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
-      return nil
-    }
-
+  private func createBrowserWindow(scene: UIWindowScene, braveCore: BraveCoreMain, profile: Profile, diskImageStore: DiskImageStore?, migration: Migration?) -> BrowserViewController {
     // Make sure current private browsing flag respects the private browsing only user preference
     PrivateBrowsingManager.shared.isPrivateBrowsing = Preferences.Privacy.privateBrowsingOnly.value
 
@@ -405,7 +429,7 @@ extension SceneDelegate {
     let browserViewController = BrowserViewController(
       profile: profile,
       diskImageStore: diskImageStore,
-      braveCore: appDelegate.braveCore,
+      braveCore: braveCore,
       migration: migration,
       crashedLastSession: crashedLastSession)
 

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -103,17 +103,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       $0.browserController = browserViewController
     }
     
-    Task { @MainActor in
-      await LaunchHelper.shared.prepareAdBlockServices(
-        adBlockService: appDelegate.braveCore.adblockService
-      )
-      
-      self.present(
-        browserViewController: browserViewController,
-        windowScene: windowScene,
-        connectionOptions: connectionOptions
-      )
-    }
+    self.present(
+      browserViewController: browserViewController,
+      windowScene: windowScene,
+      connectionOptions: connectionOptions
+    )
         
     PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.buildChannel.isPublic)
     PrivacyReportsManager.consolidateData()

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -104,30 +104,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     Task { @MainActor in
-      // Load cached data
-      // This is done first because compileResources and loadCachedRuleLists need their results
-      async let loadBundledResources: Void = await ContentBlockerManager.shared.loadBundledResources()
-      async let filterListCache: Void = await FilterListResourceDownloader.shared.loadCachedData()
-      async let adblockResourceCache: Void = await AdblockResourceDownloader.shared.loadCachedData()
-      _ = await (loadBundledResources, filterListCache, adblockResourceCache)
-
-      // Compile some engines and load cached rule lists
-      async let compiledResourcesCompile: Void = await AdBlockEngineManager.shared.compileResources()
-      async let cachedRuleListLoad: Void = await ContentBlockerManager.shared.loadCachedRuleLists()
-      _ = await (compiledResourcesCompile, cachedRuleListLoad)
+      await LaunchHelper.shared.prepareAdBlockServices(
+        adBlockService: appDelegate.braveCore.adblockService
+      )
       
       self.present(
         browserViewController: browserViewController,
         windowScene: windowScene,
         connectionOptions: connectionOptions
       )
-      
-      await ContentBlockerManager.shared.cleanupDeadRuleLists()
-      await ContentBlockerManager.shared.compilePendingResources()
-      FilterListResourceDownloader.shared.start(with: appDelegate.braveCore.adblockService)
-      await AdblockResourceDownloader.shared.startFetching()
-      ContentBlockerManager.shared.startTimer()
-      await AdBlockEngineManager.shared.startTimer()
     }
         
     PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.buildChannel.isPublic)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -40,20 +40,83 @@ private let KVOs: [KVOConstants] = [
 ]
 
 public class BrowserViewController: UIViewController {
-  public static var isFirstLaunch = true
+  private(set) lazy var webViewContainer = UIView()
+  private(set) lazy var screenshotHelper = ScreenshotHelper(tabManager: tabManager)
   
-  var webViewContainer: UIView!
-  var topToolbar: TopToolbarView!
-  var tabsBar: TabsBarViewController!
+  private(set) lazy var topToolbar: TopToolbarView = {
+    // Setup the URL bar, wrapped in a view to get transparency effect
+    let topToolbar = TopToolbarView()
+    topToolbar.translatesAutoresizingMaskIntoConstraints = false
+    topToolbar.delegate = self
+    topToolbar.tabToolbarDelegate = self
+
+    let toolBarInteraction = UIContextMenuInteraction(delegate: self)
+    topToolbar.locationView.addInteraction(toolBarInteraction)
+    return topToolbar
+  }()
+  
+  private(set) lazy var tabsBar: TabsBarViewController = {
+    let tabsBar = TabsBarViewController(tabManager: tabManager)
+    tabsBar.delegate = self
+    return tabsBar
+  }()
+
+  // These views wrap the top and bottom toolbars to provide background effects on them
+  let header = HeaderContainerView()
+  private let headerHeightLayoutGuide = UILayoutGuide()
+  
+  private(set) lazy var footer: UIView = {
+    let footer = UIView()
+    footer.translatesAutoresizingMaskIntoConstraints = false
+    return footer
+  }()
+  
+  private lazy var topTouchArea: UIButton = {
+    let topTouchArea = UIButton()
+    topTouchArea.isAccessibilityElement = false
+    return topTouchArea
+  }()
+  
+  private lazy var bottomTouchArea: UIButton = {
+    let bottomTouchArea = UIButton()
+    bottomTouchArea.isAccessibilityElement = false
+    return bottomTouchArea
+  }()
+  
+  /// These constraints allow to show/hide tabs bar
+  private var webViewContainerTopOffset: Constraint?
+
+  /// Backdrop used for displaying greyed background for private tabs
+  private lazy var webViewContainerBackdrop: UIView = {
+    let webViewContainerBackdrop = UIView()
+    webViewContainerBackdrop.backgroundColor = .braveBackground
+    webViewContainerBackdrop.alpha = 0
+    return webViewContainerBackdrop
+  }()
+  
   var readerModeBar: ReaderModeBarView?
-  var readerModeCache: ReaderModeCache
-  var statusBarOverlay: UIView!
-  fileprivate(set) var toolbar: BottomToolbarView?
+  private(set) var readerModeCache: ReaderModeCache
+  
+  private lazy var statusBarOverlay: UIView = {
+    // Temporary work around for covering the non-clipped web view content
+    let statusBarOverlay = UIView()
+    statusBarOverlay.backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
+    return statusBarOverlay
+  }()
+  
+  private(set) var toolbar: BottomToolbarView?
+  var searchLoader: SearchLoader?
   var searchController: SearchViewController?
   var favoritesController: FavoritesViewController?
-  var screenshotHelper: ScreenshotHelper!
-  var searchLoader: SearchLoader?
-  let alertStackView = UIStackView()  // All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
+  
+  /// All content that appears above the footer should be added to this view. (Find In Page/SnackBars)
+  private(set) lazy var alertStackView: UIStackView = {
+    let alertStackView = UIStackView()
+    alertStackView.axis = .vertical
+    alertStackView.alignment = .center
+    return alertStackView
+  }()
+  
   var findInPageBar: FindInPageBar?
   var pageZoomBar: UIHostingController<PageZoomView>?
   private var pageZoomListener: NSObjectProtocol?
@@ -94,25 +157,13 @@ public class BrowserViewController: UIViewController {
   let bookmarkManager: BookmarkManager
 
   /// Whether last session was a crash or not
-  fileprivate let crashedLastSession: Bool
-
-  // These views wrap the top and bottom toolbars to provide background effects on them
-  let header = HeaderContainerView()
-  private let headerHeightLayoutGuide = UILayoutGuide()
-  var footer: UIView!
-  fileprivate var topTouchArea: UIButton!
-  fileprivate let bottomTouchArea = UIButton()
+  private let crashedLastSession: Bool
+  
   // A view to place behind the bottom bar down to the toolbar during keyboard animations to avoid
   // the odd look for the URL bar floating
   private let bottomBarKeyboardBackground = UIView().then {
     $0.isUserInteractionEnabled = false
   }
-
-  // These constraints allow to show/hide tabs bar
-  var webViewContainerTopOffset: Constraint?
-
-  // Backdrop used for displaying greyed background for private tabs
-  var webViewContainerBackdrop: UIView!
 
   var toolbarVisibilityViewModel = ToolbarVisibilityViewModel(estimatedTransitionDistance: 44)
   private var toolbarLayoutGuide = UILayoutGuide().then {
@@ -398,7 +449,6 @@ public class BrowserViewController: UIViewController {
 
   fileprivate func didInit() {
     updateApplicationShortcuts()
-    screenshotHelper = ScreenshotHelper(tabManager: tabManager)
     tabManager.addDelegate(self)
     tabManager.addNavigationDelegate(self)
     tabManager.makeWalletEthProvider = { [weak self] tab in
@@ -729,6 +779,62 @@ public class BrowserViewController: UIViewController {
 
   override public func viewDidLoad() {
     super.viewDidLoad()
+    view.backgroundColor = .braveBackground
+    
+    // Add layout guides
+    view.addLayoutGuide(pageOverlayLayoutGuide)
+    view.addLayoutGuide(headerHeightLayoutGuide)
+    view.addLayoutGuide(toolbarLayoutGuide)
+    
+    // Add views
+    view.addSubview(webViewContainerBackdrop)
+    view.addSubview(webViewContainer)
+    header.expandedBarStackView.addArrangedSubview(topToolbar)
+    header.collapsedBarContainerView.addSubview(collapsedURLBarView)
+    
+    addChild(tabsBar)
+    tabsBar.didMove(toParent: self)
+
+    view.addSubview(alertStackView)
+    view.addSubview(bottomTouchArea)
+    view.addSubview(topTouchArea)
+    view.addSubview(bottomBarKeyboardBackground)
+    view.addSubview(footer)
+    view.addSubview(header)
+    view.addSubview(statusBarOverlay)
+    
+    // For now we hide some elements so they are not visible
+    header.isHidden = true
+    footer.isHidden = true
+    
+    // Setup constraints
+    setupConstraints()
+    updateToolbarStateForTraitCollection(self.traitCollection)
+    
+    // Do some migratins
+    LegacyBookmarksHelper.restore_1_12_Bookmarks() {
+      Logger.module.info("Bookmarks from old database were successfully restored")
+    }
+    
+    // Perform migration to brave-core sync objects
+    if !Migration.isChromiumMigrationCompleted,
+      !Preferences.Chromium.syncV2PasswordMigrationStarted.value {
+      Preferences.Chromium.syncV2ObjectMigrationCount.value = 0
+    }
+    
+    Task { @MainActor in
+      await LaunchHelper.shared.prepareAdBlockServices(
+        adBlockService: self.braveCore.adblockService
+      )
+      
+      self.setupInteractions()
+    }
+  }
+  
+  private func setupInteractions() {
+    // We now show some elements since we're ready to use the app
+    header.isHidden = false
+    footer.isHidden = false
     
     NotificationCenter.default.do {
       $0.addObserver(
@@ -750,86 +856,20 @@ public class BrowserViewController: UIViewController {
         self, selector: #selector(updateShieldNotifications),
         name: NSNotification.Name(rawValue: BraveGlobalShieldStats.didUpdateNotification), object: nil)
     }
-
-    view.backgroundColor = .braveBackground
+    
     KeyboardHelper.defaultHelper.addDelegate(self)
     UNUserNotificationCenter.current().delegate = self
-
-    view.addLayoutGuide(pageOverlayLayoutGuide)
-    view.addLayoutGuide(headerHeightLayoutGuide)
-
-    webViewContainerBackdrop = UIView()
-    webViewContainerBackdrop.backgroundColor = .braveBackground
-    webViewContainerBackdrop.alpha = 0
-    view.addSubview(webViewContainerBackdrop)
-
-    webViewContainer = UIView()
-    view.addSubview(webViewContainer)
-
-    // Temporary work around for covering the non-clipped web view content
-    statusBarOverlay = UIView()
-    statusBarOverlay.backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
-
-    topTouchArea = UIButton()
-    topTouchArea.isAccessibilityElement = false
+    
+    // Add interactions
     topTouchArea.addTarget(self, action: #selector(tappedTopArea), for: .touchUpInside)
-    
-    bottomTouchArea.isAccessibilityElement = false
     bottomTouchArea.addTarget(self, action: #selector(tappedTopArea), for: .touchUpInside)
-    
-    // Setup the URL bar, wrapped in a view to get transparency effect
-    topToolbar = TopToolbarView()
-    topToolbar.translatesAutoresizingMaskIntoConstraints = false
-    topToolbar.delegate = self
-    topToolbar.tabToolbarDelegate = self
-
-    let toolBarInteraction = UIContextMenuInteraction(delegate: self)
-    topToolbar.locationView.addInteraction(toolBarInteraction)
-
-    header.expandedBarStackView.addArrangedSubview(topToolbar)
-
-    tabsBar = TabsBarViewController(tabManager: tabManager)
-    tabsBar.delegate = self
-
-    header.collapsedBarContainerView.addSubview(collapsedURLBarView)
     header.collapsedBarContainerView.addTarget(self, action: #selector(tappedCollapsedURLBar), for: .touchUpInside)
-    
-    addChild(tabsBar)
-    tabsBar.didMove(toParent: self)
-
-    view.addSubview(alertStackView)
-    footer = UIView()
-    footer.translatesAutoresizingMaskIntoConstraints = false
-    view.addSubview(bottomTouchArea)
-    view.addSubview(topTouchArea)
-    view.addSubview(bottomBarKeyboardBackground)
-    view.addSubview(footer)
-    view.addSubview(header)
-    view.addSubview(statusBarOverlay)
-    alertStackView.axis = .vertical
-    alertStackView.alignment = .center
-    
-    view.addLayoutGuide(toolbarLayoutGuide)
-    toolbarLayoutGuide.snp.makeConstraints {
-      self.toolbarTopConstraint = $0.top.equalTo(view.safeArea.top).constraint
-      self.toolbarBottomConstraint = $0.bottom.equalTo(view).constraint
-      $0.leading.trailing.equalTo(view)
-    }
-
-    self.updateToolbarStateForTraitCollection(self.traitCollection)
-
-    setupConstraints()
-
     updateRewardsButtonState()
 
     // Setup UIDropInteraction to handle dragging and dropping
     // links into the view from other apps.
     let dropInteraction = UIDropInteraction(delegate: self)
     view.addInteraction(dropInteraction)
-
-    LegacyBookmarksHelper.restore_1_12_Bookmarks() {
-      Logger.module.info("Bookmarks from old database were successfully restored")
-    }
 
     // Adding a small delay before fetching gives more reliability to it,
     // epsecially when you are connected to a VPN.
@@ -845,12 +885,6 @@ public class BrowserViewController: UIViewController {
     }
 
     showWalletTransferExpiryPanelIfNeeded()
-
-    /// Perform migration to brave-core sync objects
-    if !Migration.isChromiumMigrationCompleted,
-      !Preferences.Chromium.syncV2PasswordMigrationStarted.value {
-      Preferences.Chromium.syncV2ObjectMigrationCount.value = 0
-    }
 
     doSyncMigration()
 
@@ -994,7 +1028,13 @@ public class BrowserViewController: UIViewController {
     }
   }
 
-  fileprivate func setupConstraints() {
+  private func setupConstraints() {
+    toolbarLayoutGuide.snp.makeConstraints {
+      self.toolbarTopConstraint = $0.top.equalTo(view.safeArea.top).constraint
+      self.toolbarBottomConstraint = $0.bottom.equalTo(view).constraint
+      $0.leading.trailing.equalTo(view)
+    }
+    
     collapsedURLBarView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
@@ -1406,7 +1446,7 @@ public class BrowserViewController: UIViewController {
     }
 
     if tabManager.selectedTab == nil {
-      tabsBar?.view.isHidden = true
+      tabsBar.view.isHidden = true
       return
     }
 
@@ -1430,7 +1470,7 @@ public class BrowserViewController: UIViewController {
       }
     }
 
-    let isShowing = tabsBar?.view.isHidden == false
+    let isShowing = tabsBar.view.isHidden == false
     let shouldShow = shouldShowTabBar()
 
     if isShowing != shouldShow && presentedViewController == nil {
@@ -2796,7 +2836,7 @@ extension BrowserViewController: TabManagerDelegate {
     // Update Tab Count on Tab-Tray Button
     let count = tabManager.tabsForCurrentMode.count
     toolbar?.updateTabCount(count)
-    topToolbar?.updateTabCount(count)
+    topToolbar.updateTabCount(count)
 
     // Update Actions for Tab-Tray Button
     var newTabMenuChildren: [UIAction] = []
@@ -2810,7 +2850,7 @@ extension BrowserViewController: TabManagerDelegate {
           self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
         })
 
-      if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar?.view.isHidden == true) || (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {
+      if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar.view.isHidden == true) || (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {
         newTabMenuChildren.append(openNewPrivateTab)
       }
 
@@ -2911,8 +2951,8 @@ extension BrowserViewController: TabManagerDelegate {
           alert.addAction(closeAllAction)
           alert.addAction(cancelAction)
 
-          if let popoverPresentation = alert.popoverPresentationController,
-              let tabsButton = toolbar?.tabsButton ?? topToolbar?.tabsButton {
+          if let popoverPresentation = alert.popoverPresentationController {
+            let tabsButton = toolbar?.tabsButton ?? topToolbar.tabsButton
             popoverPresentation.sourceView = tabsButton
             popoverPresentation.sourceRect =
               .init(x: tabsButton.frame.width / 2, y: tabsButton.frame.height, width: 1, height: 1)
@@ -2931,7 +2971,7 @@ extension BrowserViewController: TabManagerDelegate {
     let closeTabMenu = UIMenu(title: "", options: .displayInline, children: closeTabMenuChildren)
 
     toolbar?.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu])
-    topToolbar?.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu])
+    topToolbar.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu])
 
     // Update Actions for Add-Tab Button
     toolbar?.addTabButton.menu = UIMenu(title: "", identifier: nil, children: [addTabMenu])

--- a/Client/Frontend/Browser/Helpers/LaunchHelper.swift
+++ b/Client/Frontend/Browser/Helpers/LaunchHelper.swift
@@ -1,0 +1,67 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+
+/// This class helps to prepare the browser during launch by ensuring the state of managers, resources and downloaders before performing additional tasks.
+public actor LaunchHelper {
+  public static let shared = LaunchHelper()
+  private var loadTask: Task<(), Never>?
+  private var areAdBlockServicesReady = false
+  
+  /// This method prepares the ad-block services one time so that multiple scenes can benefit from its results
+  /// This is particularly important since we use a shared instance for most of our ad-block services.
+  public func prepareAdBlockServices(adBlockService: AdblockService) async {
+    // Check if ad-block services are already ready.
+    // If so, we don't have to do anything
+    guard !areAdBlockServicesReady else { return }
+    
+    // Check if we're still preparing the ad-block services
+    // If so we await that task
+    if let task = loadTask {
+      return await task.value
+    }
+    
+    // Otherwise prepare the services and await the task
+    let task = Task { @MainActor in
+      // Load cached data
+      // This is done first because compileResources and loadCachedRuleLists need their results
+      async let loadBundledResources: Void = await ContentBlockerManager.shared.loadBundledResources()
+      async let filterListCache: Void = await FilterListResourceDownloader.shared.loadCachedData()
+      async let adblockResourceCache: Void = await AdblockResourceDownloader.shared.loadCachedData()
+      _ = await (loadBundledResources, filterListCache, adblockResourceCache)
+
+      // Compile some engines and load cached rule lists
+      async let compiledResourcesCompile: Void = await AdBlockEngineManager.shared.compileResources()
+      async let cachedRuleListLoad: Void = await ContentBlockerManager.shared.loadCachedRuleLists()
+      _ = await (compiledResourcesCompile, cachedRuleListLoad)
+      
+      // This one is non-blocking
+      await performPostLoadTasks(adBlockService: adBlockService)
+      await markAdBlockReady()
+    }
+    
+    // Await the task and wait for the results
+    self.loadTask = task
+    await task.value
+    self.loadTask = nil
+  }
+  
+  private func markAdBlockReady() {
+    areAdBlockServicesReady = true
+  }
+  
+  private func performPostLoadTasks(adBlockService: AdblockService) {
+    Task { @MainActor in
+      await ContentBlockerManager.shared.cleanupDeadRuleLists()
+      await ContentBlockerManager.shared.compilePendingResources()
+      FilterListResourceDownloader.shared.start(with: adBlockService)
+      await AdblockResourceDownloader.shared.startFetching()
+      ContentBlockerManager.shared.startTimer()
+      await AdBlockEngineManager.shared.startTimer()
+    }
+  }
+}

--- a/Client/WebFilters/AdBlockEngineManager.swift
+++ b/Client/WebFilters/AdBlockEngineManager.swift
@@ -113,7 +113,7 @@ public actor AdBlockEngineManager: Sendable {
     }
     
     /// Tells this manager to add this resource next time it compiles this engine
-    func add(resource: ResourceWithVersion) {
+    fileprivate func add(resource: ResourceWithVersion) {
       self.enabledResources = enabledResources.filter({ resourceWithVersion in
         guard resourceWithVersion.resource == resource.resource else { return true }
         // Remove these compile results so we have to compile again
@@ -125,7 +125,7 @@ public actor AdBlockEngineManager: Sendable {
     }
     
     /// Tells this manager to remove all resources for the given source next time it compiles this engine
-    func removeResources(for source: Source, resourceTypes: Set<ResourceType> = Set(ResourceType.allCases)) {
+    fileprivate func removeResources(for source: Source, resourceTypes: Set<ResourceType> = Set(ResourceType.allCases)) {
       self.enabledResources = self.enabledResources.filter { resourceWithVersion in
         let resource = resourceWithVersion.resource
         guard resource.source == source && resourceTypes.contains(resource.type) else { return true }
@@ -134,23 +134,23 @@ public actor AdBlockEngineManager: Sendable {
     }
     
     /// Set the compile results so this manager can compute if its in sync or not
-    func set(compileResults: [ResourceWithVersion: Result<Void, Error>]) {
+    fileprivate func set(compileResults: [ResourceWithVersion: Result<Void, Error>]) {
       self.compileResults = compileResults
     }
     
     /// Set the compile results so this manager can compute if its in sync or not
-    func add(engine: AdblockEngine, for source: Source) {
+    fileprivate func add(engine: AdblockEngine, for source: Source) {
       self.cachedEngines[source] = engine
     }
     
     /// Set the current compile task to avoid overlaping compilations
-    func set(compileTask: Task<Void, Error>?) {
+    fileprivate func set(compileTask: Task<Void, Error>?) {
       self.compileTask = compileTask
     }
     
     #if DEBUG
     /// A method that logs info on the given resources
-    func debug(resources: [ResourceWithVersion]) {
+    fileprivate func debug(resources: [ResourceWithVersion]) {
       let resourcesString = resources
         .map { resourceWithVersion -> String in
           let resource = resourceWithVersion.resource
@@ -305,10 +305,7 @@ public actor AdBlockEngineManager: Sendable {
       }
       
       #if DEBUG
-      Task {
-        log.debug("AdblockEngineManager")
-        await self.data.debug(resources: resourcesWithVersion)
-      }
+      await self.data.debug(resources: resourcesWithVersion)
       #endif
     }
     

--- a/Client/WebFilters/AdBlockEngineManager.swift
+++ b/Client/WebFilters/AdBlockEngineManager.swift
@@ -26,7 +26,7 @@ public actor AdBlockEngineManager: Sendable {
       switch self {
       case .adBlock: return 0
       case .cosmeticFilters: return 3
-      case .filterList: return 7
+      case .filterList: return 100
       }
     }
   }
@@ -151,7 +151,7 @@ public actor AdBlockEngineManager: Sendable {
     #if DEBUG
     /// A method that logs info on the given resources
     fileprivate func debug(resources: [ResourceWithVersion]) {
-      let resourcesString = resources
+      let resourcesString = resources.sorted(by: { $0.order < $1.order })
         .map { resourceWithVersion -> String in
           let resource = resourceWithVersion.resource
           let type: String
@@ -265,7 +265,7 @@ public actor AdBlockEngineManager: Sendable {
   }
   
   /// Compile all resources
-  func compileResources() async {
+  public func compileResources() async {
     await data.compileTask?.cancel()
     await data.set(compileTask: nil)
     

--- a/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -279,7 +279,7 @@ final public class ContentBlockerManager: Sendable {
   public func loadCachedRuleLists() async {
     await withTaskGroup(of: Void.self) { group in
       for (identifier, resource) in await data.pendingResources {
-        group.addTask {
+        group.addTask { @MainActor in
           do {
             guard let ruleList = try await self.ruleStore.contentRuleList(forIdentifier: identifier) else {
               await self.data.movePendingResource(forIdentifier: identifier)

--- a/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -149,7 +149,7 @@ final public class ContentBlockerManager: Sendable {
   }
   
   
-  func cleanupDeadRuleLists() async {
+  public func cleanupDeadRuleLists() async {
     guard let identifiers = await ruleStore.availableIdentifiers() else { return }
     let enabledResources = await data.enabledResources
     
@@ -252,7 +252,7 @@ final public class ContentBlockerManager: Sendable {
   }
   
   /// Compile all the resources
-  func compilePendingResources() async {
+  public func compilePendingResources() async {
     let resources = await self.data.pendingResources
     
     await withTaskGroup(of: Void.self) { group in
@@ -276,7 +276,7 @@ final public class ContentBlockerManager: Sendable {
   }
   
   /// This method goes through all the resources and loads any available from the rule store so they are ready when displaying the page
-  func loadCachedRuleLists() async {
+  public func loadCachedRuleLists() async {
     await withTaskGroup(of: Void.self) { group in
       for (identifier, resource) in await data.pendingResources {
         group.addTask {

--- a/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -148,18 +148,8 @@ final public class ContentBlockerManager: Sendable {
     self.data = SyncData()
   }
   
-  public func loadCachedCompileResults() async {
-    guard let identifiers = await ruleStore.availableIdentifiers() else { return }
-    let loadedCachedResults = await load(identifiers: identifiers)
-    
-    await MainActor.run {
-      for cachedResults in loadedCachedResults {
-        self.cachedCompileResults[cachedResults.0] = (.bundled, cachedResults.1)
-      }
-    }
-  }
   
-  private func cleanupRuleLists() async {
+  func cleanupDeadRuleLists() async {
     guard let identifiers = await ruleStore.availableIdentifiers() else { return }
     let enabledResources = await data.enabledResources
     
@@ -181,7 +171,6 @@ final public class ContentBlockerManager: Sendable {
       }
     }
   }
-  
   private func load(identifiers: [String]) async -> [(String, Result<WKContentRuleList, Error>)] {
     return await withTaskGroup(of: (identifier: String, result: Result<WKContentRuleList, Error>?).self, returning: [(String, Result<WKContentRuleList, Error>)].self) { group in
       for identifier in identifiers {
@@ -228,7 +217,6 @@ final public class ContentBlockerManager: Sendable {
           try await Task.sleep(seconds: Self.compileSleepTime)
           guard await !self.data.isSynced else { return }
           await self.compilePendingResources()
-          await self.cleanupRuleLists()
         }
       }, onCancel: {
         Task { @MainActor in
@@ -261,9 +249,6 @@ final public class ContentBlockerManager: Sendable {
     case .filterList:
       break
     }
-    
-    // Cleanup some stored data
-    await cleanupRuleLists()
   }
   
   /// Compile all the resources
@@ -286,9 +271,28 @@ final public class ContentBlockerManager: Sendable {
     }
     
     #if DEBUG
-    Self.log.debug("ContentBlockerManager")
     debug(resources: resources)
     #endif
+  }
+  
+  /// This method goes through all the resources and loads any available from the rule store so they are ready when displaying the page
+  func loadCachedRuleLists() async {
+    await withTaskGroup(of: Void.self) { group in
+      for (identifier, resource) in await data.pendingResources {
+        group.addTask {
+          do {
+            guard let ruleList = try await self.ruleStore.contentRuleList(forIdentifier: identifier) else {
+              await self.data.movePendingResource(forIdentifier: identifier)
+              return
+            }
+            
+            self.cachedCompileResults[identifier] = (resource.sourceType, .success(ruleList))
+          } catch {
+            self.cachedCompileResults[identifier] = (resource.sourceType, .failure(error))
+          }
+        }
+      }
+    }
   }
   
   /// Compile the given resource

--- a/Client/WebFilters/FilterListResourceDownloader.swift
+++ b/Client/WebFilters/FilterListResourceDownloader.swift
@@ -257,6 +257,8 @@ public class FilterListResourceDownloader: ObservableObject {
     }
     
     let folderURL = URL(fileURLWithPath: folderPath)
+    let folderSubPath = FilterListSetting.extractFolderPath(fromFilterListFolderURL: folderURL)
+    Preferences.AppState.lastDefaultFilterListFolderPath.value = folderSubPath
     
     Task {
       await self.loadShields(fromFolderURL: folderURL)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6261

Tab loading awaits the preparation of some ad block data. To achieve this I had to rework how the UI is loaded on the BVC so that the elements are loaded but only "enabled" once ABD is ready.

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
