### PR TITLE
Fix #6827:  Tx Confirmation is empty when ERC721 NFT cannot be found from token registry and user assets.

### DIFF
--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -124,12 +124,16 @@ enum TransactionParser {
     case .erc20Transfer:
       guard let toAddress = transaction.txArgs[safe: 0],
             let fromValue = transaction.txArgs[safe: 1],
-            let tokenContractAddress = transaction.erc20TransferTokenContractAddress,
-            let fromToken = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
+            let tokenContractAddress = transaction.erc20TransferTokenContractAddress else {
         return nil
       }
-      let fromAmount = formatter.decimalString(for: fromValue.removingHexPrefix, radix: .hex, decimals: Int(fromToken.decimals))?.trimmingTrailingZeros ?? ""
-      let fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[fromToken.assetRatioId.lowercased(), default: 0] * (Double(fromAmount) ?? 0))) ?? "$0.00"
+      let fromToken = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
+      var fromAmount = ""
+      var fromFiat = "$0.00"
+      if let token = fromToken {
+        fromAmount = formatter.decimalString(for: fromValue.removingHexPrefix, radix: .hex, decimals: Int(token.decimals))?.trimmingTrailingZeros ?? ""
+        fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[token.assetRatioId.lowercased(), default: 0] * (Double(fromAmount) ?? 0))) ?? "$0.00"
+      }
       /*
        fromAddress="0x882F5a2c1C429e6592D801486566D0753BC1dD04"
        toAddress="0x7c24aed73d82c9d98a1b86bc2c8d2452c40419f8"
@@ -181,7 +185,7 @@ enum TransactionParser {
       /* Example:
        USDC -> DAI
        Sell Amount: 1.5
-      
+       
        fillPath = "0x07865c6e87b9f70255377e024ace6630c1eaa37fad6d458402f60fd3bd25163575031acdce07538d"
        fromTokenAddress = "0x07865c6e87b9f70255377e024ace6630c1eaa37f"
        fromToken.symbol = "USDC"
@@ -345,17 +349,20 @@ enum TransactionParser {
         .solanaSplTokenTransferWithAssociatedTokenAccountCreation:
       guard let amount = transaction.txDataUnion.solanaTxData?.amount,
             let toAddress = transaction.txDataUnion.solanaTxData?.toWalletAddress,
-            let splTokenMintAddress = transaction.txDataUnion.solanaTxData?.splTokenMintAddress,
-            let fromToken = token(for: splTokenMintAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
+            let splTokenMintAddress = transaction.txDataUnion.solanaTxData?.splTokenMintAddress else {
         return nil
       }
+      let fromToken = token(for: splTokenMintAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
       let fromValue = "\(amount)"
-      let fromValueFormatted = formatter.decimalString(for: fromValue, radix: .decimal, decimals: Int(fromToken.decimals))?.trimmingTrailingZeros ?? ""
-      let fromFiat: String
-      if fromToken.isNft {
-        fromFiat = "" // don't show fiat for NFTs
-      } else {
-        fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[fromToken.assetRatioId.lowercased(), default: 0] * (Double(fromValueFormatted) ?? 0))) ?? "$0.00"
+      var fromValueFormatted = ""
+      var fromFiat = "$0.00"
+      if let token = fromToken  {
+        fromValueFormatted = formatter.decimalString(for: fromValue, radix: .decimal, decimals: Int(token.decimals))?.trimmingTrailingZeros ?? ""
+        if token.isNft {
+          fromFiat = "" // don't show fiat for NFTs
+        } else {
+          fromFiat = currencyFormatter.string(from: NSNumber(value: assetRatios[token.assetRatioId.lowercased(), default: 0] * (Double(fromValueFormatted) ?? 0))) ?? "$0.00"
+        }
       }
       /* Example:
        Send 0.1234 SMB

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -273,10 +273,11 @@ enum TransactionParser {
       guard let owner = transaction.txArgs[safe: 0],
             let toAddress = transaction.txArgs[safe: 1],
             let tokenId = transaction.txArgs[safe: 2],
-            let tokenContractAddress = transaction.erc721ContractAddress,
-            let token = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens) else {
+            let tokenContractAddress = transaction.erc721ContractAddress else {
         return nil
       }
+      let token = token(for: tokenContractAddress, network: network, visibleTokens: visibleTokens, allTokens: allTokens)
+      
       return .init(
         transaction: transaction,
         namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
we are currently assume ERC721 NFT can be always found from token registry or user assets. this is not true, if user makes an ERC721 NFT transfer via dapp without first adding this NFT as user asset in Brave Wallet.
This PR will display as much as we can in the tx confirmation screen even though we cant fetch the NFT info from token registry or user assets.

Note: Some other transaction types could also having the same issue. .erc20Transfer, .erc721TransferFrom, .erc721SafeTransferFrom and .solanaSplTokenTransfer, .solanaSplTokenTransferWithAssociatedTokenAccountCreation
This PR has addressed them all. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6827

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. connect opensea.io with your Brave wallet 
2. make sure there is no ERC721 NFT added as user asset in Brave Wallet
3. at opensea.io try to make a ERC721 NFT transfer 
4. observe a tx confirmation will prompt with necessary information displayed 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-23 at 17 24 29](https://user-images.githubusercontent.com/1187676/214165610-cec369df-0d4e-4036-a589-3fe3d61b4cdf.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
