### PR TITLE
Fix #6623: Fix script injection overrides and double injected scripts

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/DownloadContentScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/DownloadContentScript.js
@@ -5,55 +5,57 @@
 
 "use strict";
 
-Object.defineProperty(window.__firefox__, "download", {
-  enumerable: false,
-  configurable: false,
-  writable: false,
-  value: function(url, securityToken) {
-    if (securityToken !== SECURITY_TOKEN) {
-      return;
-    }
-    
-    function getLastPathComponent(url) {
-      return url.split("/").pop();
-    }
+window.__firefox__.includeOnce("DownloadContentScript", function() {
+  Object.defineProperty(window.__firefox__, "download", {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: function(url, securityToken) {
+      if (securityToken !== SECURITY_TOKEN) {
+        return;
+      }
+      
+      function getLastPathComponent(url) {
+        return url.split("/").pop();
+      }
 
-    function blobToBase64String(blob, callback) {
-      var reader = new FileReader();
-      reader.onloadend = function() {
-        callback(this.result.split(",")[1]);
-      };
+      function blobToBase64String(blob, callback) {
+        var reader = new FileReader();
+        reader.onloadend = function() {
+          callback(this.result.split(",")[1]);
+        };
 
-      reader.readAsDataURL(blob);
-    }
+        reader.readAsDataURL(blob);
+      }
 
-    if (url.startsWith("blob:")) {
-      var xhr = new XMLHttpRequest();
-      xhr.open("GET", url, true);
-      xhr.responseType = "blob";
-      xhr.onload = function() {
-        if (this.status !== 200) {
-          return;
-        }
+      if (url.startsWith("blob:")) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url, true);
+        xhr.responseType = "blob";
+        xhr.onload = function() {
+          if (this.status !== 200) {
+            return;
+          }
 
-        var blob = this.response;
+          var blob = this.response;
 
-        blobToBase64String(blob, function(base64String) {
-          webkit.messageHandlers.downloadContentScript.postMessage({
-            url: url,
-            mimeType: blob.type,
-            size: blob.size,
-            base64String: base64String
+          blobToBase64String(blob, function(base64String) {
+            webkit.messageHandlers.downloadContentScript.postMessage({
+              url: url,
+              mimeType: blob.type,
+              size: blob.size,
+              base64String: base64String
+            });
           });
-        });
-      };
+        };
 
-      xhr.send();
-      return;
+        xhr.send();
+        return;
+      }
+
+      var link = document.createElement("a");
+      link.href = url;
+      link.dispatchEvent(new MouseEvent("click"));
     }
-
-    var link = document.createElement("a");
-    link.href = url;
-    link.dispatchEvent(new MouseEvent("click"));
-  }
+  });
 });

--- a/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/ForcePasteScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Sandboxed/AllFrames/AtDocumentStart/ForcePasteScript.js
@@ -5,28 +5,30 @@
 
 "use strict";
 
-Object.defineProperty(window.__firefox__, "forcePaste", {
-  enumerable: false,
-  configurable: false,
-  writable: false,
-  value: function(contents, securityToken) {
-    if (securityToken !== SECURITY_TOKEN) {
-      return;
+window.__firefox__.includeOnce("ForcePasteScript", function() {
+  Object.defineProperty(window.__firefox__, "forcePaste", {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: function(contents, securityToken) {
+      if (securityToken !== SECURITY_TOKEN) {
+        return;
+      }
+      var element = document.activeElement;
+      if (element instanceof HTMLIFrameElement) {
+        // If the element is an iframe, grab its active element
+        element = element.contentWindow.document.activeElement;
+      }
+      if (element === undefined) {
+        return;
+      }
+      var start = element.selectionStart;
+      // Paste into expected position, replacing contents if any are selected
+      element.value = element.value.slice(0, start) + contents + element.value.slice(element.selectionEnd);
+      // Reset caret position to expected position
+      var newSelection = start + contents.length;
+      element.selectionStart = newSelection;
+      element.selectionEnd = newSelection;
     }
-    var element = document.activeElement;
-    if (element instanceof HTMLIFrameElement) {
-      // If the element is an iframe, grab its active element
-      element = element.contentWindow.document.activeElement;
-    }
-    if (element === undefined) {
-      return;
-    }
-    var start = element.selectionStart;
-    // Paste into expected position, replacing contents if any are selected
-    element.value = element.value.slice(0, start) + contents + element.value.slice(element.selectionEnd);
-    // Reset caret position to expected position
-    var newSelection = start + contents.length;
-    element.selectionStart = newSelection;
-    element.selectionEnd = newSelection;
-  }
+  });
 });

--- a/Client/Frontend/UserContent/UserScripts/__firefox__.js
+++ b/Client/Frontend/UserContent/UserScripts/__firefox__.js
@@ -118,11 +118,13 @@ if (!window.__firefox__) {
           }
         }
 
-        $.deepFreeze(toString);
+        //$.deepFreeze(toString);
       };
       
       // Secure our custom `toString`
+      // Freeze our custom `toString`
       secureToString(toString);
+      $.deepFreeze(toString);
 
       for (const [name, property] of $Object.entries(overrides)) {
         if (name == 'toString') {
@@ -130,6 +132,10 @@ if (!window.__firefox__) {
           // They are two different functions, so we should check for both before overriding them
           if (value[name] && value[name] !== Object.prototype.toString && value[name] !== Object.toString) {
             // Secure the existing custom toString function
+            // Do NOT deepFreeze existing toString functions
+            // on custom objects we don't own. We secure it,
+            // but not freeze it.
+            // The object may want to change it or override it, etc.
             secureToString(value[name]);
             continue;
           }
@@ -139,6 +145,10 @@ if (!window.__firefox__) {
           let descriptor = $Object.getOwnPropertyDescriptor(value, name);
           if (descriptor && descriptor.value !== Object.prototype.toString && descriptor.value !== Object.toString) {
             // Secure the existing custom toString function
+            // Do NOT deepFreeze existing toString functions
+            // on custom objects we don't own. We secure it,
+            // but not freeze it.
+            // The object may want to change it or override it, etc.
             secureToString(value[name]);
             continue;
           }


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1142

## Summary of Changes
- Scripts injected into ALL frames must only be included once in that frame. Otherwise the script can throw an exception if the page modifies its source code at runtime and WebKit attempts to inject it a second time even though it is already injected.

- Do NOT `freeze` `toString` on custom objects we don't own. Scripts and objects that provide a custom `toString` should freeze it themselves.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6623, fixes #6633 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
