### PR TITLE
Fix #6401: Add button accessibility traits to URL bar text field

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -485,6 +485,11 @@ class DisplayTextField: UITextField {
       super.accessibilityCustomActions = newValue
     }
   }
+  
+  override var accessibilityTraits: UIAccessibilityTraits {
+    get { [.staticText, .button] }
+    set { }
+  }
 
   override var canBecomeFirstResponder: Bool {
     return false


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6401 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
