### PR TITLE
Fix #6578: Reply with rejection when Allow Provider Access is disabled

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -90,7 +90,7 @@ class EthereumProviderScriptHandler: TabContentScript {
     }
     
     if !Preferences.Wallet.allowEthProviderAccess.value {
-      Logger.module.error("Ethereum provider access is disabled")
+      replyHandler(nil, "{\"message\":\"The user rejected the request.\",\"code\":4001}")
       return
     }
     

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -95,7 +95,7 @@ class SolanaProviderScriptHandler: TabContentScript {
     }
     
     if !Preferences.Wallet.allowSolProviderAccess.value {
-      Logger.module.error("Solana provider access is disabled")
+      replyHandler(nil, "{\"message\":\"The user rejected the request.\",\"code\":4001}")
       return
     }
     


### PR DESCRIPTION
## Summary of Changes
- Instead of ignoring requests, respond with error message when Allow Provider Access is disabled for both Solana and Ethereum dapps

This pull request fixes #6578

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Wallet Settings
2. Tap 'Ethereum' and make sure `Default Ethereum Wallet` = `Brave Wallet` and `Allow Sites to Access the Ethereum Provider API` = off/disabled
3. Tap back to main Wallet Settings
4. Tap 'Solana' and make sure `Default Solana Wallet` = `Brave Wallet` and `Allow Sites to Access the Solana Provider API` = off/disabled
5. Open Solana test dapp site `https://pwgoom.csb.app/` and tap 'Connect'.
6. Verify website console shows `[error] connect: {"message":"The user rejected the request.","code":4001}`
7. (Only possible if attached to debugger / able to use Safari debugger) Open MetaMask test dapp site `https://metamask.github.io/test-dapp/` and open Safari debugger for this tab / site.
    - Unfortunately only possible with development builds built with local Xcode at the moment.
8. Tap 'Connect'
9. Verify console shows error log `{"message":"The user rejected the request.","code":4001}`

## Screenshots:

https://user-images.githubusercontent.com/5314553/206019584-95813ac6-9e30-4ce9-9834-03fbbc3186b8.mov

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
