### PR TITLE
Fix #6190: Add leading fade when truncating URL bar text

### DIFF
--- a/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Client/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -8,6 +8,7 @@ import SnapKit
 import BraveShared
 import Combine
 import BraveCore
+import DesignSystem
 
 protocol TabLocationViewDelegate {
   func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView)
@@ -135,6 +136,13 @@ class TabLocationView: UIView {
     urlTextField.clipsToBounds = true
     urlTextField.textColor = .braveLabel
     urlTextField.isEnabled = false
+    urlTextField.defaultTextAttributes = {
+      var attributes = urlTextField.defaultTextAttributes
+      let style = (attributes[.paragraphStyle, default: NSParagraphStyle.default] as! NSParagraphStyle).mutableCopy() as! NSMutableParagraphStyle // swiftlint:disable:this force_cast
+      style.lineBreakMode = .byClipping
+      attributes[.paragraphStyle] = style
+      return attributes
+    }()
     // Remove the default drop interaction from the URL text field so that our
     // custom drop interaction on the BVC can accept dropped URLs.
     if let dropInteraction = urlTextField.textDropInteraction {
@@ -477,6 +485,34 @@ class DisplayTextField: UITextField {
   weak var accessibilityActionsSource: AccessibilityActionsSource?
   var hostString: String = ""
   let pathPadding: CGFloat = 5.0
+  
+  private let leadingClippingFade = GradientView(
+    colors: [.braveBackground, .braveBackground.withAlphaComponent(0.0)],
+    positions: [0, 1],
+    startPoint: .init(x: 0, y: 0.5),
+    endPoint: .init(x: 1, y: 0.5)
+  )
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    
+    addSubview(leadingClippingFade)
+    leadingClippingFade.snp.makeConstraints {
+      $0.leading.top.bottom.equalToSuperview()
+      $0.width.equalTo(20)
+    }
+  }
+  
+  override var text: String? {
+    didSet {
+      leadingClippingFade.isHidden = true
+    }
+  }
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError()
+  }
 
   override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
     get {
@@ -506,6 +542,8 @@ class DisplayTextField: UITextField {
       if size.width > self.bounds.width {
         rect.origin.x = rect.origin.x - (size.width + pathPadding - self.bounds.width)
         rect.size.width = size.width + pathPadding
+        bringSubviewToFront(leadingClippingFade)
+        leadingClippingFade.isHidden = false
       }
     }
     return rect


### PR DESCRIPTION
Also fixes a bug when a really long URL had a path in it and would truncate the last letter in the TLD

## Summary of Changes

This pull request fixes #6190 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

| With Path | Without Path |
| --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 01 08](https://user-images.githubusercontent.com/529104/213541032-b06b530a-9b32-4568-a17c-9c97da1dbbe3.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 02 03](https://user-images.githubusercontent.com/529104/213541045-e35c22cd-a2eb-48dd-8ae8-238ab45538a3.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
