### PR TITLE
Fix #6327: Text size change breaking Asset Details layout on iOS 16+

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -11,6 +11,7 @@ import DesignSystem
 import Strings
 import BraveShared
 import BraveUI
+import Introspect
 
 struct AssetDetailView: View {
   @ObservedObject var assetDetailStore: AssetDetailStore
@@ -21,6 +22,10 @@ struct AssetDetailView: View {
   @State private var isShowingAddAccount: Bool = false
   @State private var transactionDetails: TransactionDetailsStore?
   @State private var isShowingAuroraBridgeAlert: Bool = false
+  
+  @Environment(\.sizeCategory) private var sizeCategory
+  /// Reference to the collection view used to back the `List` on iOS 16+
+  @State private var collectionView: UICollectionView?
 
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
@@ -134,6 +139,15 @@ struct AssetDetailView: View {
     }
     .introspectTableView { tableView in
       tableInset = -tableView.layoutMargins.left
+    }
+    .onChange(of: sizeCategory) { _ in
+      // Fix broken header when text size changes on iOS 16+
+      collectionView?.collectionViewLayout.invalidateLayout()
+    }
+    .introspect(
+      selector: TargetViewSelector.ancestorOrSiblingContaining
+    ) { (collectionView: UICollectionView) in
+      self.collectionView = collectionView
     }
     .background(
       Color.clear


### PR DESCRIPTION
## Summary of Changes
- Same fix as Portfolio in https://github.com/brave/brave-ios/issues/6312, invalidate collection view layout when text size changes

This pull request fixes #6327

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Open asset detail for any asset
2. Change accessibility text size
3. Verify layout is not broken


## Screenshots:

https://user-images.githubusercontent.com/5314553/200016621-cf545dfa-a885-43fc-a19a-465aa6263dc4.mp4

https://user-images.githubusercontent.com/5314553/200016595-0f62e529-99c9-4709-a483-b3930191f855.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
