### PR TITLE
Fix #6668: Remove link text attributes on rewards onboarding description

### DIFF
--- a/Sources/Onboarding/OnboardingRewardsAgreementViewController.swift
+++ b/Sources/Onboarding/OnboardingRewardsAgreementViewController.swift
@@ -141,13 +141,6 @@ extension OnboardingRewardsAgreementViewController {
       $0.textContainerInset = .zero
       $0.font = UIFont.systemFont(ofSize: 16, weight: UIFont.Weight.regular)
       $0.delegate = self
-
-      $0.linkTextAttributes = [
-        .font: $0.font!,
-        .foregroundColor: OnboardingCommon.UX.linkColor,
-        .underlineStyle: 0,
-      ]
-
       $0.textAlignment = .center
     }
 


### PR DESCRIPTION
For some reason on iOS 16+ the attributes defined in this dictionary override any local attributes defined on an attributed string

## Summary of Changes

This pull request fixes #6668 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

| iOS 16 | iOS 15 |
| --- | --- |
| <img width="565" alt="image" src="https://user-images.githubusercontent.com/529104/210420919-cf1cddda-1741-4639-866c-86990a99fc8c.png"> | <img width="564" alt="image" src="https://user-images.githubusercontent.com/529104/210421258-b4dcc0f3-2b33-4304-8003-e626aebd1480.png"> |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
