### PR TITLE
Fix #6792: Reject N Transactions does not dismiss tx confirmation

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -93,6 +93,10 @@ public struct CryptoView: View {
                   dismissAction?()
                 }
               )
+              .onDisappear {
+                // onDisappear allows us to catch all cases (swipe, cancel, confirm/approve/sign)
+                store.isPresentingPendingRequest = false
+              }
             case .requestPermissions(let request, let onPermittedAccountsUpdated):
               NewSiteConnectionView(
                 origin: request.requestingOrigin,

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -147,9 +147,20 @@ public class TransactionConfirmationStore: ObservableObject {
     }
   }
 
-  func rejectAllTransactions() {
+  func rejectAllTransactions(completion: @escaping (Bool) -> Void) {
+    let dispatchGroup = DispatchGroup()
+    var allRejectsSucceeded = true
     for transaction in transactions {
-      reject(transaction: transaction, completion: { _ in })
+      dispatchGroup.enter()
+      reject(transaction: transaction, completion: { success in
+        defer { dispatchGroup.leave() }
+        if !success {
+          allRejectsSucceeded = false
+        }
+      })
+    }
+    dispatchGroup.notify(queue: .main) {
+      completion(allRejectsSucceeded)
     }
   }
   

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -18,7 +18,6 @@ struct TransactionConfirmationView: View {
   var onDismiss: () -> Void
 
   @Environment(\.sizeCategory) private var sizeCategory
-  @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.openWalletURLAction) private var openWalletURL
 
   /// Blockie size for ERC 20 Approve transactions
@@ -375,7 +374,13 @@ struct TransactionConfirmationView: View {
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
           }
           if confirmationStore.transactions.count > 1 {
-            Button(action: confirmationStore.rejectAllTransactions) {
+            Button(action: {
+              confirmationStore.rejectAllTransactions { success in
+                if success {
+                  onDismiss()
+                }
+              }
+            }) {
               Text(String.localizedStringWithFormat(Strings.Wallet.rejectAllTransactions, confirmationStore.transactions.count))
                 .font(.subheadline.weight(.semibold))
                 .foregroundColor(Color(.braveBlurpleTint))


### PR DESCRIPTION
## Summary of Changes
- Fix for dismissal when using reject all transactions by calling dismiss handler to match cancel / confirm individual transaction buttons

This pull request fixes #6792

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create a transaction in a dapp
2. Swipe to dismiss that transaction
3. Create a second transaction in the dapp (more can be added if needed, but need at least 2)
4. Tap 'Reject 2 transactions'
5. Verify transaction confirmation is dismissed as expected
6. Create 2 more transactions
7. Open main wallet
8. Tap 'Reject 2 transactions'
9. Verify transaction confirmation is dismissed as expected
    - Tests separate presentation flow for tx confirmation


## Screenshots:

https://user-images.githubusercontent.com/5314553/213486471-15c5e7b6-b397-45df-8477-8244e410efd0.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
