### PR TITLE
Fix 6773: Hide Browser History Suggestion in PBM

### DIFF
--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -492,7 +492,7 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
     case .searchSuggestionsOptIn:
       return footerHeight
     case .openTabsAndHistoryAndBookmarks:
-        return footerHeight
+      return footerHeight
     }
   }
 
@@ -655,6 +655,12 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
         !dataSource.searchQuery.looksLikeAURL() &&
         !dataSource.tabType.isPrivate ? searchSuggestionsCount : 0
     case .openTabsAndHistoryAndBookmarks:
+      // Private Browsing Mode (PBM) should *not* show items from normal mode History etc
+      // when search suggestions is not enabled
+      if Preferences.Privacy.privateBrowsingOnly.value, dataSource.searchEngines?.shouldShowSearchSuggestions == false {
+        return 0
+      }
+      
       return data.count
     case .findInPage:
       if let sd = searchDelegate, sd.searchViewControllerAllowFindInPage() {


### PR DESCRIPTION
Hide the section of openTabsAndHistoryAndBookmarks when user is in PBM and Search Suggestion are disabled

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6773

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
- Add History in Normal Mode like reddit
- Settings -> Privacy -> PBM enable
- Disable Search Suggestion Settings -> Search Suggestion toggle
- Type reddit in URL(omnibox)
- No History should be shown

## Screenshots:

![IMG_1651 1 111](https://user-images.githubusercontent.com/6643505/212765328-5416821d-23b3-4d6a-8a29-64c7b9a43e90.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
