### PR TITLE
Fix: #6717 - Playlist Downloading ID not consistent

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -383,7 +383,6 @@ extension PlaylistListViewController: UITableViewDelegate {
           PlaylistCarplayManager.shared.currentPlaylistItem = item
           self.commitPlayerItemTransaction(at: indexPath, isExpired: false)
           self.delegate?.updateLastPlayedItem(item: item)
-          PlaylistManager.shared.autoDownload(item: item)
         case .cancelled:
           self.commitPlayerItemTransaction(at: indexPath, isExpired: false)
           Logger.module.debug("User cancelled Playlist Playback")

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -372,9 +372,6 @@ class PlaylistListViewController: UIViewController {
           // Even if the item was NOT previously the last played item,
           // it is now as it has begun to play
           delegate.updateLastPlayedItem(item: item)
-          
-          // Download item if necessary
-          PlaylistManager.shared.autoDownload(item: item)
         }
       }
     }

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -681,7 +681,6 @@ extension PlaylistViewController: VideoViewDelegate {
             PlaylistCarplayManager.shared.currentPlaylistItem = item
             self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)
             self.updateLastPlayedItem(item: item)
-            PlaylistManager.shared.autoDownload(item: item)
           case .cancelled:
             self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)
             Logger.module.debug("User Cancelled Playlist Playback")
@@ -763,7 +762,6 @@ extension PlaylistViewController: VideoViewDelegate {
             PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
             PlaylistCarplayManager.shared.currentPlaylistItem = item
             self.updateLastPlayedItem(item: item)
-            PlaylistManager.shared.autoDownload(item: item)
           case .cancelled:
             self.listController.commitPlayerItemTransaction(at: indexPath, isExpired: false)
             Logger.module.debug("User Cancelled Playlist Playback")

--- a/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Client/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -131,8 +131,23 @@ class PlaylistMediaStreamer {
             }
 
             if let newItem = newItem, URL(string: newItem.src) != nil {
-              PlaylistItem.updateItem(newItem) {
-                resolver(.success(newItem))
+              let updatedItem = PlaylistInfo(name: newItem.name,
+                                             src: newItem.src,
+                                             pageSrc: item.pageSrc,  // Keep the same pageSrc
+                                             pageTitle: newItem.pageTitle,
+                                             mimeType: newItem.mimeType,
+                                             duration: newItem.duration,
+                                             detected: newItem.detected,
+                                             dateAdded: item.dateAdded, // Keep the same dateAdded
+                                             tagId: item.tagId,  // Keep the same tagId
+                                             order: item.order) // Keep the same order
+              
+              PlaylistItem.updateItem(updatedItem) {
+                resolver(.success(updatedItem))
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                  PlaylistManager.shared.autoDownload(item: updatedItem)
+                }
               }
             } else if cancelled {
               resolver(.failure(.cancelled))


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix playlist downloading ID when updating via streams which can cause an item to be downloaded multiple times even if already downloaded (doesn't take extra space as it just replaces the already downloaded item, but can be annoying)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6717

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
