### PR TITLE
Fix #6114: Properly inset web page from device safe area

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2394,7 +2394,6 @@ extension BrowserViewController: TabsBarViewControllerDelegate {
 
 extension BrowserViewController: TabDelegate {
   func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {
-    webView.scrollView.contentInsetAdjustmentBehavior = .never
     webView.frame = webViewContainer.frame
     
     // Observers that live as long as the tab. Make sure these are all cleared in willDeleteWebView below!
@@ -2464,7 +2463,6 @@ extension BrowserViewController: TabDelegate {
     KVOs.forEach { webView.removeObserver(self, forKeyPath: $0.rawValue) }
     toolbarVisibilityViewModel.endScrollViewObservation(webView.scrollView)
     webView.uiDelegate = nil
-    webView.scrollView.delegate = nil
     webView.removeFromSuperview()
   }
 


### PR DESCRIPTION
Content size is not affected by insets, so the toolbar collapse/expansion math should be the same, and top inset will always be 0 anyways even with allowing the scroll view to adjust automatically and left/right isn't used in the math at all. So mostly we are dealing with bottom inset being non-zero when rubber-banding to expand the bar.

## Summary of Changes

This pull request fixes #6114 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Sanity test toolbar collapsing & expansion

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
