### PR TITLE
Fix #6724: Make WebView Delegations to be AsyncAwait compatible.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -157,6 +157,7 @@ extension BrowserViewController: WKNavigationDelegate {
     return url.scheme == "rewards" && url.host == "uphold"
   }
 
+  @MainActor
   public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences) async -> (WKNavigationActionPolicy, WKWebpagePreferences) {
     guard let url = navigationAction.request.url else {
       return (.cancel, preferences)
@@ -438,6 +439,7 @@ extension BrowserViewController: WKNavigationDelegate {
     return (.cancel, preferences)
   }
 
+  @MainActor
   public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
     let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
     let response = navigationResponse.response
@@ -527,6 +529,7 @@ extension BrowserViewController: WKNavigationDelegate {
     return .allow
   }
 
+  // When this function is moved to Async-Await, do NOT forget to move the `TabManagerNavDelegate` to async-await!
   public func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
 
     // If this is a certificate challenge, see if the certificate has previously been

--- a/Client/Frontend/Browser/TabManagerNavDelegate.swift
+++ b/Client/Frontend/Browser/TabManagerNavDelegate.swift
@@ -79,6 +79,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     return .allow
   }
   
+  @MainActor
   func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences) async -> (WKNavigationActionPolicy, WKWebpagePreferences) {
     var res = defaultAllowPolicy()
     var pref = preferences
@@ -103,6 +104,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     return (res, pref)
   }
   
+  @MainActor
   func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
     var res = WKNavigationResponsePolicy.allow
     for delegate in delegates {
@@ -121,11 +123,8 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     }
 
     if res == .allow {
-      // TabManager.subscript.getter requires MAIN-THREAD!
-      await Task { @MainActor in
-        let tab = tabManager?[webView]
-        tab?.mimeType = navigationResponse.response.mimeType
-      }.value
+      let tab = tabManager?[webView]
+      tab?.mimeType = navigationResponse.response.mimeType
     }
     
     return res

--- a/Tests/ClientTests/TabManagerNavDelegateTests.swift
+++ b/Tests/ClientTests/TabManagerNavDelegateTests.swift
@@ -102,32 +102,32 @@ class TabManagerNavDelegateTests: XCTestCase {
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDidStartProvisionalNavigation])
     }
 
-    func test_webViewDecidePolicyFor_actionPolicy_sendsCorrectMessage() {
+    @MainActor
+    func test_webViewDecidePolicyFor_actionPolicy_sendsCorrectMessage() async {
         let sut = TabManagerNavDelegate()
         let delegate1 = WKNavigationDelegateSpy()
         let delegate2 = WKNavigationDelegateSpy()
 
         sut.insert(delegate1)
         sut.insert(delegate2)
-        sut.webView(anyWebView(),
+        _ = await sut.webView(anyWebView(),
                     decidePolicyFor: WKNavigationAction(),
-                    preferences: WKWebpagePreferences(),
-                    decisionHandler: { _, _ in })
+                    preferences: WKWebpagePreferences())
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDecidePolicyWithActionPolicy])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDecidePolicyWithActionPolicy])
     }
 
-    func test_webViewDecidePolicyFor_responsePolicy_sendsCorrectMessage() {
+    @MainActor
+    func test_webViewDecidePolicyFor_responsePolicy_sendsCorrectMessage() async {
         let sut = TabManagerNavDelegate()
         let delegate1 = WKNavigationDelegateSpy()
         let delegate2 = WKNavigationDelegateSpy()
 
         sut.insert(delegate1)
         sut.insert(delegate2)
-        sut.webView(anyWebView(),
-                    decidePolicyFor: WKNavigationResponse(),
-                    decisionHandler: { _ in })
+        _ = await sut.webView(anyWebView(),
+                    decidePolicyFor: WKNavigationResponse())
 
         XCTAssertEqual(delegate1.receivedMessages, [.webViewDecidePolicyWithResponsePolicy])
         XCTAssertEqual(delegate2.receivedMessages, [.webViewDecidePolicyWithResponsePolicy])
@@ -187,11 +187,13 @@ private class WKNavigationDelegateSpy: NSObject, WKNavigationDelegate {
         receivedMessages.append(.webViewDidStartProvisionalNavigation)
     }
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
         receivedMessages.append(.webViewDecidePolicyWithResponsePolicy)
+        return .allow
     }
-
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
-        receivedMessages.append(.webViewDecidePolicyWithActionPolicy)
+  
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, preferences: WKWebpagePreferences) async -> (WKNavigationActionPolicy, WKWebpagePreferences) {
+      receivedMessages.append(.webViewDecidePolicyWithActionPolicy)
+      return (.allow, preferences)
     }
 }


### PR DESCRIPTION
## Summary of Changes
- Fixed cookie retrieval to be async-await.
- Make TabManager's WebView Delegations to be AsyncAwait compatible.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6724

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
