### PR TITLE
Fix #6641: Fix glitches with cookie consent notice toggle and popup

### DIFF
--- a/Client/Frontend/Popup/CookieNotificationBlockingConsentView.swift
+++ b/Client/Frontend/Popup/CookieNotificationBlockingConsentView.swift
@@ -28,14 +28,13 @@ struct CookieNotificationBlockingConsentView: View {
       withAnimation(animation) {
         self.showAnimation = true
       }
-
-      if !FilterListResourceDownloader.shared.enableFilterList(for: FilterList.cookieConsentNoticesComponentID, isEnabled: true) {
-        assertionFailure("This filter list should exist or this UI is completely useless")
-      }
-      
-      recordCookieListPromptP3A(answer: .tappedYes)
       
       Task { @MainActor in
+        FilterListResourceDownloader.shared.enableFilterList(
+          for: FilterList.cookieConsentNoticesComponentID, isEnabled: true
+        )
+        
+        recordCookieListPromptP3A(answer: .tappedYes)
         try await Task.sleep(seconds: 3.5)
         self.dismiss()
       }

--- a/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Client/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -71,24 +71,22 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
       .sink { filterLists in
         let filterList = filterLists.first(where: { $0.componentId == FilterList.cookieConsentNoticesComponentID })
         let isEnabled = filterList?.isEnabled == true
+        guard isEnabled != self.currentCookieConsentNoticeBlockingState else { return }
+        self.currentCookieConsentNoticeBlockingState = isEnabled
         
-        if isEnabled != self.currentCookieConsentNoticeBlockingState {
-          self.currentCookieConsentNoticeBlockingState = isEnabled
-          
-          guard let sectionIndex = self.dataSource.sections.firstIndex(where: { $0.uuid == self.shieldsSection.uuid }) else {
-            assertionFailure("Should exist")
-            return
-          }
-          
-          guard let rowIndex = self.shieldsSection.rows.firstIndex(where: { $0.uuid == self.cookieConsentNoticesRowUUID.uuidString }) else {
-            assertionFailure("Should exist")
-            return
-          }
-          
-          // Reload the section
-          self.shieldsSection.rows[rowIndex] = self.makeCookieConsentBlockingRow()
-          self.dataSource.sections[sectionIndex] = self.shieldsSection
+        guard let sectionIndex = self.dataSource.sections.firstIndex(where: { $0.uuid == self.shieldsSection.uuid }) else {
+          assertionFailure("Should exist")
+          return
         }
+        
+        guard let rowIndex = self.shieldsSection.rows.firstIndex(where: { $0.uuid == self.cookieConsentNoticesRowUUID.uuidString }) else {
+          assertionFailure("Should exist")
+          return
+        }
+        
+        // Reload the section
+        self.shieldsSection.rows[rowIndex] = self.makeCookieConsentBlockingRow()
+        self.dataSource.sections[sectionIndex] = self.shieldsSection
       }
       .store(in: &cancellables)
     
@@ -361,6 +359,8 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
         for: FilterList.cookieConsentNoticesComponentID
       ),
       valueChange: { isEnabled in
+        self.currentCookieConsentNoticeBlockingState = isEnabled
+        
         if !FilterListResourceDownloader.shared.enableFilterList(for: FilterList.cookieConsentNoticesComponentID, isEnabled: isEnabled) {
           assertionFailure("This filter list should exist or this UI is completely useless")
         }

--- a/Client/WebFilters/FilterListInterface.swift
+++ b/Client/WebFilters/FilterListInterface.swift
@@ -7,12 +7,12 @@ import Foundation
 import Data
 
 protocol FilterListInterface {
-  var uuid: String { get }
-  var filterListComponentId: String? { get }
+  @MainActor var uuid: String { get }
+  @MainActor var filterListComponentId: String? { get }
 }
  
 extension FilterListInterface {
-  var resources: [ResourceDownloader.Resource] {
+  @MainActor var resources: [ResourceDownloader.Resource] {
     guard let filterListComponentId = self.filterListComponentId else { return [] }
     
     return [
@@ -22,9 +22,9 @@ extension FilterListInterface {
 }
 
 extension FilterListSetting: FilterListInterface {
-  var filterListComponentId: String? { return componentId }
+  @MainActor var filterListComponentId: String? { return componentId }
 }
 
 extension FilterList: FilterListInterface {
-  var filterListComponentId: String? { return componentId }
+  @MainActor var filterListComponentId: String? { return componentId }
 }

--- a/Sources/Data/models/FilterListSetting.swift
+++ b/Sources/Data/models/FilterListSetting.swift
@@ -15,12 +15,12 @@ public final class FilterListSetting: NSManagedObject, CRUD {
     return FileManager.default.urls(for: location, in: .userDomainMask).first
   }
   
-  @NSManaged public var uuid: String
-  @NSManaged public var componentId: String?
-  @NSManaged public var isEnabled: Bool
-  @NSManaged private var folderPath: String?
+  @MainActor @NSManaged public var uuid: String
+  @MainActor @NSManaged public var componentId: String?
+  @MainActor @NSManaged public var isEnabled: Bool
+  @MainActor @NSManaged private var folderPath: String?
 
-  public var folderURL: URL? {
+  @MainActor public var folderURL: URL? {
     get {
       return Self.makeFolderURL(forFilterListFolderPath: folderPath)
     }
@@ -31,12 +31,12 @@ public final class FilterListSetting: NSManagedObject, CRUD {
   }
   
   /// Load all the flter list settings
-  public class func loadAllSettings(fromMemory: Bool) -> [FilterListSetting] {
+  @MainActor public class func loadAllSettings(fromMemory: Bool) -> [FilterListSetting] {
     return all(context: fromMemory ? DataController.viewContextInMemory : DataController.viewContext) ?? []
   }
   
   /// Create a filter list setting for the given UUID and enabled status
-  public class func create(uuid: String, componentId: String?, isEnabled: Bool, inMemory: Bool) -> FilterListSetting {
+  @MainActor public class func create(uuid: String, componentId: String?, isEnabled: Bool, inMemory: Bool) -> FilterListSetting {
     var newSetting: FilterListSetting!
 
     // Settings are usually accesed on view context, but when the setting doesn't exist,
@@ -55,12 +55,12 @@ public final class FilterListSetting: NSManagedObject, CRUD {
     return settingOnCorrectContext ?? newSetting
   }
   
-  public class func save(inMemory: Bool) {
+  @MainActor public class func save(inMemory: Bool) {
     self.save(on: inMemory ? DataController.viewContextInMemory : DataController.viewContext)
   }
   
   /// Save this entry
-  private class func save(
+  @MainActor private class func save(
     on writeContext: NSManagedObjectContext,
     changes: (() -> Void)? = nil
   ) {
@@ -78,7 +78,7 @@ public final class FilterListSetting: NSManagedObject, CRUD {
   }
   
   // Currently required, because not `syncable`
-  private static func entity(_ context: NSManagedObjectContext) -> NSEntityDescription {
+  @MainActor private static func entity(_ context: NSManagedObjectContext) -> NSEntityDescription {
     return NSEntityDescription.entity(forEntityName: "FilterListSetting", in: context)!
   }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix a glitch on the toggle which has to be pressed twice and toggle animations are not working
- Fix potential of cookie consent not being activated if filter lists are being downloaded still as the user interacts with the cookie consent dialog or toggle. Also may affect the "Block 'Switch to App' Notices" toggle.
- Save only enabled settings or if different than default so new defaults can be added in the future and not ignored by already created settings

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6641 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Test the toggle and ensure there is no UI glitches
2. Test the cookie consent dialogue and ensure that when the user clicks on "Block cookie notices" that it actually enables the filter list
3. Kill the app and relaunching to make sure the settings are persisted both by enabling and disabling filter lists.
4. Ensure that toggling the "Block Cookie Consent Notices" reflects the changes in the Filter lists screen (i.e. The "Easy-list cookie list" is toggled appropriately)
5. Ensure that toggling the "Easy-list cookie list" filter list reflects the changes on the Shields screen (i.e. The" Block Cookie Consent Notices" option is toggled appropriately).

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
