### PR TITLE
Fix #6758: Block all schemes except http and https from Preview Links.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3107,7 +3107,9 @@ extension BrowserViewController: WKUIDelegate {
 
   public func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo, completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
 
-    guard let url = elementInfo.linkURL else { return completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: nil)) }
+    // Only show context menu for valid links such as `http`, `https`, `data`. Safari does not show it for anything else.
+    // This is because you cannot open `javascript:something` URLs in a new page, or share it, or anything else.
+    guard let url = elementInfo.linkURL, url.isWebPage() else { return completionHandler(UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: nil)) }
 
     let actionProvider: UIContextMenuActionProvider = { _ -> UIMenu? in
       var actions = [UIAction]()
@@ -3192,7 +3194,7 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     let linkPreview: UIContextMenuContentPreviewProvider? = { [unowned self] in
-      if let tab = tabManager.tabForWebView(webView), url.schemeIsValid, ["http", "https"].contains(url.scheme) {
+      if let tab = tabManager.tabForWebView(webView) {
         return LinkPreviewViewController(url: url, for: tab, browserController: self)
       }
       return nil

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3192,7 +3192,7 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     let linkPreview: UIContextMenuContentPreviewProvider? = { [unowned self] in
-      if let tab = tabManager.tabForWebView(webView) {
+      if let tab = tabManager.tabForWebView(webView), url.schemeIsValid, ["http", "https"].contains(url.scheme) {
         return LinkPreviewViewController(url: url, for: tab, browserController: self)
       }
       return nil


### PR DESCRIPTION
## Summary of Changes
- Block all schemes except http and https from Preview Links.
- Only Http and Https schemes should be `previewed` when long-pressing a link. `file`, `data`, etc should not.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6758

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
