### PR TITLE
Fix #6305: Don't redact shortcuts lock screen widget

### DIFF
--- a/App/BraveWidgets/LockScreenShortcutWidget.swift
+++ b/App/BraveWidgets/LockScreenShortcutWidget.swift
@@ -64,6 +64,7 @@ struct LockScreenShortcutView: View {
           .font(.system(size: 20))
           .widgetLabel(entry.widgetShortcut.displayString)
           .accessibilityLabel(Text(entry.widgetShortcut.displayString))
+          .unredacted()
       )
       .widgetURL(URL(string: "brave://shortcut?path=\(entry.widgetShortcut.rawValue)"))
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6305 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
