### PR TITLE
Fix #6608 & 6609: only erc721 nft opens new NFT detail screen.

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -69,7 +69,7 @@ struct NFTDetailView: View {
             .buttonStyle(BraveFilledButtonStyle(size: .large))
           }
         }
-        if let erc721Metadata = nftDetailStore.erc721Metadata, let description = erc721Metadata.description {
+        if let erc721Metadata = nftDetailStore.erc721Metadata, let description = erc721Metadata.description, !description.isEmpty {
           VStack(alignment: .leading, spacing: 8) {
             Text(Strings.Wallet.nftDetailDescription)
               .font(.headline.weight(.semibold))
@@ -132,6 +132,7 @@ struct NFTDetailView: View {
       .padding()
     }
     .onAppear {
+      nftDetailStore.fetchNetworkInfo()
       if nftDetailStore.erc721Metadata == nil {
         nftDetailStore.fetchMetadata()
       }

--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -132,10 +132,7 @@ struct NFTDetailView: View {
       .padding()
     }
     .onAppear {
-      nftDetailStore.fetchNetworkInfo()
-      if nftDetailStore.erc721Metadata == nil {
-        nftDetailStore.fetchMetadata()
-      }
+      nftDetailStore.update()
     }
     .background(Color(UIColor.braveGroupedBackground).ignoresSafeArea())
     .navigationBarTitle(Strings.Wallet.nftDetailTitle)

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -232,13 +232,24 @@ struct PortfolioView: View {
         ),
         destination: {
           if let nftViewModel = selectedNFTViewModel {
-            NFTDetailView(
-              nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, erc721Metadata: nftViewModel.erc721Metadata),
-              buySendSwapDestination: buySendSwapDestination
-            )
+            if nftViewModel.token.isErc721 {
+              NFTDetailView(
+                nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, erc721Metadata: nftViewModel.erc721Metadata),
+                buySendSwapDestination: buySendSwapDestination
+              )
               .onDisappear {
                 cryptoStore.closeNFTDetailStore(for: nftViewModel.token)
               }
+            } else {
+              AssetDetailView(
+                assetDetailStore: cryptoStore.assetDetailStore(for: nftViewModel.token),
+                keyringStore: keyringStore,
+                networkStore: cryptoStore.networkStore
+              )
+              .onDisappear {
+                cryptoStore.closeAssetDetailStore(for: nftViewModel.token)
+              }
+            }
           }
         },
         label: {

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -65,25 +65,23 @@ class NFTDetailStore: ObservableObject {
     self.erc721Metadata = erc721Metadata
   }
   
-  func fetchNetworkInfo() {
+  func update() {
     Task { @MainActor in
       let allNetworks = await rpcService.allNetworks(nft.coin)
       if let network = allNetworks.first(where: { $0.chainId.caseInsensitiveCompare(nft.chainId) == .orderedSame }) {
         networkInfo = network
       }
-    }
-  }
-  
-  func fetchMetadata() {
-    Task { @MainActor in
-      isLoading = true
       
-      let (metaData, _, _) = await rpcService.erc721Metadata(nft.contractAddress, tokenId: nft.tokenId, chainId: nft.chainId)
-      
-      isLoading = false
-      if let data = metaData.data(using: .utf8),
-         let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
-        erc721Metadata = result
+      if erc721Metadata == nil {
+        isLoading = true
+        
+        let (metaData, _, _) = await rpcService.erc721Metadata(nft.contractAddress, tokenId: nft.tokenId, chainId: nft.chainId)
+        
+        isLoading = false
+        if let data = metaData.data(using: .utf8),
+           let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
+          erc721Metadata = result
+        }
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -65,14 +65,18 @@ class NFTDetailStore: ObservableObject {
     self.erc721Metadata = erc721Metadata
   }
   
-  func fetchMetadata() {
+  func fetchNetworkInfo() {
     Task { @MainActor in
-      isLoading = true
-      
       let allNetworks = await rpcService.allNetworks(nft.coin)
       if let network = allNetworks.first(where: { $0.chainId.caseInsensitiveCompare(nft.chainId) == .orderedSame }) {
         networkInfo = network
       }
+    }
+  }
+  
+  func fetchMetadata() {
+    Task { @MainActor in
+      isLoading = true
       
       let (metaData, _, _) = await rpcService.erc721Metadata(nft.contractAddress, tokenId: nft.tokenId, chainId: nft.chainId)
       


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
only ERC721 token will open up to the new NFT detail screen. 
any other NFT will open old asset detail screen with no price and image (same behaviour as in 1.45.2)
also fetch network info regardless nft has metadata or not

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6608 #6609

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
please refer to the issues.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
