### PR TITLE
Fix #6460: Buy/Send/Swap autodismiss from asset detail screen

### DIFF
--- a/Sources/BraveWallet/WalletPromptView.swift
+++ b/Sources/BraveWallet/WalletPromptView.swift
@@ -56,6 +56,8 @@ struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Co
   var action: (Bool, UINavigationController?) -> Bool
   var content: () -> Content
   var footer: () -> Footer
+  @Environment(\.buySendSwapDestination)
+  private var buySendSwapDestination: Binding<BuySendSwapDestination?>
   
   func makeUIViewController(context: Context) -> UIViewController {
     .init()
@@ -82,7 +84,9 @@ struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Co
       )
       uiViewController.present(controller, animated: true)
     } else {
-      uiViewController.presentedViewController?.dismiss(animated: true)
+      if buySendSwapDestination.wrappedValue == nil {
+        uiViewController.presentedViewController?.dismiss(animated: true)
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
When Buy/Send/Swap is current presented, WalletPromptView will not trigger any top view controller to be dismissed.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6460

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. open brave wallet
2. go to any asset detail screen that has buy/send/swap option
3. try to click those option quickly before asset detail is loaded 
4. observe buy/send/swap will not be dismissed after details screen is loaded at the back
5. you can also try to change selected account or selected network in buy/send/swap
6. observe buy/send/swap screen will be not be dismissed after you changed selected account/network


## Screenshots:

https://user-images.githubusercontent.com/1187676/203578604-d6ec8dee-795f-4f0e-b0e3-de1b72bcc38e.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
