### PR TITLE
Fix #6467: Add button foreground never grey out in disabled mode in ios 15 and 16

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -251,7 +251,6 @@ struct AddCustomAssetView: View {
             addCustomToken()
           }) {
             Text(Strings.Wallet.add)
-              .foregroundColor(Color(.braveBlurpleTint))
           }
           .disabled(addButtonDisabled)
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
fix on navigation bar item foreground colour 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6467

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Please refer to the ticket 


## Screenshots:
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-15 at 17 05 28](https://user-images.githubusercontent.com/1187676/207976930-9346a1a5-5be5-40fd-b157-0743e17ad336.png)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
