### PR TITLE
Fix #6739: Allow News source suggestion resource load to fail silently

### DIFF
--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -389,11 +389,16 @@ public class FeedDataSource: ObservableObject {
   }
   
   private func loadSourceSuggestions(for localeIdentifier: String) async throws -> [String: [FeedItem.SourceSimilarity]] {
-    let items = try await loadResource(.sourceSuggestions, localeIdentifier: localeIdentifier, decodedTo: [String: [FailableDecodable<FeedItem.SourceSimilarity>]].self)
-    if items.isEmpty {
-      throw BraveNewsError.resourceEmpty
+    do {
+      let items = try await loadResource(.sourceSuggestions, localeIdentifier: localeIdentifier, decodedTo: [String: [FailableDecodable<FeedItem.SourceSimilarity>]].self)
+      if items.isEmpty {
+        throw BraveNewsError.resourceEmpty
+      }
+      return items.mapValues { $0.compactMap(\.wrappedValue) }
+    } catch {
+      Logger.module.error("Failed to load source suggestions: \(error.localizedDescription)")
+      return [:]
     }
-    return items.mapValues { $0.compactMap(\.wrappedValue) }
   }
 
   /// Describes a single RSS feed's loaded data set converted into Brave News based data


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6739 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
