### PR TITLE
No bug:  use 5.10.3 version of SDWebImageView

### DIFF
--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -2366,8 +2366,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
+				kind = exactVersion;
+				version = 5.10.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -2366,8 +2366,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
 			requirement = {
-				kind = exactVersion;
-				version = 5.10.3;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.10.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -2366,8 +2366,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.10.2;
+				kind = exactVersion;
+				version = 5.10.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
-        "revision" : "3312bf5e67b52fbce7c3caf431b0cda721a9f7bb",
-        "version" : "5.14.2"
+        "revision" : "4aaca57fb2f6dc5554a2228cf1d94289bd0a6c7d",
+        "version" : "5.10.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     .package(url: "https://github.com/SwiftyJSON/SwiftyJSON", from: "5.0.0"),
     .package(url: "https://github.com/airbnb/lottie-ios", from: "3.1.9"),
     .package(url: "https://github.com/jrendel/SwiftKeychainWrapper", from: "4.0.1"),
-    .package(url: "https://github.com/SDWebImage/SDWebImage", from: "5.10.3"),
+    .package(url: "https://github.com/SDWebImage/SDWebImage", exact: "5.10.3"),
     .package(url: "https://github.com/SDWebImage/SDWebImageSVGNativeCoder", from: "0.1.1"),
     .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI", from: "2.2.0"),
     .package(url: "https://github.com/nmdias/FeedKit", from: "9.1.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     .package(url: "https://github.com/SwiftyJSON/SwiftyJSON", from: "5.0.0"),
     .package(url: "https://github.com/airbnb/lottie-ios", from: "3.1.9"),
     .package(url: "https://github.com/jrendel/SwiftKeychainWrapper", from: "4.0.1"),
-    .package(url: "https://github.com/SDWebImage/SDWebImage", from: "5.10.2"),
+    .package(url: "https://github.com/SDWebImage/SDWebImage", from: "5.10.3"),
     .package(url: "https://github.com/SDWebImage/SDWebImageSVGNativeCoder", from: "0.1.1"),
     .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI", from: "2.2.0"),
     .package(url: "https://github.com/nmdias/FeedKit", from: "9.1.2"),


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
use exact version of 5.10.3 for SDWebImageView. This could fix SDWebImgeVew crashes introduced by version upgrade.  

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
