### PR TITLE
Fix #2123, fix #1048: Allow ‘Reopen Last Closed Tab’ Shortcut (iPadOS) - Add Shake to Reopen in the Tab screen

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
@@ -32,10 +32,4 @@ extension BrowserViewController {
     )
 #endif
   }
-  
-  @objc private func toggleBraveTalkMute() {
-#if canImport(BraveTalk)
-    braveTalkJitsiCoordinator.toggleMute()
-#endif
-  }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
@@ -33,12 +33,6 @@ extension BrowserViewController {
 #endif
   }
   
-  var braveTalkKeyCommands: [UIKeyCommand] {
-    [
-      .init(input: "m", modifierFlags: [], action: #selector(BrowserViewController.toggleBraveTalkMute))
-    ]
-  }
-  
   @objc private func toggleBraveTalkMute() {
 #if canImport(BraveTalk)
     braveTalkJitsiCoordinator.toggleMute()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPageDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPageDelegate.swift
@@ -184,6 +184,12 @@ class WKWebViewFindStringFindDelegate: NSObject {
 // MARK: FindInPageBarDelegate - FindInPageScriptHandlerDelegate
 
 extension BrowserViewController: FindInPageBarDelegate, FindInPageScriptHandlerDelegate {
+  
+  enum TextSearchDirection: String {
+    case next = "findNext"
+    case previous = "findPrevious"
+  }
+  
   func findInPage(_ findInPage: FindInPageBar, didTextChange text: String) {
     find(text, function: "find")
   }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -9,11 +9,6 @@ import UIKit
 // Naming functions: use the suffix 'KeyCommand' for an additional level of namespacing (bug 1415830)
 extension BrowserViewController {
 
-  enum TextSearchDirection: String {
-    case next = "findNext"
-    case previous = "findPrevious"
-  }
-
   @objc private func reloadTabKeyCommand() {
     if let tab = tabManager.selectedTab, favoritesController == nil {
       tab.reload()
@@ -167,6 +162,10 @@ extension BrowserViewController {
 
     searchController.handleKeyCommands(sender: sender)
   }
+  
+  @objc private func toggleBraveTalkMuteCommand() {
+    braveTalkJitsiCoordinator.toggleMute()
+  }
 
   override public var keyCommands: [UIKeyCommand]? {
     let isEditingText = tabManager.selectedTab?.isEditing ?? false
@@ -271,7 +270,11 @@ extension BrowserViewController {
       UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:))),
       UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:)))
     ]
-
+    
+    let braveTalkKeyCommands: [UIKeyCommand] = [
+      UIKeyCommand(input: "m", modifierFlags: [], action: #selector(toggleBraveTalkMuteCommand))
+    ]
+    
     // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
     if #available(iOS 15, *) {
       searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -185,12 +185,12 @@ extension BrowserViewController {
       
     var navigationCommands = [
       // Web Page Key Commands
-      UIKeyCommand(title: Strings.reloadPageTitle, action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.reloadPageTitle, action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command),
     ]
 
     let tabMovementCommands = [
-      UIKeyCommand(title: Strings.backTitle, action: #selector(goBackKeyCommand), input: UIKeyCommand.inputLeftArrow, modifierFlags: .command),
-      UIKeyCommand(title: Strings.forwardTitle, action: #selector(goForwardKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: .command)
+      UIKeyCommand(title: Strings.Hotkey.backTitle, action: #selector(goBackKeyCommand), input: UIKeyCommand.inputLeftArrow, modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.forwardTitle, action: #selector(goForwardKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: .command)
     ]
     
     if !isEditingText {
@@ -204,17 +204,18 @@ extension BrowserViewController {
       
     navigationCommands += [
       // URL Bar - Tab Key Commands
-      UIKeyCommand(title: Strings.selectLocationBarTitle, action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command),
-      UIKeyCommand(title: Strings.newTabTitle, action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command),
-      UIKeyCommand(title: Strings.newPrivateTabTitle, action: #selector(newPrivateTabKeyCommand), input: "n", modifierFlags: [.command, .shift]),
-      UIKeyCommand(title: Strings.closeTabTitle, action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command),
-      UIKeyCommand(title: Strings.closeAllTabsFromTabTrayKeyCodeTitle, action: #selector(closeAllTabsKeyCommand), input: "w", modifierFlags: [.command, .alternate])
+      UIKeyCommand(title: Strings.Hotkey.selectLocationBarTitle, action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.newTabTitle, action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.newPrivateTabTitle, action: #selector(newPrivateTabKeyCommand), input: "n", modifierFlags: [.command, .shift]),
+      UIKeyCommand(title: Strings.Hotkey.recentlyClosedTabTitle, action: #selector(reopenRecentlyClosedTabCommand), input: "t", modifierFlags: [.command, .shift]),
+      UIKeyCommand(title: Strings.Hotkey.closeTabTitle, action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.closeAllTabsFromTabTrayKeyCodeTitle, action: #selector(closeAllTabsKeyCommand), input: "w", modifierFlags: [.command, .alternate])
     ]
     
     let tabNavigationKeyCommands = [
       // Tab Navigation Key Commands
-      UIKeyCommand(title: Strings.showNextTabTitle, action: #selector(nextTabKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: [.command, .alternate]),
-      UIKeyCommand(title: Strings.showPreviousTabTitle, action: #selector(previousTabKeyCommand), input: UIKeyCommand.inputLeftArrow, modifierFlags: [.command, .alternate])
+      UIKeyCommand(title: Strings.Hotkey.showNextTabTitle, action: #selector(nextTabKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: [.command, .alternate]),
+      UIKeyCommand(title: Strings.Hotkey.showPreviousTabTitle, action: #selector(previousTabKeyCommand), input: UIKeyCommand.inputLeftArrow, modifierFlags: [.command, .alternate])
     ]
     
     if !isEditingText {
@@ -224,12 +225,12 @@ extension BrowserViewController {
     navigationCommands += [
       UIKeyCommand(input: "}", modifierFlags: [.command], action: #selector(nextTabKeyCommand)),
       UIKeyCommand(input: "{", modifierFlags: [.command], action: #selector(previousTabKeyCommand)),
-      UIKeyCommand(title: Strings.showTabTrayFromTabKeyCodeTitle, action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate]),
+      UIKeyCommand(title: Strings.Hotkey.showTabTrayFromTabKeyCodeTitle, action: #selector(showTabTrayKeyCommand), input: "\t", modifierFlags: [.command, .alternate]),
       
       // Page Navigation Key Commands
-      UIKeyCommand(title: Strings.showHistoryTitle, action: #selector(showHistoryKeyCommand), input: "y", modifierFlags: [.command]),
-      UIKeyCommand(title: Strings.showDownloadsTitle, action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command),
-      UIKeyCommand(title: Strings.showShieldsTitle, action: #selector(showShieldsKeyCommand), input: ",", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.showHistoryTitle, action: #selector(showHistoryKeyCommand), input: "y", modifierFlags: [.command]),
+      UIKeyCommand(title: Strings.Hotkey.showDownloadsTitle, action: #selector(showDownloadsKeyCommand), input: "j", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.showShieldsTitle, action: #selector(showShieldsKeyCommand), input: ",", modifierFlags: .command),
 
       // Switch tab to match Safari on iOS.
       UIKeyCommand(input: "]", modifierFlags: [.command, .shift], action: #selector(nextTabKeyCommand)),
@@ -245,19 +246,19 @@ extension BrowserViewController {
 
     // Bookmarks Key Commands
     let bookmarkEditingCommands = [
-      UIKeyCommand(title: Strings.showBookmarksTitle, action: #selector(showBookmarksKeyCommand), input: "o", modifierFlags: [.shift, .command]),
-      UIKeyCommand(title: Strings.addBookmarkTitle, action: #selector(addBookmarkCommand), input: "d", modifierFlags: [.command]),
-      UIKeyCommand(title: Strings.addFavouritesTitle, action: #selector(addToFavouritesCommand), input: "d", modifierFlags: [.command, .shift]),
+      UIKeyCommand(title: Strings.Hotkey.showBookmarksTitle, action: #selector(showBookmarksKeyCommand), input: "o", modifierFlags: [.shift, .command]),
+      UIKeyCommand(title: Strings.Hotkey.addBookmarkTitle, action: #selector(addBookmarkCommand), input: "d", modifierFlags: [.command]),
+      UIKeyCommand(title: Strings.Hotkey.addFavouritesTitle, action: #selector(addToFavouritesCommand), input: "d", modifierFlags: [.command, .shift]),
     ]
 
     // Find in Page Key Commands
     var findTextCommands = [
-      UIKeyCommand(title: Strings.findInPageTitle, action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command)
+      UIKeyCommand(title: Strings.Hotkey.findInPageTitle, action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command)
     ]
 
     let findTextUtilitiesCommands = [
-      UIKeyCommand(title: Strings.findNextTitle, action: #selector(findNextCommand), input: "g", modifierFlags: [.command]),
-      UIKeyCommand(title: Strings.findPreviousTitle, action: #selector(findPreviousCommand), input: "g", modifierFlags: [.command, .shift]),
+      UIKeyCommand(title: Strings.Hotkey.findNextTitle, action: #selector(findNextCommand), input: "g", modifierFlags: [.command]),
+      UIKeyCommand(title: Strings.Hotkey.findPreviousTitle, action: #selector(findPreviousCommand), input: "g", modifierFlags: [.command, .shift]),
     ]
 
     let isFindingText = !(findInPageBar?.text?.isEmpty ?? true)
@@ -268,7 +269,7 @@ extension BrowserViewController {
 
     // Share With Key Command
     let shareCommands = [
-      UIKeyCommand(title: Strings.shareWithTitle, action: #selector(shareWithKeyCommand), input: "s", modifierFlags: .command)
+      UIKeyCommand(title: Strings.Hotkey.shareWithTitle, action: #selector(shareWithKeyCommand), input: "s", modifierFlags: .command)
     ]
 
     // Additional Commands which will have priority over system

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -184,12 +184,12 @@ extension BrowserViewController {
   
   override public var keyCommands: [UIKeyCommand]? {
     let isEditingText = tabManager.selectedTab?.isEditing ?? false
-      
+    
     var navigationCommands = [
       // Web Page Key Commands
       UIKeyCommand(title: Strings.Hotkey.reloadPageTitle, action: #selector(reloadTabKeyCommand), input: "r", modifierFlags: .command),
     ]
-
+    
     let tabMovementCommands = [
       UIKeyCommand(title: Strings.Hotkey.backTitle, action: #selector(goBackKeyCommand), input: UIKeyCommand.inputLeftArrow, modifierFlags: .command),
       UIKeyCommand(title: Strings.Hotkey.forwardTitle, action: #selector(goForwardKeyCommand), input: UIKeyCommand.inputRightArrow, modifierFlags: .command)
@@ -203,16 +203,25 @@ extension BrowserViewController {
       UIKeyCommand(input: "[", modifierFlags: .command, action: #selector(goBackKeyCommand)),
       UIKeyCommand(input: "]", modifierFlags: .command, action: #selector(goForwardKeyCommand)),
     ]
-      
+    
+    // URL Bar - Tab Key Commands
     navigationCommands += [
-      // URL Bar - Tab Key Commands
       UIKeyCommand(title: Strings.Hotkey.selectLocationBarTitle, action: #selector(selectLocationBarKeyCommand), input: "l", modifierFlags: .command),
       UIKeyCommand(title: Strings.Hotkey.newTabTitle, action: #selector(newTabKeyCommand), input: "t", modifierFlags: .command),
       UIKeyCommand(title: Strings.Hotkey.newPrivateTabTitle, action: #selector(newPrivateTabKeyCommand), input: "n", modifierFlags: [.command, .shift]),
-      UIKeyCommand(title: Strings.Hotkey.recentlyClosedTabTitle, action: #selector(reopenRecentlyClosedTabCommand), input: "t", modifierFlags: [.command, .shift]),
+    ]
+    
+    if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+      navigationCommands += [
+        UIKeyCommand(title: Strings.Hotkey.recentlyClosedTabTitle, action: #selector(reopenRecentlyClosedTabCommand), input: "t", modifierFlags: [.command, .shift])
+      ]
+    }
+    
+    navigationCommands += [
       UIKeyCommand(title: Strings.Hotkey.closeTabTitle, action: #selector(closeTabKeyCommand), input: "w", modifierFlags: .command),
       UIKeyCommand(title: Strings.Hotkey.closeAllTabsFromTabTrayKeyCodeTitle, action: #selector(closeAllTabsKeyCommand), input: "w", modifierFlags: [.command, .alternate])
     ]
+    
     
     let tabNavigationKeyCommands = [
       // Tab Navigation Key Commands

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -5,10 +5,12 @@
 import Shared
 import Foundation
 import UIKit
+import Data
 
-// Naming functions: use the suffix 'KeyCommand' for an additional level of namespacing (bug 1415830)
 extension BrowserViewController {
-
+  
+  // MARK: Actions
+  
   @objc private func reloadTabKeyCommand() {
     if let tab = tabManager.selectedTab, favoritesController == nil {
       tab.reload()
@@ -166,7 +168,18 @@ extension BrowserViewController {
   @objc private func toggleBraveTalkMuteCommand() {
     braveTalkJitsiCoordinator.toggleMute()
   }
-
+  
+  @objc private func reopenRecentlyClosedTabCommand() {
+    guard let recentlyClosed = RecentlyClosed.all().first else {
+      return
+    }
+    
+    tabManager.addAndSelectRecentlyClosed(recentlyClosed)
+    RecentlyClosed.remove(with: recentlyClosed.url)
+  }
+  
+  // MARK: KeyCommands
+  
   override public var keyCommands: [UIKeyCommand]? {
     let isEditingText = tabManager.selectedTab?.isEditing ?? false
       

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -165,10 +165,12 @@ extension BrowserViewController {
     searchController.handleKeyCommands(sender: sender)
   }
   
+#if canImport(BraveTalk)
   @objc private func toggleBraveTalkMuteCommand() {
     braveTalkJitsiCoordinator.toggleMute()
   }
-  
+#endif
+
   @objc private func reopenRecentlyClosedTabCommand() {
     guard let recentlyClosed = RecentlyClosed.all().first else {
       return
@@ -285,10 +287,12 @@ extension BrowserViewController {
       UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(moveURLCompletionKeyCommand(sender:)))
     ]
     
+#if canImport(BraveTalk)
     let braveTalkKeyCommands: [UIKeyCommand] = [
       UIKeyCommand(input: "m", modifierFlags: [], action: #selector(toggleBraveTalkMuteCommand))
     ]
-    
+#endif
+
     // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
     if #available(iOS 15, *) {
       searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -215,7 +215,7 @@ extension BrowserViewController: TabManagerDelegate {
 
     if !PrivateBrowsingManager.shared.isPrivateBrowsing {
       let openNewPrivateTab = UIAction(
-        title: Strings.newPrivateTabTitle,
+        title: Strings.Hotkey.newPrivateTabTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
           self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
@@ -229,7 +229,7 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     let openNewTab = UIAction(
-      title: PrivateBrowsingManager.shared.isPrivateBrowsing ? Strings.newPrivateTabTitle : Strings.newTabTitle,
+      title: PrivateBrowsingManager.shared.isPrivateBrowsing ? Strings.Hotkey.newPrivateTabTitle : Strings.Hotkey.newTabTitle,
       image: PrivateBrowsingManager.shared.isPrivateBrowsing ? UIImage(systemName: "plus.square.fill.on.square.fill") : UIImage(systemName: "plus.square.on.square"),
       handler: UIAction.deferredActionHandler { [unowned self] _ in
         self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
@@ -324,7 +324,7 @@ extension BrowserViewController: TabManagerDelegate {
     var closeTabMenuChildren: [UIAction] = []
 
     let closeActiveTab = UIAction(
-      title: String(format: Strings.closeTabTitle),
+      title: String(format: Strings.Hotkey.closeTabTitle),
       image: UIImage(systemName: "xmark"),
       attributes: .destructive,
       handler: UIAction.deferredActionHandler { [unowned self] _ in

--- a/Client/Frontend/Browser/Search/SearchViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController+KeyCommands.swift
@@ -1,0 +1,73 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Shared
+import Foundation
+import UIKit
+
+extension SearchViewController {
+  func handleKeyCommands(sender: UIKeyCommand) {
+    let initialSection = SearchSuggestionDataSource.SearchListSection.openTabsAndHistoryAndBookmarks.rawValue
+
+    guard let current = tableView.indexPathForSelectedRow else {
+      let numberOfRows = tableView(tableView, numberOfRowsInSection: initialSection)
+      if sender.input == UIKeyCommand.inputDownArrow, numberOfRows > 0 {
+        let next = IndexPath(item: 0, section: initialSection)
+        self.tableView(tableView, didHighlightRowAt: next)
+        tableView.selectRow(at: next, animated: false, scrollPosition: .top)
+      }
+      return
+    }
+
+    let nextSection: Int
+    let nextItem: Int
+    guard let input = sender.input else { return }
+
+    switch input {
+    case UIKeyCommand.inputUpArrow:
+      // we're going down, we should check if we've reached the first item in this section.
+      if current.item == 0 {
+        // We have, so check if we can decrement the section.
+        if current.section == initialSection {
+          // We've reached the first item in the first section.
+          searchDelegate?.searchViewController(
+            self,
+            didHighlightText: dataSource.searchQuery,
+            search: false)
+          return
+        } else {
+          nextSection = current.section - 1
+          nextItem = tableView(tableView, numberOfRowsInSection: nextSection) - 1
+        }
+      } else {
+        nextSection = current.section
+        nextItem = current.item - 1
+      }
+    case UIKeyCommand.inputDownArrow:
+      let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
+      if current.item == currentSectionItemsCount - 1 {
+        if current.section == tableView.numberOfSections - 1 {
+          // We've reached the last item in the last section
+          return
+        } else {
+          // We can go to the next section.
+          nextSection = current.section + 1
+          nextItem = 0
+        }
+      } else {
+        nextSection = current.section
+        nextItem = current.item + 1
+      }
+    default:
+      return
+    }
+
+    guard nextItem >= 0 else { return }
+
+    let next = IndexPath(item: nextItem, section: nextSection)
+    tableView(tableView, didHighlightRowAt: next)
+    tableView.selectRow(at: next, animated: false, scrollPosition: .middle)
+  }
+}

--- a/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -74,7 +74,7 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
     }
   }
 
-  private let dataSource: SearchSuggestionDataSource
+  let dataSource: SearchSuggestionDataSource
   public static var userAgent: String?
 
   // MARK: Lifecycle
@@ -711,73 +711,6 @@ extension SearchViewController: KeyboardHelperDelegate {
 
   public func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
     animateSearchEnginesWithKeyboard(state)
-  }
-}
-
-// MARK: - KeyCommands
-
-extension SearchViewController {
-  func handleKeyCommands(sender: UIKeyCommand) {
-    let initialSection = SearchSuggestionDataSource.SearchListSection.openTabsAndHistoryAndBookmarks.rawValue
-
-    guard let current = tableView.indexPathForSelectedRow else {
-      let numberOfRows = tableView(tableView, numberOfRowsInSection: initialSection)
-      if sender.input == UIKeyCommand.inputDownArrow, numberOfRows > 0 {
-        let next = IndexPath(item: 0, section: initialSection)
-        self.tableView(tableView, didHighlightRowAt: next)
-        tableView.selectRow(at: next, animated: false, scrollPosition: .top)
-      }
-      return
-    }
-
-    let nextSection: Int
-    let nextItem: Int
-    guard let input = sender.input else { return }
-
-    switch input {
-    case UIKeyCommand.inputUpArrow:
-      // we're going down, we should check if we've reached the first item in this section.
-      if current.item == 0 {
-        // We have, so check if we can decrement the section.
-        if current.section == initialSection {
-          // We've reached the first item in the first section.
-          searchDelegate?.searchViewController(
-            self,
-            didHighlightText: dataSource.searchQuery,
-            search: false)
-          return
-        } else {
-          nextSection = current.section - 1
-          nextItem = tableView(tableView, numberOfRowsInSection: nextSection) - 1
-        }
-      } else {
-        nextSection = current.section
-        nextItem = current.item - 1
-      }
-    case UIKeyCommand.inputDownArrow:
-      let currentSectionItemsCount = tableView(tableView, numberOfRowsInSection: current.section)
-      if current.item == currentSectionItemsCount - 1 {
-        if current.section == tableView.numberOfSections - 1 {
-          // We've reached the last item in the last section
-          return
-        } else {
-          // We can go to the next section.
-          nextSection = current.section + 1
-          nextItem = 0
-        }
-      } else {
-        nextSection = current.section
-        nextItem = current.item + 1
-      }
-    default:
-      return
-    }
-
-    guard nextItem >= 0 else { return }
-
-    let next = IndexPath(item: nextItem, section: nextSection)
-    tableView(tableView, didHighlightRowAt: next)
-    tableView.selectRow(at: next, animated: false, scrollPosition: .middle)
   }
 }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -468,14 +468,14 @@ class Tab: NSObject {
     // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
     // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
     if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil, !restoring {
-      syncTab?.setTitle(Strings.newTabTitle)
-      return Strings.newTabTitle
+      syncTab?.setTitle(Strings.Hotkey.newTabTitle)
+      return Strings.Hotkey.newTabTitle
     }
 
     // lets double check the sessionData in case this is a non-restored new tab
     if let firstURL = sessionData?.urls.first, sessionData?.urls.count == 1, InternalURL(firstURL)?.isAboutHomeURL ?? false {
-      syncTab?.setTitle(Strings.newTabTitle)
-      return Strings.newTabTitle
+      syncTab?.setTitle(Strings.Hotkey.newTabTitle)
+      return Strings.Hotkey.newTabTitle
     }
 
     if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {

--- a/Client/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -102,7 +102,7 @@ class TabsBarViewController: UIViewController {
 
     if !PrivateBrowsingManager.shared.isPrivateBrowsing {
       let openNewPrivateTab = UIAction(
-        title: Strings.newPrivateTabTitle,
+        title: Strings.Hotkey.newPrivateTabTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
           self.delegate?.tabsBarDidSelectAddNewTab(true)
@@ -112,7 +112,7 @@ class TabsBarViewController: UIViewController {
     }
 
     let openNewTab = UIAction(
-      title: PrivateBrowsingManager.shared.isPrivateBrowsing ? Strings.newPrivateTabTitle : Strings.newTabTitle,
+      title: PrivateBrowsingManager.shared.isPrivateBrowsing ? Strings.Hotkey.newPrivateTabTitle : Strings.Hotkey.newTabTitle,
       image: PrivateBrowsingManager.shared.isPrivateBrowsing ? UIImage(systemName: "plus.square.fill.on.square.fill") : UIImage(systemName: "plus.square.on.square"),
       handler: UIAction.deferredActionHandler { [unowned self] _ in
         self.delegate?.tabsBarDidSelectAddNewTab(PrivateBrowsingManager.shared.isPrivateBrowsing)

--- a/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+KeyCommands.swift
@@ -80,7 +80,7 @@ extension TabTrayController {
   // KeyCommands
   
   override var keyCommands: [UIKeyCommand]? {
-    let toggleText = privateMode ? Strings.switchToNonPBMKeyCodeTitle : Strings.switchToPBMKeyCodeTitle
+    let toggleText = privateMode ? Strings.Hotkey.switchToNonPBMKeyCodeTitle : Strings.Hotkey.switchToPBMKeyCodeTitle
 
     let arrowCommands: [UIKeyCommand] =
       [
@@ -99,12 +99,13 @@ extension TabTrayController {
     return [
       UIKeyCommand(title: toggleText, action: #selector(didTogglePrivateModeKeyCommand), input: "`", modifierFlags: .command),
       UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(didCloseTabKeyCommand)),
-      UIKeyCommand(title: Strings.closeTabFromTabTrayKeyCodeTitle, action: #selector(didCloseTabKeyCommand), input: "\u{8}", modifierFlags: []),
-      UIKeyCommand(title: Strings.closeAllTabsFromTabTrayKeyCodeTitle, action: #selector(didCloseAllTabsKeyCommand), input: "w", modifierFlags: [.command, .shift]),
-      UIKeyCommand(title: Strings.openSelectedTabFromTabTrayKeyCodeTitle, action: #selector(didEnterTabKeyCommand), input: "\r", modifierFlags: []),
+      UIKeyCommand(title: Strings.Hotkey.closeTabFromTabTrayKeyCodeTitle, action: #selector(didCloseTabKeyCommand), input: "\u{8}", modifierFlags: []),
+      UIKeyCommand(title: Strings.Hotkey.closeAllTabsFromTabTrayKeyCodeTitle, action: #selector(didCloseAllTabsKeyCommand), input: "w", modifierFlags: [.command, .shift]),
+      UIKeyCommand(title: Strings.Hotkey.openSelectedTabFromTabTrayKeyCodeTitle, action: #selector(didEnterTabKeyCommand), input: "\r", modifierFlags: []),
       UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(didEnterTabKeyCommand)),
       UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(didEnterTabKeyCommand)),
-      UIKeyCommand(title: Strings.openNewTabFromTabTrayKeyCodeTitle, action: #selector(didOpenNewTabKeyCommand), input: "t", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.openNewTabFromTabTrayKeyCodeTitle, action: #selector(didOpenNewTabKeyCommand), input: "t", modifierFlags: .command),
+      UIKeyCommand(title: Strings.Hotkey.recentlyClosedTabTitle, action: #selector(reopenRecentlyClosedTabCommand), input: "t", modifierFlags: [.command, .shift]),
     ] + arrowCommands
 
   }

--- a/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+KeyCommands.swift
@@ -4,37 +4,11 @@
 
 import Shared
 import UIKit
+import Data
 
 extension TabTrayController {
-  override var keyCommands: [UIKeyCommand]? {
-    let toggleText = privateMode ? Strings.switchToNonPBMKeyCodeTitle : Strings.switchToPBMKeyCodeTitle
 
-    let arrowCommands: [UIKeyCommand] =
-      [
-        UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
-        UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
-        UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
-        UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
-      ]
-
-    arrowCommands.forEach {
-      if #available(iOS 15.0, *) {
-        $0.wantsPriorityOverSystemBehavior = true
-      }
-    }
-
-    return [
-      UIKeyCommand(title: toggleText, action: #selector(didTogglePrivateModeKeyCommand), input: "`", modifierFlags: .command),
-      UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(didCloseTabKeyCommand)),
-      UIKeyCommand(title: Strings.closeTabFromTabTrayKeyCodeTitle, action: #selector(didCloseTabKeyCommand), input: "\u{8}", modifierFlags: []),
-      UIKeyCommand(title: Strings.closeAllTabsFromTabTrayKeyCodeTitle, action: #selector(didCloseAllTabsKeyCommand), input: "w", modifierFlags: [.command, .shift]),
-      UIKeyCommand(title: Strings.openSelectedTabFromTabTrayKeyCodeTitle, action: #selector(didEnterTabKeyCommand), input: "\r", modifierFlags: []),
-      UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(didEnterTabKeyCommand)),
-      UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(didEnterTabKeyCommand)),
-      UIKeyCommand(title: Strings.openNewTabFromTabTrayKeyCodeTitle, action: #selector(didOpenNewTabKeyCommand), input: "t", modifierFlags: .command),
-    ] + arrowCommands
-
-  }
+  // MARK: Actions
 
   @objc func didTogglePrivateModeKeyCommand() {
     togglePrivateModeAction()
@@ -56,6 +30,15 @@ extension TabTrayController {
 
   @objc func didOpenNewTabKeyCommand() {
     newTabAction()
+  }
+  
+  @objc private func reopenRecentlyClosedTabCommand() {
+    guard let recentlyClosed = RecentlyClosed.all().first else {
+      return
+    }
+    
+    tabManager.addAndSelectRecentlyClosed(recentlyClosed)
+    RecentlyClosed.remove(with: recentlyClosed.url)
   }
 
   @objc func didChangeSelectedTabKeyCommand(sender: UIKeyCommand) {
@@ -92,6 +75,37 @@ extension TabTrayController {
       // In all other cases when a tab selection changes, the tab tray is dismissed.
       forceReload()
     }
+  }
+  
+  // KeyCommands
+  
+  override var keyCommands: [UIKeyCommand]? {
+    let toggleText = privateMode ? Strings.switchToNonPBMKeyCodeTitle : Strings.switchToPBMKeyCodeTitle
+
+    let arrowCommands: [UIKeyCommand] =
+      [
+        UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
+        UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
+        UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
+        UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
+      ]
+
+    arrowCommands.forEach {
+      if #available(iOS 15.0, *) {
+        $0.wantsPriorityOverSystemBehavior = true
+      }
+    }
+
+    return [
+      UIKeyCommand(title: toggleText, action: #selector(didTogglePrivateModeKeyCommand), input: "`", modifierFlags: .command),
+      UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(didCloseTabKeyCommand)),
+      UIKeyCommand(title: Strings.closeTabFromTabTrayKeyCodeTitle, action: #selector(didCloseTabKeyCommand), input: "\u{8}", modifierFlags: []),
+      UIKeyCommand(title: Strings.closeAllTabsFromTabTrayKeyCodeTitle, action: #selector(didCloseAllTabsKeyCommand), input: "w", modifierFlags: [.command, .shift]),
+      UIKeyCommand(title: Strings.openSelectedTabFromTabTrayKeyCodeTitle, action: #selector(didEnterTabKeyCommand), input: "\r", modifierFlags: []),
+      UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(didEnterTabKeyCommand)),
+      UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(didEnterTabKeyCommand)),
+      UIKeyCommand(title: Strings.openNewTabFromTabTrayKeyCodeTitle, action: #selector(didOpenNewTabKeyCommand), input: "t", modifierFlags: .command),
+    ] + arrowCommands
 
   }
 }

--- a/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+KeyCommands.swift
@@ -96,7 +96,7 @@ extension TabTrayController {
       }
     }
 
-    return [
+    var navigationCommands = [
       UIKeyCommand(title: toggleText, action: #selector(didTogglePrivateModeKeyCommand), input: "`", modifierFlags: .command),
       UIKeyCommand(input: "w", modifierFlags: .command, action: #selector(didCloseTabKeyCommand)),
       UIKeyCommand(title: Strings.Hotkey.closeTabFromTabTrayKeyCodeTitle, action: #selector(didCloseTabKeyCommand), input: "\u{8}", modifierFlags: []),
@@ -104,9 +104,15 @@ extension TabTrayController {
       UIKeyCommand(title: Strings.Hotkey.openSelectedTabFromTabTrayKeyCodeTitle, action: #selector(didEnterTabKeyCommand), input: "\r", modifierFlags: []),
       UIKeyCommand(input: "\\", modifierFlags: [.command, .shift], action: #selector(didEnterTabKeyCommand)),
       UIKeyCommand(input: "\t", modifierFlags: [.command, .alternate], action: #selector(didEnterTabKeyCommand)),
-      UIKeyCommand(title: Strings.Hotkey.openNewTabFromTabTrayKeyCodeTitle, action: #selector(didOpenNewTabKeyCommand), input: "t", modifierFlags: .command),
-      UIKeyCommand(title: Strings.Hotkey.recentlyClosedTabTitle, action: #selector(reopenRecentlyClosedTabCommand), input: "t", modifierFlags: [.command, .shift]),
-    ] + arrowCommands
-
+      UIKeyCommand(title: Strings.Hotkey.openNewTabFromTabTrayKeyCodeTitle, action: #selector(didOpenNewTabKeyCommand), input: "t", modifierFlags: .command)
+    ]
+    
+    if !PrivateBrowsingManager.shared.isPrivateBrowsing {
+      navigationCommands += [
+        UIKeyCommand(title: Strings.Hotkey.recentlyClosedTabTitle, action: #selector(reopenRecentlyClosedTabCommand), input: "t", modifierFlags: [.command, .shift])
+      ]
+    }
+    
+    return navigationCommands + arrowCommands
   }
 }

--- a/Client/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -405,12 +405,12 @@ class TabTrayController: LoadingViewController {
     
     if motion == .motionShake {
       let alert = UIAlertController(
-        title: "Re-open Closed Tab",
-        message: "Do you want to open the latest closed tab?", preferredStyle: .alert)
+        title: Strings.Hotkey.recentlyClosedTabTitle,
+        message: Strings.RecentlyClosed.recentlyClosedShakeActionDescription, preferredStyle: .alert)
       
       alert.addAction(
         UIAlertAction(
-          title: "Open", style: .default,
+          title: Strings.RecentlyClosed.recentlyClosedOpenActionTitle, style: .default,
           handler: { [weak self] _ in
             self?.tabManager.addAndSelectRecentlyClosed(recentlyClosedTab)
             RecentlyClosed.remove(with: recentlyClosedTab.url)

--- a/Client/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -287,11 +287,17 @@ class TabTrayController: LoadingViewController {
       })
   
     reloadOpenTabsSession()
+    
+    becomeFirstResponder()
   }
   
   override func loadView() {
     createTypeSelectorItems()
     layoutTabTray()
+  }
+  
+  override var canBecomeFirstResponder: Bool {
+    return true
   }
   
   private func layoutTabTray() {
@@ -390,6 +396,29 @@ class TabTrayController: LoadingViewController {
     
     searchBarView?.setNeedsLayout()
     searchBarView?.layoutIfNeeded()
+  }
+  
+  override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+    guard let recentlyClosedTab = RecentlyClosed.all().first else {
+      return
+    }
+    
+    if motion == .motionShake {
+      let alert = UIAlertController(
+        title: "Re-open Closed Tab",
+        message: "Do you want to open the latest closed tab?", preferredStyle: .alert)
+      
+      alert.addAction(
+        UIAlertAction(
+          title: "Open", style: .default,
+          handler: { [weak self] _ in
+            self?.tabManager.addAndSelectRecentlyClosed(recentlyClosedTab)
+            RecentlyClosed.remove(with: recentlyClosedTab.url)
+          }))
+      alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
+      
+      self.present(alert, animated: true, completion: nil)
+    }
   }
 
   // MARK: Snapshot handling

--- a/Client/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -399,7 +399,7 @@ class TabTrayController: LoadingViewController {
   }
   
   override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-    guard let recentlyClosedTab = RecentlyClosed.all().first else {
+    guard !PrivateBrowsingManager.shared.isPrivateBrowsing, let recentlyClosedTab = RecentlyClosed.all().first else {
       return
     }
     

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -4336,17 +4336,6 @@ extension Strings {
 }
 
 extension Strings {
-  public static let showHistoryTitle = NSLocalizedString("showHistoryTitle", tableName: "BraveShared", bundle: .module, value: "Show History", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let showDownloadsTitle = NSLocalizedString("showDownloadsTitle", tableName: "BraveShared", bundle: .module, value: "Show Downloads", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let addBookmarkTitle = NSLocalizedString("addBookmarkTitle", tableName: "BraveShared", bundle: .module, value: "Add Bookmark", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let addFavouritesTitle = NSLocalizedString("addFavouritesTitle", tableName: "BraveShared", bundle: .module, value: "Add to Favourites", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let findInPageTitle = NSLocalizedString("findInPageTitle", tableName: "BraveShared", bundle: .module, value: "Find in Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let findNextTitle = NSLocalizedString("findNextTitle", tableName: "BraveShared", bundle: .module, value: "Find Next", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let findPreviousTitle = NSLocalizedString("findPreviousTitle", tableName: "BraveShared", bundle: .module, value: "Find Previous", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let shareWithTitle = NSLocalizedString("shareWithTitle", tableName: "BraveShared", bundle: .module, value: "Share with...", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-}
-
-extension Strings {
   // Errors
   public static let unsupportedInstrumentMessage = NSLocalizedString("unsupportedInstrumentMessage", tableName: "BraveShared", bundle: .module, value: "Unsupported payment instruments", comment: "Error message if list of Payment Instruments doesn't include BAT")
   public static let userCancelledMessage = NSLocalizedString("userCancelledMessage", tableName: "BraveShared", bundle: .module, value: "User cancelled", comment: "Error message if the payment workflow is canceled by the user")
@@ -4409,4 +4398,38 @@ extension Strings {
     value: "No thanks",
     comment: "An action (button title) that does not block cookie consent notices and dismisses the popup"
   )
+}
+
+// MARK: Hotkey Titles
+
+extension Strings {
+  public struct Hotkey {
+    public static let reloadPageTitle = NSLocalizedString("ReloadPageTitle", bundle: .module, value: "Reload Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let backTitle = NSLocalizedString("BackTitle", bundle: .module, value: "Back", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let forwardTitle = NSLocalizedString("ForwardTitle", bundle: .module, value: "Forward", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let selectLocationBarTitle = NSLocalizedString("SelectLocationBarTitle", bundle: .module, value: "Select Location Bar", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let newTabTitle = NSLocalizedString("NewTabTitle", bundle: .module, value: "New Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let newPrivateTabTitle = NSLocalizedString("NewPrivateTabTitle", bundle: .module, value: "New Private Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let recentlyClosedTabTitle = NSLocalizedString("RecentlyClosedTabTitle", bundle: .module, value: "Re-Open Closed Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts used for opening recently closed tab.")
+    public static let closeTabTitle = NSLocalizedString("CloseTabTitle", bundle: .module, value: "Close Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showNextTabTitle = NSLocalizedString("ShowNextTabTitle", bundle: .module, value: "Show Next Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showPreviousTabTitle = NSLocalizedString("ShowPreviousTabTitle", bundle: .module, value: "Show Previous Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showBookmarksTitle = NSLocalizedString("showBookmarksTitle", bundle: .module, value: "Show Bookmarks", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showShieldsTitle = NSLocalizedString("showShieldsTitle", bundle: .module, value: "Open Brave Shields", comment: "Label to display in the Discoverability overlay for keyboard shortcuts which is for Showing Brave Shields")
+    public static let showHistoryTitle = NSLocalizedString("showHistoryTitle", tableName: "BraveShared", bundle: .module, value: "Show History", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showDownloadsTitle = NSLocalizedString("showDownloadsTitle", tableName: "BraveShared", bundle: .module, value: "Show Downloads", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let addBookmarkTitle = NSLocalizedString("addBookmarkTitle", tableName: "BraveShared", bundle: .module, value: "Add Bookmark", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let addFavouritesTitle = NSLocalizedString("addFavouritesTitle", tableName: "BraveShared", bundle: .module, value: "Add to Favourites", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let findInPageTitle = NSLocalizedString("findInPageTitle", tableName: "BraveShared", bundle: .module, value: "Find in Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let findNextTitle = NSLocalizedString("findNextTitle", tableName: "BraveShared", bundle: .module, value: "Find Next", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let findPreviousTitle = NSLocalizedString("findPreviousTitle", tableName: "BraveShared", bundle: .module, value: "Find Previous", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let shareWithTitle = NSLocalizedString("shareWithTitle", tableName: "BraveShared", bundle: .module, value: "Share with...", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let showTabTrayFromTabKeyCodeTitle = NSLocalizedString("ShowTabTrayFromTabKeyCodeTitle", bundle: .module, value: "Show All Tabs", comment: "Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+    public static let closeTabFromTabTrayKeyCodeTitle = NSLocalizedString("CloseTabFromTabTrayKeyCodeTitle", bundle: .module, value: "Close Selected Tab", comment: "Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+    public static let closeAllTabsFromTabTrayKeyCodeTitle = NSLocalizedString("CloseAllTabsFromTabTrayKeyCodeTitle", bundle: .module, value: "Close All Tabs", comment: "Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+    public static let openSelectedTabFromTabTrayKeyCodeTitle = NSLocalizedString("OpenSelectedTabFromTabTrayKeyCodeTitle", bundle: .module, value: "Open Selected Tab", comment: "Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+    public static let openNewTabFromTabTrayKeyCodeTitle = NSLocalizedString("OpenNewTabFromTabTrayKeyCodeTitle", bundle: .module, value: "Open New Tab", comment: "Hardware shortcut to open a new tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+    public static let switchToPBMKeyCodeTitle = NSLocalizedString("SwitchToPBMKeyCodeTitle", bundle: .module, value: "Private Browsing Mode", comment: "Hardware shortcut switch to the private browsing tab or tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+    public static let switchToNonPBMKeyCodeTitle = NSLocalizedString("SwitchToNonPBMKeyCodeTitle", bundle: .module, value: "Normal Browsing Mode", comment: "Hardware shortcut for non-private tab or tab. Shown in the Discoverability overlay when the hardware Command Key is held down.")
+  }
 }

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -4332,6 +4332,23 @@ extension Strings {
         bundle: .module,
         value: "No Recently Closed Tabs.",
         comment: "Title for empty screen Recently Closed Tabs")
+    
+    public static let recentlyClosedShakeActionDescription =
+      NSLocalizedString(
+        "recently.closed.shake.description",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Do you want to open the latest closed tab?",
+        comment: "Description for alert to ask user for opening last closed tab in list")
+    
+    public static let recentlyClosedOpenActionTitle =
+      NSLocalizedString(
+        "recently.closed.open",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Open",
+        comment: "Open Tab action title")
+
   }
 }
 

--- a/Sources/Shared/SharedStrings.swift
+++ b/Sources/Shared/SharedStrings.swift
@@ -33,21 +33,6 @@ extension Strings {
   public static let updateLoginPrompt = NSLocalizedString("UpdateLoginPrompt", bundle: .module, value: "Update login %@ for %@?", comment: "Prompt for updating a login. The first parameter is the username for which the password will be updated for. The second parameter is the hostname of the site.")
 }
 
-// Hotkey Titles
-extension Strings {
-  public static let reloadPageTitle = NSLocalizedString("ReloadPageTitle", bundle: .module, value: "Reload Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let backTitle = NSLocalizedString("BackTitle", bundle: .module, value: "Back", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let forwardTitle = NSLocalizedString("ForwardTitle", bundle: .module, value: "Forward", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let selectLocationBarTitle = NSLocalizedString("SelectLocationBarTitle", bundle: .module, value: "Select Location Bar", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let newTabTitle = NSLocalizedString("NewTabTitle", bundle: .module, value: "New Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let newPrivateTabTitle = NSLocalizedString("NewPrivateTabTitle", bundle: .module, value: "New Private Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let closeTabTitle = NSLocalizedString("CloseTabTitle", bundle: .module, value: "Close Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let showNextTabTitle = NSLocalizedString("ShowNextTabTitle", bundle: .module, value: "Show Next Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let showPreviousTabTitle = NSLocalizedString("ShowPreviousTabTitle", bundle: .module, value: "Show Previous Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let showBookmarksTitle = NSLocalizedString("showBookmarksTitle", bundle: .module, value: "Show Bookmarks", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
-  public static let showShieldsTitle = NSLocalizedString("showShieldsTitle", bundle: .module, value: "Open Brave Shields", comment: "Label to display in the Discoverability overlay for keyboard shortcuts which is for Showing Brave Shields")
-}
-
 // Tabs Delete All Undo Toast
 extension Strings {
   public static let tabsDeleteAllUndoTitle = NSLocalizedString("TabsDeleteAllUndoTitle", bundle: .module, value: "%d tab(s) closed", comment: "The label indicating that all the tabs were closed")
@@ -120,15 +105,4 @@ extension Strings {
   public static let pasteAndGoTitle = NSLocalizedString("PasteAndGoTitle", bundle: .module, value: "Paste & Go", comment: "The title for the button that lets you paste and go to a URL")
   public static let pasteTitle = NSLocalizedString("PasteTitle", bundle: .module, value: "Paste", comment: "The title for the button that lets you paste into the location bar")
   public static let copyAddressTitle = NSLocalizedString("CopyAddressTitle", bundle: .module, value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.")
-}
-
-// Keyboard short cuts
-extension Strings {
-  public static let showTabTrayFromTabKeyCodeTitle = NSLocalizedString("ShowTabTrayFromTabKeyCodeTitle", bundle: .module, value: "Show All Tabs", comment: "Hardware shortcut to open the tab tray from a tab. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-  public static let closeTabFromTabTrayKeyCodeTitle = NSLocalizedString("CloseTabFromTabTrayKeyCodeTitle", bundle: .module, value: "Close Selected Tab", comment: "Hardware shortcut to close the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-  public static let closeAllTabsFromTabTrayKeyCodeTitle = NSLocalizedString("CloseAllTabsFromTabTrayKeyCodeTitle", bundle: .module, value: "Close All Tabs", comment: "Hardware shortcut to close all tabs from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-  public static let openSelectedTabFromTabTrayKeyCodeTitle = NSLocalizedString("OpenSelectedTabFromTabTrayKeyCodeTitle", bundle: .module, value: "Open Selected Tab", comment: "Hardware shortcut open the selected tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-  public static let openNewTabFromTabTrayKeyCodeTitle = NSLocalizedString("OpenNewTabFromTabTrayKeyCodeTitle", bundle: .module, value: "Open New Tab", comment: "Hardware shortcut to open a new tab from the tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-  public static let switchToPBMKeyCodeTitle = NSLocalizedString("SwitchToPBMKeyCodeTitle", bundle: .module, value: "Private Browsing Mode", comment: "Hardware shortcut switch to the private browsing tab or tab tray. Shown in the Discoverability overlay when the hardware Command Key is held down.")
-  public static let switchToNonPBMKeyCodeTitle = NSLocalizedString("SwitchToNonPBMKeyCodeTitle", bundle: .module, value: "Normal Browsing Mode", comment: "Hardware shortcut for non-private tab or tab. Shown in the Discoverability overlay when the hardware Command Key is held down.")
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2123
This pull request fixes #1048

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

Reopen Last Closed Tab Shortcut:

- Hold cmd and chose Close All Tabs shortcut or Press cmd+shift+t
- A new tab should be opened with last recently closed tab

This will work both in browser controller and Tab Tray

Shake to Reopen:

- Shake while on Tab Tray
- A dialog should appear to warn if user wants to reopen the last closed tab (latest recently closed
- Open should open a latest closed tab in a new tab

## Screenshots:

Reopen Last Closed Tab Shortcut:

https://user-images.githubusercontent.com/6643505/213610478-d0297bdc-95e5-4d59-8531-53c4e6263cb8.mov


Shake to Reopen:

https://user-images.githubusercontent.com/6643505/213610514-db2f83ca-681f-49ab-9606-3778dc800ff2.MP4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
