### PR TITLE
Fix #6456: Cannot connect to iOS sync chain code

### DIFF
--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -16,13 +16,12 @@ enum DeviceType {
 class SyncAddDeviceViewController: SyncViewController {
   var doneHandler: (() -> Void)?
 
-  private let barcodeSize: CGFloat = 200.0
+  private let barcodeSize: CGFloat = 300.0
 
   lazy var stackView: UIStackView = {
     let stack = UIStackView()
     stack.axis = .vertical
-    stack.distribution = .equalSpacing
-    stack.spacing = 4
+    stack.spacing = 20
     return stack
   }()
 
@@ -30,6 +29,7 @@ class SyncAddDeviceViewController: SyncViewController {
     let label = UILabel()
     label.font = UIFont.systemFont(ofSize: 18.0, weight: UIFont.Weight.medium)
     label.lineBreakMode = NSLineBreakMode.byWordWrapping
+    label.textAlignment = .center
     label.numberOfLines = 0
     return label
   }()
@@ -84,12 +84,12 @@ class SyncAddDeviceViewController: SyncViewController {
     title = deviceType == .computer ? Strings.syncAddComputerTitle : Strings.syncAddTabletOrPhoneTitle
 
     view.addSubview(stackView)
-    stackView.snp.makeConstraints { make in
-      make.top.equalTo(self.view.safeArea.top).inset(10)
-      make.left.right.equalTo(self.view).inset(16)
-      make.bottom.equalTo(self.view.safeArea.bottom).inset(24)
+    stackView.snp.makeConstraints {
+      $0.top.equalTo(view.safeArea.top).inset(10)
+      $0.left.right.equalTo(view).inset(16)
+      $0.bottom.equalTo(view.safeArea.bottom).inset(24)
     }
-
+  
     controlContainerView = UIView()
     controlContainerView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -97,18 +97,21 @@ class SyncAddDeviceViewController: SyncViewController {
     containerView.translatesAutoresizingMaskIntoConstraints = false
     containerView.layer.cornerRadius = 8
     containerView.layer.cornerCurve = .continuous
-    containerView.layer.masksToBounds = true
 
     qrCodeView = SyncQRCodeView(syncApi: syncAPI)
     containerView.addSubview(qrCodeView!)
-    qrCodeView?.snp.makeConstraints { make in
-      make.top.bottom.equalTo(0).inset(22)
-      make.centerX.equalTo(self.containerView)
-      make.size.equalTo(barcodeSize)
+    qrCodeView?.snp.makeConstraints {
+      if UIDevice.isIpad {
+        $0.leading.trailing.equalToSuperview().inset(24)
+        $0.width.equalTo(qrCodeView?.snp.height ?? barcodeSize)
+      } else {
+        $0.centerX.equalTo(containerView)
+        $0.size.equalTo(barcodeSize)
+      }
     }
 
-    self.codewordsView.text = syncAPI.getTimeLimitedWords(fromWords: syncAPI.getSyncCode())
-    self.setupVisuals()
+    codewordsView.text = syncAPI.getTimeLimitedWords(fromWords: syncAPI.getSyncCode())
+    setupVisuals()
   }
   
   override func viewDidAppear(_ animated: Bool) {
@@ -144,7 +147,8 @@ class SyncAddDeviceViewController: SyncViewController {
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
     titleLabel.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.semibold)
     titleLabel.textColor = .braveLabel
-    titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+    titleLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
     titleDescriptionStackView.addArrangedSubview(titleLabel)
 
     descriptionLabel = UILabel()
@@ -156,6 +160,7 @@ class SyncAddDeviceViewController: SyncViewController {
     descriptionLabel.adjustsFontSizeToFitWidth = true
     descriptionLabel.minimumScaleFactor = 0.5
     descriptionLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+    descriptionLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
     titleDescriptionStackView.addArrangedSubview(descriptionLabel)
 
     stackView.addArrangedSubview(titleDescriptionStackView)
@@ -194,6 +199,9 @@ class SyncAddDeviceViewController: SyncViewController {
 
     codewordsView.snp.makeConstraints {
       $0.edges.equalToSuperview()
+      if UIDevice.isIpad {
+        $0.size.equalTo(barcodeSize)
+      }
     }
 
     doneButton.snp.makeConstraints { (make) in
@@ -271,6 +279,13 @@ class SyncAddDeviceViewController: SyncViewController {
     codewordsView.isHidden = isFirstIndex
     copyPasteButton.isHidden = isFirstIndex
 
+    codewordsView.snp.remakeConstraints {
+      $0.edges.equalToSuperview()
+      if UIDevice.isIpad, isFirstIndex {
+        $0.size.equalTo(barcodeSize)
+      }
+    }
+    
     updateLabels()
   }
 

--- a/Client/Frontend/Sync/SyncQRCodeView.swift
+++ b/Client/Frontend/Sync/SyncQRCodeView.swift
@@ -4,7 +4,7 @@ import BraveCore
 
 class SyncQRCodeView: UIImageView {
 
-  private let barcodeSize: CGFloat = 200.0
+  private let barcodeSize: CGFloat = 300.0
 
   convenience init(syncApi: BraveSyncAPI) {
     self.init(frame: CGRect.zero)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Changing the Sync Add Device Screen Layout to provide a bigger QR Code

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6456

This solution is not ideal but to fix the problem at its core, the layout should be re-written with respect to different size classes - orientation. This will be sufficient for fixing problem with Android phones.

Aldo the original Android ticket can be found https://github.com/brave/brave-browser/issues/25952

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

- Install 1.45 on Android device
- Install 1.45 on iOS device
- Start a sync chain on iOS device
- Select add a device on the IOS device
- Begin sync flow on Android device, attempt to scan a sync code on the iOS device with the camera

## Screenshots:

![1](https://user-images.githubusercontent.com/6643505/203594876-35cecc0e-0338-4386-999f-0ec741af623e.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
