### PR TITLE
Fix #6789: Omnibox disappears when the cookie consent banner/toast appears

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -32,9 +32,8 @@ extension BrowserViewController {
   }
   
   func presentBottomBarCallout() {
-    if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
-
-    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .bottomBar) {
+    // Check the blockCookieConsentNotices callout can be shown
+    guard shouldShowCallout(calloutType: .blockCookieConsentNotices) else {
       return
     }
 
@@ -69,9 +68,8 @@ extension BrowserViewController {
   }
   
   func presentP3AScreenCallout() {
-    if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
-
-    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .p3a) {
+    // Check the blockCookieConsentNotices callout can be shown
+    guard shouldShowCallout(calloutType: .p3a) else {
       return
     }
     
@@ -114,9 +112,8 @@ extension BrowserViewController {
   }
 
   func presentVPNAlertCallout() {
-    if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
-
-    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .vpn) {
+    // Check the blockCookieConsentNotices callout can be shown
+    guard shouldShowCallout(calloutType: .vpn) else {
       return
     }
 
@@ -149,11 +146,11 @@ extension BrowserViewController {
   }
 
   func presentDefaultBrowserScreenCallout() {
-    if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
-
-    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .defaultBrowser) {
+    // Check the blockCookieConsentNotices callout can be shown
+    guard shouldShowCallout(calloutType: .defaultBrowser) else {
       return
     }
+    
 
     let onboardingController = WelcomeViewController(
       state: WelcomeViewCalloutState.defaultBrowserCallout(
@@ -188,9 +185,8 @@ extension BrowserViewController {
   }
 
   func presentBraveRewardsScreenCallout() {
-    if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented { return }
-
-    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .rewards) {
+    // Check the blockCookieConsentNotices callout can be shown
+    guard shouldShowCallout(calloutType: .rewards) else {
       return
     }
 
@@ -225,5 +221,17 @@ extension BrowserViewController {
       
       show(toast: toast, duration: ButtonToastUX.toastDismissAfter)
     }
+  }
+  
+  func shouldShowCallout(calloutType: FullScreenCalloutManager.FullScreenCalloutType) -> Bool {
+    if Preferences.DebugFlag.skipNTPCallouts == true || isOnboardingOrFullScreenCalloutPresented || topToolbar.inOverlayMode {
+      return false
+    }
+
+    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: calloutType) {
+      return false
+    }
+    
+    return true
   }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+CookieNotificationBlocking.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+CookieNotificationBlocking.swift
@@ -12,7 +12,10 @@ import Onboarding
 
 extension BrowserViewController {
   func presentCookieNotificationBlockingCalloutIfNeeded() {
-    if Preferences.DebugFlag.skipEduPopups == true { return }
+    // Check the blockCookieConsentNotices callout can be shown
+    guard shouldShowCallout(calloutType: .blockCookieConsentNotices) else {
+      return
+    }
     
     // Don't show this if we already enabled the setting
     guard !FilterListResourceDownloader.shared.isEnabled(for: FilterList.cookieConsentNoticesComponentID) else { return }
@@ -23,10 +26,7 @@ extension BrowserViewController {
     // Ensure we successfully shown basic onboarding first
     guard Preferences.FullScreenCallout.omniboxCalloutCompleted.value else { return }
 
-    // Make sure we didn't already show this popup
-    guard presentedViewController == nil && FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: .blockCookieConsentNotices) else {
-      return
-    }
+
     
     let popover = PopoverController(
       contentController: CookieNotificationBlockingConsentViewController(),


### PR DESCRIPTION
Consolidating all the callout show case and adding toolbar overlay into it

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6789

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Install/launch  and run through the initial onboarding
- Once onboarding has been completed, start typing into the omnibox and enable Recent Search & Search Suggestions
- Load blizzard.com and restart the browser
- Right after restarting the browser, quickly tap on the omnibox and start editing/typing before the cookie consent panel appears

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/6643505/213814363-c1f03785-c1af-4eab-a7aa-346b0935a079.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
