### PR TITLE
Fix #6078: Dismiss tab tray on background tap for compact-width layouts

### DIFF
--- a/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tab Tray/TabTrayController.swift
@@ -246,6 +246,10 @@ class TabTrayController: LoadingViewController {
       $0.dragDelegate = self
       $0.dropDelegate = self
       $0.dragInteractionEnabled = true
+      $0.backgroundView = UIView().then {
+        $0.backgroundColor = .clear
+        $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tappedCollectionViewBackground)))
+      }
     }
     
     tabSyncView.tableView.do {
@@ -598,6 +602,12 @@ class TabTrayController: LoadingViewController {
     UIDevice.current.forcePortraitIfIphone(for: UIApplication.shared)
 
     present(settingsNavigationController, animated: true)
+  }
+  
+  @objc private func tappedCollectionViewBackground() {
+    if traitCollection.horizontalSizeClass == .compact {
+      doneAction()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6078 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
