### PR TITLE
[Follow Up] #1938: P3A alignment and UI fixes for onboarding

### DIFF
--- a/Sources/Onboarding/Welcome/Welcome3PAViewController.swift
+++ b/Sources/Onboarding/Welcome/Welcome3PAViewController.swift
@@ -27,13 +27,7 @@ public class Welcome3PAViewController: UIViewController {
 
     view.addSubview(contentView)
     contentView.snp.makeConstraints {
-      if traitCollection.verticalSizeClass == .regular
-          && traitCollection.horizontalSizeClass == .compact {
-        $0.leading.trailing.greaterThanOrEqualTo(view)
-      } else {
-        $0.width.lessThanOrEqualTo(BraveUX.baseDimensionValue)
-      }
-
+      $0.leading.trailing.greaterThanOrEqualTo(view)
       $0.centerX.centerY.equalToSuperview()
     }
 

--- a/Sources/Onboarding/Welcome/WelcomeActionToggle.swift
+++ b/Sources/Onboarding/Welcome/WelcomeActionToggle.swift
@@ -45,20 +45,8 @@ class WelcomeShareActionToggle: BlockedAdsStackView {
     $0.numberOfLines = 0
     $0.minimumScaleFactor = 0.5
     $0.adjustsFontSizeToFitWidth = true
-    $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
-    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     $0.setContentHuggingPriority(.defaultLow, for: .vertical)
     $0.setContentCompressionResistancePriority(.required, for: .vertical)
-  }
-  
-  private let iconView = UIImageView().then {
-    $0.contentMode = .scaleAspectFit
-    $0.image = UIImage(named: "welcome-view-ntp-logo", in: .module, compatibleWith: nil)
-    $0.snp.makeConstraints {
-      $0.size.equalTo(40)
-    }
-    $0.setContentHuggingPriority(.required, for: .horizontal)
-    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
   }
   
   private(set) lazy var shareToggle = UISwitch().then {

--- a/Sources/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Sources/Onboarding/Welcome/WelcomeViewController.swift
@@ -415,7 +415,7 @@ public class WelcomeViewController: UIViewController {
     }
     
     Preferences.Onboarding.basicOnboardingProgress.value = OnboardingProgress.newTabPage.rawValue
-    presenting.dismiss(animated: true, completion: nil)
+    presenting.dismiss(animated: false, completion: nil)
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Fixing p3a popover tablet size width, switch toggle location, also fixes dismiss presentation after moving onboarding to different target so there will not be any view shown before dismiss

No ticket created cause the feature is not tested yet.

This pull request reference #1938

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please in -->

![test1 2](https://user-images.githubusercontent.com/6643505/203656801-2628f512-717e-4a2f-8a5d-42ac7f6941ca.jpg)


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
