### PR TITLE
Fix #6394: Display NFTs in Account Details

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -77,6 +77,27 @@ struct AccountActivityView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
+      if !activityStore.NFTAssets.isEmpty {
+        Section(content: {
+          Group {
+            ForEach(activityStore.NFTAssets) { nftAsset in
+              PortfolioNFTAssetView(
+                image: NFTIconView(
+                  token: nftAsset.token,
+                  network: networkStore.selectedChain,
+                  url: nftAsset.imageUrl
+                ),
+                title: nftAsset.token.nftTokenTitle,
+                symbol: nftAsset.token.symbol,
+                quantity: "\(nftAsset.balance)"
+              )
+            }
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        }, header: {
+          WalletListHeaderView(title: Text(Strings.Wallet.nftsTitle))
+        })
+      }
       Section(
         header: WalletListHeaderView(title: Text(Strings.Wallet.transactionsTitle))
       ) {

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -97,14 +97,6 @@ extension BraveWallet.BlockchainToken: Identifiable {
     // since there is no swap support for custom networks.
     return symbol == network.symbol ? BraveWallet.ethSwapAddress : contractAddress
   }
-  
-  var nftTokenTitle: String {
-    if isErc721, let tokenId = Int(tokenId.removingHexPrefix, radix: 16) {
-      return "\(name) #\(tokenId)"
-    } else {
-      return name
-    }
-  }
 }
 
 extension BraveWallet {

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -97,6 +97,14 @@ extension BraveWallet.BlockchainToken: Identifiable {
     // since there is no swap support for custom networks.
     return symbol == network.symbol ? BraveWallet.ethSwapAddress : contractAddress
   }
+  
+  var nftTokenTitle: String {
+    if isErc721, let tokenId = Int(tokenId.removingHexPrefix, radix: 16) {
+      return "\(name) #\(tokenId)"
+    } else {
+      return name
+    }
+  }
 }
 
 extension BraveWallet {


### PR DESCRIPTION
## Summary of Changes
- Add NFTs section to Account Details (Account Activity View) to match Portfolio display

This pull request fixes #6394

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Add an ERC721 NFT with balance and an ERC721 NFT without balance
2. Navigate to account details for the Ethereum account with balance
3. Verify NFT section displays the NFTs with correct balance
4. Add a Solana NFT with balance and a Solana NFT without balance
5. Navigate to account details for the Solana account with balance
6. Verify NFT section displays the NFTs with correct balance


## Screenshots:

![6394 - ethereum](https://user-images.githubusercontent.com/5314553/201983866-cf31a0fc-6461-473e-9934-e1ab7cd9a6b4.png) | ![6394 - solana](https://user-images.githubusercontent.com/5314553/201983870-c01e979c-a708-42cf-9574-e5a3f6b115c7.png)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
