### PR TITLE
No bug: bump core to 1.47.173 to have solana metadata and new favicon fetching.

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -275,7 +275,7 @@ class Tab: NSObject {
     self.configuration = configuration
     rewardsId = UInt32.random(in: 1...UInt32.max)
     nightMode = Preferences.General.nightModeEnabled.value
-    syncTab = tabGeneratorAPI?.createBraveSyncTab()
+    syncTab = tabGeneratorAPI?.createBraveSyncTab(isOffTheRecord: true)
 
     super.init()
     self.type = type

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -136,6 +136,10 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
     completion("", .internalError, "")
   }
   
+  func solTokenMetadata(_ tokenMintAddress: String, completion: @escaping (String, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion("", .internalError, "")
+  }
+  
   func erc1155Metadata(_ contract: String, tokenId: String, chainId: String, completion: @escaping (String, BraveWallet.ProviderError, String) -> Void) {
     completion("", .internalError, "")
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.168/brave-core-ios-1.47.168.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.173/brave-core-ios-1.47.173.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.47.168",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.47.168/brave-core-ios-1.47.168.tgz",
-      "integrity": "sha512-A8eyfF+Qis5pSt0JirMHwJRTDiLpMbvHF58tSS4x5wZKH1spxI54COxkP5ZfMr6uf40j5DejSoAPBzMBAUYOzg==",
+      "version": "1.47.173",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.47.173/brave-core-ios-1.47.173.tgz",
+      "integrity": "sha512-hV8pRJNQOsjmNqv+da7yIop0qvK9SD/szubXWeyrctfGcEAXjiaUc+Dv1mleXPIy7Jb2lOeAuZ9MDs5UZxUo5w==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.47.168/brave-core-ios-1.47.168.tgz",
-      "integrity": "sha512-A8eyfF+Qis5pSt0JirMHwJRTDiLpMbvHF58tSS4x5wZKH1spxI54COxkP5ZfMr6uf40j5DejSoAPBzMBAUYOzg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.47.173/brave-core-ios-1.47.173.tgz",
+      "integrity": "sha512-hV8pRJNQOsjmNqv+da7yIop0qvK9SD/szubXWeyrctfGcEAXjiaUc+Dv1mleXPIy7Jb2lOeAuZ9MDs5UZxUo5w=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.168/brave-core-ios-1.47.168.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.173/brave-core-ios-1.47.173.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
