### PR TITLE
No Bug: Fix wallet duplicated NSLocalizedString keys.

### DIFF
--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3229,21 +3229,21 @@ extension Strings {
       comment: "A warning message to tell users that the sign request message contains non-ascii characters."
     )
     public static let signMessageConsecutiveNewlineWarning = NSLocalizedString(
-      "wallet.signMessageRequestUnknownUnicodeWarning",
+      "wallet.signMessageConsecutiveNewlineWarning",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Consecutive newline characters detected!",
       comment: "A warning message to tell users that the sign request message contains consecutive new-line characters."
     )
     public static let signMessageShowUnknownUnicode = NSLocalizedString(
-      "wallet.signMessageRequestUnknownUnicodeWarning",
+      "wallet.signMessageShowUnknownUnicode",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Show encoded message",
       comment: "The title of the button that users can click to display the sign request message in ASCII encoding."
     )
     public static let signMessageShowOriginalMessage = NSLocalizedString(
-      "wallet.signMessageRequestUnknownUnicodeWarning",
+      "wallet.signMessageShowOriginalMessage",
       tableName: "BraveWallet",
       bundle: .module,
       value: "View original message",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
