### PR TITLE
Fix #6194: Display error page correctly when sharing a faulty url.

### DIFF
--- a/Client/Frontend/Browser/Helpers/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/Helpers/ErrorPageHelper.swift
@@ -90,9 +90,13 @@ class ErrorPageHelper {
   }
 
   func loadPage(_ error: NSError, forUrl url: URL, inWebView webView: WKWebView) {
-    guard var components = URLComponents(string: "\(InternalURL.baseUrl)/\(ErrorPageHandler.path)"), let webViewUrl = webView.url else {
+    guard var components = URLComponents(string: "\(InternalURL.baseUrl)/\(ErrorPageHandler.path)") else {
       return
     }
+    
+    // In rare cases the web view's url might be nil, like when opening a non existing website via share menu.
+    // In this case we fall back to the failing url.
+    let webViewUrl = webView.url ?? url
 
     // Page has failed to load again, just return and keep showing the existing error page.
     if let internalUrl = InternalURL(webViewUrl), internalUrl.originalURLFromErrorPage == url {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6194 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
