### PR TITLE
Fix #6745: Determine hash & equality of News items on source & url ids

### DIFF
--- a/Sources/BraveNews/Composer/FeedItem.swift
+++ b/Sources/BraveNews/Composer/FeedItem.swift
@@ -14,6 +14,15 @@ public struct FeedItem: Hashable, Comparable {
   public static func < (lhs: Self, rhs: Self) -> Bool {
     lhs.score < rhs.score
   }
+  
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(content.urlHash)
+    hasher.combine(source.id)
+  }
+  
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.source.id == rhs.source.id && lhs.content.urlHash == rhs.content.urlHash
+  }
 }
 
 extension FeedItem {
@@ -58,6 +67,10 @@ extension FeedItem {
       case coverURL = "cover_url"
       case backgroundColor = "background_color"
       case localeDetails = "locales"
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+      hasher.combine(id)
     }
     
     public static func == (lhs: Self, rhs: Self) -> Bool {
@@ -116,6 +129,15 @@ extension FeedItem {
     public var baseScore: Double
     public var offersCategory: String?
     public var creativeInstanceID: String?
+    
+    public func hash(into hasher: inout Hasher) {
+      hasher.combine(urlHash)
+      hasher.combine(publisherID)
+    }
+    
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.urlHash == rhs.urlHash && lhs.publisherID == rhs.publisherID
+    }
 
     enum CodingKeys: String, CodingKey {
       case publishTime = "publish_time"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6745 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
