### PR TITLE
Fix #6801: Browsing history suggestions and header shown in PBM

### DIFF
--- a/Client/Frontend/Browser/Search/SearchLoader.swift
+++ b/Client/Frontend/Browser/Search/SearchLoader.swift
@@ -6,6 +6,7 @@ import Shared
 import Storage
 import Data
 import BraveCore
+import BraveShared
 
 /// Shared data source for the SearchViewController and the URLBar domain completion.
 /// Since both of these use the same query, we can perform the query once and dispatch the results.
@@ -47,6 +48,12 @@ class SearchLoader: Loader<[Site], SearchViewController> {
   }
 
   fileprivate func completionForURL(_ url: String) -> String? {
+    // Private Browsing Mode (PBM) should *not* show items from normal mode History etc
+    // when search suggestions is not enabled
+    if Preferences.Privacy.privateBrowsingOnly.value, !Preferences.Search.showSuggestions.value {
+      return nil
+    }
+
     // Extract the pre-path substring from the URL. This should be more efficient than parsing via
     // NSURL since we need to only look at the beginning of the string.
     // Note that we won't match non-HTTP(S) URLs.

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -469,7 +469,15 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
       return 0.0
     case .searchSuggestions:
       return dataSource.suggestions.isEmpty ? 0 : headerHeight * 2.0
-    case .openTabsAndHistoryAndBookmarks: return data.isEmpty ? 0 : 2.0 * headerHeight
+    case .openTabsAndHistoryAndBookmarks:
+      // Private Browsing Mode (PBM) should *not* show items from normal mode History etc
+      // when search suggestions is not enabled
+      if Preferences.Privacy.privateBrowsingOnly.value,
+        dataSource.searchEngines?.shouldShowSearchSuggestions == false {
+        return 0
+      }
+      
+      return data.isEmpty ? 0 : 2.0 * headerHeight
     case .findInPage:
       if let sd = searchDelegate, sd.searchViewControllerAllowFindInPage() {
         return headerHeight


### PR DESCRIPTION
Removing extra header and completion of url in PBM mode when search suggestions are off

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6801

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Install 1.48
Build some history in normal browsing mode
Switch to Private Browsing via settings > Privacy > Private Browsing Mode
Search some previous websites in the URL box

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/213798806-6b9320cf-5038-455e-a643-b6fac6adf001.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
