### PR TITLE
Fix #6618: Don't show the selected network in `SignTransactionView`

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -225,6 +225,10 @@ public class NetworkStore: ObservableObject {
       completion(success)
     }
   }
+  
+  @MainActor func selectedNetwork(for coin: BraveWallet.CoinType) async -> BraveWallet.NetworkInfo {
+    await rpcService.network(coin)
+  }
 }
 
 extension NetworkStore: BraveWalletJsonRpcServiceObserver {


### PR DESCRIPTION
## Summary of Changes
- `SignTransactionView` was showing the selected network which might not match the `SignTransactionRequest` / `SignAllTransactionsRequest` network. Instead we match desktop and find the selected network for the request(s) coin type and display that.

This pull request fixes #6618

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Open [Solana test dapp site](https://pwgoom.csb.app/) and connect
  2. Tap 'Sign Transaction' and tap the notification to open the request modal
  3. Swipe to dismiss the Sign Transaction modal
  4. On the Wallet panel, change the selected network to Ethereum Mainnet
  5. Tap the bell icon to re-open the Sign Transaction modal
  6. Verify 'Solana Mainnet' is still displayed in top left. 
      - Note: we cannot distinguish between mainnet / testnet / devnet on the request from the test dapp site. The network shown will be the last selected Solana network (for solana requests, ethereum Sign Transaction requests are not available until v1.48)


## Screenshots:

https://user-images.githubusercontent.com/5314553/206539293-0362b3c8-7b09-4c84-aa38-8d562030525f.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
