### PR TITLE
Fix #6794: Fixes Playlist not working on 9anime and animedao

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/PlaylistScriptHandler.swift
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/PlaylistScriptHandler.swift
@@ -101,7 +101,7 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
   }
 
   private class func processPlaylistInfo(handler: PlaylistScriptHandler, item: PlaylistInfo?) {
-    guard let item = item, !item.src.isEmpty else {
+    guard var item = item, !item.src.isEmpty else {
       DispatchQueue.main.async {
         handler.delegate?.updatePlaylistURLBar(tab: handler.tab, state: .none, item: nil)
       }
@@ -113,6 +113,19 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
     }
     
     handler.playlistItems.insert(item.src)
+    
+    // Copy the item but use the web-view's title and location instead, if available
+    // This is due to a iFrames security
+    item = PlaylistInfo(name: item.name,
+                        src: item.src,
+                        pageSrc: handler.tab?.webView?.url?.absoluteString ?? item.pageSrc,
+                        pageTitle: handler.tab?.webView?.title ?? item.pageTitle,
+                        mimeType: item.mimeType,
+                        duration: item.duration,
+                        detected: item.detected,
+                        dateAdded: item.dateAdded,
+                        tagId: item.tagId,
+                        order: item.order)
 
     Self.queue.async { [weak handler] in
       guard let handler = handler else { return }

--- a/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
+++ b/Client/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/PlaylistScript.js
@@ -67,12 +67,23 @@ window.__firefox__.includeOnce("Playlist", function($) {
   
   function sendMessage(name, node, target, type, detected) {
     $(function() {
+      var location = "";
+      var pageTitle = "";
+      
+      try {
+        location = window.top.location.href;
+        pageTitle = window.top.document.title;
+      } catch(error) {
+        location = window.location.href;
+        pageTitle = document.title;
+      }
+      
       $.postNativeMessage('$<message_handler>', {
         "securityToken": SECURITY_TOKEN,
         "name": name,
         "src": node.src,
-        "pageSrc": window.top.location.href,
-        "pageTitle": window.top.document.title,
+        "pageSrc": location,
+        "pageTitle": pageTitle,
         "mimeType": type,
         "duration": clamp_duration(target.duration),
         "detected": detected,
@@ -85,7 +96,11 @@ window.__firefox__.includeOnce("Playlist", function($) {
     if (target) {
       var name = target.title;
       if (!name || name == "") {
-        name = window.top.document.title;
+        try {
+          name = window.top.document.title;
+        } catch(error) {
+          name = document.title;
+        }
       }
     
       if (!type || type == "") {


### PR DESCRIPTION
## Summary of Changes
- Use the page's location & title from the webView
- Ttry to access the iFrame's video title if possible, otherwise fallback to default title

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #https://github.com/brave/brave-ios/issues/6794

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
