### PR TITLE
Fix #6352: Multichain Portfolio

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -69,6 +69,7 @@ struct AccountActivityView: View {
                 image: AssetIconView(token: asset.token, network: networkStore.selectedChain),
                 title: asset.token.name,
                 symbol: asset.token.symbol,
+                networkName: asset.network.chainName,
                 amount: activityStore.currencyFormatter.string(from: NSNumber(value: (Double(asset.price) ?? 0) * asset.decimalBalance)) ?? "",
                 quantity: String(format: "%.04f", asset.decimalBalance)
               )
@@ -89,6 +90,7 @@ struct AccountActivityView: View {
                 ),
                 title: nftAsset.token.nftTokenTitle,
                 symbol: nftAsset.token.symbol,
+                networkName: nftAsset.network.chainName,
                 quantity: "\(nftAsset.balance)"
               )
             }

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -39,11 +39,8 @@ struct AssetIconView: View {
       }
     }
     
-    if network.isNativeAsset(token), let logo = network.nativeTokenLogo {
-      // check bundled images
-      if let uiImage = UIImage(named: logo, in: .module, with: nil) {
-        return Image(uiImage: uiImage)
-      }
+    if network.isNativeAsset(token), let uiImage = networkNativeTokenLogo {
+      return Image(uiImage: uiImage)
     }
     
     return nil
@@ -68,7 +65,23 @@ struct AssetIconView: View {
       }
     }
     .frame(width: length, height: length)
+    .overlay(tokenLogo, alignment: .bottomTrailing)
     .accessibilityHidden(true)
+  }
+  
+  private var networkNativeTokenLogo: UIImage? {
+    if let logo = network.nativeTokenLogo {
+      return UIImage(named: logo, in: .module, with: nil)
+    }
+    return nil
+  }
+  
+  @ViewBuilder private var tokenLogo: some View {
+    if !(token.isNft || token.isErc721), !network.isNativeAsset(token), let image = networkNativeTokenLogo {
+      Image(uiImage: image)
+        .resizable()
+        .frame(width: 15, height: 15)
+    }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -18,6 +18,8 @@ import BraveCore
 struct AssetIconView: View {
   var token: BraveWallet.BlockchainToken
   var network: BraveWallet.NetworkInfo
+  /// If we should show the native token logo on non-native assets
+  var shouldShowNativeTokenIcon: Bool = false
   @ScaledMetric var length: CGFloat = 40
 
   private var fallbackMonogram: some View {
@@ -77,7 +79,7 @@ struct AssetIconView: View {
   }
   
   @ViewBuilder private var tokenLogo: some View {
-    if !network.isNativeAsset(token), let image = networkNativeTokenLogo {
+    if shouldShowNativeTokenIcon, !network.isNativeAsset(token), let image = networkNativeTokenLogo {
       Image(uiImage: image)
         .resizable()
         .frame(width: 15, height: 15)
@@ -125,6 +127,8 @@ struct NFTIconView: View {
   var network: BraveWallet.NetworkInfo
   /// NFT image url from metadata
   var url: URL?
+  /// If we should show the native token logo on non-native assets
+  var shouldShowNativeTokenIcon: Bool = false
   
   var body: some View {
     WebImageReader(url: url) { image, isFinished in
@@ -133,7 +137,7 @@ struct NFTIconView: View {
           .resizable()
           .aspectRatio(contentMode: .fit)
       } else {
-        AssetIconView(token: token, network: network)
+        AssetIconView(token: token, network: network, shouldShowNativeTokenIcon: shouldShowNativeTokenIcon)
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -77,7 +77,7 @@ struct AssetIconView: View {
   }
   
   @ViewBuilder private var tokenLogo: some View {
-    if !(token.isNft || token.isErc721), !network.isNativeAsset(token), let image = networkNativeTokenLogo {
+    if !network.isNativeAsset(token), let image = networkNativeTokenLogo {
       Image(uiImage: image)
         .resizable()
         .frame(width: 15, height: 15)

--- a/Sources/BraveWallet/Crypto/NetworkFilterView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkFilterView.swift
@@ -1,0 +1,72 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import BraveCore
+import SwiftUI
+import BraveShared
+
+struct NetworkFilterView: View {
+  
+  @Binding var networkFilter: NetworkFilter
+  @ObservedObject var networkStore: NetworkStore
+  
+  @State private(set) var primaryNetworks: [NetworkPresentation] = []
+  @State private(set) var secondaryNetworks: [NetworkPresentation] = []
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
+  private var selectedNetwork: NetworkPresentation.Network {
+    switch networkFilter {
+    case .allNetworks:
+      return .allNetworks
+    case let .network(network):
+      return .network(network)
+    }
+  }
+  
+  var body: some View {
+    NetworkSelectionRootView(
+      navigationTitle: Strings.Wallet.networkFilterTitle,
+      selectedNetwork: selectedNetwork,
+      primaryNetworks: primaryNetworks,
+      secondaryNetworks: secondaryNetworks,
+      selectNetwork: selectNetwork
+    )
+    .onAppear {
+      fetchNetworks()
+    }
+  }
+  
+  private func fetchNetworks() {
+    let primaryNetworks = networkStore.primaryNetworks
+      .map { network in
+        let subNetworks = networkStore.subNetworks(for: network)
+        return NetworkPresentation(
+          network: .network(network),
+          subNetworks: subNetworks.count > 1 ? subNetworks : [],
+          isPrimaryNetwork: true
+        )
+      }
+    self.primaryNetworks = [.allNetworks] + primaryNetworks
+
+    self.secondaryNetworks = networkStore.secondaryNetworks
+      .map { network in
+        NetworkPresentation(
+          network: .network(network),
+          subNetworks: [],
+          isPrimaryNetwork: false
+        )
+      }
+  }
+  
+  private func selectNetwork(_ network: NetworkPresentation.Network) {
+    switch network {
+    case .allNetworks:
+      networkFilter = .allNetworks
+    case let .network(network):
+      networkFilter = .network(network)
+    }
+    presentationMode.dismiss()
+  }
+}

--- a/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
@@ -1,0 +1,329 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import BraveCore
+import SwiftUI
+
+struct NetworkPresentation: Equatable, Hashable, Identifiable {
+  enum Network: Equatable, Hashable {
+    case allNetworks
+    case network(BraveWallet.NetworkInfo)
+  }
+  
+  var id: String {
+    switch network {
+    case .allNetworks: return "allNetworks"
+    case let .network(network): return network.id
+    }
+  }
+  let network: Network
+  let subNetworks: [BraveWallet.NetworkInfo]
+  let isPrimaryNetwork: Bool
+  
+  init(
+    network: Network,
+    subNetworks: [BraveWallet.NetworkInfo],
+    isPrimaryNetwork: Bool
+  ) {
+    self.network = network
+    self.subNetworks = subNetworks
+    self.isPrimaryNetwork = isPrimaryNetwork
+  }
+  
+  static let allNetworks: Self = .init(
+    network: .allNetworks,
+    subNetworks: [],
+    isPrimaryNetwork: true
+  )
+}
+
+struct NetworkSelectionRootView: View {
+  
+  var navigationTitle: String
+  var selectedNetwork: NetworkPresentation.Network
+  var primaryNetworks: [NetworkPresentation]
+  var secondaryNetworks: [NetworkPresentation]
+  var selectNetwork: (NetworkPresentation.Network) -> Void
+  @State private var detailNetwork: NetworkPresentation?
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
+  var body: some View {
+    List {
+      Section {
+        ForEach(primaryNetworks) { presentation in
+          Button(action: { selectNetwork(presentation.network) }) {
+            NetworkRowView(
+              presentation: presentation,
+              selectedNetwork: selectedNetwork,
+              detailTappedHandler: {
+                detailNetwork = presentation
+              }
+            )
+          }
+        }
+      }
+      Section(content: {
+        ForEach(secondaryNetworks) { presentation in
+          Button(action: { selectNetwork(presentation.network) }) {
+            NetworkRowView(
+              presentation: presentation,
+              selectedNetwork: selectedNetwork
+            )
+          }
+        }
+      }, header: {
+        WalletListHeaderView(title: Text(Strings.Wallet.networkSelectionSecondaryNetworks))
+      })
+    }
+    .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
+    .navigationTitle(navigationTitle)
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItemGroup(placement: .cancellationAction) {
+        Button(action: { presentationMode.dismiss() }) {
+          Text(Strings.cancelButtonTitle)
+            .foregroundColor(Color(.braveOrange))
+        }
+      }
+    }
+    .background(
+      NavigationLink(
+        isActive: Binding(
+          get: { detailNetwork != nil },
+          set: { if !$0 { detailNetwork = nil } }
+        ),
+        destination: {
+          if let detailNetwork = detailNetwork {
+            NetworkSelectionDetailView(
+              networks: detailNetwork.subNetworks,
+              selectedNetwork: selectedNetwork,
+              navigationTitle: navigationTitle,
+              selectedNetworkHandler: { network in
+                selectNetwork(.network(network))
+              }
+            )
+          }
+        },
+        label: { EmptyView() }
+      )
+    )
+  }
+}
+
+private struct NetworkRowView: View {
+
+  var presentation: NetworkPresentation
+  var selectedNetwork: NetworkPresentation.Network
+  var detailTappedHandler: (() -> Void)?
+
+  @ScaledMetric private var length: CGFloat = 30
+  
+  init(
+    presentation: NetworkPresentation,
+    selectedNetwork: NetworkPresentation.Network,
+    detailTappedHandler: (() -> Void)? = nil
+  ) {
+    self.presentation = presentation
+    self.selectedNetwork = selectedNetwork
+    self.detailTappedHandler = detailTappedHandler
+  }
+  
+  private var isSelected: Bool {
+    if presentation.network == selectedNetwork {
+      return true
+    } else if case .network(let selectedNetwork) = self.selectedNetwork {
+      return presentation.subNetworks.contains(selectedNetwork)
+    }
+    return false
+  }
+
+  @ViewBuilder private var checkmark: some View {
+    Image(systemName: "checkmark")
+      .opacity(isSelected ? 1 : 0)
+      .foregroundColor(Color(.braveLabel))
+  }
+  
+  private var showShortChainName: Bool {
+    presentation.isPrimaryNetwork && !presentation.subNetworks.isEmpty
+  }
+  
+  private var networkName: String {
+    switch presentation.network {
+    case .allNetworks:
+      return Strings.Wallet.allNetworksTitle
+    case let .network(network):
+      return showShortChainName ? network.shortChainName : network.chainName
+    }
+  }
+
+  var body: some View {
+    HStack {
+      HStack {
+        checkmark
+        if case let .network(network) = presentation.network {
+          NetworkIcon(network: network)
+        }
+        VStack(alignment: .leading, spacing: 0) {
+          Text(networkName)
+          if case .network(let selectedNetwork) = self.selectedNetwork,
+             presentation.subNetworks.contains(selectedNetwork) {
+            Text(selectedNetwork.chainName)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .font(.footnote)
+          }
+        }
+        .frame(minHeight: length) // maintain height for All Networks row w/o icon
+        Spacer()
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+      if !presentation.subNetworks.isEmpty {
+        Button(action: { detailTappedHandler?() }) {
+          Image(systemName: "chevron.right.circle")
+            .foregroundColor(Color(.braveBlurpleTint))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(
+          Text(String.localizedStringWithFormat(
+            Strings.Wallet.networkSelectionTestnetAccessibilityLabel,
+            networkName)
+          )
+        )
+      }
+    }
+    .foregroundColor(Color(.braveLabel))
+    .padding(.vertical, 4)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .contentShape(Rectangle())
+    .listRowBackground(Color(.secondaryBraveGroupedBackground))
+  }
+}
+
+#if DEBUG
+struct NetworkRowView_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      NetworkRowView(
+        presentation: .init(
+          network: .network(.mockSolana),
+          subNetworks: [.mockSolana],
+          isPrimaryNetwork: true
+        ),
+        selectedNetwork: .network(.mockSolana)
+      )
+      NetworkRowView(
+        presentation: .init(
+          network: .network(.mockMainnet),
+          subNetworks: [.mockMainnet, .mockGoerli, .mockSepolia],
+          isPrimaryNetwork: true
+        ),
+        selectedNetwork: .network(.mockMainnet)
+      )
+      NetworkRowView(
+        presentation: .init(
+          network: .network(.mockPolygon),
+          subNetworks: [],
+          isPrimaryNetwork: false
+        ),
+        selectedNetwork: .network(.mockMainnet)
+      )
+    }
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif
+
+// MARK: Detail View
+
+private struct NetworkSelectionDetailView: View {
+  
+  var networks: [BraveWallet.NetworkInfo]
+  var selectedNetwork: NetworkPresentation.Network
+  let navigationTitle: String
+  var selectedNetworkHandler: (BraveWallet.NetworkInfo) -> Void
+  
+  var body: some View {
+    List {
+      ForEach(networks) { network in
+        Button(action: { selectedNetworkHandler(network) }) {
+          NetworkSelectionDetailRow(
+            isSelected: isSelected(network),
+            network: network
+          )
+          .contentShape(Rectangle())
+        }
+      }
+    }
+    .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
+    .navigationTitle(networks.first?.shortChainName ?? navigationTitle)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+  
+  private func isSelected(_ network: BraveWallet.NetworkInfo) -> Bool {
+    if case let .network(selectedNetwork) = self.selectedNetwork {
+      return network == selectedNetwork
+    }
+    return false
+  }
+}
+
+#if DEBUG
+struct NetworkSelectionDetailView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      NetworkSelectionDetailView(
+        networks: [.mockMainnet, .mockGoerli, .mockSepolia],
+        selectedNetwork: .network(.mockMainnet),
+        navigationTitle: Strings.Wallet.networkFilterTitle,
+        selectedNetworkHandler: { _ in }
+      )
+    }
+  }
+}
+#endif
+
+private struct NetworkSelectionDetailRow: View {
+  
+  var isSelected: Bool
+  var network: BraveWallet.NetworkInfo
+  
+  @ScaledMetric private var length: CGFloat = 30
+  
+  var body: some View {
+    HStack {
+      NetworkIcon(network: network)
+      Text(network.chainName)
+      Spacer()
+      if isSelected {
+        Image(systemName: "checkmark")
+      }
+    }
+    .foregroundColor(Color(.braveLabel))
+    .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    .accessibilityElement(children: .combine)
+  }
+}
+
+#if DEBUG
+struct NetworkSelectionDetailRow_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      NetworkSelectionDetailRow(
+        isSelected: true,
+        network: .mockMainnet
+      )
+      NetworkSelectionDetailRow(
+        isSelected: false,
+        network: .mockGoerli
+      )
+    }
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif

--- a/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
@@ -62,6 +62,7 @@ struct NetworkSelectionRootView: View {
               }
             )
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
       Section(content: {
@@ -72,6 +73,7 @@ struct NetworkSelectionRootView: View {
               selectedNetwork: selectedNetwork
             )
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }, header: {
         WalletListHeaderView(title: Text(Strings.Wallet.networkSelectionSecondaryNetworks))
@@ -199,7 +201,6 @@ private struct NetworkRowView: View {
     .padding(.vertical, 4)
     .frame(maxWidth: .infinity, alignment: .leading)
     .contentShape(Rectangle())
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
   }
 }
 
@@ -256,6 +257,7 @@ private struct NetworkSelectionDetailView: View {
           )
           .contentShape(Rectangle())
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
     .listStyle(.insetGrouped)

--- a/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
@@ -87,7 +87,7 @@ struct NetworkSelectionRootView: View {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: { presentationMode.dismiss() }) {
           Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveOrange))
+            .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }
@@ -145,7 +145,7 @@ private struct NetworkRowView: View {
   @ViewBuilder private var checkmark: some View {
     Image(systemName: "checkmark")
       .opacity(isSelected ? 1 : 0)
-      .foregroundColor(Color(.braveLabel))
+      .foregroundColor(Color(.braveBlurpleTint))
   }
   
   private var showShortChainName: Bool {

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -29,13 +29,6 @@ struct NetworkSelectionView: View {
     switch store.mode {
     case .select:
       return .network(networkStore.selectedChain)
-    case .filter:
-      switch networkStore.networkFilter {
-      case .allNetworks:
-        return .allNetworks
-      case let .network(network):
-        return .network(network)
-      }
     case .formSelection:
       return .network(store.networkSelectionInForm ?? .init())
     }
@@ -44,75 +37,23 @@ struct NetworkSelectionView: View {
   private var navigationTitle: String {
     switch store.mode {
     case .select: return Strings.Wallet.networkSelectionTitle
-    case .filter: return Strings.Wallet.networkFilterTitle
     case .formSelection: return Strings.Wallet.networkSelectionTitle
     }
   }
   
   var body: some View {
-    List {
-      Section {
-        ForEach(store.primaryNetworks) { presentation in
-          Button(action: { selectNetwork(presentation.network) }) {
-            NetworkRowView(
-              presentation: presentation,
-              selectedNetwork: selectedNetwork,
-              detailTappedHandler: {
-                store.detailNetwork = presentation
-              }
-            )
-          }
-        }
+    NetworkSelectionRootView(
+      navigationTitle: navigationTitle,
+      selectedNetwork: selectedNetwork,
+      primaryNetworks: store.primaryNetworks,
+      secondaryNetworks: store.secondaryNetworks,
+      selectNetwork: { network in
+        selectNetwork(network)
       }
-      Section(content: {
-        ForEach(store.secondaryNetworks) { presentation in
-          Button(action: { selectNetwork(presentation.network) }) {
-            NetworkRowView(
-              presentation: presentation,
-              selectedNetwork: selectedNetwork
-            )
-          }
-        }
-      }, header: {
-        WalletListHeaderView(title: Text(Strings.Wallet.networkSelectionSecondaryNetworks))
-      })
-    }
-    .listStyle(.insetGrouped)
-    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
-    .navigationTitle(navigationTitle)
-    .navigationBarTitleDisplayMode(.inline)
-    .toolbar {
-      ToolbarItemGroup(placement: .cancellationAction) {
-        Button(action: { presentationMode.dismiss() }) {
-          Text(Strings.cancelButtonTitle)
-            .foregroundColor(Color(.braveBlurpleTint))
-        }
-      }
-    }
+    )
     .onAppear {
       store.update()
     }
-    .background(
-      NavigationLink(
-        isActive: Binding(
-          get: { store.detailNetwork != nil },
-          set: { if !$0 { store.detailNetwork = nil } }
-        ),
-        destination: {
-          if let detailNetwork = store.detailNetwork {
-            NetworkSelectionDetailView(
-              networks: detailNetwork.subNetworks,
-              selectedNetwork: selectedNetwork,
-              navigationTitle: navigationTitle,
-              selectedNetworkHandler: { network in
-                selectNetwork(.network(network))
-              }
-            )
-          }
-        },
-        label: { EmptyView() }
-      )
-    )
     .background(
       Color.clear
         .alert(
@@ -158,218 +99,3 @@ struct NetworkSelectionView: View {
     }
   }
 }
-
-private struct NetworkRowView: View {
-
-  var presentation: NetworkPresentation
-  var selectedNetwork: NetworkPresentation.Network
-  var detailTappedHandler: (() -> Void)?
-
-  @ScaledMetric private var length: CGFloat = 30
-  
-  init(
-    presentation: NetworkPresentation,
-    selectedNetwork: NetworkPresentation.Network,
-    detailTappedHandler: (() -> Void)? = nil
-  ) {
-    self.presentation = presentation
-    self.selectedNetwork = selectedNetwork
-    self.detailTappedHandler = detailTappedHandler
-  }
-  
-  private var isSelected: Bool {
-    if presentation.network == selectedNetwork {
-      return true
-    } else if case .network(let selectedNetwork) = self.selectedNetwork {
-      return presentation.subNetworks.contains(selectedNetwork)
-    }
-    return false
-  }
-
-  @ViewBuilder private var checkmark: some View {
-    Image(systemName: "checkmark")
-      .opacity(isSelected ? 1 : 0)
-      .foregroundColor(Color(.braveBlurpleTint))
-  }
-  
-  private var showShortChainName: Bool {
-    presentation.isPrimaryNetwork && !presentation.subNetworks.isEmpty
-  }
-  
-  private var networkName: String {
-    switch presentation.network {
-    case .allNetworks:
-      return Strings.Wallet.allNetworksTitle
-    case let .network(network):
-      return showShortChainName ? network.shortChainName : network.chainName
-    }
-  }
-
-  var body: some View {
-    HStack {
-      HStack {
-        checkmark
-        if case let .network(network) = presentation.network {
-          NetworkIcon(network: network)
-        }
-        VStack(alignment: .leading, spacing: 0) {
-          Text(networkName)
-          if case .network(let selectedNetwork) = self.selectedNetwork,
-             presentation.subNetworks.contains(selectedNetwork) {
-            Text(selectedNetwork.chainName)
-              .foregroundColor(Color(.secondaryBraveLabel))
-              .font(.footnote)
-          }
-        }
-        .frame(minHeight: length) // maintain height for All Networks row w/o icon
-        Spacer()
-      }
-      .accessibilityElement(children: .combine)
-      .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-      if !presentation.subNetworks.isEmpty {
-        Button(action: { detailTappedHandler?() }) {
-          Image(systemName: "chevron.right.circle")
-            .foregroundColor(Color(.braveBlurpleTint))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(
-          Text(String.localizedStringWithFormat(
-            Strings.Wallet.networkSelectionTestnetAccessibilityLabel,
-            networkName)
-          )
-        )
-      }
-    }
-    .foregroundColor(Color(.braveLabel))
-    .padding(.vertical, 4)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .contentShape(Rectangle())
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
-  }
-}
-
-#if DEBUG
-struct NetworkRowView_Previews: PreviewProvider {
-  static var previews: some View {
-    Group {
-      NetworkRowView(
-        presentation: .init(
-          network: .network(.mockSolana),
-          subNetworks: [.mockSolana],
-          isPrimaryNetwork: true
-        ),
-        selectedNetwork: .network(.mockSolana)
-      )
-      NetworkRowView(
-        presentation: .init(
-          network: .network(.mockMainnet),
-          subNetworks: [.mockMainnet, .mockGoerli, .mockSepolia],
-          isPrimaryNetwork: true
-        ),
-        selectedNetwork: .network(.mockMainnet)
-      )
-      NetworkRowView(
-        presentation: .init(
-          network: .network(.mockPolygon),
-          subNetworks: [],
-          isPrimaryNetwork: false
-        ),
-        selectedNetwork: .network(.mockMainnet)
-      )
-    }
-    .previewLayout(.sizeThatFits)
-  }
-}
-#endif
-
-// MARK: Detail View
-
-private struct NetworkSelectionDetailView: View {
-  
-  var networks: [BraveWallet.NetworkInfo]
-  var selectedNetwork: NetworkPresentation.Network
-  let navigationTitle: String
-  var selectedNetworkHandler: (BraveWallet.NetworkInfo) -> Void
-  
-  var body: some View {
-    List {
-      ForEach(networks) { network in
-        Button(action: { selectedNetworkHandler(network) }) {
-          NetworkSelectionDetailRow(
-            isSelected: isSelected(network),
-            network: network
-          )
-          .contentShape(Rectangle())
-        }
-      }
-    }
-    .listStyle(.insetGrouped)
-    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
-    .navigationTitle(networks.first?.shortChainName ?? navigationTitle)
-    .navigationBarTitleDisplayMode(.inline)
-  }
-  
-  private func isSelected(_ network: BraveWallet.NetworkInfo) -> Bool {
-    if case let .network(selectedNetwork) = self.selectedNetwork {
-      return network == selectedNetwork
-    }
-    return false
-  }
-}
-
-#if DEBUG
-struct NetworkSelectionDetailView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      NetworkSelectionDetailView(
-        networks: [.mockMainnet, .mockGoerli, .mockSepolia],
-        selectedNetwork: .network(.mockMainnet),
-        navigationTitle: Strings.Wallet.networkFilterTitle,
-        selectedNetworkHandler: { _ in }
-      )
-    }
-  }
-}
-#endif
-
-private struct NetworkSelectionDetailRow: View {
-  
-  var isSelected: Bool
-  var network: BraveWallet.NetworkInfo
-  
-  @ScaledMetric private var length: CGFloat = 30
-  
-  var body: some View {
-    HStack {
-      NetworkIcon(network: network)
-      Text(network.chainName)
-      Spacer()
-      if isSelected {
-        Image(systemName: "checkmark")
-      }
-    }
-    .foregroundColor(Color(.braveLabel))
-    .listRowBackground(Color(.secondaryBraveGroupedBackground))
-    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-    .accessibilityElement(children: .combine)
-  }
-}
-
-#if DEBUG
-struct NetworkSelectionDetailRow_Previews: PreviewProvider {
-  static var previews: some View {
-    Group {
-      NetworkSelectionDetailRow(
-        isSelected: true,
-        network: .mockMainnet
-      )
-      NetworkSelectionDetailRow(
-        isSelected: false,
-        network: .mockGoerli
-      )
-    }
-    .previewLayout(.sizeThatFits)
-  }
-}
-#endif

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -270,9 +270,6 @@ struct AddCustomAssetView: View {
               get: { isPresentingNetworkSelection },
               set: {
                 isPresentingNetworkSelection = $0
-                if !$0, networkSelectionStore.detailNetwork != nil {
-                  networkSelectionStore.detailNetwork = nil
-                }
               }
             )
           ) {

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
@@ -9,6 +9,7 @@ struct PortfolioAssetView: View {
   var image: AssetIconView
   var title: String
   var symbol: String
+  let networkName: String
   var amount: String
   var quantity: String
 
@@ -20,7 +21,7 @@ struct PortfolioAssetView: View {
           .font(.footnote)
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
-        Text(symbol)
+        Text("\(symbol) on \(networkName)") // TODO: localize
           .font(.caption)
           .foregroundColor(Color(.braveLabel))
       }
@@ -46,6 +47,7 @@ struct PortfolioAssetView_Previews: PreviewProvider {
       image: AssetIconView(token: .previewToken, network: .mockMainnet),
       title: "Basic Attention Token",
       symbol: "BAT",
+      networkName: "Ethereum Mainnet Beta",
       amount: "$10,402.22",
       quantity: "10303"
     )
@@ -60,6 +62,7 @@ struct PortfolioNFTAssetView: View {
   let image: NFTIconView
   let title: String
   let symbol: String
+  let networkName: String
   let quantity: String
   
   var body: some View {
@@ -70,7 +73,7 @@ struct PortfolioNFTAssetView: View {
           .font(.footnote)
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
-        Text(symbol)
+        Text("\(symbol) on \(networkName)") // TODO: Localize
           .font(.caption)
           .foregroundColor(Color(.braveLabel))
       }
@@ -93,6 +96,7 @@ struct PortfolioNFTAssetView_Previews: PreviewProvider {
       image: NFTIconView(token: .previewToken, network: .mockMainnet),
       title: "Invisible Friends #3965",
       symbol: "INVSBLE",
+      networkName: "Ethereum Mainnet Beta",
       quantity: "1"
     )
     .previewLayout(.sizeThatFits)

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
@@ -21,7 +21,7 @@ struct PortfolioAssetView: View {
           .font(.footnote)
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
-        Text("\(symbol) on \(networkName)") // TODO: localize
+        Text(String.localizedStringWithFormat(Strings.Wallet.userAssetSymbolNetworkDesc, symbol, networkName))
           .font(.caption)
           .foregroundColor(Color(.braveLabel))
       }
@@ -73,7 +73,7 @@ struct PortfolioNFTAssetView: View {
           .font(.footnote)
           .fontWeight(.semibold)
           .foregroundColor(Color(.bravePrimary))
-        Text("\(symbol) on \(networkName)") // TODO: Localize
+        Text(String.localizedStringWithFormat(Strings.Wallet.userAssetSymbolNetworkDesc, symbol, networkName))
           .font(.caption)
           .foregroundColor(Color(.braveLabel))
       }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -94,9 +94,12 @@ struct PortfolioView: View {
     Button(action: {
       self.isPresentingNetworkFilter = true
     }) {
-      Label(portfolioStore.networkFilter.title, braveSystemImage: "brave.text.alignleft")
-        .font(.footnote.weight(.medium))
-        .foregroundColor(Color(.braveBlurpleTint))
+      HStack {
+        Text(portfolioStore.networkFilter.title)
+        Image(braveSystemName: "brave.text.alignleft")
+      }
+      .font(.footnote.weight(.medium))
+      .foregroundColor(Color(.braveBlurpleTint))
     }
     .sheet(isPresented: $isPresentingNetworkFilter) {
       NavigationView {
@@ -233,38 +236,19 @@ struct BalanceHeaderView: View {
 
   private var balanceOrDataPointView: some View {
     HStack {
-      Group {
-        if sizeCategory.isAccessibilityCategory {
-          VStack(alignment: .leading) {
-            NetworkPicker(
-              keyringStore: keyringStore,
-              networkStore: networkStore
-            )
-            Text(verbatim: balance)
-              .font(.largeTitle.bold())
-          }
-        } else {
-          HStack {
-            Text(verbatim: balance)
-              .font(.largeTitle.bold())
-            NetworkPicker(
-              keyringStore: keyringStore,
-              networkStore: networkStore
-            )
-            Spacer()
-          }
-        }
-      }
-      .opacity(selectedBalance == nil ? 1 : 0)
-      .overlay(
-        Group {
-          if let dataPoint = selectedBalance {
-            Text(dataPoint.formattedPrice)
-              .font(.largeTitle.bold())
-          }
-        },
-        alignment: .leading
-      )
+      Text(verbatim: balance)
+        .font(.largeTitle.bold())
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(selectedBalance == nil ? 1 : 0)
+        .overlay(
+          Group {
+            if let dataPoint = selectedBalance {
+              Text(dataPoint.formattedPrice)
+                .font(.largeTitle.bold())
+            }
+          },
+          alignment: .leading
+        )
       if horizontalSizeClass == .regular {
         Spacer()
         DateRangeView(selectedRange: $selectedDateRange)

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -149,6 +149,21 @@ struct PortfolioView: View {
           networkFilterButton
         }
         .textCase(nil)
+        .osAvailabilityModifiers { content in
+          if #available(iOS 15.0, *) {
+            content
+              .padding(.horizontal, -8)
+          } else if #available(iOS 14.5, *) {
+            // In iOS 14.4-14.8 for some reason List does not apply correct padding
+            // or insets to headers and footers
+            content
+              .padding(.horizontal, 8)
+          } else {
+            content
+              .padding(.horizontal, -8)
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
       })
       
       if !portfolioStore.userVisibleNFTs.isEmpty {

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -161,7 +161,7 @@ struct PortfolioView: View {
                 PortfolioNFTAssetView(
                   image: NFTIconView(
                     token: nftAsset.token,
-                    network: networkStore.selectedChain,
+                    network: nftAsset.network,
                     url: nftAsset.imageUrl
                   ),
                   title: nftAsset.token.nftTokenTitle,

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -130,7 +130,11 @@ struct PortfolioView: View {
               selectedToken = asset.token
             }) {
               PortfolioAssetView(
-                image: AssetIconView(token: asset.token, network: asset.network),
+                image: AssetIconView(
+                  token: asset.token,
+                  network: asset.network,
+                  shouldShowNativeTokenIcon: true
+                ),
                 title: asset.token.name,
                 symbol: asset.token.symbol,
                 networkName: asset.network.chainName,
@@ -177,7 +181,8 @@ struct PortfolioView: View {
                   image: NFTIconView(
                     token: nftAsset.token,
                     network: nftAsset.network,
-                    url: nftAsset.imageUrl
+                    url: nftAsset.imageUrl,
+                    shouldShowNativeTokenIcon: true
                   ),
                   title: nftAsset.token.nftTokenTitle,
                   symbol: nftAsset.token.symbol,

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -93,7 +93,7 @@ class AccountActivityStore: ObservableObject {
   ) async -> [AssetViewModel] {
     let visibleUserAssets = userVisibleTokens.filter { !$0.isErc721 && !$0.isNft }
     var updatedAssets = visibleUserAssets.map {
-      AssetViewModel(token: $0, decimalBalance: 0, price: "", history: [])
+      AssetViewModel(token: $0, network: network, decimalBalance: 0, price: "", history: [])
     }
     // fetch price for each asset
     let priceResult = await assetRatioService.priceWithIndividualRetry(
@@ -138,6 +138,7 @@ class AccountActivityStore: ObservableObject {
     var updatedNFTAssets = visibleNFTAssets.map { asset in
       NFTAssetViewModel(
         token: asset,
+        network: network,
         balance: 0
       )
     }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
@@ -7,48 +7,11 @@ import BraveCore
 import BraveShared
 import SwiftUI
 
-struct NetworkPresentation: Equatable, Hashable, Identifiable {
-  enum Network: Equatable, Hashable {
-    case allNetworks
-    case network(BraveWallet.NetworkInfo)
-  }
-  
-  var id: String {
-    switch network {
-    case .allNetworks: return "allNetworks"
-    case let .network(network): return network.id
-    }
-  }
-  let network: Network
-  let subNetworks: [BraveWallet.NetworkInfo]
-  let isPrimaryNetwork: Bool
-  
-  init(
-    network: Network,
-    subNetworks: [BraveWallet.NetworkInfo],
-    isPrimaryNetwork: Bool
-  ) {
-    self.network = network
-    self.subNetworks = subNetworks
-    self.isPrimaryNetwork = isPrimaryNetwork
-  }
-  
-  static let allNetworks: Self = .init(
-    network: .allNetworks,
-    subNetworks: [],
-    isPrimaryNetwork: true
-  )
-}
-
 class NetworkSelectionStore: ObservableObject {
   
   enum Mode: Equatable {
     case select
-    case filter
     case formSelection
-    
-    var isSelectMode: Bool { self == .select }
-    var isFilterMode: Bool { self == .filter }
   }
   
   let mode: Mode
@@ -57,8 +20,6 @@ class NetworkSelectionStore: ObservableObject {
   @Published private(set) var primaryNetworks: [NetworkPresentation] = []
   @Published private(set) var secondaryNetworks: [NetworkPresentation] = []
   
-  /// Network selected to show detail view (test networks)
-  @Published var detailNetwork: NetworkPresentation?
   /// If we are prompting the user to add an account for the `nextNetwork.coin` type
   @Published var isPresentingNextNetworkAlert = false
   /// The network the user wishes to switch to, but does not (yet) have an account for `nextNetwork.coin` type
@@ -77,45 +38,17 @@ class NetworkSelectionStore: ObservableObject {
   }
   
   func update() {
-    let subNetworks: (BraveWallet.NetworkInfo) -> [BraveWallet.NetworkInfo] = { [weak networkStore] network in
-      guard let networkStore = networkStore,
-              WalletConstants.primaryNetworkChainIds.contains(network.chainId),
-              Preferences.Wallet.showTestNetworks.value else {
-        return []
-      }
-      let isPrimaryOrTestnetChainId: (_ chainId: String) -> Bool = { chainId in
-        WalletConstants.primaryNetworkChainIds.contains(chainId)
-        || WalletConstants.supportedTestNetworkChainIds.contains(chainId)
-      }
-      return networkStore.allChains.filter {
-        $0.coin == network.coin
-        && $0.symbol == network.symbol
-        && !networkStore.isCustomChain($0)
-        && isPrimaryOrTestnetChainId($0.chainId)
-      }
-    }
-    
-    var primaryNetworks = networkStore.allChains
-      .filter { WalletConstants.primaryNetworkChainIds.contains($0.chainId) }
+    self.primaryNetworks = networkStore.primaryNetworks
       .map { network in
-        let subNetworks = subNetworks(network)
+        let subNetworks = networkStore.subNetworks(for: network)
         return NetworkPresentation(
           network: .network(network),
           subNetworks: subNetworks.count > 1 ? subNetworks : [],
           isPrimaryNetwork: true
         )
       }
-    if mode == .filter {
-      // users can filter by 'All Networks' but cannot select 'All Networks'
-      primaryNetworks.insert(.allNetworks, at: 0)
-    }
-    self.primaryNetworks = primaryNetworks
 
-    self.secondaryNetworks = networkStore.allChains
-      .filter {
-        !WalletConstants.primaryNetworkChainIds.contains($0.chainId)
-        && !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId)
-      }
+    self.secondaryNetworks = networkStore.secondaryNetworks
       .map { network in
         NetworkPresentation(
           network: .network(network),
@@ -129,7 +62,6 @@ class NetworkSelectionStore: ObservableObject {
     switch mode {
     case .select:
       guard case let .network(network) = network else { return false }
-      detailNetwork = nil
 
       let error = await networkStore.setSelectedChain(network)
       switch error {
@@ -140,14 +72,6 @@ class NetworkSelectionStore: ObservableObject {
       default:
         return true
       }
-    case .filter:
-      switch network {
-      case .allNetworks:
-        networkStore.networkFilter = .allNetworks
-      case let .network(network):
-        networkStore.networkFilter = .network(network)
-      }
-      return true
     case .formSelection:
       switch network {
       case let .network(network):

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -162,7 +162,7 @@ public class PortfolioStore: ObservableObject {
         of: [AssetsForNetwork].self,
         body: { @MainActor group -> [AssetsForNetwork] in
           for (index, network) in networks.enumerated() {
-            group.addTask {
+            group.addTask { @MainActor in
               let userAssets = await self.walletService.userAssets(network.chainId, coin: network.coin).filter(\.visible)
               return [AssetsForNetwork(network: network, tokens: userAssets, sortOrder: index)]
             }
@@ -222,9 +222,9 @@ public class PortfolioStore: ObservableObject {
           accounts: keyrings.first(where: { $0.coin == userVisibleNFT.token.coin })?.accountInfos ?? []
         )
       }
-      let totalBalances: [String: Double] = await withTaskGroup(of: [String: Double].self, body: { group in
+      let totalBalances: [String: Double] = await withTaskGroup(of: [String: Double].self, body: { @MainActor group in
         for tokenNetworkAccounts in allTokenNetworkAccounts {
-          group.addTask {
+          group.addTask { @MainActor in
             let totalBalance = await self.fetchTotalBalance(
               token: tokenNetworkAccounts.token,
               network: tokenNetworkAccounts.network,
@@ -315,9 +315,9 @@ public class PortfolioStore: ObservableObject {
     network: BraveWallet.NetworkInfo,
     accounts: [BraveWallet.AccountInfo]
   ) async -> Double {
-    let balancesForAsset = await withTaskGroup(of: [Double].self, body: { group in
+    let balancesForAsset = await withTaskGroup(of: [Double].self, body: { @MainActor group in
       for account in accounts {
-        group.addTask {
+        group.addTask { @MainActor in
           let balance = await self.rpcService.balance(
             for: token,
             in: account,

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -5,25 +5,28 @@
 
 import Foundation
 import BraveCore
+import SwiftUI
 
 public struct AssetViewModel: Identifiable, Equatable {
   var token: BraveWallet.BlockchainToken
+  var network: BraveWallet.NetworkInfo
   var decimalBalance: Double
   var price: String
   var history: [BraveWallet.AssetTimePrice]
 
   public var id: String {
-    token.id
+    token.id + network.chainId
   }
 }
 
 struct NFTAssetViewModel: Identifiable, Equatable {
   var token: BraveWallet.BlockchainToken
+  var network: BraveWallet.NetworkInfo
   var balance: Int
   var imageUrl: URL?
 
   public var id: String {
-    token.id
+    token.id + network.chainId
   }
 }
 
@@ -37,9 +40,18 @@ struct BalanceTimePrice: DataPoint, Equatable {
   }
 }
 
-enum NetworkFilter: Equatable {
+public enum NetworkFilter: Equatable {
   case allNetworks
   case network(BraveWallet.NetworkInfo)
+  
+  var title: String {
+    switch self {
+    case .allNetworks:
+      return Strings.Wallet.allNetworksTitle
+    case let .network(network):
+      return network.chainName
+    }
+  }
 }
 
 /// A store containing data around the users assets
@@ -70,7 +82,12 @@ public class PortfolioStore: ObservableObject {
       update()
     }
   }
-  @Published var networkFilter: NetworkFilter = .allNetworks
+  
+  @Published var networkFilter: NetworkFilter = .allNetworks {
+    didSet {
+      update()
+    }
+  }
 
   public private(set) lazy var userAssetsStore: UserAssetsStore = .init(
     walletService: self.walletService,
@@ -84,6 +101,12 @@ public class PortfolioStore: ObservableObject {
   
   /// Cancellable for the last running `update()` Task.
   private var updateTask: Task<(), Never>?
+  /// Cache of total balances. The key is the token's `assetBalanceId`.
+  private var totalBalancesCache: [String: Double] = [:]
+  /// Cache of prices for each token. The key is the token's `assetRatioId`.
+  private var pricesCache: [String: String] = [:]
+  /// Cache of priceHistories. The key is the token's `assetRatioId`.
+  private var priceHistoriesCache: [String: [BraveWallet.AssetTimePrice]] = [:]
 
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -122,61 +145,131 @@ public class PortfolioStore: ObservableObject {
     self.updateTask?.cancel()
     self.updateTask = Task { @MainActor in
       self.isLoadingBalances = true
-      let coin = await walletService.selectedCoin()
-      let network = await rpcService.network(coin)
-      let allVisibleUserAssets = await walletService.userAssets(network.chainId, coin: coin).filter(\.visible)
-      let visibleNFTAssets = allVisibleUserAssets.filter { $0.isErc721 || $0.isNft }
-      let visibleUserAssets = allVisibleUserAssets.filter { !$0.isErc721 && !$0.isNft }
-      // if the task was cancelled, don't update the UI
-      guard !Task.isCancelled else { return }
+      let networks: [BraveWallet.NetworkInfo]
+      switch networkFilter {
+      case .allNetworks:
+        networks = await self.rpcService.allNetworksForSupportedCoins()
+          .filter { !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId) }
+      case let .network(network):
+        networks = [network]
+      }
+      struct AssetsForNetwork: Equatable {
+        let network: BraveWallet.NetworkInfo
+        let tokens: [BraveWallet.BlockchainToken]
+        let sortOrder: Int
+      }
+      let allVisibleUserAssets = await withTaskGroup(
+        of: [AssetsForNetwork].self,
+        body: { @MainActor group -> [AssetsForNetwork] in
+          for (index, network) in networks.enumerated() {
+            group.addTask {
+              let userAssets = await self.walletService.userAssets(network.chainId, coin: network.coin).filter(\.visible)
+              return [AssetsForNetwork(network: network, tokens: userAssets, sortOrder: index)]
+            }
+          }
+          return await group.reduce([AssetsForNetwork](), { $0 + $1 })
+            .sorted(by: { $0.sortOrder < $1.sortOrder }) // maintain sort order of networks
+        }
+      )
+      let visibleUserAssetsForNetwork = allVisibleUserAssets.map {
+        AssetsForNetwork(
+          network: $0.network,
+          tokens: $0.tokens.filter { !$0.isErc721 && !$0.isNft },
+          sortOrder: $0.sortOrder
+        )
+      }
+      let visibleNFTUserAssetsForNetwork = allVisibleUserAssets.map {
+        AssetsForNetwork(
+          network: $0.network,
+          tokens: $0.tokens.filter { $0.isErc721 || $0.isNft },
+          sortOrder: $0.sortOrder
+        )
+      }
       // update userVisibleAssets on display immediately with empty values. Issue #5567
-      userVisibleAssets = visibleUserAssets.map { token in
-        AssetViewModel(
-          token: token,
-          decimalBalance: 0.0,
-          price: "",
-          history: []
-        )
+      userVisibleAssets = visibleUserAssetsForNetwork.flatMap { assetsForNetwork in
+        assetsForNetwork.tokens.map { token in
+          AssetViewModel(
+            token: token,
+            network: assetsForNetwork.network,
+            decimalBalance: totalBalancesCache[token.assetBalanceId] ?? 0,
+            price: pricesCache[token.assetRatioId.lowercased()] ?? "",
+            history: priceHistoriesCache[token.assetRatioId.lowercased()] ?? []
+          )
+        }
       }
-      userVisibleNFTs = visibleNFTAssets.map { asset in
-        NFTAssetViewModel(
-          token: asset,
-          balance: 0
-        )
+      userVisibleNFTs = visibleNFTUserAssetsForNetwork.flatMap { assetsForNetwork in
+        assetsForNetwork.tokens.map { token in
+          NFTAssetViewModel(
+            token: token,
+            network: assetsForNetwork.network,
+            balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0)
+          )
+        }
       }
-      
-      let keyring = await keyringService.keyringInfo(coin.keyringId)
-      guard !Task.isCancelled else { return } // limit network request(s) if cancelled
-      let balances = await fetchBalances(for: allVisibleUserAssets, accounts: keyring.accountInfos, network: network)
-      guard !Task.isCancelled else { return } // limit network request(s) if cancelled
-      let nonZeroBalanceTokens = balances.filter { $1 > 0 }.map { $0.key }
-      let nonZeroBalanceTokensPriceIds = visibleUserAssets.filter({ nonZeroBalanceTokens.contains($0.assetBalanceId.lowercased())}).map { $0.assetRatioId }
-      let priceHistories = await fetchPriceHistory(for: nonZeroBalanceTokensPriceIds)
-      guard !Task.isCancelled else { return } // limit network request(s) if cancelled
-      let visibleAssetRatioIds = visibleUserAssets.filter(\.visible).map { $0.assetRatioId.lowercased() }
-      let prices = await fetchPrices(for: visibleAssetRatioIds)
-      
-      // if the task was cancelled, don't update the UI
+      let keyrings = await self.keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
       guard !Task.isCancelled else { return }
+      // fetch balance for every token
+      for userVisibleAsset in self.userVisibleAssets {
+        let accountsToFetchBalance = keyrings.first(where: { $0.coin == userVisibleAsset.token.coin })?.accountInfos ?? []
+        let totalBalance = await fetchTotalBalance(
+          token: userVisibleAsset.token,
+          network: userVisibleAsset.network,
+          accounts: accountsToFetchBalance
+        )
+        totalBalancesCache[userVisibleAsset.token.assetBalanceId] = totalBalance
+      }
+      guard !Task.isCancelled else { return }
+      for userVisibleNFT in self.userVisibleNFTs {
+        let accountsToFetchBalance = keyrings.first(where: { $0.coin == userVisibleNFT.token.coin })?.accountInfos ?? []
+        // fetch balance
+        let totalBalance = await fetchTotalBalance(
+          token: userVisibleNFT.token,
+          network: userVisibleNFT.network,
+          accounts: accountsToFetchBalance
+        )
+        totalBalancesCache[userVisibleNFT.token.assetBalanceId] = totalBalance
+      }
+
+      // fetch price for every token
+      let allTokens = allVisibleUserAssets.flatMap(\.tokens)
+      let allAssetRatioIds = allTokens.map(\.assetRatioId)
+      let prices: [String: String] = await fetchPrices(for: allAssetRatioIds)
+      for (key, value) in prices { // update cached values
+        self.pricesCache[key] = value
+      }
+
+      // fetch price history for every non-zero balance token
+      let nonZeroBalanceAssetRatioIds: [String] = allTokens
+        .filter { (totalBalancesCache[$0.assetBalanceId] ?? 0) > 0 }
+        .map { $0.assetRatioId }
+      let priceHistories: [String: [BraveWallet.AssetTimePrice]] = await fetchPriceHistory(for: nonZeroBalanceAssetRatioIds)
+      for (key, value) in priceHistories { // update cached values
+        self.priceHistoriesCache[key] = value
+      }
       
+      guard !Task.isCancelled else { return }
       // build our userVisibleAssets
-      userVisibleAssets = visibleUserAssets.map { token in
-        let balanceId = token.assetBalanceId.lowercased()
-        let priceId = token.assetRatioId.lowercased()
-        return AssetViewModel(
-          token: token,
-          decimalBalance: balances[balanceId] ?? 0.0,
-          price: prices[priceId] ?? "",
-          history: priceHistories[priceId] ?? []
-        )
+      userVisibleAssets = visibleUserAssetsForNetwork.flatMap { assetsForNetwork in
+        assetsForNetwork.tokens.map { token in
+          AssetViewModel(
+            token: token,
+            network: assetsForNetwork.network,
+            decimalBalance: totalBalancesCache[token.assetBalanceId] ?? 0,
+            price: pricesCache[token.assetRatioId.lowercased()] ?? "",
+            history: priceHistoriesCache[token.assetRatioId.lowercased()] ?? []
+          )
+        }
       }
-      userVisibleNFTs = visibleNFTAssets.map { token in
-        NFTAssetViewModel(
-          token: token,
-          balance: Int(balances[token.assetBalanceId.lowercased()] ?? 0),
-          imageUrl: nil // TODO: fetch image url from erc721Metadata / erc1155Metadata / solana metadata in #6361
-        )
+      userVisibleNFTs = visibleNFTUserAssetsForNetwork.flatMap { assetsForNetwork in
+        assetsForNetwork.tokens.map { token in
+          NFTAssetViewModel(
+            token: token,
+            network: assetsForNetwork.network,
+            balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0)
+          )
+        }
       }
+      
       // Compute balance based on current prices
       let currentBalance = userVisibleAssets
         .compactMap {
@@ -204,31 +297,25 @@ public class PortfolioStore: ObservableObject {
     }
   }
   
-  /// Fetches the balances for a given list of tokens for each of the given accounts, giving a dictionary with a balance for each token symbol.
-  @MainActor func fetchBalances(
-    for tokens: [BraveWallet.BlockchainToken],
-    accounts: [BraveWallet.AccountInfo],
-    network: BraveWallet.NetworkInfo
-  ) async -> [String: Double] {
-    let balances = await withTaskGroup(of: [String: Double].self) { @MainActor group -> [String: Double] in
+  @MainActor private func fetchTotalBalance(
+    token: BraveWallet.BlockchainToken,
+    network: BraveWallet.NetworkInfo,
+    accounts: [BraveWallet.AccountInfo]
+  ) async -> Double {
+    let balancesForAsset = await withTaskGroup(of: [Double].self, body: { group in
       for account in accounts {
-        for token in tokens {
-          group.addTask { @MainActor in
-            guard let balance = await self.rpcService.balance(for: token, in: account, network: network) else {
-              return [:]
-            }
-            let balanceId = token.assetBalanceId.lowercased()
-            return [balanceId: balance]
-          }
+        group.addTask {
+          let balance = await self.rpcService.balance(
+            for: token,
+            in: account,
+            network: network
+          )
+          return [balance ?? 0]
         }
       }
-      return await group.reduce(into: [String: Double](), { partialResult, new in
-        for key in new.keys {
-          partialResult[key, default: 0] += new[key] ?? 0
-        }
-      })
-    }
-    return balances
+      return await group.reduce([Double](), { $0 + $1 })
+    })
+    return balancesForAsset.reduce(0, +)
   }
   
   /// Fetches the prices for a given list of `assetRatioId`, giving a dictionary with the price for each symbol

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -37,6 +37,11 @@ struct BalanceTimePrice: DataPoint, Equatable {
   }
 }
 
+enum NetworkFilter: Equatable {
+  case allNetworks
+  case network(BraveWallet.NetworkInfo)
+}
+
 /// A store containing data around the users assets
 public class PortfolioStore: ObservableObject {
   /// The dollar amount of your portfolio
@@ -65,6 +70,7 @@ public class PortfolioStore: ObservableObject {
       update()
     }
   }
+  @Published var networkFilter: NetworkFilter = .allNetworks
 
   public private(set) lazy var userAssetsStore: UserAssetsStore = .init(
     walletService: self.walletService,

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -225,7 +225,7 @@ extension BraveWallet.BlockchainToken {
   
   /// The id to map with the return balance from RPCService
   var assetBalanceId: String {
-    "\(contractAddress)+\(symbol)"
+    contractAddress + symbol + chainId
   }
   
   var isAuroraSupportedToken: Bool {

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3347,5 +3347,12 @@ extension Strings {
       value: "Select Network Filter",
       comment: "The title displayed on the view to filter by a network / all networks."
     )
+    public static let userAssetSymbolNetworkDesc = NSLocalizedString(
+      "wallet.userAssetSymbolNetwork",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "%@ on %@",
+      comment: "The description displayed below the token name on each row for the user assets. The first '%@' will be the token symbol, and the second '%@' will be the token's network name."
+    )
   }
 }

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -11,38 +11,67 @@ import BraveCore
 class PortfolioStoreTests: XCTestCase {
 
   private var cancellables: Set<AnyCancellable> = .init()
-
-  func testUpdateEthereum() {
-    // config test
-    let mockAccountInfos: [BraveWallet.AccountInfo] = [.mockEthAccount]
-    let chainId = BraveWallet.MainnetChainId
-    let network: BraveWallet.NetworkInfo = .mockMainnet
-    let mockUserAssets: [BraveWallet.BlockchainToken] = [
+  
+  func testUpdate() {
+    let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    let currencyFormatter = NumberFormatter().then { $0.numberStyle = .currency }
+    
+    // config Solana
+    let mockSolAccountInfos: [BraveWallet.AccountInfo] = [.mockSolAccount]
+    let solNetwork: BraveWallet.NetworkInfo = .mockSolana
+    let mockSolUserAssets: [BraveWallet.BlockchainToken] = [
+      BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true },
+      .mockSpdToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
+      .mockSolanaNFTToken
+    ]
+    let mockLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL
+    let mockSolDecimalBalance: Double = 3.8765 // rounded
+    let mockNFTBalance: Double = 1
+    let mockSolAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "sol", toAsset: "usd", price: "200.00", assetTimeframeChange: "-57.23")
+    let mockSolPriceHistory: [BraveWallet.AssetTimePrice] = [.init(date: Date(timeIntervalSinceNow: -1000), price: "$200.00"), .init(date: Date(), price: "250.00")]
+    let totalSolBalanceValue: Double = (Double(mockSolAssetPrice.price) ?? 0) * mockSolDecimalBalance
+    
+    // config Ethereum
+    let mockEthAccountInfos: [BraveWallet.AccountInfo] = [.mockEthAccount]
+    let ethNetwork: BraveWallet.NetworkInfo = .mockMainnet
+    let mockEthUserAssets: [BraveWallet.BlockchainToken] = [
       .previewToken.then { $0.visible = true },
       .mockUSDCToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
       .mockERC721NFTToken
     ]
-    let mockDecimalBalance: Double = 0.0896
-    let numDecimals = Int(mockUserAssets[0].decimals)
-    let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: numDecimals))
-    let mockBalanceWei = formatter.weiString(from: 0.0896, radix: .hex, decimals: numDecimals) ?? ""
+    let mockEthDecimalBalance: Double = 0.0896
+    let numEthDecimals = Int(mockEthUserAssets[0].decimals)
+    let mockBalanceWei = formatter.weiString(from: 0.0896, radix: .hex, decimals: numEthDecimals) ?? ""
     let mockNFTBalanceWei = formatter.weiString(from: 1, radix: .hex, decimals: 0) ?? ""
     let mockEthAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23")
     let mockEthPriceHistory: [BraveWallet.AssetTimePrice] = [.init(date: Date(timeIntervalSinceNow: -1000), price: "$3000.00"), .init(date: Date(), price: "3059.99")]
-    let totalEthBalanceValue: Double = (Double(mockEthAssetPrice.price) ?? 0) * mockDecimalBalance
-    let currencyFormatter = NumberFormatter().then { $0.numberStyle = .currency }
-    let totalEthBalance = currencyFormatter.string(from: NSNumber(value: totalEthBalanceValue)) ?? ""
-
+    let totalEthBalanceValue: Double = (Double(mockEthAssetPrice.price) ?? 0) * mockEthDecimalBalance
+    
+    let totalBalanceValue = totalEthBalanceValue + totalSolBalanceValue
+    let totalBalance = currencyFormatter.string(from: NSNumber(value: totalBalanceValue)) ?? ""
+    
     // setup test services
     let keyringService = BraveWallet.TestKeyringService()
-    keyringService._keyringInfo = { _, completion in
-      let keyring: BraveWallet.KeyringInfo = .init(
-        id: BraveWallet.DefaultKeyringId,
-        isKeyringCreated: true,
-        isLocked: false,
-        isBackedUp: true,
-        accountInfos: mockAccountInfos)
-      completion(keyring)
+    keyringService._keyringInfo = { keyringId, completion in
+      if keyringId == BraveWallet.DefaultKeyringId {
+        let keyring: BraveWallet.KeyringInfo = .init(
+          id: BraveWallet.DefaultKeyringId,
+          isKeyringCreated: true,
+          isLocked: false,
+          isBackedUp: true,
+          accountInfos: mockEthAccountInfos
+        )
+        completion(keyring)
+      } else {
+        let keyring: BraveWallet.KeyringInfo = .init(
+          id: BraveWallet.SolanaKeyringId,
+          isKeyringCreated: true,
+          isLocked: false,
+          isBackedUp: true,
+          accountInfos: mockSolAccountInfos
+        )
+        completion(keyring)
+      }
     }
     keyringService._addObserver = { _ in }
     keyringService._isLocked = { completion in
@@ -51,28 +80,58 @@ class PortfolioStoreTests: XCTestCase {
     }
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._addObserver = { _ in }
-    rpcService._chainId = { $1(chainId) }
-    rpcService._network = { $1(network) }
+    rpcService._allNetworks = { coin, completion in
+      switch coin {
+      case .eth:
+        completion([ethNetwork])
+      case .sol:
+        completion([solNetwork])
+      case .fil:
+        XCTFail("Should not fetch filecoin network")
+      @unknown default:
+        XCTFail("Should not fetch unknown network")
+      }
+    }
     rpcService._balance = { _, _, _, completion in
-      completion(mockBalanceWei, .success, "")
+      completion(mockBalanceWei, .success, "") // eth balance
     }
     rpcService._erc721TokenBalance = { _, _, _, _, completion in
-      completion(mockNFTBalanceWei, .success, "")
+      completion(mockNFTBalanceWei, .success, "") // eth nft balance
+    }
+    rpcService._solanaBalance = { accountAddress, chainId, completion in
+      completion(mockLamportBalance, .success, "") // sol balance
+    }
+    rpcService._splTokenAccountBalance = {_, _, _, completion in
+      completion("\(mockNFTBalance)", UInt8(0), "\(mockNFTBalance)", .success, "") // sol nft balance
     }
     let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { _, _, completion in
-      completion(mockUserAssets)
+    walletService._userAssets = { _, coin, completion in
+      switch coin {
+      case .eth:
+        completion(mockEthUserAssets)
+      case .sol:
+        completion(mockSolUserAssets)
+      case .fil:
+        XCTFail("Should not fetch filecoin assets")
+      @unknown default:
+        XCTFail("Should not fetch unknown assets")
+      }
     }
     walletService._addObserver = { _ in }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
     walletService._selectedCoin = { $0(BraveWallet.CoinType.eth) }
     let assetRatioService = BraveWallet.TestAssetRatioService()
-    assetRatioService._price = { _, _, _, completion in
-      completion(true, [mockEthAssetPrice])
+    assetRatioService._price = { priceId, _, _, completion in
+      completion(true, [mockEthAssetPrice, mockSolAssetPrice])
     }
-    assetRatioService._priceHistory = { _, _, _, completion in
-      completion(true, mockEthPriceHistory)
+    assetRatioService._priceHistory = { priceId, _, _, completion in
+      if priceId == "sol" {
+        completion(true, mockSolPriceHistory)
+      } else {
+        completion(true, mockEthPriceHistory)
+      }
     }
+    
     // setup store
     let store = PortfolioStore(
       keyringService: keyringService,
@@ -94,139 +153,16 @@ class PortfolioStoreTests: XCTestCase {
           XCTFail("Unexpected test result")
           return
         }
-        XCTAssertEqual(lastUpdatedVisibleAssets.count, 1)
-        XCTAssertEqual(lastUpdatedVisibleAssets[0].decimalBalance, mockDecimalBalance)
-        XCTAssertEqual(lastUpdatedVisibleAssets[0].price, mockEthAssetPrice.price)
-        XCTAssertEqual(lastUpdatedVisibleAssets[0].history, mockEthPriceHistory)
-      }.store(in: &cancellables)
-    // test that `update()` will assign new value to `userVisibleNFTs` publisher
-    let userVisibleNFTsException = expectation(description: "update-userVisibleNFTs")
-    XCTAssertTrue(store.userVisibleNFTs.isEmpty)  // Initial state
-    store.$userVisibleNFTs
-      .dropFirst()
-      .collect(2)
-      .sink { userVisibleNFTs in
-        defer { userVisibleNFTsException.fulfill() }
-        XCTAssertEqual(userVisibleNFTs.count, 2) // empty nfts, populated nfts
-        guard let lastUpdatedVisibleNFTs = userVisibleNFTs.last else {
-          XCTFail("Unexpected test result")
-          return
-        }
-        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[0].balance, Int(mockNFTBalanceWei))
-      }.store(in: &cancellables)
-    // test that `update()` will assign new value to `balance` publisher
-    let balanceException = expectation(description: "update-balance")
-    store.$balance
-      .dropFirst()
-      .first()
-      .sink { balance in
-        defer { balanceException.fulfill() }
-        XCTAssertEqual(balance, totalEthBalance)
-      }
-      .store(in: &cancellables)
-    // test that `update()` will update `isLoadingBalances` publisher
-    let isLoadingBalancesException = expectation(description: "update-isLoadingBalances")
-    store.$isLoadingBalances
-      .dropFirst()
-      .collect(2)
-      .first()
-      .sink { isLoadingUpdates in
-        defer { isLoadingBalancesException.fulfill() }
-        XCTAssertTrue(isLoadingUpdates[0])
-        XCTAssertFalse(isLoadingUpdates[1])
-      }
-      .store(in: &cancellables)
-    store.update()
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
-  }
-  
-  func testUpdateSolana() {
-    // config test
-    let mockAccountInfos: [BraveWallet.AccountInfo] = [.mockSolAccount]
-    let network: BraveWallet.NetworkInfo = .mockSolana
-    let chainId = network.chainId
-    let mockUserAssets: [BraveWallet.BlockchainToken] = [
-      BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true },
-      .mockSpdToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
-      .mockSolanaNFTToken
-    ]
-    let mockLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL
-    let mockDecimalBalance: Double = 3.8765 // rounded
-    let mockNFTBalance: Double = 1
-    let mockSolAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "sol", toAsset: "usd", price: "200.00", assetTimeframeChange: "-57.23")
-    let mockSolPriceHistory: [BraveWallet.AssetTimePrice] = [.init(date: Date(timeIntervalSinceNow: -1000), price: "$200.00"), .init(date: Date(), price: "250.00")]
-    let totalSolBalanceValue: Double = (Double(mockSolAssetPrice.price) ?? 0) * mockDecimalBalance
-    let currencyFormatter = NumberFormatter().then { $0.numberStyle = .currency }
-    let totalSolBalance = currencyFormatter.string(from: NSNumber(value: totalSolBalanceValue)) ?? ""
-
-    // setup test services
-    let keyringService = BraveWallet.TestKeyringService()
-    keyringService._keyringInfo = { _, completion in
-      let keyring: BraveWallet.KeyringInfo = .init(
-        id: BraveWallet.DefaultKeyringId,
-        isKeyringCreated: true,
-        isLocked: false,
-        isBackedUp: true,
-        accountInfos: mockAccountInfos)
-      completion(keyring)
-    }
-    keyringService._addObserver = { _ in }
-    keyringService._isLocked = { completion in
-      // unlocked would cause `update()` from call in `init` to be called prior to test being setup.
-      completion(true)
-    }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
-    rpcService._chainId = { $1(chainId) }
-    rpcService._network = { $1(network) }
-    rpcService._solanaBalance = { accountAddress, chainId, completion in
-      completion(mockLamportBalance, .success, "")
-    }
-    rpcService._splTokenAccountBalance = {_, _, _, completion in
-      completion("\(mockNFTBalance)", UInt8(0), "\(mockNFTBalance)", .success, "")
-    }
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._userAssets = { _, _, completion in
-      completion(mockUserAssets)
-    }
-    walletService._addObserver = { _ in }
-    walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.sol) }
-    let assetRatioService = BraveWallet.TestAssetRatioService()
-    assetRatioService._price = { _, _, _, completion in
-      completion(true, [mockSolAssetPrice])
-    }
-    assetRatioService._priceHistory = { _, _, _, completion in
-      completion(true, mockSolPriceHistory)
-    }
-    // setup store
-    let store = PortfolioStore(
-      keyringService: keyringService,
-      rpcService: rpcService,
-      walletService: walletService,
-      assetRatioService: assetRatioService,
-      blockchainRegistry: BraveWallet.TestBlockchainRegistry()
-    )
-    // test that `update()` will assign new value to `userVisibleAssets` publisher
-    let userVisibleAssetsException = expectation(description: "update-userVisibleAssets")
-    XCTAssertTrue(store.userVisibleAssets.isEmpty)  // Initial state
-    store.$userVisibleAssets
-      .dropFirst()
-      .collect(2)
-      .sink { userVisibleAssets in
-        defer { userVisibleAssetsException.fulfill() }
-        XCTAssertEqual(userVisibleAssets.count, 2) // empty assets, populated assets
-        guard let lastUpdatedVisibleAssets = userVisibleAssets.last else {
-          XCTFail("Unexpected test result")
-          return
-        }
-        XCTAssertEqual(lastUpdatedVisibleAssets.count, 1)
-        XCTAssertEqual(lastUpdatedVisibleAssets[0].decimalBalance, mockDecimalBalance)
+        XCTAssertEqual(lastUpdatedVisibleAssets.count, 2) // SOL on Solana mainnet, ETH on Ethereum mainnet
+        XCTAssertEqual(lastUpdatedVisibleAssets[0].token.symbol, mockSolUserAssets.first?.symbol)
+        XCTAssertEqual(lastUpdatedVisibleAssets[0].decimalBalance, mockSolDecimalBalance)
         XCTAssertEqual(lastUpdatedVisibleAssets[0].price, mockSolAssetPrice.price)
         XCTAssertEqual(lastUpdatedVisibleAssets[0].history, mockSolPriceHistory)
+        
+        XCTAssertEqual(lastUpdatedVisibleAssets[1].token.symbol, mockEthUserAssets.first?.symbol)
+        XCTAssertEqual(lastUpdatedVisibleAssets[1].decimalBalance, mockEthDecimalBalance)
+        XCTAssertEqual(lastUpdatedVisibleAssets[1].price, mockEthAssetPrice.price)
+        XCTAssertEqual(lastUpdatedVisibleAssets[1].history, mockEthPriceHistory)
       }.store(in: &cancellables)
     // test that `update()` will assign new value to `userVisibleNFTs` publisher
     let userVisibleNFTsException = expectation(description: "update-userVisibleNFTs")
@@ -241,8 +177,12 @@ class PortfolioStoreTests: XCTestCase {
           XCTFail("Unexpected test result")
           return
         }
-        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
+        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 2)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[0].token.symbol, mockSolUserAssets.last?.symbol)
         XCTAssertEqual(lastUpdatedVisibleNFTs[0].balance, Int(mockNFTBalance))
+        
+        XCTAssertEqual(lastUpdatedVisibleNFTs[1].token.symbol, mockEthUserAssets.last?.symbol)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[1].balance, Int(mockNFTBalanceWei))
       }.store(in: &cancellables)
     // test that `update()` will assign new value to `balance` publisher
     let balanceException = expectation(description: "update-balance")
@@ -251,7 +191,7 @@ class PortfolioStoreTests: XCTestCase {
       .first()
       .sink { balance in
         defer { balanceException.fulfill() }
-        XCTAssertEqual(balance, totalSolBalance)
+        XCTAssertEqual(balance, totalBalance)
       }
       .store(in: &cancellables)
     // test that `update()` will update `isLoadingBalances` publisher


### PR DESCRIPTION
## Summary of Changes
- Refactored `NetworkSelectionView` into `NetworkSelectionRootView` and add new `NetworkFilterView` wrapper. This was done so we can pass a `Binding<NetworkFilter>` to the view and use it for filtering networks (hit some issues with SwiftUI Bindings when used in `ObservableObject` and syncing between `CryptoStore` / `NetworkStore` / `PortfolioStore`). 
- Show assets from all networks on Portfolio
- Remove network picker from Portfolio (all assets now shown)

This pull request fixes #6352

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Portfolio
2. Verify total balance displays correctly, should display total balance for all assets on all non-test networks (All Networks filter selected)
3. Verify assets from all networks are displayed in Portfolio (test networks are excluded from 'All Networks')
4. Tap 'All Networks' filter button
5. Verify 'All Networks' row is displayed and selected
6. Select a specific network
7. Verify total balance displays correctly
8. Verify assets from selected network filter are displayed
9. Tap network filter button
10. Verify selected network is displayed as selected


## Screenshots:

![IMG_2B5C2777B524-1](https://user-images.githubusercontent.com/5314553/203353959-830734fa-ec61-40bd-aa28-df786008e0b1.jpeg) | ![IMG_9F8F63E2FF04-1](https://user-images.githubusercontent.com/5314553/203354159-91a75a0e-ea96-41eb-b6dd-3885b1d012eb.jpeg)
--|--

https://user-images.githubusercontent.com/5314553/203352407-68e94684-900b-4322-a7a4-c92988533dc6.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
