### PR TITLE
Fix #6521: Fix origin showing when you tap on the location bar

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -408,7 +408,7 @@ class TabLocationView: UIView {
   
   fileprivate func updateTextWithURL() {
     (urlTextField as? DisplayTextField)?.hostString = url?.withoutWWW.host ?? ""
-    urlTextField.text = URLFormatter.formatURL(forSecurityDisplay: url?.absoluteString ?? "", schemeDisplay: .omitHttpAndHttps)
+    urlTextField.text = url?.withoutWWW.schemelessAbsoluteString.trim("/")
   }
 }
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -664,13 +664,7 @@ extension TopToolbarView: TabLocationViewDelegate {
 
   func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {
     guard let (locationText, isSearchQuery) = delegate?.topToolbarDisplayTextForURL(locationView.url as URL?) else { return }
-
-    var overlayText = locationText
-    // Make sure to use the result from topToolbarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
-    if let text = locationText, let url = URL(string: text) {
-      overlayText = URLFormatter.formatURL(forSecurityDisplay: url.absoluteString, schemeDisplay: .show)
-    }
-    enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)
+    enterOverlayMode(locationText, pasted: false, search: isSearchQuery)
   }
 
   func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {


### PR DESCRIPTION
## Summary of Changes
- Fix origin showing when you tap on the location bar by reverting change.
- Will be properly fixed when: https://github.com/brave/brave-core/pull/16193 is merged

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6521

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
