### PR TITLE
Fix #6570 account status is not correct after users edit account permission from wallet panel

### DIFF
--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -258,7 +258,10 @@ struct WalletPanelView: View {
         presentWalletWithContext(.editSiteConnection(origin, handler: { accounts in
           if keyringStore.selectedAccount.coin == .eth {
             ethPermittedAccounts = accounts
+          } else if keyringStore.selectedAccount.coin == .sol {
+            solConnectedAddresses = Set(accounts)
           }
+          isConnectHidden = isConnectButtonHidden()
         }))
       }
     } label: {


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
refresh wallet panel account status and recheck hidden status button after user edit account permission

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6570

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Please refer to the issue


## Screenshots:

https://user-images.githubusercontent.com/1187676/206035921-513e7b14-5e6c-49bf-9a33-ab0b9c708386.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
