### PR TITLE
Fix #6462: Align autocomplete suggestion label correctly

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -239,7 +239,7 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
     // The label's frame must be slightly shorter to make the clear button visible.
     let clearButtonOffset: CGFloat = 30
     frame.size.width = self.frame.size.width - frame.origin.x - clearButtonOffset
-    frame.size.height = self.frame.size.height - 1
+    frame.size.height = self.frame.size.height
     label.frame = frame
     return label
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #6462 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/529104/204650471-7f2b6e57-854a-4139-ab92-3ac6e29e8efd.png">

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
