### PR TITLE
Start loading ad-block early and add wait later

### DIFF
--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -50,6 +50,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // initialization. This is because Database container may change. See bugs #3416, #3377.
     DataController.shared.initializeOnce()
     Migration.postCoreDataInitMigrations()
+    
+    Task {
+      // Start preparing the ad-block services right away
+      // So it's ready a lot faster
+      await LaunchHelper.shared.prepareAdBlockServices(
+        adBlockService: appDelegate.braveCore.adblockService
+      )
+    }
 
     Preferences.General.themeNormalMode.objectWillChange
       .receive(on: RunLoop.main)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -823,13 +823,7 @@ public class BrowserViewController: UIViewController {
       Preferences.Chromium.syncV2ObjectMigrationCount.value = 0
     }
     
-    Task { @MainActor in
-      await LaunchHelper.shared.prepareAdBlockServices(
-        adBlockService: self.braveCore.adblockService
-      )
-      
-      self.setupInteractions()
-    }
+    self.setupInteractions()
   }
   
   private func setupInteractions() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
I hope this will have some improvements of the Adblock engine loading times
The basic principle here is to load the engine as early as possible and to do the wait as late as possible so the perceived time is insignificant. So far I've had some good results on my tests where even if I remove the wait the engine is ready before the first page loads. Yes even the engine YouTube script is ready on time.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6461 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
