### PR TITLE
Fix #6304: Changing text size Portfolio layout bug

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -21,6 +21,10 @@ struct PortfolioView: View {
   @State private var dismissedBackupBannerThisSession: Bool = false
   @State private var isPresentingBackup: Bool = false
   @State private var isPresentingEditUserAssets: Bool = false
+  
+  @Environment(\.sizeCategory) private var sizeCategory
+  /// Reference to the collection view used to back the `List` on iOS 16+
+  @State private var collectionView: UICollectionView?
 
   private var isShowingBackupBanner: Bool {
     !keyringStore.defaultKeyring.isBackedUp && !dismissedBackupBannerThisSession
@@ -137,6 +141,15 @@ struct PortfolioView: View {
       withAnimation(nil) {
         tableInset = -tableView.layoutMargins.left
       }
+    }
+    .onChange(of: sizeCategory) { _ in
+      // Fix broken header when text size changes on iOS 16+
+      collectionView?.collectionViewLayout.invalidateLayout()
+    }
+    .introspect(
+      selector: TargetViewSelector.ancestorOrSiblingContaining
+    ) { (collectionView: UICollectionView) in
+      self.collectionView = collectionView
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- SwiftUI `List` uses a `UICollectionView` to back it on iOS 16. Fix for layout bug is to invalidate the collection view layout 
- I attempted to contain in a [ViewModifier](https://gist.github.com/StephenHeaps/a395ae142d90b1a099cbf941954529fc) but it seems to cause the `List` to recompute so the fix doesn't get applied to the correct collection view.

This pull request fixes #6304

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Portfolio view on iOS 16+
2. Change accessibility text size
3. Verify layout is not broken


## Screenshots:

https://user-images.githubusercontent.com/5314553/199552159-895f4e93-f3af-43d3-81d5-182172ac6b60.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
