### PR TITLE
Fix #6749: Change Playlist autoplay to be ON by default

### DIFF
--- a/Client/Migration/Migration.swift
+++ b/Client/Migration/Migration.swift
@@ -50,6 +50,7 @@ public class Migration {
       }
       // Default url bar location for new users is bottom
       Preferences.General.isUsingBottomBar.value = true
+      Preferences.Playlist.firstLoadAutoPlay.value = true
     }
 
     // Adding Observer to enable sync types


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Change Playlist autoplay to be ON by default

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6749

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan
- Fresh install - verify that the autoplay setting in playlist settings is enabled
- Existing user - verify that the autoplay setting in playlist settings has not changed

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
