### PR TITLE
Ref #6556: Fix toolbar not hiding when news is disabled on iOS 15.5

### DIFF
--- a/Sources/BraveNews/Customize/NewsSettingsView.swift
+++ b/Sources/BraveNews/Customize/NewsSettingsView.swift
@@ -245,7 +245,7 @@ public struct NewsSettingsView: View {
           Color.clear
             .toolbar {
               ToolbarItemGroup(placement: .bottomBar) {
-                if userOptedIn.value {
+                if isNewsEnabled.value {
                   Spacer()
                   Menu {
                     Button {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6556 on iOS 15.5

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
