### PR TITLE
Fix #6673: Apply IDN encoding into shields UI elements that presents domains

### DIFF
--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -10,6 +10,7 @@ import Data
 import BraveUI
 import UIKit
 import Growth
+import BraveCore
 
 /// Displays shield settings and shield stats for a given URL
 class ShieldsViewController: UIViewController, PopoverContentComponent {
@@ -234,10 +235,13 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
     } else {
       shieldsView.simpleShieldView.faviconImageView.isHidden = true
     }
-    shieldsView.simpleShieldView.hostLabel.text = url?.normalizedHost()
+    
+    let normalizedDisplayHost = URLFormatter.formatURL(url?.withoutWWW.absoluteString ?? "").removeSchemeFromURLString(url?.scheme)
+    
+    shieldsView.simpleShieldView.hostLabel.text = normalizedDisplayHost
     shieldsView.reportBrokenSiteView.urlLabel.text = url?.domainURL.absoluteString
     shieldsView.simpleShieldView.shieldsSwitch.addTarget(self, action: #selector(shieldsOverrideSwitchValueChanged), for: .valueChanged)
-    shieldsView.advancedShieldView.siteTitle.titleLabel.text = url?.normalizedHost()?.uppercased()
+    shieldsView.advancedShieldView.siteTitle.titleLabel.text = normalizedDisplayHost.uppercased()
     shieldsView.advancedShieldView.globalControlsButton.addTarget(self, action: #selector(tappedGlobalShieldsButton), for: .touchUpInside)
 
     shieldsView.advancedControlsBar.addTarget(self, action: #selector(tappedAdvancedControlsBar), for: .touchUpInside)

--- a/Client/Frontend/Shields/SimpleShieldsView.swift
+++ b/Client/Frontend/Shields/SimpleShieldsView.swift
@@ -39,10 +39,91 @@ class SimpleShieldsView: UIView {
     $0.textColor = .braveLabel
   }
 
-  // Shields Up
+  let blockCountView = BlockCountView()
 
+  let footerLabel = UILabel().then {
+    $0.text = Strings.Shields.siteBroken
+    $0.font = .systemFont(ofSize: 13.0)
+    $0.textColor = UIColor(rgb: 0x868e96)
+    $0.numberOfLines = 0
+  }
+
+  // Shields Down
+
+  let shieldsDownStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.alignment = .center
+    $0.spacing = 16
+    $0.layoutMargins = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
+    $0.isLayoutMarginsRelativeArrangement = true
+  }
+
+  private let shieldsDownDisclaimerLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 13)
+    $0.text = Strings.Shields.shieldsDownDisclaimer
+    $0.numberOfLines = 0
+    $0.textAlignment = .center
+    $0.textColor = .braveLabel
+  }
+
+  let reportSiteButton = ActionButton(type: .system).then {
+    $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+    $0.titleEdgeInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
+    $0.setTitle(Strings.Shields.reportABrokenSite, for: .normal)
+    $0.tintColor = .braveLabel
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    let stackView = UIStackView().then {
+      $0.axis = .vertical
+      $0.spacing = 16
+      $0.alignment = .center
+      $0.layoutMargins = UIEdgeInsets(top: 24, left: 12, bottom: 24, right: 12)
+      $0.isLayoutMarginsRelativeArrangement = true
+    }
+
+    addSubview(stackView)
+    stackView.snp.makeConstraints {
+      $0.edges.equalTo(self)
+    }
+
+    [shieldsDownDisclaimerLabel, reportSiteButton].forEach(shieldsDownStackView.addArrangedSubview)
+
+    stackView.addStackViewItems(
+      .view(
+        UIStackView(arrangedSubviews: [faviconImageView, hostLabel]).then {
+          $0.spacing = 8
+          $0.alignment = .center
+          $0.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
+          $0.isLayoutMarginsRelativeArrangement = true
+        }),
+      .view(shieldsSwitch),
+      .view(
+        UIStackView(arrangedSubviews: [braveShieldsLabel, statusLabel]).then {
+          $0.spacing = 4
+          $0.alignment = .center
+        }),
+      .customSpace(32),
+      .view(blockCountView),
+      .view(footerLabel),
+      .view(shieldsDownStackView)
+    )
+  }
+
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError()
+  }
+}
+
+// MARK: - BlockCountView
+
+extension SimpleShieldsView {
+  
   class BlockCountView: UIView {
-
+    
     private struct UX {
       static let descriptionEdgeInset = UIEdgeInsets(top: 13, left: 16, bottom: 13, right: 16)
       static let iconEdgeInset = UIEdgeInsets(top: 22, left: 14, bottom: 22, right: 14)
@@ -160,84 +241,6 @@ class SimpleShieldsView: UIView {
     required init(coder: NSCoder) {
       fatalError()
     }
-  }
-
-  let blockCountView = BlockCountView()
-
-  let footerLabel = UILabel().then {
-    $0.text = Strings.Shields.siteBroken
-    $0.font = .systemFont(ofSize: 13.0)
-    $0.textColor = UIColor(rgb: 0x868e96)
-    $0.numberOfLines = 0
-  }
-
-  // Shields Down
-
-  let shieldsDownStackView = UIStackView().then {
-    $0.axis = .vertical
-    $0.alignment = .center
-    $0.spacing = 16
-    $0.layoutMargins = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
-    $0.isLayoutMarginsRelativeArrangement = true
-  }
-
-  private let shieldsDownDisclaimerLabel = UILabel().then {
-    $0.font = .systemFont(ofSize: 13)
-    $0.text = Strings.Shields.shieldsDownDisclaimer
-    $0.numberOfLines = 0
-    $0.textAlignment = .center
-    $0.textColor = .braveLabel
-  }
-
-  let reportSiteButton = ActionButton(type: .system).then {
-    $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
-    $0.titleEdgeInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
-    $0.setTitle(Strings.Shields.reportABrokenSite, for: .normal)
-    $0.tintColor = .braveLabel
-  }
-
-  override init(frame: CGRect) {
-    super.init(frame: frame)
-
-    let stackView = UIStackView().then {
-      $0.axis = .vertical
-      $0.spacing = 16
-      $0.alignment = .center
-      $0.layoutMargins = UIEdgeInsets(top: 24, left: 12, bottom: 24, right: 12)
-      $0.isLayoutMarginsRelativeArrangement = true
-    }
-
-    addSubview(stackView)
-    stackView.snp.makeConstraints {
-      $0.edges.equalTo(self)
-    }
-
-    [shieldsDownDisclaimerLabel, reportSiteButton].forEach(shieldsDownStackView.addArrangedSubview)
-
-    stackView.addStackViewItems(
-      .view(
-        UIStackView(arrangedSubviews: [faviconImageView, hostLabel]).then {
-          $0.spacing = 8
-          $0.alignment = .center
-          $0.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
-          $0.isLayoutMarginsRelativeArrangement = true
-        }),
-      .view(shieldsSwitch),
-      .view(
-        UIStackView(arrangedSubviews: [braveShieldsLabel, statusLabel]).then {
-          $0.spacing = 4
-          $0.alignment = .center
-        }),
-      .customSpace(32),
-      .view(blockCountView),
-      .view(footerLabel),
-      .view(shieldsDownStackView)
-    )
-  }
-
-  @available(*, unavailable)
-  required init(coder: NSCoder) {
-    fatalError()
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6673 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
* Visit hxxps://www.xn--80ak6aa92e.com
* Open Brave Shield panel from the address bar
* "[apple.com](http://apple.com/)" SHOULD NOT BE shown in the panel

## Screenshots:

![No IDN](https://user-images.githubusercontent.com/6643505/210637563-2ec2cb6d-120a-4b92-8205-a3f10aa9ecd4.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
