### PR TITLE
Fix #6523: Auto enable maintained regional filter lists

### DIFF
--- a/Client/WebFilters/FilterList.swift
+++ b/Client/WebFilters/FilterList.swift
@@ -6,17 +6,19 @@
 import Foundation
 import BraveCore
 
-struct FilterList: Decodable, Identifiable {
-  enum CodingKeys: String, CodingKey {
-    case uuid, title, componentId, description = "desc", urlString = "url"
-  }
-  
+struct FilterList: Identifiable {
   /// The component ID of the "Fanboy's Mobile Notifications List"
   /// This is a special filter list that is enabled by default
   public static let mobileAnnoyancesComponentID = "bfpgedeaaibpoidldhjcknekahbikncb"
   /// The component id of the cookie consent notices filter list.
   /// This is a special filter list that has more accessible UI to control it
   public static let cookieConsentNoticesComponentID = "cdbbhgbmjhfnhnmgeddbliobbofkgdhe"
+  /// A list of safe filter lists that can be automatically enabled if the user has the matching localization.
+  /// - Note: These are regional fiter lists that are well maintained. For now we hardcode these values
+  /// but it would be better if our component updater told us which ones are safe in the future.
+  public static let maintainedRegionalComponentIDs = [
+    "llgjaaddopeckcifdceaaadmemagkepi" // Japanese filter lists
+  ]
   
   let uuid: String
   let title: String
@@ -24,6 +26,7 @@ struct FilterList: Decodable, Identifiable {
   let componentId: String
   let urlString: String
   var isEnabled: Bool = false
+  let languages: [String]
   
   var id: String { return uuid }
   
@@ -34,6 +37,7 @@ struct FilterList: Decodable, Identifiable {
     self.componentId = filterList.componentId
     self.isEnabled = isEnabled
     self.urlString = filterList.url
+    self.languages = filterList.languages
   }
   
   func makeRuleType() -> ContentBlockerManager.BlocklistRuleType {

--- a/Client/WebFilters/FilterListResourceDownloader.swift
+++ b/Client/WebFilters/FilterListResourceDownloader.swift
@@ -294,24 +294,13 @@ public class FilterListResourceDownloader: ObservableObject {
     )
   }
   
-  /// This method allows us to enable selected lists by default for new users.
-  /// Make sure you use componentID to identify the filter list, as `uuid` will be deprecated in the future.
-  @MainActor private func newFilterListDefault(for componentId: String) -> Bool {
-    if let value = settingsManager.pendingDefaults[componentId] {
-      return value
-    }
-    
-    let componentIDsToOverride = [FilterList.mobileAnnoyancesComponentID]
-    return componentIDsToOverride.contains(componentId) ? true : false
-  }
-  
   /// Load filter lists from the ad block service
   @MainActor private func loadFilterLists(from regionalFilterLists: [AdblockFilterListCatalogEntry], filterListSettings: [FilterListSetting]) -> [FilterList] {
     return regionalFilterLists.map { adBlockFilterList in
       let setting = filterListSettings.first(where: { $0.uuid == adBlockFilterList.uuid })
       return FilterList(
         from: adBlockFilterList,
-        isEnabled: setting?.isEnabled ?? newFilterListDefault(for: adBlockFilterList.componentId)
+        isEnabled: setting?.isEnabled ?? adBlockFilterList.defaultToggle
       )
     }
   }
@@ -342,7 +331,7 @@ public class FilterListResourceDownloader: ObservableObject {
       uuid: filterList.uuid,
       isEnabled: filterList.isEnabled,
       componentId: filterList.componentId,
-      allowCreation: filterList.isEnabled || newFilterListDefault(for: filterList.componentId) != filterList.isEnabled
+      allowCreation: filterList.defaultToggle != filterList.isEnabled
     )
     
     // Register or unregister the filter list depending on its toggle state
@@ -520,6 +509,49 @@ private extension AdblockService {
       continuation.onTermination = { @Sendable _ in
         self.unregisterFilterListComponent(filterList)
       }
+    }
+  }
+}
+
+// MARK: - FilterListLanguageProvider - A way to share `defaultToggle` logic between multiple structs/classes
+
+private protocol FilterListLanguageProvider {
+  var languages: [String] { get }
+  var componentId: String { get }
+}
+
+extension FilterList: FilterListLanguageProvider {}
+extension AdblockFilterListCatalogEntry: FilterListLanguageProvider {}
+
+private extension FilterListLanguageProvider {
+  @available(iOS 16, *)
+  /// A list of regions that this filter list focuses on.
+  /// An empty set means this filter list doesn't focus on any specific region.
+  var supportedLanguageCodes: Set<Locale.LanguageCode> {
+    return Set(languages.map({ Locale.LanguageCode($0) }))
+  }
+  
+  /// This method returns the default value for this filter list if the user does not manually toggle it.
+  /// - Warning: Make sure you use `componentID` to identify the filter list, as `uuid` will be deprecated in the future.
+  var defaultToggle: Bool {
+    let componentIDsToOverride = [FilterList.mobileAnnoyancesComponentID]
+    
+    if componentIDsToOverride.contains(componentId) {
+      return true
+    }
+    
+    // For compatibility reasons, we only enable certian regional filter lists
+    // These are the ones that are known to be well maintained.
+    guard FilterList.maintainedRegionalComponentIDs.contains(componentId) else {
+      return false
+    }
+    
+    if #available(iOS 16, *), let languageCode = Locale.current.language.languageCode {
+      return supportedLanguageCodes.contains(languageCode)
+    } else if let languageCode = Locale.current.languageCode {
+      return languages.contains(languageCode)
+    } else {
+      return false
     }
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6523 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See ticket for STR

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
