### PR TITLE
[No Bug]: Making daysInUse criteria true for non public builds for App Rating

### DIFF
--- a/Sources/Growth/AppReviewManager.swift
+++ b/Sources/Growth/AppReviewManager.swift
@@ -136,7 +136,8 @@ public class AppReviewManager: ObservableObject {
     case .launchCount:
       return Preferences.Review.launchCount.value >= launchCountLimit
     case .daysInUse:
-      return Preferences.Review.daysInUse.value.count >= daysInUseRequiredPeriod
+      return AppConstants.buildChannel.isPublic ?
+        Preferences.Review.daysInUse.value.count >= daysInUseRequiredPeriod : true
     case .sessionCrash:
       return !(!Preferences.AppState.backgroundedCleanly.value && AppConstants.buildChannel != .debug)
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #5722

We are passing the day in user main criteria to make the rest of the logic testable manually. 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
