### PR TITLE
Fix #6584: Incorrect balance can be shown on Wallet Panel

### DIFF
--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -458,7 +458,10 @@ struct WalletPanelView: View {
             }
           }
           VStack(spacing: 4) {
-            let nativeAsset = accountActivityStore.userVisibleAssets.first(where: { $0.token.symbol == networkStore.selectedChain.symbol })
+            let nativeAsset = accountActivityStore.userVisibleAssets.first(where: {
+              $0.token.symbol == networkStore.selectedChain.symbol
+              && $0.token.chainId == networkStore.selectedChainId
+            })
             Text(String(format: "%.04f %@", nativeAsset?.decimalBalance ?? 0.0, networkStore.selectedChain.symbol))
               .font(.title2.weight(.bold))
             Text(currencyFormatter.string(from: NSNumber(value: (Double(nativeAsset?.price ?? "") ?? 0) * (nativeAsset?.decimalBalance ?? 0.0))) ?? "")


### PR DESCRIPTION
## Summary of Changes
- With multichain updates, we need to also check the `chainId` and not just the `symbol` or we will may display the incorrect balance (first symbol match in user assets list).

This pull request fixes #6584

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Use Solana account with different balance on Mainnet than Testnet / Devnet
  2. Open a Solana Dapp, ex `https://pwgoom.csb.app/` or `https://app.uniswap.org/#/swap` if Solana Dapps are disabled.
  3. Tap wallet icon in url bar
  4. Change network to Solana Mainnet
  5. Verify balance is displayed correctly on the currently selected network for the selected account.
  6. Change network to Solana Testnet / Devnet
  7. Verify balance is displayed correctly on the currently selected Solana network for the selected account.
  
  Similarly can be verified with only Ethereum networks:
  1. Use a Ethereum account with a different balance on Ethereum Mainnet than on Goerli Testnet
  2. Open an Ethereum dapp, ex. `https://app.uniswap.org/#/swap`
  3. Tap wallet icon in url bar
  4. Change network to Goerli Testnet.
  5. Verify balance is displayed correctly for the Goerli Testnet for the selected account
  6. Change network to Ethereum Mainnet.
  8. Verify balance is displayed correctly for the Ethereum Mainnet for the selected account.


## Screenshots:

https://user-images.githubusercontent.com/5314553/206042447-a19e2889-8c00-4b42-b7a3-cc57733e58a5.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
