### PR TITLE
Fix #6799: NTP should work with New Tab Long Press Menu Actions

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2992,12 +2992,18 @@ extension BrowserViewController: TabManagerDelegate {
     let bookmarkMenu = UIMenu(title: "", options: .displayInline, children: bookmarkMenuChildren)
     let duplicateTabMenu = UIMenu(title: "", options: .displayInline, children: duplicateTabMenuChildren)
     let closeTabMenu = UIMenu(title: "", options: .displayInline, children: closeTabMenuChildren)
+    
+    let tabButtonMenuActionList = [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu]
+    let addTabMenuActionList = [addTabMenu]
 
-    toolbar?.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu])
-    topToolbar.tabsButton.menu = UIMenu(title: "", identifier: nil, children: [closeTabMenu, duplicateTabMenu, bookmarkMenu, newTabMenu])
-
+    toolbar?.tabsButton.menu = UIMenu(title: "", identifier: nil, children: tabButtonMenuActionList)
+    toolbar?.searchButton.menu = UIMenu(title: "", identifier: nil, children: addTabMenuActionList)
+    
+    topToolbar.tabsButton.menu = UIMenu(title: "", identifier: nil, children: tabButtonMenuActionList)
+    toolbar?.searchButton.menu = UIMenu(title: "", identifier: nil, children: addTabMenuActionList)
+    
     // Update Actions for Add-Tab Button
-    toolbar?.addTabButton.menu = UIMenu(title: "", identifier: nil, children: [addTabMenu])
+    toolbar?.addTabButton.menu = UIMenu(title: "", identifier: nil, children: addTabMenuActionList)
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->
Add New Tab Menu actions to bottom bar search button NTP

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6799

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Open the application normal mode
- Long Press magnifying glass button and check actions are working for opening tab on both private and normal browsing

## Screenshots:

https://user-images.githubusercontent.com/6643505/213533961-d8393af4-ec2e-46f8-afca-4bb0cca6ad7d.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
