### PR TITLE
Fix #6569: Receiving address missing for Sign and Send SPL Token tx

### DIFF
--- a/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -25,7 +25,7 @@ struct TransactionHeader: View {
   var body: some View {
     VStack(spacing: 8) {
       VStack(spacing: 8) {
-        if fromAccountAddress == toAccountAddress {
+        if fromAccountAddress == toAccountAddress || toAccountAddress.isEmpty {
           Blockie(address: fromAccountAddress)
             .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
           AddressView(address: fromAccountAddress) {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -416,11 +416,6 @@ enum TransactionParser {
           symbol = "SOL"
           switch instructionType {
           case .transfer, .transferWithSeed:
-            if toAddress == nil || toAddress?.isEmpty == true,
-               let toPubkey = instruction.accountMetas[safe: 1]?.pubkey {
-              toAddress = toPubkey
-            }
-            
             if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
                let instructionLamportsValue = BDouble(instructionLamports),
                let fromPubkey = instruction.accountMetas[safe: 0]?.pubkey,
@@ -439,10 +434,6 @@ enum TransactionParser {
               }
             }
           case .createAccount, .createAccountWithSeed:
-            if toAddress == nil || toAddress?.isEmpty == true,
-               let toPubkey = instruction.accountMetas[safe: 1]?.pubkey {
-              toAddress = toPubkey
-            }
             if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
                let instructionLamportsValue = BDouble(instructionLamports) {
               if let fromPubkey = instruction.accountMetas[safe: 0]?.pubkey,
@@ -464,6 +455,10 @@ enum TransactionParser {
               fromAmount = transactionTotalFormatted
             }
           }
+        }
+        if (toAddress == nil || toAddress?.isEmpty == true),
+           let toPubkey = instruction.toPubkey {
+          toAddress = toPubkey
         }
       }
       

--- a/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
+++ b/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
@@ -37,6 +37,18 @@ extension BraveWallet.SolanaInstruction {
     }
     return Strings.Wallet.solanaUnknownInstructionName
   }
+  
+  /// Returns the `to_account` pubkey for the instruction if available
+  var toPubkey: String? {
+    guard let index = decodedData?.accountParams.firstIndex(where: { $0.name == "to_account" }) else { return nil }
+    return accountMetas[safe: index]?.pubkey
+  }
+  
+  /// Returns the `from_account` pubkey for the instruction if available
+  var fromPubkey: String? {
+    guard let index = decodedData?.accountParams.firstIndex(where: { $0.name == "from_account" }) else { return nil }
+    return accountMetas[safe: index]?.pubkey
+  }
 }
 
 extension BraveWallet.SolanaSystemInstruction {


### PR DESCRIPTION
## Summary of Changes
- Resolve missing receiving address for Sign and Send SPL Token transaction

This pull request fixes #6569

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open test dapp site: https://pwgoom.csb.app/
2. Connect and tap 'Sign and Send SPL Token Transaction'
3. Verify to address is displayed correctly
    - Note: May differ to desktop until https://github.com/brave/brave-browser/issues/27187 is resolved.
    - Since this is an SPL Token transaction, we need to get the receiving address from the Solana Instructions. In this case it is a [Token Program - Transfer instruction type](https://docs.rs/spl-token/latest/src/spl_token/instruction.rs.html#97-110) so the `The destination account.` should be the second address displayed in the 'Details' tab of the Transaction Confirmation.

## Screenshots:

https://user-images.githubusercontent.com/5314553/206067552-2aeb7f55-fc40-4b32-84e9-15995e7ce93e.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
