### PR TITLE
No Bug: Add ability to inspect Chromium Local State file from settings

### DIFF
--- a/Client/Frontend/Settings/LocalStateInspectorView.swift
+++ b/Client/Frontend/Settings/LocalStateInspectorView.swift
@@ -1,0 +1,51 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SwiftUI
+
+/// Displays the contents of the Chromium `Local State` file
+struct LocalStateInspectorView: View {
+  @State private var localState: String = ""
+  var body: some View {
+    TextEditor(text: .constant(localState))
+      .navigationTitle("Local State")
+      .font(.system(.footnote, design: .monospaced))
+      .onAppear {
+        loadLocalState()
+      }
+      .toolbar {
+        ToolbarItemGroup(placement: .navigationBarTrailing) {
+          Button {
+            loadLocalState()
+          } label: {
+            Label("Refresh", braveSystemImage: "brave.refresh")
+              .imageScale(.medium)
+          }
+        }
+      }
+  }
+  
+  private func loadLocalState() {
+    do {
+      let jsonContents = try Data(
+        contentsOf: FileManager.default.url(
+          for: .applicationSupportDirectory,
+          in: .userDomainMask,
+          appropriateFor: nil,
+          create: true
+        ).appendingPathComponent("Chromium/Local State")
+      )
+      let jsonObject = try JSONSerialization.jsonObject(with: jsonContents)
+      let prettyPrintedData = try JSONSerialization.data(
+        withJSONObject: jsonObject,
+        options: [.prettyPrinted]
+      )
+      localState = String(data: prettyPrintedData, encoding: .utf8) ?? ""
+    } catch {
+      localState = "Failed to load Local State"
+    }
+  }
+}

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -671,6 +671,13 @@ class SettingsViewController: TableViewController {
             self.displayBraveSearchDebugMenu()
           }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
         Row(
+          text: "View Chromium Local State",
+          selection: { [unowned self] in
+            let controller = UIHostingController(rootView: LocalStateInspectorView())
+            self.navigationController?.pushViewController(controller, animated: true)
+          }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self
+        ),
+        Row(
           text: "View Brave Histogram (p3a) Logs",
           selection: { [unowned self] in
             let histogramsController = self.p3aUtilities.histogramsController().then {


### PR DESCRIPTION
## Summary of Changes

This will help re-test #6545, #6546 and #6547

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
