### PR TITLE
Fix #6677: Use `OrderedSet` in Brave News card generation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -340,7 +340,8 @@ let package = Package(
         "FeedKit",
         "Fuzi",
         "Growth",
-        .product(name: "Lottie", package: "lottie-ios")
+        .product(name: "Lottie", package: "lottie-ios"),
+        .product(name: "Collections", package: "swift-collections"),
       ],
       resources: [
         .copy("Lottie Assets/brave-today-welcome-graphic.json"),

--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -13,6 +13,7 @@ import BraveCore
 import CodableHelpers
 import os.log
 import SwiftUI
+import Collections
 
 /// Powers the Brave News feed.
 public class FeedDataSource: ObservableObject {
@@ -788,7 +789,7 @@ public class FeedDataSource: ObservableObject {
     dispatchPrecondition(condition: .onQueue(.main))
 
     let overridenSources = FeedSourceOverride.all()
-    var feedsFromEnabledSources = Set(items.filter { item in
+    var feedsFromEnabledSources = OrderedSet(items.filter { item in
       if item.source.isUserSource {
         return true
       }
@@ -798,7 +799,7 @@ public class FeedDataSource: ObservableObject {
     })
     for (key, value) in Preferences.BraveNews.followedChannels.value {
       let channelForLocale = Set(value)
-      feedsFromEnabledSources.formUnion(Set(items.filter({ item in
+      feedsFromEnabledSources.formUnion(OrderedSet(items.filter({ item in
         if overridenSources.first(where: { $0.publisherID == item.source.id })?.enabled == false {
           // Hidden source
           return false


### PR DESCRIPTION
## Summary of Changes

By using `Set` we accidentally dropped the sorting we did prior, which made sorting completely broken on News

This pull request fixes #6677 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
