### PR TITLE
Fix #6326: unexclude ERC721 tokens in token lists

### DIFF
--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -18,7 +18,7 @@ struct AssetSearchView: View {
   
   var body: some View {
     NavigationView {
-      TokenList(tokens: allTokens.filter { !$0.isErc721 || cryptoStore.networkStore.selectedChain.isNativeAsset($0) }) { token in
+      TokenList(tokens: allTokens) { token in
         NavigationLink(
           destination: AssetDetailView(
             assetDetailStore: cryptoStore.assetDetailStore(for: token),
@@ -51,7 +51,14 @@ struct AssetSearchView: View {
         cryptoStore.networkStore.selectedChainId,
         coin: cryptoStore.networkStore.selectedChain.coin
       ) { tokens in
-        self.allTokens = ([cryptoStore.networkStore.selectedChain.nativeToken] + tokens).sorted(by: { $0.symbol < $1.symbol })
+        if WalletDebugFlags.isNFTEnabled {
+          self.allTokens = ([cryptoStore.networkStore.selectedChain.nativeToken] + tokens).sorted(by: { $0.symbol < $1.symbol })
+        } else {
+          let tokens = ([cryptoStore.networkStore.selectedChain.nativeToken] + tokens).sorted(by: { $0.symbol < $1.symbol })
+          self.allTokens = tokens.filter {
+            !$0.isErc721 || cryptoStore.networkStore.selectedChain.isNativeAsset($0)
+          }
+        }
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -14,8 +14,18 @@ struct SendTokenSearchView: View {
   
   var network: BraveWallet.NetworkInfo
   
+  private var allTokens: [BraveWallet.BlockchainToken] {
+    if WalletDebugFlags.isNFTEnabled {
+      return sendTokenStore.userAssets
+    } else {
+      return sendTokenStore.userAssets.filter {
+        !$0.isErc721 || network.isNativeAsset($0)
+      }
+    }
+  }
+  
   var body: some View {
-    TokenList(tokens: sendTokenStore.userAssets.filter { !$0.isErc721 || network.isNativeAsset($0) }) { token in
+    TokenList(tokens: allTokens) { token in
       Button(action: {
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -82,7 +82,11 @@ public class UserAssetsStore: ObservableObject {
     walletService.userAssets(network.chainId, coin: network.coin) { [self] userAssets in
       let visibleAssetIds = userAssets.filter(\.visible).map(\.id)
       blockchainRegistry.allTokens(network.chainId, coin: network.coin) { [self] registryTokens in
-        allTokens = registryTokens + [network.nativeToken]
+        if WalletDebugFlags.isNFTEnabled {
+          allTokens = registryTokens + [network.nativeToken]
+        } else {
+          allTokens = registryTokens.filter { !$0.isErc721 } + [network.nativeToken]
+        }
         assetStores = allTokens.union(userAssets, f: { $0.id }).map { token in
           AssetStore(
             walletService: walletService,

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -98,4 +98,5 @@ struct WalletConstants {
 
 public struct WalletDebugFlags {
   public static let isSolanaDappsEnabled: Bool = false
+  public static let isNFTEnabled: Bool = false
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Include ERC721 in 
1. Asset Search
2. Edit visible assets
3. Send token list (if there is ERC721 token as visible asset)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6326

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. Check ERC721 tokens from token registry appear in asset search screen
2. Check ERC721 tokens from token registry appear in edit visible search screen
3. Add a ERC721 token from token registry (this is blocked by #6331), check this token appears in visible assets list and the token list in send screen.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
