### PR TITLE
Fix #6306: Tab sync screen empty state text does not fit the width in Polish locale

### DIFF
--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -33,6 +33,7 @@ class EmptyStateOverlayView: UIView {
     $0.textAlignment = .center
     $0.textColor = .braveLabel
     $0.numberOfLines = 0
+    $0.setContentHuggingPriority(.required, for: .horizontal)
   }
   
   private let descriptionLabel = UILabel().then {
@@ -103,6 +104,7 @@ class EmptyStateOverlayView: UIView {
     containerView.snp.remakeConstraints {
       $0.centerX.equalToSuperview()
       $0.centerY.equalToSuperview().offset(heightOffset)
+      $0.width.equalToSuperview().multipliedBy(0.75)
     }
   }
   
@@ -116,7 +118,7 @@ class EmptyStateOverlayView: UIView {
       $0.centerX.equalToSuperview()
       $0.centerY.equalToSuperview().offset(heightOffset)
       $0.width.equalToSuperview().multipliedBy(0.75)
-      $0.size.lessThanOrEqualToSuperview()
+      $0.height.lessThanOrEqualToSuperview()
     }
     
     if let icon = details.icon {
@@ -127,7 +129,7 @@ class EmptyStateOverlayView: UIView {
         $0.size.equalTo(45)
        }
       
-      containerView.setCustomSpacing(25, after: iconImageView)
+      containerView.setCustomSpacing(20, after: iconImageView)
     }
     
     if let title = details.title {
@@ -139,7 +141,7 @@ class EmptyStateOverlayView: UIView {
     if let description = details.description {
       descriptionLabel.text = description
       containerView.addArrangedSubview(descriptionLabel)
-      containerView.setCustomSpacing(35, after: descriptionLabel)
+      containerView.setCustomSpacing(25, after: descriptionLabel)
     }
     
     if let buttonText = details.buttonText {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Handling cases where width cant be determined by the width of super view

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6306

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Set language to Polish

2. Go to the tab tray, go to synced tabs

## Screenshots:

![1 2 1](https://user-images.githubusercontent.com/6643505/199780216-20db77d6-8cfc-4a9f-a641-7a587b3f206c.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
