### PR TITLE
Fix #6602: Enable link vpn receipt button for production builds.

### DIFF
--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -13,8 +13,6 @@ import os.log
 
 /// A static class to handle all things related to the Brave VPN service.
 public class BraveVPN {
-  public static let linkReceiptEnabled = false
-
   private static let housekeepingApi = GRDHousekeepingAPI()
   private static let helper = GRDVPNHelper.sharedInstance()
   private static let serverManager = GRDServerManager()

--- a/Sources/BraveVPN/BraveVPNSettingsViewController.swift
+++ b/Sources/BraveVPN/BraveVPNSettingsViewController.swift
@@ -69,12 +69,10 @@ public class BraveVPNSettingsViewController: TableViewController {
   private var linkReceiptRows: [Row] {
     var rows = [Row]()
     
-    if BraveVPN.linkReceiptEnabled {
-      rows.append(Row(text: Strings.VPN.settingsLinkReceipt,
-                      selection: { [unowned self] in
-        openURL?(BraveUX.braveVPNLinkReceiptProd)
-      }, cellClass: ButtonCell.self))
-    }
+    rows.append(Row(text: Strings.VPN.settingsLinkReceipt,
+                    selection: { [unowned self] in
+      openURL?(BraveUX.braveVPNLinkReceiptProd)
+    }, cellClass: ButtonCell.self))
     
     if BraveVPN.isSandbox {
       rows += [Row(text: "[Staging] Link Receipt",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6602 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Buy VPN.
Go to vpn settings, verify the the 'link receipt button is shown'

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
