### PR TITLE
Fix #6320: Fix issue with long wait before downloading files

### DIFF
--- a/Client/WebFilters/AdBlockEngineManager.swift
+++ b/Client/WebFilters/AdBlockEngineManager.swift
@@ -185,22 +185,19 @@ public actor AdBlockEngineManager: Sendable {
             resultString = "not compiled"
           }
           
-          let sourceDebugString =
-          """
-          {
-          order: \(resourceWithVersion.order)
-          fileName: \(resourceWithVersion.fileURL.lastPathComponent)
-          source: \(sourceString)
-          version: \(resourceWithVersion.version ?? "nil")
-          type: \(type)
-          result: \(resultString)
-          }
-          """
+          let sourceDebugString = [
+            "order: \(resourceWithVersion.order)",
+            "fileName: \(resourceWithVersion.fileURL.lastPathComponent)",
+            "source: \(sourceString)",
+            "version: \(resourceWithVersion.version ?? "nil")",
+            "type: \(type)",
+            "result: \(resultString)",
+          ].joined(separator: ", ")
           
-          return sourceDebugString
-        }
+          return ["{", sourceDebugString, "}"].joined()
+        }.joined(separator: ", ")
 
-      log.debug("Loaded \(self.enabledResources.count, privacy: .public) (total) engine resources:\n\(resourcesString, privacy: .public)")
+      log.debug("Loaded \(self.enabledResources.count, privacy: .public) (total) engine resources: \(resourcesString, privacy: .public)")
     }
     #endif
   }

--- a/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -116,19 +116,15 @@ class ContentBlockerHelper {
         ruleTypeString = "filterList(\(uuid))"
       }
       
-      let rulesDebugString =
-      """
-      {
-      ruleType: \(ruleTypeString)
-      sourceType: \(ruleTypeWithSourceType.sourceType)
-      }
-      """
+      let rulesDebugString = [
+        "ruleType: \(ruleTypeString)",
+        "sourceType: \(ruleTypeWithSourceType.sourceType)"
+      ].joined(separator: ", ")
       
-      return rulesDebugString
-    }
+      return ["{", rulesDebugString, "}"].joined()
+    }.joined(separator: ", ")
     
-    log.debug("ContentBlockerHelper")
-    log.debug("loaded \(self.loadedRuleTypeWithSourceTypes.count, privacy: .public) tab rules:\n\(rulesString, privacy: .public)")
+    log.debug("Loaded \(self.loadedRuleTypeWithSourceTypes.count, privacy: .public) tab rules: \(rulesString, privacy: .public)")
     #endif
   }
 }

--- a/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Client/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -455,21 +455,18 @@ final public class ContentBlockerManager: Sendable {
           resultString = "nil"
         }
         
-        let resourcesDebugString =
-        """
-        {
-        identifier: \(identifier)
-        fileName: \(compiledResource.url.lastPathComponent)
-        source: \(sourceString)
-        version: \(versionString)
-        result: \(resultString)
-        }
-        """
+        let resourcesDebugString = [
+          "identifier: \(identifier)",
+          "fileName: \(compiledResource.url.lastPathComponent)",
+          "source: \(sourceString)",
+          "version: \(versionString)",
+          "result: \(resultString)"
+        ].joined(separator: ", ")
         
-        return resourcesDebugString
-      }
+        return ["{", resourcesDebugString, "}"].joined()
+      }.joined(separator: ", ")
 
-    Self.log.debug("Compiled \(resources.count, privacy: .public) additional block list resources: \n\(resourcesString, privacy: .public))")
+    Self.log.debug("Compiled \(resources.count, privacy: .public) additional block list resources: \(resourcesString, privacy: .public))")
   }
   #endif
 }

--- a/Client/WebFilters/ResourceDownloaderStream.swift
+++ b/Client/WebFilters/ResourceDownloaderStream.swift
@@ -32,12 +32,16 @@ struct ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProtocol 
     if firstLoad {
       // On a first load, we return the result so that they are available right away.
       // After that we wait only for changes while sleeping
-      self.firstLoad = false
-      let result = try await resourceDownloader.download(resource: resource)
-      
-      switch result {
-      case .downloaded(let url, let date), .notModified(let url, let date):
-        return .success(DownloadResult(date: date, fileURL: url))
+      do {
+        self.firstLoad = false
+        let result = try await resourceDownloader.download(resource: resource)
+        
+        switch result {
+        case .downloaded(let url, let date), .notModified(let url, let date):
+          return .success(DownloadResult(date: date, fileURL: url))
+        }
+      } catch {
+        return .failure(error)
       }
     }
     

--- a/Client/WebFilters/ResourceDownloaderStream.swift
+++ b/Client/WebFilters/ResourceDownloaderStream.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// An endless sequence iterator for the given resource
-final class ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProtocol {
+struct ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProtocol {
   /// An object representing the download
   struct DownloadResult: Equatable {
     let date: Date
@@ -17,6 +17,7 @@ final class ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProt
   private let resource: ResourceDownloader.Resource
   private let resourceDownloader: ResourceDownloader
   private let fetchInterval: TimeInterval
+  private var firstLoad = true
   
   init(resource: ResourceDownloader.Resource, resourceDownloader: ResourceDownloader, fetchInterval: TimeInterval) {
     self.resource = resource
@@ -27,7 +28,19 @@ final class ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProt
   /// Returns the next downloaded value if it has changed since last time it was downloaded. Will return a cached result as an initial value.
   ///
   /// - Note: Only throws `CancellationError` error. Downloading errors are returned as a `Result` object
-  func next() async throws -> Element? {
+  mutating func next() async throws -> Element? {
+    if firstLoad {
+      // On a first load, we return the result so that they are available right away.
+      // After that we wait only for changes while sleeping
+      self.firstLoad = false
+      let result = try await resourceDownloader.download(resource: resource)
+      
+      switch result {
+      case .downloaded(let url, let date), .notModified(let url, let date):
+        return .success(DownloadResult(date: date, fileURL: url))
+      }
+    }
+    
     // Keep fetching new data until we get a new result
     while true {
       try await Task.sleep(seconds: fetchInterval)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Do an initial download instead of waiting on `ResourceDownloaderStream`

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6320 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
On ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
