### PR TITLE
Fix #6654: Solana NFT displaying

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -90,7 +90,7 @@ struct AccountActivityView: View {
                 image: NFTIconView(
                   token: nftAsset.token,
                   network: nftAsset.network,
-                  url: nftAsset.erc721Metadata?.imageURL,
+                  url: nftAsset.nftMetadata?.imageURL,
                   shouldShowNativeTokenIcon: true
                 ),
                 title: nftAsset.token.nftTokenTitle,

--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -112,11 +112,17 @@ struct NFTDetailView: View {
                   }
                 }) {
                   if let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
-                    Text(verbatim: "#\(tokenId)")
-                      .foregroundColor(Color(.braveBlurple))
+                    HStack {
+                      Text(verbatim: "#\(tokenId)")
+                      Image(systemName: "arrow.up.forward.square")
+                    }
+                    .foregroundColor(Color(.braveBlurple))
                   } else {
-                    Text("\(nftDetailStore.nft.name) #\(nftDetailStore.nft.tokenId)")
-                      .foregroundColor(Color(.braveBlurple))
+                    HStack {
+                      Text("\(nftDetailStore.nft.name) #\(nftDetailStore.nft.tokenId)")
+                      Image(systemName: "arrow.up.forward.square")
+                    }
+                    .foregroundColor(Color(.braveBlurple))
                   }
                 }
               }
@@ -139,8 +145,11 @@ struct NFTDetailView: View {
                     }
                   }
                 }) {
-                  Text("\(nftDetailStore.nft.contractAddress.truncatedAddress)")
-                    .foregroundColor(Color(.braveBlurple))
+                  HStack {
+                    Text("\(nftDetailStore.nft.contractAddress.truncatedAddress)")
+                    Image(systemName: "arrow.up.forward.square")
+                  }
+                  .foregroundColor(Color(.braveBlurple))
                 }
               }
             }

--- a/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/NFTDetailView.swift
@@ -12,7 +12,7 @@ import SDWebImageSwiftUI
 struct NFTDetailView: View {
   @ObservedObject var nftDetailStore: NFTDetailStore
   @Binding var buySendSwapDestination: BuySendSwapDestination? 
-  var onERC721MetadataRefreshed: ((ERC721Metadata) -> Void)?
+  var onNFTMetadataRefreshed: ((NFTMetadata) -> Void)?
   
   @Environment(\.openWalletURLAction) private var openWalletURL
   
@@ -23,8 +23,8 @@ struct NFTDetailView: View {
   }
   
   @ViewBuilder private var nftImage: some View {
-    if let erc721Metadata = nftDetailStore.erc721Metadata {
-      if let urlString = erc721Metadata.imageURLString {
+    if let nftMetadata = nftDetailStore.nftMetadata {
+      if let urlString = nftMetadata.imageURLString {
         NFTImageView(urlString: urlString) {
           noImageView
         }
@@ -38,7 +38,7 @@ struct NFTDetailView: View {
   }
   
   private var isSVGImage: Bool {
-    guard let erc721Metadata = nftDetailStore.erc721Metadata, let imageUrlString = erc721Metadata.imageURLString else { return false }
+    guard let nftMetadata = nftDetailStore.nftMetadata, let imageUrlString = nftMetadata.imageURLString else { return false }
     return imageUrlString.hasPrefix("data:image/svg") || imageUrlString.hasSuffix(".svg")
   }
   
@@ -70,7 +70,7 @@ struct NFTDetailView: View {
             .buttonStyle(BraveFilledButtonStyle(size: .large))
           }
         }
-        if let erc721Metadata = nftDetailStore.erc721Metadata, let description = erc721Metadata.description, !description.isEmpty {
+        if let nftMetadata = nftDetailStore.nftMetadata, let description = nftMetadata.description, !description.isEmpty {
           VStack(alignment: .leading, spacing: 8) {
             Text(Strings.Wallet.nftDetailDescription)
               .font(.headline.weight(.semibold))
@@ -91,30 +91,55 @@ struct NFTDetailView: View {
               Text(Strings.Wallet.nftDetailTokenStandard)
                 .font(.headline.weight(.semibold))
               Spacer()
-              Text(Strings.Wallet.nftDetailERC721)
+              Text(nftDetailStore.nft.isErc721 ? Strings.Wallet.nftDetailERC721 : Strings.Wallet.nftDetailSPL)
             }
-            HStack {
-              Text(Strings.Wallet.nftDetailTokenID)
-                .font(.headline.weight(.semibold))
-              Spacer()
-              Button(action: {
-                if let explorerURL = nftDetailStore.networkInfo.blockExplorerUrls.first {
-                  let baseURL = "\(explorerURL)/token/\(nftDetailStore.nft.contractAddress)"
-                  var nftURL = URL(string: baseURL)
-                  if let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
-                    nftURL = URL(string: "\(baseURL)?a=\(tokenId)")
+            if nftDetailStore.nft.isErc721 {
+              HStack {
+                Text(Strings.Wallet.nftDetailTokenID)
+                  .font(.headline.weight(.semibold))
+                Spacer()
+                Button(action: {
+                  if let explorerURL = nftDetailStore.networkInfo.blockExplorerUrls.first {
+                    let baseURL = "\(explorerURL)/token/\(nftDetailStore.nft.contractAddress)"
+                    var nftURL = URL(string: baseURL)
+                    if let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
+                      nftURL = URL(string: "\(baseURL)?a=\(tokenId)")
+                    }
+                    
+                    if let url = nftURL {
+                      openWalletURL?(url)
+                    }
                   }
-                  
-                  if let url = nftURL {
-                    openWalletURL?(url)
+                }) {
+                  if let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
+                    Text(verbatim: "#\(tokenId)")
+                      .foregroundColor(Color(.braveBlurple))
+                  } else {
+                    Text("\(nftDetailStore.nft.name) #\(nftDetailStore.nft.tokenId)")
+                      .foregroundColor(Color(.braveBlurple))
                   }
                 }
-              }) {
-                if let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
-                  Text(verbatim: "#\(tokenId)")
-                    .foregroundColor(Color(.braveBlurple))
-                } else {
-                  Text("\(nftDetailStore.nft.name) #\(nftDetailStore.nft.tokenId)")
+              }
+            } else {
+              HStack {
+                Text(Strings.Wallet.tokenMintAddress)
+                  .font(.headline.weight(.semibold))
+                Spacer()
+                Button(action: {
+                  if WalletConstants.supportedTestNetworkChainIds.contains(nftDetailStore.networkInfo.chainId) {
+                    if let components = nftDetailStore.networkInfo.blockExplorerUrls.first?.separatedBy("/?cluster="), let baseURL = components.first {
+                      let cluster = components.last ?? ""
+                      if let nftURL = URL(string: "\(baseURL)/address/\(nftDetailStore.nft.contractAddress)/?cluster=\(cluster)") {
+                        openWalletURL?(nftURL)
+                      }
+                    }
+                  } else {
+                    if let explorerURL = nftDetailStore.networkInfo.blockExplorerUrls.first, let nftURL = URL(string: "\(explorerURL)/address/\(nftDetailStore.nft.contractAddress)") {
+                      openWalletURL?(nftURL)
+                    }
+                  }
+                }) {
+                  Text("\(nftDetailStore.nft.contractAddress.truncatedAddress)")
                     .foregroundColor(Color(.braveBlurple))
                 }
               }
@@ -132,9 +157,9 @@ struct NFTDetailView: View {
       }
       .padding()
     }
-    .onChange(of: nftDetailStore.erc721Metadata, perform: { newValue in
+    .onChange(of: nftDetailStore.nftMetadata, perform: { newValue in
       if let newMetadata = newValue {
-        onERC721MetadataRefreshed?(newMetadata)
+        onNFTMetadataRefreshed?(newMetadata)
       }
     })
     .onAppear {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -77,11 +77,11 @@ struct SendTokenView: View {
           ) {
             HStack {
               if let token = sendTokenStore.selectedSendToken {
-                if token.isErc721 {
+                if token.isErc721 || token.isNft {
                   NFTIconView(
                     token: token,
                     network: networkStore.selectedChain,
-                    url: sendTokenStore.selectedSendTokenERC721Metadata?.imageURL,
+                    url: sendTokenStore.selectedSendNFTMetadata?.imageURL,
                     length: 26
                   )
                 } else {

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -105,7 +105,7 @@ struct AddCustomAssetView: View {
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
         Section(
-          header: WalletListHeaderView(title: Text(Strings.Wallet.tokenAddress))
+          header: WalletListHeaderView(title: networkSelectionStore.networkSelectionInForm?.coin == .sol ? Text(Strings.Wallet.tokenMintAddress) : Text(Strings.Wallet.tokenAddress))
         ) {
           TextField(Strings.Wallet.enterAddress, text: $addressInput)
             .onChange(of: addressInput) { newValue in

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -15,7 +15,7 @@ private struct EditTokenView: View {
   
   @Binding var tokenNeedsTokenId: BraveWallet.BlockchainToken?
   
-  @State var erc721Metadata: ERC721Metadata?
+  @State var nftMetadata: NFTMetadata?
   
   private var tokenName: String {
     if (assetStore.token.isErc721 || assetStore.token.isNft), !assetStore.token.tokenId.isEmpty {
@@ -34,11 +34,11 @@ private struct EditTokenView: View {
       }
     }) {
       HStack(spacing: 8) {
-        if assetStore.token.isErc721 {
+        if assetStore.token.isErc721 || assetStore.token.isNft {
           NFTIconView(
             token: assetStore.token,
             network: assetStore.network,
-            url: erc721Metadata?.imageURL,
+            url: nftMetadata?.imageURL,
             shouldShowNativeTokenIcon: true
           )
         } else {
@@ -64,7 +64,7 @@ private struct EditTokenView: View {
     }
     .onAppear {
       Task { @MainActor in
-        self.erc721Metadata = await assetStore.fetchERC721Metadata()
+        self.nftMetadata = await assetStore.fetchERC721Metadata()
       }
     }
     .accessibilityAddTraits(assetStore.isVisible ? [.isSelected] : [])

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -188,7 +188,7 @@ struct PortfolioView: View {
                   image: NFTIconView(
                     token: nftAsset.token,
                     network: nftAsset.network,
-                    url: nftAsset.erc721Metadata?.imageURL,
+                    url: nftAsset.nftMetadata?.imageURL,
                     shouldShowNativeTokenIcon: true
                   ),
                   title: nftAsset.token.nftTokenTitle,
@@ -236,9 +236,9 @@ struct PortfolioView: View {
         ),
         destination: {
           if let nftViewModel = selectedNFTViewModel {
-            if nftViewModel.token.isErc721 {
+            if nftViewModel.token.isErc721 || nftViewModel.token.isNft {
               NFTDetailView(
-                nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, erc721Metadata: nftViewModel.erc721Metadata),
+                nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, nftMetadata: nftViewModel.nftMetadata),
                 buySendSwapDestination: buySendSwapDestination
               ) { erc721Metadata in
                 portfolioStore.updateERC721MetadataCache(for: nftViewModel.token, metadata: erc721Metadata)

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -16,7 +16,7 @@ struct AssetSearchView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   
   @State private var allAssets: [AssetViewModel] = []
-  @State private var allERC721Metadata: [String: ERC721Metadata] = [:]
+  @State private var allNFTMetadata: [String: NFTMetadata] = [:]
   @State private var query = ""
   @State private var networkFilter: NetworkFilter = .allNetworks
   @State private var isPresentingNetworkFilter = false
@@ -92,10 +92,10 @@ struct AssetSearchView: View {
                   destination: {
                     if assetViewModel.token.isErc721 {
                       NFTDetailView(
-                        nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, erc721Metadata: allERC721Metadata[assetViewModel.token.id]),
+                        nftDetailStore: cryptoStore.nftDetailStore(for: assetViewModel.token, nftMetadata: allNFTMetadata[assetViewModel.token.id]),
                         buySendSwapDestination: .constant(nil)
                       ) { metadata in
-                        allERC721Metadata[assetViewModel.token.id] = metadata
+                        allNFTMetadata[assetViewModel.token.id] = metadata
                       }
                       .onDisappear {
                         cryptoStore.closeNFTDetailStore(for: assetViewModel.token)
@@ -117,11 +117,11 @@ struct AssetSearchView: View {
                     symbol: assetViewModel.token.symbol,
                     networkName: assetViewModel.network.chainName
                   ) {
-                    if assetViewModel.token.isErc721 {
+                    if assetViewModel.token.isErc721 || assetViewModel.token.isNft {
                       NFTIconView(
                         token: assetViewModel.token,
                         network: assetViewModel.network,
-                        url: allERC721Metadata[assetViewModel.token.id]?.imageURL,
+                        url: allNFTMetadata[assetViewModel.token.id]?.imageURL,
                         shouldShowNativeTokenIcon: true
                       )
                     } else {
@@ -164,7 +164,7 @@ struct AssetSearchView: View {
     .onAppear {
       Task { @MainActor in
         self.allAssets = await userAssetsStore.allAssets()
-        self.allERC721Metadata = await userAssetsStore.allERC721Metadata()
+        self.allNFTMetadata = await userAssetsStore.allNFTMetadata()
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/SendTokenSearchView.swift
@@ -12,14 +12,14 @@ struct SendTokenSearchView: View {
   
   @Environment(\.presentationMode) @Binding private var presentationMode
   
-  @State var allERC721Metadata: [String: ERC721Metadata] = [:]
+  @State var allNFTMetadata: [String: NFTMetadata] = [:]
   
   var network: BraveWallet.NetworkInfo
   
   var body: some View {
     TokenList(tokens: sendTokenStore.userAssets) { token in
       Button(action: {
-        sendTokenStore.selectedSendTokenERC721Metadata = allERC721Metadata[token.id]
+        sendTokenStore.selectedSendNFTMetadata = allNFTMetadata[token.id]
         sendTokenStore.selectedSendToken = token
         presentationMode.dismiss()
       }) {
@@ -27,11 +27,11 @@ struct SendTokenSearchView: View {
           token: token,
           network: network
         ) {
-          if token.isErc721 {
+          if token.isErc721 || token.isNft {
             NFTIconView(
               token: token,
               network: network,
-              url: allERC721Metadata[token.id]?.imageURL
+              url: allNFTMetadata[token.id]?.imageURL
             )
           } else {
             AssetIconView(
@@ -44,7 +44,7 @@ struct SendTokenSearchView: View {
     }
     .onAppear {
       Task { @MainActor in
-        self.allERC721Metadata = await sendTokenStore.fetchERC721Metadata(tokens: sendTokenStore.userAssets.filter { $0.isErc721 })
+        self.allNFTMetadata = await sendTokenStore.fetchNFTMetadata(tokens: sendTokenStore.userAssets.filter { $0.isErc721 || $0.isNft })
       }
     }
     .navigationTitle(Strings.Wallet.searchTitle)

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -146,8 +146,12 @@ class AccountActivityStore: ObservableObject {
         timeframe: .oneDay
       )
       
-      // fetch ERC721 metadata for ERC721 tokens
-      let allErc721Metadata = await rpcService.fetchERC721Metadata(tokens: userVisibleNFTs.map(\.token).filter(\.isErc721))
+      // fetch NFTs metadata
+      let allNFTMetadata = await rpcService.fetchNFTMetadata(
+        tokens: userVisibleNFTs
+          .map(\.token)
+          .filter({ $0.isErc721 || $0.isNft })
+      )
       
       guard !Task.isCancelled else { return }
       updatedUserVisibleAssets.removeAll()
@@ -160,7 +164,7 @@ class AccountActivityStore: ObservableObject {
                 token: token,
                 network: networkAssets.network,
                 balance: Int(totalBalances[token.assetBalanceId] ?? 0),
-                erc721Metadata: allErc721Metadata[token.id]
+                nftMetadata: allNFTMetadata[token.id]
               )
             )
           } else {

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -258,14 +258,14 @@ public class CryptoStore: ObservableObject {
   )
   
   private var nftDetailStore: NFTDetailStore?
-  func nftDetailStore(for nft: BraveWallet.BlockchainToken, erc721Metadata: ERC721Metadata?) -> NFTDetailStore {
+  func nftDetailStore(for nft: BraveWallet.BlockchainToken, nftMetadata: NFTMetadata?) -> NFTDetailStore {
     if let store = nftDetailStore, store.nft.id == nft.id {
       return store
     }
     let store = NFTDetailStore(
       rpcService: rpcService,
       nft: nft,
-      erc721Metadata: erc721Metadata
+      nftMetadata: nftMetadata
     )
     nftDetailStore = store
     return store

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -12,7 +12,7 @@ private extension String {
   }
 }
 
-struct ERC721Metadata: Codable, Equatable {
+struct NFTMetadata: Codable, Equatable {
   var imageURLString: String?
   var name: String?
   var description: String?
@@ -52,17 +52,17 @@ class NFTDetailStore: ObservableObject {
   private let rpcService: BraveWalletJsonRpcService
   let nft: BraveWallet.BlockchainToken
   @Published var isLoading: Bool = false
-  @Published var erc721Metadata: ERC721Metadata?
+  @Published var nftMetadata: NFTMetadata?
   @Published var networkInfo: BraveWallet.NetworkInfo = .init()
   
   init(
     rpcService: BraveWalletJsonRpcService,
     nft: BraveWallet.BlockchainToken,
-    erc721Metadata: ERC721Metadata?
+    nftMetadata: NFTMetadata?
   ) {
     self.rpcService = rpcService
     self.nft = nft
-    self.erc721Metadata = erc721Metadata
+    self.nftMetadata = nftMetadata
   }
   
   func update() {
@@ -72,16 +72,10 @@ class NFTDetailStore: ObservableObject {
         networkInfo = network
       }
       
-      if erc721Metadata == nil {
+      if nftMetadata == nil {
         isLoading = true
-        
-        let (metaData, _, _) = await rpcService.erc721Metadata(nft.contractAddress, tokenId: nft.tokenId, chainId: nft.chainId)
-        
+        nftMetadata = await rpcService.fetchNFTMetadata(for: nft)
         isLoading = false
-        if let data = metaData.data(using: .utf8),
-           let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
-          erc721Metadata = result
-        }
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -15,11 +15,11 @@ public class SendTokenStore: ObservableObject {
   /// The current selected token to send. Default with nil value.
   @Published var selectedSendToken: BraveWallet.BlockchainToken? {
     didSet {
-      update() // need to update `selectedSendTokenBalance` and `selectedSendTokenERC721Metadata`
+      update() // need to update `selectedSendTokenBalance` and `selectedSendNFTMetadata`
     }
   }
-  /// The current selected token's ERC721 metadata. Default with nil value.
-  @Published var selectedSendTokenERC721Metadata: ERC721Metadata?
+  /// The current selected NFT metadata. Default with nil value.
+  @Published var selectedSendNFTMetadata: NFTMetadata?
   /// The current selected token balance. Default with nil value.
   @Published var selectedSendTokenBalance: BDouble?
   /// A boolean indicates if this store is making an unapproved tx
@@ -112,7 +112,7 @@ public class SendTokenStore: ObservableObject {
   private var sendAddressUpdatedTimer: Timer?
   private var sendAmountUpdatedTimer: Timer?
   private var prefilledToken: BraveWallet.BlockchainToken?
-  private var metadataCache: [String: ERC721Metadata] = [:]
+  private var metadataCache: [String: NFTMetadata] = [:]
 
   public init(
     keyringService: BraveWalletKeyringService,
@@ -204,12 +204,12 @@ public class SendTokenStore: ObservableObject {
         decimalFormatStyle: .decimals(precision: Int(selectedSendToken.decimals))
       )
   
-      if selectedSendToken.isErc721, metadataCache[selectedSendToken.id] == nil {
-        metadataCache[selectedSendToken.id] = await rpcService.fetchERC721Metadata(for: selectedSendToken)
+      if (selectedSendToken.isErc721 || selectedSendToken.isNft), metadataCache[selectedSendToken.id] == nil {
+        metadataCache[selectedSendToken.id] = await rpcService.fetchNFTMetadata(for: selectedSendToken)
       }
       guard !Task.isCancelled else { return }
       self.selectedSendTokenBalance = balance
-      self.selectedSendTokenERC721Metadata = metadataCache[selectedSendToken.id]
+      self.selectedSendNFTMetadata = metadataCache[selectedSendToken.id]
       self.validateBalance()
     }
   }
@@ -472,8 +472,8 @@ public class SendTokenStore: ObservableObject {
     }
   }
   
-  @MainActor func fetchERC721Metadata(tokens: [BraveWallet.BlockchainToken]) async -> [String: ERC721Metadata] {
-    return await rpcService.fetchERC721Metadata(tokens: tokens)
+  @MainActor func fetchNFTMetadata(tokens: [BraveWallet.BlockchainToken]) async -> [String: NFTMetadata] {
+    return await rpcService.fetchNFTMetadata(tokens: tokens)
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -50,8 +50,8 @@ public class AssetStore: ObservableObject, Equatable {
     lhs.token == rhs.token && lhs.isVisible == rhs.isVisible
   }
   
-  @MainActor func fetchERC721Metadata() async -> ERC721Metadata? {
-    return await rpcService.fetchERC721Metadata(for: token)
+  @MainActor func fetchERC721Metadata() async -> NFTMetadata? {
+    return await rpcService.fetchNFTMetadata(for: token)
   }
 }
 
@@ -218,14 +218,14 @@ public class UserAssetsStore: ObservableObject {
     }
   }
   
-  @MainActor func allERC721Metadata() async -> [String: ERC721Metadata] {
+  @MainActor func allNFTMetadata() async -> [String: NFTMetadata] {
     let allNetworks = await rpcService.allNetworksForSupportedCoins()
     let allUserAssets = await walletService.allUserAssets(in: allNetworks)
     // Filter `allTokens` to remove any tokens existing in `allUserAssets`. This is possible for ERC721 tokens in the registry without a `tokenId`, which requires the user to add as a custom token
     let allUserTokens = allUserAssets.flatMap(\.tokens)
     
-    // ERC721 metadata only exists for custom NFT added by users. ERC721 tokens from token registry do not have metadata
-    return await rpcService.fetchERC721Metadata(tokens: allUserTokens.filter { $0.isErc721 })
+    // NFT metadata only exists for custom NFT added by users. ERC721 tokens from token registry do not have metadata
+    return await rpcService.fetchNFTMetadata(tokens: allUserTokens.filter { $0.isErc721 || $0.isNft })
   }
 }
 

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -283,17 +283,13 @@ extension BraveWalletJsonRpcService {
     if token.isErc721 {
       let (metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
       if result != .success {
-        if result != .success {
-          Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
-        }
+        Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
       }
       metaDataString = metaData
     } else {
       let (metaData, result, errMsg) = await self.solTokenMetadata(token.contractAddress)
       if result != .success {
-        if result != .success {
-          Logger.module.debug("Failed to load Solana NFT metadata: \(errMsg)")
-        }
+        Logger.module.debug("Failed to load Solana NFT metadata: \(errMsg)")
       }
       metaDataString = metaData
     }
@@ -314,17 +310,13 @@ extension BraveWalletJsonRpcService {
           if token.isErc721 {
             let (metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
             if result != .success {
-              if result != .success {
-                Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
-              }
+              Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
             }
             metaDataString = metaData
           } else {
             let (metaData, result, errMsg) = await self.solTokenMetadata(token.contractAddress)
             if result != .success {
-              if result != .success {
-                Logger.module.debug("Failed to load Solana NFT metadata: \(errMsg)")
-              }
+              Logger.module.debug("Failed to load Solana NFT metadata: \(errMsg)")
             }
             metaDataString = metaData
           }

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -277,41 +277,68 @@ extension BraveWalletJsonRpcService {
     }
   }
   
-  /// Returns a map of Token.id with it ERC721 metadata
-  @MainActor func fetchERC721Metadata(tokens: [BraveWallet.BlockchainToken]) async -> [String: ERC721Metadata] {
-    await withTaskGroup(of: [String: ERC721Metadata].self) {  @MainActor [weak self] group -> [String: ERC721Metadata] in
+  /// Returns a nullable NFT metadata
+  @MainActor func fetchNFTMetadata(for token: BraveWallet.BlockchainToken) async -> NFTMetadata? {
+    var metaDataString = ""
+    if token.isErc721 {
+      let (metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
+      if result != .success {
+        if result != .success {
+          Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
+        }
+      }
+      metaDataString = metaData
+    } else {
+      let (metaData, result, errMsg) = await self.solTokenMetadata(token.contractAddress)
+      if result != .success {
+        if result != .success {
+          Logger.module.debug("Failed to load Solana NFT metadata: \(errMsg)")
+        }
+      }
+      metaDataString = metaData
+    }
+    if let data = metaDataString.data(using: .utf8),
+       let result = try? JSONDecoder().decode(NFTMetadata.self, from: data) {
+      return result
+    }
+    return nil
+  }
+  
+  /// Returns a map of Token.id with its NFT metadata
+  @MainActor func fetchNFTMetadata(tokens: [BraveWallet.BlockchainToken]) async -> [String: NFTMetadata] {
+    await withTaskGroup(of: [String: NFTMetadata].self) {  @MainActor [weak self] group -> [String: NFTMetadata] in
       guard let self = self else { return [:] }
       for token in tokens {
         group.addTask { @MainActor in
-          let (metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
-          if result != .success {
+          var metaDataString = ""
+          if token.isErc721 {
+            let (metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
             if result != .success {
-              Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
+              if result != .success {
+                Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
+              }
             }
+            metaDataString = metaData
+          } else {
+            let (metaData, result, errMsg) = await self.solTokenMetadata(token.contractAddress)
+            if result != .success {
+              if result != .success {
+                Logger.module.debug("Failed to load Solana NFT metadata: \(errMsg)")
+              }
+            }
+            metaDataString = metaData
           }
-          if let data = metaData.data(using: .utf8),
-             let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
+          
+          if let data = metaDataString.data(using: .utf8),
+             let result = try? JSONDecoder().decode(NFTMetadata.self, from: data) {
             return [token.id: result]
           }
           return [:]
         }
       }
-
+      
       return await group.reduce([:], { $0.merging($1, uniquingKeysWith: { key, _ in key })
       })
     }
-  }
-  
-  /// Returns a nullable ERC721 metadata
-  @MainActor func fetchERC721Metadata(for token: BraveWallet.BlockchainToken) async -> ERC721Metadata? {
-    let (metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
-    if result != .success {
-      Logger.module.debug("Failed to load ERC721 metadata: \(errMsg)")
-    }
-    if let data = metaData.data(using: .utf8),
-       let result = try? JSONDecoder().decode(ERC721Metadata.self, from: data) {
-      return result
-    }
-    return nil
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1492,6 +1492,13 @@ extension Strings {
       value: "Token address",
       comment: "A title that will be displayed on top of the text field for users to input the custom token address"
     )
+    public static let tokenMintAddress = NSLocalizedString(
+      "wallet.tokenMintAddress",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Mint address",
+      comment: "A title that will be displayed on top of the text field for users to input the custom token mint address"
+    )
     public static let enterAddress = NSLocalizedString(
       "wallet.enterAddress",
       tableName: "BraveWallet",
@@ -3353,6 +3360,13 @@ extension Strings {
       bundle: .module,
       value: "ERC 721",
       comment: "This is one type of token standard. And most likey this does not need to be translated"
+    )
+    public static let nftDetailSPL = NSLocalizedString(
+      "wallet.nftDetailSPL",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "SPL",
+      comment: "This is one type of NFT standard. And most likey this does not need to be translated"
     )
     public static let nftDetailTokenStandard = NSLocalizedString(
       "wallet.nftDetailTokenStandard",

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -86,6 +86,16 @@ class AccountActivityStoreTests: XCTestCase {
       }
       """, .success, "")
     }
+    rpcService._solTokenMetadata = { _, completion in
+      completion(
+      """
+      {
+        "image": "sol.mock.image.url",
+        "name": "sol mock nft name",
+        "description": "sol mock nft description"
+      }
+      """, .success, "")
+    }
     
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }
@@ -127,7 +137,7 @@ class AccountActivityStoreTests: XCTestCase {
     let mockNFTBalance: Double = 1
     let mockERC721BalanceWei = formatter.weiString(from: mockNFTBalance, radix: .hex, decimals: 0) ?? ""
     
-    let mockERC721Metadata: ERC721Metadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
     
     let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy) = setupServices(
       mockEthBalanceWei: mockEthBalanceWei,
@@ -188,9 +198,9 @@ class AccountActivityStoreTests: XCTestCase {
         XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, BraveWallet.BlockchainToken.mockERC721NFTToken.symbol)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balance, Int(mockNFTBalance))
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.imageURLString, mockERC721Metadata.imageURLString)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.name, mockERC721Metadata.name)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.erc721Metadata?.description, mockERC721Metadata.description)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.imageURLString, mockERC721Metadata.imageURLString)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.name, mockERC721Metadata.name)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockERC721Metadata.description)
       }.store(in: &cancellables)
     
     let transactionSummariesExpectation = expectation(description: "accountActivityStore-transactions")
@@ -224,6 +234,8 @@ class AccountActivityStoreTests: XCTestCase {
       BraveWallet.BlockchainToken.mockSpdToken.contractAddress: "\(mockSpdTokenBalance)",
       BraveWallet.BlockchainToken.mockSolanaNFTToken.contractAddress: "\(mockSolanaNFTTokenBalance)"
     ]
+    
+    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
     
     let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy) = setupServices(
       mockLamportBalance: mockLamportBalance,
@@ -283,6 +295,9 @@ class AccountActivityStoreTests: XCTestCase {
         XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, BraveWallet.BlockchainToken.mockSolanaNFTToken.symbol)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balance, Int(mockSolanaNFTTokenBalance))
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.imageURLString, mockSolMetadata.imageURLString)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.name, mockSolMetadata.name)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockSolMetadata.description)
       }.store(in: &cancellables)
     
     let transactionSummariesExpectation = expectation(description: "accountActivityStore-transactions")

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -50,7 +50,8 @@ class PortfolioStoreTests: XCTestCase {
     let totalBalanceValue = totalEthBalanceValue + totalSolBalanceValue
     let totalBalance = currencyFormatter.string(from: NSNumber(value: totalBalanceValue)) ?? ""
     
-    let mockERC721Metadata: ERC721Metadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
     
     // setup test services
     let keyringService = BraveWallet.TestKeyringService()
@@ -113,6 +114,16 @@ class PortfolioStoreTests: XCTestCase {
         "image": "mock.image.url",
         "name": "mock nft name",
         "description": "mock nft description"
+      }
+      """, .success, "")
+    }
+    rpcService._solTokenMetadata = { _, completion in
+      completion(
+      """
+      {
+        "image": "sol.mock.image.url",
+        "name": "sol mock nft name",
+        "description": "sol mock nft description"
       }
       """, .success, "")
     }
@@ -195,9 +206,12 @@ class PortfolioStoreTests: XCTestCase {
         
         XCTAssertEqual(lastUpdatedVisibleNFTs[1].token.symbol, mockEthUserAssets.last?.symbol)
         XCTAssertEqual(lastUpdatedVisibleNFTs[1].balance, Int(mockNFTBalanceWei))
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.erc721Metadata?.imageURLString, mockERC721Metadata.imageURLString)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.erc721Metadata?.name, mockERC721Metadata.name)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.erc721Metadata?.description, mockERC721Metadata.description)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.imageURLString, mockSolMetadata.imageURLString)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.name, mockSolMetadata.name)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockSolMetadata.description)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.nftMetadata?.imageURLString, mockERC721Metadata.imageURLString)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.nftMetadata?.name, mockERC721Metadata.name)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.nftMetadata?.description, mockERC721Metadata.description)
       }.store(in: &cancellables)
     // test that `update()` will assign new value to `balance` publisher
     let balanceException = expectation(description: "update-balance")

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -52,6 +52,16 @@ class SendTokenStoreTests: XCTestCase {
       }
       """, .success, "")
     }
+    rpcService._solTokenMetadata = { _, completion in
+      completion(
+      """
+      {
+        "image": "sol.mock.image.url",
+        "name": "sol mock nft name",
+        "description": "sol mock nft description"
+      }
+      """, .success, "")
+    }
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._selectedCoin = { $0(selectedCoin) }
     walletService._userAssets = { $2(userAssets) }
@@ -541,13 +551,13 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
 
-  func testFetchSelectedERC721Metadata() {
+  func testFetchSelectedSendNFTMetadataERC721() {
     let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices()
     let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
     ethTxManagerProxy._makeErc721TransferFromData = { _, _, _, _, completion in
       completion(true, .init())
     }
-    let mockERC721Metadata: ERC721Metadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
     
     let store = SendTokenStore(
       keyringService: keyringService,
@@ -560,13 +570,13 @@ class SendTokenStoreTests: XCTestCase {
       prefilledToken: nil
     )
     
-    let selectedSendTokenERC721MetadataException = expectation(description: "accountActivityStore-selectedSendTokenERC721MetadataException")
-    XCTAssertNil(store.selectedSendTokenERC721Metadata)  // Initial state
-    store.$selectedSendTokenERC721Metadata
+    let selectedSendNFTMetadataERC721Exception = expectation(description: "sendTokenStore-selectedSendTokenERC721MetadataException")
+    XCTAssertNil(store.selectedSendNFTMetadata)  // Initial state
+    store.$selectedSendNFTMetadata
       .dropFirst()
       .collect(1)
       .sink { metadata in
-        defer { selectedSendTokenERC721MetadataException.fulfill() }
+        defer { selectedSendNFTMetadataERC721Exception.fulfill() }
         guard let lastUpdatedMetadata = metadata.last else {
           XCTFail("Unexpected test result")
           return
@@ -577,6 +587,48 @@ class SendTokenStoreTests: XCTestCase {
       }.store(in: &cancellables)
     
     store.selectedSendToken = .mockERC721NFTToken
+    
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  func testFetchSelectedSendNFTMetadataSolNFT() {
+    let (keyringService, rpcService, walletService, solTxManagerProxy) = setupServices()
+    let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
+    ethTxManagerProxy._makeErc721TransferFromData = { _, _, _, _, completion in
+      completion(true, .init())
+    }
+    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
+    
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: nil
+    )
+    
+    let selectedSendNFTMetadataSolNFTException = expectation(description: "sendTokenStore-selectedSendTokenERC721MetadataException")
+    XCTAssertNil(store.selectedSendNFTMetadata)  // Initial state
+    store.$selectedSendNFTMetadata
+      .dropFirst()
+      .collect(1)
+      .sink { metadata in
+        defer { selectedSendNFTMetadataSolNFTException.fulfill() }
+        guard let lastUpdatedMetadata = metadata.last else {
+          XCTFail("Unexpected test result")
+          return
+        }
+        XCTAssertEqual(lastUpdatedMetadata?.imageURLString, mockSolMetadata.imageURLString)
+        XCTAssertEqual(lastUpdatedMetadata?.name, mockSolMetadata.name)
+        XCTAssertEqual(lastUpdatedMetadata?.description, mockSolMetadata.description)
+      }.store(in: &cancellables)
+    
+    store.selectedSendToken = .mockSolanaNFTToken
     
     waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -612,7 +612,7 @@ class SendTokenStoreTests: XCTestCase {
       prefilledToken: nil
     )
     
-    let selectedSendNFTMetadataSolNFTException = expectation(description: "sendTokenStore-selectedSendTokenERC721MetadataException")
+    let selectedSendNFTMetadataSolNFTException = expectation(description: "sendTokenStore-selectedSendNFTMetadataSolNFTException")
     XCTAssertNil(store.selectedSendNFTMetadata)  // Initial state
     store.$selectedSendNFTMetadata
       .dropFirst()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
start fetching both solana NFT and erc721 metadata and displaying in wallet

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6654, #6707

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Add some solana NFTs via Add Custom Token. Make a send transaction if possible.
Check Solana NFT images displayed in portfolio/Send/Account Activity 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screen Recording - iPhone 14 Pro - 2023-01-16 at 12 22 33](https://user-images.githubusercontent.com/1187676/212735630-841b59cc-ffb1-4992-8b55-113231912dda.gif)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
