### PR TITLE
Fix #6648: Revert back the legacy AppReview Logic

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -817,6 +817,15 @@ public class BrowserViewController: UIViewController {
     setupConstraints()
     updateToolbarStateForTraitCollection(self.traitCollection)
     
+    // Legacy Review Handling
+    if AppConstants.buildChannel.isPublic && AppReviewManager.shared.legacyShouldRequestReview() {
+      // Request Review when the main-queue is free or on the next cycle.
+      DispatchQueue.main.async {
+        guard let windowScene = self.currentScene else { return }
+        SKStoreReviewController.requestReview(in: windowScene)
+      }
+    }
+    
     // Do some migratins
     LegacyBookmarksHelper.restore_1_12_Bookmarks() {
       Logger.module.info("Bookmarks from old database were successfully restored")

--- a/Sources/Growth/AppReviewManager.swift
+++ b/Sources/Growth/AppReviewManager.swift
@@ -41,9 +41,9 @@ public class AppReviewManager: ObservableObject {
   
   // MARK: Legacy properties - Added for swithing back to legacy logic easily
   private let legacyAppReviewLogicEnabled = true
-  private let legacyFirstThreshold = 14
-  private let legacySecondThreshold = 41
-  private let legacyLastThreshold = 121
+  let legacyFirstThreshold = 14
+  let legacySecondThreshold = 41
+  let legacyLastThreshold = 121
   private let legacyMinimumDaysBetweenReviewRequest = 60
   
   // MARK: Lifecycle

--- a/Sources/Growth/AppReviewManager.swift
+++ b/Sources/Growth/AppReviewManager.swift
@@ -39,9 +39,47 @@ public class AppReviewManager: ObservableObject {
   private let daysInUseMaxPeriod = AppConstants.buildChannel.isPublic ? 7.days : 7.minutes
   private let daysInUseRequiredPeriod = 4
   
+  // MARK: Legacy properties - Added for swithing back to legacy logic easily
+  private let legacyAppReviewLogicEnabled = true
+  private let legacyFirstThreshold = 14
+  private let legacySecondThreshold = 41
+  private let legacyLastThreshold = 121
+  private let legacyMinimumDaysBetweenReviewRequest = 60
+  
   // MARK: Lifecycle
   
   public static var shared = AppReviewManager()
+  
+  // MARK: Legacy Review Mrthods
+  
+  public func legacyShouldRequestReview(date: Date = Date()) -> Bool {
+     let launchCount = Preferences.Review.launchCount.value
+     let threshold = Preferences.LegacyReview.threshold.value
+
+     var daysSinceLastRequest = 0
+     if let previousRequest = Preferences.LegacyReview.lastReviewDate.value {
+       daysSinceLastRequest = Calendar.current.dateComponents([.day], from: previousRequest, to: date).day ?? 0
+     } else {
+       daysSinceLastRequest = legacyMinimumDaysBetweenReviewRequest
+     }
+
+     if launchCount <= threshold || daysSinceLastRequest < legacyMinimumDaysBetweenReviewRequest {
+       return false
+     }
+
+     Preferences.LegacyReview.lastReviewDate.value = date
+
+     switch threshold {
+     case legacyFirstThreshold:
+       Preferences.LegacyReview.threshold.value = legacySecondThreshold
+     case legacySecondThreshold:
+       Preferences.LegacyReview.threshold.value = legacyLastThreshold
+     default:
+       break
+     }
+
+     return legacyAppReviewLogicEnabled
+   }
   
   // MARK: Review Handler Methods
   
@@ -125,7 +163,7 @@ public class AppReviewManager: ObservableObject {
       }
     }
     
-    return mainCriteriaSatisfied && subCriteriaSatisfied
+    return legacyAppReviewLogicEnabled ? false :  mainCriteriaSatisfied && subCriteriaSatisfied
   }
   
   /// This method is for checking App Review Sub Criteria is satisfied for a type

--- a/Sources/Growth/AppReviewManager.swift
+++ b/Sources/Growth/AppReviewManager.swift
@@ -50,7 +50,7 @@ public class AppReviewManager: ObservableObject {
   
   public static var shared = AppReviewManager()
   
-  // MARK: Legacy Review Mrthods
+  // MARK: Legacy Review Methods
   
   public func legacyShouldRequestReview(date: Date = Date()) -> Bool {
      let launchCount = Preferences.Review.launchCount.value

--- a/Sources/Growth/GrowthPreferences.swift
+++ b/Sources/Growth/GrowthPreferences.swift
@@ -30,4 +30,10 @@ extension Preferences {
     public static let referralLookupOutstanding = Option<Bool?>(key: "urp.referral.lookkup-completed", default: nil)
   }
 
+  public final class LegacyReview {
+    /// Review Threshold (the total amount of launches needed for the next review to show up) Default VAlue first Threashold which will be 14
+    static let threshold = Option<Int>(key: "review.threshold", default: 14)
+    /// Last Review Date
+    static let lastReviewDate = Option<Date?>(key: "review.last-date", default: nil)
+  }
 }

--- a/Tests/GrowthTests/LegacyAppReviewTests.swift
+++ b/Tests/GrowthTests/LegacyAppReviewTests.swift
@@ -1,0 +1,120 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Shared
+import BraveShared
+@testable import Growth
+
+class LegacyAppReviewTests: XCTestCase {
+  
+  private var lastReviewDate: Date? { return Preferences.LegacyReview.lastReviewDate.value }
+  private var launchCount: Int { return Preferences.Review.launchCount.value }
+  private var threshold: Int { return Preferences.LegacyReview.threshold.value }
+
+  override func setUp() {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    super.setUp()
+
+    Preferences.LegacyReview.lastReviewDate.reset()
+    Preferences.Review.launchCount.reset()
+    Preferences.LegacyReview.threshold.reset()
+
+    // Each test should start with at least one simulated launch, to mimic behavior of regular app.
+    // (incrementing launch count at app start)
+    simulateLaunch()
+  }
+
+  func testFirstRun() {
+    let date = Date()
+
+    XCTAssertEqual(launchCount, 1, "First run should have launch count equal to 1")
+    XCTAssertNil(lastReviewDate)
+    XCTAssertEqual(threshold, AppReviewManager.shared.legacyFirstThreshold)
+
+    XCTAssertFalse(AppReviewManager.shared.legacyShouldRequestReview(date: date))
+
+    XCTAssertEqual(launchCount, 1, "Launch count shouldn't change after review request.")
+    XCTAssertNil(lastReviewDate)
+    XCTAssertEqual(threshold, AppReviewManager.shared.legacyFirstThreshold)
+  }
+
+  func testThresholdsNoDateInterval() {
+
+    // First threshold
+    for i in 2...AppReviewManager.shared.legacyFirstThreshold {
+      simulateLaunch()
+      XCTAssertFalse(AppReviewManager.shared.legacyShouldRequestReview())
+
+      XCTAssertNil(lastReviewDate)
+      XCTAssertEqual(threshold, AppReviewManager.shared.legacyFirstThreshold)
+      XCTAssertEqual(launchCount, i)
+    }
+
+    let firstDate = dateFrom(string: "2019-01-01")
+
+    simulateLaunch()
+    // Next app launch triggers the review
+    XCTAssert(AppReviewManager.shared.legacyShouldRequestReview(date: firstDate))
+
+    XCTAssertEqual(lastReviewDate, firstDate)
+    XCTAssertEqual(threshold, AppReviewManager.shared.legacySecondThreshold)
+
+    // Second threshold
+    for i in launchCount..<AppReviewManager.shared.legacySecondThreshold {
+      simulateLaunch()
+      XCTAssertFalse(AppReviewManager.shared.legacyShouldRequestReview())
+      XCTAssertEqual(lastReviewDate, firstDate)
+      XCTAssertEqual(threshold, AppReviewManager.shared.legacySecondThreshold)
+      XCTAssertEqual(launchCount, i + 1)
+    }
+
+    // Enough launches passed but not enough time between app reviews.
+    let secondDate = dateFrom(string: "2019-01-14")
+    simulateLaunch()
+    XCTAssertFalse(AppReviewManager.shared.legacyShouldRequestReview(date: secondDate))
+
+    XCTAssertEqual(lastReviewDate, firstDate)
+    XCTAssertEqual(threshold, AppReviewManager.shared.legacySecondThreshold)
+  }
+
+  func testThresholdsWithDateInterval() {
+    let firstDate = dateFrom(string: "2019-01-01")
+
+    Preferences.Review.launchCount.value = AppReviewManager.shared.legacyFirstThreshold + 3
+
+    XCTAssert(AppReviewManager.shared.legacyShouldRequestReview(date: firstDate))
+
+    // Second threshold, no date change
+    Preferences.Review.launchCount.value = AppReviewManager.shared.legacySecondThreshold + 3
+    XCTAssertFalse(AppReviewManager.shared.legacyShouldRequestReview(date: firstDate))
+
+    // Second threshold, date change
+    XCTAssert(AppReviewManager.shared.legacyShouldRequestReview(date: dateFrom(string: "2019-04-01")))
+
+    // Second threshold, not enough date interval
+    XCTAssertFalse(AppReviewManager.shared.legacyShouldRequestReview(date: dateFrom(string: "2019-05-01")))
+
+    // Third threshold, good launch count and date
+    Preferences.Review.launchCount.value = AppReviewManager.shared.legacyLastThreshold + 3
+    XCTAssert(AppReviewManager.shared.legacyShouldRequestReview(date: dateFrom(string: "2019-11-20")))
+
+    // Date and launch count far away in the future
+    Preferences.Review.launchCount.value = AppReviewManager.shared.legacyLastThreshold + 1000
+    XCTAssert(AppReviewManager.shared.legacyShouldRequestReview(date: dateFrom(string: "2022-01-01")))
+
+  }
+
+  private func simulateLaunch() {
+    Preferences.Review.launchCount.value += 1
+  }
+
+  private func dateFrom(string: String, format: String? = nil) -> Date {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = format ?? "yyyy-MM-dd"
+
+    return dateFormatter.date(from: string)!
+  }
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Adding back the legacy logic without removing the new logic in place and make it robust and easy to edit -remove when necessary.

Include test for this legacy logic

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6648

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
N/A

## Screenshots:
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
