### PR TITLE
Fix #6333: Current tab is not always focused in tab bar

### DIFF
--- a/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/TabsBar/TabsBarViewController.swift
@@ -389,8 +389,10 @@ extension TabsBarViewController: UICollectionViewDataSource {
 
       let previousOrNext = max(0, previousIndex - 1)
       tabManager.selectTab(self.tabList[previousOrNext])
-
-      self.collectionView.selectItem(at: IndexPath(row: previousOrNext, section: 0), animated: true, scrollPosition: .centeredHorizontally)
+      
+      self.collectionView.selectItem(at: IndexPath(row: previousOrNext, section: 0), animated: false, scrollPosition: .centeredHorizontally)
+      self.updateOverflowIndicatorsLayout()
+      
     }
 
     return cell


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6333

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Determine how many tabs can be opened before the tab bar "scrolls". Call this N.
- Open N + 2 tabs.
- Switch to tab N + 2
- Close tab N + 2. The page for tab N + 1 is now displayed.
- Confirm that tab N + 1 in the tab bar is fully visible. One has to scroll the tab bar in order to close tab N + 1.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/203873428-a1a41f84-e476-44c2-a2ef-fb5d9a241cfd.mov



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
