### PR TITLE
Fix # 6554: Only NTP Present, Brave Should Open External Links Within That Same Tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1830,12 +1830,18 @@ public class BrowserViewController: UIViewController {
     }
     let request: URLRequest?
     if let url = url {
+      // If only empty tab present, the url will open in existing tab
+      if tabManager.isBrowserEmptyForCurrentMode {
+        finishEditingAndSubmit(url, visitType: .link)
+        return
+      }
       request = isPrivileged ? PrivilegedRequest(url: url) as URLRequest : URLRequest(url: url)
     } else {
       request = nil
     }
 
-    _ = tabManager.addTabAndSelect(request, isPrivate: isPrivate)
+    tabManager.addTabAndSelect(request, isPrivate: isPrivate)
+    
     // Has to go after since switching tabs will cause the URL bar to update to the selected Tab's url (which
     // is going to be nil still until the web view first commits
     updateToolbarCurrentURL(url)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -94,6 +94,19 @@ class TabManager: NSObject {
   private let syncedTabsQueue = DispatchQueue(label: "synced-tabs-queue")
   private var syncTabsTask: DispatchWorkItem?
   private var metricsHeartbeat: Timer?
+  
+  /// The property returning only existing tab is NTP for current mode
+  var isBrowserEmptyForCurrentMode: Bool {
+    get {
+      guard tabsForCurrentMode.count == 1,
+            let tabURL = tabsForCurrentMode.first?.url,
+            InternalURL(tabURL)?.isAboutHomeURL == true else {
+        return false
+      }
+      
+      return true
+    }
+  }
 
   init(prefs: Prefs, imageStore: DiskImageStore?, rewards: BraveRewards?, tabGeneratorAPI: BraveTabGeneratorAPI?) {
     assert(Thread.isMainThread)


### PR DESCRIPTION
Adding check to determine IF NTP is the only tab open and redirect external url open to the current tab

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6554

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Close all open tabs in Brave — the browser automatically opens the new tab page.
- Open a link in Brave from another app.

## Screenshots:


https://user-images.githubusercontent.com/6643505/214123169-b52f2784-7b5d-4e3a-ba1d-9326c9c2a588.mp4




## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
