### PR TITLE
Fix #6601: Do not block all web3 requests when Provider Access preference is disabled

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -318,9 +318,12 @@ extension Tab: BraveWalletProviderDelegate {
   func isPermissionDenied(_ type: BraveWallet.CoinType) -> Bool {
     switch type {
     case .eth:
-      return false
+      return !Preferences.Wallet.allowEthProviderAccess.value
     case .sol:
-      return !WalletDebugFlags.isSolanaDappsEnabled
+      if WalletDebugFlags.isSolanaDappsEnabled {
+        return !Preferences.Wallet.allowSolProviderAccess.value
+      }
+      return true
     case .fil:
       return true
     @unknown default:

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -89,11 +89,6 @@ class EthereumProviderScriptHandler: TabContentScript {
       return
     }
     
-    if !Preferences.Wallet.allowEthProviderAccess.value {
-      replyHandler(nil, "{\"message\":\"The user rejected the request.\",\"code\":4001}")
-      return
-    }
-    
     // The web page has communicated with `window.ethereum`, so we should show the wallet icon
     tab.isWalletIconVisible = true
     

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -94,11 +94,6 @@ class SolanaProviderScriptHandler: TabContentScript {
       return
     }
     
-    if !Preferences.Wallet.allowSolProviderAccess.value {
-      replyHandler(nil, "{\"message\":\"The user rejected the request.\",\"code\":4001}")
-      return
-    }
-    
     // The web page has communicated with `window.solana`, so we should show the wallet icon
     tab.isWalletIconVisible = true
     

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2420,14 +2420,14 @@ extension Strings {
       "wallet.web3PreferencesAllowEthProviderAccess",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Allow Sites to Access the Ethereum Provider API",
+      value: "Ask When a Site Wants to Access the Ethereum Provider API",
       comment: "The title for the entry displaying the preferred option to allow web3 sites to access the Ethereum provider API."
     )
     public static let web3PreferencesAllowSolProviderAccess = NSLocalizedString(
       "wallet.web3PreferencesAllowSolProviderAccess",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Allow Sites to Access the Solana Provider API",
+      value: "Ask When a Site Wants to Access the Solana Provider API",
       comment: "The title for the entry displaying the preferred option to allow web3 sites to access the Solana provider API."
     )
     public static let web3PreferencesDisplayWeb3Notifications = NSLocalizedString(


### PR DESCRIPTION
## Summary of Changes
- Update copy of `Allow Sites to Access the Ethereum Provider API` preference to be more clear this is for blocking permission-required requests.
- Fix behaviour around `Ask When a Site Wants to Access the Ethereum Provider API` / `Ask When a Site Wants to Access the Solana Provider API`. When enabled, all requests should go through. When disabled, we should pass all requests to core however this preference should be checked when the Provider Delegate `IsPermissionDenied(CoinType)` function is called.
    - This will allow `eth_call` requests to go through when the preference is disabled, and but block permission requests (ex. `eth_requestAccounts`).

This pull request fixes #6601

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Ethereum:
1. Verify default settings for Ethereum, remove any dapp connections.
    - `Default Ethereum Wallet` -> `Brave Wallet`
    - `Ask When a Site Wants to Access the Ethereum Provider API` -> enabled / true.
2. Open an Ethereum dapp and try and connect. Confirm that `Connect` modal is shown with accounts to connect.
3. Remove dapp connection from Wallet Settings (if allowed)
4. Toggle `Ask When a Site Wants to Access the Ethereum Provider API` to false.
5. Open an Ethereum dapp and try and connect. Confirm that the request is blocked without prompting the user via `Connect` modal.

Solana:
1. Verify default settings for Solana, remove any dapp connections.
    - `Default Solana Wallet` -> `Brave Wallet`
    - `Ask When a Site Wants to Access the Solana Provider API` -> enabled / true.
2. Open a Solana dapp and try and connect. Confirm that `Connect` modal is shown with accounts to connect.
3. Remove dapp connection from Wallet Settings (if allowed)
4. Toggle `Ask When a Site Wants to Access the Solana Provider API` to false.
5. Open a Solana dapp and try and connect. Confirm that the request is blocked without prompting the user via `Connect` modal.

Note: it's tricky to verify that non-permission related requests are still allowed through. In videos below, I've added debug logs to `EthereumProviderScriptHandler` and `SolanaProviderScriptHandler` that show requests received and success/failure responses. For Ethereum, you can see `eth_chainId` requests being responded to successfully with the Ask When a Site Wants to Access the Ethereum Provider API` preference disabled / false.


## Screenshots:

Ethereum:

https://user-images.githubusercontent.com/5314553/206297639-e88802c4-cbb6-4dd6-91ad-e218ea341116.mov

Solana:

https://user-images.githubusercontent.com/5314553/206298708-aa59d165-bc0e-4af4-9567-be8ae58660e1.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
