### PR TITLE
Fix #5789: Pin Certs with Chromium API

### DIFF
--- a/Client/Assets/Interstitial Pages/Pages/CertificateError.html
+++ b/Client/Assets/Interstitial Pages/Pages/CertificateError.html
@@ -55,13 +55,13 @@ You can obtain one at https://mozilla.org/MPL/2.0/.
             <button id="moreDetailsButton" class="leftNavButton leftNavButtonTitle">%more_details%
                 <img id="arrow" class="arrow down" src="internal://local/interstitial-icon/Carret.png" alt="Icon" class="icon" />
             </button>
-            <button class="rightNavButton rightNavButtonTitle" onclick="history.back();">%back_to_safety%</button>
+            <button id="backToSafetyOrReloadButton" class="rightNavButton rightNavButtonTitle">%back_to_safety_or_reload%</button>
         </div>
 
         <p id="details" class="moreDetails" style="display:none;">
             %error_more_details_description%
             <br /><br />
-            <a id="proceedAnyway" class="moreDetails" href="#">%visit_unsafe%</a>.
+            <a id="proceedAnyway" class="moreDetails" href="#">%visit_unsafe%.</a>
         </p>
         
         <script type="text/javascript">
@@ -121,6 +121,21 @@ You can obtain one at https://mozilla.org/MPL/2.0/.
                         "securityToken": "%security_token%",
                         "type": "certVisitOnce"
                     });
+                });
+            }
+          
+            if (!%allow_bypass% && proceedAnywayLink != null) {
+              proceedAnywayLink.remove();
+            }
+          
+            var backToSafetyOrReloadButton = document.getElementById("backToSafetyOrReloadButton");
+            if (backToSafetyOrReloadButton != null) {
+                backToSafetyOrReloadButton.addEventListener('click', function(e) {
+                  if (%allow_bypass%) {
+                    history.back();
+                  } else {
+                    location.reload();
+                  }
                 });
             }
         </script>

--- a/Client/Frontend/Browser/Interstitial Pages/GenericErrorPageHandler.swift
+++ b/Client/Frontend/Browser/Interstitial Pages/GenericErrorPageHandler.swift
@@ -25,6 +25,7 @@ class GenericErrorPageHandler: InterstitialPageHandler {
         .cfurlErrorServerCertificateNotYetValid,
         .cfurlErrorClientCertificateRejected,
         .cfurlErrorClientCertificateRequired,
+        .braveCertificatePinningFailed,
       ]
 
       return !unhandledCodes.contains(code)
@@ -194,6 +195,8 @@ class GenericErrorPageHandler: InterstitialPageHandler {
     case .cfNetServiceErrorInvalid: return "CFNetServiceErrorInvalid"
     case .cfNetServiceErrorTimeout: return "CFNetServiceErrorTimeout"
     case .cfNetServiceErrorDNSServiceFailure: return "CFNetServiceErrorDNSServiceFailure"
+      
+    case .braveCertificatePinningFailed: return "ERR_SSL_PINNED_KEY_NOT_IN_CERT_CHAIN"
     default: return "Unknown: \(err.rawValue)"
     }
   }
@@ -254,6 +257,8 @@ class GenericErrorPageHandler: InterstitialPageHandler {
     case NSURLErrorBackgroundSessionRequiresSharedContainer: return "NSURLErrorBackgroundSessionRequiresSharedContainer"
     case NSURLErrorBackgroundSessionInUseByAnotherProcess: return "NSURLErrorBackgroundSessionInUseByAnotherProcess"
     case NSURLErrorBackgroundSessionWasDisconnected: return "NSURLErrorBackgroundSessionWasDisconnected"
+      
+    case Int(CFNetworkErrors.braveCertificatePinningFailed.rawValue): return "ERR_SSL_PINNED_KEY_NOT_IN_CERT_CHAIN"
     default: return "Unknown: \(err)"
     }
   }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -80,6 +80,7 @@ class Tab: NSObject {
   }
 
   var secureContentState: TabSecureContentState = .unknown
+  var sslPinningError: Error? = nil
 
   var walletEthProvider: BraveWalletEthereumProvider?
   var walletEthProviderScript: WKUserScript?
@@ -576,6 +577,7 @@ class Tab: NSObject {
   @discardableResult func loadRequest(_ request: URLRequest) -> WKNavigation? {
     if let webView = webView {
       lastRequest = request
+      sslPinningError = nil
       if let url = request.url {
         if url.isFileURL, request.isPrivileged {
           return webView.loadFileURL(url, allowingReadAccessTo: url)

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -849,6 +849,8 @@ extension Strings {
   public static let errorPagesNoInternetTryItem1 = NSLocalizedString("ErrorPagesNoInternetTryItem1", tableName: "BraveShared", bundle: .module, value: "Checking the network cables, modem, and router", comment: "List of things to try when internet is not working")
 
   public static let errorPagesNoInternetTryItem2 = NSLocalizedString("ErrorPagesNoInternetTryItem2", tableName: "BraveShared", bundle: .module, value: "Reconnecting to Wi-Fi", comment: "List of things to try when internet is not working")
+  
+  public static let errorPagesAdvancedErrorPinningDetails = NSLocalizedString("ErrorPagesAdvancedErrorPinningDetails", tableName: "BraveShared", bundle: .module, value: "%@ normally uses encryption to protect your information. When Brave tried to connect to %@ this time, the website sent back unusual and incorrect credentials. This may happen when an attacker is trying to pretend to be %@, or a Wi-Fi sign-in screen has interrupted the connection. Your information is still secure because Brave stopped the connection before any data was exchanged.<br />You cannot visit %@ right now because the website uses certificate pinning. Network errors and attacks are usually temporary, so this page will probably work later.", comment: "Additional warning text when clicking the Advanced button on error pages. %@ is a placeholder, do not localize it. Do not localize <br />.")
 }
 
 // MARK: - Sync

--- a/Tests/BraveSharedTests/CertificatePinningTest.swift
+++ b/Tests/BraveSharedTests/CertificatePinningTest.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 @testable import BraveShared
+@testable import BraveCore
 
 extension CertificatePinningTest {
   private func certificate(named: String) -> SecCertificate {
@@ -208,5 +209,100 @@ class CertificatePinningTest: XCTestCase {
     }
 
     wait(for: expectations, timeout: 10.0)
+  }
+  
+  // Test whether pinning via Brave-Core works
+  // https://github.com/brave/brave-core/blob/master/chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc
+  func testBraveCoreLivePinningSuccess() {
+    let urls = ["https://brave.com"]
+    
+    var managers = [URLSession]()
+    var expectations = [XCTestExpectation]()
+    for host in urls {
+      let expectation = XCTestExpectation(description: "Test Pinning Live URLs: \(host)")
+      expectations.append(expectation)
+
+      guard let hostUrl = URL(string: host) else {
+        XCTFail("Invalid URL/Host for pinning: \(host)")
+        expectation.fulfill()
+        return
+      }
+
+      let sessionManager = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
+      managers.append(sessionManager)
+
+      sessionManager.dataTask(with: hostUrl) { data, response, error in
+        if let error = error as NSError?, error.code == NSURLErrorCancelled {
+          // Pinning failed. NET::ERR_SSL_PINNED_KEY_NOT_IN_CERT_CHAIN
+          XCTFail("Invalid URL/Host for pinning: \(error.localizedDescription) for host: \(host)")
+          expectation.fulfill()
+          return
+        }
+
+        // Success. Website is pinned.
+        expectation.fulfill()
+      }.resume()
+      sessionManager.finishTasksAndInvalidate()
+    }
+
+    wait(for: expectations, timeout: 10.0)
+  }
+  
+  // Test whether pinning via Brave-Core works
+  // https://github.com/brave/brave-core/blob/master/chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc
+  func testBraveCoreLivePinningFailure() {
+    let urls = ["https://ssl-pinning.someblog.org"]
+    
+    var managers = [URLSession]()
+    var expectations = [XCTestExpectation]()
+    for host in urls {
+      let expectation = XCTestExpectation(description: "Test Pinning Live URLs: \(host)")
+      expectations.append(expectation)
+
+      guard let hostUrl = URL(string: host) else {
+        XCTFail("Invalid URL/Host for pinning: \(host)")
+        expectation.fulfill()
+        return
+      }
+
+      let sessionManager = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
+      managers.append(sessionManager)
+
+      sessionManager.dataTask(with: hostUrl) { data, response, error in
+        if let error = error as NSError?, error.code == NSURLErrorCancelled {
+          // Pinning failed. NET::ERR_SSL_PINNED_KEY_NOT_IN_CERT_CHAIN
+          expectation.fulfill()
+          return
+        }
+
+        XCTFail("Website \(host) pinned successfully. Expected to fail!")
+        expectation.fulfill()
+      }.resume()
+      sessionManager.finishTasksAndInvalidate()
+    }
+
+    wait(for: expectations, timeout: 10.0)
+  }
+}
+
+extension CertificatePinningTest: URLSessionDelegate {
+  func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+    if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+      if let serverTrust = challenge.protectionSpace.serverTrust {
+        let result = BraveCertificateUtility.verifyTrust(serverTrust, host: challenge.protectionSpace.host, port: challenge.protectionSpace.port)
+        // Cert is valid and should be pinned
+        if result == 0 {
+          return (.useCredential, URLCredential(trust: serverTrust))
+        }
+        
+        // Cert is valid and should not be pinned
+        // Let the system handle it and we'll show an error if the system cannot validate it
+        if result == Int32.min {
+          return (.performDefaultHandling, nil)
+        }
+      }
+      return (.cancelAuthenticationChallenge, nil)
+    }
+    return (.performDefaultHandling, nil)
   }
 }


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1127

## Summary of Changes
- Pin Certs with Chromium API
- Display appropriate error pages when pinning fails or certificate validation fails.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5789

## Screenshots
![image](https://user-images.githubusercontent.com/1530031/212423358-3ca233f9-dcae-4127-96cc-8f63472b1be5.png)


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
