### PR TITLE
Fix #6550: Add custom token may not dismiss iOS 14

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -90,17 +90,6 @@ struct EditUserAssetsView: View {
       .font(.footnote.weight(.medium))
       .foregroundColor(Color(.braveBlurpleTint))
     }
-    .sheet(isPresented: $isPresentingNetworkFilter) {
-      NavigationView {
-        NetworkFilterView(
-          networkFilter: $userAssetsStore.networkFilter,
-          networkStore: networkStore
-        )
-      }
-      .onDisappear {
-        networkStore.closeNetworkSelectionStore()
-      }
-    }
   }
   
   private var addCustomAssetButton: some View {
@@ -108,17 +97,6 @@ struct EditUserAssetsView: View {
       isAddingCustomAsset = true
     }) {
       Image(systemName: "plus")
-    }
-    .sheet(isPresented: $isAddingCustomAsset) {
-      AddCustomAssetView(
-        networkStore: networkStore,
-        networkSelectionStore: networkStore.openNetworkSelectionStore(mode: .formSelection),
-        keyringStore: keyringStore,
-        userAssetStore: userAssetsStore
-      )
-      .onDisappear {
-        networkStore.closeNetworkSelectionStore()
-      }
     }
   }
 
@@ -187,7 +165,11 @@ struct EditUserAssetsView: View {
       .animation(.default, value: tokenStores)
       .navigationTitle(Strings.Wallet.editVisibleAssetsButtonTitle)
       .navigationBarTitleDisplayMode(.inline)
+      .navigationViewStyle(StackNavigationViewStyle())
       .filterable(text: $query)
+      .onAppear {
+        userAssetsStore.update()
+      }
       .toolbar {
         ToolbarItemGroup(placement: .bottomBar) {
           networkFilterButton
@@ -203,36 +185,54 @@ struct EditUserAssetsView: View {
               .foregroundColor(Color(.braveBlurpleTint))
           }
         }
+      } // List
+    } // NavigationView
+    .background(Color.clear.sheet(
+      isPresented: Binding(
+        get: { tokenNeedsTokenId != nil },
+        set: { if !$0 { tokenNeedsTokenId = nil } }
+      )
+    ) {
+      AddCustomAssetView(
+        networkStore: networkStore,
+        networkSelectionStore: networkStore.openNetworkSelectionStore(mode: .formSelection),
+        keyringStore: keyringStore,
+        userAssetStore: userAssetsStore,
+        tokenNeedsTokenId: tokenNeedsTokenId
+      )
+      .onDisappear {
+        networkStore.closeNetworkSelectionStore()
       }
-      .sheet(
-        isPresented: Binding(
-          get: { tokenNeedsTokenId != nil },
-          set: { if !$0 { tokenNeedsTokenId = nil } }
-        )
-      ) {
-        AddCustomAssetView(
-          networkStore: networkStore,
-          networkSelectionStore: networkStore.openNetworkSelectionStore(mode: .formSelection),
-          keyringStore: keyringStore,
-          userAssetStore: userAssetsStore,
-          tokenNeedsTokenId: tokenNeedsTokenId
-        )
-        .onDisappear {
-          networkStore.closeNetworkSelectionStore()
-        }
-      }
-      .alert(isPresented: $isPresentingAssetRemovalError) {
-        Alert(
-          title: Text(Strings.Wallet.removeCustomTokenErrorTitle),
-          message: Text(Strings.Wallet.removeCustomTokenErrorMessage),
-          dismissButton: .default(Text(Strings.OKString))
+    })
+    .background(Color.clear.alert(isPresented: $isPresentingAssetRemovalError) {
+      Alert(
+        title: Text(Strings.Wallet.removeCustomTokenErrorTitle),
+        message: Text(Strings.Wallet.removeCustomTokenErrorMessage),
+        dismissButton: .default(Text(Strings.OKString))
+      )
+    })
+    .background(Color.clear.sheet(isPresented: $isPresentingNetworkFilter) {
+      NavigationView {
+        NetworkFilterView(
+          networkFilter: $userAssetsStore.networkFilter,
+          networkStore: networkStore
         )
       }
-    }
-    .navigationViewStyle(StackNavigationViewStyle())
-    .onAppear {
-      userAssetsStore.update()
-    }
+      .onDisappear {
+        networkStore.closeNetworkSelectionStore()
+      }
+    })
+    .background(Color.clear.sheet(isPresented: $isAddingCustomAsset) {
+      AddCustomAssetView(
+        networkStore: networkStore,
+        networkSelectionStore: networkStore.openNetworkSelectionStore(mode: .formSelection),
+        keyringStore: keyringStore,
+        userAssetStore: userAssetsStore
+      )
+      .onDisappear {
+        networkStore.closeNetworkSelectionStore()
+      }
+    })
   }
 
   private func removeCustomToken(_ token: BraveWallet.BlockchainToken) {


### PR DESCRIPTION
## Summary of Changes
- Debugged iOS 14 issue getting error alert when adding custom token to the `AddCustomAssetView` failing to dismiss after successfully adding a token, and second tap of 'Add' button causes error because the token was already added successfully.
- Re-ordering the sheet modifiers seems to resolve for iOS 14

This pull request fixes #6550

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Repeat on iOS 14 and on iOS 15 or 16
1. Unlock wallet and tap 'Edit User Assets'
2. Verify network filter button opens & selecting a network dismisses modal
3. Tap `+` in bottom toolbar to add custom asset
4. Enter asset details and tap 'Add'
5. Verify add custom asset view dismisses correctly
6. Verify Network Filter button still presents filter modal

## Screenshots:

https://user-images.githubusercontent.com/5314553/205754897-16e0c9b2-9b90-4db2-b86e-4d84b1175bae.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
