### PR TITLE
Ref #6521: URL bar only showing origin in both display & edit mode

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -408,7 +408,7 @@ class TabLocationView: UIView {
   
   fileprivate func updateTextWithURL() {
     (urlTextField as? DisplayTextField)?.hostString = url?.withoutWWW.host ?? ""
-    urlTextField.text = URLFormatter.formatURL(url?.absoluteString ?? "")
+    urlTextField.text = URLFormatter.formatURL(url?.withoutWWW.absoluteString ?? "").removeSchemeFromURLString(url?.scheme)
   }
 }
 

--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -487,6 +487,14 @@ extension String {
     }
     return nil
   }
+  
+  public func removeSchemeFromURLString(_ scheme: String?) -> String {
+    guard let scheme = scheme else {
+      return self
+    }
+    
+    return replacingOccurrences(of: "\(scheme)://", with: "")
+  }
 }
 
 // MARK: Helpers to deal with ErrorPage URLs


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request reference #6521

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Launch app and copy link (e.g. https://www.amazon.com)
Press Go and load page and check location field show proper URL display


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/206510736-e27a9aa0-0c36-4cb2-b558-9a39a148c91f.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
