### PR TITLE
Fix #6418: Swap Transaction Confirmation UI updates

### DIFF
--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -22,6 +22,9 @@ struct AssetIconView: View {
   /// If we should show the native token logo on non-native assets
   var shouldShowNativeTokenIcon: Bool = false
   @ScaledMetric var length: CGFloat = 40
+  var maxLength: CGFloat?
+  @ScaledMetric var networkSymbolLength: CGFloat = 15
+  var maxNetworkSymbolLength: CGFloat?
 
   private var fallbackMonogram: some View {
     Blockie(address: token.contractAddress)
@@ -67,7 +70,7 @@ struct AssetIconView: View {
         }
       }
     }
-    .frame(width: length, height: length)
+    .frame(width: min(length, maxLength ?? length), height: min(length, maxLength ?? length))
     .overlay(tokenLogo, alignment: .bottomTrailing)
     .accessibilityHidden(true)
   }
@@ -83,7 +86,7 @@ struct AssetIconView: View {
     if shouldShowNativeTokenIcon, !network.isNativeAsset(token), let image = networkNativeTokenLogo {
       Image(uiImage: image)
         .resizable()
-        .frame(width: 15, height: 15)
+        .frame(width: min(networkSymbolLength, maxNetworkSymbolLength ?? networkSymbolLength), height: min(networkSymbolLength, maxNetworkSymbolLength ?? networkSymbolLength))
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -16,7 +16,7 @@ public class TransactionConfirmationStore: ObservableObject {
   /// The fiat value of `value`
   @Published var fiat: String = ""
   /// The network name that this transaction is made on
-  @Published var networkChainName: String = ""
+  @Published var network: BraveWallet.NetworkInfo?
   /// The gas value for this transaction
   @Published var gasValue: String = ""
   /// The symbol of the gas token for this transaction
@@ -312,7 +312,7 @@ public class TransactionConfirmationStore: ObservableObject {
   ) async {
     originInfo = activeParsedTransaction.transaction.originInfo
     transactionDetails = activeTransactionDetails
-    networkChainName = network.chainName
+    self.network = network
     
     switch activeParsedTransaction.details {
     case let .ethSend(details),

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditNonceView.swift
@@ -26,6 +26,7 @@ struct EditNonceView: View {
       ) {
         TextField(Strings.Wallet.editNoncePlaceholder, text: $nonce)
           .keyboardType(.numberPad)
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       Section {
         Button(action: {

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 The Brave Authors. All rights reserved.
+// Copyright 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -78,7 +78,8 @@ struct SwapTransactionConfirmationView: View {
   
   @ViewBuilder private var tokenValueComparison: some View {
     if let minBuyAmount = Double(parsedTransaction?.ethSwap?.minBuyAmount ?? ""),
-       let sellAmount = Double( parsedTransaction?.ethSwap?.fromAmount ?? "") {
+       let sellAmount = Double( parsedTransaction?.ethSwap?.fromAmount ?? ""),
+       minBuyAmount != 0, sellAmount != 0 {
       let calculated = minBuyAmount / sellAmount
       let display = String(format: "1 \(parsedTransaction?.ethSwap?.fromToken?.symbol ?? "") = %.6f \(parsedTransaction?.ethSwap?.toToken?.symbol ?? "")", calculated)
       Text(display)

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
@@ -1,0 +1,299 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveCore
+import BigNumber
+import Strings
+import DesignSystem
+
+struct SwapTransactionConfirmationView: View {
+  
+  let parsedTransaction: ParsedTransaction?
+  let network: BraveWallet.NetworkInfo?
+  
+  let editGasFeeTapped: () -> Void
+  let advancedSettingsTapped: () -> Void
+  
+  @Environment(\.sizeCategory) private var sizeCategory
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.pixelLength) private var pixelLength
+  @ScaledMetric private var faviconSize = 48
+  private let maxFaviconSize: CGFloat = 72
+  @ScaledMetric private var assetIconSize: CGFloat = 40
+  private let maxAssetIconSize: CGFloat = 50
+  @ScaledMetric private var assetNetworkIconSize: CGFloat = 15
+  private let maxAssetNetworkIconSize: CGFloat = 20
+  
+  var body: some View {
+    VStack(spacing: 20) {
+      originAndFavicon
+      
+      tokenValueComparison
+
+      tokensView
+
+      networkFeeView
+    }
+    .padding(.bottom, 20)
+  }
+  
+  private var originAndFavicon: some View {
+    VStack {
+      if let originInfo = parsedTransaction?.transaction.originInfo {
+        Group {
+          if originInfo.origin == WalletConstants.braveWalletOrigin {
+            Image(uiImage: UIImage(sharedNamed: "brave.logo")!)
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .foregroundColor(Color(.braveOrange))
+          } else {
+            originInfo.origin.url.map { url in
+              FaviconReader(url: url) { image in
+                if let image = image {
+                  Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                } else {
+                  Circle()
+                    .stroke(Color(.braveSeparator), lineWidth: pixelLength)
+                }
+              }
+              .background(Color(.braveDisabled))
+              .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+          }
+        }
+        .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
+        Text(urlOrigin: originInfo.origin)
+          .foregroundColor(Color(.braveLabel))
+          .font(.subheadline)
+          .multilineTextAlignment(.center)
+          .padding(.top, 8)
+      }
+    }
+  }
+  
+  @ViewBuilder private var tokenValueComparison: some View {
+    if let minBuyAmount = Double(parsedTransaction?.ethSwap?.minBuyAmount ?? ""),
+       let sellAmount = Double( parsedTransaction?.ethSwap?.fromAmount ?? "") {
+      let calculated = minBuyAmount / sellAmount
+      let display = String(format: "1 \(parsedTransaction?.ethSwap?.fromToken?.symbol ?? "") = %.6f \(parsedTransaction?.ethSwap?.toToken?.symbol ?? "")", calculated)
+      Text(display)
+        .font(.callout)
+        .foregroundColor(Color(.secondaryBraveLabel))
+    }
+  }
+  
+  private var fromTokenView: some View {
+    VStack {
+      HStack {
+        Text(Strings.Wallet.swapConfirmationYouSpend)
+          .fontWeight(.medium)
+          .foregroundColor(Color(.secondaryBraveLabel))
+        Spacer()
+        AddressView(address: parsedTransaction?.fromAddress ?? "") {
+          HStack(spacing: 2) {
+            Blockie(address: parsedTransaction?.fromAddress ?? "")
+              .frame(width: 15, height: 15)
+            Text(parsedTransaction?.namedFromAddress ?? "")
+              .font(.footnote)
+          }
+            .padding(4)
+            .overlay(
+              RoundedRectangle(cornerSize: CGSize(width: 4, height: 4))
+                .stroke(Color(.braveSeparator), lineWidth: pixelLength)
+            )
+        }
+      }
+      TokenRow(
+        title: "\(parsedTransaction?.ethSwap?.fromAmount ?? "") \(parsedTransaction?.ethSwap?.fromToken?.symbol ?? "")",
+        subTitle: String.localizedStringWithFormat(Strings.Wallet.swapConfirmationNetworkDesc, network?.chainName ?? ""),
+        token: parsedTransaction?.ethSwap?.fromToken,
+        network: network,
+        assetIconSize: assetIconSize,
+        maxAssetIconSize: maxAssetIconSize,
+        assetNetworkIconSize: assetNetworkIconSize,
+        maxAssetNetworkIconSize: maxAssetNetworkIconSize
+      )
+    }
+  }
+  
+  private var toTokenView: some View {
+    VStack {
+      HStack {
+        Text(Strings.Wallet.swapConfirmationYoullReceive)
+          .fontWeight(.medium)
+          .foregroundColor(Color(.secondaryBraveLabel))
+        Spacer()
+      }
+      TokenRow(
+        title: "\(parsedTransaction?.ethSwap?.minBuyAmount ?? "") \(parsedTransaction?.ethSwap?.toToken?.symbol ?? "")",
+        subTitle: String.localizedStringWithFormat(Strings.Wallet.swapConfirmationNetworkDesc, network?.chainName ?? ""),
+        token: parsedTransaction?.ethSwap?.toToken,
+        network: network,
+        assetIconSize: assetIconSize,
+        maxAssetIconSize: maxAssetIconSize,
+        assetNetworkIconSize: assetNetworkIconSize,
+        maxAssetNetworkIconSize: maxAssetNetworkIconSize
+      )
+    }
+  }
+  
+  private var arrowView: some View {
+    Circle()
+      .stroke(Color(.braveSeparator), lineWidth: pixelLength)
+      .background(Color(.secondaryBraveGroupedBackground))
+      .frame(width: 32, height: 32)
+      .overlay(
+        Image(systemName: "arrow.down")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 16, height: 16)
+          .foregroundColor(Color(white: 0.75))
+      )
+  }
+  
+  private var tokensView: some View {
+    VStack {
+      fromTokenView
+        .padding(.init(top: 10, leading: 15, bottom: 10, trailing: 10))
+      Divider()
+        .overlay(arrowView, alignment: .center)
+        .padding(.vertical, 5)
+      toTokenView
+        .padding(.init(top: 10, leading: 15, bottom: 20, trailing: 10))
+    }
+    .background(Color(.secondaryBraveGroupedBackground).cornerRadius(10))
+  }
+  
+  private var networkFeeView: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack {
+        Text(Strings.Wallet.swapConfirmationNetworkFee)
+          .fontWeight(.medium)
+          .foregroundColor(Color(.secondaryBraveLabel))
+        Spacer()
+        Button(action: advancedSettingsTapped) {
+          Image(systemName: "gearshape")
+            .foregroundColor(Color(.secondaryBraveLabel))
+        }
+        .buttonStyle(.plain)
+      }
+      HStack {
+        Group {
+          if let logo = network?.nativeTokenLogo,
+             let image = UIImage(named: logo, in: .module, with: nil) {
+            Image(uiImage: image)
+              .resizable()
+          } else {
+            Circle()
+              .stroke(Color(.braveSeparator))
+          }
+        }
+        .frame(width: min(assetNetworkIconSize, maxAssetNetworkIconSize), height: min(assetNetworkIconSize, maxAssetNetworkIconSize))
+        Text(parsedTransaction?.gasFee?.fiat ?? "")
+          .foregroundColor(Color(.braveLabel))
+        Button(action: editGasFeeTapped) {
+          Text(Strings.Wallet.editGasFeeButtonTitle)
+            .fontWeight(.semibold)
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+        Spacer()
+      }
+    }
+    .frame(maxWidth: .infinity)
+  }
+  
+  private struct TokenRow: View {
+    let title: String
+    let subTitle: String
+    let token: BraveWallet.BlockchainToken?
+    let network: BraveWallet.NetworkInfo?
+    let assetIconSize: CGFloat
+    let maxAssetIconSize: CGFloat
+    let assetNetworkIconSize: CGFloat
+    let maxAssetNetworkIconSize: CGFloat
+    
+    var body: some View {
+      HStack {
+        if let token = token, let network = network {
+          AssetIconView(
+            token: token,
+            network: network,
+            shouldShowNativeTokenIcon: true,
+            length: assetIconSize,
+            maxLength: maxAssetIconSize,
+            networkSymbolLength: assetNetworkIconSize,
+            maxNetworkSymbolLength: maxAssetNetworkIconSize
+          )
+        } else {
+          Circle()
+            .stroke(Color(.braveSeparator))
+            .frame(width: assetIconSize, height: assetIconSize)
+        }
+        VStack(alignment: .leading) {
+          Text(title)
+            .font(.callout)
+            .fontWeight(.semibold)
+          Text(subTitle)
+            .font(.footnote)
+        }
+        Spacer()
+      }
+    }
+  }
+}
+
+#if DEBUG
+struct SwapTransactionConfirmationView_Previews: PreviewProvider {
+  static var transaction: BraveWallet.TransactionInfo {
+    let transaction: BraveWallet.TransactionInfo = .init()
+    transaction.originInfo = .init(
+      origin: WalletConstants.braveWalletOrigin,
+      originSpec: "brave://wallet",
+      eTldPlusOne: ""
+    )
+    return transaction
+  }
+  
+  static var previews: some View {
+    let parsedTransaction: ParsedTransaction = .init(
+      transaction: transaction,
+      namedFromAddress: "Ethereum Account 1",
+      fromAddress: BraveWallet.AccountInfo.previewAccount.address,
+      namedToAddress: "0x Exchange",
+      toAddress: "0x1111111111222222222233333333334444444444",
+      networkSymbol: "ETH",
+      details: .ethSwap(.init(
+        fromToken: .mockUSDCToken,
+        fromValue: "1.000004",
+        fromAmount: "1",
+        fromFiat: "$1.04",
+        toToken: .previewDaiToken,
+        minBuyValue: "0.994798",
+        minBuyAmount: "0.994798",
+        minBuyAmountFiat: "$0.99",
+        gasFee: .init(fee: "100", fiat: "$0.009081")
+      ))
+    )
+    Group {
+      ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
+        ScrollView {
+          SwapTransactionConfirmationView(
+            parsedTransaction: parsedTransaction,
+            network: .mockPolygon,
+            editGasFeeTapped: {},
+            advancedSettingsTapped: {}
+          )
+          Spacer()
+        }
+        .background(Color(.braveGroupedBackground).ignoresSafeArea())
+        .preferredColorScheme(colorScheme)
+      }
+    }
+  }
+}
+#endif

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -32,6 +32,8 @@ struct TransactionConfirmationView: View {
   }
 
   @State private var viewMode: ViewMode = .transaction
+  @State private var isShowingGas: Bool = false
+  @State private var isShowingAdvancedSettings: Bool = false
 
   private var transactionType: String {
     if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
@@ -245,10 +247,10 @@ struct TransactionConfirmationView: View {
             parsedTransaction: confirmationStore.activeParsedTransaction,
             network: confirmationStore.network ?? .init(),
             editGasFeeTapped: {
-              
+              isShowingGas = true
             },
             advancedSettingsTapped: {
-              
+              isShowingAdvancedSettings = true
             }
           )
         } else {
@@ -309,6 +311,40 @@ struct TransactionConfirmationView: View {
         await confirmationStore.prepare()
       }
     }
+    .background(
+      NavigationLink(
+        isActive: $isShowingGas,
+        destination: {
+          Group {
+            if let gasEstimation = confirmationStore.eip1559GasEstimation {
+              EditPriorityFeeView(
+                transaction: confirmationStore.activeParsedTransaction.transaction,
+                gasEstimation: gasEstimation,
+                confirmationStore: confirmationStore
+              )
+            } else {
+              EditGasFeeView(
+                transaction: confirmationStore.activeParsedTransaction.transaction,
+                confirmationStore: confirmationStore
+              )
+            }
+          }
+        },
+        label: { EmptyView() }
+      )
+    )
+    .background(
+      NavigationLink(
+        isActive: $isShowingAdvancedSettings,
+        destination: {
+          EditNonceView(
+            confirmationStore: confirmationStore,
+            transaction: confirmationStore.activeParsedTransaction.transaction
+          )
+        },
+        label: { EmptyView() }
+      )
+    )
   }
   
   private var currentTransactionView: some View {

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -46,6 +46,13 @@ struct TransactionConfirmationView: View {
       return confirmationStore.activeParsedTransaction.transaction.isSwap ? Strings.Wallet.swap : Strings.Wallet.send
     }
   }
+  
+  private var navigationTitle: String {
+    if confirmationStore.activeParsedTransaction.transaction.txType == .ethSwap {
+      return Strings.Wallet.swapConfirmationTitle
+    }
+    return confirmationStore.transactions.count > 1 ? Strings.Wallet.confirmTransactionsTitle : Strings.Wallet.confirmTransactionTitle
+  }
 
   /// View showing the currently selected account with a blockie
   @ViewBuilder private var accountView: some View {
@@ -215,217 +222,241 @@ struct TransactionConfirmationView: View {
   }
 
   var body: some View {
-      ScrollView(.vertical) {
-        VStack {
-          // Header
-          HStack(alignment: .top) {
-            Text(confirmationStore.networkChainName)
-            Spacer()
-            VStack(alignment: .trailing) {
-              transactionsButton
-              if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
-                accountView // for other txTypes, account is shown in `TransactionHeader`
-              }
+    ScrollView(.vertical) {
+      VStack {
+        // Current network, transaction buttons
+        HStack(alignment: .top) {
+          if confirmationStore.activeParsedTransaction.transaction.txType != .ethSwap {
+            Text(confirmationStore.network?.chainName ?? "") // network shown below each token for swap
+          }
+          Spacer()
+          VStack(alignment: .trailing) {
+            transactionsButton
+            if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
+              accountView // for other txTypes, account is shown in `TransactionHeader`
             }
           }
-          .font(.callout)
-          // Summary
-          if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
-            erc20ApproveHeader
-          } else {
-            TransactionHeader(
-              fromAccountAddress: confirmationStore.activeParsedTransaction.fromAddress,
-              fromAccountName: confirmationStore.activeParsedTransaction.namedFromAddress,
-              toAccountAddress: confirmationStore.activeParsedTransaction.toAddress,
-              toAccountName: confirmationStore.activeParsedTransaction.namedToAddress,
-              originInfo: confirmationStore.originInfo,
-              transactionType: transactionType,
-              value: "\(confirmationStore.value) \(confirmationStore.symbol)",
-              fiat: confirmationStore.fiat
-            )
-          }
-          
-          if confirmationStore.isSolTokenTransferWithAssociatedTokenAccountCreation {
-            VStack(alignment: .leading, spacing: 8) {
-              Text(Strings.Wallet.confirmationViewSolSplTokenAccountCreationWarning)
-                .foregroundColor(Color(.braveErrorLabel))
-                .font(.subheadline.weight(.medium))
-              Button {
-                openWalletURL?(WalletConstants.splTokenAccountCreationLink)
-              } label: {
-                Text(Strings.Wallet.learnMoreButton)
-                  .foregroundColor(Color(.braveBlurpleTint))
-                  .font(.subheadline)
+        }
+        .font(.callout)
+        
+        // Current Active Transaction info
+        if confirmationStore.activeParsedTransaction.transaction.txType == .ethSwap {
+          SwapTransactionConfirmationView(
+            parsedTransaction: confirmationStore.activeParsedTransaction,
+            network: confirmationStore.network ?? .init(),
+            editGasFeeTapped: {
+              
+            },
+            advancedSettingsTapped: {
+              
+            }
+          )
+        } else {
+          currentTransactionView
+        }
+        
+        // Cancel / Confirm buttons
+        if confirmationStore.transactions.count > 1 {
+          Button(action: {
+            confirmationStore.rejectAllTransactions { success in
+              if success {
+                onDismiss()
               }
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 20)
+          }) {
+            Text(String.localizedStringWithFormat(Strings.Wallet.rejectAllTransactions, confirmationStore.transactions.count))
+              .font(.subheadline.weight(.semibold))
+              .foregroundColor(Color(.braveBlurpleTint))
+          }
+          .padding(.top, 8)
+        }
+        rejectConfirmContainer
+          .padding(.top)
+          .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
+          .accessibility(hidden: sizeCategory.isAccessibilityCategory)
+      }
+      .padding()
+    }
+    .overlay(
+      Group {
+        if sizeCategory.isAccessibilityCategory {
+          rejectConfirmContainer
+            .frame(maxWidth: .infinity)
+            .padding(.top)
             .background(
-              Color(.braveErrorBackground)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+              LinearGradient(
+                stops: [
+                  .init(color: Color(.braveGroupedBackground).opacity(0), location: 0),
+                  .init(color: Color(.braveGroupedBackground).opacity(1), location: 0.05),
+                  .init(color: Color(.braveGroupedBackground).opacity(1), location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+              )
+              .ignoresSafeArea()
+              .allowsHitTesting(false)
             )
+        }
+      },
+      alignment: .bottom
+    )
+    .navigationBarTitle(navigationTitle)
+    .navigationBarTitleDisplayMode(.inline)
+    .foregroundColor(Color(.braveLabel))
+    .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
+    .onAppear {
+      Task {
+        await confirmationStore.prepare()
+      }
+    }
+  }
+  
+  private var currentTransactionView: some View {
+    VStack {
+      if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
+        erc20ApproveHeader
+      } else {
+        TransactionHeader(
+          fromAccountAddress: confirmationStore.activeParsedTransaction.fromAddress,
+          fromAccountName: confirmationStore.activeParsedTransaction.namedFromAddress,
+          toAccountAddress: confirmationStore.activeParsedTransaction.toAddress,
+          toAccountName: confirmationStore.activeParsedTransaction.namedToAddress,
+          originInfo: confirmationStore.originInfo,
+          transactionType: transactionType,
+          value: "\(confirmationStore.value) \(confirmationStore.symbol)",
+          fiat: confirmationStore.fiat
+        )
+      }
+      
+      if confirmationStore.isSolTokenTransferWithAssociatedTokenAccountCreation {
+        VStack(alignment: .leading, spacing: 8) {
+          Text(Strings.Wallet.confirmationViewSolSplTokenAccountCreationWarning)
+            .foregroundColor(Color(.braveErrorLabel))
+            .font(.subheadline.weight(.medium))
+          Button {
+            openWalletURL?(WalletConstants.splTokenAccountCreationLink)
+          } label: {
+            Text(Strings.Wallet.learnMoreButton)
+              .foregroundColor(Color(.braveBlurpleTint))
+              .font(.subheadline)
           }
-
-          // View Mode
-          VStack(spacing: 12) {
-            Picker("", selection: $viewMode) {
-              Text(Strings.Wallet.confirmationViewModeTransaction).tag(ViewMode.transaction)
-              Text(Strings.Wallet.confirmationViewModeDetails).tag(ViewMode.details)
-            }
-            .pickerStyle(SegmentedPickerStyle())
-            Group {
-              switch viewMode {
-              case .transaction:
-                VStack(spacing: 0) {
-                  HStack {
-                    VStack(alignment: .leading) {
-                      Text(confirmationStore.activeParsedTransaction.coin == .sol ? Strings.Wallet.transactionFee : Strings.Wallet.gasFee)
-                        .foregroundColor(Color(.bravePrimary))
-                      if confirmationStore.activeParsedTransaction.coin == .eth {
-                        editGasFeeButton
-                      }
-                    }
-                    Spacer()
-                    VStack(alignment: .trailing) {
-                      Text("\(confirmationStore.gasValue) \(confirmationStore.gasSymbol)")
-                        .foregroundColor(Color(.bravePrimary))
-                      Text(confirmationStore.gasFiat)
-                        .font(.footnote)
-                    }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 20)
+        .background(
+          Color(.braveErrorBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        )
+      }
+      
+      // View Mode
+      VStack(spacing: 12) {
+        Picker("", selection: $viewMode) {
+          Text(Strings.Wallet.confirmationViewModeTransaction).tag(ViewMode.transaction)
+          Text(Strings.Wallet.confirmationViewModeDetails).tag(ViewMode.details)
+        }
+        .pickerStyle(SegmentedPickerStyle())
+        Group {
+          switch viewMode {
+          case .transaction:
+            VStack(spacing: 0) {
+              HStack {
+                VStack(alignment: .leading) {
+                  Text(confirmationStore.activeParsedTransaction.coin == .sol ? Strings.Wallet.transactionFee : Strings.Wallet.gasFee)
+                    .foregroundColor(Color(.bravePrimary))
+                  if confirmationStore.activeParsedTransaction.coin == .eth {
+                    editGasFeeButton
                   }
-                  .font(.callout)
+                }
+                Spacer()
+                VStack(alignment: .trailing) {
+                  Text("\(confirmationStore.gasValue) \(confirmationStore.gasSymbol)")
+                    .foregroundColor(Color(.bravePrimary))
+                  Text(confirmationStore.gasFiat)
+                    .font(.footnote)
+                }
+              }
+              .font(.callout)
+              .padding()
+              .accessibilityElement(children: .contain)
+              Divider()
+                .padding(.leading)
+              if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
+                Group {
+                  HStack {
+                    Text(Strings.Wallet.confirmationViewCurrentAllowance)
+                    Spacer()
+                    Text("\(confirmationStore.currentAllowance) \(confirmationStore.symbol)")
+                      .multilineTextAlignment(.trailing)
+                  }
                   .padding()
                   .accessibilityElement(children: .contain)
                   Divider()
-                    .padding(.leading)
-                  if confirmationStore.activeParsedTransaction.transaction.txType == .erc20Approve {
-                    Group {
-                      HStack {
-                        Text(Strings.Wallet.confirmationViewCurrentAllowance)
-                        Spacer()
-                        Text("\(confirmationStore.currentAllowance) \(confirmationStore.symbol)")
-                          .multilineTextAlignment(.trailing)
-                      }
-                      .padding()
-                      .accessibilityElement(children: .contain)
-                      Divider()
-                      HStack {
-                        Text(Strings.Wallet.editPermissionsProposedAllowanceHeader)
-                        Spacer()
-                        Text("\(confirmationStore.value) \(confirmationStore.symbol)")
-                          .multilineTextAlignment(.trailing)
-                      }
-                      .padding()
-                      .accessibilityElement(children: .contain)
-                    }
-                    .font(.callout)
-                    .foregroundColor(Color(.bravePrimary))
-                  } else {
-                    HStack {
-                      Text(Strings.Wallet.total)
-                        .foregroundColor(Color(.bravePrimary))
-                        .font(.callout)
-                        .accessibility(sortPriority: 1)
-                      Spacer()
-                      VStack(alignment: .trailing) {
-                        Text(confirmationStore.activeParsedTransaction.coin == .sol ? Strings.Wallet.amountAndFee : Strings.Wallet.amountAndGas)
-                          .font(.footnote)
-                          .foregroundColor(Color(.secondaryBraveLabel))
-                        Text("\(confirmationStore.value) \(confirmationStore.symbol) + \(confirmationStore.gasValue) \(confirmationStore.gasSymbol)")
-                          .foregroundColor(Color(.bravePrimary))
-                        HStack(spacing: 4) {
-                          if !confirmationStore.isBalanceSufficient {
-                            Text(Strings.Wallet.insufficientBalance)
-                              .foregroundColor(Color(.braveErrorLabel))
-                          }
-                          Text(confirmationStore.totalFiat)
-                            .foregroundColor(
-                              confirmationStore.isBalanceSufficient ? Color(.braveLabel) : Color(.braveErrorLabel)
-                            )
-                        }
-                        .accessibilityElement(children: .contain)
-                        .font(.footnote)
-                      }
-                    }
-                    .padding()
-                    .accessibilityElement(children: .contain)
+                  HStack {
+                    Text(Strings.Wallet.editPermissionsProposedAllowanceHeader)
+                    Spacer()
+                    Text("\(confirmationStore.value) \(confirmationStore.symbol)")
+                      .multilineTextAlignment(.trailing)
                   }
-                  if confirmationStore.activeParsedTransaction.coin == .eth {
-                    Divider()
-                      .padding(.leading)
-                    editNonceRow
-                  }
+                  .padding()
+                  .accessibilityElement(children: .contain)
                 }
-              case .details:
-                VStack(alignment: .leading) {
-                  StaticTextView(text: confirmationStore.transactionDetails)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 200)
-                    .background(Color(.tertiaryBraveGroupedBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                .font(.callout)
+                .foregroundColor(Color(.bravePrimary))
+              } else {
+                HStack {
+                  Text(Strings.Wallet.total)
+                    .foregroundColor(Color(.bravePrimary))
+                    .font(.callout)
+                    .accessibility(sortPriority: 1)
+                  Spacer()
+                  VStack(alignment: .trailing) {
+                    Text(confirmationStore.activeParsedTransaction.coin == .sol ? Strings.Wallet.amountAndFee : Strings.Wallet.amountAndGas)
+                      .font(.footnote)
+                      .foregroundColor(Color(.secondaryBraveLabel))
+                    Text("\(confirmationStore.value) \(confirmationStore.symbol) + \(confirmationStore.gasValue) \(confirmationStore.gasSymbol)")
+                      .foregroundColor(Color(.bravePrimary))
+                    HStack(spacing: 4) {
+                      if !confirmationStore.isBalanceSufficient {
+                        Text(Strings.Wallet.insufficientBalance)
+                          .foregroundColor(Color(.braveErrorLabel))
+                      }
+                      Text(confirmationStore.totalFiat)
+                        .foregroundColor(
+                          confirmationStore.isBalanceSufficient ? Color(.braveLabel) : Color(.braveErrorLabel)
+                        )
+                    }
+                    .accessibilityElement(children: .contain)
+                    .font(.footnote)
+                  }
                 }
                 .padding()
+                .accessibilityElement(children: .contain)
+              }
+              if confirmationStore.activeParsedTransaction.coin == .eth {
+                Divider()
+                  .padding(.leading)
+                editNonceRow
               }
             }
-            .frame(maxWidth: .infinity)
-            .background(
-              Color(.secondaryBraveGroupedBackground)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-          }
-          if confirmationStore.transactions.count > 1 {
-            Button(action: {
-              confirmationStore.rejectAllTransactions { success in
-                if success {
-                  onDismiss()
-                }
-              }
-            }) {
-              Text(String.localizedStringWithFormat(Strings.Wallet.rejectAllTransactions, confirmationStore.transactions.count))
-                .font(.subheadline.weight(.semibold))
-                .foregroundColor(Color(.braveBlurpleTint))
+          case .details:
+            VStack(alignment: .leading) {
+              StaticTextView(text: confirmationStore.transactionDetails)
+                .frame(maxWidth: .infinity)
+                .frame(height: 200)
+                .background(Color(.tertiaryBraveGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
             }
-            .padding(.top, 8)
+            .padding()
           }
-          rejectConfirmContainer
-            .padding(.top)
-            .opacity(sizeCategory.isAccessibilityCategory ? 0 : 1)
-            .accessibility(hidden: sizeCategory.isAccessibilityCategory)
         }
-        .padding()
+        .frame(maxWidth: .infinity)
+        .background(
+          Color(.secondaryBraveGroupedBackground)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
       }
-      .overlay(
-        Group {
-          if sizeCategory.isAccessibilityCategory {
-            rejectConfirmContainer
-              .frame(maxWidth: .infinity)
-              .padding(.top)
-              .background(
-                LinearGradient(
-                  stops: [
-                    .init(color: Color(.braveGroupedBackground).opacity(0), location: 0),
-                    .init(color: Color(.braveGroupedBackground).opacity(1), location: 0.05),
-                    .init(color: Color(.braveGroupedBackground).opacity(1), location: 1),
-                  ],
-                  startPoint: .top,
-                  endPoint: .bottom
-                )
-                .ignoresSafeArea()
-                .allowsHitTesting(false)
-              )
-          }
-        },
-        alignment: .bottom
-      )
-      .navigationBarTitle(confirmationStore.transactions.count > 1 ? Strings.Wallet.confirmTransactionsTitle : Strings.Wallet.confirmTransactionTitle)
-      .navigationBarTitleDisplayMode(.inline)
-      .foregroundColor(Color(.braveLabel))
-      .background(Color(.braveGroupedBackground).edgesIgnoringSafeArea(.all))
-      .onAppear {
-        Task {
-          await confirmationStore.prepare()
-        }
-      }
+    }
   }
 
   @ViewBuilder private var rejectConfirmContainer: some View {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -791,6 +791,11 @@ extension ParsedTransaction {
   var coin: BraveWallet.CoinType {
     transaction.coin
   }
+
+  var ethSwap: EthSwapDetails? {
+    guard case let .ethSwap(ethSwapDetails) = details else { return nil }
+    return ethSwapDetails
+  }
 }
 
 extension BraveWallet.TransactionInfo {

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3417,5 +3417,40 @@ extension Strings {
       value: "Sign at your own risk",
       comment: "A title of a warning message that warns users the risk of signing a transaction."
     )
+    public static let swapConfirmationTitle = NSLocalizedString(
+      "wallet.swapConfirmationTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Confirm Order",
+      comment: "A title displayed in transaction confirmation navigation bar for a Swap transaction."
+    )
+    public static let swapConfirmationYouSpend = NSLocalizedString(
+      "wallet.swapConfirmationYouSpend",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "You spend",
+      comment: "A title displayed in transaction confirmation above the token being swapped from in a Swap transaction."
+    )
+    public static let swapConfirmationYoullReceive = NSLocalizedString(
+      "wallet.swapConfirmationYoullReceive",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "You'll receive",
+      comment: "A title displayed in transaction confirmation above the token being swapped for in a Swap transaction."
+    )
+    public static let swapConfirmationNetworkFee = NSLocalizedString(
+      "wallet.swapConfirmationNetworkFee",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Network Fee",
+      comment: "A title displayed in transaction confirmation above the network / gas fee for a Swap transaction."
+    )
+    public static let swapConfirmationNetworkDesc = NSLocalizedString(
+      "wallet.swapConfirmationNetworkDesc",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "on %@",
+      comment: "The description displayed below the name of the token being swapped from and to. Tthe '%@' will be the token's network name."
+    )
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Refactors `TransactionConfirmationView` so that the details for the current active transaction is separated into a computed property. This should allow us to use separate subviews for specific transaction types
- Implement Swap Confirmation UI updates

This pull request fixes #6418

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create at least two swap transactions
2. Create some non-swap transactions
3. Verify swap transactions displays necessary info from design & matches desktop. Verify edit gas fee and advanced settings (edit nonce) buttons are opening their respective detail views as expected.
4. Verify non-swap transactions are still displayed the same

## Screenshots:
![6418 - ETH to BAT](https://user-images.githubusercontent.com/5314553/214154832-33830d2a-b514-4b16-9967-7be5eee34539.png) | ![6418 - ETH to BAT (dark)](https://user-images.githubusercontent.com/5314553/214154841-5b4d0df7-cdfe-476a-8f6a-ece3c9ead7fe.png) | ![6418 - BAT to ETH](https://user-images.githubusercontent.com/5314553/214154848-82b67456-953b-492a-8e1e-62192fd3da36.png) | ![6418 - BAT to ETH (single transaction)](https://user-images.githubusercontent.com/5314553/214156198-6667bac8-0eab-4508-a4be-1afcd91686b7.png)
--|--|--|--

![6418 - ETH to BAT - iPad](https://user-images.githubusercontent.com/5314553/214156847-82c0ba76-d35a-460d-a4f5-7328ccf57bf5.png) | ![6418 - ETH to BAT - iPad (dark)](https://user-images.githubusercontent.com/5314553/214156862-d5c72e12-5f6d-40bc-b2ea-97eea9906d61.png) | ![6418 - ETH to BAT - iPad (single)](https://user-images.githubusercontent.com/5314553/214156874-3b7d1106-c641-4298-9494-1eabde001875.png)
--|--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
