### PR TITLE
Fix #6553: some copy updates and new disclaimer in NFT detail screen

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -35,6 +35,12 @@ struct NFTDetailView: View {
       noImageView
     }
   }
+  
+  private var isSVGImage: Bool {
+    guard let erc721Metadata = nftDetailStore.erc721Metadata, let imageUrlString = erc721Metadata.imageURLString else { return false }
+    return imageUrlString.hasPrefix("data:image/svg") || imageUrlString.hasSuffix(".svg")
+  }
+  
   var body: some View {
     ScrollView(.vertical) {
       VStack(alignment: .leading, spacing: 24) {
@@ -115,6 +121,13 @@ struct NFTDetailView: View {
           }
           .foregroundColor(Color(.braveLabel))
         }
+        if isSVGImage {
+          Text(Strings.Wallet.nftDetailSVGImageDisclaimer)
+            .multilineTextAlignment(.center)
+            .font(.footnote)
+            .foregroundColor(Color(.secondaryBraveLabel))
+            .frame(maxWidth: .infinity)
+        }
       }
       .padding()
     }
@@ -125,5 +138,11 @@ struct NFTDetailView: View {
     }
     .background(Color(UIColor.braveGroupedBackground).ignoresSafeArea())
     .navigationBarTitle(Strings.Wallet.nftDetailTitle)
+  }
+}
+
+private extension String {
+  var isSVGImage: Bool {
+    hasPrefix("data:image/svg") || hasSuffix(".svg")
   }
 }

--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -140,9 +140,3 @@ struct NFTDetailView: View {
     .navigationBarTitle(Strings.Wallet.nftDetailTitle)
   }
 }
-
-private extension String {
-  var isSVGImage: Bool {
-    hasPrefix("data:image/svg") || hasSuffix(".svg")
-  }
-}

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3400,7 +3400,7 @@ extension Strings {
       "wallet.nftDetailSendNFTButtonTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Send NFT",
+      value: "Send",
       comment: "The title of the button inside NFT detail screen, which user can click to start sending this NFT."
     )
     public static let nftDetailImageNotAvailable = NSLocalizedString(
@@ -3409,6 +3409,13 @@ extension Strings {
       bundle: .module,
       value: "Image is not available",
       comment: "A placeholder text, indicates this NFT image was not able to be loaded."
+    )
+    public static let nftDetailSVGImageDisclaimer = NSLocalizedString(
+      "wallet.nftDetailSVGImageDisclaimer",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "The image rendered above may not exactly match the NFT",
+      comment: "A disclaimer that appears at the bottom of a NFT detail screen which shows NFT image and other information."
     )
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
copy updates and a new disclaimer displaying at the bottom of NFT Detail screen when NFT image is in svg format.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6553

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. try to add a NFT (erc721) that has image information inside its metadata and the image is in svg format
2. after added it, go to this NFT details 
3. observe there will be a disclaimer displayed at the bottom of the detail screen.

------------------------------------------------------------------------------------

1. go to any NFT detail (erc721)
2. observe that the title of the button is now `Send` instead of `Send NFT`

## Screenshots:
![simulator_screenshot_2BB11718-0D67-41B1-B376-AB662C0CB9A7](https://user-images.githubusercontent.com/1187676/205758254-eb6b0cc4-2a14-49f8-a689-e20ad013d37e.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
