### PR TITLE
Fix #6715: Remove use of Playability API

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -780,7 +780,7 @@ extension PlaylistCarplayController {
   }
 
   func load(url: URL, autoPlayEnabled: Bool) -> AnyPublisher<Void, Error> {
-    load(asset: AVURLAsset(url: url), autoPlayEnabled: autoPlayEnabled)
+    load(asset: AVURLAsset(url: url, options: AVAsset.defaultOptions), autoPlayEnabled: autoPlayEnabled)
   }
 
   func load(asset: AVURLAsset, autoPlayEnabled: Bool) -> AnyPublisher<Void, Error> {

--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -869,7 +869,7 @@ extension PlaylistViewController: VideoViewDelegate {
   }
 
   func load(_ videoView: VideoView, url: URL, autoPlayEnabled: Bool) -> AnyPublisher<Void, MediaPlaybackError> {
-    load(videoView, asset: AVURLAsset(url: url), autoPlayEnabled: autoPlayEnabled)
+    load(videoView, asset: AVURLAsset(url: url, options: AVAsset.defaultOptions), autoPlayEnabled: autoPlayEnabled)
   }
 
   func load(_ videoView: VideoView, asset: AVURLAsset, autoPlayEnabled: Bool) -> AnyPublisher<Void, MediaPlaybackError> {

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
@@ -178,7 +178,7 @@ public class PlaylistDownloadManager: PlaylistStreamDownloadManagerDelegate {
         return nil
       }
 
-      return AVURLAsset(url: url)
+      return AVURLAsset(url: url, options: AVAsset.defaultOptions)
     } catch {
       Logger.module.error("\(error.localizedDescription)")
       return nil
@@ -235,7 +235,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
   }
 
   func downloadAsset(_ session: AVAssetDownloadURLSession, assetUrl: URL, for item: PlaylistInfo) {
-    let asset = AVURLAsset(url: assetUrl)
+    let asset = AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions)
 
     // TODO: In the future switch back to AVAggregateAssetDownloadTask after investigating progress calculation
     //        guard let task =
@@ -453,7 +453,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
             let mediaSrc = item.mediaSrc,
             let assetUrl = URL(string: mediaSrc) {
             let info = PlaylistInfo(item: item)
-            let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: AVURLAsset(url: assetUrl))
+            let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions))
             self.activeDownloadTasks[task] = asset
           }
         }
@@ -462,7 +462,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
   }
 
   func downloadAsset(_ session: URLSession, assetUrl: URL, for item: PlaylistInfo) {
-    let asset = AVURLAsset(url: assetUrl)
+    let asset = AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions)
 
     let request: URLRequest = {
       var request = URLRequest(url: assetUrl, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10.0)

--- a/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Client/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -511,7 +511,7 @@ extension PlaylistManager {
       return asset
     }
 
-    return AVURLAsset(url: URL(string: mediaSrc)!)
+    return AVURLAsset(url: URL(string: mediaSrc)!, options: AVAsset.defaultOptions)
   }
 }
 

--- a/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Client/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -121,7 +121,7 @@ class MediaPlayer: NSObject {
   }
 
   func load(url: URL) -> Deferred<AnyPublisher<Bool, MediaPlaybackError>> {
-    load(asset: AVURLAsset(url: url))
+    load(asset: AVURLAsset(url: url, options: AVAsset.defaultOptions))
   }
 
   /// On success, returns a publisher with a Boolean.
@@ -697,5 +697,16 @@ extension AVAsset {
   /// It's best to assume this type of media is a video stream.
   func isVideoTracksAvailable() -> Bool {
     !tracks.filter({ $0.mediaType == .video }).isEmpty
+  }
+  
+  static var defaultOptions: [String: Any] {
+    let userAgent = UserAgent.shouldUseDesktopMode ? UserAgent.desktop : UserAgent.mobile
+    var options: [String: Any] = [:]
+    if #available(iOS 16, *) {
+        options[AVURLAssetHTTPUserAgentKey] = userAgent
+    } else {
+        options["AVURLAssetHTTPHeaderFieldsKey"] = ["User-Agent": userAgent]
+    }
+    return options
   }
 }

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/PlaylistScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/PlaylistScriptHandler.swift
@@ -114,16 +114,11 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
         return
       }
 
-      if let url = URL(string: item.src) {
-        handler.loadAssetPlayability(url: url) { [weak handler] isPlayable in
+      if URL(string: item.src) != nil {
+        DispatchQueue.main.async { [weak handler] in
           guard let handler = handler,
             let delegate = handler.delegate
           else { return }
-
-          if !isPlayable && !item.src.hasPrefix("blob:") {
-            delegate.updatePlaylistURLBar(tab: handler.tab, state: .none, item: nil)
-            return
-          }
 
           if PlaylistItem.itemExists(pageSrc: item.pageSrc) {
             // Item already exists, so just update the database with new token or URL.
@@ -147,7 +142,7 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
       // because otherwise it will add an invalid item to playlist that can't be played.
       // IE: WebM videos aren't supported so can't be played.
       // Therefore we shouldn't prompt the user to add to playlist.
-      asset = AVURLAsset(url: url)
+      asset = AVURLAsset(url: url, options: AVAsset.defaultOptions)
     }
     
     guard let asset = asset else {


### PR DESCRIPTION
## Summary of Changes
- Use custom user agent.
- Remove use of Playability API (even though it only ever requests bytes [0-1], it affects websites where `preload=none` is set. This means we can no longer detect if an item is playable before showing it in the URL bar)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6715

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
