### PR TITLE
Fix #6324: Calculate toolbar height correctly after orientation change

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1246,8 +1246,6 @@ public class BrowserViewController: UIViewController {
     footer.snp.remakeConstraints { make in
       make.bottom.equalTo(toolbarLayoutGuide)
       make.leading.trailing.equalTo(self.view)
-      let height = self.toolbar == nil ? 0 : UIConstants.bottomToolbarHeight
-      make.height.equalTo(height)
     }
 
     bottomBarKeyboardBackground.snp.remakeConstraints {

--- a/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -40,6 +40,11 @@ class BottomToolbarView: UIView, ToolbarProtocol {
     addButtons(actionButtons)
     contentView.axis = .horizontal
     contentView.distribution = .fillEqually
+    contentView.snp.makeConstraints { make in
+      make.leading.trailing.top.equalTo(self)
+      make.bottom.equalTo(self.safeArea.bottom)
+      make.height.greaterThanOrEqualTo(UIConstants.toolbarHeight)
+    }
 
     addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(didSwipeToolbar(_:))))
     
@@ -90,14 +95,6 @@ class BottomToolbarView: UIView, ToolbarProtocol {
     } else {
       isSearchButtonEnabled = false
     }
-  }
-
-  override func updateConstraints() {
-    contentView.snp.makeConstraints { make in
-      make.leading.trailing.top.equalTo(self)
-      make.bottom.equalTo(self.safeArea.bottom)
-    }
-    super.updateConstraints()
   }
   
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -11,12 +11,6 @@ public struct UIConstants {
   static let defaultPadding: CGFloat = 10
   static let snackbarButtonHeight: CGFloat = 48
   static var toolbarHeight: CGFloat = 44
-  static var bottomToolbarHeight: CGFloat {
-    get {
-      let bottomInset: CGFloat = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0
-      return toolbarHeight + bottomInset
-    }
-  }
 
   // Static fonts
   static let defaultChromeSize: CGFloat = 16


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6324 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
