### PR TITLE
Fix #6438: Add 1.45.2 translations.

### DIFF
--- a/Sources/BraveShared/Resources/de.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/de.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Privatsphäre leicht gemacht.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Das hilft uns, zu verstehen, welche Brave-Funktionen am häufigsten genutzt werden. Sie können diese jederzeit in den Brave-Einstellungen unter „Brave Shields und Datenschutz“ ändern.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Erfahren Sie mehr über unsere Produktanalyse, die den Datenschutz respektiert (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Brave mit Ihrer Hilfe verbessern.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Teilen Sie anonyme und private Produkteinblicke.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Video ansehen";
 
@@ -830,7 +842,7 @@
 "genericErrorTitle" = "Fehler";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Gefährliche Seiten blockieren";
+"GoogleSafeBrowsing" = "Gefährliche Websites blockieren";
 
 /* No comment provided by engineer. */
 "GoogleSafeBrowsingUsingWebKitDescription" = "Sendet verschleierte URLs einiger Seiten, die Sie besuchen, an den Dienst Google Safe Browsing, wenn Ihre Sicherheit gefährdet ist.";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Andere Einstellungen";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Teilen Sie anonyme und private Produkteinblicke. Das hilft uns, zu verstehen, welche Brave-Funktionen am häufigsten genutzt werden.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Produktanalysen";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Standard-Zoomebene für Websites";

--- a/Sources/BraveShared/Resources/es.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/es.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Privacidad con total simplicidad.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Esto nos permite averiguar cuáles son las funciones de Brave que se usan con más frecuencia. Puedes cambiar de idea cuando quieras en el apartado \"Protecciones de Brave y privacidad\" de la configuración de Brave.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Obtén más información sobre nuestras estadísticas de productos que preservan la privacidad (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Ayuda a mejorar Brave.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Comparte opiniones anónimas y privadas sobre los productos.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Ver el vídeo";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Otros ajustes";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Comparte opiniones anónimas y privadas sobre los productos para que podamos averiguar cuáles son las funciones de Brave que se usan con más frecuencia.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Estadísticas de productos";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Nivel de zoom predeterminado en las páginas web";

--- a/Sources/BraveShared/Resources/fr.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/fr.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "La confidentialité. Simplifiée.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Ces informations nous aident à identifier les fonctionnalités Brave les plus utilisées. Vous pouvez modifier ceci à tout moment dans les paramètres Brave, section \"Boucliers Brave et confidentialité\".";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "En savoir plus sur nos analyses produits respectueuses de la vie privée (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Aidez-nous à améliorer Brave.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Partager des informations privées et anonymes sur les produits. ";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Regarder la vidéo";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Autres paramètres";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Partager des informations privées et anonymes sur les produits. Ces informations nous aident à identifier les fonctionnalités Brave les plus utilisées.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Analyses produits";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Niveau de zoom de la page Web par défaut";

--- a/Sources/BraveShared/Resources/id-ID.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/id-ID.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Privasi. Yang Disederhanakan.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Ini membantu kami mempelajari fitur Brave mana yang paling sering digunakan. Anda dapat mengubahnya kapan saja di Pengaturan Brave pada bagian 'Perisai Brave dan Privasi'.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Pelajari lebih lanjut tentang Analitik Produk yang Menjaga Privasi (P3A) milik kami.";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Bantulah membuat Brave lebih baik.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Membagikan wawasan produk secara privat dan anonim.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Tonton video";
 
@@ -830,7 +842,7 @@
 "genericErrorTitle" = "Kesalahan";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Blokir situs berbahaya";
+"GoogleSafeBrowsing" = "Memblokir Situs Berbahaya";
 
 /* No comment provided by engineer. */
 "GoogleSafeBrowsingUsingWebKitDescription" = "Mengirimkan URL yang membingungkan dari beberapa halaman yang Anda kunjungi ke layanan Google Safe Browsing, ketika keamanan Anda berisiko.";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Pengaturan Lain";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Membagikan wawasan produk secara privat dan anonim. Ini membantu kami mempelajari fitur Brave mana yang paling sering digunakan.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Analitik Produk";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Level Perbesar Halaman Web Bawaan";

--- a/Sources/BraveShared/Resources/it.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/it.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Privacy, in tutta semplicità.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Questa funzione ci aiuta a capire quali funzioni di Brave sono usate più spesso. Puoi modificare la tua scelta ogni volta che vuoi andando alle Impostazioni di Brave e selezionando “Protezioni Brave e privacy”.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Scopri di più sulle analisi di prodotto a tutela della privacy (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Contribuisci a migliorare Brave.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Condividi analisi di prodotto anonime e rispettose della privacy.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Guarda il video";
 
@@ -830,7 +842,7 @@
 "genericErrorTitle" = "Errore";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Blocca siti pericolosi";
+"GoogleSafeBrowsing" = "Blocca i siti pericolosi";
 
 /* No comment provided by engineer. */
 "GoogleSafeBrowsingUsingWebKitDescription" = "Invia URL offuscati di alcune delle pagine che visiti al servizio di Navigazione sicura di Google quando la tua sicurezza è a rischio.";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Altre impostazioni";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Condividi analisi di prodotto anonime e rispettose della privacy. Questo ci aiuta a capire quali funzioni di Brave sono usate più spesso.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Analisi di prodotto";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Livello di zoom predefinito per le pagine web";

--- a/Sources/BraveShared/Resources/ja.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/ja.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "シンプルに、プライバシー保護。";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "これにより、Braveのどの機能が最も頻繁に使用されているかを知ることができます。Braveの設定の「Braveシールド & プライバシー」でいつでも変更できます。";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "プライバシーを保護したプロダクト分析 (P3A) についてはこちらをご覧ください。";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Braveの品質向上にご協力ください。";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "匿名かつプライバシーに配慮した形で製品のインサイトを共有します。";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "説明を見る";
 
@@ -1343,7 +1355,7 @@
 "optionsMenu.braveNewsItemTitle" = "News";
 
 /* The subtitle description of menu item Brave Playlist */
-"optionsMenu.bravePlaylistItemDescription" = "どんな動画/ストリーミングでもオフライン再生用のプレイリストに保存。";
+"optionsMenu.bravePlaylistItemDescription" = "どんな動画/ストリーミングでもオフライン再生可能なプレイリストに追加しよう。";
 
 /* Brave News Item Menu title */
 "optionsMenu.bravePlaylistItemTitle" = "Playlist";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "その他の設定";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "匿名かつプライベートな製品インサイトを共有することができます。これにより、Braveのどの機能が最も頻繁に使用されているかを知ることができます。";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "プロダクト分析";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "デフォルトのウェブページズームレベル";
@@ -1496,13 +1514,13 @@
 "playlist.playlistAutoSaveSettingsDescription" = "動画や音声ファイルをオフライン利用可能にする際、デバイスのデータ容量や通信量を大きく消費する可能性があります。";
 
 /* Footer Text for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wi-fi)) */
-"playlist.playlistAutoSaveSettingsFooterText" = "この設定を行うと、Playlistに追加されたアイテムが、オフライン再生のために自動でデバイスに保存されます。";
+"playlist.playlistAutoSaveSettingsFooterText" = "この設定を行うと、Playlistに追加されたアイテムが、自動でオフライン再生可能になります。";
 
 /* Title for the Playlist Settings Option for Auto Save Videos for Offline (Off/On/Only Wi-fi) */
-"playlist.playlistAutoSaveSettingsTitle" = "オフライン再生のために自動保存する";
+"playlist.playlistAutoSaveSettingsTitle" = "自動でオフライン再生可能にする";
 
 /* When the user's disk space is almost full */
-"playlist.playlistDiskSpaceWarningMessage" = "動画や音声をオフライン使用のために保存することは、デバイスのデータ容量を大きく消費することがあります。容量を確保するため、いくつかのファイルを削除してください。";
+"playlist.playlistDiskSpaceWarningMessage" = "動画や音声をオフライン使用を可能にすることは、デバイスのデータ容量を大きく消費することがあります。容量を確保するため、いくつかのファイルを削除してください。";
 
 /* When the user's disk space is almost full */
 "playlist.playlistDiskSpaceWarningTitle" = "データ容量がもうすぐいっぱいです";
@@ -1529,7 +1547,7 @@
 "playlist.playlistResetPlaylistOptionFooterText" = "この設定を行うとPlaylistとオフライン再生用ストレージからすべての動画を削除します。";
 
 /* Error message when saving a playlist item for offline fails */
-"playlist.playlistSaveForOfflineErrorMessage" = "すみません、このアイテムは現在オフライン再生用に保存できません。";
+"playlist.playlistSaveForOfflineErrorMessage" = "すみません、このアイテムは現在オフライン再生ができません。";
 
 /* Title of alert when saving a playlist item for offline mode */
 "playlist.playlistSaveForOfflineErrorTitle" = "すみません。問題が発生しました";
@@ -1610,13 +1628,13 @@
 "playList.reopenButtonTitle" = "再度開く";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "オフライン再生のために保存中";
+"playList.savedForOfflineLabelTitle" = "オフライン再生の準備中";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
-"playlist.saveForOfflineButtonTitle" = "オフライン再生用に保存";
+"playlist.saveForOfflineButtonTitle" = "オフライン再生可能にする";
 
 /* Text indicator on the table cell while saving a video for offline */
-"playList.savingForOfflineLabelTitle" = "オフライン再生のために保存中...";
+"playList.savingForOfflineLabelTitle" = "オフライン再生の準備中...";
 
 /* Description of the settings option to sync folders with the server automatically, every 4 hours. */
 "playList.sharedFolderSyncAutomaticallyDescription" = "すべてのPlaylistフォルダを自動で同期する";
@@ -1748,7 +1766,7 @@
 "playlistFolderSharing.offlineManagementViewAddButtonTitle" = "Playlistを今すぐ追加";
 
 /* Description of the playlist offline data management view */
-"playlistFolderSharing.offlineManagementViewDescription" = "オフライン用に自動保存をオンにすると、Playlist (共有プレイリストを含む) に新しく追加されたデータがオフライン再生用としてデバイスに保存され、お使いのデバイスの通信量を大きく消費する可能性があります。\n\nオフラインでの自動保存は、プレイリストの設定で管理することができます。";
+"playlistFolderSharing.offlineManagementViewDescription" = "自動でオフライン再生可能にする設定をオンにすると、Playlist (共有プレイリストを含む) に新しく追加されたデータがオフライン再生可能な状態になり、お使いのデバイスの通信量を大きく消費する可能性があります。\n\n自動でオフライン再生可能にする設定は、プレイリストの設定で管理することができます。";
 
 /* Button that takes the user to the settings menu */
 "playlistFolderSharing.offlineManagementViewSettingsButtonTitle" = "設定";
@@ -1760,7 +1778,7 @@
 "playlistFolderSharing.renameMenuTitle" = "名前を変更";
 
 /* Menu Title for saving offline data/cache */
-"playlistFolderSharing.saveOfflineDataMenuTitle" = "オフライン再生用データを保存する";
+"playlistFolderSharing.saveOfflineDataMenuTitle" = "オフライン再生を可能にする";
 
 /* Menu Title for syncing playlist */
 "playlistFolderSharing.syncNowMenuTitle" = "同期を開始する";

--- a/Sources/BraveShared/Resources/ko-KR.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/ko-KR.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "프라이버시. 심플하게.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "어떤 Brave 기능이 가장 자주 사용되는지 학습할 수 있습니다. 'Brave Shields 및 프라이버시' 아래 Brave 설정에서 언제든지 변경할 수 있습니다.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "프라이버시 보호 제품 분석(P3A)에 대해 자세히 알아보기.";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Brave 개선에 참여.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "익명으로 프라이버시를 보호하며 제품 인사이트 공유.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "동영상 보기";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "기타 설정";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "익명으로 프라이버시를 보호하며 제품 인사이트를 공유합니다. 어떤 Brave 기능이 가장 자주 사용되는지 학습할 수 있습니다.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "제품 분석";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "기본 웹페이지 확대 수준";

--- a/Sources/BraveShared/Resources/ms.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/ms.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Privasi. Dihasilkan Secara Mudah.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Ini membantu kami mengetahui tentang ciri Brave yang paling kerap digunakan. Tukarkan ini pada bila-bila masa di Tetapan Brave di bawah 'Perisai Brave dan Privasi'.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Ketahui lebih lanjut tentang Analitik Produk Pengekalan Privasi (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Bantu usaha menambah baik Brave.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Kongsikan cerapan produk yang bersifat peribadi dan tanpa nama.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Tonton video";
 
@@ -830,7 +842,7 @@
 "genericErrorTitle" = "Ralat";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Sekat tapak merbahaya";
+"GoogleSafeBrowsing" = "Sekat Tapak Berbahaya";
 
 /* No comment provided by engineer. */
 "GoogleSafeBrowsingUsingWebKitDescription" = "Menghantar URL mengelirukan bagi sesetengah halaman yang anda lawati ke perkhidmatan Penyemakan Lalu Selamat Google, apabila eselamatan anda berisiko.";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Tetapan Lain";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Kongsikan cerapan produk yang bersifat peribadi dan tanpa nama. Ini membantu kami mengetahui tentang ciri Brave yang paling kerap digunakan.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Analitik Produk";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Tahap Zum Halaman-Web Lalai";

--- a/Sources/BraveShared/Resources/nb.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/nb.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Personvern. Gjort enkelt.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Dette hjelper oss å finne ut hvilke Brave-funksjoner som brukes oftest. Du kan endre dette når som helst i Brave-innstillinger under «Brave Shields og personvern».";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Finn ut mer om vår personvernbevarende produktanalyse (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Hjelp oss med å gjøre Brave bedre.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Del anonym, privat produktinnsikt.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Se på videoen";
 
@@ -830,7 +842,7 @@
 "genericErrorTitle" = "Feil";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Blokkerer farlige nettsteder";
+"GoogleSafeBrowsing" = "Blokker farlige nettsteder";
 
 /* No comment provided by engineer. */
 "GoogleSafeBrowsingUsingWebKitDescription" = "Sender tilslørte nettadresser til enkelte sider du besøker til Googles Safe Browsing-tjeneste når sikkerheten din er i fare.";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Andre innstillinger";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Del anonym, privat produktinnsikt. Dette hjelper oss med å finne ut hvilke Brave-funksjoner som brukes oftest.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Produktanalyse";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Standard zoom-nivå for nettsider";

--- a/Sources/BraveShared/Resources/pl.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/pl.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Prosty sposób na prywatność.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "To pomoże nam zrozumieć, które funkcje Brave są używane najczęściej. Możesz to zmienić w dowolnej chwili w Ustawieniach Brave w zakładce Tarcze Brave i prywatność.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Dowiedz się więcej o naszej analizie produktów z zachowaniem prywatności (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Pomóż ulepszyć Brave.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Dziel się anonimowo uwagami na temat produktów.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Zobacz film";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Inne ustawienia";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Dziel się anonimowo uwagami na temat produktów. To pomoże nam zrozumieć, które funkcje Brave są używane najczęściej.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Analiza produktów";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Domyślny stopień powiększenia strony";

--- a/Sources/BraveShared/Resources/pt-BR.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/pt-BR.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Privacidade simplificada.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Isso nos ajuda a saber quais recursos do Brave são usados com mais frequência. Altere isso a qualquer momento na seção \"Proteções do Brave e privacidade\" das Configurações do Brave.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Saiba mais sobre nossa análise de produtos com preservação da privacidade (P3A)";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Ajude a melhorar o Brave.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Compartilhe insights anônimos e privados sobre o produto.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Assistir ao vídeo";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Outras configurações";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Compartilhe insights anônimos e privados sobre o produto. Isso nos ajuda a saber quais recursos do Brave são usados com mais frequência.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Análise de dados do produto";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Nível padrão de zoom de página da web";

--- a/Sources/BraveShared/Resources/ru.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/ru.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Защитите данные одним нажатием";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Это поможет нам узнать, какими функциями Brave пользуются чаще всего. Вы можете в любое время изменить выбор в настройках в разделе «Brave Щит и конфиденциальность».";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Узнайте больше об аналитике продукта без нарушения конфиденциальности (P3A)";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Помогите сделать Brave лучше";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Делитесь анонимными и конфиденциальными сведениями о продукте";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Смотреть видео";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Другие настройки";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Делитесь анонимными и конфиденциальными сведениями о продукте. Эта информация поможет нам узнать, какими функциями Brave пользуются чаще всего.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Аналитика продукта";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Масштаб по умолчанию для веб-страниц";

--- a/Sources/BraveShared/Resources/sv.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/sv.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Integritet. Helt enkelt.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Detta hjälper oss att förstå vilka Brave-funktioner som används oftast. Du kan ändra detta när som helst i inställningarna under \"Brave Shields och sekretess\".";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Läs mer om vår integritetsbevarande produktanalys (P3A)";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Hjälp till att göra Brave bättre.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Dela privat produktstatistik anonymt.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Se videon";
 
@@ -830,7 +842,7 @@
 "genericErrorTitle" = "Fel";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Blockera farliga webbplatser";
+"GoogleSafeBrowsing" = "Blockera skadliga webbplatser";
 
 /* No comment provided by engineer. */
 "GoogleSafeBrowsingUsingWebKitDescription" = "Skickar skadliga webbadresser för vissa sidor som du besöker till Googles tjänst för säker webbsökning, när din säkerhet är i fara.";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Andra inställningar";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Dela privat produktstatistik anonymt. Det hjälper oss att förstå vilka Brave-funktioner som används mest.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Produktanalys";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Zoomnivå för webbsida som standard";

--- a/Sources/BraveShared/Resources/tr.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/tr.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Güvenlik. Artık Çok Kolay.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Bu şekilde en sık hangi Brave özelliklerinin kullanıldığını öğrenmemize yardımcı olabilirsiniz. Bu tercihi Brave Ayarları altındaki \"Brave Kalkanları ve Gizlilik\"ten istediğiniz zaman değiştirebilirsiniz.";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Gizlilik Korumalı Ürün Analizlerimiz (P3A) hakkında daha fazlasını öğrenin.";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Brave'i daha iyi hale getirmeye yardım edin.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Anonim, gizli ürün içgörüleri paylaşın.";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Videoyu izleyin";
 
@@ -830,7 +842,7 @@
 "genericErrorTitle" = "Hata";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Tehlikeli siteleri engelle";
+"GoogleSafeBrowsing" = "Tehlikeli Siteleri Engelleyin";
 
 /* No comment provided by engineer. */
 "GoogleSafeBrowsingUsingWebKitDescription" = "Güvenliğiniz risk altındayken, Google güvenli tarama hizmetine ziyaret ettiğiniz bazı sayfaların karartılmış URL'lerini gönderir.";
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Diğer Ayarlar";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Anonim, gizli ürün içgörüleri paylaşın. Bu şekilde en sık hangi Brave özelliklerinin kullanıldığını öğrenmemize yardımcı olabilirsiniz.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Ürün Analizi";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Varsayılan Web Sayfası Yakınlaştırma Seviyesi";

--- a/Sources/BraveShared/Resources/uk.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/uk.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "Конфіденційність — це просто.";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "Завдяки цьому ми дізнаємося, які функції Brave використовуються найчастіше. Ви можете змінити параметри будь-коли в налаштуваннях Brave у розділі «Brave Shields і конфіденційність»";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "Дізнайтеся більше про аналітику продуктів зі збереженням конфіденційності (P3A).";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "Допоможіть поліпшити Brave.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Ділитися анонімною та приватною інформацією про продукт";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "Переглянути відео";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "Інші налаштування";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "Анонімно діліться приватною інформацією про продукт. Це допоможе нам дізнатися, які функції Brave використовуються найчастіше.";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "Аналітика щодо продукту";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "Рівень масштабування сторінки за замовчуванням";

--- a/Sources/BraveShared/Resources/zh-TW.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/zh-TW.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "隱私不再遙不可及。";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "這有助於我們瞭解哪些 Brave 功能的使用率最高。您隨時可以在 Brave 設定中的「Brave Shields 和隱私」下變更這項設定。";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "深入瞭解保護隱私的產品分析 (P3A)。";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "協助提升 Brave 品質。";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "分享匿名、不公開的產品深入分析。";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "觀看影片";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "其他設定";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "分享匿名、不公開的產品深入分析。這有助於我們瞭解哪些 Brave 功能的使用率最高。";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "產品分析";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "預設網頁縮放比例";

--- a/Sources/BraveShared/Resources/zh.lproj/BraveShared.strings
+++ b/Sources/BraveShared/Resources/zh.lproj/BraveShared.strings
@@ -286,6 +286,18 @@
 /* Title for Default Browser Full Screen Callout */
 "callout.defaultBrowserTitle" = "隐私。让事情变得简单明了。";
 
+/* Subtitle - Description for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutDescription" = "这有助于我们了解 Brave 最常用的功能。在 Brave 设置下的 Brave 防护盾和隐私中随时更改此设置。";
+
+/* Title for the link that navigates to a webpage showing information about p3a (Privacy Preserving Analytics) */
+"callout.p3aCalloutLinkTitle" = "了解更多关于我们的隐私保护产品分析（P3A）。";
+
+/* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutTitle" = "協助提升 Brave 品質。";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "匿名分享私密的产品见解。";
+
 /* Button title for Playlist Onboarding View */
 "callout.playlistOnboardingViewButtonTitle" = "观看视频";
 
@@ -1371,6 +1383,12 @@
 
 /* Section name for other settings. */
 "OtherSettingsSection" = "其他设置";
+
+/* A subtitle shown on the setting that toggles analytics on Brave. */
+"p3a.settingSubtitle" = "匿名分享私密的产品见解。这有助于我们了解 Brave 最常用的功能。";
+
+/* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
+"p3a.settingTitle" = "产品分析";
 
 /* Title for the section for the global/default zoom level */
 "pagezoom.settings.defaultZoomLevelSectionTitle" = "默认网页缩放级别";

--- a/Sources/BraveWallet/Resources/de.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/de.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Netzwerk hinzufügen …";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Erweitert";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "Coingecko-ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Benutzerdefiniertes Token konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Benutzerdefiniertes Token kann nicht hinzugefügt werden";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "Symbol-URL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Token-ID (nur für ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Hiermit kann dieses Netzwerk in der Brave-Wallet verwendet werden.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Erweiterte Einstellungen";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Alle Netzwerke";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Betrag + Gebühren";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "URL(s) eingeben";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Netzwerk auswählen";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Netzwerk auswählen";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Benutzerdefiniert";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Sichtbare Assets bearbeiten";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Adresse eingeben";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Betrag eingeben";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Vertragsadresse eingeben";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Biometrie aktivieren";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Geben Sie Ihr Wallet-Passwort ein, um die Biometrie für Ihre Wallet zu aktivieren (Sie werden dies nur einmal gefragt)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Coingecko-ID-Token eingeben";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Tokensymbol-URL eingeben";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Token-ID eingeben";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Tokennamen eingeben";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave-Wallet";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Netzwerkfilter auswählen";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Anpassung von Wallet-Netzwerken";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Weiter";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFTs";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Keine Konten";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Heute";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Token-Vertragsadresse";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Tokenadresse";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Tokenname";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Genehmigt";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "%@ gesendet";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/es.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/es.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Añadir red…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Configuración avanzada";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "ID de CoinGecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Error al añadir el token personalizado. Inténtalo de nuevo.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "No se puede añadir el token personalizado";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "URL del icono";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Token ID (solo para ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Podrá usarse esta red en Cartera de Brave.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Ajustes avanzados";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Todas las redes";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Cantidad + comisión";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Introduce la(s) URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Seleccionar red";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Seleccionar red";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Personalizado";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Editar activos visibles";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Introduce la dirección";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Introduce el importe";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Introduce la dirección del contrato";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Habilitar biometría";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Introduce la contraseña de tu cartera para habilitar la biometría de la cartera (solo se te pedirá esto una vez)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Introduce el ID de Coingecko del token";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Introduce la URL del icono del token";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Introduce el ID del token";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Introduce el nombre del token";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Cartera de Brave";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Seleccionar el filtro de red";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Personalización de las redes de la cartera";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Siguiente";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFTs";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "No hay cuentas";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Hoy";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Dirección del contrato del token";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Dirección del token";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Nombre del token";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Aprobadas";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Se han enviado %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/fr.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/fr.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Ajouter un réseau…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Avancés";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "ID CoinGecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Impossible d'ajouter le jeton personnalisé. Veuillez réessayer.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Impossible d'ajouter le jeton personnalisé";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "URL d'icône";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Identifiant de jeton (uniquement pour ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Jeton";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Cela permettra d'utiliser ce réseau dans le portefeuille Brave.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Paramètres avancés";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Tous les réseaux";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Montant + frais";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Saisir une ou plusieurs URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Sélectionner le réseau";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Sélectionner le réseau";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Personnalisé";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Modifier les actifs visibles";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Saisissez une adresse";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Saisir un montant";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Saisir l'adresse du contrat";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Activer la biométrie";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Entrez le mot de passe de votre portefeuille pour activer la biométrie (vous n'aurez à le faire qu'une fois)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Saisir l'identifiant CoinGecko du jeton";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Saisir l'URL de l'icône du jeton";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Saisir l'identifiant du jeton";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Saisir le nom du jeton";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Portefeuille Brave";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Sélectionner un filtre réseau";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Personnalisation des réseaux du portefeuille";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Suivant";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Aucun compte";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Aujourd'hui";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Adresse du contrat du jeton";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Adresse du jeton";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Nom du jeton";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Approuvé";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "%@ envoyés";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/id-ID.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/id-ID.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Tambahkan Jaringan...";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Tingkat Lanjut";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "ID Coingecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Gagal menambahkan token khusus, silakan coba lagi.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Tidak dapat menambahkan token khusus";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "URL Ikon";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "ID Token (khusus untuk ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Ini akan memungkinkan jaringan ini untuk digunakan di dalam Dompet Brave.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Pengaturan lanjutan";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Semua Jaringan";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Jumlah + Biaya";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Masukkan URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Pilih jaringan";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Pilih jaringan";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Khusus";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Edit Aset yang Dapat Dilihat";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Masukkan alamat";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Masukkan jumlah";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Masukkan alamat kontrak";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Aktifkan Biometrik";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Masukkan kata sandi dompet Anda guna mengaktifkan biometrik untuk dompet (Anda hanya akan dimintai izin sekali saja)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Masukkan ID Coingecko token";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Masukkan URL ikon token";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Masukkan ID Token";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Masukkan nama token";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Dompet Brave";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Pilih Filter Jaringan";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Kustomisasi jaringan dompet";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Selanjutnya";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Tidak Ada Akun";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Hari ini";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Alamat kontrak token";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Alamat token";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Nama token";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Disetujui";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "%@ dikirim";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/it.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/it.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Aggiungi rete…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Avanzate";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "ID Coingecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Impossibile aggiungere il token personalizzato, riprova.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Impossibile aggiungere il token personalizzato";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "URL icona";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "ID token (solo per ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Questa rete potrà essere utilizzata nel Portafoglio di Brave.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Impostazioni avanzate";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Tutte le reti";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Importo + commissioni";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Inserisci uno o più URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Seleziona la rete";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Seleziona la rete";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Personalizzata";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Modifica asset visibili";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Inserisci indirizzo";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Inserisci importo";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Inserisci indirizzo del contratto";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Abilita i dati biometrici";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Inserisci la password del portafoglio per abilitare l’utilizzo dei dati biometrici per il portafoglio (ti sarà chiesta una volta sola)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Inserisci l’ID Coingecko del token";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Inserisci l’URL dell’icona del token";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Inserisci l’ID del token";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Inserisci nome del token";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Portafoglio Brave";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Seleziona il filtro di rete";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Personalizzazione delle reti dei wallet";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Avanti";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Nessun account";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Oggi";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Indirizzo del contratto del token";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Indirizzo del token";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Nome del token";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Approvati";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "%@ inviati";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/ja.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ja.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "ネットワークを追加…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "詳細";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "CoinGecko ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "カスタムトークンを追加できませんでした。もう一度お試しください。";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "カスタムトークンを追加できません";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "アイコンURL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "トークンID (ERC721のみ)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "トークン";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "このネットワークがBrave Walletで使用されます。";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "詳細設定";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "すべてのネットワーク";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "金額 + 手数料";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "URLを入力";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "ネットワークを選択";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "ネットワークを選択";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "カスタム";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "表示されているアセットを変更する";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "アドレスを入力";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "量を入力";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "コントラクトアドレスを入力する";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "生体認証を有効にする";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "ウォレットの生体認証を有効にするには、ウォレットのパスワードを入力（今後は入力する必要はありません）";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "トークンのCoingecko IDを入力";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "トークンのアイコンURLを入力";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "トークンのIDを入力";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "トークン名を入力する";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Braveウォレット";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "ネットワークフィルターを選択";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "ウォレットネットワークのカスタマイズ";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "次へ";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "アカウントがありません";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "（本日）";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "トークンコントラクトアドレス";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "トークンアドレス";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "トークンネーム";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "承認済";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "%@ が送信されました";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/ko-KR.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ko-KR.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "네트워크 추가...";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "고급";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "코인게코 ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "맞춤 토큰을 추가하지 못했습니다. 다시 시도하세요.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "맞춤 토큰을 추가할 수 없음";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "아이콘 URL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "토큰 ID(ERC721에만 해당)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "토큰";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Brave 월렛 내에서 이 네트워크를 사용하게 됩니다.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "고급 설정";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "모든 네트워크";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "금액 + 수수료";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "URL 입력";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "네트워크 선택";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "네트워크 선택";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "맞춤";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "표시되는 자산 편집";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "주소 입력";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "수량 입력";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "컨트랙트 주소 입력";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "생체인식 활성화";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "월렛에 생체인식을 활성화하려면 월렛 비밀번호 입력(이번 한 번만 입력하면 됨)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "토큰 코인게코 ID 입력";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "토큰 아이콘 URL 입력";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "토큰 ID 입력";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "토큰 이름 입력";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave 월렛";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "네트워크 필터 선택";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "월렛 네트워크 맞춤 설정";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "다음";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "계정 없음";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "오늘";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "토큰 컨트랙트 주소";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "토큰 주소";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "토큰 이름";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "승인됨";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "%@ 보냄";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/ms.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ms.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Tambah Rangkaian...";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Lanjutan";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "ID Coingecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Gagal menambah token tersuai, sila cuba lagi.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Tidak dapat menambah token tersuai";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "Ikon URL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "ID Token (hanya untuk ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Ini akan membenarkan rangkaian ini untuk digunakan dalam Brave Wallet.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Tetapan lanjutan";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Semua Rangkaian";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Amaun + Yuran";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Masukkan URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Pilih rangkaian";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Pilih rangkaian";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Tersuai";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Edit Aset Tampak";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Masukkan alamat";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Masukkan jumlah";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Masukkan alamat kontrak";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Dayakan Biometrik";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Masukkan kata laluan dompet anda bagi mendayakan biometrik untuk dompet (anda akan ditanya sekali sahaja)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Masukkan token ID Coingecko";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Masukkan URL ikon token";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Masukkan ID Token";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Masukkan nama token";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave Wallet";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Pilih Penapis Rangkaian";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Penyesuaian rangkaian dompet";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Seterusnya";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Tiada Akaun";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Hari ini";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Alamat kontrak token";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Alamat token";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Nama token";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Diluluskan";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Dihantar %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/nb.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/nb.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Legg til nettverk …";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Avansert";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "Coingecko-ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Kunne ikke legge til egendefinert token – prøv på nytt";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Kan ikke legge til egendefinert token";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "Ikon-URL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Token-ID (kun for ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Dette tillater at dette nettverket brukes i Brave-lommeboken.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Avanserte innstillinger";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Alle nettverk";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Beløp + Avgift";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Skriv inn nettadresse(r)";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Velg nettverk";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Velg nettverk";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Egendefinert";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Endre synlige ressurser";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Skriv inn adresse";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Skriv inn beløp";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Skriv inn kontaktadresse";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Slå på biometri";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Skriv inn passordet til lommeboken din for å aktivere biometri for lommeboken (du blir bare bedt om å gjøre dette én gang)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Angi tokenets Coingecko-ID";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Angi tokenets ikon-ID";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Angi token-ID";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Skriv inn navn på token";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave-lommebok";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Velg nettverksfilter";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Nettverkstilpasning for lommeboken";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Neste";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT-er";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Ingen kontoer";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "I dag";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Token-kontraktsadresse";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Tokenadresse";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Navn på token";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Godkjent";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Sendt %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/pl.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/pl.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Dodaj sieć...";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Zaawansowane";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "ID Coingecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Nie udało dodać się niestandardowego tokenu, spróbuj ponownie.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Nie można dodać tokenu niestandardowego";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "URL ikony";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Identyfikator tokena (tylko dla ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "To umożliwi korzystanie z tej sieci w ramach portfela Brave.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Ustawienia zaawansowane";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Wszystkie sieci";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Kwota + opłata";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Wprowadź adres/y URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Wybierz sieć";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Wybierz sieć";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Niestandardowe";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Edytuj widoczne zasoby";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Wprowadź adres";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Wpisz kwotę";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Wpisz adres kontraktu";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Włącz biometrykę";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Wprowadź hasło portfela, aby włączyć biometrykę dla portfela (zapytamy Cię o to tylko raz)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Wpisz ID tokena Coingecko";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Wpisz URL ikony tokena ";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Wpisz ID tokena";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Wpisz nazwę tokena";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave Wallet";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Wybierz filtr sieci";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Dostosuj sieci portfela";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Dalej";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Brak kont";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Dzisiaj";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Adres kontraktu tokena";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Adres tokenu";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Nazwa tokena";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Zaakceptowane";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Wysłane %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/pt-BR.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/pt-BR.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Adicionar rede…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Avançados";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "ID do CoinGecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Houve uma falha ao adicionar um token personalizado. Tente novamente.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Não foi possível adicionar um token personalizado";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "URL de ícone";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "ID do token (somente para ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Isso permitirá que esta rede seja usada na Carteira Brave.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Configurações avançadas";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Todas as redes";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Valor + taxa";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Insira URL(s)";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Selecionar rede";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Selecionar rede";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Personalizado";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Editar ativos visíveis";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Inserir endereço";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Inserir valor";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Inserir endereço de contrato";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Ativar biometria";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Insira a senha da sua carteira para ativar a biometria na carteira (você só precisará fazer isso uma vez)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Insira o ID do CoikGecko do token";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Insira o URL do ícone do token";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Insira o ID do token";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Inserir nome do token";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Carteira Brave";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Selecionar filtro de rede";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Personalização de redes de carteiras";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Próxima";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFTs";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Não há contas";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Hoje";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Endereço de contrato de token";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Endereço do token";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Nome do token";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Aprovada";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Enviou %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/ru.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ru.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Добавить сеть";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Дополнительные";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "Coingecko ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Не удалось добавить пользовательский токен. Повторите попытку.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Не удалось добавить пользовательский токен";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "Значок сайта";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Идентификатор вознаграждения (только для ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Так вы сможете использовать эту сеть в Brave Кошельке.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Расширенные настройки";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Все сети";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Сумма + комиссия";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Укажите один или несколько URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Выбор сети";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Выбор сети";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Пользовательский";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Изменить видимые активы";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Введите адрес";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Укажите сумму";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Укажите адрес контракта";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Использование биометрических данных";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Чтобы включить использование биометрических данных для кошелька, введите пароль от него (это потребуется только один раз)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Укажите идентификатор CoinGecko токена";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Укажите URL значка токена";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Укажите идентификатор токена";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Укажите название токена";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave Кошелек";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Фильтр для выбора сети";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Настройка сетей";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Далее";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Нет счетов";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "сегодня";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Адрес контракта токена";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Адрес токена";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Название токена";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Одобрено";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Отправлено: %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/sv.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/sv.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Lägg till nätverk …";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Avancerat";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "Coingecko-ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Det gick inte att lägga till anpassad token. Försök igen.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Kan inte lägga till anpassad token";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "Ikon-URL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Token-ID (endast för ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Detta gör att detta nätverk kan användas inom Brave Wallet.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Avancerade inställningar";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Alla nätverk";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Belopp + avgift";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Ange URL:er";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Välj nätverk";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Välj nätverk";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Anpassad";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Redigera synliga tillgångar";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Ange adress";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Ange belopp";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Ange kontraktsadress";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Aktivera biometri";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Ange ditt plånbokslösenord för att aktivera biometri för plånbok (du kommer bara att bli ombedd att göra detta en gång)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Ange tokens Coingecko-id";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Ange tokens ikon-URL";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Ange token-id";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Ange tokennamn";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave-plånbok";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Välj nätverksfilter";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Anpassning av plånboksnätverk";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Nästa";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFTs";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Inga konton";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "idag";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Tokenkontraktsadress";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Tokenadress";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Tokennamn";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Godkänd";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Skickade %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/tr.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/tr.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Ağ Ekle…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Advanced";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "CoinGecko Kimliği";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Özel token eklenemedi, lütfen tekrar deneyin.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Özel token eklenemiyor";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "Simge URL'si";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Token Kimliği (sadece ERC721 için)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Token";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Bu, bu ağın Brave Cüzdanı içinde kullanılmasına izin verir.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Gelişmiş ayarlar";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Tüm Ağlar";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Tutar + Ücret";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "URL'leri girin";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Ağ seç";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Ağ seç";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Özel";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Görünür Varlıkları Düzenle";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Adresi gir";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Tutarı girin";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Kontrat adresini girin";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Biyometriyi Etkinleştir";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Cüzdanınıza yönelik olarak biyometriyi etkinleştirmek için cüzdan parolanızı girin (bu sadece bir kez sorulacaktır)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Token Coingecko Kimliğini gir";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Token simgesi URL'sini gir";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Token Kimliğini gir";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Token adını girin";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave Cüzdanı";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Ağ Filtresini seç";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Digital cüzdan ağlarını özelleştirme";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Sonraki";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT'ler";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Hesap Yok";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Bugün";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Token kontrat adresi";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Token adresi";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Token adı";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Tasdik Edildi";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "%@ Gönderildi";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/uk.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/uk.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "Додати мережу…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "Розширені";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "Ідентифікатор Coingecko";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "Не вдалося додати користувацький токен, повторіть спробу.";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "Неможливо додати користувацький токен";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "URL-адреса значка";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "Ідентифікатор токена (лише для ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "Токен";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "Це дозволить використовувати цю мережу в гаманці Brave.";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "Розширені налаштування";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "Усі мережі";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "Сума + комісія";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "Уведіть URL-адреси";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "Вибрати мережу";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "Вибрати мережу";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "Користувацькі";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "Редагувати видимі активи";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "Уведіть адресу";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "Уведіть суму";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "Уведіть контактну адресу";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "Увімкнути біометричні дані";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "Укажіть пароль гаманця, щоб увімкнути біометричні дані для нього (це потрібно буде зробити лише один раз)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "Уведіть ідентифікатор токена Coingecko";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "Уведіть URL-адресу значка токена";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "Уведіть ідентифікатор токена";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "Уведіть назву токена";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Гаманець Brave";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "Виберіть фільтр для мереж";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "Налаштування мереж гаманця";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "Далі";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "Немає рахунків";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "Сьогодні";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "Адреса контракту токена";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "Адреса токена";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "Назва токена";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "Затверджено";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "Надіслано %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "新增網路…";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "進階";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "CoinGecko ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "無法新增自訂代幣，請再試一次。";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "無法新增自訂代幣";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "圖示 URL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "代幣 ID (僅適用於 ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "代碼";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "這會允許 Brave 錢包使用這個網路。";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "進階設定";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "所有網路";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "金額 + 手續費";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "輸入 URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "選擇網路";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "選擇網路";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "自訂";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "編輯可見資產";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "輸入位址";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "輸入金額";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "輸入合約網址";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "啟用生物辨識功能";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "輸入錢包密碼，為錢包啟用生物辨識功能 (系統只會要求您輸入一次)";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "輸入代幣 CoinGecko ID";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "輸入代幣圖示 URL";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "輸入代幣 ID";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "輸入代幣名稱";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave 錢包";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "選取網路過濾器";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "錢包網路自訂";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "下一筆";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "沒有帳戶";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "今天";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "代幣合約網址";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "代幣位址";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "代幣名稱";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "已核准";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "已傳送 %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
@@ -50,7 +50,7 @@
 "wallet.addCustomNFTTitle" = "NFT";
 
 /* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
-"wallet.addCustomTokenAdvanced" = "進階";
+"wallet.addCustomTokenAdvanced" = "进阶";
 
 /* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
 "wallet.addCustomTokenCoingeckoId" = "CoinGecko ID";
@@ -68,7 +68,7 @@
 "wallet.addCustomTokenId" = "代幣 ID (僅適用於 ERC721)";
 
 /* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
-"wallet.addCustomTokenTitle" = "代碼";
+"wallet.addCustomTokenTitle" = "代幣";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "這會允許 Brave 錢包使用這個網路。";

--- a/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
@@ -62,13 +62,13 @@
 "wallet.addCustomTokenErrorTitle" = "无法添加自定义令牌";
 
 /* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
-"wallet.addCustomTokenIconURL" = "圖示 URL";
+"wallet.addCustomTokenIconURL" = "输入代币图标网址";
 
 /* A title that will be displayed on top of the text field for users to input the custom token's ID. */
-"wallet.addCustomTokenId" = "代幣 ID (僅適用於 ERC721)";
+"wallet.addCustomTokenId" = "代币 ID (仅限用于 ERC721)";
 
 /* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
-"wallet.addCustomTokenTitle" = "代幣";
+"wallet.addCustomTokenTitle" = "代币";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "这将允许在 Brave Wallet 中使用该网络。";
@@ -89,7 +89,7 @@
 "wallet.advancedSettingsTransaction" = "进阶设置";
 
 /* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
-"wallet.allNetworksTitle" = "所有網路";
+"wallet.allNetworksTitle" = "所有网络";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "金额 + 费用";

--- a/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
@@ -554,13 +554,13 @@
 "wallet.enterPasswordForBiometricsTitle" = "输入您的钱包的密码以启用钱包的生物识别功能（只会要求您输入一次）";
 
 /* A placeholder for the text field that users will input the custom token Coingecko ID. */
-"wallet.enterTokenCoingeckoId" = "输入令牌 Coingecko ID";
+"wallet.enterTokenCoingeckoId" = "输入代币 Coingecko ID";
 
 /* A placeholder for the text field that users will input the custom token icon URL */
-"wallet.enterTokenIconURL" = "输入令牌图标网址";
+"wallet.enterTokenIconURL" = "输入代币图标网址";
 
 /* A placeholder for the text field that users will input the custom token's ID. */
-"wallet.enterTokenId" = "输入令牌 ID";
+"wallet.enterTokenId" = "输入代币 ID";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "输入代币名称";
@@ -1241,7 +1241,7 @@
 "wallet.today" = "今天";
 
 /* A title that will be displayed on top of the text field for users to input the custom token address */
-"wallet.tokenAddress" = "令牌地址";
+"wallet.tokenAddress" = "代币地址";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "代币名称";

--- a/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
@@ -46,11 +46,29 @@
 /* The title of last option in the network selection dropdown menu. A short-cut for user to add new custom network. */
 "wallet.addCustomNetworkDropdownButtonTitle" = "新增网络...";
 
+/* A title of one segment on top of Add Custom Assets screen. Users would need to select this segment if they are willing to add a custom non-fungible token. */
+"wallet.addCustomNFTTitle" = "NFT";
+
+/* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
+"wallet.addCustomTokenAdvanced" = "高级";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
+"wallet.addCustomTokenCoingeckoId" = "Coingecko ID";
+
 /* The message of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorMessage" = "添加自定义代币失败，请重试。";
 
 /* The title of the error pop up when there is an error occurs during the process of adding a custom token. */
 "wallet.addCustomTokenErrorTitle" = "无法添加自定义令牌";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's icon URL. */
+"wallet.addCustomTokenIconURL" = "圖示 URL";
+
+/* A title that will be displayed on top of the text field for users to input the custom token's ID. */
+"wallet.addCustomTokenId" = "代幣 ID (僅適用於 ERC721)";
+
+/* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
+"wallet.addCustomTokenTitle" = "代碼";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "这将允许在 Brave Wallet 中使用该网络。";
@@ -69,6 +87,9 @@
 
 /* The title of the button that is displayed under the total gas fee in the confirmation transaction screen. Users can click it to go to advanced settings screen. */
 "wallet.advancedSettingsTransaction" = "进阶设置";
+
+/* The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network. */
+"wallet.allNetworksTitle" = "所有網路";
 
 /* A title displayed above two numbers (the amount and transaction fee) showing the user the breakdown of the amount transferred and transaction fee for any Solana transaction. The \"+\" is a literal plus as the label below will show such as \"0.004 SOL + 0.00064 SOL\" */
 "wallet.amountAndFee" = "金额 + 费用";
@@ -331,6 +352,12 @@
 /* The placeholder for the input field for users to input network rpc url in Custom Network Details Screen. */
 "wallet.customNetworkUrlsPlaceholder" = "输入 URL";
 
+/* A title for the btton that users can click to choose the network they are willing to add custom asset in. */
+"wallet.customTokenNetworkButtonTitle" = "选择网络";
+
+/* A title that will be displayed on top of the text field for users to choose a network they are willing to add the custom asset in. */
+"wallet.customTokenNetworkHeader" = "选择网络";
+
 /* The title displayed on the add custom token screen */
 "wallet.customTokenTitle" = "自定义";
 
@@ -514,17 +541,26 @@
 /* The button title for showing the screen to change what assets are visible */
 "wallet.editVisibleAssetsButtonTitle" = "编辑可见资产";
 
+/* A placeholder for the text field that users will input the custom token address */
+"wallet.enterAddress" = "输入地址";
+
 /* The header title for the textField users will input the dollar value of the crypto they want to buy */
 "wallet.enterAmount" = "输入金额";
-
-/* A placeholder for the text field that users will input the custom token contract address */
-"wallet.enterContractAddress" = "输入合约地址";
 
 /* The navigation bar title displayed on the screen to enter wallet password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsNavTitle" = "启用生物识别";
 
 /* The title displayed on the screen to enter password to enable biometrics unlock from wallet settings. */
 "wallet.enterPasswordForBiometricsTitle" = "输入您的钱包的密码以启用钱包的生物识别功能（只会要求您输入一次）";
+
+/* A placeholder for the text field that users will input the custom token Coingecko ID. */
+"wallet.enterTokenCoingeckoId" = "输入令牌 Coingecko ID";
+
+/* A placeholder for the text field that users will input the custom token icon URL */
+"wallet.enterTokenIconURL" = "输入令牌图标网址";
+
+/* A placeholder for the text field that users will input the custom token's ID. */
+"wallet.enterTokenId" = "输入令牌 ID";
 
 /* A placeholder for the text field that users will input the custom token name */
 "wallet.enterTokenName" = "输入代币名称";
@@ -667,6 +703,9 @@
 /* The title shown on the wallet settings page, and the value shown when selecting the default wallet as Brave Wallet in wallet settings. */
 "wallet.module" = "Brave 钱包";
 
+/* The title displayed on the view to filter by a network / all networks. */
+"wallet.networkFilterTitle" = "选择网络筛选";
+
 /* The footer beneath the networks title in settings screen. */
 "wallet.networkFooter" = "钱包网络自定义";
 
@@ -705,6 +744,9 @@
 
 /* 1. A button title next indicating the user to go to the next transaction. Will sit next to a label such as \"1 of 4\" where tapping next would move them to the second transaction. 2. Title of the button for users to click to the next step during the process of dapp permission requests. */
 "wallet.next" = "下一笔";
+
+/* The title which is displayed above a list of NFTs. 'NFT' is an acronym for Non-Fungible Token. */
+"wallet.nftsTitle" = "NFT";
 
 /* The empty state displayed when the user has no accounts associated with a transaction or asset */
 "wallet.noAccounts" = "无账户";
@@ -1198,8 +1240,8 @@
 /* A label appended after a certain dollar or percent change. Example: 'Up 1.4% Today' */
 "wallet.today" = "今天";
 
-/* A title that will be displayed on top of the text field for users to input the custom token contract address */
-"wallet.tokenContractAddress" = "代币合约地址";
+/* A title that will be displayed on top of the text field for users to input the custom token address */
+"wallet.tokenAddress" = "令牌地址";
 
 /* A title that will be displayed on top of the text field for users to input the custom token name */
 "wallet.tokenName" = "代币名称";
@@ -1297,7 +1339,7 @@
 /* The title shown for ERC20 approvals when the user doesn't have the visible asset added */
 "wallet.transactionUnknownApprovalTitle" = "已批准";
 
-/* A title shown for a erc 20 transfer, or erc 721 transaction. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
+/* A title shown for a erc 20 transfer. The first '%@' becomes the symbol for the cryptocurrency For example: \"Sent ETH\" */
 "wallet.transactionUnknownSendTitle" = "已发送 %@";
 
 /* An error message displayed when an unspecified problem occurs. */

--- a/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
@@ -50,7 +50,7 @@
 "wallet.addCustomNFTTitle" = "NFT";
 
 /* A title of an initally hidden section in Add custom asset screen for users to input icon url and coingecko id. */
-"wallet.addCustomTokenAdvanced" = "高级";
+"wallet.addCustomTokenAdvanced" = "进阶";
 
 /* A title that will be displayed on top of the text field for users to input the custom token's coingecko ID. */
 "wallet.addCustomTokenCoingeckoId" = "Coingecko ID";
@@ -68,7 +68,7 @@
 "wallet.addCustomTokenId" = "代幣 ID (僅適用於 ERC721)";
 
 /* A title of one segment on top of Add Custom Assets screen, which is default selected. Users would need to select this segment if they are willing to add a custom fungible token. */
-"wallet.addCustomTokenTitle" = "代碼";
+"wallet.addCustomTokenTitle" = "代幣";
 
 /* The description of the view shown over a dapps website that describes what adding a new network will do. */
 "wallet.addNetworkDescription" = "这将允许在 Brave Wallet 中使用该网络。";


### PR DESCRIPTION
Translations were ordered off development branch so this change includes partial translations for 1.46 as well.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6438 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
NFTs basica support localization are implemented in two places: 
1. In portfolio, we will have a new section to display NFTs tokens if users set some NFTs as visible assets. The section title is a copy we localized (although most of the languages will stay the same as English `NFTs` or `NFT`)
2. In Add Custom Asset screen, we had some updates for adding fungible tokens (network selection; advanced). We also add a segment on top so that users can choose to add fungible token of non-fungible token (NFT segment is entirely new). All the strings should be localized in this screen.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
