### PR TITLE
Fix #6350: Typo in Playlist broke Bichute and unofficially supported websites

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
@@ -115,7 +115,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
           if (node.src && node.src !== "") {
             if ((node.closest('video') === target) || (node.closest('audio') === target)) {
               tagNode(target);
-              sendMessaage(name, node, target, type, detected);
+              sendMessage(name, node, target, type, detected);
             }
           }
         });


### PR DESCRIPTION
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6350

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Screenshots:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/1530031/200589062-a5f63158-c5ee-4401-ac3b-cee8a9622e36.png">

## Test plan:
STR in the ticket

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
