### PR TITLE
Fix #5725: Add network selection in add custom asset

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -408,7 +408,7 @@ struct SwapCryptoView: View {
             isLoading: swapTokensStore.isMakingTx,
             action: {
               swapTokensStore.prepareSwap { success in
-                if (success){
+                if success {
                   appRatingRequest?()
                 }
                 completion?(success)

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -45,6 +45,7 @@ struct NetworkSelectionView: View {
     switch store.mode {
     case .select: return Strings.Wallet.networkSelectionTitle
     case .filter: return Strings.Wallet.networkFilterTitle
+    case .formSelection: return Strings.Wallet.networkSelectionTitle
     }
   }
   

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -37,7 +37,7 @@ struct NetworkSelectionView: View {
         return .network(network)
       }
     case .formSelection:
-      return .networkSelection(store.networkSelectionInForm)
+      return .network(store.networkSelectionInForm ?? .init())
     }
   }
   
@@ -152,14 +152,8 @@ struct NetworkSelectionView: View {
   
   private func selectNetwork(_ presentation: NetworkPresentation.Network) {
     Task { @MainActor in
-      if case .formSelection = store.mode {
-        guard case let .network(network) = presentation else { return }
-        store.networkSelectionInForm = network
+      if await store.selectNetwork(presentation) {
         presentationMode.dismiss()
-      } else {
-        if await store.selectNetwork(presentation) {
-          presentationMode.dismiss()
-        }
       }
     }
   }
@@ -188,9 +182,6 @@ private struct NetworkRowView: View {
       return true
     } else if case .network(let selectedNetwork) = self.selectedNetwork {
       return presentation.subNetworks.contains(selectedNetwork)
-    } else if case .networkSelection(let networkInfo) = selectedNetwork {
-      guard case .network(let presentationNetwork) = presentation.network else { return false}
-      return networkInfo == presentationNetwork
     }
     return false
   }
@@ -211,11 +202,6 @@ private struct NetworkRowView: View {
       return Strings.Wallet.allNetworksTitle
     case let .network(network):
       return showShortChainName ? network.shortChainName : network.chainName
-    case let .networkSelection(network):
-      if let network = network {
-        return showShortChainName ? network.shortChainName : network.chainName
-      }
-      return ""
     }
   }
 

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -62,6 +62,8 @@ struct AddCustomAssetView: View {
         ) {
           HStack {
             TextField("", text: $nameInput)
+              .autocapitalization(.none)
+              .autocorrectionDisabled()
               .disabled(userAssetStore.isSearchingToken)
             if userAssetStore.isSearchingToken && nameInput.isEmpty {
               ProgressView()
@@ -90,6 +92,8 @@ struct AddCustomAssetView: View {
                 }
               }
             }
+            .autocapitalization(.none)
+            .autocorrectionDisabled()
             .disabled(userAssetStore.isSearchingToken)
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
@@ -98,6 +102,8 @@ struct AddCustomAssetView: View {
         ) {
           HStack {
             TextField("", text: $symbolInput)
+              .autocapitalization(.none)
+              .autocorrectionDisabled()
               .disabled(userAssetStore.isSearchingToken)
             if userAssetStore.isSearchingToken && symbolInput.isEmpty {
               ProgressView()
@@ -155,6 +161,8 @@ struct AddCustomAssetView: View {
           ) {
             HStack {
               TextField("", text: $logo)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
                 .disabled(userAssetStore.isSearchingToken)
               if userAssetStore.isSearchingToken && decimalsInput.isEmpty {
                 ProgressView()
@@ -167,6 +175,8 @@ struct AddCustomAssetView: View {
           ) {
             HStack {
               TextField("", text: $coingeckoId)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
                 .disabled(userAssetStore.isSearchingToken)
               if userAssetStore.isSearchingToken && decimalsInput.isEmpty {
                 ProgressView()

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -48,12 +48,12 @@ struct AddCustomAssetView: View {
               isPresentingNetworkSelection = true
             }) {
               Text(networkSelectionStore.networkSelectionInForm?.chainName ?? Strings.Wallet.customTokenNetworkButtonTitle)
-                .foregroundColor(networkSelectionStore.networkSelectionInForm == nil ? .secondary : Color(.braveLabel))
+                .foregroundColor(networkSelectionStore.networkSelectionInForm == nil ? .gray.opacity(0.6) : Color(.braveLabel))
             }
             .disabled(userAssetStore.isSearchingToken)
             Spacer()
             Image(systemName: "chevron.down.circle")
-              .foregroundColor(.gray)
+              .foregroundColor(Color(.braveBlurple))
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
@@ -61,7 +61,7 @@ struct AddCustomAssetView: View {
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenName))
         ) {
           HStack {
-            TextField("", text: $nameInput)
+            TextField(Strings.Wallet.enterTokenName, text: $nameInput)
               .autocapitalization(.none)
               .autocorrectionDisabled()
               .disabled(userAssetStore.isSearchingToken)
@@ -74,7 +74,7 @@ struct AddCustomAssetView: View {
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenContractAddress))
         ) {
-          TextField("", text: $addressInput)
+          TextField(Strings.Wallet.enterContractAddress, text: $addressInput)
             .onChange(of: addressInput) { newValue in
               if !newValue.isEmpty, newValue.isETHAddress {
                 userAssetStore.tokenInfo(by: newValue) { token in
@@ -101,7 +101,7 @@ struct AddCustomAssetView: View {
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenSymbol))
         ) {
           HStack {
-            TextField("", text: $symbolInput)
+            TextField(Strings.Wallet.enterTokenSymbol, text: $symbolInput)
               .autocapitalization(.none)
               .autocorrectionDisabled()
               .disabled(userAssetStore.isSearchingToken)
@@ -115,7 +115,7 @@ struct AddCustomAssetView: View {
           header: WalletListHeaderView(title: Text(Strings.Wallet.decimalsPrecision))
         ) {
           HStack {
-            TextField("", text: $decimalsInput)
+            TextField(NumberFormatter().string(from: NSNumber(value: 0)) ?? "0", text: $decimalsInput)
               .keyboardType(.numberPad)
               .disabled(userAssetStore.isSearchingToken)
             if userAssetStore.isSearchingToken && decimalsInput.isEmpty {
@@ -160,7 +160,7 @@ struct AddCustomAssetView: View {
             header: WalletListHeaderView(title: Text(Strings.Wallet.addCustomTokenIconURL))
           ) {
             HStack {
-              TextField("", text: $logo)
+              TextField(Strings.Wallet.enterTokenIconURL, text: $logo)
                 .autocapitalization(.none)
                 .autocorrectionDisabled()
                 .disabled(userAssetStore.isSearchingToken)
@@ -174,7 +174,7 @@ struct AddCustomAssetView: View {
             header: WalletListHeaderView(title: Text(Strings.Wallet.addCustomTokenCoingeckoId))
           ) {
             HStack {
-              TextField("", text: $coingeckoId)
+              TextField(Strings.Wallet.enterTokenCoingeckoId, text: $coingeckoId)
                 .autocapitalization(.none)
                 .autocorrectionDisabled()
                 .disabled(userAssetStore.isSearchingToken)

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -38,6 +38,8 @@ private struct EditTokenView: View {
 }
 
 struct EditUserAssetsView: View {
+  var networkStore: NetworkStore
+  var keyringStore: KeyringStore
   @ObservedObject var userAssetsStore: UserAssetsStore
   var assetsUpdated: () -> Void
 
@@ -146,7 +148,11 @@ struct EditUserAssetsView: View {
         }
       }
       .sheet(isPresented: $isAddingCustomAsset) {
-        AddCustomAssetView(userAssetStore: userAssetsStore)
+        AddCustomAssetView(
+          networkStore: networkStore,
+          keyringStore: keyringStore,
+          userAssetStore: userAssetsStore
+        )
       }
       .alert(isPresented: $isPresentingAssetRemovalError) {
         Alert(

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -104,7 +104,11 @@ struct PortfolioView: View {
               .frame(maxWidth: .infinity)
           }
           .sheet(isPresented: $isPresentingEditUserAssets) {
-            EditUserAssetsView(userAssetsStore: portfolioStore.userAssetsStore) {
+            EditUserAssetsView(
+              networkStore: networkStore,
+              keyringStore: keyringStore,
+              userAssetsStore: portfolioStore.userAssetsStore
+            ) {
               portfolioStore.update()
             }
           }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
@@ -11,12 +11,14 @@ struct NetworkPresentation: Equatable, Hashable, Identifiable {
   enum Network: Equatable, Hashable {
     case allNetworks
     case network(BraveWallet.NetworkInfo)
+    case networkSelection(BraveWallet.NetworkInfo?)
   }
   
   var id: String {
     switch network {
     case .allNetworks: return "allNetworks"
     case let .network(network): return network.id
+    case let .networkSelection(network): return network?.id ?? "empty"
     }
   }
   let network: Network
@@ -45,6 +47,7 @@ class NetworkSelectionStore: ObservableObject {
   enum Mode: Equatable {
     case select
     case filter
+    case formSelection
     
     var isSelectMode: Bool { self == .select }
     var isFilterMode: Bool { self == .filter }
@@ -64,6 +67,8 @@ class NetworkSelectionStore: ObservableObject {
   @Published var nextNetwork: BraveWallet.NetworkInfo?
   /// If we are prompting the user to create a new account for the `nextNetwork.coin` type
   @Published var isPresentingAddAccount: Bool = false
+  /// The network the user wishes to choose for adding a custom asset
+  @Published var networkSelectionInForm: BraveWallet.NetworkInfo?
   
   init(
     mode: Mode = .select,
@@ -143,8 +148,12 @@ class NetworkSelectionStore: ObservableObject {
         networkStore.networkFilter = .allNetworks
       case let .network(network):
         networkStore.networkFilter = .network(network)
+      default:
+        return false
       }
       return true
+    case .formSelection:
+      return false
     }
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
@@ -11,14 +11,12 @@ struct NetworkPresentation: Equatable, Hashable, Identifiable {
   enum Network: Equatable, Hashable {
     case allNetworks
     case network(BraveWallet.NetworkInfo)
-    case networkSelection(BraveWallet.NetworkInfo?)
   }
   
   var id: String {
     switch network {
     case .allNetworks: return "allNetworks"
     case let .network(network): return network.id
-    case let .networkSelection(network): return network?.id ?? "empty"
     }
   }
   let network: Network
@@ -148,12 +146,16 @@ class NetworkSelectionStore: ObservableObject {
         networkStore.networkFilter = .allNetworks
       case let .network(network):
         networkStore.networkFilter = .network(network)
-      default:
-        return false
       }
       return true
     case .formSelection:
-      return false
+      switch network {
+      case let .network(network):
+        networkSelectionInForm = network
+        return true
+      default:
+        return false
+      }
     }
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -112,25 +112,31 @@ public class UserAssetsStore: ObservableObject {
     coingeckoId: String,
     completion: @escaping (_ success: Bool) -> Void
   ) {
-    let token = BraveWallet.BlockchainToken(
-      contractAddress: address,
-      name: name,
-      logo: logo,
-      isErc20: network.coin == .eth,
-      isErc721: false,
-      symbol: symbol,
-      decimals: Int32(decimals),
-      visible: true,
-      tokenId: "",
-      coingeckoId: coingeckoId,
-      chainId: network.chainId,
-      coin: network.coin
-    )
-    self.walletService.addUserAsset(token) { success in
-      if success {
-        self.updateSelectedAssets(network)
+    walletService.selectedCoin { [weak self] coinType in
+      guard let self = self else { return }
+      
+      self.rpcService.network(coinType) { currentNetwork in
+        let token = BraveWallet.BlockchainToken(
+          contractAddress: address,
+          name: name,
+          logo: logo,
+          isErc20: network.coin == .eth,
+          isErc721: false,
+          symbol: symbol,
+          decimals: Int32(decimals),
+          visible: true,
+          tokenId: "",
+          coingeckoId: coingeckoId,
+          chainId: network.chainId,
+          coin: network.coin
+        )
+        self.walletService.addUserAsset(token) { success in
+          if success, network == currentNetwork {
+            self.updateSelectedAssets(network)
+          }
+          completion(success)
+        }
       }
-      completion(success)
     }
   }
 

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -107,33 +107,30 @@ public class UserAssetsStore: ObservableObject {
     name: String,
     symbol: String,
     decimals: Int,
+    network: BraveWallet.NetworkInfo,
+    logo: String,
+    coingeckoId: String,
     completion: @escaping (_ success: Bool) -> Void
   ) {
-    walletService.selectedCoin { [weak self] coinType in
-      guard let self = self else { return }
-      // TODO: Add network selection picker to `AddCustomAssetView`: Issue #5725
-      self.rpcService.network(coinType) { network in
-        let token = BraveWallet.BlockchainToken(
-          contractAddress: address,
-          name: name,
-          logo: "",
-          isErc20: coinType == .eth,
-          isErc721: false,
-          symbol: symbol,
-          decimals: Int32(decimals),
-          visible: true,
-          tokenId: "",
-          coingeckoId: "",
-          chainId: network.chainId,
-          coin: network.coin
-        )
-        self.walletService.addUserAsset(token) { success in
-          if success {
-            self.updateSelectedAssets(network)
-          }
-          completion(success)
-        }
+    let token = BraveWallet.BlockchainToken(
+      contractAddress: address,
+      name: name,
+      logo: logo,
+      isErc20: network.coin == .eth,
+      isErc721: false,
+      symbol: symbol,
+      decimals: Int32(decimals),
+      visible: true,
+      tokenId: "",
+      coingeckoId: coingeckoId,
+      chainId: network.chainId,
+      coin: network.coin
+    )
+    self.walletService.addUserAsset(token) { success in
+      if success {
+        self.updateSelectedAssets(network)
       }
+      completion(success)
     }
   }
 

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1478,6 +1478,13 @@ extension Strings {
       value: "Token name",
       comment: "A title that will be displayed on top of the text field for users to input the custom token name"
     )
+    public static let enterTokenName = NSLocalizedString(
+      "wallet.enterTokenName",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enter token name",
+      comment: "A placeholder for the text field that users will input the custom token name"
+    )
     public static let tokenContractAddress = NSLocalizedString(
       "wallet.tokenContractAddress",
       tableName: "BraveWallet",
@@ -1485,12 +1492,26 @@ extension Strings {
       value: "Token contract address",
       comment: "A title that will be displayed on top of the text field for users to input the custom token contract address"
     )
+    public static let enterContractAddress = NSLocalizedString(
+      "wallet.enterContractAddress",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enter contract address",
+      comment: "A placeholder for the text field that users will input the custom token contract address"
+    )
     public static let tokenSymbol = NSLocalizedString(
       "wallet.tokenSymbol",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Token symbol",
       comment: "A title that will be displayed on top of the text field for users to input the custom token symbol"
+    )
+    public static let enterTokenSymbol = NSLocalizedString(
+      "wallet.enterTokenSymbol",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enter token symbol",
+      comment: "A placeholder for the text field that users will input the custom token symbol"
     )
     public static let decimalsPrecision = NSLocalizedString(
       "wallet.decimalsPrecision",
@@ -1513,12 +1534,26 @@ extension Strings {
       value: "Icon URL",
       comment: "A title that will be displayed on top of the text field for users to input the custom token's icon URL."
     )
+    public static let enterTokenIconURL = NSLocalizedString(
+      "wallet.enterTokenIconURL",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enter token icon URL",
+      comment: "A placeholder for the text field that users will input the custom token icon URL"
+    )
     public static let addCustomTokenCoingeckoId = NSLocalizedString(
       "wallet.addCustomTokenCoingeckoId",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Coingecko ID",
-      comment: "A title that will be displayed on top of the text field for users to input the custom token's coingecko id."
+      comment: "A title that will be displayed on top of the text field for users to input the custom token's coingecko ID."
+    )
+    public static let enterTokenCoingeckoId = NSLocalizedString(
+      "wallet.enterTokenCoingeckoId",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enter token Coingecko ID",
+      comment: "A placeholder for the text field that users will input the custom token Coingecko ID."
     )
     public static let addCustomTokenErrorTitle = NSLocalizedString(
       "wallet.addCustomTokenErrorTitle",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1450,6 +1450,20 @@ extension Strings {
       value: "Unknown",
       comment: "A transaction status that the app currently does not support displaying"
     )
+    public static let customTokenNetworkHeader = NSLocalizedString(
+      "wallet.customTokenNetworkHeader",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Select network",
+      comment: "A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in."
+    )
+    public static let customTokenNetworkButtonTitle = NSLocalizedString(
+      "wallet.customTokenNetworkButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Select network",
+      comment: "A title for the btton that users can click to choose the network they are willing to add custom asset in."
+    )
     public static let customTokenTitle = NSLocalizedString(
       "wallet.customTokenTitle",
       tableName: "BraveWallet",
@@ -1464,26 +1478,12 @@ extension Strings {
       value: "Token name",
       comment: "A title that will be displayed on top of the text field for users to input the custom token name"
     )
-    public static let enterTokenName = NSLocalizedString(
-      "wallet.enterTokenName",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Enter token name",
-      comment: "A placeholder for the text field that users will input the custom token name"
-    )
     public static let tokenContractAddress = NSLocalizedString(
       "wallet.tokenContractAddress",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Token contract address",
       comment: "A title that will be displayed on top of the text field for users to input the custom token contract address"
-    )
-    public static let enterContractAddress = NSLocalizedString(
-      "wallet.enterContractAddress",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Enter contract address",
-      comment: "A placeholder for the text field that users will input the custom token contract address"
     )
     public static let tokenSymbol = NSLocalizedString(
       "wallet.tokenSymbol",
@@ -1492,19 +1492,33 @@ extension Strings {
       value: "Token symbol",
       comment: "A title that will be displayed on top of the text field for users to input the custom token symbol"
     )
-    public static let enterTokenSymbol = NSLocalizedString(
-      "wallet.enterTokenSymbol",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Enter token symbol",
-      comment: "A placeholder for the text field that users will input the custom token symbol"
-    )
     public static let decimalsPrecision = NSLocalizedString(
       "wallet.decimalsPrecision",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Decimals of precision",
       comment: "A title that will be displayed on top of the text field for users to input the custom token's decimals of precision"
+    )
+    public static let addCustomTokenAdvanced = NSLocalizedString(
+      "wallet.addCustomTokenAdvanced",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Advanced",
+      comment: "A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id."
+    )
+    public static let addCustomTokenIconURL = NSLocalizedString(
+      "wallet.addCustomTokenIconURL",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Icon URL",
+      comment: "A title that will be displayed on top of the text field for users to input the custom token's icon URL."
+    )
+    public static let addCustomTokenCoingeckoId = NSLocalizedString(
+      "wallet.addCustomTokenCoingeckoId",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Coingecko ID",
+      comment: "A title that will be displayed on top of the text field for users to input the custom token's coingecko id."
     )
     public static let addCustomTokenErrorTitle = NSLocalizedString(
       "wallet.addCustomTokenErrorTitle",

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -236,7 +236,7 @@ import BraveShared
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     let success = await store.selectNetwork(.network(.mockGoerli))
-    XCTAssertTrue(success, "Expected success for selecting Ropsten because we have ethereum accounts.")
+    XCTAssertTrue(success, "Expected success for selecting Goerli because we have ethereum accounts.")
     XCTAssertNil(store.detailNetwork, "Expected to reset detail network to nil to pop detail view")
   }
   
@@ -274,6 +274,22 @@ import BraveShared
     let success = await store.selectNetwork(.network(.mockMainnet))
     XCTAssertTrue(success, "Expected success for selecting Ethereum Mainnet.")
     XCTAssertEqual(networkStore.networkFilter, .network(.mockMainnet))
+  }
+  
+  func testSelectedNetworkFormSelectionMode() async {
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
+    
+    let networkStore = NetworkStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      swapService: swapService
+    )
+    
+    let store = NetworkSelectionStore(mode: .formSelection, networkStore: networkStore)
+    let success = await store.selectNetwork(.network(.mockGoerli))
+    XCTAssertTrue(success, "Expected success for selecting Goerli")
+    XCTAssertEqual(store.networkSelectionInForm, .mockGoerli)
   }
   
   func testSelectNetworkFilterModeAllNetworks() async {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Add a new field for users to select a network they are willing to add custom asset in.
Also add a new `Advanced` section where users can input icon url and coingecko id for the custom asset. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5725 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. open Brave Wallet and unlock your wallet if it's locked 
2. click `Edit Visible Assets`
3. click `Add custom asset`
4. observe a new field on the top of the form `Select network` with no value selected initially. 
5. click `Select network`
6. observe a list of available networks will be presented (same as network filter. Testnets will also be available if it is enabled from the wallet settings.)
7. pick any network in the list
8. observe the network list will be dismissed and the selected network value appears in the form. 
=========================================================================
1. open Brave Wallet and unlock your wallet if it's locked 
2. make sure you are on eth mainnet
3. click `Edit Visible Assets`
4. click `Add custom asset`
5. try to add a custom asset that can be found in token registry but not available for a network (e.x Frax can be found in token registry but not available in Avalanche C-Chain) by adding its contract address
6. observe token name, token symbol and decimal of precision will be filled automatically. 
7. select Avalanche C-Chain for the network you want to add `Frax` in (Leave the `Advanced` section empty)
8. observe `Frax` should be added to the list with a checked mark on indicated it is visible asset. 
9. Click `Done` to dismiss the `Edit Visible Assets` screen
10. observe the visible assets list for Eth mainnet remain the same 
11. Click the network picker in portfolio and select Avalanche C-Chain
12. observe `Frax` appears in visible assets list
13. click `Frax` to check the token details
14. observe the market price and graph should be correct
=========================================================================
Let's add an asset that does not exist in token registry
1. Try to add [Bitcoin Avalanche Bridged (BTC.b) (BTC.B)](https://www.coingecko.com/en/coins/bitcoin-avalanche-bridged-btc-b) which only exists in Avalanche C-Chain
2. fill in the name/address/symbol/decimal and select network Avalanche C-Chain but leave `Advanced` section empty then click `add`
3. observe the token will be successfully added in the list but the logo is in monogram (it is because we didnt provide icon url)
4. click `Done` to go back to portfolio screen
5. click `Bitcoin Avalanche Bridged` to see the asset details
6. observe the price is 0.0000 but graph appears correctly (it is because we didnt provide coingecko id)
7. lets readd it again by deleting the existed `Bitcoin Avalanche Bridge` first.
8. fill in the name/address/symbol/decimal and select network Avalanche C-Chain and input icon url: https://assets.coingecko.com/coins/images/26115/small/btcb.png and coingecko id: bitcoin-avalanche-bridged-btc-b
9. click `add`
10. observe this time the token icon will appear and correct market price and graph will appear in the asset details screen.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screen Shot - iPhone 14 Pro - 2022-11-07 at 11 04 57](https://user-images.githubusercontent.com/1187676/200357493-4308b53f-336a-4044-9f13-5a28712352b3.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-07 at 11 05 00](https://user-images.githubusercontent.com/1187676/200357508-bd91c7fc-9445-491a-9195-7b30edea7c59.png)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
