### PR TITLE
Fix # 6567: fix button title gets cut in sign transaction panel

### DIFF
--- a/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
+++ b/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
@@ -226,6 +226,7 @@ struct SignTransactionView: View {
         }
       }) {
         Label(Strings.Wallet.sign, braveSystemImage: "brave.key")
+          .fixedSize(horizontal: true, vertical: false)
           .imageScale(.large)
       }
       .buttonStyle(BraveFilledButtonStyle(size: .large))
@@ -245,7 +246,9 @@ struct SignTransactionView: View {
         onDismiss()
       }
     }) {
-      Text(Strings.cancelButtonTitle)
+      Label(Strings.cancelButtonTitle, systemImage: "xmark")
+        .fixedSize(horizontal: true, vertical: false)
+        .imageScale(.large)
     }
     .buttonStyle(BraveOutlineButtonStyle(size: .large))
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
fix in sign transaction panel, button title will get cut in smaller screen devices.
also add `x` image to make cancel button aligned through out wallet.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6567

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. use a smaller screen device 
2. open wallet and connect solana account with a solana dapp
3. make dapp request sign transaction
4. a sign transaction panel will show up (if wallet is not locked)
5. observe cancel button has a `x` to aligned with other cancel button in brave wallet
6. observe no button title is truncated 
7. click `continue`
8. observe `sign` button title is no longer truncated. 


## Screenshots:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-12-06 at 16 17 54](https://user-images.githubusercontent.com/1187676/206025079-2ccb9fab-5c25-4f40-9b61-a3613384beb1.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-12-06 at 16 17 57](https://user-images.githubusercontent.com/1187676/206025081-4a0ea114-7d57-4e45-a0d1-cb3ec1d0ec86.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
