### PR TITLE
Fix #6730: Improve URL bar & progress bar responsiveness on slow networks

### DIFF
--- a/Client/Frontend/Widgets/GradientProgressBar.swift
+++ b/Client/Frontend/Widgets/GradientProgressBar.swift
@@ -170,10 +170,6 @@ open class GradientProgressBar: UIProgressView {
   }
 
   override open func setProgress(_ progress: Float, animated: Bool) {
-    if progress < self.progress && self.progress != 1 {
-      return
-    }
-
     // Setup animations
     gradientLayer.removeAnimation(forKey: "position")
     if gradientLayer.animation(forKey: "colorChange") == nil {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6730 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

*Prefix*:
- Enable network link conditioner using Very Bad Network, Edge, etc. to simulate a slower network

*For the following tests*:
- Test loading URLs from outside of the app (via share extension, default browser on prod, etc.)
- Test loading URLs via tab restore (kill & relaunch app with tabs)
- Test loading URLs via URL bar submission

*Verify*:
- That the URL bar shows the loading URL immediately instead of remaining empty
- That the progress bar shows a small bit more quickly so it appears like progress is being made

*Aside*:
- This PR contains changes to how the progress bar changes progress, so it'd be good to go through tests around changing tabs with both pages loading, one page loading, stopping page loads, removing tabs that are loading, etc.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
