### PR TITLE
Fix #6198: Disable scriplets and css rules when shields are down

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -305,7 +305,7 @@ extension BrowserViewController: WKNavigationDelegate {
        let scriptTypes = tab?.currentPageData?.makeUserScriptTypes(
         forRequestURL: url,
         isForMainFrame: targetFrame.isMainFrame,
-        options: isPrivateBrowsing ? .privateBrowsing : .default
+        persistentDomain: !isPrivateBrowsing
        ) {
       tab?.setCustomUserScript(scripts: scriptTypes)
     }
@@ -456,7 +456,7 @@ extension BrowserViewController: WKNavigationDelegate {
        let scriptTypes = tab?.currentPageData?.makeUserScriptTypes(
         forResponseURL: responseURL,
         isForMainFrame: navigationResponse.isForMainFrame,
-        options: isPrivateBrowsing ? .privateBrowsing : .default
+        persistentDomain: !isPrivateBrowsing
        ) {
       tab?.setCustomUserScript(scripts: scriptTypes)
     }

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -574,7 +574,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
        let customUserScripts = tab.currentPageData?.makeUserScriptTypes(
         forRequestURL: requestURL,
         isForMainFrame: targetFrame.isMainFrame,
-        options: .playlistCacheLoader
+        persistentDomain: false
        ) {
       tab.setCustomUserScript(scripts: customUserScripts)
     }
@@ -646,7 +646,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
        let scriptTypes = tab.currentPageData?.makeUserScriptTypes(
         forResponseURL: responseURL,
         isForMainFrame: navigationResponse.isForMainFrame,
-        options: .playlistCacheLoader
+        persistentDomain: false
        ) {
       tab.setCustomUserScript(scripts: scriptTypes)
     }

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -6,6 +6,7 @@
 import Foundation
 import WebKit
 import Shared
+import Data
 import os.log
 
 /// This handler receives a list of ids and selectors for a given frame for which it is then able to inject scripts and css rules in order to hide certain elements
@@ -51,7 +52,8 @@ class CosmeticFiltersScriptHandler: TabContentScript {
         return
       }
       
-      let selectors = AdBlockStats.shared.cachedEngines.flatMap { cachedEngine -> [String] in
+      let domain = Domain.getOrCreate(forUrl: frameURL, persistent: tab?.isPrivate == true ? false : true)
+      let selectors = AdBlockStats.shared.cachedEngines(for: domain).flatMap { cachedEngine -> [String] in
         do {
           return try cachedEngine.selectorsForCosmeticRules(
             frameURL: frameURL,

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -61,8 +61,9 @@ class SiteStateListenerScriptHandler: TabContentScript {
         return
       }
       
-      if let frameInfo = tab.currentPageData?.framesInfo[frameURL] {
-        let models = AdBlockStats.shared.cosmeticFilterModels(forFrameURL: frameURL)
+      if let pageData = tab.currentPageData, let frameInfo = pageData.framesInfo[frameURL] {
+        let domain = pageData.domain(persistent: !tab.isPrivate)
+        let models = AdBlockStats.shared.cosmeticFilterModels(forFrameURL: frameURL, domain: domain)
         
         let hideSelectors = models.reduce(Set<String>(), { partialResult, model in
           return partialResult.union(model.hideSelectors)

--- a/Client/WebFilters/AdBlockEngineManager.swift
+++ b/Client/WebFilters/AdBlockEngineManager.swift
@@ -275,9 +275,9 @@ public actor AdBlockEngineManager: Sendable {
       })
       
       var allCompileResults: [ResourceWithVersion: Result<Void, Error>] = [:]
-      var allEngines: [AdblockEngine] = []
+      var allEngines: [CachedAdBlockEngine] = []
       
-      for (_, group) in await self.group(resources: resourcesWithVersion) {
+      for (source, group) in await self.group(resources: resourcesWithVersion) {
         try Task.checkCancellation()
         
         // Combine all rule lists that need to be injected during initialization
@@ -291,7 +291,7 @@ public actor AdBlockEngineManager: Sendable {
           allCompileResults[resourceWithVersion] = compileResult
         }
         
-        allEngines.append(engine)
+        allEngines.append(CachedAdBlockEngine(engine: engine, source: source))
       }
       
       // Set the results and clear some things

--- a/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Client/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -5,6 +5,7 @@ import Shared
 import BraveShared
 import Combine
 import BraveCore
+import Data
 import os.log
 
 struct CosmeticFilterModel: Codable {
@@ -44,7 +45,11 @@ public class CachedAdBlockEngine {
   /// We cache the models so that they load faster when we need to poll information about the frame
   private var cachedCosmeticFilterModels = FifoDict<URL, CosmeticFilterModel?>()
   private var cachedShouldBlockResult = FifoDict<String, Bool>()
+  /// We cache the user scripts so that they load faster on refreshes and back and forth
+  private var cachedFrameScriptTypes = FifoDict<URL, Set<UserScriptType>>()
+  
   let engine: AdblockEngine
+  let source: AdBlockEngineManager.Source
   
   /// Returns all the models for this frame URL
   /// The results are cached per url, so you may call this method as many times for the same url without any performance implications.
@@ -91,28 +96,61 @@ public class CachedAdBlockEngine {
     return shouldBlock
   }
   
+  /// This returns all the user script types for the given frame
+  func makeEngineScriptTypes(frameURL: URL, isMainFrame: Bool, domain: Domain, index: Int) throws -> Set<UserScriptType> {
+    if let userScriptTypes = cachedFrameScriptTypes.getElement(frameURL) {
+      return userScriptTypes
+    }
+    
+    // Add the selectors poller scripts for this frame
+    var userScriptTypes: Set<UserScriptType> = []
+    
+    if let source = try cosmeticFilterModel(forFrameURL: frameURL)?.injectedScript, !source.isEmpty {
+      let configuration = UserScriptType.EngineScriptConfiguration(
+        frameURL: frameURL, isMainFrame: isMainFrame, source: source, order: index,
+        isDeAMPEnabled: Preferences.Shields.autoRedirectAMPPages.value
+      )
+      
+      userScriptTypes.insert(.engineScript(configuration))
+    }
+      
+    cachedFrameScriptTypes.addElement(userScriptTypes, forKey: frameURL)
+    return userScriptTypes
+  }
+  
   /// Clear the caches. Useful 
   func clearCaches() {
     cachedCosmeticFilterModels = FifoDict()
     cachedShouldBlockResult = FifoDict()
   }
   
-  init(engine: AdblockEngine) {
+  init(engine: AdblockEngine, source: AdBlockEngineManager.Source) {
     self.engine = engine
+    self.source = source
+  }
+  
+  /// Returns a boolean indicating if the engine is enabled for the given domain.
+  ///
+  /// This is determined by checking the source of the engine and checking the appropriate shields.
+  func isEnabled(for domain: Domain) -> Bool {
+    switch source {
+    case .adBlock:
+      // This engine source type is enabled only if shields are enabled
+      // for the given domain
+      return domain.isShieldExpected(.AdblockAndTp, considerAllShieldsOption: true)
+    case .filterList, .cosmeticFilters:
+      // Filter lists are controlled via the filter lists UI
+      // whereas the cosmetic filters are always applied
+      return true
+    }
   }
 }
 
 public class AdBlockStats {
   public static let shared = AdBlockStats()
-  
-  /// We cache the user scripts so that they load faster on refreshes and back and forth
-  private var cachedFrameScriptTypes = FifoDict<URL, Set<UserScriptType>>()
 
   // Adblock engine for general adblock lists.
-  private(set) var cachedEngines: [CachedAdBlockEngine]
-
-  /// The task that downloads all the files. Can be cancelled
-  private var downloadTask: AnyCancellable?
+  private var cachedEngines: [CachedAdBlockEngine]
 
   init() {
     cachedEngines = []
@@ -121,7 +159,6 @@ public class AdBlockStats {
   static let adblockSerialQueue = DispatchQueue(label: "com.brave.adblock-dispatch-queue")
   
   func clearCaches(clearEngineCaches: Bool = true) {
-    cachedFrameScriptTypes = FifoDict()
     guard clearEngineCaches else { return }
     cachedEngines.forEach({ $0.clearCaches() })
   }
@@ -152,54 +189,53 @@ public class AdBlockStats {
     })
   }
   
-  func set(engines: [AdblockEngine]) {
-    self.cachedEngines = engines.map({ CachedAdBlockEngine(engine: $0) })
+  func set(engines: [CachedAdBlockEngine]) {
+    self.cachedEngines = engines
     self.clearCaches(clearEngineCaches: false)
   }
   
   /// This returns all the user script types for the given frame
-  func makeEngineScriptTypes(frameURL: URL, isMainFrame: Bool) -> Set<UserScriptType> {
-    if let userScriptTypes = cachedFrameScriptTypes.getElement(frameURL) {
-      return userScriptTypes
-    }
-    
-    // Grab the relevant models for this frame
-    let models = cosmeticFilterModels(forFrameURL: frameURL)
-    
+  func makeEngineScriptTypes(frameURL: URL, isMainFrame: Bool, domain: Domain) -> Set<UserScriptType> {
     // Add the selectors poller scripts for this frame
     var userScriptTypes: Set<UserScriptType> = []
     
     // Add any engine scripts for this frame
-    for (index, model) in models.enumerated() {
-      let source = model.injectedScript
-      guard !source.isEmpty else { continue }
-      
-      let configuration = UserScriptType.EngineScriptConfiguration(
-        frameURL: frameURL, isMainFrame: isMainFrame, source: source, order: index,
-        isDeAMPEnabled: Preferences.Shields.autoRedirectAMPPages.value
-      )
-      
-      userScriptTypes.insert(.engineScript(configuration))
+    for (index, cachedEngine) in cachedEngines(for: domain).enumerated() {
+      do {
+        let scriptTypes = try cachedEngine.makeEngineScriptTypes(
+          frameURL: frameURL, isMainFrame: isMainFrame, domain: domain, index: index
+        )
+        userScriptTypes = userScriptTypes.union(scriptTypes)
+      } catch {
+        assertionFailure()
+      }
     }
     
-    cachedFrameScriptTypes.addElement(userScriptTypes, forKey: frameURL)
     return userScriptTypes
   }
   
   /// Returns all the models for this frame URL
-  func cosmeticFilterModels(forFrameURL frameURL: URL) -> [CosmeticFilterModel] {
-    return cachedEngines.compactMap({ cachedEngine -> CosmeticFilterModel? in
+  func cachedEngines(for domain: Domain) -> [CachedAdBlockEngine] {
+    return cachedEngines.filter({ cachedEngine in
+      return cachedEngine.isEnabled(for: domain)
+    })
+  }
+  
+  /// Returns all the models for this frame URL
+  func cosmeticFilterModels(forFrameURL frameURL: URL, domain: Domain) -> [CosmeticFilterModel] {
+    return cachedEngines(for: domain).compactMap { cachedEngine in
       do {
         return try cachedEngine.cosmeticFilterModel(forFrameURL: frameURL)
       } catch {
-        assertionFailure(error.localizedDescription)
+        assertionFailure()
         return nil
       }
-    })
+    }
   }
 }
 
 private extension AdblockEngine {
+  /// Parse a `CosmeticFilterModel` from the engine
   func cosmeticFilterModel(forFrameURL frameURL: URL) throws -> CosmeticFilterModel? {
     let rules = cosmeticResourcesForURL(frameURL.absoluteString)
     guard let data = rules.data(using: .utf8) else { return nil }

--- a/Tests/ClientTests/PageDataTests.swift
+++ b/Tests/ClientTests/PageDataTests.swift
@@ -20,7 +20,7 @@ final class PageDataTests: XCTestCase {
     // When
     // We get the script types for the main frame
     let mainFrameRequestTypes = pageData.makeUserScriptTypes(
-      forRequestURL: mainFrameURL, isForMainFrame: true, options: .privateBrowsing
+      forRequestURL: mainFrameURL, isForMainFrame: true, persistentDomain: false
     )
     
     // Then
@@ -33,7 +33,7 @@ final class PageDataTests: XCTestCase {
     // When
     // Nothing has changed
     let unchangedScriptTypes = pageData.makeUserScriptTypes(
-      forRequestURL: mainFrameURL, isForMainFrame: true, options: .privateBrowsing
+      forRequestURL: mainFrameURL, isForMainFrame: true, persistentDomain: false
     )
     
     // Then

--- a/Tests/ClientTests/Web Filters/AdBlockEngineManagerTests.swift
+++ b/Tests/ClientTests/Web Filters/AdBlockEngineManagerTests.swift
@@ -5,6 +5,7 @@
 
 import XCTest
 import BraveCore
+import Data
 @testable import Brave
 
 class AdBlockEngineManagerTests: XCTestCase {
@@ -80,12 +81,18 @@ class AdBlockEngineManagerTests: XCTestCase {
       await engineManager.compileResources()
       
       Task { @MainActor in
-        XCTAssertEqual(stats.cachedEngines.count, 3)
-        let types = stats.makeEngineScriptTypes(frameURL: URL(string:  "https://stackoverflow.com")!, isMainFrame: true)
+        let url = URL(string:  "https://stackoverflow.com")!
+        let domain = Domain.getOrCreate(forUrl: url, persistent: false)
+        let cachedEngines = stats.cachedEngines(for: domain)
+        XCTAssertEqual(cachedEngines.count, 3)
+        
+        let types = stats.makeEngineScriptTypes(frameURL: url, isMainFrame: true, domain: domain)
         // We should have no scripts injected
         XCTAssertEqual(types.count, 0)
         
-        let types2 = stats.makeEngineScriptTypes(frameURL: URL(string:  "https://reddit.com")!, isMainFrame: true)
+        let url2 = URL(string:  "https://stackoverflow.com")!
+        let domain2 = Domain.getOrCreate(forUrl: url2, persistent: false)
+        let types2 = stats.makeEngineScriptTypes(frameURL: URL(string:  "https://reddit.com")!, isMainFrame: true, domain: domain2)
         // We should have 1 engine script injected
         XCTAssertEqual(types2.count, 1)
         XCTAssertTrue(types2.contains(where: { scriptType in


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6198 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
