### PR TITLE
Fix #6610: Fix playlist to work on pages with dynamic embedded frames

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
@@ -71,8 +71,8 @@ window.__firefox__.includeOnce("Playlist", function($) {
         "securityToken": SECURITY_TOKEN,
         "name": name,
         "src": node.src,
-        "pageSrc": window.location.href,
-        "pageTitle": document.title,
+        "pageSrc": window.top.location.href,
+        "pageTitle": window.top.document.title,
         "mimeType": type,
         "duration": clamp_duration(target.duration),
         "detected": detected,
@@ -85,7 +85,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
     if (target) {
       var name = target.title;
       if (!name || name == "") {
-        name = document.title;
+        name = window.top.document.title;
       }
     
       if (!type || type == "") {


### PR DESCRIPTION
## Summary of Changes
- Fix Title and page URL for DailyMotion since the videos are now embedded into a special iFrame that returns the incorrect page source and title, but correct video URL.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6610

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![image](https://user-images.githubusercontent.com/1530031/206477477-c4d3e47a-71a9-459b-9a49-68e8a1b3a5a2.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
