### PR TITLE
Fix #6386: Filter non-visible custom user assets out of Portfolio

### DIFF
--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -19,6 +19,7 @@ class PortfolioStoreTests: XCTestCase {
     let network: BraveWallet.NetworkInfo = .mockMainnet
     let mockUserAssets: [BraveWallet.BlockchainToken] = [
       .previewToken.then { $0.visible = true },
+      .mockUSDCToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
       .mockERC721NFTToken
     ]
     let mockDecimalBalance: Double = 0.0896
@@ -149,6 +150,7 @@ class PortfolioStoreTests: XCTestCase {
     let chainId = network.chainId
     let mockUserAssets: [BraveWallet.BlockchainToken] = [
       BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true },
+      .mockSpdToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
       .mockSolanaNFTToken
     ]
     let mockLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL


### PR DESCRIPTION
## Summary of Changes
- Filter non-visible user assets out of Portfolio

This pull request fixes #6386

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Add a custom user asset that is not in our token registry, ex. [Metaspace 2045](https://www.coingecko.com/en/coins/meta-space-2045)
2. Verify asset is shown in Portfolio
3. Tap 'Edit User Assets' and tap the Metaspace 2045 (or whichever custom token was added) to de-select
4. Tap 'Done' to dismiss Edit User Assets
5. Verify asset it not shown
6. Repeat from Step 1 with a custom NFT asset

## Screenshots:

https://user-images.githubusercontent.com/5314553/201776725-c02487d8-cc3b-4f6d-931c-b97058a2bfc2.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
