### PR TITLE
Fix #6363: Display NFTs section in Portfolio

### DIFF
--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -103,3 +103,25 @@ struct AssetIconView_Previews: PreviewProvider {
   }
 }
 #endif
+
+struct NFTIconView: View {
+  
+  /// NFT token
+  var token: BraveWallet.BlockchainToken
+  /// Network for token
+  var network: BraveWallet.NetworkInfo
+  /// NFT image url from metadata
+  var url: URL?
+  
+  var body: some View {
+    WebImageReader(url: url) { image, isFinished in
+      if let image = image {
+        Image(uiImage: image)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+      } else {
+        AssetIconView(token: token, network: network)
+      }
+    }
+  }
+}

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
@@ -54,3 +54,49 @@ struct PortfolioAssetView_Previews: PreviewProvider {
   }
 }
 #endif
+
+struct PortfolioNFTAssetView: View {
+  
+  let image: NFTIconView
+  let title: String
+  let symbol: String
+  let quantity: String
+  
+  var body: some View {
+    HStack {
+      image
+      VStack(alignment: .leading) {
+        Text(title)
+          .font(.footnote)
+          .fontWeight(.semibold)
+          .foregroundColor(Color(.bravePrimary))
+        Text(symbol)
+          .font(.caption)
+          .foregroundColor(Color(.braveLabel))
+      }
+      Spacer()
+      Text(quantity)
+        .font(.footnote)
+        .foregroundColor(Color(.braveLabel))
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 6)
+    .accessibilityElement()
+    .accessibilityLabel("\(title), \(quantity) \(symbol)")
+  }
+}
+
+#if DEBUG
+struct PortfolioNFTAssetView_Previews: PreviewProvider {
+  static var previews: some View {
+    PortfolioNFTAssetView(
+      image: NFTIconView(token: .previewToken, network: .mockMainnet),
+      title: "Invisible Friends #3965",
+      symbol: "INVSBLE",
+      quantity: "1"
+    )
+    .previewLayout(.sizeThatFits)
+    .previewColorSchemes()
+  }
+}
+#endif

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -133,7 +133,7 @@ struct PortfolioView: View {
                     network: networkStore.selectedChain,
                     url: nftAsset.imageUrl
                   ),
-                  title: nftAsset.token.name,
+                  title: nftAsset.token.nftTokenTitle,
                   symbol: nftAsset.token.symbol,
                   quantity: "\(nftAsset.balance)"
                 )
@@ -295,3 +295,13 @@ struct PortfolioViewController_Previews: PreviewProvider {
   }
 }
 #endif
+
+private extension BraveWallet.BlockchainToken {
+  var nftTokenTitle: String {
+    if isErc721, let tokenId = Int(tokenId.removingHexPrefix, radix: 16) {
+      return "\(name) #\(tokenId)"
+    } else {
+      return name
+    }
+  }
+}

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -69,6 +69,25 @@ struct PortfolioView: View {
   @State private var tableInset: CGFloat = -16.0
 
   @State private var selectedToken: BraveWallet.BlockchainToken?
+  
+  private var editUserAssetsButton: some View {
+    Button(action: { isPresentingEditUserAssets = true }) {
+      Text(Strings.Wallet.editVisibleAssetsButtonTitle)
+        .multilineTextAlignment(.center)
+        .font(.footnote.weight(.semibold))
+        .foregroundColor(Color(.bravePrimary))
+        .frame(maxWidth: .infinity)
+    }
+    .sheet(isPresented: $isPresentingEditUserAssets) {
+      EditUserAssetsView(
+        networkStore: networkStore,
+        keyringStore: keyringStore,
+        userAssetsStore: portfolioStore.userAssetsStore
+      ) {
+        portfolioStore.update()
+      }
+    }
+  }
 
   var body: some View {
     List {
@@ -79,9 +98,7 @@ struct PortfolioView: View {
           .resetListHeaderStyle()
       ) {
       }
-      Section(
-        header: WalletListHeaderView(title: Text(Strings.Wallet.assetsTitle))
-      ) {
+      Section(content: {
         Group {
           ForEach(portfolioStore.userVisibleAssets) { asset in
             Button(action: {
@@ -96,24 +113,38 @@ struct PortfolioView: View {
               )
             }
           }
-          Button(action: { isPresentingEditUserAssets = true }) {
-            Text(Strings.Wallet.editVisibleAssetsButtonTitle)
-              .multilineTextAlignment(.center)
-              .font(.footnote.weight(.semibold))
-              .foregroundColor(Color(.bravePrimary))
-              .frame(maxWidth: .infinity)
-          }
-          .sheet(isPresented: $isPresentingEditUserAssets) {
-            EditUserAssetsView(
-              networkStore: networkStore,
-              keyringStore: keyringStore,
-              userAssetsStore: portfolioStore.userAssetsStore
-            ) {
-              portfolioStore.update()
-            }
-          }
+          editUserAssetsButton
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      }, header: {
+        WalletListHeaderView(title: Text(Strings.Wallet.assetsTitle))
+      })
+      
+      if WalletDebugFlags.isNFTEnabled, !portfolioStore.userVisibleNFTs.isEmpty {
+        Section(content: {
+          Group {
+            ForEach(portfolioStore.userVisibleNFTs) { nftAsset in
+              Button(action: {
+                selectedToken = nftAsset.token
+              }) {
+                PortfolioNFTAssetView(
+                  image: NFTIconView(
+                    token: nftAsset.token,
+                    network: networkStore.selectedChain,
+                    url: nftAsset.imageUrl
+                  ),
+                  title: nftAsset.token.name,
+                  symbol: nftAsset.token.symbol,
+                  quantity: "\(nftAsset.balance)"
+                )
+              }
+            }
+            editUserAssetsButton
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        }, header: {
+          WalletListHeaderView(title: Text(Strings.Wallet.nftsTitle))
+        })
       }
     }
     .background(

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -120,7 +120,7 @@ struct PortfolioView: View {
         WalletListHeaderView(title: Text(Strings.Wallet.assetsTitle))
       })
       
-      if WalletDebugFlags.isNFTEnabled, !portfolioStore.userVisibleNFTs.isEmpty {
+      if !portfolioStore.userVisibleNFTs.isEmpty {
         Section(content: {
           Group {
             ForEach(portfolioStore.userVisibleNFTs) { nftAsset in

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -41,7 +41,7 @@ struct BalanceTimePrice: DataPoint, Equatable {
 public class PortfolioStore: ObservableObject {
   /// The dollar amount of your portfolio
   @Published private(set) var balance: String = "$0.00"
-  /// The users visible assets
+  /// The users visible fungible tokens. NFTs are separated into `userVisibleNFTs`.
   @Published private(set) var userVisibleAssets: [AssetViewModel] = []
   /// The users visible NFTs
   @Published private(set) var userVisibleNFTs: [NFTAssetViewModel] = []

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -17,7 +17,7 @@ public struct AssetViewModel: Identifiable, Equatable {
   }
 }
 
-public struct NFTAssetViewModel: Identifiable, Equatable {
+struct NFTAssetViewModel: Identifiable, Equatable {
   var token: BraveWallet.BlockchainToken
   var balance: Int
   var imageUrl: URL?
@@ -168,7 +168,7 @@ public class PortfolioStore: ObservableObject {
         NFTAssetViewModel(
           token: token,
           balance: Int(balances[token.assetBalanceId.lowercased()] ?? 0),
-          imageUrl: nil // TODO: fetch image url from erc721Metadata / erc1155Metadata / solana metadata
+          imageUrl: nil // TODO: fetch image url from erc721Metadata / erc1155Metadata / solana metadata in #6361
         )
       }
       // Compute balance based on current prices

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -132,13 +132,11 @@ public class PortfolioStore: ObservableObject {
           history: []
         )
       }
-      if WalletDebugFlags.isNFTEnabled {
-        userVisibleNFTs = nftAssets.map { asset in
-          NFTAssetViewModel(
-            token: asset,
-            balance: 0
-          )
-        }
+      userVisibleNFTs = nftAssets.map { asset in
+        NFTAssetViewModel(
+          token: asset,
+          balance: 0
+        )
       }
       
       let keyring = await keyringService.keyringInfo(coin.keyringId)
@@ -166,14 +164,12 @@ public class PortfolioStore: ObservableObject {
           history: priceHistories[priceId] ?? []
         )
       }
-      if WalletDebugFlags.isNFTEnabled {
-        userVisibleNFTs = nftAssets.map { token in
-          NFTAssetViewModel(
-            token: token,
-            balance: Int(balances[token.assetBalanceId.lowercased()] ?? 0),
-            imageUrl: nil // TODO: fetch image url from erc721Metadata / erc1155Metadata / solana metadata
-          )
-        }
+      userVisibleNFTs = nftAssets.map { token in
+        NFTAssetViewModel(
+          token: token,
+          balance: Int(balances[token.assetBalanceId.lowercased()] ?? 0),
+          imageUrl: nil // TODO: fetch image url from erc721Metadata / erc1155Metadata / solana metadata
+        )
       }
       // Compute balance based on current prices
       let currentBalance = userVisibleAssets

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -119,8 +119,8 @@ public class PortfolioStore: ObservableObject {
       let coin = await walletService.selectedCoin()
       let network = await rpcService.network(coin)
       let allUserAssets = await walletService.userAssets(network.chainId, coin: coin)
-      let nftAssets = allUserAssets.filter(\.isErc721)
-      let userAssets = allUserAssets.filter { !$0.isErc721 }
+      let nftAssets = allUserAssets.filter { $0.isErc721 || $0.isNft }
+      let userAssets = allUserAssets.filter { !$0.isErc721 && !$0.isNft }
       // if the task was cancelled, don't update the UI
       guard !Task.isCancelled else { return }
       // update userVisibleAssets on display immediately with empty values. Issue #5567

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -89,12 +89,13 @@ extension BraveWallet.BlockchainToken {
     coin: .sol
   )
   
-  static let mockNFTToken: BraveWallet.BlockchainToken = .init(
+  static let mockERC721NFTToken: BraveWallet.BlockchainToken = .init(
     contractAddress: "0xaaaaaaaaaa222222222233333333334444444444",
     name: "XENFT",
     logo: "",
     isErc20: false,
     isErc721: true,
+    isNft: true,
     symbol: "XENFT",
     decimals: 0,
     visible: true,

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -88,6 +88,21 @@ extension BraveWallet.BlockchainToken {
     chainId: BraveWallet.SolanaMainnet,
     coin: .sol
   )
+  
+  static let mockNFTToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0xaaaaaaaaaa222222222233333333334444444444",
+    name: "XENFT",
+    logo: "",
+    isErc20: false,
+    isErc721: true,
+    symbol: "XENFT",
+    decimals: 0,
+    visible: true,
+    tokenId: "30934",
+    coingeckoId: "",
+    chainId: "0x1",
+    coin: .eth
+  )
 }
 
 extension BraveWallet.AccountInfo {

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -104,6 +104,22 @@ extension BraveWallet.BlockchainToken {
     chainId: "0x1",
     coin: .eth
   )
+  
+  static let mockSolanaNFTToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "0xaaaaaaaaaa222222222233333333334444444444",
+    name: "SOLNFT",
+    logo: "",
+    isErc20: false,
+    isErc721: false,
+    isNft: true,
+    symbol: "SOLNFT",
+    decimals: 0,
+    visible: true,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: "0x65",
+    coin: .sol
+  )
 }
 
 extension BraveWallet.AccountInfo {

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -98,5 +98,5 @@ struct WalletConstants {
 
 public struct WalletDebugFlags {
   public static let isSolanaDappsEnabled: Bool = false
-  public static var isNFTEnabled: Bool = false
+  public static let isNFTEnabled: Bool = false
 }

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -98,5 +98,5 @@ struct WalletConstants {
 
 public struct WalletDebugFlags {
   public static let isSolanaDappsEnabled: Bool = false
-  public static let isNFTEnabled: Bool = false
+  public static var isNFTEnabled: Bool = false
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -69,7 +69,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .module,
       value: "NFTs",
-      comment: "The title which is displayed above a list of NFTs"
+      comment: "The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token."
     )
     public static let transactionsTitle = NSLocalizedString(
       "wallet.transactionsTitle",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -64,6 +64,13 @@ extension Strings {
       value: "Assets",
       comment: "The title which is displayed above a list of assets/tokens"
     )
+    public static let nftsTitle = NSLocalizedString(
+      "wallet.nftsTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "NFTs",
+      comment: "The title which is displayed above a list of NFTs"
+    )
     public static let transactionsTitle = NSLocalizedString(
       "wallet.transactionsTitle",
       tableName: "BraveWallet",

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -13,7 +13,6 @@ class PortfolioStoreTests: XCTestCase {
   private var cancellables: Set<AnyCancellable> = .init()
 
   func testUpdateEthereum() {
-    WalletDebugFlags.isNFTEnabled = true
     // config test
     let mockAccountInfos: [BraveWallet.AccountInfo] = [.mockEthAccount]
     let chainId = BraveWallet.MainnetChainId
@@ -144,7 +143,6 @@ class PortfolioStoreTests: XCTestCase {
   }
   
   func testUpdateSolana() {
-    WalletDebugFlags.isNFTEnabled = true
     // config test
     let mockAccountInfos: [BraveWallet.AccountInfo] = [.mockSolAccount]
     let network: BraveWallet.NetworkInfo = .mockSolana

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -20,7 +20,7 @@ class PortfolioStoreTests: XCTestCase {
     let network: BraveWallet.NetworkInfo = .mockMainnet
     let mockUserAssets: [BraveWallet.BlockchainToken] = [
       .previewToken.then { $0.visible = true },
-      .mockNFTToken
+      .mockERC721NFTToken
     ]
     let mockDecimalBalance: Double = 0.0896
     let numDecimals = Int(mockUserAssets[0].decimals)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6363

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Verify no NFTs section shown in Portfolio when no NFTs are added
2. Add an Ethereum ERC721 NFT asset.
3. Verify the asset is displayed in Portfolio in an NFT section. Verify NFT balance displays as expected.
4. Add a Solana NFT asset.
5. Verify the asset is displayed in Portfolio in an NFT section. Verify NFT balance displays as expected.


## Screenshots:

![Portfolio NFTs](https://user-images.githubusercontent.com/5314553/201374083-b9acd275-f8ee-480e-9a6f-ded3a78613c1.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-11-11 at 11 02 50](https://user-images.githubusercontent.com/5314553/201381224-310bc0e4-eb30-4593-b155-0815fa1a2951.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
