### PR TITLE
Fix #6407: Title case for "Block cookie consent notices"

### DIFF
--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -4246,7 +4246,7 @@ extension Strings {
   public static let blockCookieConsentNotices = NSLocalizedString(
     "BlockCookieConsentNotices",
     tableName: "BraveShared", bundle: .module,
-    value: "Block cookie consent notices",
+    value: "Block Cookie Consent Notices",
     comment: "A title for a toggle that allows user to block cookie consent notices"
   )
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Fixed the title case for cookie consent notices

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6407 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
