### PR TITLE
No Bug: Fix evaluateSafeJavascript may not be called on main thread

### DIFF
--- a/Sources/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Sources/Shared/Extensions/WKWebViewExtensions.swift
@@ -99,13 +99,15 @@ public extension WKWebView {
     asFunction: Bool = true
   ) async -> (Any?, Error?) {
     await withCheckedContinuation { continuation in
-      evaluateSafeJavaScript(
-        functionName: functionName,
-        args: args,
-        contentWorld: contentWorld,
-        escapeArgs: escapeArgs,
-        asFunction: asFunction) { value, error in
-          continuation.resume(returning: (value, error))
+      DispatchQueue.main.async {
+        self.evaluateSafeJavaScript(
+          functionName: functionName,
+          args: args,
+          contentWorld: contentWorld,
+          escapeArgs: escapeArgs,
+          asFunction: asFunction) { value, error in
+            continuation.resume(returning: (value, error))
+        }
       }
     }
   }

--- a/Sources/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Sources/Shared/Extensions/WKWebViewExtensions.swift
@@ -69,23 +69,25 @@ public extension WKWebView {
       javascript = js.javascript
     }
 
-    if #available(iOS 14.3, *) {
-      // swiftlint:disable:next safe_javascript
-      evaluateJavaScript(javascript, in: frame, in: contentWorld) { result in
-        switch result {
-        case .success(let value):
-          completion?(value, nil)
-        case .failure(let error):
-          completion?(nil, error)
+    DispatchQueue.main.async {
+      if #available(iOS 14.3, *) {
+        // swiftlint:disable:next safe_javascript
+        self.evaluateJavaScript(javascript, in: frame, in: contentWorld) { result in
+          switch result {
+          case .success(let value):
+            completion?(value, nil)
+          case .failure(let error):
+            completion?(nil, error)
+          }
         }
-      }
-    } else {
-      // swiftlint:disable:next safe_javascript
-      evaluateJavaScript(javascript) { result, error in
-        if let error = error {
-          completion?(nil, error)
-        } else {
-          completion?(result, error)
+      } else {
+        // swiftlint:disable:next safe_javascript
+        self.evaluateJavaScript(javascript) { result, error in
+          if let error = error {
+            completion?(nil, error)
+          } else {
+            completion?(result, error)
+          }
         }
       }
     }
@@ -99,15 +101,13 @@ public extension WKWebView {
     asFunction: Bool = true
   ) async -> (Any?, Error?) {
     await withCheckedContinuation { continuation in
-      DispatchQueue.main.async {
-        self.evaluateSafeJavaScript(
-          functionName: functionName,
-          args: args,
-          contentWorld: contentWorld,
-          escapeArgs: escapeArgs,
-          asFunction: asFunction) { value, error in
-            continuation.resume(returning: (value, error))
-        }
+      evaluateSafeJavaScript(
+        functionName: functionName,
+        args: args,
+        contentWorld: contentWorld,
+        escapeArgs: escapeArgs,
+        asFunction: asFunction) { value, error in
+          continuation.resume(returning: (value, error))
       }
     }
   }


### PR DESCRIPTION
## Summary of Changes
- Update async wrapper for `evaluateSafeJavaScript` to call within `DispatchQueue.main.async` to guarantee main thread on iOS 14

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Launch app on iOS 14.4 (maybe other iOS 14 versions). 
    - `updateSolanaProperties()` function calls `evaluateSafeJavascript` async wrapper causing main thread checker issue.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
