### PR TITLE
Add Brave Ads status headers to search.brave.com

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -319,6 +319,17 @@ extension BrowserViewController: WKNavigationDelegate {
 
     if navigationAction.targetFrame?.isMainFrame == true,
       BraveSearchManager.isValidURL(url) {
+
+      // Add Brave Search headers if Rewards is enabled
+      if !isPrivateBrowsing && rewards.isEnabled && navigationAction.request.allHTTPHeaderFields?["X-Brave-Ads-Enabled"] == nil {
+        decisionHandler(.cancel, preferences)
+
+        var modifiedRequest = URLRequest(url: url)
+        modifiedRequest.setValue("1", forHTTPHeaderField: "X-Brave-Ads-Enabled")
+        tab?.loadRequest(modifiedRequest)
+        return
+      }
+
       // We fetch cookies to determine if backup search was enabled on the website.
       let profile = self.profile
       webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes [#6024](https://github.com/brave/brave-ios/issues/6024)

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Confirm header is sent if Rewards/ads are enabled
Confirm header is not sent if Rewards/ads are not enable
Confirm header is not sent for non Brave Search URLs

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
