### PR TITLE
Fix #6501: Displaying NFT image in wallet

### DIFF
--- a/Sources/BraveUI/SwiftUI/WebImageReader.swift
+++ b/Sources/BraveUI/SwiftUI/WebImageReader.swift
@@ -6,7 +6,6 @@
 import SwiftUI
 import SDWebImage
 import SDWebImageSVGNativeCoder
-import os.log
 
 private class WalletWebImageManager: ObservableObject {
   /// loaded image, note when progressive loading, this will published multiple times with different partial image
@@ -84,29 +83,5 @@ public struct WebImageReader<Content: View>: View {
           }
         }
       }
-  }
-}
-
-public struct WebSVGImageView: UIViewRepresentable {
-  let url: URL?
-  
-  public init(url: URL?) {
-    self.url = url
-  }
-  
-  public func makeUIView(context: Context) -> UIImageView {
-    let result = UIImageView()
-    result.contentMode = .scaleAspectFit
-    result.clipsToBounds = true
-    return result
-  }
-  
-  public func updateUIView(_ uiView: UIImageView, context: Context) {
-    uiView.sd_setImage(with: url) { image, error, cacheType, url in
-      guard image != nil else {
-        Logger.module.debug("SVG image failed to load. Error: \(error.debugDescription)")
-        return
-      }
-    }
   }
 }

--- a/Sources/BraveUI/SwiftUI/WebImageReader.swift
+++ b/Sources/BraveUI/SwiftUI/WebImageReader.swift
@@ -95,7 +95,10 @@ public struct WebSVGImageView: UIViewRepresentable {
   }
   
   public func makeUIView(context: Context) -> UIImageView {
-    return UIImageView()
+    let result = UIImageView()
+    result.contentMode = .scaleAspectFit
+    result.clipsToBounds = true
+    return result
   }
   
   public func updateUIView(_ uiView: UIImageView, context: Context) {

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -45,6 +45,15 @@ struct AccountActivityView: View {
       .multilineTextAlignment(.center)
       .foregroundColor(Color(.secondaryBraveLabel))
   }
+  
+  private func imageURL(nftViewModel: NFTAssetViewModel) -> URL? {
+    var imageURL: URL? = nil
+    if let metaData = nftViewModel.erc721Metadata,
+       let urlString = metaData.imageURL, let url = URL(string: urlString) {
+      imageURL = url
+    }
+    return imageURL
+  }
 
   var body: some View {
     List {
@@ -90,7 +99,7 @@ struct AccountActivityView: View {
                 image: NFTIconView(
                   token: nftAsset.token,
                   network: nftAsset.network,
-                  url: nftAsset.imageUrl,
+                  url: imageURL(nftViewModel: nftAsset),
                   shouldShowNativeTokenIcon: true
                 ),
                 title: nftAsset.token.nftTokenTitle,

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -45,15 +45,6 @@ struct AccountActivityView: View {
       .multilineTextAlignment(.center)
       .foregroundColor(Color(.secondaryBraveLabel))
   }
-  
-  private func imageURL(nftViewModel: NFTAssetViewModel) -> URL? {
-    var imageURL: URL? = nil
-    if let metaData = nftViewModel.erc721Metadata,
-       let urlString = metaData.imageURL, let url = URL(string: urlString) {
-      imageURL = url
-    }
-    return imageURL
-  }
 
   var body: some View {
     List {
@@ -99,7 +90,7 @@ struct AccountActivityView: View {
                 image: NFTIconView(
                   token: nftAsset.token,
                   network: nftAsset.network,
-                  url: imageURL(nftViewModel: nftAsset),
+                  url: nftAsset.erc721Metadata?.imageURL,
                   shouldShowNativeTokenIcon: true
                 ),
                 title: nftAsset.token.nftTokenTitle,

--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -24,8 +24,8 @@ struct NFTDetailView: View {
   @ViewBuilder private var nftImage: some View {
     if let erc721Metadata = nftDetailStore.erc721Metadata {
       let test: String? = "https://d4rgq65mqvxhk.cloudfront.net/public/gift_icons/officialGift%2378548ed1-9c95-4634-b355-ca8c2a53da4f.svg"
-      if let imageURL = erc721Metadata.imageURL {
-        NFTImageView(urlString: imageURL) {
+      if let urlString = erc721Metadata.imageURLString {
+        NFTImageView(urlString: urlString) {
           noImageView
         }
         .cornerRadius(10)

--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -23,13 +23,11 @@ struct NFTDetailView: View {
   
   @ViewBuilder private var nftImage: some View {
     if let erc721Metadata = nftDetailStore.erc721Metadata {
-      let test: String? = "https://d4rgq65mqvxhk.cloudfront.net/public/gift_icons/officialGift%2378548ed1-9c95-4634-b355-ca8c2a53da4f.svg"
       if let urlString = erc721Metadata.imageURLString {
         NFTImageView(urlString: urlString) {
           noImageView
         }
         .cornerRadius(10)
-//        .frame(maxWidth: .infinity, minHeight: 300)
       } else {
         noImageView
       }
@@ -40,28 +38,30 @@ struct NFTDetailView: View {
   var body: some View {
     ScrollView(.vertical) {
       VStack(alignment: .leading, spacing: 24) {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(spacing: 8) {
           if nftDetailStore.isLoading {
             ProgressView()
               .frame(maxWidth: .infinity, minHeight: 300)
           } else {
             nftImage
           }
-          Text(nftDetailStore.nft.nftTokenTitle)
-            .font(.title3.weight(.semibold))
-            .foregroundColor(Color(.braveLabel))
-          Text(nftDetailStore.nft.name)
-            .foregroundColor(Color(.secondaryBraveLabel))
-          Button(action: {
-            buySendSwapDestination = BuySendSwapDestination(
-              kind: .send,
-              initialToken: nftDetailStore.nft
-            )
-          }) {
-            Text(Strings.Wallet.nftDetailSendNFTButtonTitle)
-              .frame(maxWidth: .infinity)
+          VStack(alignment: .leading, spacing: 8) {
+            Text(nftDetailStore.nft.nftTokenTitle)
+              .font(.title3.weight(.semibold))
+              .foregroundColor(Color(.braveLabel))
+            Text(nftDetailStore.nft.name)
+              .foregroundColor(Color(.secondaryBraveLabel))
+            Button(action: {
+              buySendSwapDestination = BuySendSwapDestination(
+                kind: .send,
+                initialToken: nftDetailStore.nft
+              )
+            }) {
+              Text(Strings.Wallet.nftDetailSendNFTButtonTitle)
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(BraveFilledButtonStyle(size: .large))
           }
-          .buttonStyle(BraveFilledButtonStyle(size: .large))
         }
         if let erc721Metadata = nftDetailStore.erc721Metadata, let description = erc721Metadata.description {
           VStack(alignment: .leading, spacing: 8) {

--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -22,38 +22,14 @@ struct NFTDetailView: View {
   }
   
   @ViewBuilder private var nftImage: some View {
-    if let erc721MetaData = nftDetailStore.erc721MetaData {
-      if let imageURL = erc721MetaData.imageURL {
-        if imageURL.hasPrefix("data:image/") {
-          WebImageReader(url: URL(string: imageURL)) { image, isFinished in
-            if let image = image {
-              Image(uiImage: image)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .cornerRadius(10)
-            } else {
-              noImageView
-            }
-          }
-        } else {
-          if imageURL.hasSuffix(".svg") {
-            WebSVGImageView(url: URL(string: imageURL))
-              .frame(maxWidth: .infinity, minHeight: 300)
-              .cornerRadius(10)
-          } else {
-            WebImage(url: URL(string: erc721MetaData.imageURL ?? ""))
-              .resizable()
-              .placeholder {
-                Text(Strings.Wallet.nftDetailImageNotAvailable)
-                  .foregroundColor(Color(.secondaryBraveLabel))
-                  .frame(maxWidth: .infinity, minHeight: 300)
-              }
-              .indicator(.activity)
-              .transition(.fade(duration: 0.5))
-              .aspectRatio(contentMode: .fit)
-              .cornerRadius(10)
-          }
+    if let erc721Metadata = nftDetailStore.erc721Metadata {
+      let test: String? = "https://d4rgq65mqvxhk.cloudfront.net/public/gift_icons/officialGift%2378548ed1-9c95-4634-b355-ca8c2a53da4f.svg"
+      if let imageURL = erc721Metadata.imageURL {
+        NFTImageView(urlString: imageURL) {
+          noImageView
         }
+        .cornerRadius(10)
+//        .frame(maxWidth: .infinity, minHeight: 300)
       } else {
         noImageView
       }
@@ -62,7 +38,7 @@ struct NFTDetailView: View {
     }
   }
   var body: some View {
-    ScrollView {
+    ScrollView(.vertical) {
       VStack(alignment: .leading, spacing: 24) {
         VStack(alignment: .leading, spacing: 8) {
           if nftDetailStore.isLoading {
@@ -87,7 +63,7 @@ struct NFTDetailView: View {
           }
           .buttonStyle(BraveFilledButtonStyle(size: .large))
         }
-        if let erc721MetaData = nftDetailStore.erc721MetaData, let description = erc721MetaData.description {
+        if let erc721Metadata = nftDetailStore.erc721Metadata, let description = erc721Metadata.description {
           VStack(alignment: .leading, spacing: 8) {
             Text(Strings.Wallet.nftDetailDescription)
               .font(.headline.weight(.semibold))
@@ -143,7 +119,9 @@ struct NFTDetailView: View {
       .padding()
     }
     .onAppear {
-      nftDetailStore.fetchMetaData()
+      if nftDetailStore.erc721Metadata == nil {
+        nftDetailStore.fetchMetadata()
+      }
     }
     .background(Color(UIColor.braveGroupedBackground).ignoresSafeArea())
     .navigationBarTitle(Strings.Wallet.nftDetailTitle)

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -131,15 +131,29 @@ struct NFTIconView: View {
   /// If we should show the native token logo on non-native assets
   var shouldShowNativeTokenIcon: Bool = false
   
-  var body: some View {
-    WebImageReader(url: url) { image, isFinished in
-      if let image = image {
-        Image(uiImage: image)
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-      } else {
-        AssetIconView(token: token, network: network, shouldShowNativeTokenIcon: shouldShowNativeTokenIcon)
-      }
+  @ScaledMetric var length: CGFloat = 40
+  
+  private var networkNativeTokenLogo: UIImage? {
+    if let logo = network.nativeTokenLogo {
+      return UIImage(named: logo, in: .module, with: nil)
     }
+    return nil
+  }
+  
+  @ViewBuilder private var tokenLogo: some View {
+    if shouldShowNativeTokenIcon, !network.isNativeAsset(token), let image = networkNativeTokenLogo {
+      Image(uiImage: image)
+        .resizable()
+        .frame(width: 15, height: 15)
+    }
+  }
+  
+  var body: some View {
+    NFTImageView(urlString: url?.absoluteString ?? "") {
+      AssetIconView(token: token, network: network, shouldShowNativeTokenIcon: shouldShowNativeTokenIcon)
+    }
+    .frame(width: length, height: length)
+    .overlay(tokenLogo, alignment: .bottomTrailing)
+    .accessibilityHidden(true)
   }
 }

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -152,8 +152,10 @@ struct NFTIconView: View {
     NFTImageView(urlString: url?.absoluteString ?? "") {
       AssetIconView(token: token, network: network, shouldShowNativeTokenIcon: shouldShowNativeTokenIcon)
     }
+    .cornerRadius(5)
     .frame(width: length, height: length)
     .overlay(tokenLogo, alignment: .bottomTrailing)
+    .allowsHitTesting(false)
     .accessibilityHidden(true)
   }
 }

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -150,7 +150,7 @@ struct NFTIconView: View {
   
   var body: some View {
     NFTImageView(urlString: url?.absoluteString ?? "") {
-      AssetIconView(token: token, network: network, shouldShowNativeTokenIcon: shouldShowNativeTokenIcon)
+      AssetIconView(token: token, network: network, shouldShowNativeTokenIcon: shouldShowNativeTokenIcon, length: length)
     }
     .cornerRadius(5)
     .frame(width: length, height: length)

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -76,11 +76,20 @@ struct SendTokenView: View {
           ) {
             HStack {
               if let token = sendTokenStore.selectedSendToken {
-                AssetIconView(
-                  token: token,
-                  network: networkStore.selectedChain,
-                  length: 26
-                )
+                if token.isErc721 {
+                  NFTIconView(
+                    token: token,
+                    network: networkStore.selectedChain,
+                    url: sendTokenStore.selectedSendTokenERC721Metadata?.imageURL,
+                    length: 26
+                  )
+                } else {
+                  AssetIconView(
+                    token: token,
+                    network: networkStore.selectedChain,
+                    length: 26
+                  )
+                }
               }
               Text(sendTokenStore.selectedSendToken?.symbol ?? "")
                 .font(.title3.weight(.semibold))

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -83,12 +83,14 @@ struct SendTokenView: View {
                     url: sendTokenStore.selectedSendTokenERC721Metadata?.imageURL,
                     length: 26
                   )
+                  .background(Color(.secondaryBraveGroupedBackground)) // swiftui issue won't erase old view
                 } else {
                   AssetIconView(
                     token: token,
                     network: networkStore.selectedChain,
                     length: 26
                   )
+                  .background(Color(.secondaryBraveGroupedBackground)) // swiftui issue won't erase old view
                 }
               }
               Text(sendTokenStore.selectedSendToken?.symbol ?? "")

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -83,14 +83,12 @@ struct SendTokenView: View {
                     url: sendTokenStore.selectedSendTokenERC721Metadata?.imageURL,
                     length: 26
                   )
-                  .background(Color(.secondaryBraveGroupedBackground)) // swiftui issue won't erase old view
                 } else {
                   AssetIconView(
                     token: token,
                     network: networkStore.selectedChain,
                     length: 26
                   )
-                  .background(Color(.secondaryBraveGroupedBackground)) // swiftui issue won't erase old view
                 }
               }
               Text(sendTokenStore.selectedSendToken?.symbol ?? "")

--- a/Sources/BraveWallet/Crypto/NFTImageView.swift
+++ b/Sources/BraveWallet/Crypto/NFTImageView.swift
@@ -46,7 +46,6 @@ struct NFTImageView<Placeholder: View>: View {
           .resizable()
           .placeholder { placeholder() }
           .indicator(.activity)
-          .transition(.fade(duration: 0.5))
           .aspectRatio(contentMode: .fit)
       }
     }

--- a/Sources/BraveWallet/Crypto/NFTImageView.swift
+++ b/Sources/BraveWallet/Crypto/NFTImageView.swift
@@ -7,17 +7,16 @@ import SwiftUI
 import BraveUI
 import SDWebImageSwiftUI
 
-struct NFTImageView<Fallback: View>: View {
-  let urlString: String
-  
-  private var fallback: () -> Fallback
+struct NFTImageView<Placeholder: View>: View {
+  private let urlString: String
+  private var placeholder: () -> Placeholder
   
   init(
     urlString: String,
-    @ViewBuilder fallback: @escaping () -> Fallback
+    @ViewBuilder placeholder: @escaping () -> Placeholder
   ) {
     self.urlString = urlString
-    self.fallback = fallback
+    self.placeholder = placeholder
   }
   
   var body: some View {
@@ -28,16 +27,24 @@ struct NFTImageView<Fallback: View>: View {
             .resizable()
             .aspectRatio(contentMode: .fit)
         } else {
-          fallback()
+          placeholder()
         }
       }
     } else {
       if urlString.hasSuffix(".svg") {
-        WebSVGImageView(url: URL(string: urlString))
+        WebImageReader(url: URL(string: urlString)) { image, isFinished in
+          if let image = image {
+            Image(uiImage: image)
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+          } else {
+            placeholder()
+          }
+        }
       } else {
         WebImage(url: URL(string: urlString))
           .resizable()
-          .placeholder { fallback() }
+          .placeholder { placeholder() }
           .indicator(.activity)
           .transition(.fade(duration: 0.5))
           .aspectRatio(contentMode: .fit)

--- a/Sources/BraveWallet/Crypto/NFTImageView.swift
+++ b/Sources/BraveWallet/Crypto/NFTImageView.swift
@@ -1,0 +1,47 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import SwiftUI
+import BraveUI
+import SDWebImageSwiftUI
+
+struct NFTImageView<Fallback: View>: View {
+  let urlString: String
+  
+  private var fallback: () -> Fallback
+  
+  init(
+    urlString: String,
+    @ViewBuilder fallback: @escaping () -> Fallback
+  ) {
+    self.urlString = urlString
+    self.fallback = fallback
+  }
+  
+  var body: some View {
+    if urlString.hasPrefix("data:image/") {
+      WebImageReader(url: URL(string: urlString)) { image, isFinished in
+        if let image = image {
+          Image(uiImage: image)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+        } else {
+          fallback()
+        }
+      }
+    } else {
+      if urlString.hasSuffix(".svg") {
+        WebSVGImageView(url: URL(string: urlString))
+      } else {
+        WebImage(url: URL(string: urlString))
+          .resizable()
+          .placeholder { fallback() }
+          .indicator(.activity)
+          .transition(.fade(duration: 0.5))
+          .aspectRatio(contentMode: .fit)
+      }
+    }
+  }
+}

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -64,7 +64,7 @@ private struct EditTokenView: View {
     }
     .onAppear {
       Task { @MainActor in
-        self.erc721Metadata = await assetStore.fetchERC721Metada()
+        self.erc721Metadata = await assetStore.fetchERC721Metadata()
       }
     }
     .accessibilityAddTraits(assetStore.isVisible ? [.isSelected] : [])

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -15,6 +15,8 @@ private struct EditTokenView: View {
   
   @Binding var tokenNeedsTokenId: BraveWallet.BlockchainToken?
   
+  @State var erc721Metadata: ERC721Metadata?
+  
   private var tokenName: String {
     if (assetStore.token.isErc721 || assetStore.token.isNft), !assetStore.token.tokenId.isEmpty {
       return assetStore.token.nftTokenTitle
@@ -32,11 +34,20 @@ private struct EditTokenView: View {
       }
     }) {
       HStack(spacing: 8) {
-        AssetIconView(
-          token: assetStore.token,
-          network: assetStore.network,
-          shouldShowNativeTokenIcon: true
-        )
+        if assetStore.token.isErc721 {
+          NFTIconView(
+            token: assetStore.token,
+            network: assetStore.network,
+            url: erc721Metadata?.imageURL,
+            shouldShowNativeTokenIcon: true
+          )
+        } else {
+          AssetIconView(
+            token: assetStore.token,
+            network: assetStore.network,
+            shouldShowNativeTokenIcon: true
+          )
+        }
         VStack(alignment: .leading) {
           Text(tokenName)
             .fontWeight(.semibold)
@@ -50,6 +61,11 @@ private struct EditTokenView: View {
           .opacity(assetStore.isVisible ? 1 : 0)
       }
       .padding(.vertical, 8)
+    }
+    .onAppear {
+      Task { @MainActor in
+        self.erc721Metadata = await assetStore.fetchERC721Metada()
+      }
     }
     .accessibilityAddTraits(assetStore.isVisible ? [.isSelected] : [])
   }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -116,15 +116,6 @@ struct PortfolioView: View {
       }
     }
   }
-  
-  private func imageURL(nftViewModel: NFTAssetViewModel) -> URL? {
-    var imageURL: URL? = nil
-    if let metaData = nftViewModel.erc721Metadata,
-       let urlString = metaData.imageURL, let url = URL(string: urlString) {
-      imageURL = url
-    }
-    return imageURL
-  }
 
   var body: some View {
     List {
@@ -193,7 +184,7 @@ struct PortfolioView: View {
                   image: NFTIconView(
                     token: nftAsset.token,
                     network: nftAsset.network,
-                    url: imageURL(nftViewModel: nftAsset),
+                    url: nftAsset.erc721Metadata?.imageURL,
                     shouldShowNativeTokenIcon: true
                   ),
                   title: nftAsset.token.nftTokenTitle,

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -16,7 +16,7 @@ struct AssetSearchView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   
   @State private var allAssets: [AssetViewModel] = []
-  @State private var allERC721Metadta: [String: ERC721Metadata] = [:]
+  @State private var allERC721Metadata: [String: ERC721Metadata] = [:]
   @State private var query = ""
   @State private var networkFilter: NetworkFilter = .allNetworks
   @State private var isPresentingNetworkFilter = false
@@ -92,7 +92,7 @@ struct AssetSearchView: View {
                   destination: {
                     if assetViewModel.token.isErc721 {
                       NFTDetailView(
-                        nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, erc721Metadata: allERC721Metadta[assetViewModel.token.id]),
+                        nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, erc721Metadata: allERC721Metadata[assetViewModel.token.id]),
                         buySendSwapDestination: .constant(nil)
                       )
                       .onDisappear {
@@ -119,7 +119,7 @@ struct AssetSearchView: View {
                       NFTIconView(
                         token: assetViewModel.token,
                         network: assetViewModel.network,
-                        url: allERC721Metadta[assetViewModel.token.id]?.imageURL,
+                        url: allERC721Metadata[assetViewModel.token.id]?.imageURL,
                         shouldShowNativeTokenIcon: true
                       )
                     } else {
@@ -162,7 +162,7 @@ struct AssetSearchView: View {
     .onAppear {
       Task { @MainActor in
         self.allAssets = await userAssetsStore.allAssets()
-        self.allERC721Metadta = await userAssetsStore.allERC721Metadata()
+        self.allERC721Metadata = await userAssetsStore.allERC721Metadata()
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -92,7 +92,7 @@ struct AssetSearchView: View {
                   destination: {
                     if assetViewModel.token.isErc721 {
                       NFTDetailView(
-                        nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, erc721Metadata: allERC721Metadta[assetViewModel.token.id + assetViewModel.token.chainId]),
+                        nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, erc721Metadata: allERC721Metadta[assetViewModel.token.id]),
                         buySendSwapDestination: .constant(nil)
                       )
                       .onDisappear {
@@ -119,7 +119,7 @@ struct AssetSearchView: View {
                       NFTIconView(
                         token: assetViewModel.token,
                         network: assetViewModel.network,
-                        url: allERC721Metadta[assetViewModel.token.id + assetViewModel.token.chainId]?.imageURL,
+                        url: allERC721Metadta[assetViewModel.token.id]?.imageURL,
                         shouldShowNativeTokenIcon: true
                       )
                     } else {

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -16,6 +16,7 @@ struct AssetSearchView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   
   @State private var allAssets: [AssetViewModel] = []
+  @State private var allERC721Metadta: [String: ERC721Metadata] = [:]
   @State private var query = ""
   @State private var networkFilter: NetworkFilter = .allNetworks
   @State private var isPresentingNetworkFilter = false
@@ -86,26 +87,49 @@ struct AssetSearchView: View {
                 .frame(maxWidth: .infinity)
             } else {
               ForEach(filteredTokens) { assetViewModel in
+                
                 NavigationLink(
-                  destination: AssetDetailView(
-                    assetDetailStore: cryptoStore.assetDetailStore(for: assetViewModel.token),
-                    keyringStore: keyringStore,
-                    networkStore: cryptoStore.networkStore
-                  )
-                  .onDisappear {
-                    cryptoStore.closeAssetDetailStore(for: assetViewModel.token)
+                  destination: {
+                    if assetViewModel.token.isErc721 {
+                      NFTDetailView(
+                        nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, erc721Metadata: allERC721Metadta[assetViewModel.token.id + assetViewModel.token.chainId]),
+                        buySendSwapDestination: .constant(nil)
+                      )
+                      .onDisappear {
+                        cryptoStore.closeNFTDetailStore(for: assetViewModel.token)
+                      }
+                    } else {
+                      AssetDetailView(
+                        assetDetailStore: cryptoStore.assetDetailStore(for: assetViewModel.token),
+                        keyringStore: keyringStore,
+                        networkStore: cryptoStore.networkStore
+                      )
+                      .onDisappear {
+                        cryptoStore.closeAssetDetailStore(for: assetViewModel.token)
+                      }
+                    }
                   }
                 ) {
                   SearchAssetView(
-                    image: AssetIconView(
-                      token: assetViewModel.token,
-                      network: assetViewModel.network,
-                      shouldShowNativeTokenIcon: true
-                    ),
                     title: title(for: assetViewModel.token),
                     symbol: assetViewModel.token.symbol,
                     networkName: assetViewModel.network.chainName
-                  )
+                  ) {
+                    if assetViewModel.token.isErc721 {
+                      NFTIconView(
+                        token: assetViewModel.token,
+                        network: assetViewModel.network,
+                        url: allERC721Metadta[assetViewModel.token.id + assetViewModel.token.chainId]?.imageURL,
+                        shouldShowNativeTokenIcon: true
+                      )
+                    } else {
+                      AssetIconView(
+                        token: assetViewModel.token,
+                        network: assetViewModel.network,
+                        shouldShowNativeTokenIcon: true
+                      )
+                    }
+                  }
                 }
               }
             }
@@ -138,6 +162,7 @@ struct AssetSearchView: View {
     .onAppear {
       Task { @MainActor in
         self.allAssets = await userAssetsStore.allAssets()
+        self.allERC721Metadta = await userAssetsStore.allERC721Metadata()
       }
     }
   }
@@ -151,15 +176,27 @@ struct AssetSearchView: View {
   }
 }
 
-struct SearchAssetView: View {
-  var image: AssetIconView
+struct SearchAssetView<ImageView: View>: View {
+  var image: () -> ImageView
   var title: String
   var symbol: String
   let networkName: String
+  
+  init(
+    title: String,
+    symbol: String,
+    networkName: String,
+    @ViewBuilder image: @escaping () -> ImageView
+  ) {
+    self.title = title
+    self.symbol = symbol
+    self.networkName = networkName
+    self.image = image
+  }
 
   var body: some View {
     HStack {
-      image
+      image()
       VStack(alignment: .leading) {
         Text(title)
           .font(.footnote)

--- a/Sources/BraveWallet/Crypto/Search/BuyTokenSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/BuyTokenSearchView.swift
@@ -19,7 +19,12 @@ struct BuyTokenSearchView: View {
         buyTokenStore.selectedBuyToken = token
         presentationMode.dismiss()
       }) {
-        TokenView(token: token, network: network)
+        TokenView(
+          token: token,
+          network: network
+        ) {
+          AssetIconView(token: token, network: network)
+        }
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle.capitalized)

--- a/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -44,7 +44,7 @@ struct SendTokenSearchView: View {
     }
     .onAppear {
       Task { @MainActor in
-        self.allERC721Metadata = await sendTokenStore.fetchERC721Metada(tokens: sendTokenStore.userAssets.filter { $0.isErc721 })
+        self.allERC721Metadata = await sendTokenStore.fetchERC721Metadata(tokens: sendTokenStore.userAssets.filter { $0.isErc721 })
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle)

--- a/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -12,15 +12,39 @@ struct SendTokenSearchView: View {
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   
+  @State var allERC721Metadata: [String: ERC721Metadata] = [:]
+  
   var network: BraveWallet.NetworkInfo
   
   var body: some View {
     TokenList(tokens: sendTokenStore.userAssets) { token in
       Button(action: {
+        sendTokenStore.selectedSendTokenERC721Metadata = allERC721Metadata[token.id + token.chainId]
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()
       }) {
-        TokenView(token: token, network: network)
+        TokenView(
+          token: token,
+          network: network
+        ) {
+          if token.isErc721 {
+            NFTIconView(
+              token: token,
+              network: network,
+              url: allERC721Metadata[token.id + token.chainId]?.imageURL
+            )
+          } else {
+            AssetIconView(
+              token: token,
+              network: network
+            )
+          }
+        }
+      }
+    }
+    .onAppear {
+      Task { @MainActor in
+        self.allERC721Metadata = await sendTokenStore.fetchERC721Metada(tokens: sendTokenStore.userAssets.filter { $0.isErc721 })
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle)

--- a/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -19,7 +19,7 @@ struct SendTokenSearchView: View {
   var body: some View {
     TokenList(tokens: sendTokenStore.userAssets) { token in
       Button(action: {
-        sendTokenStore.selectedSendTokenERC721Metadata = allERC721Metadata[token.id + token.chainId]
+        sendTokenStore.selectedSendTokenERC721Metadata = allERC721Metadata[token.id]
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()
       }) {
@@ -31,7 +31,7 @@ struct SendTokenSearchView: View {
             NFTIconView(
               token: token,
               network: network,
-              url: allERC721Metadata[token.id + token.chainId]?.imageURL
+              url: allERC721Metadata[token.id]?.imageURL
             )
           } else {
             AssetIconView(

--- a/Sources/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/SwapTokenSearchView.swift
@@ -33,7 +33,15 @@ struct SwapTokenSearchView: View {
         }
         presentationMode.dismiss()
       }) {
-        TokenView(token: token, network: network)
+        TokenView(
+          token: token,
+          network: network
+        ) {
+          AssetIconView(
+            token: token,
+            network: network
+          )
+        }
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle)

--- a/Sources/BraveWallet/Crypto/Search/TokenView.swift
+++ b/Sources/BraveWallet/Crypto/Search/TokenView.swift
@@ -6,13 +6,24 @@
 import SwiftUI
 import BraveCore
 
-struct TokenView: View {
+struct TokenView<ImageView: View>: View {
   var token: BraveWallet.BlockchainToken
   var network: BraveWallet.NetworkInfo
+  var image: () -> ImageView
+  
+  init(
+    token: BraveWallet.BlockchainToken,
+    network: BraveWallet.NetworkInfo,
+    @ViewBuilder image: @escaping () -> ImageView
+  ) {
+    self.token = token
+    self.network = network
+    self.image = image
+  }
   
   var body: some View {
     HStack(spacing: 8) {
-      AssetIconView(token: token, network: network)
+      image()
       VStack(alignment: .leading) {
         Text(token.name)
           .fontWeight(.semibold)
@@ -29,7 +40,9 @@ struct TokenView: View {
 #if DEBUG
 struct TokenView_Previews: PreviewProvider {
   static var previews: some View {
-    TokenView(token: MockBlockchainRegistry.testTokens.first!, network: .mockMainnet)
+    TokenView(token: MockBlockchainRegistry.testTokens.first!, network: .mockMainnet) {
+      AssetIconView(token: MockBlockchainRegistry.testTokens.first!, network: .mockMainnet)
+    }
   }
 }
 #endif

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -156,7 +156,7 @@ class AccountActivityStore: ObservableObject {
                 token: token,
                 network: networkAssets.network,
                 balance: Int(totalBalances[token.assetBalanceId] ?? 0),
-                erc721Metadata: allErc721Metadata[token.id + token.chainId]
+                erc721Metadata: allErc721Metadata[token.id]
               )
             )
           } else {

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -142,6 +142,9 @@ class AccountActivityStore: ObservableObject {
         timeframe: .oneDay
       )
       
+      // fetch ERC721 metadata for ERC721 tokens
+      let allErc721Metadata = await rpcService.fetchERC721Metadata(tokens: allTokens.filter { $0.isErc721 })
+      
       guard !Task.isCancelled else { return }
       updatedUserVisibleAssets.removeAll()
       updatedUserVisibleNFTs.removeAll()
@@ -152,7 +155,8 @@ class AccountActivityStore: ObservableObject {
               NFTAssetViewModel(
                 token: token,
                 network: networkAssets.network,
-                balance: Int(totalBalances[token.assetBalanceId] ?? 0)
+                balance: Int(totalBalances[token.assetBalanceId] ?? 0),
+                erc721Metadata: allErc721Metadata[token.id + token.chainId]
               )
             )
           } else {

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -258,13 +258,14 @@ public class CryptoStore: ObservableObject {
   )
   
   private var nftDetailStore: NFTDetailStore?
-  func nftDetailStore(for nft: BraveWallet.BlockchainToken) -> NFTDetailStore {
+  func nftDetailStore(for nft: BraveWallet.BlockchainToken, erc721Metadata: ERC721Metadata?) -> NFTDetailStore {
     if let store = nftDetailStore, store.nft.id == nft.id {
       return store
     }
     let store = NFTDetailStore(
       rpcService: rpcService,
-      nft: nft
+      nft: nft,
+      erc721Metadata: erc721Metadata
     )
     nftDetailStore = store
     return store

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -32,6 +32,16 @@ struct ERC721Metadata: Codable {
     self.description = try container.decodeIfPresent(String.self, forKey: .description)
   }
   
+  init(
+    imageURLString: String?,
+    name: String?,
+    description: String?
+  ) {
+    self.imageURLString = imageURLString
+    self.name = name
+    self.description = description
+  }
+  
   var imageURL: URL? {
     guard let urlString = imageURLString else { return nil }
     return URL(string: urlString)

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -13,23 +13,28 @@ private extension String {
 }
 
 struct ERC721Metadata: Codable {
-  var imageURL: String?
+  var imageURLString: String?
   var name: String?
   var description: String?
   
   enum CodingKeys: String, CodingKey {
-    case imageURL = "image"
+    case imageURLString = "image"
     case name
     case description
   }
   
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    if let imageString = try container.decodeIfPresent(String.self, forKey: .imageURL) {
-      self.imageURL = imageString.hasPrefix("data:image") ? imageString : imageString.httpifyIpfsUrl
+    if let imageString = try container.decodeIfPresent(String.self, forKey: .imageURLString) {
+      self.imageURLString = imageString.hasPrefix("data:image") ? imageString : imageString.httpifyIpfsUrl
     }
     self.name = try container.decodeIfPresent(String.self, forKey: .name)
     self.description = try container.decodeIfPresent(String.self, forKey: .description)
+  }
+  
+  var imageURL: URL? {
+    guard let urlString = imageURLString else { return nil }
+    return URL(string: urlString)
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -12,7 +12,7 @@ private extension String {
   }
 }
 
-struct ERC721MetaData: Codable {
+struct ERC721Metadata: Codable {
   var imageURL: String?
   var name: String?
   var description: String?
@@ -37,18 +37,20 @@ class NFTDetailStore: ObservableObject {
   private let rpcService: BraveWalletJsonRpcService
   let nft: BraveWallet.BlockchainToken
   @Published var isLoading: Bool = false
-  @Published var erc721MetaData: ERC721MetaData?
+  @Published var erc721Metadata: ERC721Metadata?
   @Published var networkInfo: BraveWallet.NetworkInfo = .init()
   
   init(
     rpcService: BraveWalletJsonRpcService,
-    nft: BraveWallet.BlockchainToken
+    nft: BraveWallet.BlockchainToken,
+    erc721Metadata: ERC721Metadata?
   ) {
     self.rpcService = rpcService
     self.nft = nft
+    self.erc721Metadata = erc721Metadata
   }
   
-  func fetchMetaData() {
+  func fetchMetadata() {
     Task { @MainActor in
       isLoading = true
       
@@ -61,8 +63,8 @@ class NFTDetailStore: ObservableObject {
       
       isLoading = false
       if let data = metaData.data(using: .utf8),
-         let result = try? JSONDecoder().decode(ERC721MetaData.self, from: data) {
-        erc721MetaData = result
+         let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
+        erc721Metadata = result
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -23,10 +23,14 @@ struct NFTAssetViewModel: Identifiable, Equatable {
   var token: BraveWallet.BlockchainToken
   var network: BraveWallet.NetworkInfo
   var balance: Int
-  var imageUrl: URL?
+  var erc721Metadata: ERC721Metadata?
 
   public var id: String {
     token.id + network.chainId
+  }
+  
+  static func == (lhs: NFTAssetViewModel, rhs: NFTAssetViewModel) -> Bool {
+    lhs.id == rhs.id
   }
 }
 
@@ -107,6 +111,8 @@ public class PortfolioStore: ObservableObject {
   private var pricesCache: [String: String] = [:]
   /// Cache of priceHistories. The key is the token's `assetRatioId`.
   private var priceHistoriesCache: [String: [BraveWallet.AssetTimePrice]] = [:]
+  /// Cache of metadata for erc721 token. The key is the token's `id`.
+  private var metadataCache: [String: ERC721Metadata] = [:]
 
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -242,6 +248,10 @@ public class PortfolioStore: ObservableObject {
         self.priceHistoriesCache[key] = value
       }
       
+      // fetch ERC721 metadata for ERC721 tokens
+      let erc721Tokens = allTokens.filter { $0.isErc721 }
+      metadataCache = await rpcService.fetchERC721Metadata(tokens: erc721Tokens)
+      
       guard !Task.isCancelled else { return }
       updatedUserVisibleAssets.removeAll()
       updatedUserVisibleNFTs.removeAll()
@@ -252,7 +262,8 @@ public class PortfolioStore: ObservableObject {
               NFTAssetViewModel(
                 token: token,
                 network: networkAssets.network,
-                balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0)
+                balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0),
+                erc721Metadata: metadataCache[token.id]
               )
             )
           } else {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -111,7 +111,7 @@ public class PortfolioStore: ObservableObject {
   private var pricesCache: [String: String] = [:]
   /// Cache of priceHistories. The key is the token's `assetRatioId`.
   private var priceHistoriesCache: [String: [BraveWallet.AssetTimePrice]] = [:]
-  /// Cache of metadata for erc721 token. The key is the token's `id`.
+  /// Cache of metadata for erc721 token. The key is the token's `id` + token's `chainId`.
   private var metadataCache: [String: ERC721Metadata] = [:]
 
   private let keyringService: BraveWalletKeyringService
@@ -174,7 +174,8 @@ public class PortfolioStore: ObservableObject {
               NFTAssetViewModel(
                 token: token,
                 network: networkAssets.network,
-                balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0)
+                balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0),
+                erc721Metadata: metadataCache[token.id + token.chainId]
               )
             )
           } else {
@@ -263,7 +264,7 @@ public class PortfolioStore: ObservableObject {
                 token: token,
                 network: networkAssets.network,
                 balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0),
-                erc721Metadata: metadataCache[token.id]
+                erc721Metadata: metadataCache[token.id + token.chainId]
               )
             )
           } else {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -111,7 +111,7 @@ public class PortfolioStore: ObservableObject {
   private var pricesCache: [String: String] = [:]
   /// Cache of priceHistories. The key is the token's `assetRatioId`.
   private var priceHistoriesCache: [String: [BraveWallet.AssetTimePrice]] = [:]
-  /// Cache of metadata for erc721 token. The key is the token's `id` + token's `chainId`.
+  /// Cache of metadata for erc721 token. The key is the token's `id`.
   private var metadataCache: [String: ERC721Metadata] = [:]
 
   private let keyringService: BraveWalletKeyringService
@@ -175,7 +175,7 @@ public class PortfolioStore: ObservableObject {
                 token: token,
                 network: networkAssets.network,
                 balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0),
-                erc721Metadata: metadataCache[token.id + token.chainId]
+                erc721Metadata: metadataCache[token.id]
               )
             )
           } else {
@@ -264,7 +264,7 @@ public class PortfolioStore: ObservableObject {
                 token: token,
                 network: networkAssets.network,
                 balance: Int(totalBalancesCache[token.assetBalanceId] ?? 0),
-                erc721Metadata: metadataCache[token.id + token.chainId]
+                erc721Metadata: metadataCache[token.id]
               )
             )
           } else {

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -194,13 +194,12 @@ public class SendTokenStore: ObservableObject {
         decimalFormatStyle: .decimals(precision: Int(selectedSendToken.decimals))
       )
   
-      let metadataId = selectedSendToken.id + selectedSendToken.chainId
-      if selectedSendToken.isErc721, metadataCache[metadataId] == nil {
-        metadataCache[metadataId] = await rpcService.fetchERC721Metadata(for: selectedSendToken)
+      if selectedSendToken.isErc721, metadataCache[selectedSendToken.id] == nil {
+        metadataCache[selectedSendToken.id] = await rpcService.fetchERC721Metadata(for: selectedSendToken)
       }
       guard !Task.isCancelled else { return }
       self.selectedSendTokenBalance = balance
-      self.selectedSendTokenERC721Metadata = metadataCache[metadataId]
+      self.selectedSendTokenERC721Metadata = metadataCache[selectedSendToken.id]
       self.validateBalance()
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -419,7 +419,7 @@ public class SendTokenStore: ObservableObject {
     }
   }
   
-  @MainActor func fetchERC721Metada(tokens: [BraveWallet.BlockchainToken]) async -> [String: ERC721Metadata] {
+  @MainActor func fetchERC721Metadata(tokens: [BraveWallet.BlockchainToken]) async -> [String: ERC721Metadata] {
     return await rpcService.fetchERC721Metadata(tokens: tokens)
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -50,7 +50,7 @@ public class AssetStore: ObservableObject, Equatable {
     lhs.token == rhs.token && lhs.isVisible == rhs.isVisible
   }
   
-  @MainActor func fetchERC721Metada() async -> ERC721Metadata? {
+  @MainActor func fetchERC721Metadata() async -> ERC721Metadata? {
     return await rpcService.fetchERC721Metadata(for: token)
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -27,16 +27,19 @@ public class AssetStore: ObservableObject, Equatable {
   var network: BraveWallet.NetworkInfo
 
   private let walletService: BraveWalletBraveWalletService
+  private let rpcService: BraveWalletJsonRpcService
   private(set) var isCustomToken: Bool
 
   init(
     walletService: BraveWalletBraveWalletService,
+    rpcService: BraveWalletJsonRpcService,
     network: BraveWallet.NetworkInfo,
     token: BraveWallet.BlockchainToken,
     isCustomToken: Bool,
     isVisible: Bool
   ) {
     self.walletService = walletService
+    self.rpcService = rpcService
     self.network = network
     self.token = token
     self.isCustomToken = isCustomToken
@@ -45,6 +48,10 @@ public class AssetStore: ObservableObject, Equatable {
 
   public static func == (lhs: AssetStore, rhs: AssetStore) -> Bool {
     lhs.token == rhs.token && lhs.isVisible == rhs.isVisible
+  }
+  
+  @MainActor func fetchERC721Metada() async -> ERC721Metadata? {
+    return await rpcService.fetchERC721Metadata(for: token)
   }
 }
 
@@ -120,6 +127,7 @@ public class UserAssetsStore: ObservableObject {
           }
           return AssetStore(
             walletService: walletService,
+            rpcService: rpcService,
             network: assetsForNetwork.network,
             token: token,
             isCustomToken: isCustomToken,
@@ -208,6 +216,16 @@ public class UserAssetsStore: ObservableObject {
         )
       }
     }
+  }
+  
+  @MainActor func allERC721Metadata() async -> [String: ERC721Metadata] {
+    let allNetworks = await rpcService.allNetworksForSupportedCoins()
+    let allUserAssets = await walletService.allUserAssets(in: allNetworks)
+    // Filter `allTokens` to remove any tokens existing in `allUserAssets`. This is possible for ERC721 tokens in the registry without a `tokenId`, which requires the user to add as a custom token
+    let allUserTokens = allUserAssets.flatMap(\.tokens)
+    
+    // ERC721 metadata only exists for custom NFT added by users. ERC721 tokens from token registry do not have metadata
+    return await rpcService.fetchERC721Metadata(tokens: allUserTokens.filter { $0.isErc721 })
   }
 }
 

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -288,7 +288,8 @@ extension BraveWalletJsonRpcService {
           }
           if let data = metaData.data(using: .utf8),
              let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
-            return [token.id: result]
+            let newId = token.id + token.chainId
+            return [newId: result]
           }
           return [:]
         }
@@ -297,5 +298,18 @@ extension BraveWalletJsonRpcService {
       return await group.reduce([:], { $0.merging($1, uniquingKeysWith: { key, _ in key })
       })
     }
+  }
+  
+  /// Returns a nullable ERC721 metadata
+  @MainActor func fetchERC721Metadata(for token: BraveWallet.BlockchainToken) async -> ERC721Metadata? {
+    let (metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
+    if result != .success {
+      print(errMsg)
+    }
+    if let data = metaData.data(using: .utf8),
+       let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
+      return result
+    }
+    return nil
   }
 }

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -76,6 +76,9 @@ class AccountActivityStoreTests: XCTestCase {
       // spd token, sol nft balance
       completion(mockSplTokenBalances[tokenMintAddress] ?? "", UInt8(0), mockSplTokenBalances[tokenMintAddress] ?? "", .success, "")
     }
+    rpcService._erc721Metadata = { _, _, _, completion in
+      completion("", .internalError, "")
+    }
     
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -127,6 +127,8 @@ class AccountActivityStoreTests: XCTestCase {
     let mockNFTBalance: Double = 1
     let mockERC721BalanceWei = formatter.weiString(from: mockNFTBalance, radix: .hex, decimals: 0) ?? ""
     
+    let mockERC721Metadata: ERC721Metadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    
     let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy) = setupServices(
       mockEthBalanceWei: mockEthBalanceWei,
       mockERC20BalanceWei: mockERC20BalanceWei,
@@ -186,6 +188,9 @@ class AccountActivityStoreTests: XCTestCase {
         XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, BraveWallet.BlockchainToken.mockERC721NFTToken.symbol)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balance, Int(mockNFTBalance))
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.imageURLString, mockERC721Metadata.imageURLString)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.name, mockERC721Metadata.name)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.description, mockERC721Metadata.description)
       }.store(in: &cancellables)
     
     let transactionSummariesExpectation = expectation(description: "accountActivityStore-transactions")
@@ -293,65 +298,6 @@ class AccountActivityStoreTests: XCTestCase {
     
     accountActivityStore.update()
 
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
-  }
-  
-  func testFetchERC721Metadata() {
-    let account: BraveWallet.AccountInfo = .mockEthAccount
-    let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
-    let mockEthDecimalBalance: Double = 0.0896
-    let numEthDecimals = Int(BraveWallet.NetworkInfo.mockMainnet.nativeToken.decimals)
-    let mockEthBalanceWei = formatter.weiString(from: mockEthDecimalBalance, radix: .hex, decimals: numEthDecimals) ?? ""
-    let mockERC20DecimalBalance = 1.5
-    let mockERC20BalanceWei = formatter.weiString(from: mockERC20DecimalBalance, radix: .hex, decimals: Int(BraveWallet.BlockchainToken.mockUSDCToken.decimals)) ?? ""
-    let mockNFTBalance: Double = 1
-    let mockERC721BalanceWei = formatter.weiString(from: mockNFTBalance, radix: .hex, decimals: 0) ?? ""
-    
-    let mockERC721Metadata: ERC721Metadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
-    
-    let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy) = setupServices(
-      mockEthBalanceWei: mockEthBalanceWei,
-      mockERC20BalanceWei: mockERC20BalanceWei,
-      mockERC721BalanceWei: mockERC721BalanceWei,
-      selectedNetwork: .mockMainnet
-    )
-    
-    let accountActivityStore = AccountActivityStore(
-      account: account,
-      observeAccountUpdates: false,
-      keyringService: keyringService,
-      walletService: walletService,
-      rpcService: rpcService,
-      assetRatioService: assetRatioService,
-      txService: txService,
-      blockchainRegistry: blockchainRegistry,
-      solTxManagerProxy: solTxManagerProxy
-    )
-    
-    let userVisibleNFTsMetadataException = expectation(description: "accountActivityStore-userVisibleNFTsMetadata")
-    XCTAssertTrue(accountActivityStore.userVisibleNFTs.isEmpty)  // Initial state
-    accountActivityStore.$userVisibleNFTs
-      .dropFirst()
-      .collect(2)
-      .sink { userVisibleNFTs in
-        defer { userVisibleNFTsMetadataException.fulfill() }
-        XCTAssertEqual(userVisibleNFTs.count, 2) // empty nfts, populated nfts
-        guard let lastUpdatedVisibleNFTs = userVisibleNFTs.last else {
-          XCTFail("Unexpected test result")
-          return
-        }
-        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, BraveWallet.BlockchainToken.mockERC721NFTToken.symbol)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balance, Int(mockNFTBalance))
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.imageURLString, mockERC721Metadata.imageURLString)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.name, mockERC721Metadata.name)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.description, mockERC721Metadata.description)
-      }.store(in: &cancellables)
-    
-    accountActivityStore.update()
-    
     waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -50,6 +50,8 @@ class PortfolioStoreTests: XCTestCase {
     let totalBalanceValue = totalEthBalanceValue + totalSolBalanceValue
     let totalBalance = currencyFormatter.string(from: NSNumber(value: totalBalanceValue)) ?? ""
     
+    let mockERC721Metadata: ERC721Metadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    
     // setup test services
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = { keyringId, completion in
@@ -105,7 +107,14 @@ class PortfolioStoreTests: XCTestCase {
       completion("\(mockNFTBalance)", UInt8(0), "\(mockNFTBalance)", .success, "") // sol nft balance
     }
     rpcService._erc721Metadata = { _, _, _, completion in
-      completion("", .internalError, "")
+      completion(
+      """
+      {
+        "image": "mock.image.url",
+        "name": "mock nft name",
+        "description": "mock nft description"
+      }
+      """, .success, "")
     }
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._userAssets = { _, coin, completion in
@@ -186,6 +195,9 @@ class PortfolioStoreTests: XCTestCase {
         
         XCTAssertEqual(lastUpdatedVisibleNFTs[1].token.symbol, mockEthUserAssets.last?.symbol)
         XCTAssertEqual(lastUpdatedVisibleNFTs[1].balance, Int(mockNFTBalanceWei))
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.erc721Metadata?.imageURLString, mockERC721Metadata.imageURLString)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.erc721Metadata?.name, mockERC721Metadata.name)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.erc721Metadata?.description, mockERC721Metadata.description)
       }.store(in: &cancellables)
     // test that `update()` will assign new value to `balance` publisher
     let balanceException = expectation(description: "update-balance")

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -104,6 +104,9 @@ class PortfolioStoreTests: XCTestCase {
     rpcService._splTokenAccountBalance = {_, _, _, completion in
       completion("\(mockNFTBalance)", UInt8(0), "\(mockNFTBalance)", .success, "") // sol nft balance
     }
+    rpcService._erc721Metadata = { _, _, _, completion in
+      completion("", .internalError, "")
+    }
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._userAssets = { _, coin, completion in
       switch coin {

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -38,6 +38,9 @@ class SendTokenStoreTests: XCTestCase {
     rpcService._splTokenAccountBalance = {_, _, _, completion in
       completion(splTokenBalance, UInt8(6), "", .success, "")
     }
+    rpcService._erc721Metadata = { _, _, _, completion in
+      completion("", .internalError, "")
+    }
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._selectedCoin = { $0(selectedCoin) }
     walletService._userAssets = { $2(userAssets) }
@@ -320,6 +323,9 @@ class SendTokenStoreTests: XCTestCase {
       completion(mockBalanceWei, .success, "")
     }
     rpcService._addObserver = { _ in }
+    rpcService._erc721Metadata = { _, _, _, completion in
+      completion("", .internalError, "")
+    }
 
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._userAssets = { $2([.previewToken]) }

--- a/Tests/BraveWalletTests/UserAssetsStoreTests.swift
+++ b/Tests/BraveWalletTests/UserAssetsStoreTests.swift
@@ -35,6 +35,9 @@ class UserAssetsStoreTests: XCTestCase {
     rpcService._allNetworks = { coin, completion in
       completion(self.networks[coin] ?? [])
     }
+    rpcService._erc721Metadata = { _, _, _, completion in
+      completion("", .internalError, "")
+    }
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._userAssets = { chainId, coin, completion in
       completion(self.visibleAssetsForCoins[coin] ?? [])


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Support NFT images through out the wallet

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6501

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Add some NFTs
Verify the images are being displayed in portfolio, asset search, edit visible asset, account activities and send token list in send. 
If NFT metadata didnt load successfully or no image information, a basic monogram logo will be displayed. (monogram logo is also a placeholder while image is loading)

## Screenshots:


https://user-images.githubusercontent.com/1187676/205160871-4559e030-d9bd-4b3e-8468-4b97378e734e.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
