### PR TITLE
Fix #6335: Refactor NetworkSelectionView to allow filtering networks

### DIFF
--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -39,6 +39,13 @@ struct NetworkSelectionView: View {
     }
   }
   
+  private var navigationTitle: String {
+    switch store.mode {
+    case .select: return Strings.Wallet.networkSelectionTitle
+    case .filter: return Strings.Wallet.networkFilterTitle
+    }
+  }
+  
   var body: some View {
     List {
       Section {
@@ -69,7 +76,7 @@ struct NetworkSelectionView: View {
     }
     .listStyle(.insetGrouped)
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
-    .navigationTitle(Strings.Wallet.networkSelectionTitle)
+    .navigationTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItemGroup(placement: .cancellationAction) {
@@ -93,6 +100,7 @@ struct NetworkSelectionView: View {
             NetworkSelectionDetailView(
               networks: detailNetwork.subNetworks,
               selectedNetwork: selectedNetwork,
+              navigationTitle: navigationTitle,
               selectedNetworkHandler: { network in
                 selectNetwork(.network(network))
               }
@@ -278,6 +286,7 @@ private struct NetworkSelectionDetailView: View {
   
   var networks: [BraveWallet.NetworkInfo]
   var selectedNetwork: NetworkPresentation.Network
+  let navigationTitle: String
   var selectedNetworkHandler: (BraveWallet.NetworkInfo) -> Void
   
   var body: some View {
@@ -294,7 +303,7 @@ private struct NetworkSelectionDetailView: View {
     }
     .listStyle(.insetGrouped)
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
-    .navigationTitle(networks.first?.shortChainName ?? Strings.Wallet.networkSelectionTitle)
+    .navigationTitle(networks.first?.shortChainName ?? navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
   }
   
@@ -313,6 +322,7 @@ struct NetworkSelectionDetailView_Previews: PreviewProvider {
       NetworkSelectionDetailView(
         networks: [.mockMainnet, .mockGoerli, .mockSepolia],
         selectedNetwork: .network(.mockMainnet),
+        navigationTitle: Strings.Wallet.networkFilterTitle,
         selectedNetworkHandler: { _ in }
       )
     }

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -92,7 +92,7 @@ struct NetworkSelectionView: View {
           if let detailNetwork = store.detailNetwork {
             NetworkSelectionDetailView(
               networks: detailNetwork.subNetworks,
-              selectedNetwork: networkStore.selectedChain,
+              selectedNetwork: selectedNetwork,
               selectedNetworkHandler: { network in
                 selectNetwork(.network(network))
               }
@@ -277,7 +277,7 @@ struct NetworkRowView_Previews: PreviewProvider {
 private struct NetworkSelectionDetailView: View {
   
   var networks: [BraveWallet.NetworkInfo]
-  var selectedNetwork: BraveWallet.NetworkInfo
+  var selectedNetwork: NetworkPresentation.Network
   var selectedNetworkHandler: (BraveWallet.NetworkInfo) -> Void
   
   var body: some View {
@@ -285,7 +285,7 @@ private struct NetworkSelectionDetailView: View {
       ForEach(networks) { network in
         Button(action: { selectedNetworkHandler(network) }) {
           NetworkSelectionDetailRow(
-            isSelected: selectedNetwork == network,
+            isSelected: isSelected(network),
             network: network
           )
           .contentShape(Rectangle())
@@ -297,6 +297,13 @@ private struct NetworkSelectionDetailView: View {
     .navigationTitle(networks.first?.shortChainName ?? Strings.Wallet.networkSelectionTitle)
     .navigationBarTitleDisplayMode(.inline)
   }
+  
+  private func isSelected(_ network: BraveWallet.NetworkInfo) -> Bool {
+    if case let .network(selectedNetwork) = self.selectedNetwork {
+      return network == selectedNetwork
+    }
+    return false
+  }
 }
 
 #if DEBUG
@@ -305,7 +312,7 @@ struct NetworkSelectionDetailView_Previews: PreviewProvider {
     NavigationView {
       NetworkSelectionDetailView(
         networks: [.mockMainnet, .mockGoerli, .mockSepolia],
-        selectedNetwork: .mockMainnet,
+        selectedNetwork: .network(.mockMainnet),
         selectedNetworkHandler: { _ in }
       )
     }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -27,6 +27,12 @@ public class NetworkStore: ObservableObject {
     allChains.first(where: { $0.chainId == self.selectedChainId }) ?? .init()
   }
   
+  enum NetworkFilter: Equatable {
+    case allNetworks
+    case network(BraveWallet.NetworkInfo)
+  }
+  @Published var networkFilter: NetworkFilter = .allNetworks
+  
   @Published private(set) var isSwapSupported: Bool = true
 
   private let keyringService: BraveWalletKeyringService

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3249,5 +3249,12 @@ extension Strings {
       value: "View original message",
       comment: "The title of the button that users can click to display the sign request message as its original content."
     )
+    public static let allNetworksTitle = NSLocalizedString(
+      "wallet.allNetworksTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "All Networks",
+      comment: "The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network."
+    )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3256,5 +3256,12 @@ extension Strings {
       value: "All Networks",
       comment: "The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network."
     )
+    public static let networkFilterTitle = NSLocalizedString(
+      "wallet.networkFilterTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Select Network Filter",
+      comment: "The title displayed on the view to filter by a network / all networks."
+    )
   }
 }

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -88,12 +88,12 @@ import BraveShared
     
     store.update()
     
-    let expectedPrimaryNetworks: [NetworkSelectionStore.NetworkPresentation] = [
-      .init(network: .mockSolana, subNetworks: [], isPrimaryNetwork: true),
-      .init(network: .mockMainnet, subNetworks: [], isPrimaryNetwork: true)
+    let expectedPrimaryNetworks: [NetworkPresentation] = [
+      .init(network: .network(.mockSolana), subNetworks: [], isPrimaryNetwork: true),
+      .init(network: .network(.mockMainnet), subNetworks: [], isPrimaryNetwork: true)
     ]
-    let expectedSecondaryNetworks: [NetworkSelectionStore.NetworkPresentation] = [
-      .init(network: .mockPolygon, subNetworks: [], isPrimaryNetwork: false)
+    let expectedSecondaryNetworks: [NetworkPresentation] = [
+      .init(network: .network(.mockPolygon), subNetworks: [], isPrimaryNetwork: false)
     ]
     XCTAssertEqual(store.primaryNetworks, expectedPrimaryNetworks, "Unexpected primary networks set")
     XCTAssertEqual(store.secondaryNetworks, expectedSecondaryNetworks, "Unexpected secondary networks set")
@@ -127,12 +127,12 @@ import BraveShared
     
     store.update()
     
-    let expectedPrimaryNetworks: [NetworkSelectionStore.NetworkPresentation] = [
-      .init(network: .mockSolana, subNetworks: [.mockSolana, .mockSolanaTestnet], isPrimaryNetwork: true),
-      .init(network: .mockMainnet, subNetworks: [.mockMainnet, .mockGoerli, .mockSepolia], isPrimaryNetwork: true)
+    let expectedPrimaryNetworks: [NetworkPresentation] = [
+      .init(network: .network(.mockSolana), subNetworks: [.mockSolana, .mockSolanaTestnet], isPrimaryNetwork: true),
+      .init(network: .network(.mockMainnet), subNetworks: [.mockMainnet, .mockGoerli, .mockSepolia], isPrimaryNetwork: true)
     ]
-    let expectedSecondaryNetworks: [NetworkSelectionStore.NetworkPresentation] = [
-      .init(network: .mockPolygon, subNetworks: [], isPrimaryNetwork: false)
+    let expectedSecondaryNetworks: [NetworkPresentation] = [
+      .init(network: .network(.mockPolygon), subNetworks: [], isPrimaryNetwork: false)
     ]
     XCTAssertEqual(store.primaryNetworks, expectedPrimaryNetworks, "Unexpected primary networks set")
     XCTAssertEqual(store.secondaryNetworks, expectedSecondaryNetworks, "Unexpected secondary networks set")
@@ -149,7 +149,7 @@ import BraveShared
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)
-    let success = await store.selectNetwork(network: .mockGoerli)
+    let success = await store.selectNetwork(.network(.mockGoerli))
     XCTAssertTrue(success, "Expected success for selecting Ropsten because we have ethereum accounts.")
     XCTAssertNil(store.detailNetwork, "Expected to reset detail network to nil to pop detail view")
   }
@@ -165,7 +165,7 @@ import BraveShared
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)
-    let success = await store.selectNetwork(network: .mockSolana)
+    let success = await store.selectNetwork(.network(.mockSolana))
     XCTAssertFalse(success, "Expected failure for selecting Solana because we have no Solana accounts.")
     XCTAssertTrue(store.isPresentingNextNetworkAlert, "Expected to set isPresentingNextNetworkAlert to true to show alert asking user to create Solana account")
     XCTAssertNil(store.detailNetwork, "Expected to reset detail network to nil to pop detail view")
@@ -182,7 +182,7 @@ import BraveShared
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)
-    store.detailNetwork = .init(network: .mockSolana, subNetworks: [.mockSolana], isPrimaryNetwork: true)
+    store.detailNetwork = .init(network: .network(.mockSolana), subNetworks: [.mockSolana], isPrimaryNetwork: true)
     
     store.handleCreateAccountAlertResponse(shouldCreateAccount: true)
     
@@ -201,7 +201,7 @@ import BraveShared
     )
     
     let store = NetworkSelectionStore(networkStore: networkStore)
-    store.detailNetwork = .init(network: .mockSolana, subNetworks: [.mockSolana], isPrimaryNetwork: true)
+    store.detailNetwork = .init(network: .network(.mockSolana), subNetworks: [.mockSolana], isPrimaryNetwork: true)
     store.isPresentingNextNetworkAlert = true
     
     store.handleCreateAccountAlertResponse(shouldCreateAccount: false)
@@ -267,7 +267,7 @@ import BraveShared
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     
-    let success = await store.selectNetwork(network: .mockSolana)
+    let success = await store.selectNetwork(.network(.mockSolana))
     XCTAssertFalse(success, "Expected failure to select network due to no accounts")
     XCTAssertTrue(store.isPresentingNextNetworkAlert, "Expected to present next network alert")
     


### PR DESCRIPTION
## Summary of Changes
- Add new `NetworkFilter` enum and property to `NetworkStore`, which will be used for filtering User Assets in Portfolio (default is all networks).
- Refactors `NetworkSelectionView` / `NetworkSelectionStore` to contain a `Mode` enum with `select` / `filter` cases. `Mode.select` is used for selecting a network in the wallet (current behaviour), where the new `filter` option will update the `networkFilter: NetworkFilter` property in `NetworkStore`

This pull request fixes #6335

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Update `NetworkPicker.swift` so `NetworkSelectionStore` is initialized with `mode: .filter`
2. Build & run, tap any network picker button (ex. in Portfolio).
3. Select a network
4. Tap network picker button again to verify previous selection saved
5. Verify wallet active network did not change
6. Tap network picker button and select 'All Networks'
7. Tap network picker button again to verify 'All Networks' is checked/selected


## Screenshots:

https://user-images.githubusercontent.com/5314553/200069326-3a06382a-56ca-4b7a-b70b-cf7168fb6184.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
