### PR TITLE
Fix #6691: Separate Brave News card generation logic and add unit tests

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -710,7 +710,6 @@ class NewTabPageViewController: UIViewController {
     if !feedDataSource.shouldLoadContent {
       return
     }
-    rewards.ads.purgeOrphanedAdEvents(.inlineContentAd) { _ in }
     feedDataSource.load(completion)
   }
 

--- a/Sources/BraveNews/Composer/FeedCardGenerator.swift
+++ b/Sources/BraveNews/Composer/FeedCardGenerator.swift
@@ -1,0 +1,280 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+import Collections
+import BraveShared
+import OSLog
+
+/// Generates the cards that appear on the Brave News feed
+///
+/// This is an AsyncSequence, so cards will be generated seqeuntially in order one-by-one. You can get each
+/// card by `await`ing on the sequence like so
+///
+/// ```
+/// let generator = FeedCardGenerator(...)
+/// for await card in generator {
+///   // Use card
+/// }
+/// ```
+struct FeedCardGenerator: AsyncSequence {
+  typealias Element = [FeedCard]
+  
+  private var items: [FeedItem]
+  private var sequence: [FeedSequenceElement]
+  private var followedSources: Set<String>
+  private var hiddenSources: Set<String>
+  private var followedChannels: [String: Set<String>]
+  private var ads: BraveAds?
+  
+  init(
+    scoredItems: [FeedItem],
+    sequence: [FeedSequenceElement],
+    followedSources: Set<String>,
+    hiddenSources: Set<String>,
+    followedChannels: [String: Set<String>],
+    ads: BraveAds?
+  ) {
+    self.items = scoredItems
+    self.sequence = sequence
+    self.followedSources = followedSources
+    self.hiddenSources = hiddenSources
+    self.followedChannels = followedChannels
+    self.ads = ads
+  }
+  
+  func makeAsyncIterator() -> AsyncIterator {
+    var feedsFromEnabledSources = OrderedSet(items.filter { item in
+      if item.source.isUserSource {
+        return true
+      }
+      return followedSources.contains(item.source.id)
+    })
+    for (key, value) in followedChannels {
+      let channelForLocale = Set(value)
+      feedsFromEnabledSources.formUnion(OrderedSet(items.filter({ item in
+        if hiddenSources.contains(item.source.id) {
+          return false
+        }
+        return item.source.localeDetails?.contains(where: {
+          $0.locale == key && !$0.channels.intersection(channelForLocale).isEmpty
+        }) ?? false
+      })))
+    }
+    let feedItems = Array(feedsFromEnabledSources)
+    let sponsors = feedItems.filter { $0.content.contentType == .sponsor }
+    let partners = feedItems.filter { $0.content.contentType == .partner }
+    let deals = feedItems.filter { $0.content.contentType == .deals }
+    let articles = feedItems.filter { $0.content.contentType == .article }
+    
+    return AsyncIterator(
+      sponsors: sponsors,
+      deals: deals,
+      partners: partners,
+      articles: articles,
+      sequence: sequence,
+      ads: ads
+    )
+  }
+}
+
+extension FeedCardGenerator {
+  struct AsyncIterator: AsyncIteratorProtocol {
+    var sponsors: [FeedItem]
+    var deals: [FeedItem]
+    var partners: [FeedItem]
+    var articles: [FeedItem]
+    var sequence: [FeedSequenceElement]
+    let ads: BraveAds?
+    private let categoryGroupFillStrategy: CategoryFillStrategy<String>
+    private let dealsFillStrategy: CategoryFillStrategy<String?>
+    private var contentAdsQueryFailed: Bool = false
+    private var inlineContentAdsPurged: Bool = false
+    private var repeatingSequence: [FeedSequenceElement]?
+    private var repeatedSequenceCardCount: Int = 0
+    
+    init(
+      sponsors: [FeedItem],
+      deals: [FeedItem],
+      partners: [FeedItem],
+      articles: [FeedItem],
+      sequence: [FeedSequenceElement],
+      ads: BraveAds? = nil
+    ) {
+      self.sponsors = sponsors
+      self.deals = deals
+      self.partners = partners
+      self.articles = articles
+      self.sequence = sequence
+      self.ads = ads
+      // These fill strategies currently require knowledge of the current set of filtered items so we'll
+      // create them here instead and use them directly in `makeCards(for:fillStrategy:)`
+      self.categoryGroupFillStrategy = CategoryFillStrategy(
+        categories: Set(articles.map(\.source.category)),
+        category: \.source.category,
+        initialCategory: FeedDataSource.topNewsCategory
+      )
+      self.dealsFillStrategy = CategoryFillStrategy(
+        categories: Set(deals.compactMap(\.content.offersCategory)),
+        category: \.content.offersCategory
+      )
+    }
+    
+    mutating func next() async throws -> Element? {
+      guard var rule = sequence.first else {
+        return nil
+      }
+      try Task.checkCancellation()
+      sequence.removeFirst()
+      // When we hit a infinitely repeating sequence (with at least one element), replace the current sequence
+      // with that one.
+      //
+      // If we needed to support multiple infinite repeating we'll need to implement some sort of push/pop
+      // version of this.
+      if case .repeating(let repeatingSequence, let count) = rule,
+         count == .max,
+         let firstRepeatedRule = repeatingSequence.first {
+        sequence = repeatingSequence
+        self.repeatingSequence = repeatingSequence
+        rule = firstRepeatedRule
+      }
+      let cards = await makeCards(for: rule, fillStrategy: DefaultFillStrategy()) ?? []
+      if let repeatingSequence {
+        repeatedSequenceCardCount += cards.count
+        // Hit the end of the repeating sequence, check if we added any cards, if not then we're done
+        if sequence.isEmpty {
+          if repeatedSequenceCardCount == 0 {
+            return nil
+          }
+          sequence = repeatingSequence
+          repeatedSequenceCardCount = 0
+        }
+      }
+      return cards
+    }
+    
+    private mutating func makeCards(
+      for element: FeedSequenceElement,
+      fillStrategy: FillStrategy
+    ) async -> [FeedCard]? {
+      switch element {
+      case .sponsor:
+        return fillStrategy.next(from: &sponsors).map {
+          [.sponsor($0)]
+        }
+      case .deals:
+        return dealsFillStrategy.next(3, from: &deals).map {
+          let title = $0.first?.content.offersCategory
+          return [.deals($0, title: title ?? Strings.BraveNews.deals)]
+        }
+      case .partner:
+        let imageExists = { (item: FeedItem) -> Bool in
+          item.content.imageURL != nil
+        }
+        return fillStrategy.next(from: &partners, where: imageExists).map {
+          [.partner($0)]
+        }
+      case .braveAd:
+        // If we fail to obtain inline content ads during a card gen it can be assumed that
+        // all further calls will fail since cards are generated all at once
+        guard !contentAdsQueryFailed, let ads = ads else { return [] }
+        if !inlineContentAdsPurged {
+          inlineContentAdsPurged = true
+          await withCheckedContinuation { c in
+            DispatchQueue.main.async {
+              ads.purgeOrphanedAdEvents(.inlineContentAd, completion: { _ in
+                c.resume()
+              })
+            }
+          }
+        }
+        let contentAd = await withCheckedContinuation { c in
+          DispatchQueue.main.async {
+            ads.inlineContentAds(
+              dimensions: "900x750",
+              completion: { dimensions, ad in
+                c.resume(returning: ad)
+              })
+          }
+        }
+        guard let ad = contentAd else {
+          contentAdsQueryFailed = true
+          Logger.module.debug("Inline content ads could not be filled; Skipping for the rest of this feed generation")
+          return []
+        }
+        return [.ad(ad)]
+      case .headline(let paired):
+        if articles.isEmpty { return [] }
+        let imageExists = { (item: FeedItem) -> Bool in
+          item.content.imageURL != nil
+        }
+        if paired {
+          if articles.count < 2 {
+            return []
+          }
+          return fillStrategy.next(2, from: &articles, where: imageExists).map {
+            [.headlinePair(.init($0[0], $0[1]))]
+          }
+        } else {
+          return fillStrategy.next(from: &articles, where: imageExists).map {
+            [.headline($0)]
+          }
+        }
+      case .categoryGroup:
+        return categoryGroupFillStrategy.next(3, from: &articles).map {
+          let title = $0.first?.source.category ?? ""
+          return [.group($0, title: title, direction: .vertical, displayBrand: false)]
+        }
+      case .brandedGroup(let numbered):
+        if let item = fillStrategy.next(from: &articles) {
+          return fillStrategy.next(2, from: &articles, where: { $0.source == item.source }).map {
+            let items = [item] + $0
+            if numbered {
+              return [.numbered(items, title: item.source.name)]
+            } else {
+              return [.group(items, title: "", direction: .vertical, displayBrand: true)]
+            }
+          }
+        }
+        return []
+      case .group:
+        return fillStrategy.next(3, from: &articles).map {
+          [.group($0, title: "", direction: .vertical, displayBrand: false)]
+        }
+      case .fillUsing(let strategy, let fallbackStrategy, let elements):
+        var cards: [FeedCard] = []
+        for element in elements {
+          if let elementCards = await makeCards(for: element, fillStrategy: strategy) {
+            cards.append(contentsOf: elementCards)
+          } else {
+            if let fallbackStrategy, let elementCards = await makeCards(for: element, fillStrategy: fallbackStrategy) {
+              cards.append(contentsOf: elementCards)
+            }
+          }
+        }
+        return cards
+      case .repeating(let elements, let times):
+        var index = 0
+        var cards: [FeedCard] = []
+        repeat {
+          var repeatedCards: [FeedCard] = []
+          for element in elements {
+            if let elementCards = await makeCards(for: element, fillStrategy: fillStrategy) {
+              repeatedCards.append(contentsOf: elementCards)
+            }
+          }
+          if repeatedCards.isEmpty {
+            // Couldn't fill any of the cards so no reason to continue
+            break
+          }
+          cards.append(contentsOf: repeatedCards)
+          index += 1
+        } while !articles.isEmpty && index < times
+        return cards
+      }
+    }
+  }
+}

--- a/Tests/BraveNewsTests/CardGeneratorTests.swift
+++ b/Tests/BraveNewsTests/CardGeneratorTests.swift
@@ -1,0 +1,240 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import XCTest
+@testable import BraveNews
+
+extension FeedCardGenerator {
+  /// Convenience method for tests to retrieve all cards in the sequence
+  fileprivate var allCards: [FeedCard] {
+    get async throws {
+      var result: [FeedCard] = []
+      for try await cards in self {
+        result.append(contentsOf: cards)
+      }
+      return result
+    }
+  }
+}
+
+final class CardGeneratorTests: XCTestCase {
+  
+  private static let mockSources: [FeedItem.Source] = [
+    .init(id: "1", isDefault: false, category: "Top News", name: "Top News", destinationDomains: [], localeDetails: [.init(channels: ["Top Sources"], locale: "en_US")]),
+    .init(id: "2", isDefault: false, category: "Top News", name: "Top News 2", destinationDomains: [], localeDetails: [.init(channels: ["Top Sources"], locale: "en_US")]),
+    .init(id: "3", isDefault: false, category: "Top News", name: "Top News 3", destinationDomains: [], localeDetails: [.init(channels: ["Top Sources"], locale: "en_US")]),
+    .init(id: "4", isDefault: false, category: "Technology", name: "Technology", destinationDomains: [], localeDetails: [.init(channels: ["Technology"], locale: "ja_JP")]),
+    .init(id: "5", isDefault: false, category: "Technology", name: "Technology 2", destinationDomains: [], localeDetails: [.init(channels: ["Technology"], locale: "ja_JP")]),
+    .init(id: "6", isDefault: false, category: "Technology", name: "Technology 3", destinationDomains: [], localeDetails: [.init(channels: ["Technology"], locale: "ja_JP")]),
+  ]
+  
+  private static let scoredItems: [FeedItem] = Range<Int>(1...6)
+    .compactMap { id -> FeedItem? in
+      guard let source = mockSources.first(where: { $0.id == String(id) }) else { return nil }
+      return .init(
+        score: Double(id),
+        content: .init(
+          publishTime: Date(),
+          imageURL: URL(string: "image")!,
+          title: "",
+          description: "",
+          contentType: .article,
+          publisherID: String(id),
+          urlHash: "1",
+          baseScore: Double(id)
+        ),
+        source: source
+      )
+    }
+    .sorted(by: <)
+  
+  /// Tests that no cards will generate when the user follows no sources or channels within the list of items
+  func testEmptyFollowList() async throws {
+    let sequence: [FeedSequenceElement] = [
+      .headline(paired: false)
+    ]
+    let generator = FeedCardGenerator(
+      scoredItems: Self.scoredItems,
+      sequence: sequence,
+      followedSources: [],
+      hiddenSources: [],
+      followedChannels: [:],
+      ads: nil
+    )
+    let cards = try await generator.allCards
+    XCTAssertTrue(cards.isEmpty)
+  }
+  
+  /// Tests that following a channel will render cards from sources that the user doesn't follow explicilty
+  func testFollowedChannel() async throws {
+    let sequence: [FeedSequenceElement] = [
+      .repeating([
+        .headline(paired: false),
+      ]),
+    ]
+    let generator = FeedCardGenerator(
+      scoredItems: Self.scoredItems,
+      sequence: sequence,
+      followedSources: [],
+      hiddenSources: [],
+      followedChannels: ["en_US": ["Top Sources"]],
+      ads: nil
+    )
+    let expectedItems = Self.scoredItems.filter({
+      $0.source.localeDetails?.contains(where: {
+        $0.locale == "en_US" && !$0.channels.intersection(["Top Sources"]).isEmpty
+      }) ?? false
+    })
+    let cards = try await generator.allCards
+    XCTAssertFalse(cards.isEmpty)
+    XCTAssertEqual(cards.map(\.items).flatMap { $0 }, expectedItems)
+  }
+  
+  /// Tests that hidden sources dont generate cards even if they exist in a followed channel
+  func testHiddenSources() async throws {
+    let sequence: [FeedSequenceElement] = [
+      .repeating([
+        .headline(paired: false),
+      ]),
+    ]
+    let generator = FeedCardGenerator(
+      scoredItems: Self.scoredItems,
+      sequence: sequence,
+      followedSources: [],
+      hiddenSources: ["1"],
+      followedChannels: ["en_US": ["Top Sources"]],
+      ads: nil
+    )
+    let expectedItems = Self.scoredItems.filter({
+      if $0.source.id == "1" { return false }
+      return $0.source.localeDetails?.contains(where: {
+        $0.locale == "en_US" && !$0.channels.intersection(["Top Sources"]).isEmpty
+      }) ?? false
+    })
+    let cards = try await generator.allCards
+    XCTAssertFalse(cards.isEmpty)
+    XCTAssertEqual(cards.map(\.items).flatMap { $0 }, expectedItems)
+  }
+  
+  /// Tests that an empty sequence results in no cards
+  func testEmptySequence() async throws {
+    let generator = FeedCardGenerator(
+      scoredItems: Self.scoredItems,
+      sequence: [],
+      followedSources: [],
+      hiddenSources: [],
+      followedChannels: [:],
+      ads: nil
+    )
+    let cards = try await generator.allCards
+    XCTAssertTrue(cards.isEmpty)
+  }
+  
+  /// Tests a finite sequence that only generates cards until rules run out
+  func testFiniteSequence() async throws {
+    let sequence: [FeedSequenceElement] = [
+      .headline(paired: false),
+    ]
+    let generator = FeedCardGenerator(
+      scoredItems: Self.scoredItems,
+      sequence: sequence,
+      followedSources: Set(Self.mockSources.map(\.id)),
+      hiddenSources: [],
+      followedChannels: [:],
+      ads: nil
+    )
+    let expectedItem = Self.scoredItems.first(where: { $0.content.contentType == .article })
+    let cards = try await generator.allCards
+    XCTAssertEqual(cards.count, 1)
+    if case .headline(let item) = cards.first {
+      XCTAssertEqual(item, expectedItem)
+    } else {
+      XCTFail()
+    }
+  }
+  
+  /// Tests generating cards using a repeating sequence that will fill cards until there are none left to fill
+  func testRepeatingSequence() async throws {
+    let sequence: [FeedSequenceElement] = [
+      .repeating([
+        .headline(paired: false),
+      ]),
+    ]
+    let generator = FeedCardGenerator(
+      scoredItems: Self.scoredItems,
+      sequence: sequence,
+      followedSources: Set(Self.mockSources.map(\.id)),
+      hiddenSources: [],
+      followedChannels: [:],
+      ads: nil
+    )
+    let expectedItems = Self.scoredItems.filter({
+      $0.content.contentType == .article && $0.content.imageURL != nil
+    })
+    let cards = try await generator.allCards
+    XCTAssertEqual(cards.count, expectedItems.count)
+    XCTAssertTrue(cards.allSatisfy({
+      if case .headline = $0 {
+        return true
+      }
+      return false
+    }))
+    XCTAssertEqual(cards.map(\.items).flatMap { $0 }, expectedItems)
+  }
+  
+  /// Tests generating a category group card, which by default will always be a Top News category initially
+  func testInitialCategoryGroup() async throws {
+    let sequence: [FeedSequenceElement] = [
+      .categoryGroup
+    ]
+    let generator = FeedCardGenerator(
+      scoredItems: Self.scoredItems,
+      sequence: sequence,
+      followedSources: Set(Self.mockSources.map(\.id)),
+      hiddenSources: [],
+      followedChannels: [:],
+      ads: nil
+    )
+    let expectedItems = Self.scoredItems.filter({
+      $0.content.contentType == .article && $0.source.category == "Top News"
+    })
+    let cards = try await generator.allCards
+    XCTAssertEqual(cards.count, 1)
+    XCTAssertTrue(cards.allSatisfy({
+      if case .group = $0 {
+        return true
+      }
+      return false
+    }))
+    XCTAssertEqual(cards.map(\.items).flatMap { $0 }, expectedItems)
+  }
+  
+  /// Tests generating a deals card with feed items that have the `deals` content type and an offers category
+  func testDealsCard() async throws {
+    let sequence: [FeedSequenceElement] = [
+      .deals
+    ]
+    let dealsSource = FeedItem.Source(id: "1", isDefault: false, category: "Deals", name: "Deals", destinationDomains: [], backgroundColor: nil, localeDetails: [.init(channels: ["Brave"], locale: "en_US")])
+    let dealsItems: [FeedItem] = (1...3).map {
+      .init(score: Double($0), content: .init(publishTime: Date(), title: "", description: "", contentType: .deals, publisherID: dealsSource.id, urlHash: "1", baseScore: Double($0), offersCategory: "Deal"), source: dealsSource)
+    }
+    let generator = FeedCardGenerator(
+      scoredItems: dealsItems,
+      sequence: sequence,
+      followedSources: [dealsSource.id],
+      hiddenSources: [],
+      followedChannels: [:],
+      ads: nil
+    )
+    let cards = try await generator.allCards
+    XCTAssertEqual(cards.count, 1)
+    if case .deals(let items, _) = cards.first {
+      XCTAssertEqual(items, dealsItems)
+    } else {
+      XCTFail()
+    }
+  }
+}


### PR DESCRIPTION
This also improves time to showing News cards to the user as the cards are can be generated one-by-one rather than block entirely until finished. Currently we do this after generating 10 cards, which should ensure we generated more than just ads

The improvement is ~80ms to first card visibility instead of ~600ms

## Summary of Changes

This pull request fixes #6691 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Basic sanity test

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
