### PR TITLE
[Release] Fix #6122, #6491: Bump Brave Core 1.45.134

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.124/brave-core-ios-1.45.124.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.134/brave-core-ios-1.45.134.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.45.124",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.124/brave-core-ios-1.45.124.tgz",
-      "integrity": "sha512-/t8fIC7ECInBdiu451WG0w4tZszGo+OZdTNslHs4VK7BSeC1T2LmMckv+QHmuE/t4Zcny5sbd1GZtR0Advhh1g==",
+      "version": "1.45.134",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.45.134/brave-core-ios-1.45.134.tgz",
+      "integrity": "sha512-HqsXww0jj+i4YEos9QOlI8FOn5TKFfLcHYLuxxM2vMubu8dKocj2o+IE+1vEUZ2ThmNL7zYgM8039bNgBdKnXQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.124/brave-core-ios-1.45.124.tgz",
-      "integrity": "sha512-/t8fIC7ECInBdiu451WG0w4tZszGo+OZdTNslHs4VK7BSeC1T2LmMckv+QHmuE/t4Zcny5sbd1GZtR0Advhh1g=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.45.134/brave-core-ios-1.45.134.tgz",
+      "integrity": "sha512-HqsXww0jj+i4YEos9QOlI8FOn5TKFfLcHYLuxxM2vMubu8dKocj2o+IE+1vEUZ2ThmNL7zYgM8039bNgBdKnXQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.124/brave-core-ios-1.45.124.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.45.134/brave-core-ios-1.45.134.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Bump BraveCore to v1.45.134

This pull request 
fixes #6122, 
fixes #6491

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Install 1.45.2 on iOS 16 device
  2. Create wallet 
  3. Add this Custom NFT as asset: https://testnets.opensea.io/assets/goerli/0xd046b780bcc00f59a6a0294a042e9468d08ceb0d/23
      - This asset returns an error when calling GetERC721Balance with message `execution reverted: ERC721: owner query for nonexistent token` which causes the bug. Any asset returning this error message should result in the same.
  4. Select network dropdown and change network
  5. Verify network selection updates as expected


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
