### PR TITLE
Fix #6652: Asset auto-discovery on wallet open

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -33,7 +33,7 @@ struct CryptoPagesView: View {
         // Give the animation time
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
           self.fetchedPendingRequestsThisSession = true
-          self.cryptoStore.prepare()
+          self.cryptoStore.prepare(isInitialOpen: true)
         }
       }
     }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -152,6 +152,10 @@ struct PortfolioView: View {
       }, header: {
         HStack {
           Text(Strings.Wallet.assetsTitle)
+          if portfolioStore.isLoadingDiscoverAssets {
+            ProgressView()
+              .padding(.leading, 5)
+          }
           Spacer()
           networkFilterButton
         }

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -277,8 +277,11 @@ public class CryptoStore: ObservableObject {
     }
   }
   
-  func prepare() {
+  func prepare(isInitialOpen: Bool = false) {
     Task { @MainActor in
+      if isInitialOpen {
+        portfolioStore.discoverAssetsOnAllSupportedChains()
+      }
       let pendingTransactions = await fetchPendingTransactions()
       if !pendingTransactions.isEmpty {
         if self.buySendSwapDestination != nil {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -92,6 +92,7 @@ public class PortfolioStore: ObservableObject {
       update()
     }
   }
+  @Published private(set) var isLoadingDiscoverAssets: Bool = false
 
   public private(set) lazy var userAssetsStore: UserAssetsStore = .init(
     walletService: self.walletService,
@@ -145,6 +146,11 @@ public class PortfolioStore: ObservableObject {
     walletService.defaultBaseCurrency { [self] currencyCode in
       self.currencyCode = currencyCode
     }
+  }
+  
+  func discoverAssetsOnAllSupportedChains() {
+    isLoadingDiscoverAssets = true
+    walletService.discoverAssetsOnAllSupportedChains()
   }
   
   func update() {
@@ -419,5 +425,9 @@ extension PortfolioStore: BraveWalletBraveWalletServiceObserver {
   }
   
   public func onDiscoverAssetsCompleted(_ discoveredAssets: [BraveWallet.BlockchainToken]) {
+    isLoadingDiscoverAssets = false
+    if !discoveredAssets.isEmpty {
+      update()
+    }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Implements asset auto discovery when the wallet opens. Displayed in a loading indicator beside 'Assets' section title in Portfolio.

This pull request fixes #6652

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Have an account with an asset that will be auto discovered. I used UNI / Uniswap token on Ethereum mainnet, which can be swapped for using Uniswap dapp.
2. Unlock your wallet
3. Observe loading spinner to the right of `Assets` section title (may need network link conditioner, it can load quick).
4. Verify discovered asset is displayed in assets list.

Note: There is one issue when importing a wallet from seed phrase, or importing an account from private key. The discovered asset will not be displayed until the wallet is closed and re-opened, or another token is added/removed (anything to trigger Portfolio refresh). This will be resolved with https://github.com/brave/brave-browser/issues/27776.


## Screenshots:

Network link condition used to slow network to show loading state:

https://user-images.githubusercontent.com/5314553/212123651-d4997e06-e5d5-4c3c-894b-632e8a8f65d8.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
