### PR TITLE
Fix #6514: Buy / Swap can be displayed incorrect in Asset Details

### DIFF
--- a/Sources/BraveUI/SwiftUI/Shimmer.swift
+++ b/Sources/BraveUI/SwiftUI/Shimmer.swift
@@ -38,9 +38,15 @@ private struct ShimmerViewModifier: ViewModifier {
         endPoint: points.1
       )
       .onAppear {
-        DispatchQueue.main.async { [self] in  // Need this due to a SwiftUI bug…
+        if #available(iOS 16, *) {
           withAnimation(animation) {
             points = (.trailing, UnitPoint(x: 2, y: 0.5))
+          }
+        } else {
+          DispatchQueue.main.async { [self] in  // Need this due to a SwiftUI bug…
+            withAnimation(animation) {
+              points = (.trailing, UnitPoint(x: 2, y: 0.5))
+            }
           }
         }
       }

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -50,7 +50,7 @@ struct AssetDetailHeaderView: View {
   }
   
   @ViewBuilder private var actionButtonsContainer: some View {
-    if assetDetailStore.isBuySupported && networkStore.isSwapSupported {
+    if assetDetailStore.isBuySupported && assetDetailStore.isSwapSupported {
       VStack {
         actionButtons
       }
@@ -92,7 +92,7 @@ struct AssetDetailHeaderView: View {
       ) {
         Text(Strings.Wallet.send)
       }
-      if networkStore.isSwapSupported && assetDetailStore.token.isFungibleToken {
+      if assetDetailStore.isSwapSupported && assetDetailStore.token.isFungibleToken {
         Button(
           action: {
             buySendSwapDestination = BuySendSwapDestination(

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -191,9 +191,11 @@ struct AssetDetailHeaderView: View {
               .foregroundColor(Color(.secondaryBraveLabel))
           }
           .redacted(reason: assetDetailStore.isInitialState ? .placeholder : [])
+          .shimmer(assetDetailStore.isLoadingPrice)
           let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
           LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
             Color(.walletGreen)
+              .shimmer(assetDetailStore.isLoadingChart)
           }
           .chartAccessibility(
             title: String.localizedStringWithFormat(

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -191,11 +191,9 @@ struct AssetDetailHeaderView: View {
               .foregroundColor(Color(.secondaryBraveLabel))
           }
           .redacted(reason: assetDetailStore.isInitialState ? .placeholder : [])
-          .shimmer(assetDetailStore.isLoadingPrice)
           let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
           LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
             Color(.walletGreen)
-              .shimmer(assetDetailStore.isLoadingChart)
           }
           .chartAccessibility(
             title: String.localizedStringWithFormat(

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -49,13 +49,8 @@ struct AssetDetailHeaderView: View {
     (0..<300).map { _ in .init(date: Date(), price: "0.0") }
   }
   
-  private var isBuySupported: Bool {
-    assetDetailStore.isBuySupported
-    && WalletConstants.supportedBuyWithWyreNetworkChainIds.contains(networkStore.selectedChainId)
-  }
-  
   @ViewBuilder private var actionButtonsContainer: some View {
-    if isBuySupported && networkStore.isSwapSupported {
+    if assetDetailStore.isBuySupported && networkStore.isSwapSupported {
       VStack {
         actionButtons
       }
@@ -75,7 +70,7 @@ struct AssetDetailHeaderView: View {
   
   @ViewBuilder var buySendSwapButtonsContainer: some View {
     HStack {
-      if isBuySupported {
+      if assetDetailStore.isBuySupported {
         Button(
           action: {
             buySendSwapDestination = BuySendSwapDestination(

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -124,6 +124,20 @@ struct AssetDetailHeaderView: View {
     }
     .buttonStyle(BraveFilledButtonStyle(size: .normal))
   }
+  
+  @ViewBuilder private var tokenImageNameAndNetwork: some View {
+    AssetIconView(token: assetDetailStore.token, network: assetDetailStore.network ?? networkStore.selectedChain)
+    VStack(alignment: .leading) {
+      Text(assetDetailStore.token.name)
+        .fixedSize(horizontal: false, vertical: true)
+        .font(.title3.weight(.semibold))
+      if let chainName = assetDetailStore.network?.chainName {
+        Text(chainName)
+          .fixedSize(horizontal: false, vertical: true)
+          .font(.caption)
+      }
+    }
+  }
 
   var body: some View {
     VStack(alignment: assetDetailStore.token.isFungibleToken ? .center : .leading, spacing: 0) {
@@ -140,19 +154,13 @@ struct AssetDetailHeaderView: View {
                   )
               }
               HStack {
-                AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
-                Text(assetDetailStore.token.name)
-                  .fixedSize(horizontal: false, vertical: true)
-                  .font(.title3.weight(.semibold))
+                tokenImageNameAndNetwork
               }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
           } else {
             HStack {
-              AssetIconView(token: assetDetailStore.token, network: networkStore.selectedChain)
-              Text(assetDetailStore.token.name)
-                .fixedSize(horizontal: false, vertical: true)
-                .font(.title3.weight(.semibold))
+              tokenImageNameAndNetwork
               if horizontalSizeClass == .regular {
                 Spacer()
                 DateRangeView(selectedRange: $assetDetailStore.timeframe)

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -38,6 +38,7 @@ class AssetDetailStore: ObservableObject {
   @Published private(set) var accounts: [AccountAssetViewModel] = []
   @Published private(set) var transactionSummaries: [TransactionSummary] = []
   @Published private(set) var isBuySupported: Bool = true
+  @Published private(set) var isSwapSupported: Bool = true
   @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
     didSet {
       currencyFormatter.currencyCode = currencyCode
@@ -56,6 +57,7 @@ class AssetDetailStore: ObservableObject {
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+  private let swapService: BraveWalletSwapService
 
   let token: BraveWallet.BlockchainToken
 
@@ -67,6 +69,7 @@ class AssetDetailStore: ObservableObject {
     txService: BraveWalletTxService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
+    swapService: BraveWalletSwapService,
     token: BraveWallet.BlockchainToken
   ) {
     self.assetRatioService = assetRatioService
@@ -76,6 +79,7 @@ class AssetDetailStore: ObservableObject {
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
     self.solTxManagerProxy = solTxManagerProxy
+    self.swapService = swapService
     self.token = token
 
     self.keyringService.add(self)
@@ -108,6 +112,7 @@ class AssetDetailStore: ObservableObject {
       let sardineBuyTokens = await blockchainRegistry.buyTokens(.sardine, chainId: network.chainId)
       let buyTokens = wyreBuyTokens + rampBuyTokens + sardineBuyTokens
       self.isBuySupported = buyTokens.first(where: { $0.symbol.caseInsensitiveCompare(token.symbol) == .orderedSame }) != nil
+      self.isSwapSupported = await swapService.isiOSSwapSupported(chainId: token.chainId, coin: token.coin)
       
       // fetch accounts
       let keyring = await keyringService.keyringInfo(coin.keyringId)

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -45,6 +45,7 @@ class AssetDetailStore: ObservableObject {
       update()
     }
   }
+  @Published private(set) var network: BraveWallet.NetworkInfo?
 
   let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
 
@@ -104,6 +105,7 @@ class AssetDetailStore: ObservableObject {
       let allNetworks = await rpcService.allNetworks(coin)
       let selectedNetwork = await rpcService.network(coin)
       let network = allNetworks.first(where: { $0.chainId == token.chainId }) ?? selectedNetwork
+      self.network = network
       var wyreBuyTokens: [BraveWallet.BlockchainToken] = []
       if WalletConstants.supportedBuyWithWyreNetworkChainIds.contains(network.chainId) {
         wyreBuyTokens = await blockchainRegistry.buyTokens(.wyre, chainId: network.chainId)

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -182,6 +182,7 @@ public class CryptoStore: ObservableObject {
       txService: txService,
       blockchainRegistry: blockchainRegistry,
       solTxManagerProxy: solTxManagerProxy,
+      swapService: swapService,
       token: token
     )
     assetDetailStore = store

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -123,6 +123,7 @@ extension AssetDetailStore {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
+      swapService: MockSwapService(),
       token: .previewToken
     )
   }


### PR DESCRIPTION
## Summary of Changes
- Fix 'Buy' button not displayed on Asset Details unless supported by Wyre
- Fix 'Swap' relying on selected network; no longer correct with Multichain updates

This pull request fixes #6514

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Wallet
2. Tap 'SOL' on Solana Mainnet in Portfolio assets list
3. Verify 'Buy' button is displayed, 'Swap' is not displayed.
4. Tap 'Back'
5. Tap 'MATIC' on Polygon Mainnet
6. Verify 'Buy' button is displayed. Verify 'Swap' button is displayed.
    - Note: Currently, buy/send/swap do not change networks to match the token's network (see: #6509). Buy will not prefill the token if the currently selected network does not match, send & swap will display the prefilled token but for the wrong network so balance will be 0.


## Screenshots:

https://user-images.githubusercontent.com/5314553/204664390-37a01044-1c09-45bb-8c64-694deb3e550f.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
