### PR TITLE
Fix #6294: Bookmark import not working

### DIFF
--- a/Client/Frontend/Sync/BraveCore/BraveCoreImportExportUtility.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveCoreImportExportUtility.swift
@@ -51,14 +51,14 @@ class BraveCoreImportExportUtility {
       }
       
       self.importer.import(fromFile: nativePath, topLevelFolderName: Strings.Sync.importFolderName, automaticImport: true) { [weak self] state, bookmarks in
-        guard let self = self, state != .started else { return }
-        
         defer {
           // Each call to startAccessingSecurityScopedResource must be balanced with a call to stopAccessingSecurityScopedResource
           // (Note: this is not reference counted)
           path.stopAccessingSecurityScopedResource()
         }
         
+        guard let self = self, state != .started else { return }
+            
         do {
           try self.rethrow(state)
           self.state = .none
@@ -98,11 +98,11 @@ class BraveCoreImportExportUtility {
       }
       
       self.importer.import(fromFile: nativePath, topLevelFolderName: Strings.Sync.importFolderName, automaticImport: false) { [weak self] state, bookmarks in
-        guard let self = self, state != .started else { return }
-
         defer {
           path.stopAccessingSecurityScopedResource()
         }
+        
+        guard let self = self, state != .started else { return }
         
         do {
           try self.rethrow(state)
@@ -213,7 +213,7 @@ extension BraveCoreImportExportUtility {
   func nativeURLPathFromURL(_ url: URL) -> String? {
     return url.withUnsafeFileSystemRepresentation { bytes -> String? in
       guard let bytes = bytes else { return nil }
-      return String(cString: bytes)//.replacingOccurrences(of: " ", with: "%20").replacingOccurrences(of: "file://", with: "")
+      return String(cString: bytes)
     }
   }
 }

--- a/Client/Frontend/Sync/BraveCore/BraveCoreImportExportUtility.swift
+++ b/Client/Frontend/Sync/BraveCore/BraveCoreImportExportUtility.swift
@@ -43,6 +43,9 @@ class BraveCoreImportExportUtility {
 
     state = .importing
     self.queue.async {
+      // While accessing document URL from UIDocumentPickerViewController to access the file
+      // startAccessingSecurityScopedResource should be called for that URL
+      // Reference: https://stackoverflow.com/a/73912499/2239348
       guard path.startAccessingSecurityScopedResource() else {
         return
       }
@@ -51,6 +54,8 @@ class BraveCoreImportExportUtility {
         guard let self = self, state != .started else { return }
         
         defer {
+          // Each call to startAccessingSecurityScopedResource must be balanced with a call to stopAccessingSecurityScopedResource
+          // (Note: this is not reference counted)
           path.stopAccessingSecurityScopedResource()
         }
         
@@ -86,6 +91,8 @@ class BraveCoreImportExportUtility {
 
     state = .importing
     self.queue.async {
+      // To access a document URL from UIDocumentPickerViewController
+      // startAccessingSecurityScopedResource should be called
       guard path.startAccessingSecurityScopedResource() else {
         return
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

While accessing document URL from UIDocumentPickerViewController to access the file startAccessingSecurityScopedResource should be called for that URL.

Given an NSURL created by resolving a bookmark data created with security scope, make the resource referenced by the url accessible to the process. When access to this resource is no longer needed the client must call stopAccessingSecurityScopedResource. Each call to startAccessingSecurityScopedResource must be balanced with a call to stopAccessingSecurityScopedResource (Note: this is not reference counted).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6294

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Add a website to Bookmarks
- Export the Bookmarks on the same phone to iCloud or otherwise
- Import Bookmarks

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
