### PR TITLE
Fix #6242: Improve URL bar collapsing behaviour on certain pages

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1068,8 +1068,9 @@ public class BrowserViewController: UIViewController {
     
     toolbarVisibilityViewModel.transitionDistance = header.expandedBarStackView.bounds.height - header.collapsedBarContainerView.bounds.height
     // Since the height of the WKWebView changes while collapsing we need to use a stable value to determine
-    // if the toolbars can collapse
-    toolbarVisibilityViewModel.minimumCollapsableContentHeight = webViewContainer.bounds.height + header.bounds.height + footer.bounds.height + view.safeAreaInsets.top + view.safeAreaInsets.bottom
+    // if the toolbars can collapse. We don't subtract the bottom safe area inset because the footer includes
+    // that safe area
+    toolbarVisibilityViewModel.minimumCollapsableContentHeight = view.bounds.height - view.safeAreaInsets.top
     
     var additionalInsets: UIEdgeInsets = .zero
     if isUsingBottomBar {


### PR DESCRIPTION
1. Corrects the minimum collapsible content height which could change because `webViewContainer` itself was getting bigger.
2. Adds additional safety to the drag events so that upon a page becoming ineligible for collapsing it will expand automatically

## Summary of Changes

This pull request fixes #6242 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
