### PR TITLE
Fix #6314: Bump BraveCore to v1.46.130

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.127/brave-core-ios-1.46.127.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.130/brave-core-ios-1.46.130.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.46.127",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.127/brave-core-ios-1.46.127.tgz",
-      "integrity": "sha512-xWsmLuFUqYOiFMEqL3DbDZdO+VIqNEISJj5T4a3Uz6IAqAZZQ+PswXnL2dLmjbru0nZuyay1bMydsNB+E17Zlg==",
+      "version": "1.46.130",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.130/brave-core-ios-1.46.130.tgz",
+      "integrity": "sha512-4NNBqBBuDMY5ItyQAsLjGmu14vJ+CWvqzkbl2RvPDvdQbcOgYrukMiqo+1Em+NAUhfGV3OiMaeT4yVCRcx+/lw==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.127/brave-core-ios-1.46.127.tgz",
-      "integrity": "sha512-xWsmLuFUqYOiFMEqL3DbDZdO+VIqNEISJj5T4a3Uz6IAqAZZQ+PswXnL2dLmjbru0nZuyay1bMydsNB+E17Zlg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.130/brave-core-ios-1.46.130.tgz",
+      "integrity": "sha512-4NNBqBBuDMY5ItyQAsLjGmu14vJ+CWvqzkbl2RvPDvdQbcOgYrukMiqo+1Em+NAUhfGV3OiMaeT4yVCRcx+/lw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.127/brave-core-ios-1.46.127.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.130/brave-core-ios-1.46.130.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Resolves JsonRpcService disconnect issue / ERC721Balance fetch issue needed for v1.45.2 hotfix, but for v1.46.x

This pull request fixes #6314

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
