### PR TITLE
Fix #6436: Update RPC Service extensions for use with any network

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -132,7 +132,7 @@ class AssetDetailStore: ObservableObject {
         self.priceHistory = priceHistory
       }
       
-      self.accounts = await fetchAccountBalances(updatedAccounts, keyring: keyring)
+      self.accounts = await fetchAccountBalances(updatedAccounts, keyring: keyring, network: network)
       let assetRatios = [token.assetRatioId.lowercased(): assetPriceValue]
       self.transactionSummaries = await fetchTransactionSummarys(keyring: keyring, assetRatios: assetRatios)
     }
@@ -140,7 +140,8 @@ class AssetDetailStore: ObservableObject {
   
   @MainActor private func fetchAccountBalances(
     _ accountAssetViewModels: [AccountAssetViewModel],
-    keyring: BraveWallet.KeyringInfo
+    keyring: BraveWallet.KeyringInfo,
+    network: BraveWallet.NetworkInfo
   ) async -> [AccountAssetViewModel] {
     var accountAssetViewModels = accountAssetViewModels
     isLoadingAccountBalances = true
@@ -148,7 +149,7 @@ class AssetDetailStore: ObservableObject {
     let tokenBalances = await withTaskGroup(of: [AccountBalance].self) { @MainActor group -> [AccountBalance] in
       for account in keyring.accountInfos {
         group.addTask { @MainActor in
-          let balance = await self.rpcService.balance(for: self.token, in: account)
+          let balance = await self.rpcService.balance(for: self.token, in: account, network: network)
           return [AccountBalance(account, balance)]
         }
       }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -69,22 +69,7 @@ public class NetworkStore: ObservableObject {
 
   private func updateChainList() {
     Task { @MainActor in // fetch all networks for all coin types
-      self.allChains = await withTaskGroup(of: [BraveWallet.NetworkInfo].self) { @MainActor [weak rpcService] group -> [BraveWallet.NetworkInfo] in
-        guard let rpcService = rpcService else { return [] }
-        for coinType in WalletConstants.supportedCoinTypes {
-          group.addTask { @MainActor in
-            let chains = await rpcService.allNetworks(coinType)
-            return chains.filter { // localhost not supported
-              $0.chainId != BraveWallet.LocalhostChainId
-            }
-          }
-        }
-        let allChains = await group.reduce([BraveWallet.NetworkInfo](), { $0 + $1 })
-        return allChains.sorted { lhs, rhs in
-          // sort solana chains to the front of the list
-          lhs.coin == .sol && rhs.coin != .sol
-        }
-      }
+      self.allChains = await rpcService.allNetworksForSupportedCoins()
       
       let customChainIds = await rpcService.customNetworks(.eth) // only support Ethereum custom chains
       self.customChains = allChains.filter { customChainIds.contains($0.id) }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -162,7 +162,7 @@ public class SendTokenStore: ObservableObject {
       let balance = await self.rpcService.balance(
         for: selectedSendToken,
         in: selectedAccount,
-        with: coin,
+        network: network,
         decimalFormatStyle: .decimals(precision: Int(selectedSendToken.decimals))
       )
       guard !Task.isCancelled else { return }

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -174,11 +174,11 @@ public class SwapTokenStore: ObservableObject {
       return
     }
     
-    walletService.selectedCoin { [weak self] coinType in
+    rpcService.network(token.coin) { [weak self] network in
       self?.rpcService.balance(
         for: token,
         in: account.address,
-        with: coinType,
+        network: network,
         decimalFormatStyle: .decimals(precision: Int(token.decimals))
       ) { balance in
         completion(balance)

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -257,9 +257,10 @@ public class TransactionConfirmationStore: ObservableObject {
   
   @MainActor func fetchGasTokenBalance(
     token: BraveWallet.BlockchainToken,
-    account: BraveWallet.AccountInfo
+    account: BraveWallet.AccountInfo,
+    network: BraveWallet.NetworkInfo
   ) async {
-    if let gasTokenBalance = await rpcService.balance(for: token, in: account) {
+    if let gasTokenBalance = await rpcService.balance(for: token, in: account, network: network) {
       gasTokenBalanceCache["\(token.symbol)\(account.address)"] = gasTokenBalance
       updateTransaction(with: activeTransaction, shouldFetchCurrentAllowance: false, shouldFetchGasTokenBalance: false)
     }
@@ -302,7 +303,7 @@ public class TransactionConfirmationStore: ObservableObject {
           }
         } else if shouldFetchGasTokenBalance {
           if let account = keyring.accountInfos.first(where: { $0.address == activeParsedTransaction.fromAddress }) {
-            await fetchGasTokenBalance(token: network.nativeToken, account: account)
+            await fetchGasTokenBalance(token: network.nativeToken, account: account, network: network)
           }
         }
       }
@@ -330,7 +331,7 @@ public class TransactionConfirmationStore: ObservableObject {
           }
         } else if shouldFetchGasTokenBalance {
           if let account = keyring.accountInfos.first(where: { $0.address == activeParsedTransaction.fromAddress }) {
-            await fetchGasTokenBalance(token: network.nativeToken, account: account)
+            await fetchGasTokenBalance(token: network.nativeToken, account: account, network: network)
           }
         }
       }
@@ -363,7 +364,7 @@ public class TransactionConfirmationStore: ObservableObject {
           }
         } else if shouldFetchGasTokenBalance {
           if let account = keyring.accountInfos.first(where: { $0.address == activeParsedTransaction.fromAddress }) {
-            await fetchGasTokenBalance(token: network.nativeToken, account: account)
+            await fetchGasTokenBalance(token: network.nativeToken, account: account, network: network)
           }
         }
         
@@ -388,7 +389,7 @@ public class TransactionConfirmationStore: ObservableObject {
           }
         } else if shouldFetchGasTokenBalance {
           if let account = keyring.accountInfos.first(where: { $0.address == activeParsedTransaction.fromAddress }) {
-            await fetchGasTokenBalance(token: network.nativeToken, account: account)
+            await fetchGasTokenBalance(token: network.nativeToken, account: account, network: network)
           }
         }
         
@@ -416,7 +417,7 @@ public class TransactionConfirmationStore: ObservableObject {
           }
         } else if shouldFetchGasTokenBalance {
           if let account = keyring.accountInfos.first(where: { $0.address == activeParsedTransaction.fromAddress }) {
-            await fetchGasTokenBalance(token: network.nativeToken, account: account)
+            await fetchGasTokenBalance(token: network.nativeToken, account: account, network: network)
           }
         }
       }


### PR DESCRIPTION
## Summary of Changes
- Update RPC Service extensions to support any network given as a parameter

This pull request fixes #6436

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit portfolio for any networks with some crypto balance, verify balance shows correctly
2. Visit account details for any networks with some crypto balance, verify balance shows correctly
3. Visit send/swap for any networks with some crypto balance, verify balance shows correctly
4. etc


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
