### PR TITLE
Fix #6509: Buy / Send / Swap doesn't respect prefilled token network

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -199,11 +199,9 @@ struct AssetDetailHeaderView: View {
               .foregroundColor(Color(.secondaryBraveLabel))
           }
           .redacted(reason: assetDetailStore.isInitialState ? .placeholder : [])
-          .shimmer(assetDetailStore.isLoadingPrice)
           let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
           LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
             Color(.walletGreen)
-              .shimmer(assetDetailStore.isLoadingChart)
           }
           .chartAccessibility(
             title: String.localizedStringWithFormat(

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -199,9 +199,11 @@ struct AssetDetailHeaderView: View {
               .foregroundColor(Color(.secondaryBraveLabel))
           }
           .redacted(reason: assetDetailStore.isInitialState ? .placeholder : [])
+          .shimmer(assetDetailStore.isLoadingPrice)
           let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
           LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
             Color(.walletGreen)
+              .shimmer(assetDetailStore.isLoadingChart)
           }
           .chartAccessibility(
             title: String.localizedStringWithFormat(

--- a/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
@@ -31,6 +31,7 @@ public class BuyTokenStore: ObservableObject {
   private let assetRatioService: BraveWalletAssetRatioService
   private var selectedNetwork: BraveWallet.NetworkInfo = .init()
   private(set) var orderedSupportedBuyOptions: OrderedSet<BraveWallet.OnRampProvider> = []
+  private var prefilledToken: BraveWallet.BlockchainToken?
   
   /// A map between chain id and gas token's symbol
   static let gasTokens: [String: [String]] = [
@@ -57,9 +58,7 @@ public class BuyTokenStore: ObservableObject {
     self.rpcService = rpcService
     self.walletService = walletService
     self.assetRatioService = assetRatioService
-    if let prefilledToken = prefilledToken {
-      validatePrefilledToken(prefilledToken)
-    }
+    self.prefilledToken = prefilledToken
     
     self.rpcService.add(self)
     
@@ -68,26 +67,27 @@ public class BuyTokenStore: ObservableObject {
     }
   }
   
-  func validatePrefilledToken(_ prefilledToken: BraveWallet.BlockchainToken) {
-    Task { @MainActor in
-      let selectedCoin = await walletService.selectedCoin()
-      let selectedNetwork = await rpcService.network(selectedCoin)
-      if prefilledToken.coin == selectedCoin && prefilledToken.chainId == selectedNetwork.chainId {
-        // valid for current network
+  @MainActor private func validatePrefilledToken(on network: BraveWallet.NetworkInfo) async {
+    guard let prefilledToken = self.prefilledToken else {
+      return
+    }
+    if prefilledToken.coin == network.coin && prefilledToken.chainId == network.chainId {
+      // valid for current network
+      self.selectedBuyToken = prefilledToken
+    } else {
+      // need to try and select correct network.
+      let allNetworksForTokenCoin = await rpcService.allNetworks(prefilledToken.coin)
+      guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
+        // don't set prefilled token if it belongs to a network we don't know
+        return
+      }
+      let success = await rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin)
+      if success {
+        self.selectedNetwork = networkForToken
         self.selectedBuyToken = prefilledToken
-      } else {
-        // need to try and select correct network.
-        let allNetworksForTokenCoin = await rpcService.allNetworks(prefilledToken.coin)
-        guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
-          // don't set prefilled token if it belongs to a network we don't know
-          return
-        }
-        let success = await rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin)
-        if success {
-          self.selectedBuyToken = prefilledToken
-        }
       }
     }
+    self.prefilledToken = nil
   }
 
   func fetchBuyUrl(
@@ -176,6 +176,7 @@ public class BuyTokenStore: ObservableObject {
     
     let coin = await walletService.selectedCoin()
     selectedNetwork = await rpcService.network(coin)
+    await validatePrefilledToken(on: selectedNetwork) // selectedNetwork may change
     await fetchBuyTokens(network: selectedNetwork)
   
     // exclude all buy options that its available buy tokens list does not include the

--- a/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
@@ -57,12 +57,36 @@ public class BuyTokenStore: ObservableObject {
     self.rpcService = rpcService
     self.walletService = walletService
     self.assetRatioService = assetRatioService
-    self.selectedBuyToken = prefilledToken
+    if let prefilledToken = prefilledToken {
+      validatePrefilledToken(prefilledToken)
+    }
     
     self.rpcService.add(self)
     
     Task {
       await updateInfo()
+    }
+  }
+  
+  func validatePrefilledToken(_ prefilledToken: BraveWallet.BlockchainToken) {
+    Task { @MainActor in
+      let selectedCoin = await walletService.selectedCoin()
+      let selectedNetwork = await rpcService.network(selectedCoin)
+      if prefilledToken.coin == selectedCoin && prefilledToken.chainId == selectedNetwork.chainId {
+        // valid for current network
+        self.selectedBuyToken = prefilledToken
+      } else {
+        // need to try and select correct network.
+        let allNetworksForTokenCoin = await rpcService.allNetworks(prefilledToken.coin)
+        guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
+          // don't set prefilled token if it belongs to a network we don't know
+          return
+        }
+        let success = await rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin)
+        if success {
+          self.selectedBuyToken = prefilledToken
+        }
+      }
     }
   }
 

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -99,6 +99,7 @@ public class SendTokenStore: ObservableObject {
   private var allTokens: [BraveWallet.BlockchainToken] = []
   private var sendAddressUpdatedTimer: Timer?
   private var sendAmountUpdatedTimer: Timer?
+  private var prefilledToken: BraveWallet.BlockchainToken?
 
   public init(
     keyringService: BraveWalletKeyringService,
@@ -117,9 +118,7 @@ public class SendTokenStore: ObservableObject {
     self.blockchainRegistry = blockchainRegistry
     self.ethTxManagerProxy = ethTxManagerProxy
     self.solTxManagerProxy = solTxManagerProxy
-    if let prefilledToken = prefilledToken {
-      validatePrefilledToken(prefilledToken)
-    }
+    self.prefilledToken = prefilledToken
 
     self.keyringService.add(self)
     self.rpcService.add(self)
@@ -135,26 +134,26 @@ public class SendTokenStore: ObservableObject {
     sendAmount = ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
   }
   
-  func validatePrefilledToken(_ prefilledToken: BraveWallet.BlockchainToken) {
-    Task { @MainActor in
-      let selectedCoin = await walletService.selectedCoin()
-      let selectedNetwork = await rpcService.network(selectedCoin)
-      if prefilledToken.coin == selectedCoin && prefilledToken.chainId == selectedNetwork.chainId {
-        // valid for current network
+  @MainActor private func validatePrefilledToken(on network: inout BraveWallet.NetworkInfo) async {
+    guard let prefilledToken = self.prefilledToken else {
+      return
+    }
+    if prefilledToken.coin == network.coin && prefilledToken.chainId == network.chainId {
+      // valid for current network
+      self.selectedSendToken = prefilledToken
+    } else {
+      // need to try and select correct network.
+      let allNetworksForTokenCoin = await rpcService.allNetworks(prefilledToken.coin)
+      guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
+        // don't set prefilled token if it belongs to a network we don't know
+        return
+      }
+      let success = await rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin)
+      if success {
         self.selectedSendToken = prefilledToken
-      } else {
-        // need to try and select correct network.
-        let allNetworksForTokenCoin = await rpcService.allNetworks(prefilledToken.coin)
-        guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
-          // don't set prefilled token if it belongs to a network we don't know
-          return
-        }
-        let success = await rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin)
-        if success {
-          self.selectedSendToken = prefilledToken
-        }
       }
     }
+    self.prefilledToken = nil
   }
 
   /// Cancellable for the last running `update()` Task.
@@ -165,8 +164,10 @@ public class SendTokenStore: ObservableObject {
     self.updateTask = Task { @MainActor in
       self.isLoading = true
       defer { self.isLoading = false }
-      let coin = await self.walletService.selectedCoin()
-      let network = await self.rpcService.network(coin)
+      var coin = await self.walletService.selectedCoin()
+      var network = await self.rpcService.network(coin)
+      await validatePrefilledToken(on: &network) // network may change
+      coin = network.coin // in case network changed
       // fetch user assets
       let userAssets = await self.walletService.userAssets(network.chainId, coin: network.coin)
       let allTokens = await self.blockchainRegistry.allTokens(network.chainId, coin: network.coin)

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -121,6 +121,7 @@ public class SwapTokenStore: ObservableObject {
   private var timer: Timer?
   private let batSymbol = "BAT"
   private let daiSymbol = "DAI"
+  private var prefilledToken: BraveWallet.BlockchainToken?
 
   enum SwapParamsBase {
     // calculating based on sell asset amount
@@ -159,34 +160,10 @@ public class SwapTokenStore: ObservableObject {
     self.txService = txService
     self.walletService = walletService
     self.ethTxManagerProxy = ethTxManagerProxy
-    if let prefilledToken = prefilledToken {
-      validatePrefilledToken(prefilledToken)
-    }
+    self.prefilledToken = prefilledToken
 
     self.keyringService.add(self)
     self.rpcService.add(self)
-  }
-  
-  func validatePrefilledToken(_ prefilledToken: BraveWallet.BlockchainToken) {
-    Task { @MainActor in
-      let selectedCoin = await walletService.selectedCoin()
-      let selectedNetwork = await rpcService.network(selectedCoin)
-      if prefilledToken.coin == selectedCoin && prefilledToken.chainId == selectedNetwork.chainId {
-        // valid for current network
-        self.selectedFromToken = prefilledToken
-      } else {
-        // need to try and select correct network.
-        let allNetworksForTokenCoin = await rpcService.allNetworks(prefilledToken.coin)
-        guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
-          // don't set prefilled token if it belongs to a network we don't know
-          return
-        }
-        let success = await rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin)
-        if success {
-          self.selectedFromToken = prefilledToken
-        }
-      }
-    }
   }
 
   private func fetchTokenBalance(
@@ -680,29 +657,60 @@ public class SwapTokenStore: ObservableObject {
     walletService.selectedCoin { [weak self] coinType in
       guard let self = self else { return }
       self.rpcService.network(coinType) { network in
-        self.blockchainRegistry.allTokens(network.chainId, coin: network.coin) { tokens in
-          // Native token on the current selected network
-          let nativeAsset = network.nativeToken
-          // Custom tokens added by users
-          self.walletService.userAssets(network.chainId, coin: network.coin) { userAssets in
-            let customTokens = userAssets.filter { asset in
-              !tokens.contains(where: { $0.contractAddress(in: network).caseInsensitiveCompare(asset.contractAddress) == .orderedSame })
+        // Closure run after validating the prefilledToken (if applicable)
+        let continueClosure: (BraveWallet.NetworkInfo) -> Void = { [weak self] network in
+          guard let self = self else { return }
+          self.blockchainRegistry.allTokens(network.chainId, coin: network.coin) { tokens in
+            // Native token on the current selected network
+            let nativeAsset = network.nativeToken
+            // Custom tokens added by users
+            self.walletService.userAssets(network.chainId, coin: network.coin) { userAssets in
+              let customTokens = userAssets.filter { asset in
+                !tokens.contains(where: { $0.contractAddress(in: network).caseInsensitiveCompare(asset.contractAddress) == .orderedSame })
+              }
+              let sortedCustomTokens = customTokens.sorted {
+                if $0.contractAddress(in: network).caseInsensitiveCompare(nativeAsset.contractAddress) == .orderedSame {
+                  return true
+                } else {
+                  return $0.symbol < $1.symbol
+                }
+              }
+              self.allTokens = sortedCustomTokens + tokens.sorted(by: { $0.symbol < $1.symbol })
+              // Seems like user assets always include the selected network's native asset
+              // But let's make sure all token list includes the native asset
+              if !self.allTokens.contains(where: { $0.symbol.lowercased() == nativeAsset.symbol.lowercased() }) {
+                self.allTokens.insert(nativeAsset, at: 0)
+              }
+              updateSelectedTokens(in: network)
             }
-            let sortedCustomTokens = customTokens.sorted {
-              if $0.contractAddress(in: network).caseInsensitiveCompare(nativeAsset.contractAddress) == .orderedSame {
-                return true
-              } else {
-                return $0.symbol < $1.symbol
+          }
+        }
+        
+        // validate the `prefilledToken`
+        if let prefilledToken = self.prefilledToken {
+          if prefilledToken.coin == network.coin && prefilledToken.chainId == network.chainId {
+            self.selectedFromToken = prefilledToken
+            continueClosure(network)
+          } else {
+            self.rpcService.allNetworks(prefilledToken.coin) { allNetworksForTokenCoin in
+              guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
+                // don't set prefilled token if it belongs to a network we don't know
+                continueClosure(network)
+                return
+              }
+              self.rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin) { success in
+                if success {
+                  self.selectedFromToken = prefilledToken
+                  continueClosure(networkForToken) // network changed
+                } else {
+                  continueClosure(network)
+                }
               }
             }
-            self.allTokens = sortedCustomTokens + tokens.sorted(by: { $0.symbol < $1.symbol })
-            // Seems like user assets always include the selected network's native asset
-            // But let's make sure all token list includes the native asset
-            if !self.allTokens.contains(where: { $0.symbol.lowercased() == nativeAsset.symbol.lowercased() }) {
-              self.allTokens.insert(nativeAsset, at: 0)
-            }
-            updateSelectedTokens(in: network)
           }
+          self.prefilledToken = nil
+        } else { // `prefilledToken` is nil
+          continueClosure(network)
         }
       }
     }

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -21,7 +21,7 @@ extension BraveWallet.BlockchainToken {
     visible: false,
     tokenId: "",
     coingeckoId: "",
-    chainId: "",
+    chainId: BraveWallet.MainnetChainId,
     coin: .eth
   )
   


### PR DESCRIPTION
## Summary of Changes
- When `BuyTokenStore`, `SendTokenStore`, or `SwapTokenStore` are opened with a `prefilledToken` that does not belong to the currently selected network, we switch to that network before assigning it as the selected token.

This pull request fixes #6509

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Make sure to have visible asset for multiple different networks in Portfolio.
2. Open asset detail view for any asset and tap buy/send/swap
3. Verify correct network is displayed
4. Switch network to a different network and dismiss buy/send/swap
5. Tap buy/send/swap
6. Verify correctly switches back to the token's network. 
7. Repeat from step 1 for each buy/send/swap button available for that token to verify the network switches correctly for buy, send and swap.
8. Start from step 2, but open asset detail view for a token on a different network that originally tested

## Screenshots:

https://user-images.githubusercontent.com/5314553/205174684-de4e9c88-93b8-4f4d-aed6-6e165c68201f.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
