### PR TITLE
Ref #6314: Update BraveCore to v1.46.114

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.104/brave-core-ios-1.46.104.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.46.104",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.104/brave-core-ios-1.46.104.tgz",
-      "integrity": "sha512-JElFVrjuUPqQdkdSfwjqnhunki8OUiXbKFVrQnExXQFiv47tmX4ELuIpSS7ISs70hO4coHFwWpX/CKp5ATyrhg==",
+      "version": "1.46.114",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
+      "integrity": "sha512-OVSdwKzBrvYP+aI+y7dJ+AhMLvhAZcl0V1fanz9yiWsIxLrqKauMk7F2Eq29bS22OS4j1TNJ49/uRv9wza1/oQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.104/brave-core-ios-1.46.104.tgz",
-      "integrity": "sha512-JElFVrjuUPqQdkdSfwjqnhunki8OUiXbKFVrQnExXQFiv47tmX4ELuIpSS7ISs70hO4coHFwWpX/CKp5ATyrhg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
+      "integrity": "sha512-OVSdwKzBrvYP+aI+y7dJ+AhMLvhAZcl0V1fanz9yiWsIxLrqKauMk7F2Eq29bS22OS4j1TNJ49/uRv9wza1/oQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.104/brave-core-ios-1.46.104.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

- Update BraveCore to 1.46.114 for Add static method to initialize ICU for unit tests, it will be used in IDN URL testing

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #6314

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
