### PR TITLE
Fix #6750: Pending requests shown after changing network

### DIFF
--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -483,7 +483,11 @@ struct WalletPanelView: View {
     )
     .onChange(of: cryptoStore.pendingRequest) { newValue in
       if newValue != nil {
-        presentWalletWithContext(.pendingRequests)
+        // if user had just changed networks, there is a potential race condition
+        // blocking present here, as Network Selection might still be on screen
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+          presentWalletWithContext(.pendingRequests)
+        }
       }
     }
     .onChange(of: tabDappStore.solConnectedAddresses) { newValue in

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -521,6 +521,9 @@ struct WalletPanelView: View {
             isConnectHidden = false
           }
         }))
+      } else if cryptoStore.pendingRequest != nil {
+        // race condition for when `pendingRequest` is assigned in CryptoStore before this view visible
+        presentWalletWithContext(.pendingRequests)
       } else {
         cryptoStore.prepare()
       }


### PR DESCRIPTION
## Summary of Changes
- Fix race condition when presenting pending request(s). Previously it was possible that the network selection modal is still on screen when we attempt to present a new pending request, this would cause the new pending request to fail to present. Added a 0.5s delay to overcome this, similar to buy/send/swap present waiting for pan modal dismiss.
- Fix automatic presentation of a request after a user manually swipes to dismiss (not cancel / approve). This bug was caused by us re-assigning the same pending request, which triggered the publisher to present. By only assigning a new pending request _when it changes_ we can avoid presenting the pending request after the user has previously dismissed it

This pull request fixes #6750

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create a Solana Sign Transaction
2. Swipe down to dismiss the transaction approval screen
3. Change network to Ethereum, transaction approval screen shows up
4. Dismiss the screen and change to Polygon
5. Verify Solana transaction approval screen does not present automatically


## Screenshots:

https://user-images.githubusercontent.com/5314553/212724489-d7961fa3-39e0-48f4-abcb-d62108160c64.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
