### PR TITLE
Fix #6298: [Follow up to 5856] Save login toggle hidden behind search bar when deleting a credentials

### DIFF
--- a/Client/Frontend/Login/LoginListViewController.swift
+++ b/Client/Frontend/Login/LoginListViewController.swift
@@ -337,6 +337,8 @@ extension LoginListViewController {
         handler: { [weak self] _ in
           guard let self = self else { return }
 
+          self.tableView.isEditing = false
+          self.setEditing(false, animated: false)
           self.passwordAPI.removeLogin(credential)
           self.fetchLoginInfo()
         }))


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6298

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Open Settings -> Logins & Passwords
- Tap on edit
- Delete login

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/203860441-33efe59a-8e63-42d4-ba0c-b1b124a2b3a2.mov



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
