### PR TITLE
Fix #6446: Changing Brand / Interaction Color

### DIFF
--- a/App/BraveWidgets/SingleStatWidget.swift
+++ b/App/BraveWidgets/SingleStatWidget.swift
@@ -83,9 +83,9 @@ private struct StatView: View {
 #if DEBUG
 struct SingleStatWidget_Previews: PreviewProvider {
   static var previews: some View {
-    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Ads & Trackers Blocked", value: "100k", color: UIColor.braveBlurple)))
+    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Ads & Trackers Blocked", value: "100k", color: UIColor.braveBlurpleTint)))
       .previewContext(WidgetPreviewContext(family: .systemSmall))
-    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Placeholder Count", value: "100k", color: UIColor.braveBlurple)))
+    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Placeholder Count", value: "100k", color: UIColor.braveBlurpleTint)))
       .redacted(reason: .placeholder)
       .previewContext(WidgetPreviewContext(family: .systemSmall))
   }

--- a/App/BraveWidgets/SingleStatWidget.swift
+++ b/App/BraveWidgets/SingleStatWidget.swift
@@ -83,9 +83,9 @@ private struct StatView: View {
 #if DEBUG
 struct SingleStatWidget_Previews: PreviewProvider {
   static var previews: some View {
-    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Ads & Trackers Blocked", value: "100k", color: UIColor.braveOrange)))
+    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Ads & Trackers Blocked", value: "100k", color: UIColor.braveBlurple)))
       .previewContext(WidgetPreviewContext(family: .systemSmall))
-    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Placeholder Count", value: "100k", color: UIColor.braveOrange)))
+    StatView(entry: StatEntry(date: Date(), statData: .init(name: "Placeholder Count", value: "100k", color: UIColor.braveBlurple)))
       .redacted(reason: .placeholder)
       .previewContext(WidgetPreviewContext(family: .systemSmall))
   }

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -126,12 +126,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let window = UIWindow(windowScene: windowScene).then {
       $0.backgroundColor = .black
       $0.overrideUserInterfaceStyle = expectedThemeOverride
-      $0.tintColor = UIColor {
-        if $0.userInterfaceStyle == .dark {
-          return .braveLighterBlurple
-        }
-        return .braveBlurple
-      }
+      $0.tintColor = .braveBlurpleTint
       
       $0.rootViewController = navigationController
     }

--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -17,7 +17,7 @@ extension UIView {
   /// - warning: Be careful adjusting colors here, and make sure impact is well known
   public static func applyAppearanceDefaults() {
     UIToolbar.appearance().do {
-      $0.tintColor = .braveOrange
+      $0.tintColor = .braveBlurple
       let appearance: UIToolbarAppearance = {
         let appearance = UIToolbarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -35,7 +35,7 @@ extension UIView {
     }
 
     UINavigationBar.appearance().do {
-      $0.tintColor = .braveOrange
+      $0.tintColor = .braveBlurple
       let appearance: UINavigationBarAppearance = {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -50,7 +50,7 @@ extension UIView {
       $0.scrollEdgeAppearance = appearance
     }
 
-    UISwitch.appearance().onTintColor = UIColor.braveOrange
+    UISwitch.appearance().onTintColor = UIColor.braveBlurple
 
     /// Used as color a table will use as the base (e.g. background)
     let tablePrimaryColor = UIColor.braveGroupedBackground
@@ -61,7 +61,7 @@ extension UIView {
     UITableView.appearance().separatorColor = .braveSeparator
 
     UITableViewCell.appearance().do {
-      $0.tintColor = .braveOrange
+      $0.tintColor = .braveBlurple
       $0.backgroundColor = tableSecondaryColor
     }
 

--- a/Client/Extensions/AppearanceExtensions.swift
+++ b/Client/Extensions/AppearanceExtensions.swift
@@ -17,7 +17,7 @@ extension UIView {
   /// - warning: Be careful adjusting colors here, and make sure impact is well known
   public static func applyAppearanceDefaults() {
     UIToolbar.appearance().do {
-      $0.tintColor = .braveBlurple
+      $0.tintColor = .braveBlurpleTint
       let appearance: UIToolbarAppearance = {
         let appearance = UIToolbarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -35,7 +35,7 @@ extension UIView {
     }
 
     UINavigationBar.appearance().do {
-      $0.tintColor = .braveBlurple
+      $0.tintColor = .braveBlurpleTint
       let appearance: UINavigationBarAppearance = {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -50,7 +50,7 @@ extension UIView {
       $0.scrollEdgeAppearance = appearance
     }
 
-    UISwitch.appearance().onTintColor = UIColor.braveBlurple
+    UISwitch.appearance().onTintColor = UIColor.braveBlurpleTint
 
     /// Used as color a table will use as the base (e.g. background)
     let tablePrimaryColor = UIColor.braveGroupedBackground
@@ -61,7 +61,7 @@ extension UIView {
     UITableView.appearance().separatorColor = .braveSeparator
 
     UITableViewCell.appearance().do {
-      $0.tintColor = .braveBlurple
+      $0.tintColor = .braveBlurpleTint
       $0.backgroundColor = tableSecondaryColor
     }
 

--- a/Client/Frontend/Brave Rewards/Ads/AdView.swift
+++ b/Client/Frontend/Brave Rewards/Ads/AdView.swift
@@ -9,7 +9,7 @@ import Shared
 public class AdView: UIView {
   let adContentButton = AdContentButton()
   let openSwipeButton = AdSwipeButton(contentType: .text(Strings.Ads.open, textColor: .white)).then {
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
   }
   let dislikeSwipeButton = AdSwipeButton(contentType: .image(UIImage(named: "dislike-ad-icon", in: .module, compatibleWith: nil)!)).then {
     $0.backgroundColor = .braveErrorLabel

--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsPublisherView.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsPublisherView.swift
@@ -43,7 +43,7 @@ class BraveRewardsPublisherView: UIStackView {
 
   let learnMoreButton = BraveButton(type: .system).then {
     $0.setTitle(Strings.learnMore, for: .normal)
-    $0.tintColor = .braveBlurple
+    $0.tintColor = .braveBlurpleTint
     $0.isHidden = true
   }
 

--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
@@ -18,7 +18,7 @@ extension BraveRewardsViewController {
     }
     let rewardsToggle = UISwitch().then {
       $0.setContentHuggingPriority(.required, for: .horizontal)
-      $0.onTintColor = .braveOrange
+      $0.onTintColor = .braveBlurple
     }
     private let titleLabel = UILabel().then {
       $0.text = Strings.braveRewardsTitle

--- a/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
+++ b/Client/Frontend/Brave Rewards/Panel/BraveRewardsView.swift
@@ -18,7 +18,7 @@ extension BraveRewardsViewController {
     }
     let rewardsToggle = UISwitch().then {
       $0.setContentHuggingPriority(.required, for: .horizontal)
-      $0.onTintColor = .braveBlurple
+      $0.onTintColor = .braveBlurpleTint
     }
     private let titleLabel = UILabel().then {
       $0.text = Strings.braveRewardsTitle

--- a/Client/Frontend/Brave Rewards/Transfer/WalletTransferView.swift
+++ b/Client/Frontend/Brave Rewards/Transfer/WalletTransferView.swift
@@ -36,7 +36,7 @@ extension WalletTransferViewController {
     }
     let learnMoreButton = UIButton(type: .system).then {
       $0.setTitle(Strings.learnMore, for: .normal)
-      $0.setTitleColor(.braveBlurple, for: .normal)
+      $0.setTitleColor(.braveBlurpleTint, for: .normal)
       $0.titleLabel?.font = .systemFont(ofSize: 17)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
@@ -31,7 +31,7 @@ class OpenSearchEngineButton: BraveButton {
       case .enabled:
         isLoading = false
         setImage(UIImage(named: "AddSearch", in: .module, compatibleWith: nil)!.template, for: .normal)
-        tintColor = .braveOrange
+        tintColor = .braveBlurple
         isUserInteractionEnabled = true
       case .loading:
         isLoading = true
@@ -47,7 +47,7 @@ class OpenSearchEngineButton: BraveButton {
   override init(frame: CGRect) {
     self.action = .disabled
     super.init(frame: frame)
-    setTitleColor(.braveOrange, for: .normal)
+    setTitleColor(.braveBlurple, for: .normal)
   }
 
   convenience init(title: String? = nil, hidesWhenDisabled: Bool) {

--- a/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
+++ b/Client/Frontend/Browser/BrowserViewController/OpenSearch/OpenSearchEngineButton.swift
@@ -31,7 +31,7 @@ class OpenSearchEngineButton: BraveButton {
       case .enabled:
         isLoading = false
         setImage(UIImage(named: "AddSearch", in: .module, compatibleWith: nil)!.template, for: .normal)
-        tintColor = .braveBlurple
+        tintColor = .braveBlurpleTint
         isUserInteractionEnabled = true
       case .loading:
         isLoading = true
@@ -47,7 +47,7 @@ class OpenSearchEngineButton: BraveButton {
   override init(frame: CGRect) {
     self.action = .disabled
     super.init(frame: frame)
-    setTitleColor(.braveBlurple, for: .normal)
+    setTitleColor(.braveBlurpleTint, for: .normal)
   }
 
   convenience init(title: String? = nil, hidesWhenDisabled: Bool) {

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageFeedOverlayView.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageFeedOverlayView.swift
@@ -141,7 +141,7 @@ class NewContentAvailableButton: SpringButton {
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    backgroundColor = .braveOrange
+    backgroundColor = .braveBlurple
     layer.cornerCurve = .continuous
 
     clipsToBounds = true

--- a/Client/Frontend/Browser/New Tab Page/NewTabPageFeedOverlayView.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageFeedOverlayView.swift
@@ -141,7 +141,7 @@ class NewContentAvailableButton: SpringButton {
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    backgroundColor = .braveBlurple
+    backgroundColor = .braveBlurpleTint
     layer.cornerCurve = .continuous
 
     clipsToBounds = true

--- a/Client/Frontend/Browser/New Tab Page/Notifications/NTPLearnMoreContentView.swift
+++ b/Client/Frontend/Browser/New Tab Page/Notifications/NTPLearnMoreContentView.swift
@@ -165,7 +165,7 @@ private func detailLinkLabel(with text: String) -> LinkLabel {
   LinkLabel().then {
     $0.font = .systemFont(ofSize: 12.0)
     $0.textColor = UIColor(white: 0, alpha: 0.7)
-    $0.linkColor = UIColor.braveBlurple
+    $0.linkColor = UIColor.braveBlurpleTint
     $0.text = text
     $0.textContainerInset = .zero
     $0.textContainer.lineFragmentPadding = 0

--- a/Client/Frontend/Browser/New Tab Page/Notifications/NTPLearnMoreContentView.swift
+++ b/Client/Frontend/Browser/New Tab Page/Notifications/NTPLearnMoreContentView.swift
@@ -165,7 +165,7 @@ private func detailLinkLabel(with text: String) -> LinkLabel {
   LinkLabel().then {
     $0.font = .systemFont(ofSize: 12.0)
     $0.textColor = UIColor(white: 0, alpha: 0.7)
-    $0.linkColor = UIColor.braveOrange
+    $0.linkColor = UIColor.braveBlurple
     $0.text = text
     $0.textContainerInset = .zero
     $0.textContainer.lineFragmentPadding = 0

--- a/Client/Frontend/Browser/New Tab Page/Notifications/NTPNotificationView.swift
+++ b/Client/Frontend/Browser/New Tab Page/Notifications/NTPNotificationView.swift
@@ -53,7 +53,7 @@ class NTPNotificationView: UIStackView {
   lazy var body = LinkLabel().then {
     $0.font = .systemFont(ofSize: 12.0)
     $0.textColor = config.textColor
-    $0.linkColor = UIColor.braveOrange
+    $0.linkColor = UIColor.braveBlurple
     $0.text = config.bodyText?.text
 
     $0.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 313), for: .vertical)

--- a/Client/Frontend/Browser/New Tab Page/Notifications/NTPNotificationView.swift
+++ b/Client/Frontend/Browser/New Tab Page/Notifications/NTPNotificationView.swift
@@ -53,7 +53,7 @@ class NTPNotificationView: UIStackView {
   lazy var body = LinkLabel().then {
     $0.font = .systemFont(ofSize: 12.0)
     $0.textColor = config.textColor
-    $0.linkColor = UIColor.braveBlurple
+    $0.linkColor = UIColor.braveBlurpleTint
     $0.text = config.bodyText?.text
 
     $0.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 313), for: .vertical)
@@ -63,7 +63,7 @@ class NTPNotificationView: UIStackView {
 
   lazy var primaryButton = RoundInterfaceButton(type: .system).then {
     $0.setTitle(config.primaryButtonConfig?.text, for: .normal)
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
     $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     $0.contentEdgeInsets = UIEdgeInsets(top: 12, left: 25, bottom: 12, right: 25)
     $0.setTitleColor(.white, for: .normal)

--- a/Client/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
+++ b/Client/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
@@ -81,7 +81,7 @@ struct PageZoomSettingsView: View {
               if preferredZoomLevel == zoomLevel {
                 Image(systemName: "checkmark")
                   .font(.system(.body).weight(.medium))
-                  .foregroundColor(Color(.braveOrange))
+                  .foregroundColor(Color(.braveBlurple))
               }
             }
           })

--- a/Client/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
+++ b/Client/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
@@ -81,7 +81,7 @@ struct PageZoomSettingsView: View {
               if preferredZoomLevel == zoomLevel {
                 Image(systemName: "checkmark")
                   .font(.system(.body).weight(.medium))
-                  .foregroundColor(Color(.braveBlurple))
+                  .foregroundColor(Color(.braveBlurpleTint))
               }
             }
           })

--- a/Client/Frontend/Browser/PageZoom/PageZoomView.swift
+++ b/Client/Frontend/Browser/PageZoom/PageZoomView.swift
@@ -138,7 +138,7 @@ struct PageZoomView: View {
           dismiss?()
         } label: {
           Image(systemName: "xmark")
-            .foregroundColor(Color(UIColor.braveBlurple))
+            .foregroundColor(Color(UIColor.braveBlurpleTint))
             .font(.system(.footnote).weight(.medium))
         }
         .frame(maxWidth: .infinity, alignment: .trailing)

--- a/Client/Frontend/Browser/Playlist/Cells/PlaylistMenuHeader.swift
+++ b/Client/Frontend/Browser/Playlist/Cells/PlaylistMenuHeader.swift
@@ -123,7 +123,7 @@ class PlaylistMenuHeader: UITableViewHeaderFooterView {
     case .add:
       menuButton.setTitle(Strings.PlaylistFolderSharing.addButtonTitle, for: .normal)
       menuButton.setImage(UIImage(systemName: "plus"), for: .normal)
-      menuButton.backgroundColor = .braveBlurple
+      menuButton.backgroundColor = .braveBlurpleTint
       menuButton.accessibilityLabel = Strings.PlaylistFolderSharing.addButtonAccessibilityTitle
       menuButton.contentEdgeInsets = UIEdgeInsets(top: 6.0, left: 20.0, bottom: 6.0, right: 20.0)
       menuButton.sizeToFit()

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistFolderController.swift
@@ -384,7 +384,7 @@ extension PlaylistFolderController: UITableViewDelegate {
       })
 
     editAction.image = UIImage(systemName: "pencil")
-    editAction.backgroundColor = .braveBlurple
+    editAction.backgroundColor = .braveBlurpleTint
 
     deleteAction.image = UIImage(braveSystemNamed: "brave.trash")!
     deleteAction.backgroundColor = .braveErrorLabel

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
@@ -58,7 +58,7 @@ private struct PlaylistFolderView: View {
     HStack {
       HStack(spacing: 10.0) {
         Image(braveSystemName: "brave.folder")
-          .foregroundColor(isSourceFolder ? Color(.braveDisabled.resolvedColor(with: .init(userInterfaceStyle: .light))) : Color(.braveBlurple))
+          .foregroundColor(isSourceFolder ? Color(.braveDisabled.resolvedColor(with: .init(userInterfaceStyle: .light))) : Color(.braveBlurpleTint))
           .frame(width: imageSize)
 
         VStack(alignment: .leading) {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
@@ -58,7 +58,7 @@ private struct PlaylistFolderView: View {
     HStack {
       HStack(spacing: 10.0) {
         Image(braveSystemName: "brave.folder")
-          .foregroundColor(isSourceFolder ? Color(.braveDisabled.resolvedColor(with: .init(userInterfaceStyle: .light))) : Color(.braveOrange))
+          .foregroundColor(isSourceFolder ? Color(.braveDisabled.resolvedColor(with: .init(userInterfaceStyle: .light))) : Color(.braveBlurple))
           .frame(width: imageSize)
 
         VStack(alignment: .leading) {

--- a/Client/Frontend/Browser/Playlist/PlaylistPopoverView.swift
+++ b/Client/Frontend/Browser/Playlist/PlaylistPopoverView.swift
@@ -109,7 +109,7 @@ struct PlaylistPopoverView: View {
           }
         }
         .buttonStyle(BraveFilledButtonStyle(size: .small))
-        .foregroundColor(Color(UIColor.braveBlurple))
+        .foregroundColor(Color(UIColor.braveBlurpleTint))
       }
 
       Button(action: {

--- a/Client/Frontend/Browser/PrivacyHub/AllVPNAlertsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/AllVPNAlertsView.swift
@@ -141,7 +141,7 @@ extension PrivacyReportsView {
       .toolbar {
         ToolbarItem(placement: .confirmationAction) {
           Button(Strings.done, action: onDismiss)
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
       .onAppear {

--- a/Client/Frontend/Browser/PrivacyHub/AllVPNAlertsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/AllVPNAlertsView.swift
@@ -141,7 +141,7 @@ extension PrivacyReportsView {
       .toolbar {
         ToolbarItem(placement: .confirmationAction) {
           Button(Strings.done, action: onDismiss)
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
       .onAppear {

--- a/Client/Frontend/Browser/PrivacyHub/PrivacyReportAllTimeListsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/PrivacyReportAllTimeListsView.swift
@@ -202,7 +202,7 @@ struct PrivacyReportAllTimeListsView: View {
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button(Strings.done, action: onDismiss)
-          .foregroundColor(Color(.braveOrange))
+          .foregroundColor(Color(.braveBlurple))
       }
     }
     .onAppear {

--- a/Client/Frontend/Browser/PrivacyHub/PrivacyReportAllTimeListsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/PrivacyReportAllTimeListsView.swift
@@ -202,7 +202,7 @@ struct PrivacyReportAllTimeListsView: View {
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button(Strings.done, action: onDismiss)
-          .foregroundColor(Color(.braveBlurple))
+          .foregroundColor(Color(.braveBlurpleTint))
       }
     }
     .onAppear {

--- a/Client/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
@@ -50,7 +50,7 @@ struct PrivacyReportsView: View {
       Image(uiImage: .init(braveSystemNamed: "brave.trash")!.template)
     })
       .accessibility(label: Text(Strings.PrivacyHub.clearAllDataAccessibility))
-      .foregroundColor(Color(.braveOrange))
+      .foregroundColor(Color(.braveBlurple))
       .actionSheet(isPresented: $showClearDataPrompt) {
         // Currently .actionSheet does not allow you leave empty title for the sheet.
         // This could get converted to .confirmationPrompt or Menu with destructive buttons
@@ -69,7 +69,7 @@ struct PrivacyReportsView: View {
   
   private var doneButton: some View {
     Button(Strings.done, action: dismissView)
-      .foregroundColor(Color(.braveOrange))
+      .foregroundColor(Color(.braveBlurple))
   }
   
   private var noDataCalloutView: some View {

--- a/Client/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
+++ b/Client/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
@@ -50,7 +50,7 @@ struct PrivacyReportsView: View {
       Image(uiImage: .init(braveSystemNamed: "brave.trash")!.template)
     })
       .accessibility(label: Text(Strings.PrivacyHub.clearAllDataAccessibility))
-      .foregroundColor(Color(.braveBlurple))
+      .foregroundColor(Color(.braveBlurpleTint))
       .actionSheet(isPresented: $showClearDataPrompt) {
         // Currently .actionSheet does not allow you leave empty title for the sheet.
         // This could get converted to .confirmationPrompt or Menu with destructive buttons
@@ -69,7 +69,7 @@ struct PrivacyReportsView: View {
   
   private var doneButton: some View {
     Button(Strings.done, action: dismissView)
-      .foregroundColor(Color(.braveBlurple))
+      .foregroundColor(Color(.braveBlurpleTint))
   }
   
   private var noDataCalloutView: some View {

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -229,7 +229,7 @@ class QRCodeViewController: UIViewController {
         captureDevice.torchMode = AVCaptureDevice.TorchMode.on
         captureDevice.unlockForConfiguration()
         navigationItem.leftBarButtonItem?.image = UIImage(named: "qrcode-isLighting", in: .module, compatibleWith: nil)!
-        navigationItem.leftBarButtonItem?.tintColor = .braveOrange
+        navigationItem.leftBarButtonItem?.tintColor = .braveBlurple
       } catch {
         Logger.module.error("\(error.localizedDescription)")
       }

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -229,7 +229,7 @@ class QRCodeViewController: UIViewController {
         captureDevice.torchMode = AVCaptureDevice.TorchMode.on
         captureDevice.unlockForConfiguration()
         navigationItem.leftBarButtonItem?.image = UIImage(named: "qrcode-isLighting", in: .module, compatibleWith: nil)!
-        navigationItem.leftBarButtonItem?.tintColor = .braveBlurple
+        navigationItem.leftBarButtonItem?.tintColor = .braveBlurpleTint
       } catch {
         Logger.module.error("\(error.localizedDescription)")
       }

--- a/Client/Frontend/Browser/Search/BraveSearchPromotionCell.swift
+++ b/Client/Frontend/Browser/Search/BraveSearchPromotionCell.swift
@@ -155,7 +155,7 @@ class BraveSearchPromotionCell: UITableViewCell {
       $0.titleLabel.snp.makeConstraints {
         $0.edges.equalToSuperview().inset(8.0)
       }
-      $0.backgroundColor = .braveBlurple
+      $0.backgroundColor = .braveBlurpleTint
     }
 
     dismissButton.do {
@@ -164,7 +164,7 @@ class BraveSearchPromotionCell: UITableViewCell {
           Strings.BraveSearchPromotion.braveSearchPromotionBannerMaybeLaterButtonTitle :
           Strings.BraveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle,
         for: .normal)
-      $0.setTitleColor(.braveBlurple, for: .normal)
+      $0.setTitleColor(.braveBlurpleTint, for: .normal)
       $0.titleLabel?.font = .preferredFont(forTextStyle: .subheadline, weight: .semibold)
       $0.titleLabel?.minimumScaleFactor = 0.5
       $0.titleEdgeInsets = titleEdgeInsets
@@ -221,7 +221,7 @@ class TrySearchButton: UIControl {
   private let backgroundView: UIVisualEffectView = {
     let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterial))
     backgroundView.isUserInteractionEnabled = false
-    backgroundView.contentView.backgroundColor = .braveBlurple
+    backgroundView.contentView.backgroundColor = .braveBlurpleTint
     backgroundView.layer.cornerRadius = 16
     backgroundView.layer.cornerCurve = .continuous
     backgroundView.layer.masksToBounds = true

--- a/Client/Frontend/Browser/Search/BraveSearchPromotionCell.swift
+++ b/Client/Frontend/Browser/Search/BraveSearchPromotionCell.swift
@@ -155,7 +155,7 @@ class BraveSearchPromotionCell: UITableViewCell {
       $0.titleLabel.snp.makeConstraints {
         $0.edges.equalToSuperview().inset(8.0)
       }
-      $0.backgroundColor = .braveOrange
+      $0.backgroundColor = .braveBlurple
     }
 
     dismissButton.do {
@@ -164,7 +164,7 @@ class BraveSearchPromotionCell: UITableViewCell {
           Strings.BraveSearchPromotion.braveSearchPromotionBannerMaybeLaterButtonTitle :
           Strings.BraveSearchPromotion.braveSearchPromotionBannerDismissButtonTitle,
         for: .normal)
-      $0.setTitleColor(.braveOrange, for: .normal)
+      $0.setTitleColor(.braveBlurple, for: .normal)
       $0.titleLabel?.font = .preferredFont(forTextStyle: .subheadline, weight: .semibold)
       $0.titleLabel?.minimumScaleFactor = 0.5
       $0.titleEdgeInsets = titleEdgeInsets
@@ -221,7 +221,7 @@ class TrySearchButton: UIControl {
   private let backgroundView: UIVisualEffectView = {
     let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterial))
     backgroundView.isUserInteractionEnabled = false
-    backgroundView.contentView.backgroundColor = .braveOrange
+    backgroundView.contentView.backgroundColor = .braveBlurple
     backgroundView.layer.cornerRadius = 16
     backgroundView.layer.cornerCurve = .continuous
     backgroundView.layer.masksToBounds = true

--- a/Client/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
+++ b/Client/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
@@ -139,7 +139,7 @@ class RecentSearchHeaderView: UICollectionReusableView {
     if showRecentSearches {
       showButton.do {
         $0.setTitle(Strings.recentShowMore, for: .normal)
-        $0.setTitleColor(.braveBlurple, for: .normal)
+        $0.setTitleColor(.braveBlurpleTint, for: .normal)
         $0.titleLabel?.font = .systemFont(ofSize: 12.0)
         $0.layer.cornerRadius = 0.0
         $0.layer.borderColor = nil
@@ -151,7 +151,7 @@ class RecentSearchHeaderView: UICollectionReusableView {
 
       hideClearButton.do {
         $0.setTitle(Strings.recentSearchClear, for: .normal)
-        $0.setTitleColor(.braveBlurple, for: .normal)
+        $0.setTitleColor(.braveBlurpleTint, for: .normal)
         $0.titleLabel?.font = .systemFont(ofSize: 12.0)
         $0.layer.cornerRadius = 0.0
         $0.layer.borderColor = nil
@@ -171,7 +171,7 @@ class RecentSearchHeaderView: UICollectionReusableView {
         $0.layer.borderWidth = 0.0
         $0.titleEdgeInsets = titleEdgeInsets
         $0.contentEdgeInsets = contentEdgeInsets
-        $0.backgroundColor = .braveBlurple
+        $0.backgroundColor = .braveBlurpleTint
       }
 
       hideClearButton.do {

--- a/Client/Frontend/Browser/Search/SearchSuggestionsPromptView.swift
+++ b/Client/Frontend/Browser/Search/SearchSuggestionsPromptView.swift
@@ -49,7 +49,7 @@ class SearchSuggestionPromptCell: UITableViewCell {
       left: DesignUX.paddingX,
       bottom: DesignUX.paddingY,
       right: DesignUX.paddingX)
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
   }
 
   private lazy var disableButton = UIButton().then {

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -255,7 +255,7 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
     searchButton.layer.backgroundColor = SearchViewControllerUX.engineButtonBackgroundColor
     searchButton.addTarget(self, action: #selector(didClickSearchButton), for: .touchUpInside)
     searchButton.accessibilityLabel = Strings.searchSettingsButtonTitle
-    searchButton.tintColor = .braveBlurple
+    searchButton.tintColor = .braveBlurpleTint
 
     searchButton.imageView?.snp.makeConstraints { make in
       make.width.height.equalTo(SearchViewControllerUX.searchImageWidth)

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -255,7 +255,7 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
     searchButton.layer.backgroundColor = SearchViewControllerUX.engineButtonBackgroundColor
     searchButton.addTarget(self, action: #selector(didClickSearchButton), for: .touchUpInside)
     searchButton.accessibilityLabel = Strings.searchSettingsButtonTitle
-    searchButton.tintColor = .braveOrange
+    searchButton.tintColor = .braveBlurple
 
     searchButton.imageView?.snp.makeConstraints { make in
       make.width.height.equalTo(SearchViewControllerUX.searchImageWidth)

--- a/Client/Frontend/Browser/SendTab/SendTabToSelfController.swift
+++ b/Client/Frontend/Browser/SendTab/SendTabToSelfController.swift
@@ -228,7 +228,7 @@ class SendTabToSelfContentHeaderFooterView: UITableViewHeaderFooterView, TableVi
   
   private(set) var titleLabel = UILabel().then {
     $0.numberOfLines = 0
-    $0.textColor = .braveBlurple
+    $0.textColor = .braveBlurpleTint
     $0.textAlignment = .center
   }
 

--- a/Client/Frontend/Browser/SendTab/SendTabToSelfController.swift
+++ b/Client/Frontend/Browser/SendTab/SendTabToSelfController.swift
@@ -228,7 +228,7 @@ class SendTabToSelfContentHeaderFooterView: UITableViewHeaderFooterView, TableVi
   
   private(set) var titleLabel = UILabel().then {
     $0.numberOfLines = 0
-    $0.textColor = .braveOrange
+    $0.textColor = .braveBlurple
     $0.textAlignment = .center
   }
 

--- a/Client/Frontend/Browser/Tab Tray/Views/TabTrayPrivateModeInfoView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabTrayPrivateModeInfoView.swift
@@ -56,7 +56,7 @@ extension TabTrayController {
 
     let learnMoreButton = UIButton(type: .system).then {
       $0.setTitle(Strings.privateTabLink, for: [])
-      $0.setTitleColor(.braveOrange, for: [])
+      $0.setTitleColor(.braveBlurple, for: [])
       $0.titleLabel?.font = UX.learnMoreFont
       $0.titleLabel?.numberOfLines = 0
     }

--- a/Client/Frontend/Browser/Tab Tray/Views/TabTrayPrivateModeInfoView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabTrayPrivateModeInfoView.swift
@@ -56,7 +56,7 @@ extension TabTrayController {
 
     let learnMoreButton = UIButton(type: .system).then {
       $0.setTitle(Strings.privateTabLink, for: [])
-      $0.setTitleColor(.braveBlurple, for: [])
+      $0.setTitleColor(.braveBlurpleTint, for: [])
       $0.titleLabel?.font = UX.learnMoreFont
       $0.titleLabel?.numberOfLines = 0
     }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -48,7 +48,7 @@ class EmptyStateOverlayView: UIView {
     $0.layer.cornerRadius = UX.buttonHeight / 2.0
     $0.titleEdgeInsets = UX.titleEdgeInsets
     $0.contentEdgeInsets = UX.contentEdgeInsets
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
   }
   
   private let actionDescriptionLabel = UILabel().then {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -49,7 +49,7 @@ private struct MenuView<Content: View>: View {
       content
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity)
-        .accentColor(Color(.braveBlurple))
+        .accentColor(Color(.braveBlurpleTint))
     }
   }
 }

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/Menu/MenuViewController.swift
@@ -49,7 +49,7 @@ private struct MenuView<Content: View>: View {
       content
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity)
-        .accentColor(Color(.braveOrange))
+        .accentColor(Color(.braveBlurple))
     }
   }
 }

--- a/Client/Frontend/Browser/Toolbars/ToolbarButton.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarButton.swift
@@ -30,7 +30,7 @@ class ToolbarButton: UIButton {
     adjustsImageWhenHighlighted = false
     imageView?.contentMode = .scaleAspectFit
 
-    selectedTintColor = .braveBlurple
+    selectedTintColor = .braveBlurpleTint
     primaryTintColor = .braveLabel
     tintColor = primaryTintColor
     imageView?.tintColor = tintColor

--- a/Client/Frontend/Browser/Toolbars/ToolbarButton.swift
+++ b/Client/Frontend/Browser/Toolbars/ToolbarButton.swift
@@ -30,7 +30,7 @@ class ToolbarButton: UIButton {
     adjustsImageWhenHighlighted = false
     imageView?.contentMode = .scaleAspectFit
 
-    selectedTintColor = .braveOrange
+    selectedTintColor = .braveBlurple
     primaryTintColor = .braveLabel
     tintColor = primaryTintColor
     imageView?.tintColor = tintColor

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -166,7 +166,7 @@ class TabLocationView: UIView {
     readerModeButton.accessibilityIdentifier = "TabLocationView.readerModeButton"
     readerModeButton.accessibilityCustomActions = [UIAccessibilityCustomAction(name: Strings.tabToolbarReaderViewButtonTitle, target: self, selector: #selector(readerModeCustomAction))]
     readerModeButton.unselectedTintColor = .braveLabel
-    readerModeButton.selectedTintColor = .braveOrange
+    readerModeButton.selectedTintColor = .braveBlurple
     return readerModeButton
   }()
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -166,7 +166,7 @@ class TabLocationView: UIView {
     readerModeButton.accessibilityIdentifier = "TabLocationView.readerModeButton"
     readerModeButton.accessibilityCustomActions = [UIAccessibilityCustomAction(name: Strings.tabToolbarReaderViewButtonTitle, target: self, selector: #selector(readerModeCustomAction))]
     readerModeButton.unselectedTintColor = .braveLabel
-    readerModeButton.selectedTintColor = .braveBlurple
+    readerModeButton.selectedTintColor = .braveBlurpleTint
     return readerModeButton
   }()
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -120,7 +120,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
   fileprivate lazy var progressBar: GradientProgressBar = {
     let progressBar = GradientProgressBar()
     progressBar.clipsToBounds = false
-    progressBar.setGradientColors(startColor: .braveOrange, endColor: .braveOrange)
+    progressBar.setGradientColors(startColor: .braveBlurple, endColor: .braveBlurple)
     return progressBar
   }()
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -120,7 +120,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
   fileprivate lazy var progressBar: GradientProgressBar = {
     let progressBar = GradientProgressBar()
     progressBar.clipsToBounds = false
-    progressBar.setGradientColors(startColor: .braveBlurple, endColor: .braveBlurple)
+    progressBar.setGradientColors(startColor: .braveBlurpleTint, endColor: .braveBlurpleTint)
     return progressBar
   }()
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
@@ -42,7 +42,7 @@ class WalletURLBarButton: UIButton {
   
   override open var isHighlighted: Bool {
     didSet {
-      self.tintColor = isHighlighted ? .braveOrange : .braveLabel
+      self.tintColor = isHighlighted ? .braveBlurple : .braveLabel
     }
   }
   

--- a/Client/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
@@ -42,7 +42,7 @@ class WalletURLBarButton: UIButton {
   
   override open var isHighlighted: Bool {
     didSet {
-      self.tintColor = isHighlighted ? .braveBlurple : .braveLabel
+      self.tintColor = isHighlighted ? .braveBlurpleTint : .braveLabel
     }
   }
   

--- a/Client/Frontend/Login/LoginInfoViewController.swift
+++ b/Client/Frontend/Login/LoginInfoViewController.swift
@@ -235,7 +235,7 @@ extension LoginInfoViewController {
       let cell = tableView.dequeueReusableCell(for: indexPath) as CenteredButtonCell
       cell.do {
         $0.textLabel?.text = Strings.delete
-        $0.tintColor = .braveBlurple
+        $0.tintColor = .braveBlurpleTint
       }
       return cell
     default:

--- a/Client/Frontend/Login/LoginInfoViewController.swift
+++ b/Client/Frontend/Login/LoginInfoViewController.swift
@@ -235,7 +235,7 @@ extension LoginInfoViewController {
       let cell = tableView.dequeueReusableCell(for: indexPath) as CenteredButtonCell
       cell.do {
         $0.textLabel?.text = Strings.delete
-        $0.tintColor = .braveOrange
+        $0.tintColor = .braveBlurple
       }
       return cell
     default:

--- a/Client/Frontend/Passcode/WindowProtection.swift
+++ b/Client/Frontend/Passcode/WindowProtection.swift
@@ -22,7 +22,7 @@ public class WindowProtection {
       $0.setTitle("Unlock", for: .normal)
       $0.titleLabel?.font = .preferredFont(forTextStyle: .headline)
       $0.titleLabel?.adjustsFontForContentSizeCategory = true
-      $0.backgroundColor = .braveBlurple
+      $0.backgroundColor = .braveBlurpleTint
       $0.isHidden = true
     }
 

--- a/Client/Frontend/Popup/QRCodePopupView.swift
+++ b/Client/Frontend/Popup/QRCodePopupView.swift
@@ -40,7 +40,7 @@ class QRCodePopupView: UIKitPopupView {
     $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
     $0.layer.borderWidth = 1
     $0.snp.makeConstraints { $0.height.equalTo(44) }
-    $0.tintColor = .braveOrange
+    $0.tintColor = .braveBlurple
     $0.setImage(UIImage(named: "nav-share", in: .module, compatibleWith: nil)!, for: .normal)
     $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -18, bottom: 0, right: 0)
     $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
@@ -61,7 +61,7 @@ class QRCodePopupView: UIKitPopupView {
     }
 
     shareButton.layer.borderColor =
-      UIColor.braveOrange
+      UIColor.braveBlurple
       .resolvedColor(with: traitCollection).cgColor
 
     [qrCodeImage, title, shareButton, closeButton].forEach(contentView.addSubview(_:))
@@ -120,7 +120,7 @@ class QRCodePopupView: UIKitPopupView {
     super.traitCollectionDidChange(previousTraitCollection)
     if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
       shareButton.layer.borderColor =
-        UIColor.braveOrange
+        UIColor.braveBlurple
         .resolvedColor(with: traitCollection).cgColor
     }
   }

--- a/Client/Frontend/Popup/QRCodePopupView.swift
+++ b/Client/Frontend/Popup/QRCodePopupView.swift
@@ -40,7 +40,7 @@ class QRCodePopupView: UIKitPopupView {
     $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
     $0.layer.borderWidth = 1
     $0.snp.makeConstraints { $0.height.equalTo(44) }
-    $0.tintColor = .braveBlurple
+    $0.tintColor = .braveBlurpleTint
     $0.setImage(UIImage(named: "nav-share", in: .module, compatibleWith: nil)!, for: .normal)
     $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -18, bottom: 0, right: 0)
     $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
@@ -61,7 +61,7 @@ class QRCodePopupView: UIKitPopupView {
     }
 
     shareButton.layer.borderColor =
-      UIColor.braveBlurple
+      UIColor.braveBlurpleTint
       .resolvedColor(with: traitCollection).cgColor
 
     [qrCodeImage, title, shareButton, closeButton].forEach(contentView.addSubview(_:))
@@ -120,7 +120,7 @@ class QRCodePopupView: UIKitPopupView {
     super.traitCollectionDidChange(previousTraitCollection)
     if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
       shareButton.layer.borderColor =
-        UIColor.braveBlurple
+        UIColor.braveBlurpleTint
         .resolvedColor(with: traitCollection).cgColor
     }
   }

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -151,7 +151,7 @@ class ReaderModeStyleViewController: UIViewController {
     let slider = UISlider()
     brightnessRow.addSubview(slider)
     slider.accessibilityLabel = Strings.readerModeBrightSliderAccessibilityLabel
-    slider.tintColor = .braveBlurple
+    slider.tintColor = .braveBlurpleTint
     slider.addTarget(self, action: #selector(changeBrightness), for: .valueChanged)
 
     slider.snp.makeConstraints { make in
@@ -371,7 +371,7 @@ class ThemeButton: UIButton {
 
   private func themeBorders() {
     layer.borderWidth = isSelected ? 2 : 1
-    layer.borderColor = isSelected ? UIColor.braveBlurple.cgColor : UIColor.braveSeparator.cgColor
+    layer.borderColor = isSelected ? UIColor.braveBlurpleTint.cgColor : UIColor.braveSeparator.cgColor
   }
 
   override var isSelected: Bool {

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -151,7 +151,7 @@ class ReaderModeStyleViewController: UIViewController {
     let slider = UISlider()
     brightnessRow.addSubview(slider)
     slider.accessibilityLabel = Strings.readerModeBrightSliderAccessibilityLabel
-    slider.tintColor = .braveOrange
+    slider.tintColor = .braveBlurple
     slider.addTarget(self, action: #selector(changeBrightness), for: .valueChanged)
 
     slider.snp.makeConstraints { make in
@@ -371,7 +371,7 @@ class ThemeButton: UIButton {
 
   private func themeBorders() {
     layer.borderWidth = isSelected ? 2 : 1
-    layer.borderColor = isSelected ? UIColor.braveOrange.cgColor : UIColor.braveSeparator.cgColor
+    layer.borderColor = isSelected ? UIColor.braveBlurple.cgColor : UIColor.braveSeparator.cgColor
   }
 
   override var isSelected: Bool {

--- a/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
+++ b/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
@@ -75,7 +75,7 @@ private struct BasicStringInputView: View {
           presentationMode.dismiss()
         } label: {
           Text("Save")
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }
@@ -128,7 +128,7 @@ private struct BasicPickerInputView: View {
           presentationMode.dismiss()
         } label: {
           Text("Save")
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }

--- a/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
+++ b/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
@@ -75,7 +75,7 @@ private struct BasicStringInputView: View {
           presentationMode.dismiss()
         } label: {
           Text("Save")
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
     }
@@ -128,7 +128,7 @@ private struct BasicPickerInputView: View {
           presentationMode.dismiss()
         } label: {
           Text("Save")
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
     }

--- a/Client/Frontend/Settings/LocationViewPositionPickerCell.swift
+++ b/Client/Frontend/Settings/LocationViewPositionPickerCell.swift
@@ -104,7 +104,7 @@ class LocationViewPositionPickerCell: UITableViewCell, Cell {
     override var isSelected: Bool {
       didSet {
         checkmarkView.image = UIImage(systemName: isSelected ? "checkmark.circle" : "circle")
-        checkmarkView.tintColor = isSelected ? .braveBlurple : .braveDisabled
+        checkmarkView.tintColor = isSelected ? .braveBlurpleTint : .braveDisabled
       }
     }
     

--- a/Client/Frontend/Settings/LocationViewPositionPickerCell.swift
+++ b/Client/Frontend/Settings/LocationViewPositionPickerCell.swift
@@ -104,7 +104,7 @@ class LocationViewPositionPickerCell: UITableViewCell, Cell {
     override var isSelected: Bool {
       didSet {
         checkmarkView.image = UIImage(systemName: isSelected ? "checkmark.circle" : "circle")
-        checkmarkView.tintColor = isSelected ? .braveOrange : .braveDisabled
+        checkmarkView.tintColor = isSelected ? .braveBlurple : .braveDisabled
       }
     }
     

--- a/Client/Frontend/Settings/ManageWebsiteDataView.swift
+++ b/Client/Frontend/Settings/ManageWebsiteDataView.swift
@@ -156,7 +156,7 @@ struct ManageWebsiteDataView: View {
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: onDismiss) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
         ToolbarItemGroup(placement: .bottomBar) {
@@ -169,7 +169,7 @@ struct ManageWebsiteDataView: View {
             }
           }) {
             Text(editMode.isEditing ? Strings.done : Strings.edit)
-              .foregroundColor(visibleRecords.isEmpty ? Color(.braveDisabled) : Color(.braveOrange))
+              .foregroundColor(visibleRecords.isEmpty ? Color(.braveDisabled) : Color(.braveBlurple))
           }
           .disabled(visibleRecords.isEmpty)
           Spacer()

--- a/Client/Frontend/Settings/ManageWebsiteDataView.swift
+++ b/Client/Frontend/Settings/ManageWebsiteDataView.swift
@@ -156,7 +156,7 @@ struct ManageWebsiteDataView: View {
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: onDismiss) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
         ToolbarItemGroup(placement: .bottomBar) {
@@ -169,7 +169,7 @@ struct ManageWebsiteDataView: View {
             }
           }) {
             Text(editMode.isEditing ? Strings.done : Strings.edit)
-              .foregroundColor(visibleRecords.isEmpty ? Color(.braveDisabled) : Color(.braveBlurple))
+              .foregroundColor(visibleRecords.isEmpty ? Color(.braveDisabled) : Color(.braveBlurpleTint))
           }
           .disabled(visibleRecords.isEmpty)
           Spacer()

--- a/Client/Frontend/Settings/Rewards Internals/RewardsInternalsShareController.swift
+++ b/Client/Frontend/Settings/Rewards Internals/RewardsInternalsShareController.swift
@@ -19,7 +19,7 @@ private class RewardsInternalsSharableCell: UITableViewCell, TableViewReusable {
     detailTextLabel?.numberOfLines = 0
     selectedBackgroundView = UIView()
     selectedBackgroundView?.backgroundColor = .init {
-      $0.userInterfaceStyle == .dark ? UIColor(white: 0.2, alpha: 1.0) : UIColor.braveOrange.withAlphaComponent(0.06)
+      $0.userInterfaceStyle == .dark ? UIColor(white: 0.2, alpha: 1.0) : UIColor.braveBlurple.withAlphaComponent(0.06)
     }
   }
   @available(*, unavailable)

--- a/Client/Frontend/Settings/Rewards Internals/RewardsInternalsShareController.swift
+++ b/Client/Frontend/Settings/Rewards Internals/RewardsInternalsShareController.swift
@@ -19,7 +19,7 @@ private class RewardsInternalsSharableCell: UITableViewCell, TableViewReusable {
     detailTextLabel?.numberOfLines = 0
     selectedBackgroundView = UIView()
     selectedBackgroundView?.backgroundColor = .init {
-      $0.userInterfaceStyle == .dark ? UIColor(white: 0.2, alpha: 1.0) : UIColor.braveBlurple.withAlphaComponent(0.06)
+      $0.userInterfaceStyle == .dark ? UIColor(white: 0.2, alpha: 1.0) : UIColor.braveBlurpleTint.withAlphaComponent(0.06)
     }
   }
   @available(*, unavailable)

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -97,7 +97,7 @@ class SettingsViewController: TableViewController {
     tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
 
     view.backgroundColor = .braveGroupedBackground
-    view.tintColor = .braveBlurple
+    view.tintColor = .braveBlurpleTint
     navigationController?.view.backgroundColor = .braveGroupedBackground
   }
 

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -97,7 +97,7 @@ class SettingsViewController: TableViewController {
     tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
 
     view.backgroundColor = .braveGroupedBackground
-    view.tintColor = .braveOrange
+    view.tintColor = .braveBlurple
     navigationController?.view.backgroundColor = .braveGroupedBackground
   }
 

--- a/Client/Frontend/Shields/AdvancedShieldsView.swift
+++ b/Client/Frontend/Shields/AdvancedShieldsView.swift
@@ -84,7 +84,7 @@ extension AdvancedShieldsView {
     }()
 
     let toggleSwitch = UISwitch().then {
-      $0.onTintColor = UIColor.braveBlurple
+      $0.onTintColor = UIColor.braveBlurpleTint
     }
     var valueToggled: ((Bool) -> Void)?
 

--- a/Client/Frontend/Shields/AdvancedShieldsView.swift
+++ b/Client/Frontend/Shields/AdvancedShieldsView.swift
@@ -84,7 +84,7 @@ extension AdvancedShieldsView {
     }()
 
     let toggleSwitch = UISwitch().then {
-      $0.onTintColor = UIColor.braveOrange
+      $0.onTintColor = UIColor.braveBlurple
     }
     var valueToggled: ((Bool) -> Void)?
 

--- a/Client/Frontend/Shields/ReportBrokenSiteView.swift
+++ b/Client/Frontend/Shields/ReportBrokenSiteView.swift
@@ -32,7 +32,7 @@ class ReportBrokenSiteView: UIStackView {
   }
 
   let urlLabel = UILabel().then {
-    $0.textColor = .braveBlurple
+    $0.textColor = .braveBlurpleTint
     $0.font = .systemFont(ofSize: 16.0)
     $0.numberOfLines = 0
   }
@@ -47,7 +47,7 @@ class ReportBrokenSiteView: UIStackView {
   let submitButton = ActionButton(type: .system).then {
     $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
     $0.titleEdgeInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
     $0.setTitleColor(.white, for: .normal)
     $0.setTitle(Strings.Shields.reportBrokenSubmitButtonTitle, for: .normal)
     $0.layer.borderWidth = 0

--- a/Client/Frontend/Shields/ReportBrokenSiteView.swift
+++ b/Client/Frontend/Shields/ReportBrokenSiteView.swift
@@ -32,7 +32,7 @@ class ReportBrokenSiteView: UIStackView {
   }
 
   let urlLabel = UILabel().then {
-    $0.textColor = .braveOrange
+    $0.textColor = .braveBlurple
     $0.font = .systemFont(ofSize: 16.0)
     $0.numberOfLines = 0
   }
@@ -47,7 +47,7 @@ class ReportBrokenSiteView: UIStackView {
   let submitButton = ActionButton(type: .system).then {
     $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
     $0.titleEdgeInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
-    $0.backgroundColor = .braveOrange
+    $0.backgroundColor = .braveBlurple
     $0.setTitleColor(.white, for: .normal)
     $0.setTitle(Strings.Shields.reportBrokenSubmitButtonTitle, for: .normal)
     $0.layer.borderWidth = 0

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -38,7 +38,7 @@ class SyncAddDeviceViewController: SyncViewController {
     let button = UIButton()
     button.setTitle(Strings.copyToClipboard, for: .normal)
     button.addTarget(self, action: #selector(SEL_copy), for: .touchUpInside)
-    button.setTitleColor(UIColor.braveBlurple, for: .normal)
+    button.setTitleColor(UIColor.braveBlurpleTint, for: .normal)
     button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
     button.isHidden = true
     return button
@@ -131,7 +131,7 @@ class SyncAddDeviceViewController: SyncViewController {
     modeControl.isHidden = deviceType == .computer
     modeControl.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
-    modeControl.selectedSegmentTintColor = UIColor.braveBlurple
+    modeControl.selectedSegmentTintColor = UIColor.braveBlurpleTint
     modeControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
     stackView.addArrangedSubview(modeControl)
 
@@ -176,7 +176,7 @@ class SyncAddDeviceViewController: SyncViewController {
     doneButton.setTitle(Strings.done, for: .normal)
     doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
     doneButton.setTitleColor(.white, for: .normal)
-    doneButton.backgroundColor = .braveBlurple
+    doneButton.backgroundColor = .braveBlurpleTint
     doneButton.addTarget(self, action: #selector(SEL_done), for: .touchUpInside)
 
     doneEnterWordsStackView.addArrangedSubview(doneButton)

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -38,7 +38,7 @@ class SyncAddDeviceViewController: SyncViewController {
     let button = UIButton()
     button.setTitle(Strings.copyToClipboard, for: .normal)
     button.addTarget(self, action: #selector(SEL_copy), for: .touchUpInside)
-    button.setTitleColor(UIColor.braveOrange, for: .normal)
+    button.setTitleColor(UIColor.braveBlurple, for: .normal)
     button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
     button.isHidden = true
     return button
@@ -131,7 +131,7 @@ class SyncAddDeviceViewController: SyncViewController {
     modeControl.isHidden = deviceType == .computer
     modeControl.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
-    modeControl.selectedSegmentTintColor = UIColor.braveOrange
+    modeControl.selectedSegmentTintColor = UIColor.braveBlurple
     modeControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
     stackView.addArrangedSubview(modeControl)
 
@@ -176,7 +176,7 @@ class SyncAddDeviceViewController: SyncViewController {
     doneButton.setTitle(Strings.done, for: .normal)
     doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
     doneButton.setTitleColor(.white, for: .normal)
-    doneButton.backgroundColor = .braveOrange
+    doneButton.backgroundColor = .braveBlurple
     doneButton.addTarget(self, action: #selector(SEL_done), for: .touchUpInside)
 
     doneEnterWordsStackView.addArrangedSubview(doneButton)

--- a/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
+++ b/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
@@ -13,7 +13,7 @@ class SyncDeviceTypeButton: UIControl {
   var type: DeviceType!
 
   // Color for the opposite state of `pressed`
-  private var pressedReversedColor = UIColor.braveOrange
+  private var pressedReversedColor = UIColor.braveBlurple
   var pressed: Bool = false {
     didSet {
       if pressed == oldValue {

--- a/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
+++ b/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
@@ -13,7 +13,7 @@ class SyncDeviceTypeButton: UIControl {
   var type: DeviceType!
 
   // Color for the opposite state of `pressed`
-  private var pressedReversedColor = UIColor.braveBlurple
+  private var pressedReversedColor = UIColor.braveBlurpleTint
   var pressed: Bool = false {
     didSet {
       if pressed == oldValue {

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -390,7 +390,7 @@ extension SyncSettingsTableViewController {
     cell.textLabel?.do {
       $0.text = Strings.syncAddAnotherDevice
       $0.textAlignment = .center
-      $0.textColor = .braveOrange
+      $0.textColor = .braveBlurple
       $0.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.regular)
     }
   }

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -390,7 +390,7 @@ extension SyncSettingsTableViewController {
     cell.textLabel?.do {
       $0.text = Strings.syncAddAnotherDevice
       $0.textAlignment = .center
-      $0.textColor = .braveBlurple
+      $0.textColor = .braveBlurpleTint
       $0.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.regular)
     }
   }

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -111,7 +111,7 @@ class SyncWelcomeViewController: SyncViewController {
     button.setTitle(Strings.newSyncCode, for: .normal)
     button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
     button.setTitleColor(.white, for: .normal)
-    button.backgroundColor = .braveOrange
+    button.backgroundColor = .braveBlurple
     button.addTarget(self, action: #selector(newToSyncAction), for: .touchUpInside)
 
     button.snp.makeConstraints { make in

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -111,7 +111,7 @@ class SyncWelcomeViewController: SyncViewController {
     button.setTitle(Strings.newSyncCode, for: .normal)
     button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
     button.setTitleColor(.white, for: .normal)
-    button.backgroundColor = .braveBlurple
+    button.backgroundColor = .braveBlurpleTint
     button.addTarget(self, action: #selector(newToSyncAction), for: .touchUpInside)
 
     button.snp.makeConstraints { make in

--- a/Client/Frontend/Widgets/GradientProgressBar.swift
+++ b/Client/Frontend/Widgets/GradientProgressBar.swift
@@ -48,9 +48,7 @@ open class GradientProgressBar: UIProgressView {
   }
 
   func setGradientColors(startColor: UIColor, endColor: UIColor) {
-    gradientColors = [startColor, endColor, startColor, endColor, startColor, endColor, startColor].map {
-      $0.resolvedColor(with: traitCollection).cgColor
-    }
+    gradientColors = [startColor, endColor, startColor, endColor, startColor, endColor, startColor].map(\.cgColor)
     gradientLayer.colors = gradientColors
   }
 

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -31,7 +31,7 @@ class SnackButton: UIButton {
 
     setTitle(title, for: .normal)
     titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
-    setTitleColor(.braveBlurple, for: .highlighted)
+    setTitleColor(.braveBlurpleTint, for: .highlighted)
     setTitleColor(.braveLabel, for: .normal)
     addTarget(self, action: #selector(onClick), for: .touchUpInside)
     self.accessibilityIdentifier = accessibilityIdentifier

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -31,7 +31,7 @@ class SnackButton: UIButton {
 
     setTitle(title, for: .normal)
     titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
-    setTitleColor(.braveOrange, for: .highlighted)
+    setTitleColor(.braveBlurple, for: .highlighted)
     setTitleColor(.braveLabel, for: .normal)
     addTarget(self, action: #selector(onClick), for: .touchUpInside)
     self.accessibilityIdentifier = accessibilityIdentifier

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -50,7 +50,7 @@ class TabsButton: UIButton {
 
   override var isHighlighted: Bool {
     didSet {
-      let color: UIColor = isHighlighted ? .braveBlurple : .braveLabel
+      let color: UIColor = isHighlighted ? .braveBlurpleTint : .braveLabel
       countLabel.textColor = color
       borderView.layer.borderColor = color.resolvedColor(with: traitCollection).cgColor
     }
@@ -63,7 +63,7 @@ class TabsButton: UIButton {
   
   private func updateForTraitCollection() {
     // CGColor's do not get automatic updates
-    borderView.layer.borderColor = isHighlighted ? UIColor.braveBlurple.cgColor : UIColor.braveLabel.resolvedColor(with: traitCollection).cgColor
+    borderView.layer.borderColor = isHighlighted ? UIColor.braveBlurpleTint.cgColor : UIColor.braveLabel.resolvedColor(with: traitCollection).cgColor
     
     let toolbarTraitCollection = UITraitCollection(preferredContentSizeCategory: traitCollection.toolbarButtonContentSizeCategory)
     let metrics = UIFontMetrics(forTextStyle: .body)

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -50,7 +50,7 @@ class TabsButton: UIButton {
 
   override var isHighlighted: Bool {
     didSet {
-      let color: UIColor = isHighlighted ? .braveOrange : .braveLabel
+      let color: UIColor = isHighlighted ? .braveBlurple : .braveLabel
       countLabel.textColor = color
       borderView.layer.borderColor = color.resolvedColor(with: traitCollection).cgColor
     }
@@ -63,7 +63,7 @@ class TabsButton: UIButton {
   
   private func updateForTraitCollection() {
     // CGColor's do not get automatic updates
-    borderView.layer.borderColor = isHighlighted ? UIColor.braveOrange.cgColor : UIColor.braveLabel.resolvedColor(with: traitCollection).cgColor
+    borderView.layer.borderColor = isHighlighted ? UIColor.braveBlurple.cgColor : UIColor.braveLabel.resolvedColor(with: traitCollection).cgColor
     
     let toolbarTraitCollection = UITraitCollection(preferredContentSizeCategory: traitCollection.toolbarButtonContentSizeCategory)
     let metrics = UIFontMetrics(forTextStyle: .body)

--- a/Sources/BraveNews/Cards/AdCardView.swift
+++ b/Sources/BraveNews/Cards/AdCardView.swift
@@ -90,7 +90,7 @@ private class BraveAdCalloutView: UIView {
       .view(
         UILabel().then {
           $0.text = "Ad"
-          $0.textColor = .braveBlurple
+          $0.textColor = .braveBlurpleTint
           $0.font = {
             let metrics = UIFontMetrics(forTextStyle: .footnote)
             let desc = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote)

--- a/Sources/BraveNews/Cards/BraveNewsErrorView.swift
+++ b/Sources/BraveNews/Cards/BraveNewsErrorView.swift
@@ -22,7 +22,7 @@ public class BraveNewsErrorView: UIView, FeedCardContent {
   }
 
   public let refreshButton = ActionButton().then {
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
     $0.setTitle(Strings.BraveNews.refresh, for: .normal)
     $0.titleLabel?.font = .systemFont(ofSize: 15.0, weight: .semibold)
     $0.layer.borderWidth = 0

--- a/Sources/BraveNews/Cards/BraveNewsErrorView.swift
+++ b/Sources/BraveNews/Cards/BraveNewsErrorView.swift
@@ -22,7 +22,7 @@ public class BraveNewsErrorView: UIView, FeedCardContent {
   }
 
   public let refreshButton = ActionButton().then {
-    $0.backgroundColor = .braveOrange
+    $0.backgroundColor = .braveBlurple
     $0.setTitle(Strings.BraveNews.refresh, for: .normal)
     $0.titleLabel?.font = .systemFont(ofSize: 15.0, weight: .semibold)
     $0.layer.borderWidth = 0

--- a/Sources/BraveNews/Settings/BraveNewsAddSourceViewController.swift
+++ b/Sources/BraveNews/Settings/BraveNewsAddSourceViewController.swift
@@ -78,7 +78,7 @@ public class BraveNewsAddSourceViewController: UITableViewController {
   @objc private func textFieldTextChanged() {
     if let cell = tableView.cellForRow(at: IndexPath(row: 1, section: 0)) as? CenteredButtonCell {
       // Update the color of the search row when text field is non empty
-      cell.tintColor = isSearchEnabled && !isLoading ? .braveOrange : .braveDisabled
+      cell.tintColor = isSearchEnabled && !isLoading ? .braveBlurple : .braveDisabled
     }
   }
 
@@ -287,7 +287,7 @@ public class BraveNewsAddSourceViewController: UITableViewController {
       case 1:
         let cell = tableView.dequeueReusableCell(for: indexPath) as CenteredButtonCell
         cell.textLabel?.text = Strings.BraveNews.searchButtonTitle
-        cell.tintColor = isSearchEnabled && !isLoading ? .braveOrange : .braveDisabled
+        cell.tintColor = isSearchEnabled && !isLoading ? .braveBlurple : .braveDisabled
         return cell
       default:
         fatalError("No cell available for index path: \(indexPath)")
@@ -295,7 +295,7 @@ public class BraveNewsAddSourceViewController: UITableViewController {
     case 1:
       let cell = tableView.dequeueReusableCell(for: indexPath) as CenteredButtonCell
       cell.textLabel?.text = Strings.BraveNews.importOPML
-      cell.tintColor = .braveOrange
+      cell.tintColor = .braveBlurple
       return cell
     default:
       fatalError("No cell available for index path: \(indexPath)")

--- a/Sources/BraveNews/Settings/BraveNewsAddSourceViewController.swift
+++ b/Sources/BraveNews/Settings/BraveNewsAddSourceViewController.swift
@@ -78,7 +78,7 @@ public class BraveNewsAddSourceViewController: UITableViewController {
   @objc private func textFieldTextChanged() {
     if let cell = tableView.cellForRow(at: IndexPath(row: 1, section: 0)) as? CenteredButtonCell {
       // Update the color of the search row when text field is non empty
-      cell.tintColor = isSearchEnabled && !isLoading ? .braveBlurple : .braveDisabled
+      cell.tintColor = isSearchEnabled && !isLoading ? .braveBlurpleTint : .braveDisabled
     }
   }
 
@@ -287,7 +287,7 @@ public class BraveNewsAddSourceViewController: UITableViewController {
       case 1:
         let cell = tableView.dequeueReusableCell(for: indexPath) as CenteredButtonCell
         cell.textLabel?.text = Strings.BraveNews.searchButtonTitle
-        cell.tintColor = isSearchEnabled && !isLoading ? .braveBlurple : .braveDisabled
+        cell.tintColor = isSearchEnabled && !isLoading ? .braveBlurpleTint : .braveDisabled
         return cell
       default:
         fatalError("No cell available for index path: \(indexPath)")
@@ -295,7 +295,7 @@ public class BraveNewsAddSourceViewController: UITableViewController {
     case 1:
       let cell = tableView.dequeueReusableCell(for: indexPath) as CenteredButtonCell
       cell.textLabel?.text = Strings.BraveNews.importOPML
-      cell.tintColor = .braveBlurple
+      cell.tintColor = .braveBlurpleTint
       return cell
     default:
       fatalError("No cell available for index path: \(indexPath)")

--- a/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -182,7 +182,7 @@ private struct LanguagePicker: View {
             }
             Image(systemName: "checkmark")
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       } header: {

--- a/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -182,7 +182,7 @@ private struct LanguagePicker: View {
             }
             Image(systemName: "checkmark")
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       } header: {

--- a/Sources/BraveNews/Source List/FeedSourceListViewController.swift
+++ b/Sources/BraveNews/Source List/FeedSourceListViewController.swift
@@ -76,7 +76,7 @@ class FeedSourceListViewController: UITableViewController {
     tableView.estimatedRowHeight = UITableView.automaticDimension
     tableView.delegate = self
     tableView.dataSource = self
-    tableView.sectionIndexColor = .braveOrange
+    tableView.sectionIndexColor = .braveBlurple
 
     title = category ?? Strings.BraveNews.allSources
     if category != nil {

--- a/Sources/BraveNews/Source List/FeedSourceListViewController.swift
+++ b/Sources/BraveNews/Source List/FeedSourceListViewController.swift
@@ -76,7 +76,7 @@ class FeedSourceListViewController: UITableViewController {
     tableView.estimatedRowHeight = UITableView.automaticDimension
     tableView.delegate = self
     tableView.dataSource = self
-    tableView.sectionIndexColor = .braveBlurple
+    tableView.sectionIndexColor = .braveBlurpleTint
 
     title = category ?? Strings.BraveNews.allSources
     if category != nil {

--- a/Sources/BraveUI/Buttons/InsetButton.swift
+++ b/Sources/BraveUI/Buttons/InsetButton.swift
@@ -63,7 +63,7 @@ public class SelectedInsetButton: InsetButton {
     layer.cornerCurve = .continuous
 
     setTitleColor(.braveLabel, for: .normal)
-    selectedBackgroundColor = .braveOrange
+    selectedBackgroundColor = .braveBlurple
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/Sources/BraveUI/Buttons/InsetButton.swift
+++ b/Sources/BraveUI/Buttons/InsetButton.swift
@@ -63,7 +63,7 @@ public class SelectedInsetButton: InsetButton {
     layer.cornerCurve = .continuous
 
     setTitleColor(.braveLabel, for: .normal)
-    selectedBackgroundColor = .braveBlurple
+    selectedBackgroundColor = .braveBlurpleTint
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/Sources/BraveUI/Text/LinkLabel.swift
+++ b/Sources/BraveUI/Text/LinkLabel.swift
@@ -169,7 +169,7 @@ final public class LinkLabel: UITextView {
 
   private struct UX {
     static let textColor = UIColor.braveLabel
-    static let linkColor = UIColor.braveBlurple
+    static let linkColor = UIColor.braveBlurpleTint
   }
 }
 

--- a/Sources/BraveUI/UIKit/OptionSelectionViewController.swift
+++ b/Sources/BraveUI/UIKit/OptionSelectionViewController.swift
@@ -88,7 +88,7 @@ public class OptionSelectionViewController<OptionType: RepresentableOptionType>:
     super.viewDidLoad()
 
     view.backgroundColor = .braveGroupedBackground
-    view.tintColor = .braveBlurple
+    view.tintColor = .braveBlurpleTint
   }
 
   @available(*, unavailable)

--- a/Sources/BraveUI/UIKit/OptionSelectionViewController.swift
+++ b/Sources/BraveUI/UIKit/OptionSelectionViewController.swift
@@ -88,7 +88,7 @@ public class OptionSelectionViewController<OptionType: RepresentableOptionType>:
     super.viewDidLoad()
 
     view.backgroundColor = .braveGroupedBackground
-    view.tintColor = .braveOrange
+    view.tintColor = .braveBlurple
   }
 
   @available(*, unavailable)

--- a/Sources/BraveUI/UIKit/UIKitPopupView.swift
+++ b/Sources/BraveUI/UIKit/UIKitPopupView.swift
@@ -57,7 +57,7 @@ open class UIKitPopupView: UIView, UIGestureRecognizerDelegate {
     var backgroundColor: UIColor {
       switch self {
       case .primary:
-        return .braveBlurple
+        return .braveBlurpleTint
       case .secondary:
         return .secondaryButtonTint
       case .destructive:
@@ -69,7 +69,7 @@ open class UIKitPopupView: UIView, UIGestureRecognizerDelegate {
 
     var titleColor: UIColor {
       if self == .link {
-        return .braveBlurple
+        return .braveBlurpleTint
       }
       return .white
     }

--- a/Sources/BraveVPN/EnableVPNSettingHeader.swift
+++ b/Sources/BraveVPN/EnableVPNSettingHeader.swift
@@ -49,7 +49,7 @@ public class EnableVPNSettingHeader: UIView {
     }()
 
     $0.setTitle(title, for: .normal)
-    $0.backgroundColor = .braveOrange
+    $0.backgroundColor = .braveBlurple
     $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
     $0.setTitleColor(.white, for: .normal)
     $0.snp.makeConstraints { make in

--- a/Sources/BraveVPN/EnableVPNSettingHeader.swift
+++ b/Sources/BraveVPN/EnableVPNSettingHeader.swift
@@ -49,7 +49,7 @@ public class EnableVPNSettingHeader: UIView {
     }()
 
     $0.setTitle(title, for: .normal)
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
     $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
     $0.setTitleColor(.white, for: .normal)
     $0.snp.makeConstraints { make in

--- a/Sources/BraveVPN/InstallVPNView.swift
+++ b/Sources/BraveVPN/InstallVPNView.swift
@@ -93,7 +93,7 @@ extension InstallVPNViewController {
 
     let installVPNButton = BraveButton().then {
       $0.setTitle(Strings.VPN.installProfileButtonText, for: .normal)
-      $0.backgroundColor = .braveBlurple
+      $0.backgroundColor = .braveBlurpleTint
       $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
       $0.setTitleColor(.white, for: .normal)
       $0.snp.makeConstraints { make in

--- a/Sources/BraveVPN/InstallVPNView.swift
+++ b/Sources/BraveVPN/InstallVPNView.swift
@@ -93,7 +93,7 @@ extension InstallVPNViewController {
 
     let installVPNButton = BraveButton().then {
       $0.setTitle(Strings.VPN.installProfileButtonText, for: .normal)
-      $0.backgroundColor = .braveOrange
+      $0.backgroundColor = .braveBlurple
       $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
       $0.setTitleColor(.white, for: .normal)
       $0.snp.makeConstraints { make in

--- a/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -44,7 +44,7 @@ struct AccountListView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
         ToolbarItemGroup(placement: .primaryAction) {
@@ -52,7 +52,7 @@ struct AccountListView: View {
             isPresentingAddAccount = true
           }) {
             Label(Strings.Wallet.addAccountTitle, systemImage: "plus")
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountListView.swift
@@ -44,7 +44,7 @@ struct AccountListView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
         ToolbarItemGroup(placement: .primaryAction) {
@@ -52,7 +52,7 @@ struct AccountListView: View {
             isPresentingAddAccount = true
           }) {
             Label(Strings.Wallet.addAccountTitle, systemImage: "plus")
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -38,7 +38,7 @@ struct AccountsHeaderView: View {
             }
             .navigationViewStyle(StackNavigationViewStyle())
             .environment(\.modalPresentationMode, $isPresentingBackup)
-            .accentColor(Color(.braveBlurple))
+            .accentColor(Color(.braveBlurpleTint))
           }
       )
       Spacer()

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -38,7 +38,7 @@ struct AccountsHeaderView: View {
             }
             .navigationViewStyle(StackNavigationViewStyle())
             .environment(\.modalPresentationMode, $isPresentingBackup)
-            .accentColor(Color(.braveOrange))
+            .accentColor(Color(.braveBlurple))
           }
       )
       Spacer()

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -169,7 +169,7 @@ struct AddAccountView: View {
           presentationMode.dismiss()
         }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -169,7 +169,7 @@ struct AddAccountView: View {
           presentationMode.dismiss()
         }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
     }

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -90,18 +90,18 @@ struct AccountDetailsView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { presentationMode.dismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: renameAccountAndDismiss) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }
     }
-    .accentColor(Color(.braveOrange)) // needed for navigation bar back button(s)
+    .accentColor(Color(.braveBlurple)) // needed for navigation bar back button(s)
     .onAppear {
       if name.isEmpty {
         // Wait until next runloop pass to fix bug where body isn't recomputed based on state change

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -90,18 +90,18 @@ struct AccountDetailsView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { presentationMode.dismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: renameAccountAndDismiss) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }
     }
-    .accentColor(Color(.braveBlurple)) // needed for navigation bar back button(s)
+    .accentColor(Color(.braveBlurpleTint)) // needed for navigation bar back button(s)
     .onAppear {
       if name.isEmpty {
         // Wait until next runloop pass to fix bug where body isn't recomputed based on state change

--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -102,7 +102,7 @@ struct BuyTokenView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -102,7 +102,7 @@ struct BuyTokenView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -216,7 +216,7 @@ struct SendTokenView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -216,7 +216,7 @@ struct SendTokenView: View {
         ToolbarItemGroup(placement: .cancellationAction) {
           Button(action: { onDismiss() }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -491,7 +491,7 @@ struct SwapCryptoView: View {
             onDismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -90,7 +90,7 @@ struct SlippageGrid: View {
             .padding(.vertical, 12)
             .frame(maxWidth: .infinity)
             .foregroundColor(Color(isPredefinedOptionSelected(option.id) ? .white : .secondaryBraveLabel))
-            .background(BuySendSwapGridBackgroundView(backgroundColor: Color(isSelected ? .braveBlurple : .secondaryBraveGroupedBackground)))
+            .background(BuySendSwapGridBackgroundView(backgroundColor: Color(isSelected ? .braveBlurpleTint : .secondaryBraveGroupedBackground)))
             .padding(.top, 8)
         }
         .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -117,7 +117,7 @@ struct SlippageGrid: View {
         .frame(maxWidth: .infinity)
         .accentColor(customSlippage != nil ? .white : nil)
         .foregroundColor(Color(customSlippage != nil ? .white : .secondaryBraveLabel))
-        .background(BuySendSwapGridBackgroundView(backgroundColor: Color(customSlippage != nil ? .braveBlurple : .secondaryBraveGroupedBackground)))
+        .background(BuySendSwapGridBackgroundView(backgroundColor: Color(customSlippage != nil ? .braveBlurpleTint : .secondaryBraveGroupedBackground)))
         .padding(.top, 8)
         .accessibilityAddTraits(customSlippage != nil ? .isSelected : [])
     }
@@ -491,7 +491,7 @@ struct SwapCryptoView: View {
             onDismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -85,7 +85,7 @@ struct CryptoPagesView: View {
         }) {
           Label(Strings.Wallet.searchTitle, systemImage: "magnifyingglass")
             .labelStyle(.iconOnly)
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
         Menu {
           Button(action: {
@@ -112,7 +112,7 @@ struct CryptoPagesView: View {
                   .imageScale(.large)
               }
             }
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
         .accessibilityLabel(Strings.Wallet.otherWalletActionsAccessibilityTitle)
       }

--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -85,7 +85,7 @@ struct CryptoPagesView: View {
         }) {
           Label(Strings.Wallet.searchTitle, systemImage: "magnifyingglass")
             .labelStyle(.iconOnly)
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
         Menu {
           Button(action: {
@@ -112,7 +112,7 @@ struct CryptoPagesView: View {
                   .imageScale(.large)
               }
             }
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
         .accessibilityLabel(Strings.Wallet.otherWalletActionsAccessibilityTitle)
       }

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -66,7 +66,7 @@ public struct CryptoView: View {
       }) {
         Image("wallet-dismiss", bundle: .module)
           .renderingMode(.template)
-          .foregroundColor(Color(.braveOrange))
+          .foregroundColor(Color(.braveBlurple))
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -66,7 +66,7 @@ public struct CryptoView: View {
       }) {
         Image("wallet-dismiss", bundle: .module)
           .renderingMode(.template)
-          .foregroundColor(Color(.braveBlurple))
+          .foregroundColor(Color(.braveBlurpleTint))
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/NetworkPicker.swift
+++ b/Sources/BraveWallet/Crypto/NetworkPicker.swift
@@ -101,7 +101,7 @@ struct NetworkPicker: View {
                 networkSelectionStore: networkSelectionStore
               )
             }
-            .accentColor(Color(.braveOrange))
+            .accentColor(Color(.braveBlurple))
             .navigationViewStyle(.stack)
           }
         }

--- a/Sources/BraveWallet/Crypto/NetworkPicker.swift
+++ b/Sources/BraveWallet/Crypto/NetworkPicker.swift
@@ -101,7 +101,7 @@ struct NetworkPicker: View {
                 networkSelectionStore: networkSelectionStore
               )
             }
-            .accentColor(Color(.braveBlurple))
+            .accentColor(Color(.braveBlurpleTint))
             .navigationViewStyle(.stack)
           }
         }

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -85,7 +85,7 @@ struct NetworkSelectionView: View {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: { presentationMode.dismiss() }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
     }
@@ -189,7 +189,7 @@ private struct NetworkRowView: View {
   @ViewBuilder private var checkmark: some View {
     Image(systemName: "checkmark")
       .opacity(isSelected ? 1 : 0)
-      .foregroundColor(Color(.braveLabel))
+      .foregroundColor(Color(.braveBlurple))
   }
   
   private var showShortChainName: Bool {

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -85,7 +85,7 @@ struct NetworkSelectionView: View {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: { presentationMode.dismiss() }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }
@@ -189,7 +189,7 @@ private struct NetworkRowView: View {
   @ViewBuilder private var checkmark: some View {
     Image(systemName: "checkmark")
       .opacity(isSelected ? 1 : 0)
-      .foregroundColor(Color(.braveBlurple))
+      .foregroundColor(Color(.braveBlurpleTint))
   }
   
   private var showShortChainName: Bool {

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupRecoveryPhraseView.swift
@@ -85,6 +85,7 @@ struct BackupRecoveryPhraseView: View {
         }
         Toggle(Strings.Wallet.backupRecoveryPhraseDisclaimer, isOn: $confirmedPhraseBackup)
           .fixedSize(horizontal: false, vertical: true)
+          .toggleStyle(SwitchToggleStyle(tint: .accentColor))
           .font(.footnote)
           .padding(.vertical, 30)
           .padding(.horizontal, 20)

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -136,7 +136,7 @@ struct BackupWalletView: View {
                 presentationMode.dismiss()
               }) {
                 Text(Strings.cancelButtonTitle)
-                  .foregroundColor(Color(.braveBlurple))
+                  .foregroundColor(Color(.braveBlurpleTint))
               }
             }
           }

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -60,6 +60,7 @@ struct BackupWalletView: View {
         
         Toggle(Strings.Wallet.backupWalletDisclaimer, isOn: $acknowledgedWarning)
           .font(.footnote)
+          .toggleStyle(SwitchToggleStyle(tint: .accentColor))
           .foregroundColor(Color(.braveLabel))
           .padding(.horizontal, 20)
           .padding(.vertical, 10)
@@ -135,7 +136,7 @@ struct BackupWalletView: View {
                 presentationMode.dismiss()
               }) {
                 Text(Strings.cancelButtonTitle)
-                  .foregroundColor(Color(.braveOrange))
+                  .foregroundColor(Color(.braveBlurple))
               }
             }
           }

--- a/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -165,6 +165,7 @@ private struct RestoreWalletView: View {
           HStack {
             Toggle(Strings.Wallet.restoreWalletShowRecoveryPhrase, isOn: $showingRecoveryPhase)
               .labelsHidden()
+              .toggleStyle(SwitchToggleStyle(tint: .accentColor))
               .scaleEffect(0.75)
               .padding(-6)
             Text(Strings.Wallet.restoreWalletShowRecoveryPhrase)

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -86,7 +86,7 @@ struct AddCustomAssetView: View {
             }
             Spacer()
             Image(systemName: "chevron.down.circle")
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
@@ -242,7 +242,7 @@ struct AddCustomAssetView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
         ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -251,7 +251,7 @@ struct AddCustomAssetView: View {
             addCustomToken()
           }) {
             Text(Strings.Wallet.add)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
           .disabled(addButtonDisabled)
         }
@@ -283,7 +283,7 @@ struct AddCustomAssetView: View {
                 networkSelectionStore: networkSelectionStore
               )
             }
-            .accentColor(Color(.braveBlurple))
+            .accentColor(Color(.braveBlurpleTint))
             .navigationViewStyle(.stack)
           }
       )

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -242,7 +242,7 @@ struct AddCustomAssetView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
         ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -251,7 +251,7 @@ struct AddCustomAssetView: View {
             addCustomToken()
           }) {
             Text(Strings.Wallet.add)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
           .disabled(addButtonDisabled)
         }
@@ -283,7 +283,7 @@ struct AddCustomAssetView: View {
                 networkSelectionStore: networkSelectionStore
               )
             }
-            .accentColor(Color(.braveOrange))
+            .accentColor(Color(.braveBlurple))
             .navigationViewStyle(.stack)
           }
       )

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -158,7 +158,7 @@ struct EditUserAssetsView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -158,7 +158,7 @@ struct EditUserAssetsView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -52,7 +52,7 @@ struct PortfolioView: View {
             )
           }
           .environment(\.modalPresentationMode, $isPresentingBackup)
-          .accentColor(Color(.braveBlurple))
+          .accentColor(Color(.braveBlurpleTint))
         }
       }
       BalanceHeaderView(

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -52,7 +52,7 @@ struct PortfolioView: View {
             )
           }
           .environment(\.modalPresentationMode, $isPresentingBackup)
-          .accentColor(Color(.braveOrange))
+          .accentColor(Color(.braveBlurple))
         }
       }
       BalanceHeaderView(

--- a/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
+++ b/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
@@ -36,7 +36,7 @@ struct AddressQRCodeScannerView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }
@@ -56,7 +56,7 @@ struct AddressQRCodeScannerView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
+++ b/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
@@ -36,7 +36,7 @@ struct AddressQRCodeScannerView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }
@@ -56,7 +56,7 @@ struct AddressQRCodeScannerView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -40,7 +40,7 @@ struct AssetSearchView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -40,7 +40,7 @@ struct AssetSearchView: View {
             presentationMode.dismiss()
           }) {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -112,7 +112,7 @@ struct TransactionDetailsView: View {
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: { presentationMode.dismiss() }) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -112,7 +112,7 @@ struct TransactionDetailsView: View {
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: { presentationMode.dismiss() }) {
             Text(Strings.done)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -186,7 +186,7 @@ struct EditSiteConnectionView: View {
             onDismiss(permittedAccounts)
           } label: {
             Text(Strings.done)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -186,7 +186,7 @@ struct EditSiteConnectionView: View {
             onDismiss(permittedAccounts)
           } label: {
             Text(Strings.done)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -160,7 +160,7 @@ public struct NewSiteConnectionView: View {
             onDismiss()
           } label: {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -160,7 +160,7 @@ public struct NewSiteConnectionView: View {
             onDismiss()
           } label: {
             Text(Strings.cancelButtonTitle)
-              .foregroundColor(Color(.braveOrange))
+              .foregroundColor(Color(.braveBlurple))
           }
         }
       }

--- a/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -184,7 +184,7 @@ struct EncryptionView: View {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: { onDismiss() }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
     }

--- a/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -184,7 +184,7 @@ struct EncryptionView: View {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: { onDismiss() }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }

--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -132,7 +132,7 @@ struct SignatureRequestView: View {
               } label: {
                 Text(showOrignalMessage[requestIndex] == true ? Strings.Wallet.signMessageShowUnknownUnicode : Strings.Wallet.signMessageShowOriginalMessage)
                   .font(.subheadline)
-                  .foregroundColor(Color(.braveBlurple))
+                  .foregroundColor(Color(.braveBlurpleTint))
               }
             }
             .padding(12)

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -189,7 +189,7 @@ struct PasswordEntryView: View {
           ToolbarItemGroup(placement: .cancellationAction) {
             Button(action: { presentationMode.dismiss() }) {
               Text(Strings.cancelButtonTitle)
-                .foregroundColor(Color(.braveOrange))
+                .foregroundColor(Color(.braveBlurple))
             }
           }
         }

--- a/Sources/BraveWallet/PasswordEntryView.swift
+++ b/Sources/BraveWallet/PasswordEntryView.swift
@@ -189,7 +189,7 @@ struct PasswordEntryView: View {
           ToolbarItemGroup(placement: .cancellationAction) {
             Button(action: { presentationMode.dismiss() }) {
               Text(Strings.cancelButtonTitle)
-                .foregroundColor(Color(.braveBlurple))
+                .foregroundColor(Color(.braveBlurpleTint))
             }
           }
         }

--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -391,7 +391,7 @@ struct CustomNetworkDetailsView: View {
               addCustomNetwork()
             }) {
               Text(Strings.Wallet.saveButtonTitle)
-                .foregroundColor(Color(.braveOrange))
+                .foregroundColor(Color(.braveBlurple))
             }
           }
         }
@@ -401,7 +401,7 @@ struct CustomNetworkDetailsView: View {
           presentationMode.dismiss()
         }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
     }

--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -391,7 +391,7 @@ struct CustomNetworkDetailsView: View {
               addCustomNetwork()
             }) {
               Text(Strings.Wallet.saveButtonTitle)
-                .foregroundColor(Color(.braveBlurple))
+                .foregroundColor(Color(.braveBlurpleTint))
             }
           }
         }
@@ -401,7 +401,7 @@ struct CustomNetworkDetailsView: View {
           presentationMode.dismiss()
         }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }

--- a/Sources/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkListView.swift
@@ -132,7 +132,7 @@ struct CustomNetworkListView: View {
           isPresentingNetworkDetails = .init()
         }) {
           Label(Strings.Wallet.addCustomNetworkBarItemTitle, systemImage: "plus")
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurple))
         }
       }
     }

--- a/Sources/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkListView.swift
@@ -132,7 +132,7 @@ struct CustomNetworkListView: View {
           isPresentingNetworkDetails = .init()
         }) {
           Label(Strings.Wallet.addCustomNetworkBarItemTitle, systemImage: "plus")
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }

--- a/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -227,7 +227,7 @@ private struct SiteRow: View {
         }
         if siteConnection.connectedAddresses.count > maxBlockies {
           Circle()
-            .foregroundColor(Color(.braveBlurple))
+            .foregroundColor(Color(.braveBlurpleTint))
             .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
             .overlay(
               HStack(spacing: 1) {

--- a/Sources/DesignSystem/Colors/Colors.xcassets/Brand/interactive05.colorset/Contents.json
+++ b/Sources/DesignSystem/Colors/Colors.xcassets/Brand/interactive05.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xD2",
-          "green" : "0x53",
-          "red" : "0x4B"
+          "blue" : "0xEE",
+          "green" : "0x3E",
+          "red" : "0x42"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xD2",
-          "green" : "0x53",
-          "red" : "0x4B"
+          "blue" : "0xEE",
+          "green" : "0x3E",
+          "red" : "0x42"
         }
       },
       "idiom" : "universal"

--- a/Sources/Onboarding/OnboadingPlaylistView.swift
+++ b/Sources/Onboarding/OnboadingPlaylistView.swift
@@ -33,7 +33,7 @@ public struct PlaylistOnboardingView: View {
             Image("welcome-view-playlist-play-icon", bundle: .module)
             Text(Strings.Callout.playlistOnboardingViewButtonTitle)
               .font(.title3.weight(.medium))
-              .foregroundColor(Color(.braveBlurple))
+              .foregroundColor(Color(.braveBlurpleTint))
           }
         }
       }

--- a/Sources/Onboarding/OnboardingCommon.swift
+++ b/Sources/Onboarding/OnboardingCommon.swift
@@ -29,7 +29,7 @@ struct OnboardingCommon {
     static func primaryButton(text: String = Strings.OBContinueButton) -> UIButton {
       let button = RoundInterfaceButton().then {
         $0.setTitle(text, for: .normal)
-        $0.backgroundColor = .braveOrange
+        $0.backgroundColor = .braveBlurple
         $0.contentEdgeInsets = UIEdgeInsets(top: 12, left: 25, bottom: 12, right: 25)
       }
 

--- a/Sources/Onboarding/OnboardingCommon.swift
+++ b/Sources/Onboarding/OnboardingCommon.swift
@@ -17,7 +17,7 @@ struct OnboardingCommon {
     /// A negative spacing is needed to make rounded corners for details view visible.
     static let negativeSpacing = -16.0
     static let descriptionContentInset = 25.0
-    static let linkColor: UIColor = .braveBlurple
+    static let linkColor: UIColor = .braveBlurpleTint
     static let animationContentInset = 50.0
     static let checkboxInsets = -44.0
 
@@ -29,7 +29,7 @@ struct OnboardingCommon {
     static func primaryButton(text: String = Strings.OBContinueButton) -> UIButton {
       let button = RoundInterfaceButton().then {
         $0.setTitle(text, for: .normal)
-        $0.backgroundColor = .braveBlurple
+        $0.backgroundColor = .braveBlurpleTint
         $0.contentEdgeInsets = UIEdgeInsets(top: 12, left: 25, bottom: 12, right: 25)
       }
 

--- a/Sources/Onboarding/OnboardingRewardsAgreementViewController.swift
+++ b/Sources/Onboarding/OnboardingRewardsAgreementViewController.swift
@@ -87,7 +87,7 @@ extension OnboardingRewardsAgreementViewController {
 
     let turnOnButton = OnboardingCommon.Views.primaryButton(text: Strings.yes).then {
       $0.accessibilityIdentifier = "OnboardingRewardsAgreementViewController.OBTurnOnButton"
-      $0.backgroundColor = .braveBlurple
+      $0.backgroundColor = .braveBlurpleTint
       $0.titleLabel?.minimumScaleFactor = 0.75
     }
 

--- a/Sources/Onboarding/OnboardingVPNDetailsView.swift
+++ b/Sources/Onboarding/OnboardingVPNDetailsView.swift
@@ -63,7 +63,7 @@ public struct OnboardingVPNDetailsView: View {
           .font(.title3.weight(.medium))
           .padding(EdgeInsets(top: 12, leading: 24, bottom: 12, trailing: 24))
       }
-      .background(Color(.braveBlurple))
+      .background(Color(.braveBlurpleTint))
       .accentColor(Color(.white))
       .clipShape(Capsule())
     }

--- a/Sources/Onboarding/OnboardingVPNDetailsView.swift
+++ b/Sources/Onboarding/OnboardingVPNDetailsView.swift
@@ -63,7 +63,7 @@ public struct OnboardingVPNDetailsView: View {
           .font(.title3.weight(.medium))
           .padding(EdgeInsets(top: 12, leading: 24, bottom: 12, trailing: 24))
       }
-      .background(Color(.braveOrange))
+      .background(Color(.braveBlurple))
       .accentColor(Color(.white))
       .clipShape(Capsule())
     }

--- a/Sources/Onboarding/Welcome/WelcomeActionToggle.swift
+++ b/Sources/Onboarding/Welcome/WelcomeActionToggle.swift
@@ -63,7 +63,7 @@ class WelcomeShareActionToggle: BlockedAdsStackView {
   
   private(set) lazy var shareToggle = UISwitch().then {
     $0.addTarget(self, action: #selector(didToggleShare), for: .valueChanged)
-    $0.onTintColor = .braveBlurple
+    $0.onTintColor = .braveBlurpleTint
     $0.setContentHuggingPriority(.required, for: .horizontal)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
   }

--- a/Sources/Onboarding/Welcome/WelcomeNTPOnboardingView.swift
+++ b/Sources/Onboarding/Welcome/WelcomeNTPOnboardingView.swift
@@ -43,7 +43,7 @@ public class WelcomeNTPOnboardingController: UIViewController, PopoverContentCom
   
   private let button = RoundInterfaceButton(type: .custom).then {
     $0.setTitleColor(.white, for: .normal)
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
     $0.titleLabel?.numberOfLines = 0
     $0.titleLabel?.minimumScaleFactor = 0.7
     $0.titleLabel?.adjustsFontSizeToFitWidth = true

--- a/Sources/Onboarding/Welcome/WelcomeViewCallout.swift
+++ b/Sources/Onboarding/Welcome/WelcomeViewCallout.swift
@@ -116,7 +116,7 @@ class WelcomeViewCallout: UIView {
 
   private let primaryButton = RoundInterfaceButton(type: .custom).then {
     $0.setTitleColor(.white, for: .normal)
-    $0.backgroundColor = .braveBlurple
+    $0.backgroundColor = .braveBlurpleTint
     $0.titleLabel?.numberOfLines = 0
     $0.titleLabel?.minimumScaleFactor = 0.7
     $0.titleLabel?.adjustsFontSizeToFitWidth = true
@@ -141,7 +141,7 @@ class WelcomeViewCallout: UIView {
   }
 
   private let secondaryButton = RoundInterfaceButton(type: .custom).then {
-    $0.setTitleColor(.braveBlurple, for: .normal)
+    $0.setTitleColor(.braveBlurpleTint, for: .normal)
     $0.backgroundColor = .clear
     $0.setContentHuggingPriority(.required, for: .horizontal)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)


### PR DESCRIPTION
And adding the tint accent color thorough out the app

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6446

- Switching the orange to the purple, finding places we use braveOrange and swapping it with the blurple

- Updating the actual blurple can be done in the asset catalog in the DesignSystem module/folder

- Additionally include some parts of the app which are missing accent color on checkmark and toggle.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
