### PR TITLE
Fix #6779: Customize Brave Tabs bar modal doesn't show Maybe later button on iOS 14 light theme

### DIFF
--- a/Sources/Onboarding/Callouts/OnboardingBottomBarView.swift
+++ b/Sources/Onboarding/Callouts/OnboardingBottomBarView.swift
@@ -57,6 +57,7 @@ public struct OnboardingBottomBarView: View {
         Text(Strings.Callout.bottomBarCalloutDismissButtonTitle)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .font(.title3.weight(.medium))
+          .foregroundColor(Color(.bravePrimary))
       }
       .frame(height: 44)
       .background(Color(.clear))


### PR DESCRIPTION
## Summary of Changes

Adding missing foreground color to maybe later button in Tab Bar Callout

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6779

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Install 1.46.2 from App store
- Switch to light theme
- Move tabs bar to top from settings
- Visit a couple of pages in a new tab
- Upgrade to 1.47
- On launch shows Customize Brave Tabs Bar message but doesn't show the Maybe later button`
- Change theme to dark from action centre, Maybe later message is shown

## Screenshots:

![121 1 14 1](https://user-images.githubusercontent.com/6643505/212946947-08712da9-2182-402f-acbe-9b4e79daded6.png)



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
