### PR TITLE
Fix #6425: Unknown token in ERC20 approve transaction confirmation

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -32,6 +32,9 @@ class AccountActivityStore: ObservableObject {
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+  /// Cache for storing `BlockchainToken`s that are not in user assets or our token registry.
+  /// This could occur with a dapp creating a transaction.
+  private var tokenInfoCache: [String: BraveWallet.BlockchainToken] = [:]
 
   init(
     account: BraveWallet.AccountInfo,
@@ -76,6 +79,7 @@ class AccountActivityStore: ObservableObject {
         let sortOrder: Int
       }
       let allVisibleUserAssets = await walletService.allVisibleUserAssets(in: networks)
+      let allTokens = await blockchainRegistry.allTokens(in: networks).flatMap(\.tokens)
       var updatedUserVisibleAssets: [AssetViewModel] = []
       var updatedUserVisibleNFTs: [NFTAssetViewModel] = []
       for networkAssets in allVisibleUserAssets {
@@ -133,17 +137,17 @@ class AccountActivityStore: ObservableObject {
         })
       })
       
-      // fetch price for every token
-      let allTokens = allVisibleUserAssets.flatMap(\.tokens)
-      let allAssetRatioIds = allTokens.map(\.assetRatioId)
+      // fetch price for every visible token
+      let allVisibleTokens = allVisibleUserAssets.flatMap(\.tokens)
+      let allVisibleTokenAssetRatioIds = allVisibleTokens.map(\.assetRatioId)
       let prices: [String: String] = await assetRatioService.fetchPrices(
-        for: allAssetRatioIds,
+        for: allVisibleTokenAssetRatioIds,
         toAssets: [currencyFormatter.currencyCode],
         timeframe: .oneDay
       )
       
       // fetch ERC721 metadata for ERC721 tokens
-      let allErc721Metadata = await rpcService.fetchERC721Metadata(tokens: allTokens.filter { $0.isErc721 })
+      let allErc721Metadata = await rpcService.fetchERC721Metadata(tokens: userVisibleNFTs.map(\.token).filter(\.isErc721))
       
       guard !Task.isCancelled else { return }
       updatedUserVisibleAssets.removeAll()
@@ -201,17 +205,20 @@ class AccountActivityStore: ObservableObject {
     if account.coin == .sol {
       solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(for: transactions.map(\.id))
     }
-    let unknownERC20ApproveTokenContractAddresses = transactions
-      .filter { $0.txType == .erc20Approve }
-      .compactMap { $0.txDataUnion.ethTxData1559?.baseData.to }
+    let unknownTokenContractAddresses = transactions
+      .flatMap { $0.tokenContractAddresses }
       .filter { contractAddress in
         !userVisibleTokens.contains(where: { $0.contractAddress.caseInsensitiveCompare(contractAddress) == .orderedSame })
         && !allTokens.contains(where: { $0.contractAddress.caseInsensitiveCompare(contractAddress) == .orderedSame })
+        && !tokenInfoCache.keys.contains(where: { $0.caseInsensitiveCompare(contractAddress) == .orderedSame })
       }
-    // fetch unknown token contract addresses
-    var unknownTokens: [BraveWallet.BlockchainToken] = []
-    if !unknownERC20ApproveTokenContractAddresses.isEmpty {
-      unknownTokens = await assetRatioService.fetchTokens(for: unknownERC20ApproveTokenContractAddresses)
+    var allTokens = allTokens
+    if !unknownTokenContractAddresses.isEmpty {
+      let unknownTokens = await assetRatioService.fetchTokens(for: unknownTokenContractAddresses)
+      for unknownToken in unknownTokens {
+        tokenInfoCache[unknownToken.contractAddress] = unknownToken
+      }
+      allTokens.append(contentsOf: unknownTokens)
     }
     return transactions
       .sorted(by: { $0.createdTime > $1.createdTime })
@@ -221,7 +228,7 @@ class AccountActivityStore: ObservableObject {
           network: network,
           accountInfos: accountInfos,
           visibleTokens: userVisibleTokens,
-          allTokens: allTokens + unknownTokens,
+          allTokens: allTokens,
           assetRatios: assetRatios,
           solEstimatedTxFee: solEstimatedTxFees[transaction.id],
           currencyFormatter: currencyFormatter

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -249,8 +249,8 @@ public class TransactionConfirmationStore: ObservableObject {
     }
     
     let formatter = WeiFormatter(decimalFormatStyle: .balance)
-    let (allowance, _, _) = await rpcService.erc20TokenAllowance(details.token.contractAddress(in: selectedChain), ownerAddress: parsedTransaction.fromAddress, spenderAddress: details.spenderAddress)
-    let allowanceString = formatter.decimalString(for: allowance.removingHexPrefix, radix: .hex, decimals: Int(details.token.decimals)) ?? ""
+    let (allowance, _, _) = await rpcService.erc20TokenAllowance(details.token?.contractAddress(in: selectedChain) ?? "", ownerAddress: parsedTransaction.fromAddress, spenderAddress: details.spenderAddress)
+    let allowanceString = formatter.decimalString(for: allowance.removingHexPrefix, radix: .hex, decimals: Int(details.token?.decimals ?? selectedChain.decimals)) ?? ""
     currentAllowanceCache[parsedTransaction.transaction.id] = allowanceString
     updateTransaction(with: activeTransaction, shouldFetchCurrentAllowance: false, shouldFetchGasTokenBalance: false)
   }
@@ -312,7 +312,7 @@ public class TransactionConfirmationStore: ObservableObject {
       
     case let .ethErc20Approve(details):
       value = details.approvalAmount
-      symbol = details.token.symbol
+      symbol = details.token?.symbol ?? "<Unknown>"
       proposedAllowance = details.approvalValue
       isUnlimitedApprovalRequested = details.isUnlimited
       

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -116,8 +116,8 @@ class TransactionDetailsStore: ObservableObject {
         self.fiat = details.fromFiat
       case let .ethErc20Approve(details):
         self.title = Strings.Wallet.approveNetworkButtonTitle
-        self.value = String(format: "%@ %@", details.approvalAmount, details.token.symbol)
-        if let tokenPrice = assetRatios[details.token.assetRatioId.lowercased()] {
+        self.value = String(format: "%@ %@", details.approvalAmount, details.token?.symbol ?? "<Unknown>")
+        if let token = details.token, let tokenPrice = assetRatios[token.assetRatioId.lowercased()] {
           self.marketPrice = currencyFormatter.string(from: NSNumber(value: tokenPrice)) ?? "$0.00"
         }
       case let .erc721Transfer(details):

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -33,7 +33,7 @@ struct EditPermissionsView: View {
     
     var decimals: Int = 18
     if case .ethErc20Approve(let details) = confirmationStore.activeParsedTransaction.details {
-      decimals = Int(details.token.decimals)
+      decimals = Int(details.token?.decimals ?? networkStore.selectedChain.decimals)
     }
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: decimals))
     let customAllowanceInWei = weiFormatter.weiString(from: customAllowance, radix: .hex, decimals: decimals) ?? "0"

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -74,7 +74,7 @@ extension TransactionParser {
     }
     switch parsedTransaction.details {
     case let .ethSend(details):
-      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "")
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken?.symbol ?? "", details.fromFiat ?? "")
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
@@ -84,7 +84,7 @@ extension TransactionParser {
         networkSymbol: parsedTransaction.networkSymbol
       )
     case let .erc20Transfer(details):
-      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "")
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken?.symbol ?? "", details.fromFiat ?? "")
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
@@ -138,7 +138,7 @@ extension TransactionParser {
         networkSymbol: parsedTransaction.networkSymbol
       )
     case let .solSystemTransfer(details), let .solSplTokenTransfer(details):
-      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken.symbol, details.fromFiat ?? "").replacingOccurrences(of: "()", with: "") // if fiat is empty string, remove `()`
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.fromAmount, details.fromToken?.symbol ?? "", details.fromFiat ?? "").replacingOccurrences(of: "()", with: "") // if fiat is empty string, remove `()`
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -110,9 +110,9 @@ extension TransactionParser {
     case let .ethErc20Approve(details):
       let title: String
       if details.isUnlimited {
-        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, Strings.Wallet.editPermissionsApproveUnlimited, details.token?.symbol ?? "<Unknown>")
+        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, Strings.Wallet.editPermissionsApproveUnlimited, details.token?.symbol ?? "")
       } else {
-        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, details.approvalAmount, details.token?.symbol ?? "<Unknown>")
+        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, details.approvalAmount, details.token?.symbol ?? "")
       }
       return .init(
         txInfo: transaction,

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -110,9 +110,9 @@ extension TransactionParser {
     case let .ethErc20Approve(details):
       let title: String
       if details.isUnlimited {
-        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, Strings.Wallet.editPermissionsApproveUnlimited, details.token.symbol)
+        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, Strings.Wallet.editPermissionsApproveUnlimited, details.token?.symbol ?? "<Unknown>")
       } else {
-        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, details.approvalAmount, details.token.symbol)
+        title = String.localizedStringWithFormat(Strings.Wallet.transactionApproveSymbolTitle, details.approvalAmount, details.token?.symbol ?? "<Unknown>")
       }
       return .init(
         txInfo: transaction,

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -124,7 +124,7 @@ enum TransactionParser {
     case .erc20Transfer:
       guard let toAddress = transaction.txArgs[safe: 0],
             let fromValue = transaction.txArgs[safe: 1],
-            let tokenContractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
+            let tokenContractAddress = transaction.erc20TransferTokenContractAddress,
             let fromToken = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
         return nil
       }
@@ -162,17 +162,11 @@ enum TransactionParser {
         )
       )
     case .ethSwap:
-      guard let fillPath = transaction.txArgs[safe: 0],
-            let sellAmountValue = transaction.txArgs[safe: 1],
+      guard let sellAmountValue = transaction.txArgs[safe: 1],
             let minBuyAmountValue = transaction.txArgs[safe: 2] else {
         return nil
       }
-      
-      let fillPathNoHexPrefix = fillPath.removingHexPrefix
-      let fillPathLength = fillPathNoHexPrefix.count / 2
-      let splitIndex = fillPathNoHexPrefix.index(fillPathNoHexPrefix.startIndex, offsetBy: fillPathLength)
-      let fromTokenAddress = String(fillPathNoHexPrefix[..<splitIndex]).addingHexPrefix
-      let toTokenAddress = String(fillPathNoHexPrefix[splitIndex...]).addingHexPrefix
+      let (fromTokenAddress, toTokenAddress) = transaction.ethSwapTokenContractAddresses ?? ("", "")
       
       let fromToken = token(for: fromTokenAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
       let fromTokenDecimals = Int(fromToken?.decimals ?? network.decimals)
@@ -227,7 +221,7 @@ enum TransactionParser {
         )
       )
     case .erc20Approve:
-      guard let contractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
+      guard let contractAddress = transaction.erc20ApproveTokenContractAddress,
             let spenderAddress = transaction.txArgs[safe: 0],
             let value = transaction.txArgs[safe: 1] else {
         return nil
@@ -279,7 +273,7 @@ enum TransactionParser {
       guard let owner = transaction.txArgs[safe: 0],
             let toAddress = transaction.txArgs[safe: 1],
             let tokenId = transaction.txArgs[safe: 2],
-            let tokenContractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
+            let tokenContractAddress = transaction.erc721ContractAddress,
             let token = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
         return nil
       }
@@ -488,6 +482,8 @@ enum TransactionParser {
       )
     case .erc1155SafeTransferFrom:
       return nil
+    case .solanaSwap:
+      return nil
     @unknown default:
       return nil
     }
@@ -682,7 +678,7 @@ struct EthErc20ApproveDetails: Equatable {
 
 struct SendDetails: Equatable {
   /// Token being swapped from
-  let fromToken: BraveWallet.BlockchainToken
+  let fromToken: BraveWallet.BlockchainToken?
   /// From value prior to formatting
   let fromValue: String
   /// From amount formatted
@@ -794,5 +790,70 @@ extension BraveWallet.TransactionInfo {
 extension ParsedTransaction {
   var coin: BraveWallet.CoinType {
     transaction.coin
+  }
+}
+
+extension BraveWallet.TransactionInfo {
+  /// Contract address for the ERC20 token being approved
+  var erc20ApproveTokenContractAddress: String? {
+    guard txType == .erc20Approve else { return nil }
+    return txDataUnion.ethTxData1559?.baseData.to
+  }
+  
+  /// Contract address for the ERC20 token being transferred
+  var erc20TransferTokenContractAddress: String? {
+    guard txType == .erc20Transfer else { return nil }
+    return txDataUnion.ethTxData1559?.baseData.to
+  }
+  
+  /// Contract address for the from and to token being swapped
+  var ethSwapTokenContractAddresses: (from: String, to: String)? {
+    guard txType == .ethSwap, let fillPath = txArgs[safe: 0] else { return nil }
+    let fillPathNoHexPrefix = fillPath.removingHexPrefix
+    let fillPathLength = fillPathNoHexPrefix.count / 2
+    let splitIndex = fillPathNoHexPrefix.index(fillPathNoHexPrefix.startIndex, offsetBy: fillPathLength)
+    let fromTokenAddress = String(fillPathNoHexPrefix[..<splitIndex]).addingHexPrefix
+    let toTokenAddress = String(fillPathNoHexPrefix[splitIndex...]).addingHexPrefix
+    return (fromTokenAddress, toTokenAddress)
+  }
+  
+  /// Contract address for the ERC721 token
+  var erc721ContractAddress: String? {
+    guard txType == .erc721TransferFrom || txType == .erc721SafeTransferFrom else { return nil }
+    return txDataUnion.ethTxData1559?.baseData.to
+  }
+  
+  /// The contract addresses of the tokens in the transaction
+  var tokenContractAddresses: [String] {
+    switch txType {
+    case .erc20Approve:
+      if let erc20ApproveTokenContractAddress {
+        return [erc20ApproveTokenContractAddress]
+      }
+    case .ethSwap:
+      if let (fromTokenContractAddress, toTokenContractAddress) = ethSwapTokenContractAddresses {
+        return [fromTokenContractAddress, toTokenContractAddress]
+      }
+    case .erc20Transfer:
+      if let erc20TransferTokenContractAddress {
+        return [erc20TransferTokenContractAddress]
+      }
+    case .erc721TransferFrom, .erc721SafeTransferFrom:
+      if let erc721ContractAddress {
+        return [erc721ContractAddress]
+      }
+    case .ethSend, .erc1155SafeTransferFrom, .other:
+      break
+    case .solanaSystemTransfer,
+        .solanaSplTokenTransfer,
+        .solanaSplTokenTransferWithAssociatedTokenAccountCreation,
+        .solanaDappSignTransaction,
+        .solanaDappSignAndSendTransaction,
+        .solanaSwap:
+      break
+    @unknown default:
+      break
+    }
+    return []
   }
 }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -261,6 +261,7 @@ enum TransactionParser {
         details: .ethErc20Approve(
           .init(
             token: token,
+            tokenContractAddress: contractAddress,
             approvalValue: value,
             approvalAmount: approvalAmount,
             isUnlimited: isUnlimited,
@@ -665,6 +666,8 @@ struct ParsedTransaction: Equatable {
 struct EthErc20ApproveDetails: Equatable {
   /// Token being approved
   let token: BraveWallet.BlockchainToken?
+  /// The contract address of the token being approved
+  let tokenContractAddress: String
   /// Value being approved prior to formatting
   let approvalValue: String
   /// Value being approved formatted

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -229,16 +229,16 @@ enum TransactionParser {
     case .erc20Approve:
       guard let contractAddress = transaction.txDataUnion.ethTxData1559?.baseData.to,
             let spenderAddress = transaction.txArgs[safe: 0],
-            let value = transaction.txArgs[safe: 1],
-            let token = token(for: contractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
+            let value = transaction.txArgs[safe: 1] else {
         return nil
       }
+      let token = token(for: contractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
       let isUnlimited = value.caseInsensitiveCompare(WalletConstants.MAX_UINT256) == .orderedSame
       let approvalAmount: String
       if isUnlimited {
         approvalAmount = Strings.Wallet.editPermissionsApproveUnlimited
       } else {
-        approvalAmount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token.decimals))?.trimmingTrailingZeros ?? ""
+        approvalAmount = formatter.decimalString(for: value.removingHexPrefix, radix: .hex, decimals: Int(token?.decimals ?? network.decimals))?.trimmingTrailingZeros ?? ""
       }
       /* Example:
        Approve DAI
@@ -664,7 +664,7 @@ struct ParsedTransaction: Equatable {
 
 struct EthErc20ApproveDetails: Equatable {
   /// Token being approved
-  let token: BraveWallet.BlockchainToken
+  let token: BraveWallet.BlockchainToken?
   /// Value being approved prior to formatting
   let approvalValue: String
   /// Value being approved formatted

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -435,6 +435,7 @@ class TransactionParserTests: XCTestCase {
       details: .ethErc20Approve(
         .init(
           token: .previewDaiToken,
+          tokenContractAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
           approvalValue: "0x2386f26fc10000",
           approvalAmount: "0.01",
           isUnlimited: false,
@@ -514,6 +515,7 @@ class TransactionParserTests: XCTestCase {
       details: .ethErc20Approve(
         .init(
           token: .previewDaiToken,
+          tokenContractAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
           approvalValue: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
           approvalAmount: "Unlimited",
           isUnlimited: true,


### PR DESCRIPTION
## Summary of Changes
- It's possible we have a transaction with a contract address for a token and we don't store the token in our user assets or our blockchain registry. For ERC20 approve, this would cause Transaction Parser to fail to parse and display the empty state for Transaction Confirmation.
- This change makes the tokens optional in parsed transaction models, and if unknown we use the asset ratio service to fetch that token by it's contract address

This pull request fixes #6425

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Setup an ERC20 Approve transaction for an unknown token.
    - I used [Uniswap](https://app.uniswap.org/) on Goerli to swap `ETH` -> `UNI`, then when trying to swap `UNI` to `ETH` I need to approve the UNI token (not in our token registry) to perform the swap. Note: Uniswap is first sending a sign message request for the token approval, if you cancel this you should receive a ERC20 Approve transaction after you've cancelled.
2. Tap swap to create the pending transaction
3. Verify that `UNI` token loads in and displays `UNI`
4. Approve, reject or temporarily ignore the transaction. Open Transactions list from the Wallet Panel
5. Verify `UNI` token is shown in the summary, and tap the transaction to open Transaction Detail
6. Verify `UNI` token is shown in the transaction summary


## Screenshots:

https://user-images.githubusercontent.com/5314553/208120099-4af47c8d-fc99-49c5-a075-16d9fafbd105.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
