### PR TITLE
Fix #6450: Add ability to set P3A command line switches in debug menu

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -43,11 +43,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var switches: [BraveCoreSwitch] = []
     if !AppConstants.buildChannel.isPublic {
       // Check prefs for additional switches
-      let activeSwitches = Preferences.BraveCore.activeSwitches.value
+      let activeSwitches = Set(Preferences.BraveCore.activeSwitches.value)
       let switchValues = Preferences.BraveCore.switchValues.value
       for activeSwitch in activeSwitches {
-        if let value = switchValues[activeSwitch], !value.isEmpty {
-          switches.append(.init(key: .init(rawValue: activeSwitch), value: value))
+        let key = BraveCoreSwitchKey(rawValue: activeSwitch)
+        if key.isValueless {
+          switches.append(.init(key: key))
+        } else if let value = switchValues[activeSwitch], !value.isEmpty {
+          switches.append(.init(key: key, value: value))
         }
       }
     }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6450 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots

![Simulator Screen Shot - iPhone 14 Pro - 2022-11-23 at 14 44 37](https://user-images.githubusercontent.com/529104/203633675-32b10d43-1d0a-4840-a759-7081c4057cd6.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
