### PR TITLE
Fix #6675: Both reveal and copy password actions should prompt for authentication

### DIFF
--- a/Client/Frontend/Login/LoginInfoTableViewCell.swift
+++ b/Client/Frontend/Login/LoginInfoTableViewCell.swift
@@ -16,6 +16,7 @@ protocol LoginInfoTableViewCellDelegate: AnyObject {
   /// Table Row Commands Related Actions (Copy - Open)
   func canPerform(action: Selector, for cell: LoginInfoTableViewCell) -> Bool
   func didSelectOpenWebsite(_ cell: LoginInfoTableViewCell)
+  func didSelectCopyWebsite(_ cell: LoginInfoTableViewCell, authenticationRequired: Bool)
   func didSelectReveal(_ cell: LoginInfoTableViewCell, completion: ((Bool) -> Void)?)
 }
 
@@ -173,11 +174,7 @@ extension LoginInfoTableViewCell: MenuHelperInterface {
   }
 
   func menuHelperCopy() {
-    let expireDate = Date().addingTimeInterval(5.minutes)
-
-    UIPasteboard.general.setItems(
-      [[UIPasteboard.typeAutomatic: descriptionTextField.text ?? ""]],
-      options: [UIPasteboard.OptionsKey.expirationDate: expireDate])
+    delegate?.didSelectCopyWebsite(self, authenticationRequired: displayDescriptionAsPassword)
   }
 
   func menuHelperOpenWebsite() {

--- a/Client/Frontend/Login/LoginInfoViewController.swift
+++ b/Client/Frontend/Login/LoginInfoViewController.swift
@@ -417,7 +417,27 @@ extension LoginInfoViewController: LoginInfoTableViewCellDelegate {
       completion?(status)
     }
   }
+  
+  func didSelectCopyWebsite(_ cell: LoginInfoTableViewCell, authenticationRequired: Bool) {
+    func addPasswordToPasteBoardWithExpiry() {
+      let expireDate = Date().addingTimeInterval(5.minutes)
 
+      UIPasteboard.general.setItems(
+        [[UIPasteboard.typeAutomatic: cell.descriptionTextField.text ?? ""]],
+        options: [UIPasteboard.OptionsKey.expirationDate: expireDate])
+    }
+    
+    if authenticationRequired {
+      askForAuthentication() { status in
+        if status {
+          addPasswordToPasteBoardWithExpiry()
+        }
+      }
+    } else {
+      addPasswordToPasteBoardWithExpiry()
+    }
+  }
+  
   func textFieldDidEndEditing(_ cell: LoginInfoTableViewCell) {
     if cell.tag == InfoItem.passwordItem.rawValue {
       cell.displayDescriptionAsPassword = true


### PR DESCRIPTION
Securing password copy in case password is not revealed stage for additional security

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6675

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

- Save a login credential (any)
- Go Settings - Logins & Password
- Go Password Details
- Click password for actions

While Password Reveal is not activate action cop ask authentication in that stage

## Screenshots:



https://user-images.githubusercontent.com/6643505/210639266-e6115ded-b69f-4aae-8053-bf3ff0668bde.mov



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
