### PR TITLE
Fix #16677: URLFormatter Displays incorrect format

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -408,7 +408,16 @@ class TabLocationView: UIView {
   
   fileprivate func updateTextWithURL() {
     (urlTextField as? DisplayTextField)?.hostString = url?.withoutWWW.host ?? ""
-    urlTextField.text = URLFormatter.formatURL(url?.withoutWWW.absoluteString ?? "", formatTypes: .omitDefaults, unescapeOptions: []).removeSchemeFromURLString(url?.scheme)
+    
+    // Note: Only use `URLFormatter.formatURLOrigin(forSecurityDisplay: url?.withoutWWW.absoluteString ?? "", schemeDisplay: .omitHttpAndHttps)`
+    // If displaying the host ONLY! This follows Google Chrome and Safari.
+    // However, for Brave as no decision has been made on what shows YET, we will display the entire URL (truncated!)
+    // Therefore we only omit defaults (username & password, http [not https], and trailing slash) + omit "www".
+    // We must NOT un-escape the URL!
+    // --
+    // The requirement to remove scheme comes from Desktop. Also we do not remove the path like in other browsers either.
+    // Therefore, we follow Brave Desktop instead of Chrome or Safari iOS
+    urlTextField.text = URLFormatter.formatURL(url?.withoutWWW.absoluteString ?? "", formatTypes: [.omitDefaults], unescapeOptions: []).removeSchemeFromURLString(url?.scheme)
   }
 }
 

--- a/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -670,7 +670,8 @@ extension TopToolbarView: TabLocationViewDelegate {
     
     var overlayText = locationText
     // Make sure to use the result from topToolbarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
-    if let text = locationText, let url = URL(string: text) {
+    if let text = locationText, let url = NSURL(idnString: text) as? URL {
+      // When the user is entering text into the URL bar, we must show the entire URL, omitting NOTHING (not even the scheme, or www), and un-escaping NOTHING!
       overlayText = URLFormatter.formatURL(url.absoluteString, formatTypes: [], unescapeOptions: [])
     }
     enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)

--- a/Client/Frontend/Shields/ShieldsViewController.swift
+++ b/Client/Frontend/Shields/ShieldsViewController.swift
@@ -236,7 +236,8 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
       shieldsView.simpleShieldView.faviconImageView.isHidden = true
     }
     
-    let normalizedDisplayHost = URLFormatter.formatURL(url?.withoutWWW.absoluteString ?? "", formatTypes: [], unescapeOptions: []).removeSchemeFromURLString(url?.scheme)
+    // Follows the logic in `updateTextWithURL` for formatting
+    let normalizedDisplayHost = URLFormatter.formatURL(url?.withoutWWW.absoluteString ?? "", formatTypes: .omitDefaults, unescapeOptions: []).removeSchemeFromURLString(url?.scheme)
     
     shieldsView.simpleShieldView.hostLabel.text = normalizedDisplayHost
     shieldsView.reportBrokenSiteView.urlLabel.text = url?.domainURL.absoluteString


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1166

## Summary of Changes
- Apply different URLFormatting options to the URL Bar in `FULL DISPLAY` (overlay shown when the user taps on the URL bar) vs. when it is truncated (when the URL bar is not active).
- Also do NOT unescape anything in the URL anywhere at all.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #https://github.com/brave/internal/issues/991 and https://github.com/brave/brave-ios/issues/6798 and https://github.com/brave/brave-ios/issues/6790
Depends On: https://github.com/brave/brave-core/pull/16677

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- See the internal issue attached to the Brave-Core PR.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
