### PR TITLE
No Bug: Add locale picker to Brave News debug settings

### DIFF
--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -63,7 +63,7 @@ public class FeedDataSource: ObservableObject {
       reloadChannels()
     }
   }
-  private var availableLocales: Set<String> = []
+  private(set) var availableLocales: Set<String> = []
   private var localesWithFollowing: Set<String> = []
   @Published private var allChannels: [String: Set<String>] = [:]
   var channels: Set<String> {
@@ -175,6 +175,7 @@ public class FeedDataSource: ObservableObject {
     "ja_JP",
     "es_ES",
     "es_MX",
+    "pt_BR",
   ]
 
   private struct NewsBucket {

--- a/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -42,9 +42,11 @@ public struct BraveNewsDebugSettingsView: View {
     self.dismissAction = dismissAction
     // These values should always be overridden
     self._environment = .init(wrappedValue: dataSource.environment)
+    self._localeOverride = .init(wrappedValue: dataSource.selectedLocale)
   }
   
   @State private var environment: FeedDataSource.Environment = .production
+  @State private var localeOverride: String = "en_US"
   
   public var body: some View {
     List {
@@ -54,8 +56,13 @@ public struct BraveNewsDebugSettingsView: View {
             Text(env.name)
           }
         }
+        Picker("Selected Locale", selection: $localeOverride) {
+          ForEach(Array(feedDataSource.availableLocales).sorted(), id: \.self) { locale in
+            Text(locale).tag(locale)
+          }
+        }
       } footer: {
-        Text("Changing the environment or language will purge all cached resources immediately.")
+        Text("Changing the environment will purge all cached resources immediately.")
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
       Section {
@@ -110,6 +117,10 @@ public struct BraveNewsDebugSettingsView: View {
     }
     .onChange(of: environment) { _ in
       feedDataSource.environment = environment
+    }
+    .onChange(of: localeOverride) { locale in
+      Preferences.BraveNews.selectedLocale.value = locale
+      feedDataSource.selectedLocale = locale
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes

This adds a locale picker to the News debug settings allowing you to change the selected locale to one that is available in `sources.global.json`

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-06 at 10 17 33](https://user-images.githubusercontent.com/529104/205951053-3175e4bf-05a8-41d4-a57f-9853fa0dcb57.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
