### PR TITLE
Fix #6379: ERC721 tokens from token registry will fail to be added as visible assets

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -275,6 +275,7 @@ struct AddCustomAssetView: View {
                 networkSelectionStore: networkSelectionStore
               )
             }
+            .onDisappear { networkSelectionStore.detailNetwork = nil }
             .accentColor(Color(.braveOrange))
             .navigationViewStyle(.stack)
           }

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -266,7 +266,15 @@ struct AddCustomAssetView: View {
       .background(
         Color.clear
           .sheet(
-            isPresented: $isPresentingNetworkSelection
+            isPresented: Binding(
+              get: { isPresentingNetworkSelection },
+              set: {
+                isPresentingNetworkSelection = $0
+                if !$0, networkSelectionStore.detailNetwork != nil {
+                  networkSelectionStore.detailNetwork = nil
+                }
+              }
+            )
           ) {
             NavigationView {
               NetworkSelectionView(
@@ -275,7 +283,6 @@ struct AddCustomAssetView: View {
                 networkSelectionStore: networkSelectionStore
               )
             }
-            .onDisappear { networkSelectionStore.detailNetwork = nil }
             .accentColor(Color(.braveOrange))
             .navigationViewStyle(.stack)
           }

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -13,6 +13,7 @@ struct AddCustomAssetView: View {
   @ObservedObject var networkSelectionStore: NetworkSelectionStore
   var keyringStore: KeyringStore
   @ObservedObject var userAssetStore: UserAssetsStore
+  var tokenNeedsTokenId: BraveWallet.BlockchainToken?
   @Environment(\.presentationMode) @Binding private var presentationMode
 
   enum TokenType: Int, Identifiable, CaseIterable {
@@ -62,14 +63,16 @@ struct AddCustomAssetView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section {
-        } header: {
-          Picker("", selection: $selectedTokenType) {
-            ForEach(TokenType.allCases) { type in
-              Text(type.title)
+        if tokenNeedsTokenId == nil {
+          Section {
+          } header: {
+            Picker("", selection: $selectedTokenType) {
+              ForEach(TokenType.allCases) { type in
+                Text(type.title)
+              }
             }
+            .pickerStyle(.segmented)
           }
-          .pickerStyle(.segmented)
         }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.customTokenNetworkHeader))
@@ -227,6 +230,7 @@ struct AddCustomAssetView: View {
       }
       .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .onChange(of: selectedTokenType, perform: { _ in
+        guard tokenNeedsTokenId == nil else { return }
         resignFirstResponder()
         clearInput()
       })
@@ -275,6 +279,17 @@ struct AddCustomAssetView: View {
             .navigationViewStyle(.stack)
           }
       )
+      .onAppear {
+        if let token = tokenNeedsTokenId {
+          Task { @MainActor in
+            selectedTokenType = .nft
+            networkSelectionStore.networkSelectionInForm = await userAssetStore.ethMainnet()
+            nameInput = token.name
+            symbolInput = token.symbol
+            addressInput = token.contractAddress
+          }
+        }
+      }
     }
   }
 
@@ -318,21 +333,33 @@ struct AddCustomAssetView: View {
       if let tokenIdValue = Int16(tokenId) {
         tokenIdToHex = "0x\(String(format: "%02x", tokenIdValue))"
       }
-      token = BraveWallet.BlockchainToken(
-        contractAddress: addressInput,
-        name: nameInput,
-        logo: "",
-        isErc20: false,
-        isErc721: network.coin != .sol && !tokenIdToHex.isEmpty,
-        isNft: true,
-        symbol: symbolInput,
-        decimals: 0,
-        visible: true,
-        tokenId: tokenIdToHex,
-        coingeckoId: coingeckoId,
-        chainId: network.chainId,
-        coin: network.coin
-      )
+      if let knownERC721Token = tokenNeedsTokenId {
+        knownERC721Token.tokenId = tokenIdToHex
+        knownERC721Token.chainId = networkSelectionStore.networkSelectionInForm?.chainId ?? BraveWallet.MainnetChainId
+        if knownERC721Token.name != nameInput {
+          knownERC721Token.name = nameInput
+        }
+        if knownERC721Token.symbol != symbolInput {
+          knownERC721Token.symbol = symbolInput
+        }
+        token = knownERC721Token
+      } else {
+        token = BraveWallet.BlockchainToken(
+          contractAddress: addressInput,
+          name: nameInput,
+          logo: "",
+          isErc20: false,
+          isErc721: network.coin != .sol && !tokenIdToHex.isEmpty,
+          isNft: true,
+          symbol: symbolInput,
+          decimals: 0,
+          visible: true,
+          tokenId: tokenIdToHex,
+          coingeckoId: coingeckoId,
+          chainId: network.chainId,
+          coin: network.coin
+        )
+      }
     }
     userAssetStore.addUserAsset(token) { [self] success in
       if success {

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -283,7 +283,7 @@ struct AddCustomAssetView: View {
         if let token = tokenNeedsTokenId {
           Task { @MainActor in
             selectedTokenType = .nft
-            networkSelectionStore.networkSelectionInForm = await userAssetStore.ethMainnet()
+            networkSelectionStore.networkSelectionInForm = await userAssetStore.networkInfo(by: token.chainId, coin: token.coin)
             nameInput = token.name
             symbolInput = token.symbol
             addressInput = token.contractAddress
@@ -335,7 +335,9 @@ struct AddCustomAssetView: View {
       }
       if let knownERC721Token = tokenNeedsTokenId {
         knownERC721Token.tokenId = tokenIdToHex
-        knownERC721Token.chainId = networkSelectionStore.networkSelectionInForm?.chainId ?? BraveWallet.MainnetChainId
+        if let userSelectedNetworkId = networkSelectionStore.networkSelectionInForm?.chainId {
+          knownERC721Token.chainId = userSelectedNetworkId
+        }
         if knownERC721Token.name != nameInput {
           knownERC721Token.name = nameInput
         }

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -15,6 +15,14 @@ private struct EditTokenView: View {
   
   @Binding var tokenNeedsTokenId: BraveWallet.BlockchainToken?
   
+  private var tokenName: String {
+    if (assetStore.token.isErc721 || assetStore.token.isNft), !assetStore.token.tokenId.isEmpty {
+      return assetStore.token.nftTokenTitle
+    } else {
+      return assetStore.token.name
+    }
+  }
+  
   var body: some View {
     Button(action: {
       if assetStore.token.isErc721, assetStore.token.tokenId.isEmpty {
@@ -26,7 +34,7 @@ private struct EditTokenView: View {
       HStack(spacing: 8) {
         AssetIconView(token: assetStore.token, network: assetStore.network)
         VStack(alignment: .leading) {
-          Text(assetStore.token.name)
+          Text(tokenName)
             .fontWeight(.semibold)
             .foregroundColor(Color(.bravePrimary))
           Text(assetStore.token.symbol.uppercased())

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -295,13 +295,3 @@ struct PortfolioViewController_Previews: PreviewProvider {
   }
 }
 #endif
-
-private extension BraveWallet.BlockchainToken {
-  var nftTokenTitle: String {
-    if isErc721, let tokenId = Int(tokenId.removingHexPrefix, radix: 16) {
-      return "\(name) #\(tokenId)"
-    } else {
-      return name
-    }
-  }
-}

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -83,14 +83,34 @@ public class UserAssetsStore: ObservableObject {
       let visibleAssetIds = userAssets.filter(\.visible).map(\.id)
       blockchainRegistry.allTokens(network.chainId, coin: network.coin) { [self] registryTokens in
         allTokens = registryTokens + [network.nativeToken]
-        assetStores = allTokens.union(userAssets, f: { $0.id }).map { token in
-          AssetStore(
+        var uniqueAssets: [BraveWallet.BlockchainToken] = []
+        // we need to swap out the ERC721 assets that are from token registry but was added back as custom tokens with token id.
+        for registeryToken in allTokens {
+          if let matchedUserAsset = userAssets.first(where: { $0.id == registeryToken.id }) {
+            uniqueAssets.append(matchedUserAsset)
+          } else {
+            uniqueAssets.append(registeryToken)
+          }
+        }
+        
+        assetStores = uniqueAssets.union(userAssets, f: { $0.id }).map { token in
+          var isCustomToken: Bool {
+            if token.contractAddress.isEmpty {
+              return false
+            }
+            // Any token with a tokenId should be considered a custom token.
+            if !token.tokenId.isEmpty {
+              return true
+            }
+            return !allTokens.contains(where: {
+              $0.contractAddress(in: network).caseInsensitiveCompare(token.contractAddress) == .orderedSame
+            })
+          }
+          return AssetStore(
             walletService: walletService,
             network: network,
             token: token,
-            isCustomToken: !allTokens.contains(where: {
-              $0.contractAddress(in: network).caseInsensitiveCompare(token.contractAddress) == .orderedSame
-            }),
+            isCustomToken: isCustomToken,
             isVisible: visibleAssetIds.contains(token.id)
           )
         }
@@ -162,6 +182,11 @@ public class UserAssetsStore: ObservableObject {
           }
         })
     }
+  }
+  
+  @MainActor func ethMainnet() async -> BraveWallet.NetworkInfo? {
+    let allNetworks = await rpcService.allNetworks(.eth)
+    return allNetworks.first { $0.chainId.caseInsensitiveCompare(BraveWallet.MainnetChainId) == .orderedSame }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -184,9 +184,9 @@ public class UserAssetsStore: ObservableObject {
     }
   }
   
-  @MainActor func ethMainnet() async -> BraveWallet.NetworkInfo? {
-    let allNetworks = await rpcService.allNetworks(.eth)
-    return allNetworks.first { $0.chainId.caseInsensitiveCompare(BraveWallet.MainnetChainId) == .orderedSame }
+  @MainActor func networkInfo(by chainId: String, coin: BraveWallet.CoinType) async -> BraveWallet.NetworkInfo? {
+    let allNetworks = await rpcService.allNetworks(coin)
+    return allNetworks.first { $0.chainId.caseInsensitiveCompare(chainId) == .orderedSame }
   }
 }
 

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -233,6 +233,14 @@ extension BraveWallet.BlockchainToken {
       .contains(where: { $0.caseInsensitiveCompare(contractAddress) == .orderedSame })
     return (contractAddress.isEmpty || isSupportedContractAddress) && chainId == BraveWallet.MainnetChainId
   }
+  
+  var nftTokenTitle: String {
+    if isErc721, let tokenId = Int(tokenId.removingHexPrefix, radix: 16) {
+      return "\(name) #\(tokenId)"
+    } else {
+      return name
+    }
+  }
 }
 
 extension BraveWallet.OnRampProvider {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
ERC721 tokens from token registry does not have any `tokenId` value, which will cause users fail to add them as their visible assets.
In order to finish this flow, we need to prompt users the Add Custom NFT screen to ask them to input token id or modify other fields if they need.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6379

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
on Eth Mainnet there are 5 ERC721 tokens from token registry do not have token id values
- Crypto Kitties
- PUNKS Comic
- Kudos
- Sandbox's LANDs
- Su Squares

1. Open Brave and go to wallet
2. unlock your wallet if its locked
3. Click `Edit Visible Assets` either in the visible fungible tokens section or the visible non-fungible tokens section
4. search for one of the above 5 ERC721 tokens (let say Token A)
5. try to click the row of this token
6. observe Add Custom Asset screen should show up with no segment to allow users to switch to Add Token mode
7. observe Token A token's name, address, symbol are prefilled; network is selected as Eth mainnet
8. enter a token id and click `Add`
9. observe Add Custom Asset screen will be dismissed
10. observe in the token list, Token A will be displayed with checked mark
11. dismiss this screen to go back to portfolio screen
12. observe, Token A will appear in the visible NFT section with correct balance 
13. click `Edit Visible Asset` again either in the visible fungible tokens section or the visible non-fungible tokens section
14. check if Token A is being displayed with a checkmark
15. uncheck Token A by clicking its row
16. dismiss this screen to go back to portfolio screen
17. check Token A should be no longer in the visible NFT section

## Screenshots:

https://user-images.githubusercontent.com/1187676/201960115-4f6fd38c-e8bc-4af7-9678-99e8b422e2d6.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
