### PR TITLE
Fix #6369: asset details updates for NFTs

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -131,7 +131,7 @@ struct AssetDetailHeaderView: View {
   }
 
   var body: some View {
-    VStack(spacing: 0) {
+    VStack(alignment: assetDetailStore.token.isFungibleToken ? .center : .leading, spacing: 0) {
       if assetDetailStore.token.isFungibleToken {
         VStack(alignment: .leading) {
           if sizeCategory.isAccessibilityCategory {
@@ -221,7 +221,7 @@ struct AssetDetailHeaderView: View {
       } else {
         HStack {
           AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
-          Text(assetDetailStore.token.name)
+          Text(assetDetailStore.token.nftTokenTitle)
             .fixedSize(horizontal: false, vertical: true)
             .font(.title3.weight(.semibold))
           Spacer()
@@ -233,6 +233,7 @@ struct AssetDetailHeaderView: View {
           .padding(.bottom)
       }
       actionButtonsContainer
+        .padding(.horizontal, assetDetailStore.token.isFungibleToken ? 0 : 16)
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -97,7 +97,7 @@ struct AssetDetailHeaderView: View {
       ) {
         Text(Strings.Wallet.send)
       }
-      if networkStore.isSwapSupported {
+      if networkStore.isSwapSupported && assetDetailStore.token.isFungibleToken {
         Button(
           action: {
             buySendSwapDestination = BuySendSwapDestination(
@@ -132,93 +132,106 @@ struct AssetDetailHeaderView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      VStack(alignment: .leading) {
-        if sizeCategory.isAccessibilityCategory {
-          VStack(alignment: .leading) {
-            if horizontalSizeClass == .regular {
-              DateRangeView(selectedRange: $assetDetailStore.timeframe)
-                .padding(6)
-                .overlay(
-                  RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(Color(.secondaryButtonTint))
-                )
+      if assetDetailStore.token.isFungibleToken {
+        VStack(alignment: .leading) {
+          if sizeCategory.isAccessibilityCategory {
+            VStack(alignment: .leading) {
+              if horizontalSizeClass == .regular {
+                DateRangeView(selectedRange: $assetDetailStore.timeframe)
+                  .padding(6)
+                  .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                      .strokeBorder(Color(.secondaryButtonTint))
+                  )
+              }
+              HStack {
+                AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
+                Text(assetDetailStore.token.name)
+                  .fixedSize(horizontal: false, vertical: true)
+                  .font(.title3.weight(.semibold))
+              }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+          } else {
             HStack {
               AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
               Text(assetDetailStore.token.name)
                 .fixedSize(horizontal: false, vertical: true)
                 .font(.title3.weight(.semibold))
-            }
-          }
-          .frame(maxWidth: .infinity, alignment: .leading)
-        } else {
-          HStack {
-            AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
-            Text(assetDetailStore.token.name)
-              .fixedSize(horizontal: false, vertical: true)
-              .font(.title3.weight(.semibold))
-            if horizontalSizeClass == .regular {
-              Spacer()
-              DateRangeView(selectedRange: $assetDetailStore.timeframe)
-                .padding(6)
-                .overlay(
-                  RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .strokeBorder(Color(.secondaryButtonTint))
-                )
-            }
-          }
-        }
-        Text(
-          String.localizedStringWithFormat(
-            Strings.Wallet.assetDetailSubtitle,
-            assetDetailStore.token.name,
-            assetDetailStore.token.symbol)
-        )
-        .font(.footnote)
-        .foregroundColor(Color(.secondaryBraveLabel))
-        VStack(alignment: .leading) {
-          HStack {
-            Group {
-              if let selectedCandle = selectedCandle,
-                let formattedString = assetDetailStore.currencyFormatter.string(from: NSNumber(value: selectedCandle.value)) {
-                Text(formattedString)
-              } else {
-                Text(assetDetailStore.price)
+              if horizontalSizeClass == .regular {
+                Spacer()
+                DateRangeView(selectedRange: $assetDetailStore.timeframe)
+                  .padding(6)
+                  .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                      .strokeBorder(Color(.secondaryButtonTint))
+                  )
               }
             }
-            .font(.title2.bold())
-            deltaText
-            Spacer()
           }
-          Text(assetDetailStore.btcRatio)
-            .font(.footnote)
-            .foregroundColor(Color(.secondaryBraveLabel))
+          Text(
+            String.localizedStringWithFormat(
+              Strings.Wallet.assetDetailSubtitle,
+              assetDetailStore.token.name,
+              assetDetailStore.token.symbol)
+          )
+          .font(.footnote)
+          .foregroundColor(Color(.secondaryBraveLabel))
+          VStack(alignment: .leading) {
+            HStack {
+              Group {
+                if let selectedCandle = selectedCandle,
+                   let formattedString = assetDetailStore.currencyFormatter.string(from: NSNumber(value: selectedCandle.value)) {
+                  Text(formattedString)
+                } else {
+                  Text(assetDetailStore.price)
+                }
+              }
+              .font(.title2.bold())
+              deltaText
+              Spacer()
+            }
+            Text(assetDetailStore.btcRatio)
+              .font(.footnote)
+              .foregroundColor(Color(.secondaryBraveLabel))
+          }
+          .redacted(reason: assetDetailStore.isInitialState ? .placeholder : [])
+          .shimmer(assetDetailStore.isLoadingPrice)
+          let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
+          LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
+            Color(.walletGreen)
+              .shimmer(assetDetailStore.isLoadingChart)
+          }
+          .chartAccessibility(
+            title: String.localizedStringWithFormat(
+              Strings.Wallet.assetDetailSubtitle,
+              assetDetailStore.token.name,
+              assetDetailStore.token.symbol),
+            dataPoints: data
+          )
+          .disabled(data.isEmpty)
+          .frame(height: 128)
+          .padding(.horizontal, -16)
+          .animation(.default, value: data)
+          if horizontalSizeClass == .compact {
+            DateRangeView(selectedRange: $assetDetailStore.timeframe)
+          }
         }
-        .redacted(reason: assetDetailStore.isInitialState ? .placeholder : [])
-        .shimmer(assetDetailStore.isLoadingPrice)
-        let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
-        LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
-          Color(.walletGreen)
-            .shimmer(assetDetailStore.isLoadingChart)
+        .padding(16)
+      } else {
+        HStack {
+          AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
+          Text(assetDetailStore.token.name)
+            .fixedSize(horizontal: false, vertical: true)
+            .font(.title3.weight(.semibold))
+          Spacer()
         }
-        .chartAccessibility(
-          title: String.localizedStringWithFormat(
-            Strings.Wallet.assetDetailSubtitle,
-            assetDetailStore.token.name,
-            assetDetailStore.token.symbol),
-          dataPoints: data
-        )
-        .disabled(data.isEmpty)
-        .frame(height: 128)
-        .padding(.horizontal, -16)
-        .animation(.default, value: data)
-        if horizontalSizeClass == .compact {
-          DateRangeView(selectedRange: $assetDetailStore.timeframe)
-        }
+        .padding(16)
       }
-      .padding(16)
-      Divider()
-        .padding(.bottom)
+      if assetDetailStore.token.isFungibleToken {
+        Divider()
+          .padding(.bottom)
+      }
       actionButtonsContainer
     }
   }
@@ -241,3 +254,9 @@ struct CurrencyDetailHeaderView_Previews: PreviewProvider {
   }
 }
 #endif
+
+private extension BraveWallet.BlockchainToken {
+  var isFungibleToken: Bool {
+    return !isErc721 && !isNft
+  }
+}

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -71,16 +71,24 @@ struct AssetDetailView: View {
                 }
                 let showFiatPlaceholder = viewModel.fiatBalance.isEmpty && assetDetailStore.isLoadingPrice
                 let showBalancePlaceholder = viewModel.balance.isEmpty && assetDetailStore.isLoadingAccountBalances
-                VStack(alignment: .trailing) {
-                  Text(showFiatPlaceholder ? "$0.00" : viewModel.fiatBalance)
-                    .redacted(reason: showFiatPlaceholder ? .placeholder : [])
-                    .shimmer(assetDetailStore.isLoadingPrice)
-                  Text(showBalancePlaceholder ? "0.0000 \(assetDetailStore.token.symbol)" : "\(viewModel.balance) \(assetDetailStore.token.symbol)")
+                if assetDetailStore.token.isNft || assetDetailStore.token.isErc721 {
+                  Text(showBalancePlaceholder ? "0 \(assetDetailStore.token.symbol)" : "\(viewModel.balance) \(assetDetailStore.token.symbol)")
                     .redacted(reason: showBalancePlaceholder ? .placeholder : [])
                     .shimmer(assetDetailStore.isLoadingAccountBalances)
+                    .font(.footnote)
+                    .foregroundColor(Color(.secondaryBraveLabel))
+                } else {
+                  VStack(alignment: .trailing) {
+                    Text(showFiatPlaceholder ? "$0.00" : viewModel.fiatBalance)
+                      .redacted(reason: showFiatPlaceholder ? .placeholder : [])
+                      .shimmer(assetDetailStore.isLoadingPrice)
+                    Text(showBalancePlaceholder ? "0.0000 \(assetDetailStore.token.symbol)" : "\(viewModel.balance) \(assetDetailStore.token.symbol)")
+                      .redacted(reason: showBalancePlaceholder ? .placeholder : [])
+                      .shimmer(assetDetailStore.isLoadingAccountBalances)
+                  }
+                  .font(.footnote)
+                  .foregroundColor(Color(.secondaryBraveLabel))
                 }
-                .font(.footnote)
-                .foregroundColor(Color(.secondaryBraveLabel))
               }
             }
           }

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -118,16 +118,18 @@ struct AssetDetailView: View {
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
-      Section {
-        EmptyView()
-      } header: {
-        Text(Strings.Wallet.coinGeckoDisclaimer)
-          .multilineTextAlignment(.center)
-          .font(.footnote)
-          .foregroundColor(Color(.secondaryBraveLabel))
-          .frame(maxWidth: .infinity)
-          .listRowBackground(Color(.braveGroupedBackground))
-          .resetListHeaderStyle(insets: nil)
+      if !assetDetailStore.token.isNft && !assetDetailStore.token.isErc721 {
+        Section {
+          EmptyView()
+        } header: {
+          Text(Strings.Wallet.coinGeckoDisclaimer)
+            .multilineTextAlignment(.center)
+            .font(.footnote)
+            .foregroundColor(Color(.secondaryBraveLabel))
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color(.braveGroupedBackground))
+            .resetListHeaderStyle(insets: nil)
+        }
       }
     }
     .listStyle(InsetGroupedListStyle())

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -154,7 +154,11 @@ class AssetDetailStore: ObservableObject {
     for tokenBalance in tokenBalances {
       if let index = accounts.firstIndex(where: { $0.account.address == tokenBalance.account.address }) {
         accountAssetViewModels[index].decimalBalance = tokenBalance.balance ?? 0.0
-        accountAssetViewModels[index].balance = String(format: "%.4f", tokenBalance.balance ?? 0.0)
+        if token.isErc721 || token.isNft {
+          accountAssetViewModels[index].balance = (tokenBalance.balance ?? 0) > 0 ? "1" : "0"
+        } else {
+          accountAssetViewModels[index].balance = String(format: "%.4f", tokenBalance.balance ?? 0.0)
+        }
         accountAssetViewModels[index].fiatBalance = self.currencyFormatter.string(from: NSNumber(value: accountAssetViewModels[index].decimalBalance * assetPriceValue)) ?? ""
       }
     }

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -105,29 +105,32 @@ class AssetDetailStore: ObservableObject {
       var updatedAccounts = keyring.accountInfos.map {
         AccountAssetViewModel(account: $0, decimalBalance: 0.0, balance: "", fiatBalance: "")
       }
-      // fetch prices for the asset
-      let (_, prices) = await assetRatioService.price([token.assetRatioId], toAssets: [currencyFormatter.currencyCode, "btc"], timeframe: timeframe)
-      self.isLoadingPrice = false
-      self.isInitialState = false
-      if let assetPrice = prices.first(where: { $0.toAsset.caseInsensitiveCompare(self.currencyFormatter.currencyCode) == .orderedSame }),
-        let value = Double(assetPrice.price) {
-        self.assetPriceValue = value
-        self.price = self.currencyFormatter.string(from: NSNumber(value: value)) ?? ""
-        if let deltaValue = Double(assetPrice.assetTimeframeChange) {
-          self.priceIsDown = deltaValue < 0
-          self.priceDelta = self.percentFormatter.string(from: NSNumber(value: deltaValue / 100.0)) ?? ""
+      
+      if !token.isErc721 && !token.isNft {
+        // fetch prices for the asset
+        let (_, prices) = await assetRatioService.price([token.assetRatioId], toAssets: [currencyFormatter.currencyCode, "btc"], timeframe: timeframe)
+        self.isLoadingPrice = false
+        self.isInitialState = false
+        if let assetPrice = prices.first(where: { $0.toAsset.caseInsensitiveCompare(self.currencyFormatter.currencyCode) == .orderedSame }),
+           let value = Double(assetPrice.price) {
+          self.assetPriceValue = value
+          self.price = self.currencyFormatter.string(from: NSNumber(value: value)) ?? ""
+          if let deltaValue = Double(assetPrice.assetTimeframeChange) {
+            self.priceIsDown = deltaValue < 0
+            self.priceDelta = self.percentFormatter.string(from: NSNumber(value: deltaValue / 100.0)) ?? ""
+          }
+          for index in 0..<updatedAccounts.count {
+            updatedAccounts[index].fiatBalance = self.currencyFormatter.string(from: NSNumber(value: updatedAccounts[index].decimalBalance * self.assetPriceValue)) ?? ""
+          }
         }
-        for index in 0..<updatedAccounts.count {
-          updatedAccounts[index].fiatBalance = self.currencyFormatter.string(from: NSNumber(value: updatedAccounts[index].decimalBalance * self.assetPriceValue)) ?? ""
+        if let assetPrice = prices.first(where: { $0.toAsset == "btc" }) {
+          self.btcRatio = "\(assetPrice.price) BTC"
         }
+        // fetch price history for the asset
+        let (_, priceHistory) = await assetRatioService.priceHistory(token.assetRatioId, vsAsset: currencyFormatter.currencyCode, timeframe: timeframe)
+        self.isLoadingChart = false
+        self.priceHistory = priceHistory
       }
-      if let assetPrice = prices.first(where: { $0.toAsset == "btc" }) {
-        self.btcRatio = "\(assetPrice.price) BTC"
-      }
-      // fetch price history for the asset
-      let (_, priceHistory) = await assetRatioService.priceHistory(token.assetRatioId, vsAsset: currencyFormatter.currencyCode, timeframe: timeframe)
-      self.isLoadingChart = false
-      self.priceHistory = priceHistory
       
       self.accounts = await fetchAccountBalances(updatedAccounts, keyring: keyring)
       let assetRatios = [token.assetRatioId.lowercased(): assetPriceValue]
@@ -158,8 +161,8 @@ class AssetDetailStore: ObservableObject {
           accountAssetViewModels[index].balance = (tokenBalance.balance ?? 0) > 0 ? "1" : "0"
         } else {
           accountAssetViewModels[index].balance = String(format: "%.4f", tokenBalance.balance ?? 0.0)
+          accountAssetViewModels[index].fiatBalance = self.currencyFormatter.string(from: NSNumber(value: accountAssetViewModels[index].decimalBalance * assetPriceValue)) ?? ""
         }
-        accountAssetViewModels[index].fiatBalance = self.currencyFormatter.string(from: NSNumber(value: accountAssetViewModels[index].decimalBalance * assetPriceValue)) ?? ""
       }
     }
     self.isLoadingAccountBalances = false
@@ -196,8 +199,11 @@ class AssetDetailStore: ObservableObject {
             return false
           }
           return tokenContractAddress.caseInsensitiveCompare(self.token.contractAddress) == .orderedSame
-        case .ethSend, .ethSwap, .other, .erc721TransferFrom, .erc721SafeTransferFrom:
+        case .ethSend, .ethSwap, .other:
           return network.symbol.caseInsensitiveCompare(self.token.symbol) == .orderedSame
+        case .erc721TransferFrom, .erc721SafeTransferFrom:
+          guard let tokenContractAddress = tx.txDataUnion.ethTxData1559?.baseData.to else { return false }
+          return tokenContractAddress.caseInsensitiveCompare(self.token.contractAddress) == .orderedSame
         case .solanaSystemTransfer:
           return network.symbol.caseInsensitiveCompare(self.token.symbol) == .orderedSame
         case .solanaSplTokenTransfer, .solanaSplTokenTransferWithAssociatedTokenAccountCreation:
@@ -205,7 +211,7 @@ class AssetDetailStore: ObservableObject {
             return false
           }
           return tokenContractAddress.caseInsensitiveCompare(self.token.contractAddress) == .orderedSame
-        case .erc1155SafeTransferFrom, .solanaDappSignTransaction, .solanaDappSignAndSendTransaction:
+        case .erc1155SafeTransferFrom, .solanaDappSignTransaction, .solanaDappSignAndSendTransaction, .solanaSwap:
           return false
         @unknown default:
           return false

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -18,7 +18,7 @@ struct TransactionSummary: Equatable, Identifiable {
   /// Account name for the to address of the transaction
   let namedToAddress: String
   /// The title for the transaction summary.
-  /// Ex. "Sent 1.0000 ETH ($1.00"',  "Swapped 2.0000 ETH ($2.00)" / "Approved 1.0000 DAI" /  "Sent ETH"
+  /// Ex. "Sent 1.0000 ETH ($1.00)"',  "Swapped 2.0000 ETH ($2.00)" / "Approved 1.0000 DAI" /  "Sent ETH" / "Sent 1 INVSBLE"
   let title: String
   /// The gas fee and fiat for the transaction
   let gasFee: GasFee?
@@ -125,7 +125,7 @@ extension TransactionParser {
     case let .erc721Transfer(details):
       let title: String
       if let token = details.fromToken {
-        title = String.localizedStringWithFormat(Strings.Wallet.transactionUnknownSendTitle, token.symbol)
+        title = "\(Strings.Wallet.send) 1 \(token.symbol)"
       } else {
         title = Strings.Wallet.send
       }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1392,7 +1392,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .module,
       value: "Sent %@",
-      comment: "A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\""
+      comment: "A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\""
     )
     public static let viewOnBlockExplorer = NSLocalizedString(
       "wallet.viewOnBlockExplorer",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
A temporary updates for NFTs, since we are not handling metadata. 
Price and price changes graph are removed. NFT balance is displayed correctly. 
Goincecko info label is removed.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6369

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. Open wallet
2. Choose a NFT to go to its detail screen
3. check there should be no price or price graph or anything related to price information.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 21 33 55](https://user-images.githubusercontent.com/1187676/202070310-53b89e96-d231-4e41-bb9c-82ec742c7454.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
