### PR TITLE
No Bug: Remove unneeded `await` from `TransactionConfirmationStoreTests`

### DIFF
--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -297,7 +297,7 @@ import BraveCore
         XCTAssertEqual(id, mockTransaction.id)
       }
       .store(in: &cancellables)
-    await waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
     
@@ -312,7 +312,7 @@ import BraveCore
         }
       }
     )
-    await waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
   }
@@ -343,7 +343,7 @@ import BraveCore
         XCTAssertEqual(id, mockTransaction.id)
       }
       .store(in: &cancellables)
-    await waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
     
@@ -358,7 +358,7 @@ import BraveCore
         }
       }
     )
-    await waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
   }
@@ -389,7 +389,7 @@ import BraveCore
         XCTAssertEqual(id, mockTransaction.id)
       }
       .store(in: &cancellables)
-    await waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
     
@@ -404,7 +404,7 @@ import BraveCore
         }
       }
     )
-    await waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
   }


### PR DESCRIPTION
## Summary of Changes
Causing a couple test failures:
1. https://github.com/brave/brave-ios/actions/runs/3533474801/jobs/5929143688
2. https://github.com/brave/brave-ios/actions/runs/3533488994/jobs/5932681621

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
