### PR TITLE
No Bug: bump core to 1.46.118

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.118/brave-core-ios-1.46.118.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.46.114",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
-      "integrity": "sha512-OVSdwKzBrvYP+aI+y7dJ+AhMLvhAZcl0V1fanz9yiWsIxLrqKauMk7F2Eq29bS22OS4j1TNJ49/uRv9wza1/oQ==",
+      "version": "1.46.118",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.118/brave-core-ios-1.46.118.tgz",
+      "integrity": "sha512-3vHVrPefQweXc7bl8XY7P8THHJrtvjENP7EH6umgEuK2UbII4+hQ75wpkSOsLawTE+Rlf2cLvk2BvPshP2dEGQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
-      "integrity": "sha512-OVSdwKzBrvYP+aI+y7dJ+AhMLvhAZcl0V1fanz9yiWsIxLrqKauMk7F2Eq29bS22OS4j1TNJ49/uRv9wza1/oQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.118/brave-core-ios-1.46.118.tgz",
+      "integrity": "sha512-3vHVrPefQweXc7bl8XY7P8THHJrtvjENP7EH6umgEuK2UbII4+hQ75wpkSOsLawTE+Rlf2cLvk2BvPshP2dEGQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.114/brave-core-ios-1.46.114.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.118/brave-core-ios-1.46.118.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This core version enable ipfs build flag for ios.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
