### PR TITLE
Fix #6359: Fix playlist expired videos on extremely slow networks

### DIFF
--- a/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
+++ b/Client/Frontend/Browser/Playlist/Cells/PlaylistCell.swift
@@ -77,6 +77,9 @@ class PlaylistCell: UITableViewCell {
   }
 
   func prepareForDisplay() {
+    titleLabel.text = nil
+    detailLabel.text = nil
+    iconView.image = nil
     thumbnailGenerator.cancel()
     iconView.cancelFaviconLoad()
   }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
@@ -83,11 +83,12 @@ extension PlaylistListViewController: UITableViewDataSource {
       }
       
       let domain = URL(string: item.pageSrc)?.baseDomain ?? "0s"
-      let rootView = PlaylistCellRedactedView(thumbnail: nil, title: item.name, details: domain, contentSize: view.bounds.size)
       
       cell.do {
         $0.showsReorderControl = false
-        $0.setRootView(rootView, parent: self)
+        $0.setTitle(title: item.name)
+        $0.setDetails(details: domain)
+        $0.setContentSize(parentController: self, size: view.bounds.size)
         
         if let url = URL(string: item.pageSrc) {
           $0.loadThumbnail(for: url)

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -714,6 +714,8 @@ extension PlaylistListViewController {
         }
         
         let items = try await PlaylistSharedFolderNetwork.fetchMediaItemInfo(item: model, viewForInvisibleWebView: self.view)
+        try Task.checkCancellation()
+        
         try folder.playlistItems?.forEach({ playlistItem in
           try Task.checkCancellation()
           

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -340,20 +340,13 @@ class PlaylistWebLoader: UIView {
   private weak var certStore: CertStore?
   private var handler: ((PlaylistInfo?) -> Void)?
 
-  init(handler: @escaping (PlaylistInfo?) -> Void) {
+  init() {
     super.init(frame: .zero)
     
-    self.handler = { [weak self] in
-      // Handler cannot be called more than once!
-      self?.handler = nil
-      handler($0)
-    }
-
     guard let webView = tab.webView else {
-      handler(nil)
       return
     }
-
+    
     self.addSubview(webView)
     webView.snp.makeConstraints {
       $0.edges.equalToSuperview()
@@ -368,9 +361,16 @@ class PlaylistWebLoader: UIView {
     self.removeFromSuperview()
   }
 
-  func load(url: URL) {
+  func load(url: URL, handler: @escaping (PlaylistInfo?) -> Void) {
+    self.handler = { [weak self] in
+      // Handler cannot be called more than once!
+      self?.handler = nil
+      handler($0)
+    }
+    
     guard let webView = tab.webView,
           let browserViewController = self.currentScene?.browserViewController else {
+      self.handler?(nil)
       return
     }
     
@@ -392,7 +392,7 @@ class PlaylistWebLoader: UIView {
     tab.replaceContentScript(PlaylistWebLoaderContentHelper(self),
                              name: PlaylistWebLoaderContentHelper.scriptName,
                              forTab: tab)
-    
+
     webView.frame = superview?.bounds ?? self.bounds
     webView.load(URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 60.0))
   }
@@ -434,59 +434,58 @@ class PlaylistWebLoader: UIView {
     static let userScript: WKUserScript? = nil
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-      defer { replyHandler(nil, nil) }
+      replyHandler(nil, nil)
+      
+      let cancelRequest = {
+        self.timeout?.cancel()
+        self.timeout = nil
+        self.webLoader?.handler?(nil)
+        self.webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
+        self.webLoader = nil
+      }
 
       guard let item = PlaylistInfo.from(message: message),
         item.detected
       else {
-        timeout?.cancel()
-        timeout = nil
-        webLoader?.handler?(nil)
-        webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
-        webLoader = nil
+        cancelRequest()
         return
       }
 
       // For now, we ignore base64 video mime-types loaded via the `data:` scheme.
       if item.duration <= 0.0 && !item.detected || item.src.isEmpty || item.src.hasPrefix("data:") || item.src.hasPrefix("blob:") {
-        timeout?.cancel()
-        timeout = nil
-        webLoader?.handler?(nil)
-        webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
-        webLoader = nil
+        cancelRequest()
         return
       }
-
-      // We have to create an AVURLAsset here to determine if the item is playable
-      // because otherwise it will add an invalid item to playlist that can't be played.
-      // IE: WebM videos aren't supported so can't be played.
-      // Therefore we shouldn't prompt the user to add to playlist.
-      if let url = URL(string: item.src), !AVURLAsset(url: url).isPlayable {
-        timeout?.cancel()
-        timeout = nil
-        webLoader?.handler?(nil)
-        webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
-        webLoader = nil
+      
+      guard let url = URL(string: item.src) else {
+        cancelRequest()
         return
       }
-
-      if !playlistItems.contains(item.src) {
-        playlistItems.insert(item.src)
-
-        timeout?.cancel()
-        timeout = nil
-        webLoader?.handler?(item)
-        webLoader = nil
-      }
-
-      // This line MAY cause problems.. because some websites have a loading delay for the source of the media item
-      // If the second we receive the src, we reload the page by doing the below HTML,
-      // It may not have received all info necessary to play the item such as MetadataInfo
-      // For now it works 100% of the time and it is safe to do it. If we come across such a website, that causes problems,
-      // we'll need to find a different way of forcing the WebView to STOP loading metadata in the background
-      DispatchQueue.main.async {
-        self.webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
-        self.webLoader = nil
+      
+      PlaylistMediaStreamer.loadAssetPlayability(asset: AVURLAsset(url: url)) { isPlayable in
+        if !isPlayable {
+          cancelRequest()
+          return
+        }
+        
+        DispatchQueue.main.async {
+          if !self.playlistItems.contains(item.src) {
+            self.playlistItems.insert(item.src)
+            
+            self.timeout?.cancel()
+            self.timeout = nil
+            self.webLoader?.handler?(item)
+            self.webLoader = nil
+          }
+          
+          // This line MAY cause problems.. because some websites have a loading delay for the source of the media item
+          // If the second we receive the src, we reload the page by doing the below HTML,
+          // It may not have received all info necessary to play the item such as MetadataInfo
+          // For now it works 100% of the time and it is safe to do it. If we come across such a website, that causes problems,
+          // we'll need to find a different way of forcing the WebView to STOP loading metadata in the background
+          self.webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
+          self.webLoader = nil
+        }
       }
     }
   }

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -320,7 +320,7 @@ public class PlaylistMimeTypeDetector {
 }
 
 class PlaylistWebLoader: UIView {
-  fileprivate static var pageLoadTimeout = 10.0
+  fileprivate static var pageLoadTimeout = 300.0
   private var pendingHTTPUpgrades = [String: URLRequest]()
   private var pendingRequests = [String: URLRequest]()
 
@@ -456,36 +456,24 @@ class PlaylistWebLoader: UIView {
         cancelRequest()
         return
       }
-      
-      guard let url = URL(string: item.src) else {
-        cancelRequest()
-        return
-      }
-      
-      PlaylistMediaStreamer.loadAssetPlayability(asset: AVURLAsset(url: url)) { isPlayable in
-        if !isPlayable {
-          cancelRequest()
-          return
-        }
         
-        DispatchQueue.main.async {
-          if !self.playlistItems.contains(item.src) {
-            self.playlistItems.insert(item.src)
-            
-            self.timeout?.cancel()
-            self.timeout = nil
-            self.webLoader?.handler?(item)
-            self.webLoader = nil
-          }
+      DispatchQueue.main.async {
+        if !self.playlistItems.contains(item.src) {
+          self.playlistItems.insert(item.src)
           
-          // This line MAY cause problems.. because some websites have a loading delay for the source of the media item
-          // If the second we receive the src, we reload the page by doing the below HTML,
-          // It may not have received all info necessary to play the item such as MetadataInfo
-          // For now it works 100% of the time and it is safe to do it. If we come across such a website, that causes problems,
-          // we'll need to find a different way of forcing the WebView to STOP loading metadata in the background
-          self.webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
+          self.timeout?.cancel()
+          self.timeout = nil
+          self.webLoader?.handler?(item)
           self.webLoader = nil
         }
+        
+        // This line MAY cause problems.. because some websites have a loading delay for the source of the media item
+        // If the second we receive the src, we reload the page by doing the below HTML,
+        // It may not have received all info necessary to play the item such as MetadataInfo
+        // For now it works 100% of the time and it is safe to do it. If we come across such a website, that causes problems,
+        // we'll need to find a different way of forcing the WebView to STOP loading metadata in the background
+        self.webLoader?.tab.webView?.loadHTMLString("<html><body>PlayList</body></html>", baseURL: nil)
+        self.webLoader = nil
       }
     }
   }

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -593,9 +593,6 @@ extension PlaylistManager {
     // So we first need to check the track status before attempting to access it!
     var error: NSError?
     let trackStatus = asset.statusOfValue(forKey: "tracks", error: &error)
-    if let error = error {
-      Logger.module.error("AVAsset.statusOfValue error occurred: \(error.localizedDescription)")
-    }
 
     if trackStatus == .loaded {
       if !asset.tracks.isEmpty,
@@ -607,17 +604,11 @@ extension PlaylistManager {
         }
         return
       }
-    } else if trackStatus != .loading {
-      Logger.module.debug("AVAsset.statusOfValue not loaded. Status: \(String(describing: trackStatus))")
     }
 
     // Accessing duration or commonMetadata blocks the main-thread if not already loaded
     // So we first need to check the track status before attempting to access it!
     let durationStatus = asset.statusOfValue(forKey: "duration", error: &error)
-    if let error = error {
-      Logger.module.error("AVAsset.statusOfValue error occurred: \(error.localizedDescription)")
-    }
-
     if durationStatus == .loaded {
       // If it's live/indefinite
       if asset.duration.isIndefinite {
@@ -630,8 +621,6 @@ extension PlaylistManager {
         completion(asset.duration.seconds)
         return
       }
-    } else if durationStatus != .loading {
-      Logger.module.debug("AVAsset.statusOfValue not loaded. Status: \(durationStatus.rawValue)")
     }
 
     switch Reach().connectionStatus() {

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -543,11 +543,15 @@ extension PlaylistManager: NSFetchedResultsControllerDelegate {
 extension PlaylistManager {
   func getAssetDuration(item: PlaylistInfo, _ completion: @escaping (TimeInterval?) -> Void) {
     if assetInformation.contains(where: { $0.itemId == item.tagId }) {
+      completion(nil)
       return
     }
 
     fetchAssetDuration(item: item) { [weak self] duration in
-      guard let self = self else { return }
+      guard let self = self else {
+        completion(nil)
+        return
+      }
 
       if let index = self.assetInformation.firstIndex(where: { $0.itemId == item.tagId }) {
         let assetFetcher = self.assetInformation.remove(at: index)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Remove asset playability check due to extremely slow networks (Apple has its own internal timeout that we cannot control and on slow networks it will timeout and deem the asset unplayable). 
- Refactor cells on iOS 16 for animation bug on extremely slow networks. 
- Increase asset loading timeout massively for extremely slow networks (3G speeds). 
- Add fav-icon in-memory only cache for shared folders to help with extremely slow networks.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6359

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Load: https://playlist.brave.com/bsa-sample/ on a very slow network
- Videos should not be expired when testing the above


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
