### PR TITLE
Fix #6367: Send NFTs

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -28,7 +28,8 @@ struct SendTokenView: View {
           let token = sendTokenStore.selectedSendToken,
           !sendTokenStore.isMakingTx,
           !sendTokenStore.sendAddress.isEmpty,
-          sendTokenStore.addressError == nil else {
+          sendTokenStore.addressError == nil,
+          sendTokenStore.sendError == nil else {
       return true
     }
     if token.isErc721 || token.isNft {
@@ -42,6 +43,14 @@ struct SendTokenView: View {
       return true
     }
     return sendAmount == 0 || sendAmount > balance || sendTokenStore.sendAmount.isEmpty
+  }
+  
+  private var sendButtonTitle: String {
+    if let error = sendTokenStore.sendError {
+      return error.localizedDescription
+    } else {
+      return Strings.Wallet.sendCryptoSendButtonTitle
+    }
   }
 
   var body: some View {
@@ -161,7 +170,7 @@ struct SendTokenView: View {
         Section(
           header:
             WalletLoadingButton(
-              isLoading: sendTokenStore.isMakingTx,
+              isLoading: sendTokenStore.isLoading || sendTokenStore.isMakingTx,
               action: {
                 sendTokenStore.sendToken(
                   amount: sendTokenStore.sendAmount
@@ -174,7 +183,7 @@ struct SendTokenView: View {
                 }
               },
               label: {
-                Text(Strings.Wallet.sendCryptoSendButtonTitle)
+                Text(sendButtonTitle)
               }
             )
             .buttonStyle(BraveFilledButtonStyle(size: .normal))
@@ -213,7 +222,7 @@ struct SendTokenView: View {
       }
     }
     .onAppear {
-      sendTokenStore.fetchAssets()
+      sendTokenStore.update()
     }
     .navigationViewStyle(.stack)
   }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -24,20 +24,24 @@ struct SendTokenView: View {
   var onDismiss: () -> Void
 
   private var isSendDisabled: Bool {
-    guard let sendAmount = BDouble(sendTokenStore.sendAmount.normalizedDecimals),
-      let balance = sendTokenStore.selectedSendTokenBalance,
-      let token = sendTokenStore.selectedSendToken,
-      !sendTokenStore.isMakingTx
-    else {
+    guard let balance = sendTokenStore.selectedSendTokenBalance,
+          let token = sendTokenStore.selectedSendToken,
+          !sendTokenStore.isMakingTx,
+          !sendTokenStore.sendAddress.isEmpty,
+          sendTokenStore.addressError == nil else {
       return true
     }
-
+    if token.isErc721 || token.isNft {
+      return balance < 1
+    }
+    guard let sendAmount = BDouble(sendTokenStore.sendAmount.normalizedDecimals) else {
+      return true
+    }
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: Int(token.decimals)))
     if weiFormatter.weiString(from: sendTokenStore.sendAmount.normalizedDecimals, radix: .decimal, decimals: Int(token.decimals)) == nil {
       return true
     }
-
-    return sendAmount == 0 || sendAmount > balance || sendTokenStore.sendAmount.isEmpty || sendTokenStore.sendAddress.isEmpty || (sendTokenStore.addressError != nil && sendTokenStore.addressError != .missingChecksum)
+    return sendAmount == 0 || sendAmount > balance || sendTokenStore.sendAmount.isEmpty
   }
 
   var body: some View {
@@ -81,29 +85,31 @@ struct SendTokenView: View {
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        Section(
-          header:
-            WalletListHeaderView(
-              title: Text(
-                String.localizedStringWithFormat(
-                  Strings.Wallet.sendCryptoAmountTitle,
-                  sendTokenStore.selectedSendToken?.symbol ?? "")
-              )
-            ),
-          footer: ShortcutAmountGrid(action: { amount in
-            sendTokenStore.suggestedAmountTapped(amount)
-          })
-          .listRowInsets(.zero)
-          .padding(.bottom, 8)
-        ) {
-          TextField(
-            String.localizedStringWithFormat(
-              Strings.Wallet.amountInCurrency,
-              sendTokenStore.selectedSendToken?.symbol ?? ""),
-            text: $sendTokenStore.sendAmount
-          )
-          .keyboardType(.decimalPad)
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        if sendTokenStore.selectedSendToken?.isErc721 == false && sendTokenStore.selectedSendToken?.isNft == false {
+          Section(
+            header:
+              WalletListHeaderView(
+                title: Text(
+                  String.localizedStringWithFormat(
+                    Strings.Wallet.sendCryptoAmountTitle,
+                    sendTokenStore.selectedSendToken?.symbol ?? "")
+                )
+              ),
+            footer: ShortcutAmountGrid(action: { amount in
+              sendTokenStore.suggestedAmountTapped(amount)
+            })
+            .listRowInsets(.zero)
+            .padding(.bottom, 8)
+          ) {
+            TextField(
+              String.localizedStringWithFormat(
+                Strings.Wallet.amountInCurrency,
+                sendTokenStore.selectedSendToken?.symbol ?? ""),
+              text: $sendTokenStore.sendAmount
+            )
+            .keyboardType(.decimalPad)
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
+          }
         }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoToTitle)),

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -15,8 +15,7 @@ public class SendTokenStore: ObservableObject {
   /// The current selected token to send. Default with nil value.
   @Published var selectedSendToken: BraveWallet.BlockchainToken? {
     didSet {
-      fetchAssetBalance()
-      validateSendAddress()
+      update() // need to update `selectedSendTokenBalance`
     }
   }
   /// The current selected token balance. Default with nil value.
@@ -26,9 +25,10 @@ public class SendTokenStore: ObservableObject {
   /// The destination account address
   @Published var sendAddress = "" {
     didSet {
-      timer?.invalidate()
-      timer = Timer.scheduledTimer(
-        withTimeInterval: 0.25, repeats: false,
+      sendAddressUpdatedTimer?.invalidate()
+      sendAddressUpdatedTimer = Timer.scheduledTimer(
+        withTimeInterval: 0.25, // try not to validate for every character entered
+        repeats: false,
         block: { [weak self] _ in
           self?.validateSendAddress()
         })
@@ -37,7 +37,21 @@ public class SendTokenStore: ObservableObject {
   /// An error for input send address. Nil for no error.
   @Published var addressError: AddressError?
   /// The amount the user inputs to send
-  @Published var sendAmount = ""
+  @Published var sendAmount = "" {
+    didSet {
+      sendAmountUpdatedTimer?.invalidate()
+      sendAmountUpdatedTimer = Timer.scheduledTimer(
+        withTimeInterval: 0.25, // try not to validate for every character entered
+        repeats: false,
+        block: { [weak self] _ in
+          self?.validateBalance()
+        })
+    }
+  }
+  /// An error for input, ex insufficient balance
+  @Published var sendError: SendError?
+  /// If we are loading `userAssets`, `allTokens`, and `selectedSendTokenBalance`
+  @Published var isLoading: Bool = false
 
   enum AddressError: LocalizedError {
     case sameAsFromAddress
@@ -64,6 +78,16 @@ public class SendTokenStore: ObservableObject {
       }
     }
   }
+  
+  enum SendError: LocalizedError {
+    case insufficientBalance
+    
+    var errorDescription: String? {
+      switch self {
+      case .insufficientBalance: return Strings.Wallet.insufficientBalance
+      }
+    }
+  }
 
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -73,8 +97,8 @@ public class SendTokenStore: ObservableObject {
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   private var allTokens: [BraveWallet.BlockchainToken] = []
-  private var currentAccountAddress: String?
-  private var timer: Timer?
+  private var sendAddressUpdatedTimer: Timer?
+  private var sendAmountUpdatedTimer: Timer?
 
   public init(
     keyringService: BraveWalletKeyringService,
@@ -97,38 +121,6 @@ public class SendTokenStore: ObservableObject {
 
     self.keyringService.add(self)
     self.rpcService.add(self)
-
-    self.walletService.selectedCoin { coin in
-      self.keyringService.selectedAccount(coin) { address in
-        self.currentAccountAddress = address
-      }
-    }
-  }
-
-  func fetchAssets() {
-    walletService.selectedCoin { [weak self] coin in
-      guard let self = self else { return }
-      self.rpcService.network(coin) { network in
-        self.walletService.userAssets(network.chainId, coin: network.coin) { tokens in
-          self.userAssets = tokens
-          
-          if let selectedToken = self.selectedSendToken {
-            if tokens.isEmpty {
-              self.selectedSendToken = nil
-            } else if let token = tokens.first(where: { $0.id == selectedToken.id }) {
-              self.selectedSendToken = token
-            }
-          } else {
-            self.selectedSendToken = tokens.first
-          }
-        }
-        
-        // store tokens in `allTokens` for address validation
-        self.blockchainRegistry.allTokens(network.chainId, coin: network.coin) { tokens in
-          self.allTokens = tokens + [network.nativeToken]
-        }
-      }
-    }
   }
   
   func suggestedAmountTapped(_ amount: ShortcutAmountGrid.Amount) {
@@ -141,44 +133,41 @@ public class SendTokenStore: ObservableObject {
     sendAmount = ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
   }
 
-  private func fetchAssetBalance() {
-    guard let token = selectedSendToken else {
-      selectedSendTokenBalance = nil
-      return
-    }
-
-    walletService.selectedCoin { [weak self] coin in
-      guard let self = self else { return }
-      self.rpcService.network(coin) { network in
-        self.walletService.userAssets(network.chainId, coin: network.coin) { tokens in
-          guard let index = tokens.firstIndex(where: { $0.id == token.id }) else {
-            self.selectedSendTokenBalance = nil
-            return
-          }
-          self.fetchBalance(for: tokens[index])
-        }
+  /// Cancellable for the last running `update()` Task.
+  private var updateTask: Task<(), Never>?
+  /// Updates the `userAssets`, `allTokens`, and `selectedSendTokenBalance`
+  func update() {
+    self.updateTask?.cancel()
+    self.updateTask = Task { @MainActor in
+      self.isLoading = true
+      defer { self.isLoading = false }
+      let coin = await self.walletService.selectedCoin()
+      let network = await self.rpcService.network(coin)
+      // fetch user assets
+      let userAssets = await self.walletService.userAssets(network.chainId, coin: network.coin)
+      let allTokens = await self.blockchainRegistry.allTokens(network.chainId, coin: network.coin)
+      guard !Task.isCancelled else { return }
+      if selectedSendToken == nil {
+        self.selectedSendToken = userAssets.first
       }
-    }
-  }
-
-  private func fetchBalance(for token: BraveWallet.BlockchainToken) {
-    walletService.selectedCoin { [weak self] coin in
-      guard let self = self else { return }
-      self.keyringService.selectedAccount(coin) { accountAddress in
-        guard let accountAddress = accountAddress else {
-          self.selectedSendTokenBalance = nil
-          return
-        }
-        
-        self.rpcService.balance(
-          for: token,
-          in: accountAddress,
-          with: coin,
-          decimalFormatStyle: .decimals(precision: Int(token.decimals))
-        ) { balance in
-          self.selectedSendTokenBalance = balance
-        }
+      self.userAssets = userAssets
+      self.allTokens = allTokens
+      self.validateSendAddress() // `sendAddress` may match a token contract address
+      // fetch balance for `selectedSendToken`
+      guard let selectedAccount = await self.keyringService.selectedAccount(coin),
+            let selectedSendToken = self.selectedSendToken else {
+        self.selectedSendTokenBalance = nil // no selected account, or send token is nil
+        return
       }
+      let balance = await self.rpcService.balance(
+        for: selectedSendToken,
+        in: selectedAccount,
+        with: coin,
+        decimalFormatStyle: .decimals(precision: Int(selectedSendToken.decimals))
+      )
+      guard !Task.isCancelled else { return }
+      self.selectedSendTokenBalance = balance
+      self.validateBalance()
     }
   }
 
@@ -195,25 +184,29 @@ public class SendTokenStore: ObservableObject {
     }
   }
 
+  /// Validate the `sendAddress`
   private func validateSendAddress() {
-    guard !sendAddress.isEmpty, let token = selectedSendToken else {
-      addressError = nil
-      return
-    }
-    let normalizedSendAddress = sendAddress.lowercased()
-    if token.coin == .eth {
-      if !sendAddress.isETHAddress {
-        // 1. check if send address is a valid eth address
-        addressError = .notEthAddress
-      } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
-        // 2. check if send address is the same as the from address
-        addressError = .sameAsFromAddress
-      } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil)
-                  || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedSendAddress }) != nil) {
-        // 3. check if send address is a contract address
-        addressError = .contractAddress
-      } else {
-        keyringService.checksumEthAddress(sendAddress) { [self] checksumAddress in
+    Task { @MainActor in
+      let coin = await self.walletService.selectedCoin()
+      guard let sendFromAddress = await self.keyringService.selectedAccount(coin),
+            !sendAddress.isEmpty,
+            let token = selectedSendToken else {
+        return
+      }
+      let normalizedSendToAddress = sendAddress.lowercased()
+      if token.coin == .eth {
+        if !sendAddress.isETHAddress {
+          // 1. check if send address is a valid eth address
+          addressError = .notEthAddress
+        } else if sendFromAddress.lowercased() == normalizedSendToAddress {
+          // 2. check if send address is the same as the from address
+          addressError = .sameAsFromAddress
+        } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedSendToAddress }) != nil)
+                    || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedSendToAddress }) != nil) {
+          // 3. check if send address is a contract address
+          addressError = .contractAddress
+        } else {
+          let checksumAddress = await keyringService.checksumEthAddress(sendAddress)
           if sendAddress == checksumAddress {
             // 4. check if send address is the same as the checksum address from the `KeyringService`
             addressError = nil
@@ -226,18 +219,29 @@ public class SendTokenStore: ObservableObject {
             addressError = .invalidChecksum
           }
         }
-      }
-    } else if token.coin == .sol {
-      walletService.isBase58EncodedSolanaPubkey(sendAddress) { [self] valid in
-        if !valid {
+      } else if token.coin == .sol {
+        let isValid = await walletService.isBase58EncodedSolanaPubkey(sendAddress)
+        if !isValid {
           addressError = .notSolAddress
-        } else if currentAccountAddress?.lowercased() == normalizedSendAddress {
+        } else if sendFromAddress.lowercased() == normalizedSendToAddress {
           addressError = .sameAsFromAddress
         } else {
           addressError = nil
         }
       }
     }
+  }
+  
+  /// Validate `selectedSendTokenBalance` against the `sendAmount`
+  private func validateBalance() {
+    guard let selectedSendToken = self.selectedSendToken,
+          let balance = selectedSendTokenBalance,
+          case let sendAmount = (selectedSendToken.isErc721 || selectedSendToken.isNft) ? "1" : self.sendAmount,
+          let sendAmount = BDouble(sendAmount) else {
+      sendError = nil
+      return
+    }
+    sendError = balance < sendAmount ? .insufficientBalance : nil
   }
 
   func sendToken(
@@ -251,13 +255,19 @@ public class SendTokenStore: ObservableObject {
     let amount = (token.isErc721 || token.isNft) ? "1" : amount
     walletService.selectedCoin { [weak self] coin in
       guard let self = self else { return }
-      switch coin {
-      case .eth:
-        self.sendTokenOnEth(amount: amount, token: token, completion: completion)
-      case .sol:
-        self.sendTokenOnSol(amount: amount, token: token, completion: completion)
-      default:
-        break
+      self.keyringService.selectedAccount(coin) { selectedAccount in
+        guard let selectedAccount = selectedAccount else {
+          completion(false, "An Internal Error")
+          return
+        }
+        switch coin {
+        case .eth:
+          self.sendTokenOnEth(amount: amount, token: token, fromAddress: selectedAccount, completion: completion)
+        case .sol:
+          self.sendTokenOnSol(amount: amount, token: token, fromAddress: selectedAccount, completion: completion)
+        default:
+          break
+        }
       }
     }
   }
@@ -265,11 +275,11 @@ public class SendTokenStore: ObservableObject {
   func sendTokenOnEth(
     amount: String,
     token: BraveWallet.BlockchainToken,
+    fromAddress: String,
     completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
-    guard let weiHexString = weiFormatter.weiString(from: amount.normalizedDecimals, radix: .hex, decimals: Int(token.decimals)),
-          let fromAddress = currentAccountAddress else {
+    guard let weiHexString = weiFormatter.weiString(from: amount.normalizedDecimals, radix: .hex, decimals: Int(token.decimals)) else {
       completion(false, "An Internal Error")
       return
     }
@@ -331,14 +341,14 @@ public class SendTokenStore: ObservableObject {
   private func sendTokenOnSol(
     amount: String,
     token: BraveWallet.BlockchainToken,
+    fromAddress: String,
     completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
-    guard let fromAddress = currentAccountAddress,
-          let amount = WeiFormatter.decimalToAmount(amount.normalizedDecimals, tokenDecimals: Int(token.decimals)) else {
+    guard let amount = WeiFormatter.decimalToAmount(amount.normalizedDecimals, tokenDecimals: Int(token.decimals)) else {
       completion(false, "An Internal Error")
       return
     }
-    
+
     rpcService.network(.sol) { [weak self] network in
       guard let self = self else { return }
       if network.isNativeAsset(token) {
@@ -375,13 +385,6 @@ public class SendTokenStore: ObservableObject {
       }
     }
   }
-
-  #if DEBUG
-  func setUpTest() {
-    currentAccountAddress = "test-current-account-address"
-    sendAddress = "test-send-address"
-  }
-  #endif
 }
 
 extension SendTokenStore: BraveWalletKeyringServiceObserver {
@@ -410,19 +413,19 @@ extension SendTokenStore: BraveWalletKeyringServiceObserver {
   }
 
   public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-    fetchAssetBalance()
-    keyringService.selectedAccount(coinType) { [weak self] address in
-      self?.currentAccountAddress = address
-      self?.validateSendAddress()
-    }
+    selectedSendTokenBalance = nil
+    addressError = nil
+    update() // `selectedSendTokenBalance` needs updated for new account
+    validateSendAddress() // `sendAddress` may equal selected account address
   }
 }
 
 extension SendTokenStore: BraveWalletJsonRpcServiceObserver {
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
-    // nil `selectedSendToken` to force refresh `selectedSendToken` in `fetchAssets()`
     selectedSendToken = nil
-    fetchAssets()
+    selectedSendTokenBalance = nil
+    update() // `selectedSendToken` & `selectedSendTokenBalance` need updated for new chain
+    validateSendAddress() // `sendAddress` may no longer be valid if coin type changed
   }
 
   public func onAddEthereumChainRequestCompleted(_ chainId: String, error: String) {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -372,6 +372,28 @@ public class TransactionConfirmationStore: ObservableObject {
     case let .erc721Transfer(details):
       symbol = details.fromToken?.symbol ?? ""
       value = details.fromAmount
+      
+      if let gasFee = details.gasFee {
+        gasValue = gasFee.fee
+        gasFiat = gasFee.fiat
+        gasSymbol = activeParsedTransaction.networkSymbol
+        gasAssetRatio = assetRatios[activeParsedTransaction.networkSymbol.lowercased(), default: 0]
+        
+        if let gasBalance = gasTokenBalanceCache["\(network.nativeToken.symbol)\(activeParsedTransaction.fromAddress)"] {
+          if let gasValue = BDouble(gasFee.fee),
+             BDouble(gasBalance) > gasValue {
+            isBalanceSufficient = true
+          } else {
+            isBalanceSufficient = false
+          }
+        } else if shouldFetchGasTokenBalance {
+          if let account = keyring.accountInfos.first(where: { $0.address == activeParsedTransaction.fromAddress }) {
+            await fetchGasTokenBalance(token: network.nativeToken, account: account)
+          }
+        }
+        
+        totalFiat = totalFiat(value: value, tokenAssetRatioId: details.fromToken?.assetRatioId ?? "", gasValue: gasValue, gasSymbol: gasSymbol, assetRatios: assetRatios, currencyFormatter: currencyFormatter)
+      }
     case let .solDappTransaction(details):
       symbol = details.symbol ?? ""
       value = details.fromAmount

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -138,7 +138,7 @@ extension TransactionParser {
         networkSymbol: parsedTransaction.networkSymbol
       )
     case let .solSystemTransfer(details), let .solSplTokenTransfer(details):
-      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "")
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "").replacingOccurrences(of: "()", with: "") // if fiat is empty string, remove `()`
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -355,7 +355,12 @@ enum TransactionParser {
       }
       let fromValue = "\(amount)"
       let fromValueFormatted = formatter.decimalString(for: fromValue, radix: .decimal, decimals: Int(fromToken.decimals))?.trimmingTrailingZeros ?? ""
-      let fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[fromToken.assetRatioId.lowercased(), default: 0] * (Double(fromValueFormatted) ?? 0))) ?? "$0.00"
+      let fromFiat: String
+      if fromToken.isNft {
+        fromFiat = "" // don't show fiat for NFTs
+      } else {
+        fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[fromToken.assetRatioId.lowercased(), default: 0] * (Double(fromValueFormatted) ?? 0))) ?? "$0.00"
+      }
       /* Example:
        Send 0.1234 SMB
        

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -295,7 +295,13 @@ enum TransactionParser {
             fromValue: "1", // Can only send 1 erc721 at a time
             fromAmount: "1",
             owner: owner,
-            tokenId: tokenId
+            tokenId: tokenId,
+            gasFee: gasFee(
+              from: transaction,
+              network: network,
+              assetRatios: assetRatios,
+              currencyFormatter: currencyFormatter
+            )
           )
         )
       )
@@ -720,6 +726,8 @@ struct Eth721TransferDetails: Equatable {
   let owner: String
   /// The token id
   let tokenId: String
+  /// Gas fee for the transaction
+  let gasFee: GasFee?
 }
 
 struct SolanaDappTxDetails: Equatable {

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -189,6 +189,19 @@ extension BraveWalletJsonRpcService {
     }
   }
   
+  @MainActor func balance(
+    for token: BraveWallet.BlockchainToken,
+    in accountAddress: String,
+    with coin: BraveWallet.CoinType,
+    decimalFormatStyle: WeiFormatter.DecimalFormatStyle
+  ) async -> BDouble? {
+    await withCheckedContinuation { continuation in
+      balance(for: token, in: accountAddress, with: coin, decimalFormatStyle: decimalFormatStyle) { value in
+        continuation.resume(returning: value)
+      }
+    }
+  }
+  
   private func ethBalance(
     for token: BraveWallet.BlockchainToken,
     in accountAddress: String,

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -12,7 +12,39 @@ import BigNumber
 class SendTokenStoreTests: XCTestCase {
   private var cancellables: Set<AnyCancellable> = []
   private let batSymbol = "BAT"
+  
+  private func setupServices(
+    accountAddress: String = BraveWallet.AccountInfo.previewAccount.address,
+    userAssets: [BraveWallet.BlockchainToken] = [.previewToken],
+    selectedCoin: BraveWallet.CoinType = .eth,
+    selectedNetwork: BraveWallet.NetworkInfo = .mockGoerli,
+    balance: String = "0",
+    erc20Balance: String = "0",
+    erc721Balance: String = "0",
+    solanaBalance: UInt64 = 0,
+    splTokenBalance: String = "0"
+  ) -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestSolanaTxManagerProxy) {
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._addObserver = { _ in }
+    keyringService._selectedAccount = { $1(accountAddress) }
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._network = { $1(selectedNetwork) }
+    rpcService._addObserver = { _ in }
+    rpcService._balance = { $3(balance, .success, "") }
+    rpcService._erc20TokenBalance = { $3(erc20Balance, .success, "") }
+    rpcService._erc721TokenBalance = { $4(erc721Balance, .success, "") }
+    rpcService._solanaBalance = { $2(solanaBalance, .success, "") }
+    rpcService._splTokenAccountBalance = {_, _, _, completion in
+      completion(splTokenBalance, UInt8(6), "", .success, "")
+    }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._selectedCoin = { $0(selectedCoin) }
+    walletService._userAssets = { $2(userAssets) }
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    return (keyringService, rpcService, walletService, solTxManagerProxy)
+  }
 
+  /// Test given a `prefilledToken` will be assigned to `selectedSendToken`
   func testPrefilledToken() {
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     
@@ -41,19 +73,17 @@ class SendTokenStoreTests: XCTestCase {
     XCTAssertEqual(store.selectedSendToken?.symbol.lowercased(), BraveWallet.BlockchainToken.previewToken.symbol.lowercased())
   }
 
-  func testFetchAssets() {
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._network = { $1(.mockGoerli) }
-    rpcService._addObserver = { _ in }
+  /// Test `update()` will update the `selectedSendToken` if nil, and update `selectedSendTokenBalance` with the token balance
+  func testUpdate() {
+    let mockUserAssets: [BraveWallet.BlockchainToken] = [.previewToken, .previewDaiToken]
+    let mockDecimalBalance: Double = 0.0896
+    let numDecimals = Int(mockUserAssets[0].decimals)
+    let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: numDecimals))
+    let mockBalanceWei = formatter.weiString(from: mockDecimalBalance, radix: .hex, decimals: numDecimals) ?? ""
     
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
-    walletService._userAssets = { $2([.previewToken]) }
-    
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    
+    let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices(balance: mockBalanceWei)
     let store = SendTokenStore(
-      keyringService: MockKeyringService(),
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       txService: MockTxService(),
@@ -62,34 +92,42 @@ class SendTokenStoreTests: XCTestCase {
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil
     )
-    let ex = expectation(description: "fetch-assets")
+    let selectedSendTokenExpectation = expectation(description: "update-selectedSendToken")
     XCTAssertNil(store.selectedSendToken)  // Initial state
-    store.$selectedSendToken.dropFirst().sink { token in
-      defer { ex.fulfill() }
-      guard let token = token else {
-        XCTFail("Token was nil")
-        return
-      }
-      rpcService.network(.eth) { network in
-        XCTAssertEqual(token.symbol, network.symbol)
-      }
-    }.store(in: &cancellables)
-    store.fetchAssets()
-    waitForExpectations(timeout: 3) { error in
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { selectedSendTokenExpectation.fulfill() }
+        guard let selectedSendToken = selectedSendToken else {
+          XCTFail("selectedSendToken was nil")
+          return
+        }
+        XCTAssertEqual(selectedSendToken.symbol, BraveWallet.NetworkInfo.mockGoerli.nativeToken.symbol)
+      }.store(in: &cancellables)
+    let sendTokenBalanceExpectation = expectation(description: "update-sendTokenBalance")
+    XCTAssertNil(store.selectedSendTokenBalance)  // Initial state
+    store.$selectedSendTokenBalance
+      .dropFirst()
+      .sink { sendTokenBalance in
+        defer { sendTokenBalanceExpectation.fulfill() }
+        guard let sendTokenBalance = sendTokenBalance else {
+          XCTFail("sendTokenBalance was nil")
+          return
+        }
+        XCTAssertEqual(sendTokenBalance, BDouble(mockDecimalBalance))
+      }.store(in: &cancellables)
+    store.update()
+    waitForExpectations(timeout: 30) { error in
       XCTAssertNil(error)
     }
   }
 
+  /// Test making an ETH EIP 1559 transaction
   func testMakeSendETHEIP1559Transaction() {
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
-    walletService._userAssets = { $2([.previewToken]) }
-    
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    
+    let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices()
     let store = SendTokenStore(
-      keyringService: MockKeyringService(),
-      rpcService: MockJsonRpcService(),
+      keyringService: keyringService,
+      rpcService: rpcService,
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
@@ -97,7 +135,6 @@ class SendTokenStoreTests: XCTestCase {
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
-    store.setUpTest()
     let ex = expectation(description: "send-eth-eip1559-transaction")
     store.sendToken(amount: "0.01") { success, _ in
       defer { ex.fulfill() }
@@ -108,19 +145,11 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
 
+  /// Test making a ETH Send transaction
   func testMakeSendETHTransaction() {
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._network = { $1(.mockGoerli) }
-    rpcService._addObserver = { _ in }
-    
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
-    walletService._userAssets = { $2([.previewToken]) }
-    
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    
+    let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices()
     let store = SendTokenStore(
-      keyringService: MockKeyringService(),
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       txService: MockTxService(),
@@ -129,7 +158,6 @@ class SendTokenStoreTests: XCTestCase {
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
-    store.setUpTest()
 
     let ex = expectation(description: "send-eth-transaction")
     store.sendToken(amount: "0.01") { success, _ in
@@ -141,16 +169,12 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
 
+  /// Test making an ERC20 EIP 1559 transaction
   func testMakeSendERC20EIP1559Transaction() {
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
-    walletService._userAssets = { $2([.previewToken]) }
-    
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    
+    let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices()
     let store = SendTokenStore(
-      keyringService: MockKeyringService(),
-      rpcService: MockJsonRpcService(),
+      keyringService: keyringService,
+      rpcService: rpcService,
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
@@ -160,7 +184,6 @@ class SendTokenStoreTests: XCTestCase {
     )
     let token: BraveWallet.BlockchainToken = .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, isNft: false, symbol: batSymbol, decimals: 18, visible: true, tokenId: "", coingeckoId: "", chainId: "", coin: .eth)
     store.selectedSendToken = token
-    store.setUpTest()
 
     let ex = expectation(description: "send-bat-eip1559-transaction")
     store.sendToken(amount: "0.01") { success, _ in
@@ -172,27 +195,19 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
 
+  /// Test making a Send ERC20 transaction
   func testMakeSendERC20Transaction() {
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._network = { $1(.mockGoerli) }
-    rpcService._addObserver = { _ in }
-    
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
-    
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    
+    let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices()
     let store = SendTokenStore(
-      keyringService: MockKeyringService(),
+      keyringService: keyringService,
       rpcService: rpcService,
-      walletService: MockBraveWalletService(),
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
-    store.setUpTest()
 
     let ex = expectation(description: "send-bat-transaction")
     store.sendToken(amount: "0.01") { success, _ in
@@ -204,32 +219,23 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
   
+  /// Test making ERC721 (NFT) Transaction
   func testMakeSendERC721Transaction() {
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._network = { $1(.mockGoerli) }
-    rpcService._addObserver = { _ in }
-    
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
-    
+    let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices()
     let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
     ethTxManagerProxy._makeErc721TransferFromData = { _, _, _, _, completion in
       completion(true, .init())
     }
-    
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    
     let store = SendTokenStore(
-      keyringService: MockKeyringService(),
+      keyringService: keyringService,
       rpcService: rpcService,
-      walletService: MockBraveWalletService(),
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockERC721NFTToken
     )
-    store.setUpTest()
 
     let ex = expectation(description: "send-NFT-transaction")
     store.sendToken(amount: "") { success, _ in
@@ -241,11 +247,12 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
   
+  /// Test `suggestedAmountTapped(.all)` will not round the amount
   func testSendFullBalanceNoRounding() {
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     let mockBalance = "47.156499657504857477"
     let mockBalanceWei = formatter.weiString(from: mockBalance, radix: .hex, decimals: 18) ?? ""
-    
+
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockGoerli.chainId) }
     rpcService._network = { $1(BraveWallet.NetworkInfo.mockGoerli)}
@@ -253,17 +260,17 @@ class SendTokenStoreTests: XCTestCase {
       completion(mockBalanceWei, .success, "")
     }
     rpcService._addObserver = { _ in }
-    
+
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._userAssets = { $2([.previewToken]) }
     walletService._selectedCoin = { $0(BraveWallet.CoinType.eth) }
-    
+
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._selectedAccount = { $1("account-address") }
     keyringService._addObserver = { _ in }
-    
+
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    
+
     let store = SendTokenStore(
       keyringService: keyringService,
       rpcService: rpcService,
@@ -274,54 +281,47 @@ class SendTokenStoreTests: XCTestCase {
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken
     )
-    store.setUpTest()
     
     let fetchSelectedTokenBalanceEx = expectation(description: "fetchSelectedTokenBalance")
     store.$selectedSendTokenBalance
+      .dropFirst()
       .sink { balance in
+        defer { fetchSelectedTokenBalanceEx.fulfill() }
         XCTAssertEqual(balance, BDouble(mockBalance)!)
-        store.suggestedAmountTapped(.all)
-        fetchSelectedTokenBalanceEx.fulfill()
       }
       .store(in: &cancellables)
-    
+
+    store.update() // fetch balance
+    waitForExpectations(timeout: 3) { error in // wait for balance to be updated
+      XCTAssertNil(error)
+    }
     let sendFullBalanceEx = expectation(description: "sendFullBalance")
     store.$sendAmount
+      .dropFirst()
       .sink { amount in
+        defer { sendFullBalanceEx.fulfill() }
         XCTAssertEqual("\(amount)", "\(mockBalance)")
-        sendFullBalanceEx.fulfill()
       }
       .store(in: &cancellables)
-    
-    waitForExpectations(timeout: 3) { error in
+    store.suggestedAmountTapped(.all) // balance fetched, simulate user tapping 100%
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
   }
-  
+
+  /// Test making Solana System Program Transfer transaction
   func testSolSendSystemProgramTransfer() {
-    let mockBalance = 47
-    
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockSolana.chainId) }
-    rpcService._network = { $1(BraveWallet.NetworkInfo.mockSolana)}
-    rpcService._solanaBalance = { _, _ , completion in
-      completion(UInt64(mockBalance), .success, "")
-    }
-    rpcService._addObserver = { _ in }
-    
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { $2([.mockSolToken]) }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
-    
-    let keyringService = BraveWallet.TestKeyringService()
-    keyringService._selectedAccount = { $1("account-address") }
-    keyringService._addObserver = { _ in }
-    
+    let mockBalance: UInt64 = 47
+    let (keyringService, rpcService, walletService, _) = setupServices(
+      userAssets: [.mockSolToken],
+      selectedCoin: .sol,
+      selectedNetwork: .mockSolana,
+      solanaBalance: mockBalance
+    )
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     solTxManagerProxy._makeSystemProgramTransferTxData = {_, _, _, completion in
       completion(.init(), .success, "")
     }
-    
     let store = SendTokenStore(
       keyringService: keyringService,
       rpcService: rpcService,
@@ -346,28 +346,19 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
   
+  /// Test making Solana Token Program Transfer transaction
   func testSolSendTokenProgramTransfer() {
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockSolana.chainId) }
-    rpcService._network = { $1(BraveWallet.NetworkInfo.mockSolana)}
-    rpcService._splTokenAccountBalance = {_, _, _, completion in
-      completion("1000000", UInt8(6), "1", .success, "")
-    }
-    rpcService._addObserver = { _ in }
-    
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { $2([.mockSpdToken]) }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
-    
-    let keyringService = BraveWallet.TestKeyringService()
-    keyringService._selectedAccount = { $1("account-address") }
-    keyringService._addObserver = { _ in }
-    
+    let splTokenBalance = "1000000"
+    let (keyringService, rpcService, walletService, _) = setupServices(
+      userAssets: [.mockSpdToken],
+      selectedCoin: .sol,
+      selectedNetwork: .mockSolana,
+      splTokenBalance: splTokenBalance
+    )
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     solTxManagerProxy._makeTokenProgramTransferTxData = { _, _, _, _, completion in
       completion(.init(), .success, "")
     }
-    
     let store = SendTokenStore(
       keyringService: keyringService,
       rpcService: rpcService,
@@ -377,6 +368,46 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSpdToken
+    )
+
+    let ex = expectation(description: "send-sol-transaction")
+    store.sendToken(
+      amount: "0.01"
+    ) { success, errMsg in
+      defer { ex.fulfill() }
+      XCTAssertTrue(success)
+    }
+    
+    waitForExpectations(timeout: 3) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test Solana System Program transaction is created with correct lamports value for the `mockSolToken` (9 decimals)
+  func testSendSolAmount() {
+    let mockBalance: UInt64 = 47
+    let (keyringService, rpcService, walletService, _) = setupServices(
+      userAssets: [.mockSolToken, .mockSpdToken],
+      selectedCoin: .sol,
+      selectedNetwork: .mockSolana,
+      solanaBalance: mockBalance
+    )
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._makeSystemProgramTransferTxData = {_, _, lamports, completion in
+      let solValueString = "10000000" // 0.01
+      XCTAssertNotNil(UInt64(solValueString))
+      XCTAssertEqual(lamports, UInt64(solValueString)!)
+      completion(.init(), .success, "")
+    }
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      ethTxManagerProxy: MockEthTxManagerProxy(),
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: .mockSolToken
     )
     
     let ex = expectation(description: "send-sol-transaction")
@@ -392,95 +423,23 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
   
-  func testSendSolAmount() {
-    let mockBalance = 47
-    let sendSolAmountDecimalString = "0.01"
-    
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockSolana.chainId) }
-    rpcService._network = { $1(BraveWallet.NetworkInfo.mockSolana)}
-    rpcService._solanaBalance = { _, _ , completion in
-      completion(UInt64(mockBalance), .success, "")
-    }
-    rpcService._addObserver = { _ in }
-    
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { $2([.mockSolToken, .mockSpdToken]) }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
-    
-    let keyringService = BraveWallet.TestKeyringService()
-    keyringService._selectedAccount = { $1("account-address") }
-    keyringService._addObserver = { _ in }
-    
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
-    solTxManagerProxy._makeSystemProgramTransferTxData = {_, _, lamports, completion in
-      let solValueString = "10000000"
-      XCTAssertNotNil(UInt64(solValueString))
-      XCTAssertEqual(lamports, UInt64(solValueString)!)
-      completion(.init(), .success, "")
-    }
-    
-    let store = SendTokenStore(
-      keyringService: keyringService,
-      rpcService: rpcService,
-      walletService: walletService,
-      txService: MockTxService(),
-      blockchainRegistry: MockBlockchainRegistry(),
-      ethTxManagerProxy: MockEthTxManagerProxy(),
-      solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: BraveWallet.NetworkInfo.mockSolana.nativeToken
-    )
-    
-    let ex = expectation(description: "send-sol-transaction")
-    store.sendToken(
-      amount: sendSolAmountDecimalString
-    ) { success, errMsg in
-      defer { ex.fulfill() }
-      XCTAssertTrue(success)
-    }
-    
-    waitForExpectations(timeout: 3) { error in
-      XCTAssertNil(error)
-    }
-  }
-  
+  /// Test Solana SPL Token Program transaction is created with correct amount value for the `mockSpdToken` (6 decimals)
   func testSendSplTokenAmount() {
-    let mockBalance = 47
-    let sendSplAmountDecimalString = "0.01"
-    
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._chainId = { $1(BraveWallet.NetworkInfo.mockSolana.chainId) }
-    rpcService._network = { $1(BraveWallet.NetworkInfo.mockSolana)}
-    rpcService._solanaBalance = { _, _ , completion in
-      completion(UInt64(mockBalance), .success, "")
-    }
-    rpcService._splTokenAccountBalance = { _, tokenAddress, _, completion in
-      // balance of 0.1 SPD for token
-      guard tokenAddress.caseInsensitiveCompare(BraveWallet.BlockchainToken.mockSpdToken.contractAddress) == .orderedSame else {
-        completion("", UInt8(0), "", .internalError, "")
-        XCTFail("Unexpected spl token balance fetched")
-        return
-      }
-      completion("100000", UInt8(6), "0.1", .success, "")
-    }
-    rpcService._addObserver = { _ in }
-    
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { $2([.mockSolToken, .mockSpdToken]) }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
-    
-    let keyringService = BraveWallet.TestKeyringService()
-    keyringService._selectedAccount = { $1("account-address") }
-    keyringService._addObserver = { _ in }
-    
+    let mockBalance: UInt64 = 47
+    let (keyringService, rpcService, walletService, _) = setupServices(
+      userAssets: [.mockSolToken, .mockSpdToken],
+      selectedCoin: .sol,
+      selectedNetwork: .mockSolana,
+      solanaBalance: mockBalance
+    )
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     solTxManagerProxy._makeTokenProgramTransferTxData = { _, _, _, amount, completion in
-      let splValueString = "10000"
+      let splValueString = "10000" // 0.01 SPD
       XCTAssertNotNil(UInt64(splValueString))
       XCTAssertEqual(amount, UInt64(splValueString)!)
       completion(.init(), .success, "")
     }
-    
+
     let store = SendTokenStore(
       keyringService: keyringService,
       rpcService: rpcService,
@@ -491,15 +450,15 @@ class SendTokenStoreTests: XCTestCase {
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSpdToken
     )
-    
+
     let ex = expectation(description: "send-spl-transaction")
     store.sendToken(
-      amount: sendSplAmountDecimalString
+      amount: "0.01"
     ) { success, errMsg in
       defer { ex.fulfill() }
       XCTAssertTrue(success)
     }
-    
+
     waitForExpectations(timeout: 3) { error in
       XCTAssertNil(error)
     }

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -600,7 +600,11 @@ class TransactionParserTests: XCTestCase {
           fromValue: "1",
           fromAmount: "1",
           owner: "0x1111111111aaaaaaaaaa2222222222bbbbbbbbbb",
-          tokenId: "token.id"
+          tokenId: "token.id",
+          gasFee: .init(
+            fee: "0.000031",
+            fiat: "$0.000031"
+          )
         )
       )
     )
@@ -618,7 +622,7 @@ class TransactionParserTests: XCTestCase {
       XCTFail("Failed to parse erc721TransferFrom transaction")
       return
     }
-    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+    XCTAssertNoDifference(expectedParsedTransaction, parsedTransaction)
   }
   
   func testSolanaSystemTransfer() {

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -35,7 +35,7 @@ class TransactionParserTests: XCTestCase {
     .init(address: "0xeeeeeeeeeeffffffffff11111111112222222222", name: "Solana Account 2", coin: .sol)
   ]
   private let tokens: [BraveWallet.BlockchainToken] = [
-    .previewToken, .previewDaiToken, .mockUSDCToken, .mockSolToken, .mockSpdToken
+    .previewToken, .previewDaiToken, .mockUSDCToken, .mockSolToken, .mockSpdToken, .mockSolanaNFTToken
   ]
   let assetRatios: [String: Double] = ["eth": 1,
                                        "dai": 2,
@@ -765,6 +765,82 @@ class TransactionParserTests: XCTestCase {
           fromValue: "43210000",
           fromAmount: "43.21",
           fromFiat: "$648.15",
+          gasFee: .init(
+            fee: "0.0123",
+            fiat: "$0.246"
+          )
+        )
+      )
+    )
+    
+    guard let parsedTransaction = TransactionParser.parseTransaction(
+      transaction: transaction,
+      network: network,
+      accountInfos: accountInfos,
+      visibleTokens: tokens,
+      allTokens: tokens,
+      assetRatios: assetRatios,
+      solEstimatedTxFee: 12300000,
+      currencyFormatter: currencyFormatter
+    ) else {
+      XCTFail("Failed to parse solanaSplTokenTransfer transaction")
+      return
+    }
+    
+    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+  }
+  
+  func testSolanaNFTSplTokenTransfer() {
+    let network: BraveWallet.NetworkInfo = .mockSolana
+    
+    let transactionData: BraveWallet.SolanaTxData = .init(
+      recentBlockhash: "",
+      lastValidBlockHeight: 0,
+      feePayer: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+      toWalletAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      splTokenMintAddress: BraveWallet.BlockchainToken.mockSolanaNFTToken.contractAddress,
+      lamports: 0,
+      amount: 1,
+      txType: .solanaSplTokenTransfer,
+      instructions: [
+        .init(
+          programId: "",
+          accountMetas: [.init(pubkey: "", isSigner: false, isWritable: false)],
+          data: [],
+          decodedData: nil)
+      ],
+      send: .init(maxRetries: .init(maxRetries: 1), preflightCommitment: nil, skipPreflight: nil),
+      signTransactionParam: nil
+    )
+    let transaction = BraveWallet.TransactionInfo(
+      id: "7",
+      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: .init(solanaTxData: transactionData),
+      txStatus: .confirmed,
+      txType: .solanaSplTokenTransfer,
+      txParams: [],
+      txArgs: [
+      ],
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil,
+      groupId: nil
+    )
+    let expectedParsedTransaction = ParsedTransaction(
+      transaction: transaction,
+      namedFromAddress: "Solana Account 1",
+      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+      namedToAddress: "Solana Account 2",
+      toAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      networkSymbol: "SOL",
+      details: .solSplTokenTransfer(
+        .init(
+          fromToken: .mockSolanaNFTToken,
+          fromValue: "1",
+          fromAmount: "1",
+          fromFiat: "",
           gasFee: .init(
             fee: "0.0123",
             fiat: "$0.246"


### PR DESCRIPTION
## Summary of Changes
- Add support for sending ERC721 NFTs on Ethereum / EVMs
- Add support for sending Solana NFTs on Solana networks
- Resolve race condition in Send view when switching networks

This pull request fixes #6367

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Ethereum / ERC721 NFT:
1. Add at least one ERC721 asset you do not own, and one you do own (needs balance)
2. Open Send view, enter a valid ethereum address select the ERC721 NFT asset you do not own
3. Verify the send button is disabled (0 balance)
4. Select the ERC721 NFT asset you do own
5. Verify the send button is enabled, tap send
6. Verify transaction is created and displayed, expected gas balance shown
7. Send the transaction, verify transaction displays in Account Details list

Solana NFT:
1. Add at least one Solana NFT asset you do not own, and one you do own (needs balance)
2. Open Send view, enter a valid Solana address select the Solana NFT asset you do not own
3. Verify the send button is disabled (0 balance)
4. Select the Solana NFT asset you do own
5. Verify the send button is enabled, tap send
6. Verify transaction is created and displayed, expected gas balance shown
7. Send the transaction, verify transaction displays in Account Details list

Insufficient Balance:
1. Open send and enter a valid address for the network type
2. Tap 100%
3. Verify 'send' button is enabled
4. Add any non-zero digit
5. Verify 'send' button becomes 'Insufficient balance'
6. Select an NFT with balance
7. Verify 'send' button is enabled
8. Select an NFT without any balance
9. Verify 'send' button is disabled

## Screenshots:

Ethereum ERC721 NFT:

https://user-images.githubusercontent.com/5314553/201737660-9f5fd8a9-7370-4f31-b535-51a8ddff4c2f.mp4 

Solana NFT:

https://user-images.githubusercontent.com/5314553/201744224-206bbb6c-3050-4c1a-939b-5bf9ba0dfef5.mp4

Insufficient Balance:

https://user-images.githubusercontent.com/5314553/201953463-2c82bf20-74c8-4e04-96ab-889320814cb0.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
