### PR TITLE
Fix #6721: Sort feed items by score after collecting enabled sources

### DIFF
--- a/Sources/BraveNews/Composer/FeedCardGenerator.swift
+++ b/Sources/BraveNews/Composer/FeedCardGenerator.swift
@@ -64,7 +64,7 @@ struct FeedCardGenerator: AsyncSequence {
         }) ?? false
       })))
     }
-    let feedItems = Array(feedsFromEnabledSources)
+    let feedItems = feedsFromEnabledSources.sorted(by: <)
     let sponsors = feedItems.filter { $0.content.contentType == .sponsor }
     let partners = feedItems.filter { $0.content.contentType == .partner }
     let deals = feedItems.filter { $0.content.contentType == .deals }
@@ -180,7 +180,7 @@ extension FeedCardGenerator {
       case .braveAd:
         // If we fail to obtain inline content ads during a card gen it can be assumed that
         // all further calls will fail since cards are generated all at once
-        guard !contentAdsQueryFailed, let ads = ads else { return [] }
+        guard !contentAdsQueryFailed, let ads = ads, ads.isAdsServiceRunning() else { return [] }
         if !inlineContentAdsPurged {
           inlineContentAdsPurged = true
           await withCheckedContinuation { c in

--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -745,8 +745,6 @@ public class FeedDataSource: ObservableObject {
 
   /// Scores a set of items in the feed based on recency, personalization and variety.
   ///
-  /// The items returned in `completion` will be sorted based on score
-  ///
   /// Must be called on the main thread, `completion` is called on main thread
   private func score(
     feeds: [FeedItem.Content],
@@ -776,7 +774,6 @@ public class FeedDataSource: ObservableObject {
         }
         return FeedItem(score: score, content: content, source: source)
       }
-      .sorted(by: <)
       DispatchQueue.main.async {
         completion(items)
       }


### PR DESCRIPTION
Also fixes a potential bug where the ads may not be initialized in time and will cause a continuation leak

## Summary of Changes

This pull request fixes #6721 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
