### PR TITLE
Fix #6056: Wallet panel left-align, full network name

### DIFF
--- a/Sources/BraveWallet/Crypto/NetworkPicker.swift
+++ b/Sources/BraveWallet/Crypto/NetworkPicker.swift
@@ -8,12 +8,6 @@ import BraveCore
 import BraveShared
 import Strings
 
-extension BraveWallet.NetworkInfo {
-  var shortChainName: String {
-    chainName.split(separator: " ").first?.capitalized ?? chainName
-  }
-}
-
 struct NetworkPicker: View {
   
   struct Style: Equatable {
@@ -68,7 +62,7 @@ struct NetworkPicker: View {
       networkSelectionStore = .init(networkStore: networkStore)
     }) {
       HStack {
-        Text(networkStore.selectedChain.shortChainName)
+        Text(networkStore.selectedChain.chainName)
           .fontWeight(.bold)
         Image(systemName: "chevron.down.circle")
       }

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -24,6 +24,10 @@ extension BraveWallet.NetworkInfo: Identifiable {
   public var id: String {
     chainId
   }
+  
+  var shortChainName: String {
+    chainName.split(separator: " ").first?.capitalized ?? chainName
+  }
 
   public var nativeToken: BraveWallet.BlockchainToken {
     .init(

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -422,21 +422,14 @@ struct WalletPanelView: View {
           )
         }
         VStack {
-          if sizeCategory.isAccessibilityCategory {
-            VStack {
+          HStack {
+            VStack(alignment: .leading) {
+              networkPickerButton
               if !isConnectHidden {
                 connectButton
               }
-              networkPickerButton
             }
-          } else {
-            HStack {
-              if !isConnectHidden {
-                connectButton
-              }
-              Spacer()
-              networkPickerButton
-            }
+            Spacer()
           }
           VStack(spacing: 12) {
             Button {


### PR DESCRIPTION
## Summary of Changes
- Left-align the network picker above the connect button
- Show full network name in the network picker

This pull request fixes #6056

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Test on iPhone and iPad
1. Open wallet panel, verify full network name is shown and network picker is on the left
2. ~Open wallet Portfolio, verify full network name is shown~
    - The Network Picker button was removed from Portfolio as part of [Multichain Portfolio updates](https://github.com/brave/brave-ios/issues/6352).
3. Open buy/send/swap, verify full network name is shown


## Screenshots:

Panel | Portfolio | Swap
--|--|--
![full network name - panel - iPhone](https://user-images.githubusercontent.com/5314553/199986578-ae66b1c0-c7f9-4eca-b916-2dc5626d821d.png) | ![full network name - portfolio - iPhone](https://user-images.githubusercontent.com/5314553/199986573-6bb7bb07-4660-42db-8ce1-9aae7a274fe8.png) | ![full network name - swap - iPhone](https://user-images.githubusercontent.com/5314553/199986570-7aafc87f-8a3c-4500-8b5f-0cc9aff758c8.png)
 ![full network name - panel - iPad](https://user-images.githubusercontent.com/5314553/199986715-b35cc5b3-f6aa-40a9-aeb7-ac89b7cc07c1.png) | ![full network name - portfolio - iPad](https://user-images.githubusercontent.com/5314553/199986711-ed2cac19-5816-42be-9565-f74506070953.png) | ![full network name - swap - iPad](https://user-images.githubusercontent.com/5314553/199986713-24f2cca0-97b8-4516-b9bf-b345e3b284fc.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
