### PR TITLE
No bug: Enable solana dapps for non-public build

### DIFF
--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -6,6 +6,7 @@
 import Foundation
 import BraveCore
 import OrderedCollections
+import Shared
 
 struct WalletConstants {
   /// The Brave swap fee as a % value
@@ -97,5 +98,5 @@ struct WalletConstants {
 }
 
 public struct WalletDebugFlags {
-  public static let isSolanaDappsEnabled: Bool = false
+  public static let isSolanaDappsEnabled: Bool = !AppConstants.buildChannel.isPublic
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Enable solana dapps for non-public build for QA testing while [sec-review ](https://github.com/brave/security/issues/1129) is in progress.
The actual solana dapp enabling by default PR is [here](https://github.com/brave/brave-ios/pull/6530) 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
