### PR TITLE
Fix #6639: Integrate SNS to allow sending tokens to .sol domains

### DIFF
--- a/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
+++ b/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
@@ -29,10 +29,9 @@ extension BraveCoreSwitchKey {
       return "Express Rotation Interval"
     case .p3aUploadServerURL:
       return "Upload Server URL"
+    case .enableFeatures:
+      return "Enable Features"
     default:
-      if rawValue == "enable-features" {
-        return "Enable Features"
-      }
       return ""
     }
   }
@@ -45,6 +44,8 @@ extension BraveCoreSwitchKey {
       return false
     }
   }
+  
+  static let enableFeatures: Self = .init(rawValue: "enable-features")
 }
 
 private enum SkusEnvironment: String, CaseIterable {
@@ -251,9 +252,9 @@ struct BraveCoreDebugSwitchesView: View {
             SwitchContainer(.vModule)
           }
           NavigationLink {
-            BasicStringInputView(coreSwitch: BraveCoreSwitchKey(rawValue: "enable-features"), hint: "Should match the format:\n\n{feature_name}")
+            BasicStringInputView(coreSwitch: .enableFeatures, hint: "Should match the format:\n\n{feature_name}\n\nMultiple features can be enabled via comma separation")
           } label: {
-            SwitchContainer(BraveCoreSwitchKey(rawValue: "enable-features"))
+            SwitchContainer(.enableFeatures)
           }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))

--- a/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
+++ b/Client/Frontend/Settings/BraveCoreDebugSwitchesView.swift
@@ -30,6 +30,9 @@ extension BraveCoreSwitchKey {
     case .p3aUploadServerURL:
       return "Upload Server URL"
     default:
+      if rawValue == "enable-features" {
+        return "Enable Features"
+      }
       return ""
     }
   }
@@ -246,6 +249,11 @@ struct BraveCoreDebugSwitchesView: View {
             BasicStringInputView(coreSwitch: .vModule, hint: "Should match the format:\n\n{folder-expression}={level}\n\nDefaults to */brave/*=5")
           } label: {
             SwitchContainer(.vModule)
+          }
+          NavigationLink {
+            BasicStringInputView(coreSwitch: BraveCoreSwitchKey(rawValue: "enable-features"), hint: "Should match the format:\n\n{feature_name}")
+          } label: {
+            SwitchContainer(BraveCoreSwitchKey(rawValue: "enable-features"))
           }
         }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -149,6 +149,14 @@ struct SendTokenView: View {
               .font(.footnote)
               .foregroundColor(Color(.braveErrorLabel))
               .padding(.bottom)
+            } else {
+              // SwiftUI will add/remove this Section footer when addressError
+              // optionality is changed. This can cause keyboard to dismiss.
+              // By using clear square, the footer remains and section is not
+              // redrawn, so the keyboard does not dismiss as user types.
+              Color.clear.frame(width: 1, height: 1)
+                .accessibility(hidden: true)
+                .transition(.identity)
             }
           }
         ) {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -28,6 +28,7 @@ struct SendTokenView: View {
           let token = sendTokenStore.selectedSendToken,
           !sendTokenStore.isMakingTx,
           !sendTokenStore.sendAddress.isEmpty,
+          !sendTokenStore.isResolvingAddress,
           sendTokenStore.addressError == nil,
           sendTokenStore.sendError == nil else {
       return true
@@ -151,28 +152,51 @@ struct SendTokenView: View {
             }
           }
         ) {
-          HStack(spacing: 14.0) {
-            TextField(Strings.Wallet.sendToCryptoAddressPlaceholder, text: $sendTokenStore.sendAddress)
-            Button(action: {
-              if let string = UIPasteboard.general.string {
-                sendTokenStore.sendAddress = string
+          VStack {
+            HStack(spacing: 14.0) {
+              TextField(Strings.Wallet.sendToCryptoAddressPlaceholder, text: $sendTokenStore.sendAddress)
+                .autocorrectionDisabled()
+                .osAvailabilityModifiers {
+                  if #available(iOS 15, *) {
+                    $0.textInputAutocapitalization(.never)
+                  } else {
+                    $0.autocapitalization(.none)
+                  }
+                }
+              Button(action: {
+                if let string = UIPasteboard.general.string {
+                  sendTokenStore.sendAddress = string
+                }
+              }) {
+                Label(Strings.Wallet.pasteFromPasteboard, braveSystemImage: "brave.clipboard")
+                  .labelStyle(.iconOnly)
+                  .foregroundColor(Color(.primaryButtonTint))
+                  .font(.body)
               }
-            }) {
-              Label(Strings.Wallet.pasteFromPasteboard, braveSystemImage: "brave.clipboard")
-                .labelStyle(.iconOnly)
-                .foregroundColor(Color(.primaryButtonTint))
-                .font(.body)
+              .buttonStyle(PlainButtonStyle())
+              Button(action: {
+                isShowingScanner = true
+              }) {
+                Label(Strings.Wallet.scanQRCodeAccessibilityLabel, braveSystemImage: "brave.qr-code")
+                  .labelStyle(.iconOnly)
+                  .foregroundColor(Color(.primaryButtonTint))
+                  .font(.body)
+              }
+              .buttonStyle(PlainButtonStyle())
             }
-            .buttonStyle(PlainButtonStyle())
-            Button(action: {
-              isShowingScanner = true
-            }) {
-              Label(Strings.Wallet.scanQRCodeAccessibilityLabel, braveSystemImage: "brave.qr-code")
-                .labelStyle(.iconOnly)
-                .foregroundColor(Color(.primaryButtonTint))
-                .font(.body)
+            Group {
+              if sendTokenStore.isResolvingAddress {
+                ProgressView()
+              }
+              if let resolvedAddress = sendTokenStore.resolvedAddress {
+                AddressView(address: resolvedAddress) {
+                  Text(resolvedAddress)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .foregroundColor(Color(.secondaryBraveLabel))
+                }
+              }
             }
-            .buttonStyle(PlainButtonStyle())
+            .frame(maxWidth: .infinity, alignment: .leading)
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -477,16 +477,6 @@ public class SendTokenStore: ObservableObject {
   }
 }
 
-private extension String {
-  var endsWithSupportedENSExtension: Bool {
-    WalletConstants.supportedENSExtensions.contains(where: hasSuffix)
-  }
-  
-  var endsWithSupportedSNSExtension: Bool {
-    WalletConstants.supportedSNSExtensions.contains(where: hasSuffix)
-  }
-}
-
 extension SendTokenStore: BraveWalletKeyringServiceObserver {
   public func keyringReset() {
   }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -27,6 +27,9 @@ public class SendTokenStore: ObservableObject {
   /// The destination account address
   @Published var sendAddress = "" {
     didSet {
+      if oldValue != sendAddress {
+        resolvedAddress = nil
+      }
       sendAddressUpdatedTimer?.invalidate()
       sendAddressUpdatedTimer = Timer.scheduledTimer(
         withTimeInterval: 0.25, // try not to validate for every character entered
@@ -54,6 +57,10 @@ public class SendTokenStore: ObservableObject {
   @Published var sendError: SendError?
   /// If we are loading `userAssets`, `allTokens`, and `selectedSendTokenBalance`
   @Published var isLoading: Bool = false
+  /// If we are currently resolving an SNS or ENS address
+  @Published private(set) var isResolvingAddress: Bool = false
+  /// The address returned from SNS / ENS
+  @Published private(set) var resolvedAddress: String?
 
   enum AddressError: LocalizedError {
     case sameAsFromAddress
@@ -62,6 +69,8 @@ public class SendTokenStore: ObservableObject {
     case missingChecksum
     case invalidChecksum
     case notSolAddress
+    case ensError
+    case snsError
 
     var errorDescription: String? {
       switch self {
@@ -77,6 +86,10 @@ public class SendTokenStore: ObservableObject {
         return Strings.Wallet.sendWarningAddressInvalidChecksum
       case .notSolAddress:
         return Strings.Wallet.sendWarningSolAddressNotValid
+      case .ensError:
+        return "Failed to resolve address via ENS."
+      case .snsError:
+        return "Failed to resolve address via SNS."
       }
     }
   }
@@ -216,51 +229,90 @@ public class SendTokenStore: ObservableObject {
       completion(success, errorMessage)
     }
   }
-
-  /// Validate the `sendAddress`
+  
+  private var validateSendAddressTask: Task<Void, Never>?
   private func validateSendAddress() {
-    Task { @MainActor in
-      let coin = await self.walletService.selectedCoin()
-      guard let sendFromAddress = await self.keyringService.selectedAccount(coin),
-            !sendAddress.isEmpty,
-            let token = selectedSendToken else {
+    validateSendAddressTask?.cancel()
+    validateSendAddressTask = Task { @MainActor in
+      guard !sendAddress.isEmpty,
+            case let coin = await self.walletService.selectedCoin(),
+            let sendFromAddress = await self.keyringService.selectedAccount(coin),
+            !Task.isCancelled else {
         return
       }
-      let normalizedSendToAddress = sendAddress.lowercased()
-      if token.coin == .eth {
-        if !sendAddress.isETHAddress {
-          // 1. check if send address is a valid eth address
-          addressError = .notEthAddress
-        } else if sendFromAddress.lowercased() == normalizedSendToAddress {
-          // 2. check if send address is the same as the from address
-          addressError = .sameAsFromAddress
-        } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedSendToAddress }) != nil)
-                    || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedSendToAddress }) != nil) {
-          // 3. check if send address is a contract address
-          addressError = .contractAddress
-        } else {
-          let checksumAddress = await keyringService.checksumEthAddress(sendAddress)
-          if sendAddress == checksumAddress {
-            // 4. check if send address is the same as the checksum address from the `KeyringService`
-            addressError = nil
-          } else if sendAddress.removingHexPrefix.lowercased() == sendAddress.removingHexPrefix || sendAddress.removingHexPrefix.uppercased() == sendAddress.removingHexPrefix {
-            // 5. check if send address has each of the alphabetic character as uppercase, or has each of
-            // the alphabeic character as lowercase
-            addressError = .missingChecksum
-          } else {
-            // 6. send address has mixed with uppercase and lowercase and does not match with the checksum address
-            addressError = .invalidChecksum
-          }
-        }
-      } else if token.coin == .sol {
-        let isValid = await walletService.isBase58EncodedSolanaPubkey(sendAddress)
-        if !isValid {
-          addressError = .notSolAddress
-        } else if sendFromAddress.lowercased() == normalizedSendToAddress {
-          addressError = .sameAsFromAddress
-        } else {
-          addressError = nil
-        }
+      switch coin {
+      case .eth:
+        await validateEthereumSendAddress(fromAddress: sendFromAddress)
+      case .sol:
+        await validateSolanaSendAddress(fromAddress: sendFromAddress)
+      case .fil:
+        break
+      @unknown default:
+        break
+      }
+    }
+  }
+  
+  @MainActor private func validateEthereumSendAddress(fromAddress: String) async {
+    let normalizedFromAddress = fromAddress.lowercased()
+    let normalizedToAddress = sendAddress.lowercased()
+    // TODO: Support ENS #5787
+    if !sendAddress.isETHAddress {
+      // 1. check if send address is a valid eth address
+      addressError = .notEthAddress
+    } else if normalizedFromAddress == normalizedToAddress {
+      // 2. check if send address is the same as the from address
+      addressError = .sameAsFromAddress
+    } else if (userAssets.first(where: { $0.contractAddress.lowercased() == normalizedToAddress }) != nil)
+                || (allTokens.first(where: { $0.contractAddress.lowercased() == normalizedToAddress }) != nil) {
+      // 3. check if send address is a contract address
+      addressError = .contractAddress
+    } else {
+      let checksumAddress = await keyringService.checksumEthAddress(sendAddress)
+      if sendAddress == checksumAddress {
+        // 4. check if send address is the same as the checksum address from the `KeyringService`
+        addressError = nil
+      } else if sendAddress.removingHexPrefix.lowercased() == sendAddress.removingHexPrefix || sendAddress.removingHexPrefix.uppercased() == sendAddress.removingHexPrefix {
+        // 5. check if send address has each of the alphabetic character as uppercase, or has each of
+        // the alphabeic character as lowercase
+        addressError = .missingChecksum
+      } else {
+        // 6. send address has mixed with uppercase and lowercase and does not match with the checksum address
+        addressError = .invalidChecksum
+      }
+    }
+  }
+  
+  @MainActor private func validateSolanaSendAddress(fromAddress: String) async {
+    let normalizedFromAddress = fromAddress.lowercased()
+    let normalizedToAddress = sendAddress.lowercased()
+    let isSupportedSNSExtension = sendAddress.endsWithSupportedSNSExtension
+    if isSupportedSNSExtension {
+      self.isResolvingAddress = true
+      defer { self.isResolvingAddress = false }
+      // If value ends with a supported SNS extension, will call findSNSAddress.
+      let (address, status, _) = await rpcService.snsGetSolAddr(sendAddress)
+      guard !Task.isCancelled else { return }
+      if status != .success || address.isEmpty {
+        addressError = .snsError
+        return
+      }
+      // If found address is the same as the selectedAccounts Wallet Address
+      if address.lowercased() == normalizedFromAddress {
+        addressError = .sameAsFromAddress
+        return
+      }
+      // store address for sending
+      resolvedAddress = address
+      addressError = nil
+    } else { // not supported SNS extension, validate address
+      let isValid = await walletService.isBase58EncodedSolanaPubkey(sendAddress)
+      if !isValid {
+        addressError = .notSolAddress
+      } else if normalizedFromAddress == normalizedToAddress {
+        addressError = .sameAsFromAddress
+      } else {
+        addressError = nil
       }
     }
   }
@@ -316,12 +368,14 @@ public class SendTokenStore: ObservableObject {
       completion(false, "An Internal Error")
       return
     }
+    
+    let sendToAddress = resolvedAddress ?? sendAddress
 
     isMakingTx = true
     rpcService.network(.eth) { [weak self] network in
       guard let self = self else { return }
       if network.isNativeAsset(token) {
-        let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: self.sendAddress, value: "0x\(weiHexString)", data: .init())
+        let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: sendToAddress, value: "0x\(weiHexString)", data: .init())
         if network.isEip1559 {
           self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success, errorMessage  in
             self.isMakingTx = false
@@ -335,7 +389,7 @@ public class SendTokenStore: ObservableObject {
           }
         }
       } else if token.isErc721 {
-        self.ethTxManagerProxy.makeErc721Transfer(fromData: fromAddress, to: self.sendAddress, tokenId: token.tokenId, contractAddress: token.contractAddress) { success, data in
+        self.ethTxManagerProxy.makeErc721Transfer(fromData: fromAddress, to: sendToAddress, tokenId: token.tokenId, contractAddress: token.contractAddress) { success, data in
           guard success else {
             completion(false, nil)
             return
@@ -348,7 +402,7 @@ public class SendTokenStore: ObservableObject {
           }
         }
       } else {
-        self.ethTxManagerProxy.makeErc20TransferData(self.sendAddress, amount: "0x\(weiHexString)") { success, data in
+        self.ethTxManagerProxy.makeErc20TransferData(sendToAddress, amount: "0x\(weiHexString)") { success, data in
           guard success else {
             completion(false, nil)
             return
@@ -381,13 +435,15 @@ public class SendTokenStore: ObservableObject {
       completion(false, "An Internal Error")
       return
     }
+    
+    let sendToAddress = resolvedAddress ?? sendAddress
 
     rpcService.network(.sol) { [weak self] network in
       guard let self = self else { return }
       if network.isNativeAsset(token) {
         self.solTxManagerProxy.makeSystemProgramTransferTxData(
           fromAddress,
-          to: self.sendAddress,
+          to: sendToAddress,
           lamports: amount
         ) { solTxData, error, errMsg in
           guard let solanaTxData = solTxData else {
@@ -403,7 +459,7 @@ public class SendTokenStore: ObservableObject {
         self.solTxManagerProxy.makeTokenProgramTransferTxData(
           token.contractAddress,
           fromWalletAddress: fromAddress,
-          toWalletAddress: self.sendAddress,
+          toWalletAddress: sendToAddress,
           amount: amount
         ) { solTxData, error, errMsg in
           guard let solanaTxData = solTxData else {
@@ -421,6 +477,16 @@ public class SendTokenStore: ObservableObject {
   
   @MainActor func fetchERC721Metadata(tokens: [BraveWallet.BlockchainToken]) async -> [String: ERC721Metadata] {
     return await rpcService.fetchERC721Metadata(tokens: tokens)
+  }
+}
+
+private extension String {
+  var endsWithSupportedENSExtension: Bool {
+    WalletConstants.supportedENSExtensions.contains(where: hasSuffix)
+  }
+  
+  var endsWithSupportedSNSExtension: Bool {
+    WalletConstants.supportedSNSExtensions.contains(where: hasSuffix)
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -69,8 +69,7 @@ public class SendTokenStore: ObservableObject {
     case missingChecksum
     case invalidChecksum
     case notSolAddress
-    case ensError
-    case snsError
+    case snsError(domain: String)
 
     var errorDescription: String? {
       switch self {
@@ -86,10 +85,8 @@ public class SendTokenStore: ObservableObject {
         return Strings.Wallet.sendWarningAddressInvalidChecksum
       case .notSolAddress:
         return Strings.Wallet.sendWarningSolAddressNotValid
-      case .ensError:
-        return "Failed to resolve address via ENS."
-      case .snsError:
-        return "Failed to resolve address via SNS."
+      case .snsError(let domain):
+        return String.localizedStringWithFormat(Strings.Wallet.sendErrorDomainNotRegistered, domain)
       }
     }
   }
@@ -294,7 +291,7 @@ public class SendTokenStore: ObservableObject {
       let (address, status, _) = await rpcService.snsGetSolAddr(sendAddress)
       guard !Task.isCancelled else { return }
       if status != .success || address.isEmpty {
-        addressError = .snsError
+        addressError = .snsError(domain: sendAddress)
         return
       }
       // If found address is the same as the selectedAccounts Wallet Address

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -62,7 +62,7 @@ public class SendTokenStore: ObservableObject {
   /// The address returned from SNS / ENS
   @Published private(set) var resolvedAddress: String?
 
-  enum AddressError: LocalizedError {
+  enum AddressError: LocalizedError, Equatable {
     case sameAsFromAddress
     case contractAddress
     case notEthAddress

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -288,3 +288,15 @@ extension BraveWallet.OnRampProvider {
     }
   }
 }
+
+public extension String {
+  /// Returns true if the string ends with a supported ENS extension.
+  var endsWithSupportedENSExtension: Bool {
+    WalletConstants.supportedENSExtensions.contains(where: hasSuffix)
+  }
+  
+  /// Returns true if the string ends with a supported SNS extension.
+  var endsWithSupportedSNSExtension: Bool {
+    WalletConstants.supportedSNSExtensions.contains(where: hasSuffix)
+  }
+}

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -41,6 +41,11 @@ struct WalletConstants {
     return [.eth, .sol]
   }
   
+  /// The supported Ethereum Name Service (ENS) extensions
+  static let supportedENSExtensions = [".eth"]
+  /// The supported Solana Name Service (SNS) extensions
+  static let supportedSNSExtensions = [".sol"]
+  
   /// The link for users to learn more about Solana SPL token account creation in transaction confirmation screen
   static let splTokenAccountCreationLink = URL(string: "https://support.brave.com/hc/en-us/articles/5546517853325")!
   

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1766,7 +1766,7 @@ extension Strings {
       comment: "A warning that appears below the send crypto address text field, when the input `To` address is not a valid SOL address."
     )
     public static let sendErrorDomainNotRegistered = NSLocalizedString(
-      "wallet.sendWarningDomainNotRegistered",
+      "wallet.sendErrorDomainNotRegistered",
       tableName: "BraveWallet",
       bundle: .module,
       value: "%@ is not registered",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1765,6 +1765,13 @@ extension Strings {
       value: "Not a valid SOL address",
       comment: "A warning that appears below the send crypto address text field, when the input `To` address is not a valid SOL address."
     )
+    public static let sendErrorDomainNotRegistered = NSLocalizedString(
+      "wallet.sendWarningDomainNotRegistered",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "%@ is not registered",
+      comment: "An error that appears below the send crypto address text field, when the input `To` domain/url that we cannot resolve to a wallet address. Ex. `Stephen.sol`"
+    )
     public static let customNetworkChainIdTitle = NSLocalizedString(
       "wallet.customNetworkChainIdTitle",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Add SNS support to Send Token View / Send Token Store

This pull request fixes #6639

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Settings, navigate to `BraveCore Switches` and open the debug menu.
2. Tap `Enable Features` row and enter `BraveWalletSns` and tap save. You will have to re-launch for the feature flag to take effect.
3. Open Send Token view & select a Solana token
4. Enter a valid value > 0
5. Enter an unregistered .sol domain as the to address
6. Verify send button is disabled as the address is not registered
7. Enter a registered .sol domain as the to address
8. Verify full address is displayed below the SNS domain after loading
9. Tap and hold to verify copy/paste is working
10. Tap send, verify correct send to address is used in Transaction Confirmation


## Screenshots:

https://user-images.githubusercontent.com/5314553/211575324-56349557-b879-41ee-a0ba-7df5543bd4d8.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
