### PR TITLE
Fix #6495: Perform page actions after dismissing the menu

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -249,8 +249,9 @@ extension BrowserViewController {
           }
           ForEach(activities, id: \.activityTitle) { activity in
             MenuItemButton(icon: activity.activityImage?.template ?? UIImage(), title: activity.activityTitle ?? "") {
-              browserViewController.dismiss(animated: true)
-              activity.perform()
+              browserViewController.dismiss(animated: true) {
+                activity.perform()
+              }
             }
           }
         }


### PR DESCRIPTION
This matches the behaviour of the share sheet

## Summary of Changes

This pull request fixes #6495 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
