### PR TITLE
Fix #6676, #6638: Bump BraveCore to v1.47.179, support The Wallet Standard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.177/brave-core-ios-1.47.177.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.179/brave-core-ios-1.47.179.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.47.177",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.47.177/brave-core-ios-1.47.177.tgz",
-      "integrity": "sha512-P5wb/QtFwTqSvo8FFqC5ei1D/sM4B/eUOkaDNn4JcLtmrjEkKvO6+2uOiFVIYhUKl1pmDInhEYq3IsgvExw/VA==",
+      "version": "1.47.179",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.47.179/brave-core-ios-1.47.179.tgz",
+      "integrity": "sha512-abPO3Mk4BoP1O7nywsH3+tXlqQq8wS/+cx3ro6q22jsdRSKcL+4V+9wYgpPw9cBuyrPC1cAdbe2WIYNbmWZEuQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.47.177/brave-core-ios-1.47.177.tgz",
-      "integrity": "sha512-P5wb/QtFwTqSvo8FFqC5ei1D/sM4B/eUOkaDNn4JcLtmrjEkKvO6+2uOiFVIYhUKl1pmDInhEYq3IsgvExw/VA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.47.179/brave-core-ios-1.47.179.tgz",
+      "integrity": "sha512-abPO3Mk4BoP1O7nywsH3+tXlqQq8wS/+cx3ro6q22jsdRSKcL+4V+9wYgpPw9cBuyrPC1cAdbe2WIYNbmWZEuQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.177/brave-core-ios-1.47.177.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.179/brave-core-ios-1.47.179.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Bump BraveCore version to v1.47.179 to support from The Wallet Standard

This pull request fixes #6676,
#6638

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Wallet standard testplan shared with [desktop](https://github.com/brave/brave-core/pull/16724):
1. Make sure wallet is ready to use
2. Navigate to https://solana-labs.github.io/wallet-adapter/example/
3. Should be able to choose Brave Wallet.
4. After choosing it, click Airdrop and switch to dev net
5. Test `SignTransaction`, `SignMessage` and `SendTransaction`
6. <img width="473" alt="Screen Shot 2022-12-19 at 14 55 55" src="https://user-images.githubusercontent.com/11330831/208542623-80285f2d-43b8-4b80-bb5e-8ffa1087a2a3.png"> should be greyed out until we support versioned transaction.


## Screenshots:

https://user-images.githubusercontent.com/5314553/213776407-b4f78e2a-a190-4ce3-aeaa-cd28a1c9622e.mp4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
