### PR TITLE
Fix #6359: Playlist shared folders not loading when website itself does NOT load

### DIFF
--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -434,6 +434,11 @@ class PlaylistWebLoader: UIView {
     static let userScript: WKUserScript? = nil
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+      if !verifyMessage(message: message) {
+        assertionFailure("Missing required security token.")
+        return
+      }
+      
       replyHandler(nil, nil)
       
       let cancelRequest = {
@@ -505,6 +510,13 @@ extension PlaylistWebLoader: WKNavigationDelegate {
       return true
     }
     return false
+  }
+  
+  func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+    webView.evaluateSafeJavaScript(functionName: "window.__firefox__.playlistProcessDocumentLoad()",
+                                   args: [],
+                                   contentWorld: PlaylistWebLoaderContentHelper.scriptSandbox,
+                                   asFunction: false)
   }
 
   func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
@@ -237,7 +237,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
 
     function onReady(fn) {
       if (document.readyState === "complete" || document.readyState === "ready") {
-        setTimeout(fn, 1);
+        fn();
       } else {
         document.addEventListener("DOMContentLoaded", fn);
       }
@@ -324,7 +324,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
           });
           
           // Timeinterval is needed for DailyMotion as their DOM is bad
-          var interval = setInterval(function() {
+          let interval = setInterval(function() {
             getAllVideoElements().forEach(function(node) {
               observeNode(node);
               notifyNode(node, 'video', true, true);
@@ -336,9 +336,8 @@ window.__firefox__.includeOnce("Playlist", function($) {
             });
           }, 1000);
 
-          var timeout = setTimeout(function() {
+          let timeout = setTimeout(function() {
             clearInterval(interval);
-            clearTimeout(timeout);
           }, 10000);
         }
       });

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
@@ -81,7 +81,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
     })();
   }
   
-  function notify(target, type, detected) {
+  function notifyNode(target, type, detected, ignoreSource) {
     if (target) {
       var name = target.title;
       if (!name || name == "") {
@@ -89,16 +89,16 @@ window.__firefox__.includeOnce("Playlist", function($) {
       }
     
       if (!type || type == "") {
-        if (node.constructor.name == 'HTMLVideoElement') {
+        if (target.constructor.name == 'HTMLVideoElement') {
           type = 'video';
         }
 
-        if (node.constructor.name == 'HTMLAudioElement') {
+        if (target.constructor.name == 'HTMLAudioElement') {
           type = 'audio';
         }
         
-        if (node.constructor.name == 'HTMLSourceElement') {
-          if (node.closest('video')) {
+        if (target.constructor.name == 'HTMLSourceElement') {
+          if (target.closest('video')) {
             type = 'video'
           } else {
             type = 'audio'
@@ -106,7 +106,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
         }
       }
       
-      if (target.src && target.src !== "") {
+      if (ignoreSource || (target.src && target.src !== "")) {
         tagNode(target);
         sendMessage(name, target, target, type, detected);
       }
@@ -121,6 +121,10 @@ window.__firefox__.includeOnce("Playlist", function($) {
         });
       }
     }
+  }
+  
+  function notify(target, type, detected) {
+    notifyNode(target, type, detected, false);
   }
   
   function setupLongPress() {
@@ -212,11 +216,11 @@ window.__firefox__.includeOnce("Playlist", function($) {
   
   function setupDetector() {
     function getAllVideoElements() {
-        return document.querySelectorAll('video');
+      return document.querySelectorAll('video');
     }
 
     function getAllAudioElements() {
-        return document.querySelectorAll('audio');
+      return document.querySelectorAll('audio');
     }
     
     function requestWhenIdleShim(fn) {
@@ -229,6 +233,14 @@ window.__firefox__.includeOnce("Playlist", function($) {
           },
         })
       }, 2000);  // Resolution of 1000ms is fine for us.
+    }
+
+    function onReady(fn) {
+      if (document.readyState === "complete" || document.readyState === "ready") {
+        setTimeout(fn, 1);
+      } else {
+        document.addEventListener("DOMContentLoaded", fn);
+      }
     }
     
     function observePage() {
@@ -278,6 +290,58 @@ window.__firefox__.includeOnce("Playlist", function($) {
           }
           return document_createElement.call(this, tag);
       };*/
+      
+      // Needed for Japanese videos like tver.jp which literally never loads automatically
+      Object.defineProperty(window.__firefox__, 'playlistProcessDocumentLoad', {
+        enumerable: false,
+        configurable: false,
+        writable: false,
+        value:
+        function() {
+          onReady(function() {
+            let videos = getAllVideoElements();
+            let audios = getAllAudioElements();
+            
+            if (videos.length == 0 && audios.length == 0) {
+              $(function() {
+                $.postNativeMessage('$<message_handler>', {
+                  "securityToken": SECURITY_TOKEN,
+                  "state": document.readyState
+                });
+              })();
+              return;
+            }
+            
+            videos.forEach(function(node) {
+              observeNode(node);
+              notifyNode(node, 'video', true, true);
+            });
+
+            audios.forEach(function(node) {
+              observeNode(node);
+              notifyNode(node, 'audio', true, true);
+            });
+          });
+          
+          // Timeinterval is needed for DailyMotion as their DOM is bad
+          var interval = setInterval(function() {
+            getAllVideoElements().forEach(function(node) {
+              observeNode(node);
+              notifyNode(node, 'video', true, true);
+            });
+
+            getAllAudioElements().forEach(function(node) {
+              observeNode(node);
+              notifyNode(node, 'audio', true, true);
+            });
+          }, 1000);
+
+          var timeout = setTimeout(function() {
+            clearInterval(interval);
+            clearTimeout(timeout);
+          }, 10000);
+        }
+      });
     }
 
     observePage();


### PR DESCRIPTION
…load or contain videos.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add another timeout in Playlist, in Javascript for websites like the Japanese ones that contain no videos and websites that just do NOT load (also Japanese ones). Technically we should not be adding sites to playlist shared folders that has no videos or audio.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6359

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
