### PR TITLE
Fix #6615 #6025 -  Callout-Popover Related Problems

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -219,6 +219,9 @@ public class BrowserViewController: UIViewController {
   /// Boolean which is tracking If a product notification is presented
   /// in order to not to try to present another one over existing popover
   var benchmarkNotificationPresented = false
+  /// The string domain will be kept temporarily which is tracking site notification presented
+  /// in order to not to process site list again and again
+  var currentBenchmarkWebsite = ""
 
   /// Used to determine when to present benchmark pop-overs
   /// Current session ad count is compared with live ad count

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -116,7 +116,8 @@ extension BrowserViewController {
     }
 
     // If a controller is already presented (such as menu), do not show onboarding
-    guard presentedViewController == nil else {
+    // It also includes the case for overlay mode and tabtray opened
+    guard presentedViewController == nil, !topToolbar.inOverlayMode, !isTabTrayActive else {
       return
     }
     

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ProductNotification.swift
@@ -58,6 +58,12 @@ extension BrowserViewController {
       
       let domain = url.baseDomain ?? url.host ?? url.schemelessAbsoluteString
       
+      guard currentBenchmarkWebsite != domain else {
+        return
+      }
+      
+      currentBenchmarkWebsite = domain
+      
       guard let trackersDetail = BlockedTrackerParser.parse(
         blockedRequestURLs: blockedRequestURLs,
         selectedTabURL: url) else {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6615
This pull request fixes #6025

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

#6615 

- Install 1.46
- Load amazon.com
- Open any page in new tab OR open NTP and load same website and navigate to another page in the same domain in the second tab

#6025

- Do not interact with privacy hub
- Visit pages so that stats value increase to a threshold where it triggers the notification
- Open a new tab so focus is set to URLbar
- Privacy hub notification is shown on top of NTP favourites rather than on stats

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
N/A

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
