### PR TITLE
Ref #6429: Update Following UI to match desktop & fix copy

### DIFF
--- a/Sources/BraveNews/Customize/FollowingListView.swift
+++ b/Sources/BraveNews/Customize/FollowingListView.swift
@@ -38,47 +38,35 @@ struct FollowingListView: View {
   
   var body: some View {
     List {
-      if !followedSources.isEmpty {
-        Section {
-          ForEach(followedSources) { source in
-            SourceLabel(source: source, isFollowing: isFollowingSource(source))
-          }
+      if !followedChannels.isEmpty {
+        ForEach(followedChannels) { channel in
+          let shouldShowRegionSubtitle = followedChannels.filter {
+            $0.name == channel.name
+          }.count > 1
+          ChannelLabel(
+            title: channel.name,
+            subtitle: shouldShowRegionSubtitle ? channel.localeDescription : nil,
+            isFollowing: isFollowingChannel(channel)
+          )
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        } header: {
-          Text(Strings.BraveNews.sourcesHeaderTitle)
+          .padding(.vertical, 4)
         }
       }
-      if !followedChannels.isEmpty {
-        Section {
-          ForEach(followedChannels) { channel in
-            let shouldShowRegionSubtitle = followedChannels.filter {
-              $0.name == channel.name
-            }.count > 1
-            ChannelLabel(
-              title: channel.name,
-              subtitle: shouldShowRegionSubtitle ? channel.localeDescription : nil,
-              isFollowing: isFollowingChannel(channel)
-            )
-            .listRowBackground(Color(.secondaryBraveGroupedBackground))
-            .padding(.vertical, 4)
-          }
-        } header: {
-          Text(Strings.BraveNews.channelsHeaderTitle)
+      if !followedSources.isEmpty {
+        ForEach(followedSources) { source in
+          SourceLabel(source: source, isFollowing: isFollowingSource(source))
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       if !followedRSSFeeds.isEmpty {
-        Section {
-          ForEach(followedRSSFeeds) { feed in
-            RSSFeedLabel(feed: feed, isFollowing: isFollowingRSSFeed(feed))
-          }
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        } header: {
-          Text(Strings.BraveNews.userSourcesHeaderTitle)
+        ForEach(followedRSSFeeds) { feed in
+          RSSFeedLabel(feed: feed, isFollowing: isFollowingRSSFeed(feed))
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
     .listBackgroundColor(Color(.braveGroupedBackground))
-    .listStyle(.insetGrouped)
+    .listStyle(.grouped)
     .environment(\.defaultMinListRowHeight, 0)
     .navigationTitle(Strings.BraveNews.followingTitle)
     .navigationBarTitleDisplayMode(.inline)

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3416,13 +3416,6 @@ extension Strings {
       value: "Search for site, topic or RSS feed",
       comment: "Placeholder text that appears in the search bar when empty. Site as in website."
     )
-    public static let isEnabledToggleSubtitle = NSLocalizedString(
-      "today.isEnabledToggleSubtitle",
-      tableName: "BraveShared",
-      bundle: .module,
-      value: "Ad-supported, private and anonymised ads matched on your device.",
-      comment: "Displays beneath the toggle to turn on Brave News that explains it shows ads."
-    )
     public static let popularSourcesButtonTitle = NSLocalizedString(
       "today.popularSourcesDestinationTitle",
       tableName: "BraveShared",

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3406,7 +3406,7 @@ extension Strings {
       "today.popularSourcesTitle",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Channels",
+      value: "Popular Sources",
       comment: "A title at the top of the screen that shows a list of sources that are ranked the highest"
     )
     public static let searchPlaceholder = NSLocalizedString(

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3427,14 +3427,14 @@ extension Strings {
       "today.popularSourcesDestinationTitle",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Popular Sources",
+      value: "Popular",
       comment: "A button title that when tapped shows users a list of news sources that are ranked the highest"
     )
     public static let popularSourcesButtonSubtitle = NSLocalizedString(
       "today.popularSourcesButtonSubtitle",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Currently trending sources",
+      value: "Ranked list of sources",
       comment: "Shown below 'Popular Sources' explaining what sources will be shown."
     )
     public static let suggestedSourcesButtonTitle = NSLocalizedString(
@@ -3448,7 +3448,7 @@ extension Strings {
       "today.suggestedSourcesButtonSubtitle",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Our curated list of sources",
+      value: "Some sources you might like",
       comment: "Shown below 'Suggested' explaining what sources will be shown."
     )
     public static let channelsButtonTitle = NSLocalizedString(
@@ -3462,7 +3462,7 @@ extension Strings {
       "today.channelsButtonSubtitle",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Follow topics relevant to you",
+      value: "Follow topics that interest you",
       comment: "Shown below 'Channels' explaining what will be shown when tapping on it."
     )
     public static let followingButtonTitle = NSLocalizedString(
@@ -3476,7 +3476,7 @@ extension Strings {
       "today.followingButtonSubtitle",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Manage your following list",
+      value: "Manage sources for your feed",
       comment: "Shown below 'Following' explaining that they can manage their list of followed sources by tapping on it"
     )
     public static let availableRSSFeedsHeaderTitle = NSLocalizedString(


### PR DESCRIPTION
## Summary of Changes

Follow-up PR to fix a copy mistake and adjust additional UI based on product requests

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
