### PR TITLE
No Bug: Add iOS 16.2 check to list offset workaround modifier

### DIFF
--- a/Sources/BraveUI/SwiftUI/ListInitialOffsetWorkaround.swift
+++ b/Sources/BraveUI/SwiftUI/ListInitialOffsetWorkaround.swift
@@ -7,7 +7,7 @@ import Foundation
 import SwiftUI
 import Introspect
 
-struct iOS16ListInitialOffsetFixViewModifier: ViewModifier {
+private struct iOS16ListInitialOffsetFixViewModifier: ViewModifier {
   @State private var isFixApplied: Bool = false
   func body(content: Content) -> some View {
     content.introspect(
@@ -27,8 +27,19 @@ extension View {
   ///
   /// This workaround resets the initial content offset once on iOS 16.1 and later. On lower versions, this
   /// modifier does nothing.
+  ///
+  /// This bug is fixed in iOS 16.2
+  @available(iOS, introduced: 14.0, deprecated: 16.2)
   @ViewBuilder public func listInitialOffsetWorkaround() -> some View {
-#if swift(>=5.7.1)
+#if swift(>=5.7.2)
+    if #available(iOS 16.2, *) {
+      modifier(EmptyModifier())
+    } else if #available(iOS 16.1, *) {
+      modifier(iOS16ListInitialOffsetFixViewModifier())
+    } else {
+      modifier(EmptyModifier())
+    }
+#elseif swift(>=5.7.1)
     if #available(iOS 16.1, *) {
       modifier(iOS16ListInitialOffsetFixViewModifier())
     } else {


### PR DESCRIPTION
## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
