### PR TITLE
No Bug: Don't initialize the P3A service in debug builds

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -348,7 +348,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     // DAU may not have pinged on the first launch so weekOfInstallation pref may not be set yet
     if let weekOfInstall = Preferences.DAU.weekOfInstallation.value ??
-        Preferences.DAU.installationDate.value?.mondayOfCurrentWeekFormatted {
+        Preferences.DAU.installationDate.value?.mondayOfCurrentWeekFormatted,
+       AppConstants.buildChannel != .debug {
       braveCore.initializeP3AService(
         forChannel: AppConstants.buildChannel.serverChannelParam,
         weekOfInstall: weekOfInstall


### PR DESCRIPTION
Questions can still be reported and checked in the histograms viewer, but no API calls will happen

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
