### PR TITLE
Fix #6481, #6476: Show tokens from all networks in token search

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -74,7 +74,8 @@ struct CryptoPagesView: View {
         .sheet(isPresented: $cryptoStore.isPresentingAssetSearch) {
           AssetSearchView(
             keyringStore: keyringStore,
-            cryptoStore: cryptoStore
+            cryptoStore: cryptoStore,
+            userAssetsStore: cryptoStore.portfolioStore.userAssetsStore
           )
         }
     )

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -102,7 +102,7 @@ struct AssetSearchView: View {
                       network: assetViewModel.network,
                       shouldShowNativeTokenIcon: true
                     ),
-                    title: assetViewModel.token.name,
+                    title: title(for: assetViewModel.token),
                     symbol: assetViewModel.token.symbol,
                     networkName: assetViewModel.network.chainName
                   )
@@ -139,6 +139,14 @@ struct AssetSearchView: View {
       Task { @MainActor in
         self.allAssets = await userAssetsStore.allAssets()
       }
+    }
+  }
+  
+  private func title(for token: BraveWallet.BlockchainToken) -> String {
+    if (token.isErc721 || token.isNft), !token.tokenId.isEmpty {
+      return token.nftTokenTitle
+    } else {
+      return token.name
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -11,27 +11,110 @@ import Strings
 struct AssetSearchView: View {
   var keyringStore: KeyringStore
   var cryptoStore: CryptoStore
+  var userAssetsStore: UserAssetsStore
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   
-  @State private var allTokens: [BraveWallet.BlockchainToken] = []
+  @State private var allAssets: [AssetViewModel] = []
+  @State private var query = ""
+  @State private var networkFilter: NetworkFilter = .allNetworks
+  @State private var isPresentingNetworkFilter = false
+
+  private var filteredTokens: [AssetViewModel] {
+    let allAssets: [AssetViewModel]
+    switch networkFilter {
+    case .allNetworks:
+      allAssets = self.allAssets
+    case .network(let network):
+      allAssets = self.allAssets.filter { $0.network.chainId == network.chainId }
+    }
+    let normalizedQuery = query.lowercased()
+    if normalizedQuery.isEmpty {
+      return allAssets
+    }
+    return allAssets.filter {
+      $0.token.symbol.lowercased().contains(normalizedQuery) || $0.token.name.lowercased().contains(normalizedQuery)
+    }
+  }
+  
+  private var networkFilterButton: some View {
+    Button(action: {
+      self.isPresentingNetworkFilter = true
+    }) {
+      HStack {
+        Image(braveSystemName: "brave.text.alignleft")
+        Text(networkFilter.title)
+      }
+      .font(.footnote.weight(.medium))
+      .foregroundColor(Color(.braveBlurpleTint))
+    }
+    .sheet(isPresented: $isPresentingNetworkFilter) {
+      NavigationView {
+        NetworkFilterView(
+          networkFilter: $networkFilter,
+          networkStore: cryptoStore.networkStore
+        )
+      }
+      .onDisappear {
+        cryptoStore.networkStore.closeNetworkSelectionStore()
+      }
+    }
+  }
   
   var body: some View {
     NavigationView {
-      TokenList(tokens: allTokens) { token in
-        NavigationLink(
-          destination: AssetDetailView(
-            assetDetailStore: cryptoStore.assetDetailStore(for: token),
-            keyringStore: keyringStore,
-            networkStore: cryptoStore.networkStore
+      List {
+        Section(
+          header: WalletListHeaderView(
+            title: Text(Strings.Wallet.assetsTitle)
           )
-            .onDisappear {
-              cryptoStore.closeAssetDetailStore(for: token)
+          .osAvailabilityModifiers { content in
+            if #available(iOS 15.0, *) {
+              content  // Padding already applied
+            } else {
+              content
+                .padding(.top)
             }
+          }
         ) {
-          TokenView(token: token, network: cryptoStore.networkStore.selectedChain)
+          Group {
+            if filteredTokens.isEmpty {
+              Text(Strings.Wallet.assetSearchEmpty)
+                .font(.footnote)
+                .foregroundColor(Color(.secondaryBraveLabel))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+            } else {
+              ForEach(filteredTokens) { assetViewModel in
+                NavigationLink(
+                  destination: AssetDetailView(
+                    assetDetailStore: cryptoStore.assetDetailStore(for: assetViewModel.token),
+                    keyringStore: keyringStore,
+                    networkStore: cryptoStore.networkStore
+                  )
+                  .onDisappear {
+                    cryptoStore.closeAssetDetailStore(for: assetViewModel.token)
+                  }
+                ) {
+                  SearchAssetView(
+                    image: AssetIconView(
+                      token: assetViewModel.token,
+                      network: assetViewModel.network,
+                      shouldShowNativeTokenIcon: true
+                    ),
+                    title: assetViewModel.token.name,
+                    symbol: assetViewModel.token.symbol,
+                    networkName: assetViewModel.network.chainName
+                  )
+                }
+              }
+            }
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
+      .listStyle(.insetGrouped)
+      .listBackgroundColor(Color(UIColor.braveGroupedBackground))
       .navigationTitle(Strings.Wallet.searchTitle.capitalized)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
@@ -43,16 +126,46 @@ struct AssetSearchView: View {
               .foregroundColor(Color(.braveBlurpleTint))
           }
         }
+        ToolbarItemGroup(placement: .bottomBar) {
+          networkFilterButton
+          Spacer()
+        }
       }
+      .animation(nil, value: query)
+      .filterable(text: $query)
     }
     .navigationViewStyle(StackNavigationViewStyle())
     .onAppear {
-      cryptoStore.blockchainRegistry.allTokens(
-        cryptoStore.networkStore.selectedChainId,
-        coin: cryptoStore.networkStore.selectedChain.coin
-      ) { tokens in
-        self.allTokens = ([cryptoStore.networkStore.selectedChain.nativeToken] + tokens).sorted(by: { $0.symbol < $1.symbol })
+      Task { @MainActor in
+        self.allAssets = await userAssetsStore.allAssets()
       }
     }
+  }
+}
+
+struct SearchAssetView: View {
+  var image: AssetIconView
+  var title: String
+  var symbol: String
+  let networkName: String
+
+  var body: some View {
+    HStack {
+      image
+      VStack(alignment: .leading) {
+        Text(title)
+          .font(.footnote)
+          .fontWeight(.semibold)
+          .foregroundColor(Color(.bravePrimary))
+        Text(String.localizedStringWithFormat(Strings.Wallet.userAssetSymbolNetworkDesc, symbol, networkName))
+          .font(.caption)
+          .foregroundColor(Color(.braveLabel))
+      }
+      Spacer()
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 6)
+    .accessibilityElement()
+    .accessibilityLabel("\(title), \(symbol), \(networkName)")
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -152,16 +152,16 @@ class AssetDetailStore: ObservableObject {
     isLoadingAccountBalances = true
     typealias AccountBalance = (account: BraveWallet.AccountInfo, balance: Double?)
     let tokenBalances = await withTaskGroup(of: [AccountBalance].self) { @MainActor group -> [AccountBalance] in
-      for account in keyring.accountInfos {
+      for accountAssetViewModel in accountAssetViewModels {
         group.addTask { @MainActor in
-          let balance = await self.rpcService.balance(for: self.token, in: account, network: network)
-          return [AccountBalance(account, balance)]
+          let balance = await self.rpcService.balance(for: self.token, in: accountAssetViewModel.account, network: network)
+          return [AccountBalance(accountAssetViewModel.account, balance)]
         }
       }
       return await group.reduce([AccountBalance](), { $0 + $1 })
     }
     for tokenBalance in tokenBalances {
-      if let index = accounts.firstIndex(where: { $0.account.address == tokenBalance.account.address }) {
+      if let index = accountAssetViewModels.firstIndex(where: { $0.account.address == tokenBalance.account.address }) {
         accountAssetViewModels[index].decimalBalance = tokenBalance.balance ?? 0.0
         if token.isErc721 || token.isNft {
           accountAssetViewModels[index].balance = (tokenBalance.balance ?? 0) > 0 ? "1" : "0"

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -41,6 +41,9 @@ class AssetDetailStore: ObservableObject {
   @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
     didSet {
       currencyFormatter.currencyCode = currencyCode
+      guard oldValue != currencyCode, // only if currency code changed
+            !isInitialState // only update if we're not in initial state
+      else { return }
       update()
     }
   }

--- a/Sources/BraveWallet/Extensions/BlockchainRegistryExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BlockchainRegistryExtensions.swift
@@ -1,0 +1,27 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+
+extension BraveWalletBlockchainRegistry {
+  
+  /// Returns all the `BlockchainToken`s for each of the given networks
+  @MainActor func allTokens(in networks: [BraveWallet.NetworkInfo]) async -> [NetworkAssets] {
+    await withTaskGroup(
+      of: [NetworkAssets].self,
+      body: { @MainActor group -> [NetworkAssets] in
+        for (index, network) in networks.enumerated() {
+          group.addTask { @MainActor in
+            let allTokens = await self.allTokens(network.chainId, coin: network.coin)
+            return [NetworkAssets(network: network, tokens: allTokens + [network.nativeToken], sortOrder: index)]
+          }
+        }
+        return await group.reduce([NetworkAssets](), { $0 + $1 })
+          .sorted(by: { $0.sortOrder < $1.sortOrder }) // maintain sort order of networks
+      }
+    )
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Update `AssetSearchView` to display tokens from all networks, and include a network filter button.
- Fixed separate issue where custom tokens are not displayed in token search.

This pull request fixes #6481
and #6476 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
For #6481:
1. Open wallet and tap search icon in navigation bar
2. Verify network name is displayed for tokens in search
3. Tap network filter in bottom left and select a network
4. Verify only tokens from selected network filter are displayed

For #6476:
1. Add a custom asset that is not in token registry
2. Open token search and search the custom asset name or symbol, verify it is displayed in the list


## Screenshots:

All Networks | Filtered Network | ERC721 Asset
--|--|--
![all networks](https://user-images.githubusercontent.com/5314553/204645087-5a78a4fc-4a85-4fd9-b457-497a8e35bc4d.png) | ![network filter](https://user-images.githubusercontent.com/5314553/204645103-6fa69e48-82a5-49f3-a983-b170922cf848.png) | ![custom asset](https://user-images.githubusercontent.com/5314553/204645117-a670eec7-3c20-4502-a43d-71af54dd86dd.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
