### PR TITLE
Fix #6714: Ensure the search bar appears in news after enabling it

### DIFF
--- a/Sources/BraveNews/Customize/NewsSettingsView.swift
+++ b/Sources/BraveNews/Customize/NewsSettingsView.swift
@@ -41,10 +41,10 @@ public class NewsSettingsViewController: UIHostingController<NewsSettingsView> {
     }
     navigationItem.largeTitleDisplayMode = .never
     navigationItem.title = Strings.BraveNews.braveNews
-    navigationItem.hidesSearchBarWhenScrolling = false
     if Preferences.BraveNews.isEnabled.value {
       navigationItem.searchController = searchController
     }
+    navigationItem.hidesSearchBarWhenScrolling = false
     if #available(iOS 16.0, *) {
       navigationItem.preferredSearchBarPlacement = .stacked
     }
@@ -54,6 +54,7 @@ public class NewsSettingsViewController: UIHostingController<NewsSettingsView> {
       .sink { [weak self] isEnabled in
         guard let self else { return }
         self.navigationItem.searchController = isEnabled ? self.searchController : nil
+        self.navigationItem.hidesSearchBarWhenScrolling = false
         if #available(iOS 16.0, *) {
           // Setting `searchController` to nil seems to invalidate this setting and needs to be set again
           self.navigationItem.preferredSearchBarPlacement = .stacked


### PR DESCRIPTION
This moves assigning `hidesSearchBarWhenScrolling` to false and re-assigns it when `searchController` is reset. It seems to act similarly to `preferredSearchBarPlacement` which takes no effect unless you have a non-nil `searchController` already set

## Summary of Changes

This pull request fixes #6714 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
