### PR TITLE
Fix #6344: Improve lockscreen favorite img for no-favorites-found state.

### DIFF
--- a/App/BraveWidgets/LockScreenFavoriteWidget.swift
+++ b/App/BraveWidgets/LockScreenFavoriteWidget.swift
@@ -94,13 +94,15 @@ private struct LockScreenFavoriteView: View {
     } else {
       Image(braveSystemName: "brave.logo")
         .imageScale(.large)
-        .font(.system(size: 26))
+        .font(.system(size: 24))
         .foregroundColor(Color.black)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
           Color(white: 0.9)
-            .clipShape(Circle())
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .padding(12)
         )
+        .background(Color.black)
     }
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6344 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="313" alt="Zrzut ekranu 2022-11-7 o 18 36 07" src="https://user-images.githubusercontent.com/6950387/200379213-c923c7a8-6a16-460b-8d94-298b7dcce5ab.png">


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
