### PR TITLE
Fix #4475: Hide home indicator when using playlist in full screen mode.

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -523,6 +523,16 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
     } else {
       detailController.onFullscreen()
     }
+    
+    setNeedsUpdateOfHomeIndicatorAutoHidden()
+  }
+  
+  override var prefersHomeIndicatorAutoHidden: Bool {
+    if !UIDevice.isIpad || splitController.isCollapsed {
+      return listController.tableView.isHidden
+    } else {
+      return detailController.navigationController?.isNavigationBarHidden == true
+    }
   }
 
   func onExitFullscreen() {
@@ -535,6 +545,7 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
         dismiss(animated: true, completion: nil)
       }
     }
+    setNeedsUpdateOfHomeIndicatorAutoHidden()
   }
   
   func showStaticImage(image: UIImage?) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4475

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
