### PR TITLE
Fix #6374: Fix crash in URL bar when dragging and dropping on itself

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -879,6 +879,7 @@ public class BrowserViewController: UIViewController {
     // links into the view from other apps.
     let dropInteraction = UIDropInteraction(delegate: self)
     view.addInteraction(dropInteraction)
+    topToolbar.addInteraction(dropInteraction)
 
     // Adding a small delay before fetching gives more reliability to it,
     // epsecially when you are connected to a VPN.

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -380,6 +380,9 @@ class TopToolbarView: UIView, ToolbarProtocol {
     locationTextField.attributedPlaceholder = self.locationView.placeholder
     locationTextField.rightView = qrCodeButton
     locationTextField.rightViewMode = .never
+    
+    let dragInteraction = UIDragInteraction(delegate: self)
+    locationTextField.addInteraction(dragInteraction)
 
     locationContainer.addSubview(locationTextField)
     locationTextField.snp.remakeConstraints { make in
@@ -746,5 +749,17 @@ extension TopToolbarView: AutocompleteTextFieldDelegate {
   func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField) {
     leaveOverlayMode(didCancel: true)
     updateLocationBarRightView(showQrCodeButton: false)
+  }
+}
+
+extension TopToolbarView: UIDragInteractionDelegate {
+  func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+    guard let text = locationTextField?.text else {
+      return []
+    }
+    
+    let dragItem = UIDragItem(itemProvider: NSItemProvider(object: text as NSString))
+    dragItem.localObject = locationTextField
+    return [dragItem]
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Fix crash in drag-drop when dragging the URL bar's text on itself as the keyboard collapses.
- Implemented a custom drag-drop to accomplish this, as the default is trying to drag-drop an array for some reason.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6374

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
