### PR TITLE
Fix #6453: Add Hide for now capability to Filter Open Tab Session

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -44,7 +44,7 @@ class TabTrayController: LoadingViewController {
   }
 
   let tabManager: TabManager
-  private let braveCore: BraveCoreMain
+  let braveCore: BraveCoreMain
   private var openTabsSessionServiceListener: OpenTabsSessionStateListener?
   
   weak var delegate: TabTrayDelegate?

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 import BraveUI
+import BraveShared
 
 protocol TabSyncHeaderViewDelegate {
   func toggleSection(_ header: TabSyncHeaderView, section: Int)
@@ -143,7 +144,7 @@ extension TabSyncHeaderView: UIContextMenuInteractionDelegate {
       var actionMenuChildren: [UIAction] = []
 
       let allOpenAction = UIAction(
-        title: "Open all",
+        title: Strings.OpenTabs.openSessionOpenAllActionTitle,
         image: UIImage(systemName: "plus"),
         handler: UIAction.deferredActionHandler { _ in
           self.delegate?.openAll(self, section: self.section)
@@ -151,7 +152,7 @@ extension TabSyncHeaderView: UIContextMenuInteractionDelegate {
         })
 
       let hideForAction = UIAction(
-        title: "Hide for now",
+        title: Strings.OpenTabs.openSessionHideAllActionTitle,
         image: UIImage(systemName: "eye.slash"),
         attributes: .destructive,
         handler: UIAction.deferredActionHandler { _ in

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
@@ -148,7 +148,6 @@ extension TabSyncHeaderView: UIContextMenuInteractionDelegate {
         image: UIImage(systemName: "plus"),
         handler: UIAction.deferredActionHandler { _ in
           self.delegate?.openAll(self, section: self.section)
-
         })
 
       let hideForAction = UIAction(
@@ -157,7 +156,6 @@ extension TabSyncHeaderView: UIContextMenuInteractionDelegate {
         attributes: .destructive,
         handler: UIAction.deferredActionHandler { _ in
           self.delegate?.hideForNow(self, section: self.section)
-
         })
 
       actionMenuChildren = [allOpenAction, hideForAction]

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
@@ -8,6 +8,8 @@ import BraveUI
 
 protocol TabSyncHeaderViewDelegate {
   func toggleSection(_ header: TabSyncHeaderView, section: Int)
+  func hideForNow(_ header: TabSyncHeaderView, section: Int)
+  func openAll(_ header: TabSyncHeaderView, section: Int)
 }
 
 class TabSyncHeaderView: UITableViewHeaderFooterView, TableViewReusable {
@@ -90,6 +92,9 @@ class TabSyncHeaderView: UITableViewHeaderFooterView, TableViewReusable {
     }
 
     addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapHeader(_:))))
+    
+    let toolBarInteraction = UIContextMenuInteraction(delegate: self)
+    self.contentView.addInteraction(toolBarInteraction)
   }
     
   required init?(coder aDecoder: NSCoder) {
@@ -129,6 +134,47 @@ class TabSyncHeaderView: UITableViewHeaderFooterView, TableViewReusable {
     arrowIconView.layer.add(animation, forKey: nil)
     
     CATransaction.commit()
+  }
+}
+
+extension TabSyncHeaderView: UIContextMenuInteractionDelegate {
+  public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+    return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] _ in
+      var actionMenuChildren: [UIAction] = []
+
+      let allOpenAction = UIAction(
+        title: "Open all",
+        image: UIImage(systemName: "plus"),
+        handler: UIAction.deferredActionHandler { _ in
+          self.delegate?.openAll(self, section: self.section)
+
+        })
+
+      let hideForAction = UIAction(
+        title: "Hide for now",
+        image: UIImage(systemName: "eye.slash"),
+        attributes: .destructive,
+        handler: UIAction.deferredActionHandler { _ in
+          self.delegate?.hideForNow(self, section: self.section)
+
+        })
+
+      actionMenuChildren = [allOpenAction, hideForAction]
+
+      return UIMenu(title: "", identifier: nil, children: actionMenuChildren)
+    }
+  }
+  
+  func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configuration: UIContextMenuConfiguration, highlightPreviewForItemWithIdentifier identifier: NSCopying) -> UITargetedPreview? {
+    let parameters = UIPreviewParameters().then {
+      $0.backgroundColor = .clear
+    }
+  
+    return UITargetedPreview(view: self, parameters: parameters)
+  }
+  
+  func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configuration: UIContextMenuConfiguration, dismissalPreviewForItemWithIdentifier identifier: NSCopying) -> UITargetedPreview? {
+    self.contextMenuInteraction(interaction, configuration: configuration, highlightPreviewForItemWithIdentifier: identifier)
   }
 }
 

--- a/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
+++ b/Client/Frontend/Browser/Tab Tray/Views/TabSyncCustomView.swift
@@ -152,7 +152,7 @@ extension TabSyncHeaderView: UIContextMenuInteractionDelegate {
 
       let hideForAction = UIAction(
         title: Strings.OpenTabs.openSessionHideAllActionTitle,
-        image: UIImage(systemName: "eye.slash"),
+        image: UIImage(braveSystemNamed: "brave.eye.slash"),
         attributes: .destructive,
         handler: UIAction.deferredActionHandler { _ in
           self.delegate?.hideForNow(self, section: self.section)

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3221,6 +3221,20 @@ extension Strings {
         bundle: .module,
         value: "Devices",
         comment: "The title displayed on table header for open tabs list from other devices")
+    public static let openSessionOpenAllActionTitle =
+      NSLocalizedString(
+        "opentabs.openSessionOpenAllActionTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Open All",
+        comment: "The title for the action to open all the tabs in a synced open session")
+    public static let openSessionHideAllActionTitle =
+      NSLocalizedString(
+        "opentabs.openSessionHideAllActionTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Hide for now",
+        comment: "The title for the action to hide open session with all tabs")
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

This pull request includes **Hide for now** functionality on client side along with the Open All to session header and also include open - share - copy to tab information in the list.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6453

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Join a sync chain with multiple devices
- Sync different tabs between devices
- Leave sync chain with a device
- Check the open tab session from device which left the sync chain is present
- Long press on session on table view
- Press Hide for now

## Screenshots:

![1 1](https://user-images.githubusercontent.com/6643505/203374934-6af01264-e2e7-4ac3-89e6-1c4dd49064d4.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
