### PR TITLE
Fix #6657 - #6665 - #6456: Sync QR Code related issues

### DIFF
--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -8,54 +8,105 @@ import Data
 import BraveWallet
 import BraveUI
 
-enum DeviceType {
+enum SyncDeviceType {
   case mobile
   case computer
 }
 
 class SyncAddDeviceViewController: SyncViewController {
-  var doneHandler: (() -> Void)?
 
+  // MARK: UX
+  
   private let barcodeSize: CGFloat = 300.0
 
-  lazy var stackView: UIStackView = {
-    let stack = UIStackView()
-    stack.axis = .vertical
-    stack.spacing = 20
-    return stack
-  }()
+  private var scrollViewContainer = UIScrollView()
+  
+  private var stackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 20
+  }
+  
+  private var modeControl = UISegmentedControl(items: [Strings.QRCode, Strings.codeWords]).then {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.selectedSegmentIndex = 0
+    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    $0.selectedSegmentTintColor = UIColor.braveBlurpleTint
+    $0.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
+  }
+  
+  private let titleDescriptionStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 2
+    $0.alignment = .center
+  }
+  
+  private var titleLabel = UILabel().then {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.semibold)
+    $0.textColor = .braveLabel
+    $0.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+  }
+  
+  private var descriptionLabel = UILabel().then {
+    $0.font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.regular)
+    $0.textColor = .braveLabel
+    $0.numberOfLines = 0
+    $0.lineBreakMode = .byTruncatingTail
+    $0.textAlignment = .center
+    $0.adjustsFontSizeToFitWidth = true
+    $0.minimumScaleFactor = 0.5
+    $0.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+  }
 
-  lazy var codewordsView: UILabel = {
-    let label = UILabel()
-    label.font = UIFont.systemFont(ofSize: 18.0, weight: UIFont.Weight.medium)
-    label.lineBreakMode = NSLineBreakMode.byWordWrapping
-    label.textAlignment = .center
-    label.numberOfLines = 0
-    return label
-  }()
-
-  lazy var copyPasteButton: UIButton = {
-    let button = UIButton()
-    button.setTitle(Strings.copyToClipboard, for: .normal)
-    button.addTarget(self, action: #selector(SEL_copy), for: .touchUpInside)
-    button.setTitleColor(UIColor.braveBlurpleTint, for: .normal)
-    button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
-    button.isHidden = true
-    return button
-  }()
-  var controlContainerView: UIView!
-  var containerView: UIView!
-  var qrCodeView: SyncQRCodeView?
-  var modeControl: UISegmentedControl!
-  var titleLabel: UILabel!
-  var descriptionLabel: UILabel!
-  var doneButton: RoundInterfaceButton!
-  var enterWordsButton: RoundInterfaceButton!
-  var pageTitle: String = Strings.sync
-  var deviceType: DeviceType = .mobile
-  var didCopy = false {
+  let syncDetailsContainerView = UIStackView().then {
+    $0.axis = .vertical
+    $0.alignment = .center
+  }
+  
+  private let qrCodeView: SyncQRCodeView
+  
+  private lazy var codewordsView = UILabel().then {
+    $0.font = UIFont.systemFont(ofSize: 18.0, weight: UIFont.Weight.medium)
+    $0.lineBreakMode = NSLineBreakMode.byWordWrapping
+    $0.textAlignment = .center
+    $0.numberOfLines = 0
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+  }
+  
+  private let doneEnterWordsStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 4
+    $0.distribution = .fillEqually
+    $0.setContentCompressionResistancePriority(.required, for: .vertical)
+  }
+  
+  private var doneButton = RoundInterfaceButton(type: .roundedRect).then {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.setTitle(Strings.done, for: .normal)
+    $0.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
+    $0.setTitleColor(.white, for: .normal)
+    $0.backgroundColor = .braveBlurpleTint
+  }
+  
+  private lazy var copyPasteButton = UIButton().then {
+    $0.setTitle(Strings.copyToClipboard, for: .normal)
+    $0.addTarget(self, action: #selector(copyToClipboard), for: .touchUpInside)
+    $0.setTitleColor(UIColor.braveBlurpleTint, for: .normal)
+    $0.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+    $0.isHidden = true
+  }
+  
+  // MARK: Internal
+  
+  private var pageTitle: String = Strings.sync
+  
+  private var deviceType: SyncDeviceType = .mobile
+  
+  private var copyButtonPressed = false {
     didSet {
-      if didCopy {
+      if copyButtonPressed {
         copyPasteButton.setTitle(Strings.copiedToClipboard, for: .normal)
       } else {
         copyPasteButton.setTitle(Strings.copyToClipboard, for: .normal)
@@ -64,9 +115,13 @@ class SyncAddDeviceViewController: SyncViewController {
   }
 
   private let syncAPI: BraveSyncAPI
+  var addDeviceHandler: (() -> Void)?
 
-  init(title: String, type: DeviceType, syncAPI: BraveSyncAPI) {
+  // MARK: Lifecycle
+  
+  init(title: String, type: SyncDeviceType, syncAPI: BraveSyncAPI) {
     self.syncAPI = syncAPI
+    qrCodeView = SyncQRCodeView(syncApi: syncAPI)
     super.init(nibName: nil, bundle: nil)
 
     pageTitle = title
@@ -81,37 +136,10 @@ class SyncAddDeviceViewController: SyncViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    title = deviceType == .computer ? Strings.syncAddComputerTitle : Strings.syncAddTabletOrPhoneTitle
-
-    view.addSubview(stackView)
-    stackView.snp.makeConstraints {
-      $0.top.equalTo(view.safeArea.top).inset(10)
-      $0.left.right.equalTo(view).inset(16)
-      $0.bottom.equalTo(view.safeArea.bottom).inset(24)
-    }
-  
-    controlContainerView = UIView()
-    controlContainerView.translatesAutoresizingMaskIntoConstraints = false
-
-    containerView = UIView()
-    containerView.translatesAutoresizingMaskIntoConstraints = false
-    containerView.layer.cornerRadius = 8
-    containerView.layer.cornerCurve = .continuous
-
-    qrCodeView = SyncQRCodeView(syncApi: syncAPI)
-    containerView.addSubview(qrCodeView!)
-    qrCodeView?.snp.makeConstraints {
-      if UIDevice.isIpad {
-        $0.leading.trailing.equalToSuperview().inset(24)
-        $0.width.equalTo(qrCodeView?.snp.height ?? barcodeSize)
-      } else {
-        $0.centerX.equalTo(containerView)
-        $0.size.equalTo(barcodeSize)
-      }
-    }
-
-    codewordsView.text = syncAPI.getTimeLimitedWords(fromWords: syncAPI.getSyncCode())
-    setupVisuals()
+    setTheme()
+    doLayout()
+    
+    enableDeviceType()
   }
   
   override func viewDidAppear(_ animated: Bool) {
@@ -121,107 +149,83 @@ class SyncAddDeviceViewController: SyncViewController {
       showInitializationError()
     }
   }
+  
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    
+    scrollViewContainer.contentSize = CGSize(width: stackView.frame.width, height: stackView.frame.height)
+    updateLabels()
+  }
+  
+  private func setTheme() {
+    title = deviceType == .computer ? Strings.syncAddComputerTitle : Strings.syncAddTabletOrPhoneTitle
 
+    codewordsView.text = syncAPI.getTimeLimitedWords(fromWords: syncAPI.getSyncCode())
+    
+    modeControl.do {
+      $0.isHidden = deviceType == .computer
+      $0.addTarget(self, action: #selector(changeMode), for: .valueChanged)
+    }
+    
+    doneButton.addTarget(self, action: #selector(done), for: .touchUpInside)
+  }
+
+  private func doLayout() {
+    // Scroll View
+    view.addSubview(scrollViewContainer)
+    scrollViewContainer.snp.makeConstraints {
+      $0.top.equalTo(view.safeArea.top).inset(10)
+      $0.left.right.equalTo(view)
+      $0.bottom.equalTo(view.safeArea.bottom).inset(24)
+    }
+    
+    // Content StackView
+    scrollViewContainer.addSubview(stackView)
+    stackView.snp.makeConstraints {
+      $0.top.bottom.equalToSuperview()
+      $0.leading.trailing.equalTo(view).inset(16)
+      $0.width.equalToSuperview()
+    }
+    
+    // Segmented Control
+    stackView.addArrangedSubview(modeControl)
+
+    // Title - Description Label
+    titleDescriptionStackView.addArrangedSubview(titleLabel)
+    titleDescriptionStackView.addArrangedSubview(descriptionLabel)
+    stackView.addArrangedSubview(titleDescriptionStackView)
+
+    // Code Words View - QR Code
+    syncDetailsContainerView.addArrangedSubview(qrCodeView)
+    syncDetailsContainerView.addArrangedSubview(codewordsView)
+    
+    qrCodeView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview().inset(24)
+      $0.width.equalTo(qrCodeView.snp.height)
+    }
+    
+    codewordsView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    codewordsView.isHidden = true
+    stackView.addArrangedSubview(syncDetailsContainerView)
+
+    // Copy - Paste - Done Button
+    doneButton.snp.makeConstraints {
+      $0.height.equalTo(40)
+    }
+    doneEnterWordsStackView.addArrangedSubview(copyPasteButton)
+    doneEnterWordsStackView.addArrangedSubview(doneButton)
+    stackView.addArrangedSubview(doneEnterWordsStackView)
+  }
+
+  // MARK: Private
+  
   private func showInitializationError() {
     present(SyncAlerts.initializationError, animated: true)
   }
-
-  private func setupVisuals() {
-    modeControl = UISegmentedControl(items: [Strings.QRCode, Strings.codeWords])
-    modeControl.translatesAutoresizingMaskIntoConstraints = false
-    modeControl.selectedSegmentIndex = 0
-    modeControl.addTarget(self, action: #selector(SEL_changeMode), for: .valueChanged)
-    modeControl.isHidden = deviceType == .computer
-    modeControl.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-
-    modeControl.selectedSegmentTintColor = UIColor.braveBlurpleTint
-    modeControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
-    stackView.addArrangedSubview(modeControl)
-
-    let titleDescriptionStackView = UIStackView()
-    titleDescriptionStackView.axis = .vertical
-    titleDescriptionStackView.spacing = 2
-    titleDescriptionStackView.alignment = .center
-
-    titleLabel = UILabel()
-    titleLabel.translatesAutoresizingMaskIntoConstraints = false
-    titleLabel.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.semibold)
-    titleLabel.textColor = .braveLabel
-    titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-    titleLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
-    titleDescriptionStackView.addArrangedSubview(titleLabel)
-
-    descriptionLabel = UILabel()
-    descriptionLabel.font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.regular)
-    descriptionLabel.textColor = .braveLabel
-    descriptionLabel.numberOfLines = 0
-    descriptionLabel.lineBreakMode = .byTruncatingTail
-    descriptionLabel.textAlignment = .center
-    descriptionLabel.adjustsFontSizeToFitWidth = true
-    descriptionLabel.minimumScaleFactor = 0.5
-    descriptionLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-    descriptionLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
-    titleDescriptionStackView.addArrangedSubview(descriptionLabel)
-
-    stackView.addArrangedSubview(titleDescriptionStackView)
-
-    codewordsView.isHidden = true
-    containerView.addSubview(codewordsView)
-    stackView.addArrangedSubview(containerView)
-
-    let doneEnterWordsStackView = UIStackView()
-    doneEnterWordsStackView.axis = .vertical
-    doneEnterWordsStackView.spacing = 4
-    doneEnterWordsStackView.distribution = .fillEqually
-
-    doneEnterWordsStackView.addArrangedSubview(copyPasteButton)
-
-    doneButton = RoundInterfaceButton(type: .roundedRect)
-    doneButton.translatesAutoresizingMaskIntoConstraints = false
-    doneButton.setTitle(Strings.done, for: .normal)
-    doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.bold)
-    doneButton.setTitleColor(.white, for: .normal)
-    doneButton.backgroundColor = .braveBlurpleTint
-    doneButton.addTarget(self, action: #selector(SEL_done), for: .touchUpInside)
-
-    doneEnterWordsStackView.addArrangedSubview(doneButton)
-
-    enterWordsButton = RoundInterfaceButton(type: .roundedRect)
-    enterWordsButton.translatesAutoresizingMaskIntoConstraints = false
-    enterWordsButton.setTitle(Strings.showCodeWords, for: .normal)
-    enterWordsButton.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.semibold)
-    enterWordsButton.setTitleColor(.braveLabel, for: .normal)
-    enterWordsButton.addTarget(self, action: #selector(SEL_showCodewords), for: .touchUpInside)
-
-    doneEnterWordsStackView.setContentCompressionResistancePriority(.required, for: .vertical)
-
-    stackView.addArrangedSubview(doneEnterWordsStackView)
-
-    codewordsView.snp.makeConstraints {
-      $0.edges.equalToSuperview()
-      if UIDevice.isIpad {
-        $0.size.equalTo(barcodeSize)
-      }
-    }
-
-    doneButton.snp.makeConstraints { (make) in
-      make.height.equalTo(40)
-    }
-
-    enterWordsButton.snp.makeConstraints { (make) in
-      make.height.equalTo(20)
-    }
-
-    if deviceType == .computer {
-      SEL_showCodewords()
-    }
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    updateLabels()
-  }
-
+  
   private func updateLabels() {
     let isFirstIndex = modeControl.selectedSegmentIndex == 0
 
@@ -258,38 +262,44 @@ class SyncAddDeviceViewController: SyncViewController {
     guard let lastSentence = text.split(separator: "\n").last else { return nil }
     return (text as NSString).range(of: String(lastSentence))
   }
+  
+  private func enableDeviceType() {
+    if deviceType == .computer {
+      showCodewords()
+    }
+  }
+}
 
-  @objc func SEL_showCodewords() {
+// MARK: Actions
+
+extension SyncAddDeviceViewController {
+  @objc func showCodewords() {
     modeControl.selectedSegmentIndex = 1
-    enterWordsButton.isHidden = true
-    SEL_changeMode()
+    changeMode()
   }
 
-  @objc func SEL_copy() {
+  @objc func copyToClipboard() {
     if let words = self.codewordsView.text {
       UIPasteboard.general.setSecureString(words, expirationDate: Date().addingTimeInterval(30))
-      didCopy = true
+      copyButtonPressed = true
     }
   }
 
-  @objc func SEL_changeMode() {
+  @objc func changeMode() {
     let isFirstIndex = modeControl.selectedSegmentIndex == 0
 
-    qrCodeView?.isHidden = !isFirstIndex
+    qrCodeView.isHidden = !isFirstIndex
     codewordsView.isHidden = isFirstIndex
     copyPasteButton.isHidden = isFirstIndex
 
     codewordsView.snp.remakeConstraints {
       $0.edges.equalToSuperview()
-      if UIDevice.isIpad, isFirstIndex {
-        $0.size.equalTo(barcodeSize)
-      }
     }
     
     updateLabels()
   }
 
-  @objc func SEL_done() {
-    doneHandler?()
+  @objc func done() {
+    addDeviceHandler?()
   }
 }

--- a/Client/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Client/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -65,6 +65,12 @@ class SyncAddDeviceViewController: SyncViewController {
     $0.alignment = .center
   }
   
+  // This view is created to create white frame around the QR code
+  // It is done to solve problems scanning QR code with Android devices
+  private let qrCodeContainerView = UIView().then {
+    $0.backgroundColor = .white
+  }
+  
   private let qrCodeView: SyncQRCodeView
   
   private lazy var codewordsView = UILabel().then {
@@ -160,7 +166,10 @@ class SyncAddDeviceViewController: SyncViewController {
   private func setTheme() {
     title = deviceType == .computer ? Strings.syncAddComputerTitle : Strings.syncAddTabletOrPhoneTitle
 
-    codewordsView.text = syncAPI.getTimeLimitedWords(fromWords: syncAPI.getSyncCode())
+    codewordsView.do {
+      $0.text = syncAPI.getTimeLimitedWords(fromWords: syncAPI.getSyncCode())
+      $0.isHidden = true
+    }
     
     modeControl.do {
       $0.isHidden = deviceType == .computer
@@ -196,19 +205,24 @@ class SyncAddDeviceViewController: SyncViewController {
     stackView.addArrangedSubview(titleDescriptionStackView)
 
     // Code Words View - QR Code
-    syncDetailsContainerView.addArrangedSubview(qrCodeView)
+    syncDetailsContainerView.addArrangedSubview(qrCodeContainerView)
     syncDetailsContainerView.addArrangedSubview(codewordsView)
     
+    qrCodeContainerView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview().inset(12)
+      $0.width.equalTo(qrCodeContainerView.snp.height)
+    }
+    
+    qrCodeContainerView.addSubview(qrCodeView)
+    
     qrCodeView.snp.makeConstraints {
-      $0.leading.trailing.equalToSuperview().inset(24)
-      $0.width.equalTo(qrCodeView.snp.height)
+      $0.edges.equalToSuperview().inset(12)
     }
     
     codewordsView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
     
-    codewordsView.isHidden = true
     stackView.addArrangedSubview(syncDetailsContainerView)
 
     // Copy - Paste - Done Button
@@ -288,13 +302,9 @@ extension SyncAddDeviceViewController {
   @objc func changeMode() {
     let isFirstIndex = modeControl.selectedSegmentIndex == 0
 
-    qrCodeView.isHidden = !isFirstIndex
+    qrCodeContainerView.isHidden = !isFirstIndex
     codewordsView.isHidden = isFirstIndex
     copyPasteButton.isHidden = isFirstIndex
-
-    codewordsView.snp.remakeConstraints {
-      $0.edges.equalToSuperview()
-    }
     
     updateLabels()
   }

--- a/Client/Frontend/Sync/SyncQRCodeView.swift
+++ b/Client/Frontend/Sync/SyncQRCodeView.swift
@@ -14,7 +14,7 @@ class SyncQRCodeView: UIImageView {
     let json = syncApi.qrCodeJson(fromHexSeed: syncApi.hexSeed(fromSyncCode: syncApi.getSyncCode()))
     let result = QRCodeGenerator().generateQRCode(QRCodeGenerator.Options(data: json,
                                                                           shouldRender: true,
-                                                                          renderLogoInCenter: true,
+                                                                          renderLogoInCenter: false,
                                                                           renderModuleStyle: .circles,
                                                                           renderLocatorStyle: .rounded))
     image = result.image ?? getQRCodeImage(json, size: CGSize(width: barcodeSize, height: barcodeSize))

--- a/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
+++ b/Client/Frontend/Sync/SyncSelectDeviceTypeViewController.swift
@@ -10,7 +10,7 @@ class SyncDeviceTypeButton: UIControl {
 
   var imageView: UIImageView = UIImageView()
   var label: UILabel = UILabel()
-  var type: DeviceType!
+  var type: SyncDeviceType!
 
   // Color for the opposite state of `pressed`
   private var pressedReversedColor = UIColor.braveBlurpleTint
@@ -33,7 +33,7 @@ class SyncDeviceTypeButton: UIControl {
     }
   }
 
-  convenience init(image: String, title: String, type: DeviceType) {
+  convenience init(image: String, title: String, type: SyncDeviceType) {
     self.init(frame: CGRect.zero)
 
     backgroundColor = .braveBackground
@@ -96,7 +96,7 @@ class SyncDeviceTypeButton: UIControl {
 }
 
 class SyncSelectDeviceTypeViewController: SyncViewController {
-  var syncInitHandler: ((String, DeviceType) -> Void)?
+  var syncInitHandler: ((String, SyncDeviceType) -> Void)?
 
   let loadingView = UIView()
   let chooseDeviceLabel = UILabel().then {

--- a/Client/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Client/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -467,7 +467,7 @@ extension SyncSettingsTableViewController {
 
     view.syncInitHandler = { title, type in
       let view = SyncAddDeviceViewController(title: title, type: type, syncAPI: self.syncAPI)
-      view.doneHandler = {
+      view.addDeviceHandler = {
         self.navigationController?.popToViewController(self, animated: true)
       }
       self.navigationController?.pushViewController(view, animated: true)

--- a/Client/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Client/Frontend/Sync/SyncWelcomeViewController.swift
@@ -224,7 +224,7 @@ class SyncWelcomeViewController: SyncViewController {
         }
 
         let view = SyncAddDeviceViewController(title: title, type: type, syncAPI: self.syncAPI)
-        view.doneHandler = self.pushSettings
+        view.addDeviceHandler = self.pushSettings
         view.navigationItem.hidesBackButton = true
         self.navigationController?.pushViewController(view, animated: true)
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

This PR is trying to solve the problems related with QR Code screen and fix the issues with scanning QR from Android phone.

Basically it is trying to

 1. Layout on small screen sizes
 2. Add white border around QR code image which is always white even when dark mode is activated
 3. Set the parameter renderLogoInCenter no for no logo QR  
 
## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6665
This pull request fixes #6657

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:

iPhone X:_


https://user-images.githubusercontent.com/6643505/210902500-395b0b97-6aa3-446d-bcf1-5620759a4335.MP4


iPhone SE:_

https://user-images.githubusercontent.com/6643505/210902526-79aef1e5-22a4-4bfa-84de-ae82745ad713.mp4


iPad 12.9":_



https://user-images.githubusercontent.com/6643505/210902620-6dd3baac-cb97-4d5d-821e-d4acbecf271b.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
