### PR TITLE
No bug: NFT image loading improvement

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -11,7 +11,8 @@ import SDWebImageSwiftUI
 
 struct NFTDetailView: View {
   @ObservedObject var nftDetailStore: NFTDetailStore
-  @Binding var buySendSwapDestination: BuySendSwapDestination?
+  @Binding var buySendSwapDestination: BuySendSwapDestination? 
+  var onERC721MetadataRefreshed: ((ERC721Metadata) -> Void)?
   
   @Environment(\.openWalletURLAction) private var openWalletURL
   
@@ -131,6 +132,11 @@ struct NFTDetailView: View {
       }
       .padding()
     }
+    .onChange(of: nftDetailStore.erc721Metadata, perform: { newValue in
+      if let newMetadata = newValue {
+        onERC721MetadataRefreshed?(newMetadata)
+      }
+    })
     .onAppear {
       nftDetailStore.update()
     }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -236,7 +236,9 @@ struct PortfolioView: View {
               NFTDetailView(
                 nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, erc721Metadata: nftViewModel.erc721Metadata),
                 buySendSwapDestination: buySendSwapDestination
-              )
+              ) { erc721Metadata in
+                portfolioStore.updateERC721MetadataCache(for: nftViewModel.token, metadata: erc721Metadata)
+              }
               .onDisappear {
                 cryptoStore.closeNFTDetailStore(for: nftViewModel.token)
               }

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -94,7 +94,9 @@ struct AssetSearchView: View {
                       NFTDetailView(
                         nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, erc721Metadata: allERC721Metadata[assetViewModel.token.id]),
                         buySendSwapDestination: .constant(nil)
-                      )
+                      ) { metadata in
+                        allERC721Metadata[assetViewModel.token.id] = metadata
+                      }
                       .onDisappear {
                         cryptoStore.closeNFTDetailStore(for: assetViewModel.token)
                       }

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -12,7 +12,7 @@ private extension String {
   }
 }
 
-struct ERC721Metadata: Codable {
+struct ERC721Metadata: Codable, Equatable {
   var imageURLString: String?
   var name: String?
   var description: String?

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -251,7 +251,10 @@ public class PortfolioStore: ObservableObject {
       
       // fetch ERC721 metadata for ERC721 tokens
       let erc721Tokens = allTokens.filter { $0.isErc721 }
-      metadataCache = await rpcService.fetchERC721Metadata(tokens: erc721Tokens)
+      let allMetadata = await rpcService.fetchERC721Metadata(tokens: erc721Tokens)
+      for (key, value) in allMetadata { // update cached values
+        metadataCache[key] = value
+      }
       
       guard !Task.isCancelled else { return }
       updatedUserVisibleAssets.removeAll()
@@ -338,6 +341,13 @@ public class PortfolioStore: ObservableObject {
       })
     }
     return priceHistories
+  }
+  
+  func updateERC721MetadataCache(for token: BraveWallet.BlockchainToken, metadata: ERC721Metadata) {
+    metadataCache[token.id] = metadata
+    if let index = userVisibleNFTs.firstIndex(where: { $0.token.id == token.id }), let viewModel = userVisibleNFTs[safe: index] {
+      userVisibleNFTs[index] = NFTAssetViewModel(token: viewModel.token, network: viewModel.network, balance: viewModel.balance, erc721Metadata: metadata)
+    }
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This change improves NFT image loading in portfolio and asset search screen as in the case that when NFT image failed to load, however it loads in detail screen, when user navigate back to portfolio or asset search screen from NFT detail screen, the NFT image will load inside portfolio or asset search screen.
This change also improves the cache inside portfolio screen.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request **partially** fixes #6563
The real potential fix for #6563 needs core version 1.47.x

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. open brave wallet 
2. add some NFTs and make sure they failed to load on portfolio 
3. keep going back and forward between portfolio and NFT Detail screen, until the NFT image loads in NFT Detail screen
4. observe as long as NFT image loads inside NFT Detail screen, once you go back to portfolio screen, the NFT icon should loads. 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
