### PR TITLE
Fix #6353: Multichain in Edit User Assets

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -226,6 +226,9 @@ struct EditUserAssetsView: View {
       }
     }
     .navigationViewStyle(StackNavigationViewStyle())
+    .onAppear {
+      userAssetsStore.update()
+    }
   }
 
   private func removeCustomToken(_ token: BraveWallet.BlockchainToken) {

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -32,7 +32,11 @@ private struct EditTokenView: View {
       }
     }) {
       HStack(spacing: 8) {
-        AssetIconView(token: assetStore.token, network: assetStore.network)
+        AssetIconView(
+          token: assetStore.token,
+          network: assetStore.network,
+          shouldShowNativeTokenIcon: true
+        )
         VStack(alignment: .leading) {
           Text(tokenName)
             .fontWeight(.semibold)

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -37,7 +37,7 @@ private struct EditTokenView: View {
           Text(tokenName)
             .fontWeight(.semibold)
             .foregroundColor(Color(.bravePrimary))
-          Text(assetStore.token.symbol.uppercased())
+          Text(String.localizedStringWithFormat(Strings.Wallet.userAssetSymbolNetworkDesc, assetStore.token.symbol, assetStore.network.chainName))
             .foregroundColor(Color(.secondaryBraveLabel))
         }
         .font(.footnote)
@@ -71,10 +71,7 @@ struct EditUserAssetsView: View {
         $0.token.symbol.lowercased().contains(normalizedQuery) || $0.token.name.lowercased().contains(normalizedQuery)
       }
     }
-    return
-      stores
-      .sorted(by: { $0.token.symbol.caseInsensitiveCompare($1.token.symbol) == .orderedAscending })
-      .sorted(by: { $0.isVisible && !$1.isVisible })
+    return stores.sorted(by: { $0.isVisible && !$1.isVisible })
   }
 
   var body: some View {

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -75,25 +75,66 @@ public class UserAssetsStore: ObservableObject {
     self.rpcService.add(self)
     self.keyringService.add(self)
 
-    fetchVisibleAssets()
+    update()
   }
-
-  private func updateSelectedAssets(_ network: BraveWallet.NetworkInfo) {
-    walletService.userAssets(network.chainId, coin: network.coin) { [self] userAssets in
-      let visibleAssetIds = userAssets.filter(\.visible).map(\.id)
-      blockchainRegistry.allTokens(network.chainId, coin: network.coin) { [self] registryTokens in
-        allTokens = registryTokens + [network.nativeToken]
-        var uniqueAssets: [BraveWallet.BlockchainToken] = []
-        // we need to swap out the ERC721 assets that are from token registry but was added back as custom tokens with token id.
-        for registeryToken in allTokens {
-          if let matchedUserAsset = userAssets.first(where: { $0.id == registeryToken.id }) {
-            uniqueAssets.append(matchedUserAsset)
-          } else {
-            uniqueAssets.append(registeryToken)
+  
+  @Published var networkFilter: NetworkFilter = .allNetworks
+  
+  func update() {
+    Task { @MainActor in
+      let networks: [BraveWallet.NetworkInfo]
+      switch networkFilter {
+      case .allNetworks:
+        networks = await self.rpcService.allNetworksForSupportedCoins()
+      case let .network(network):
+        networks = [network]
+      }
+      struct AssetsForNetwork: Equatable {
+        let network: BraveWallet.NetworkInfo
+        let tokens: [BraveWallet.BlockchainToken]
+        let sortOrder: Int
+      }
+      let allUserAssets = await withTaskGroup(
+        of: [AssetsForNetwork].self,
+        body: { @MainActor group -> [AssetsForNetwork] in
+          for (index, network) in networks.enumerated() {
+            group.addTask { @MainActor in
+              let userAssets = await self.walletService.userAssets(network.chainId, coin: network.coin)
+              return [AssetsForNetwork(network: network, tokens: userAssets, sortOrder: index)]
+            }
           }
+          return await group.reduce([AssetsForNetwork](), { $0 + $1 })
+            .sorted(by: { $0.sortOrder < $1.sortOrder }) // maintain sort order of networks
         }
-        
-        assetStores = uniqueAssets.union(userAssets, f: { $0.id }).map { token in
+      )
+      
+      var allTokens = await withTaskGroup(
+        of: [AssetsForNetwork].self,
+        body: { @MainActor group -> [AssetsForNetwork] in
+          for (index, network) in networks.enumerated() {
+            group.addTask { @MainActor in
+              let allTokens = await self.blockchainRegistry.allTokens(network.chainId, coin: network.coin)
+              return [AssetsForNetwork(network: network, tokens: allTokens + [network.nativeToken], sortOrder: index)]
+            }
+          }
+          return await group.reduce([AssetsForNetwork](), { $0 + $1 })
+            .sorted(by: { $0.sortOrder < $1.sortOrder }) // maintain sort order of networks
+        }
+      )
+      // Filter `allTokens` to remove any tokens existing in `allUserAssets`. This is possible for ERC721 tokens in the registry without a `tokenId`, which requires the user to add as a custom token
+      let allUserTokens = allUserAssets.flatMap(\.tokens)
+      allTokens = allTokens.map { assetsForNetwork in
+        AssetsForNetwork(
+          network: assetsForNetwork.network,
+          tokens: assetsForNetwork.tokens.filter { token in
+            !allUserTokens.contains(where: { $0.id == token.id })
+          },
+          sortOrder: assetsForNetwork.sortOrder)
+      }
+      
+      let visibleIds = allUserAssets.flatMap(\.tokens).filter(\.visible).map { $0.id + $0.chainId }
+      assetStores = (allUserAssets + allTokens).flatMap { assetsForNetwork in
+        assetsForNetwork.tokens.map { token in
           var isCustomToken: Bool {
             if token.contractAddress.isEmpty {
               return false
@@ -102,16 +143,16 @@ public class UserAssetsStore: ObservableObject {
             if !token.tokenId.isEmpty {
               return true
             }
-            return !allTokens.contains(where: {
-              $0.contractAddress(in: network).caseInsensitiveCompare(token.contractAddress) == .orderedSame
+            return !allTokens.flatMap(\.tokens).contains(where: {
+              $0.contractAddress(in: assetsForNetwork.network).caseInsensitiveCompare(token.contractAddress) == .orderedSame
             })
           }
           return AssetStore(
             walletService: walletService,
-            network: network,
+            network: assetsForNetwork.network,
             token: token,
             isCustomToken: isCustomToken,
-            isVisible: visibleAssetIds.contains(token.id)
+            isVisible: visibleIds.contains(where: { $0 == (token.id + token.chainId) })
           )
         }
       }
@@ -122,39 +163,20 @@ public class UserAssetsStore: ObservableObject {
     _ asset: BraveWallet.BlockchainToken,
     completion: @escaping (_ success: Bool) -> Void
   ) {
-    walletService.selectedCoin { [weak self] coinType in
-      guard let self = self else { return }
-      
-      self.rpcService.network(coinType) { currentNetwork in
-        self.walletService.addUserAsset(asset) { success in
-          if success, asset.chainId.caseInsensitiveCompare(currentNetwork.chainId) == .orderedSame {
-            self.updateSelectedAssets(currentNetwork)
-          }
-          completion(success)
-        }
+    walletService.addUserAsset(asset) { [weak self] success in
+      if success {
+        self?.update()
       }
+      completion(success)
     }
   }
 
   func removeUserAsset(token: BraveWallet.BlockchainToken, completion: @escaping (_ success: Bool) -> Void) {
-    walletService.selectedCoin { [weak self] coin in
-      guard let self = self else { return }
-      self.rpcService.network(coin) { network in
-        self.walletService.removeUserAsset(token) { success in
-          if success {
-            self.updateSelectedAssets(network)
-          }
-          completion(success)
-        }
+    walletService.removeUserAsset(token) { [weak self] success in
+      if success {
+        self?.update()
       }
-    }
-  }
-
-  func fetchVisibleAssets() {
-    walletService.selectedCoin { [weak self] coin in
-      self?.rpcService.network(coin) { network in
-        self?.updateSelectedAssets(network)
-      }
+      completion(success)
     }
   }
 
@@ -192,9 +214,6 @@ public class UserAssetsStore: ObservableObject {
 
 extension UserAssetsStore: BraveWalletJsonRpcServiceObserver {
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
-    rpcService.network(coin) { [weak self] network in
-      self?.updateSelectedAssets(network)
-    }
   }
   public func onAddEthereumChainRequestCompleted(_ chainId: String, error: String) {
   }
@@ -204,7 +223,7 @@ extension UserAssetsStore: BraveWalletJsonRpcServiceObserver {
 
 extension UserAssetsStore: BraveWalletKeyringServiceObserver {
   public func keyringCreated(_ keyringId: String) {
-    fetchVisibleAssets()
+    update()
   }
   
   public func keyringRestored(_ keyringId: String) {

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -74,8 +74,6 @@ public class UserAssetsStore: ObservableObject {
     self.assetRatioService = assetRatioService
     self.rpcService.add(self)
     self.keyringService.add(self)
-
-    update()
   }
   
   @Published var networkFilter: NetworkFilter = .allNetworks {

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -72,7 +72,6 @@ public class UserAssetsStore: ObservableObject {
     self.rpcService = rpcService
     self.keyringService = keyringService
     self.assetRatioService = assetRatioService
-    self.rpcService.add(self)
     self.keyringService.add(self)
   }
   
@@ -211,15 +210,6 @@ public class UserAssetsStore: ObservableObject {
   @MainActor func networkInfo(by chainId: String, coin: BraveWallet.CoinType) async -> BraveWallet.NetworkInfo? {
     let allNetworks = await rpcService.allNetworks(coin)
     return allNetworks.first { $0.chainId.caseInsensitiveCompare(chainId) == .orderedSame }
-  }
-}
-
-extension UserAssetsStore: BraveWalletJsonRpcServiceObserver {
-  public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
-  }
-  public func onAddEthereumChainRequestCompleted(_ chainId: String, error: String) {
-  }
-  public func onIsEip1559Changed(_ chainId: String, isEip1559: Bool) {
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -78,7 +78,11 @@ public class UserAssetsStore: ObservableObject {
     update()
   }
   
-  @Published var networkFilter: NetworkFilter = .allNetworks
+  @Published var networkFilter: NetworkFilter = .allNetworks {
+    didSet {
+      update()
+    }
+  }
   
   func update() {
     Task { @MainActor in

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -42,7 +42,7 @@ extension BraveWallet.NetworkInfo: Identifiable {
       visible: false,
       tokenId: "",
       coingeckoId: "",
-      chainId: "",
+      chainId: chainId,
       coin: coin
     )
   }
@@ -88,7 +88,7 @@ extension BraveWallet.SignMessageRequest {
 
 extension BraveWallet.BlockchainToken: Identifiable {
   public var id: String {
-    contractAddress.lowercased()
+    contractAddress.lowercased() + chainId + symbol + tokenId
   }
 
   public func contractAddress(in network: BraveWallet.NetworkInfo) -> String {

--- a/Tests/BraveWalletTests/UserAssetsStoreTests.swift
+++ b/Tests/BraveWalletTests/UserAssetsStoreTests.swift
@@ -1,0 +1,143 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import XCTest
+import Combine
+import BraveCore
+@testable import BraveWallet
+
+class UserAssetsStoreTests: XCTestCase {
+  
+  private var cancellables: Set<AnyCancellable> = .init()
+  
+  let networks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
+    .eth: [.mockMainnet],
+    .sol: [.mockSolana]
+  ]
+  let visibleAssetsForCoins: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [
+    .eth: [BraveWallet.NetworkInfo.mockMainnet.nativeToken.then { $0.visible = true }, .mockERC721NFTToken.then { $0.visible = true }],
+    .sol: [BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true }, .mockSolanaNFTToken.then { $0.visible = true }]
+  ]
+  let tokenRegistry: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [
+    .eth: [.mockUSDCToken],
+    .sol: [.mockSpdToken]
+  ]
+  
+  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestBlockchainRegistry, BraveWallet.TestAssetRatioService) {
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._addObserver = { _ in }
+    
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._addObserver = { _ in }
+    rpcService._allNetworks = { coin, completion in
+      completion(self.networks[coin] ?? [])
+    }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._userAssets = { chainId, coin, completion in
+      completion(self.visibleAssetsForCoins[coin] ?? [])
+    }
+    
+    let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
+    blockchainRegistry._allTokens = { chainId, coin, completion in
+      completion(self.tokenRegistry[coin] ?? [])
+    }
+    
+    let assetRatioService = BraveWallet.TestAssetRatioService()
+
+    return (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService)
+  }
+  
+  func testUpdate() {
+    let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService) = setupServices()
+    
+    let userAssetsStore = UserAssetsStore(
+      walletService: walletService,
+      blockchainRegistry: blockchainRegistry,
+      rpcService: rpcService,
+      keyringService: keyringService,
+      assetRatioService: assetRatioService
+    )
+    
+    let assetStoresException = expectation(description: "userAssetsStore-assetStores")
+    userAssetsStore.$assetStores
+      .dropFirst()
+      .sink { assetStores in
+        defer { assetStoresException.fulfill() }
+        XCTAssertEqual(assetStores.count, 6)
+        
+        XCTAssertEqual(assetStores[0].token.symbol, BraveWallet.NetworkInfo.mockSolana.nativeToken.symbol)
+        XCTAssertTrue(assetStores[0].token.visible)
+        XCTAssertEqual(assetStores[0].network, BraveWallet.NetworkInfo.mockSolana)
+        
+        XCTAssertEqual(assetStores[1].token.symbol, BraveWallet.BlockchainToken.mockSolanaNFTToken.symbol)
+        XCTAssertTrue(assetStores[1].token.visible)
+        XCTAssertEqual(assetStores[1].network, BraveWallet.NetworkInfo.mockSolana)
+        
+        XCTAssertEqual(assetStores[2].token.symbol, BraveWallet.NetworkInfo.mockMainnet.nativeToken.symbol)
+        XCTAssertTrue(assetStores[2].token.visible)
+        XCTAssertEqual(assetStores[2].network, BraveWallet.NetworkInfo.mockMainnet)
+        
+        XCTAssertEqual(assetStores[3].token.symbol, BraveWallet.BlockchainToken.mockERC721NFTToken.symbol)
+        XCTAssertTrue(assetStores[3].token.visible)
+        XCTAssertEqual(assetStores[3].network, BraveWallet.NetworkInfo.mockMainnet)
+        
+        XCTAssertEqual(assetStores[4].token.symbol, BraveWallet.BlockchainToken.mockSpdToken.symbol)
+        XCTAssertFalse(assetStores[4].token.visible)
+        XCTAssertEqual(assetStores[4].network, BraveWallet.NetworkInfo.mockSolana)
+        
+        XCTAssertEqual(assetStores[5].token.symbol, BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+        XCTAssertFalse(assetStores[5].token.visible)
+        XCTAssertEqual(assetStores[5].network, BraveWallet.NetworkInfo.mockMainnet)
+      }
+      .store(in: &cancellables)
+    
+    userAssetsStore.update()
+    
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  func testUpdateWithNetworkFilter() {
+    let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService) = setupServices()
+    
+    let userAssetsStore = UserAssetsStore(
+      walletService: walletService,
+      blockchainRegistry: blockchainRegistry,
+      rpcService: rpcService,
+      keyringService: keyringService,
+      assetRatioService: assetRatioService
+    )
+    
+    let assetStoresException = expectation(description: "userAssetsStore-assetStores")
+    userAssetsStore.$assetStores
+      .dropFirst()
+      .sink { assetStores in
+        defer { assetStoresException.fulfill() }
+        XCTAssertEqual(assetStores.count, 3)
+        
+        XCTAssertEqual(assetStores[0].token.symbol, BraveWallet.NetworkInfo.mockMainnet.nativeToken.symbol)
+        XCTAssertTrue(assetStores[0].token.visible)
+        XCTAssertEqual(assetStores[0].network, BraveWallet.NetworkInfo.mockMainnet)
+        
+        XCTAssertEqual(assetStores[1].token.symbol, BraveWallet.BlockchainToken.mockERC721NFTToken.symbol)
+        XCTAssertTrue(assetStores[1].token.visible)
+        XCTAssertEqual(assetStores[1].network, BraveWallet.NetworkInfo.mockMainnet)
+        
+        XCTAssertEqual(assetStores[2].token.symbol, BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+        XCTAssertFalse(assetStores[2].token.visible)
+        XCTAssertEqual(assetStores[2].network, BraveWallet.NetworkInfo.mockMainnet)
+      }
+      .store(in: &cancellables)
+    
+    // network filter assignment should call `update()` and update `assetStores`
+    userAssetsStore.networkFilter = .network(.mockMainnet)
+    
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Show network name for each asset in Edit User Assets view
- Show assets from all networks in Edit User Assets view
- Show network filter in Edit User Assets view

This pull request fixes #6353

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Tap 'Edit Visible Assets'
2. Verify network name is shown for each asset
3. Verify network filter in bottom left is filtering by network
4. Verify search still functions as expected
5. Verify add custom asset button (moved to bottom right) is still displaying add custom asset modal


## Screenshots:

https://user-images.githubusercontent.com/5314553/203809665-964cf9dd-b4d6-4e3f-b35e-df606664ba33.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
