### PR TITLE
Fix #6830: block wallet displaying unsecure images

### DIFF
--- a/Sources/BraveWallet/Crypto/NFTImageView.swift
+++ b/Sources/BraveWallet/Crypto/NFTImageView.swift
@@ -31,22 +31,26 @@ struct NFTImageView<Placeholder: View>: View {
         }
       }
     } else {
-      if urlString.hasSuffix(".svg") {
-        WebImageReader(url: URL(string: urlString)) { image, isFinished in
-          if let image = image {
-            Image(uiImage: image)
-              .resizable()
-              .aspectRatio(contentMode: .fit)
-          } else {
-            placeholder()
+      if let url = URL(string: urlString), url.isSecureWebPage() {
+        if urlString.hasSuffix(".svg") {
+          WebImageReader(url: url) { image, isFinished in
+            if let image = image {
+              Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+            } else {
+              placeholder()
+            }
           }
+        } else {
+          WebImage(url: url)
+            .resizable()
+            .placeholder { placeholder() }
+            .indicator(.activity)
+            .aspectRatio(contentMode: .fit)
         }
       } else {
-        WebImage(url: URL(string: urlString))
-          .resizable()
-          .placeholder { placeholder() }
-          .indicator(.activity)
-          .aspectRatio(contentMode: .fit)
+        placeholder()
       }
     }
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
doing the same as android as checking if image has https scheme. will display a placeholder if its not secure. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6830

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Unfortunately dev can't find any NFT has an un-secure image url. But dev has tested end-to-end with hardcoded un-secure image url. 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
