### PR TITLE
Ref #6521: URL bar only showing origin in both display & edit mode

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -408,7 +408,7 @@ class TabLocationView: UIView {
   
   fileprivate func updateTextWithURL() {
     (urlTextField as? DisplayTextField)?.hostString = url?.withoutWWW.host ?? ""
-    urlTextField.text = url?.withoutWWW.schemelessAbsoluteString.trim("/")
+    urlTextField.text = URLFormatter.formatURL(url?.absoluteString ?? "")
   }
 }
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -664,7 +664,13 @@ extension TopToolbarView: TabLocationViewDelegate {
 
   func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {
     guard let (locationText, isSearchQuery) = delegate?.topToolbarDisplayTextForURL(locationView.url as URL?) else { return }
-    enterOverlayMode(locationText, pasted: false, search: isSearchQuery)
+    
+    var overlayText = locationText
+    // Make sure to use the result from topToolbarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
+    if let text = locationText, let url = URL(string: text) {
+      overlayText = URLFormatter.formatURL(url.absoluteString)
+    }
+    enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)
   }
 
   func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {

--- a/Tests/ClientTests/SearchTests.swift
+++ b/Tests/ClientTests/SearchTests.swift
@@ -125,7 +125,9 @@ class SearchTests: XCTestCase {
     
     XCTAssertEqual(URLFormatter.formatURLOrigin(forSecurityDisplay: "https://biṇaṇce.com", schemeDisplay: .show), "https://xn--biace-4l1bb.com")
     XCTAssertEqual(URLFormatter.formatURLOrigin(forSecurityDisplay: "https://дом.рф", schemeDisplay: .show), "https://дом.рф")
+    XCTAssertEqual(URLFormatter.formatURL("https://дом.рф"), "https://дом.рф")
     XCTAssertEqual(URLFormatter.formatURLOrigin(forSecurityDisplay: "https://дoм.рф", schemeDisplay: .show), "https://xn--o-gtbz.рф")
+    XCTAssertEqual(URLFormatter.formatURL("https://дoм.рф"), "https://xn--o-gtbz.рф")
   }
 
   fileprivate func checkValidURL(_ beforeFixup: String, afterFixup: String) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

After merging https://github.com/brave/brave-core/pull/16193, the URL formatter method is changed.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request reference #6521

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

- Launch app and visit any page (e.g. amazon.com)
- Navigate to other pages
- See URL bar only displaying the origin
- Tap to edit the URL bar
- See URL inside the text field is also only displaying the origin

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
