### PR TITLE
Fix #6537: Bump BraveCore to 1.46.137

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -68,7 +68,7 @@ class CollapsedURLBarView: UIView {
   var currentURL: URL? {
     didSet {
       urlLabel.text = currentURL.map {
-        URLFormatter.formatURL(forDisplayOmitSchemePathAndTrivialSubdomains: $0.absoluteString)
+        URLFormatter.formatURLOrigin(forDisplayOmitSchemePathAndTrivialSubdomains: $0.absoluteString)
       }
     }
   }

--- a/Tests/ClientTests/SearchTests.swift
+++ b/Tests/ClientTests/SearchTests.swift
@@ -123,9 +123,9 @@ class SearchTests: XCTestCase {
     checkValidURL("http://ebаy.com/", afterFixup: "http://xn--eby-7cd.com/")
     checkValidURL("https://biṇaṇce.com", afterFixup: "https://xn--biace-4l1bb.com/")
     
-    XCTAssertEqual(URLFormatter.formatURL(forSecurityDisplay: "https://biṇaṇce.com", schemeDisplay: .show), "https://xn--biace-4l1bb.com")
-    XCTAssertEqual(URLFormatter.formatURL(forSecurityDisplay: "https://дом.рф", schemeDisplay: .show), "https://дом.рф")
-    XCTAssertEqual(URLFormatter.formatURL(forSecurityDisplay: "https://дoм.рф", schemeDisplay: .show), "https://xn--o-gtbz.рф")
+    XCTAssertEqual(URLFormatter.formatURLOrigin(forSecurityDisplay: "https://biṇaṇce.com", schemeDisplay: .show), "https://xn--biace-4l1bb.com")
+    XCTAssertEqual(URLFormatter.formatURLOrigin(forSecurityDisplay: "https://дом.рф", schemeDisplay: .show), "https://дом.рф")
+    XCTAssertEqual(URLFormatter.formatURLOrigin(forSecurityDisplay: "https://дoм.рф", schemeDisplay: .show), "https://xn--o-gtbz.рф")
   }
 
   fileprivate func checkValidURL(_ beforeFixup: String, afterFixup: String) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.133/brave-core-ios-1.46.133.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.137/brave-core-ios-1.46.137.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.46.133",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.133/brave-core-ios-1.46.133.tgz",
-      "integrity": "sha512-A11zVEYewXgVGX99vYr6fzbc1csQ1Hy4Wjy41qci1/xjQLb+NUnznGEPPvXsKZkJYw1UK66uGOmoBogdRBqsxA==",
+      "version": "1.46.137",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.46.137/brave-core-ios-1.46.137.tgz",
+      "integrity": "sha512-ssvFY31vd0Pd8NMWEXpl8JFmPDpjAqKlnfhBm+twESNnnyxxaFZPYkI2nrgd4GWC42mWqzRwIPbpObh+Qlmggg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.133/brave-core-ios-1.46.133.tgz",
-      "integrity": "sha512-A11zVEYewXgVGX99vYr6fzbc1csQ1Hy4Wjy41qci1/xjQLb+NUnznGEPPvXsKZkJYw1UK66uGOmoBogdRBqsxA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.46.137/brave-core-ios-1.46.137.tgz",
+      "integrity": "sha512-ssvFY31vd0Pd8NMWEXpl8JFmPDpjAqKlnfhBm+twESNnnyxxaFZPYkI2nrgd4GWC42mWqzRwIPbpObh+Qlmggg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.133/brave-core-ios-1.46.133.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.46.137/brave-core-ios-1.46.137.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6537 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
