### PR TITLE
Fix #6593: account creation flow for users has no solana account not able to dismiss in ios14

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -209,10 +209,12 @@ public struct CryptoView: View {
                   onCreate: {
                     // request is fullfilled.
                     request.responseHandler(.created)
+                    dismissAction?()
                   },
                   onDismiss: {
                     // request get declined by clicking `Cancel`
                     request.responseHandler(.rejected)
+                    dismissAction?()
                   }
                 )
               }


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
add dismissAction to ensure add account view is dismissed across all supported os

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6593

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Please refer to the ticket.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
