### PR TITLE
Fix #6719: Web3 settings updates and settings for SNS domain

### DIFF
--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -729,39 +729,36 @@ class SettingsViewController: TableViewController {
   private func setUpSections() {
     if let cryptoStore = cryptoStore, let keyringStore = keyringStore {
       let settingsStore = cryptoStore.settingsStore
-      settingsStore.isDefaultKeyringCreated { [weak self] created in
-        guard let self = self else { return }
-        var copyOfSections = self.sections
-        if let featureSectionIndex = self.sections.firstIndex(where: {
-          $0.uuid == self.featureSectionUUID.uuidString
-        }) {
-          let walletRowIndex = copyOfSections[featureSectionIndex].rows.firstIndex(where: {
-            $0.uuid == self.walletRowUUID.uuidString
-          })
-          if created, walletRowIndex == nil {
-            settingsStore.addKeyringServiceObserver(self)
-            copyOfSections[featureSectionIndex].rows.append(
-              Row(
-                text: Strings.Wallet.braveWallet,
-                selection: { [unowned self] in
-                  let walletSettingsView = WalletSettingsView(
-                    settingsStore: settingsStore,
-                    networkStore: cryptoStore.networkStore,
-                    keyringStore: keyringStore
-                  )
-                  let vc = UIHostingController(rootView: walletSettingsView)
-                  self.navigationController?.pushViewController(vc, animated: true)
-                },
-                image: UIImage(named: "menu-crypto", in: .module, compatibleWith: nil)!.template,
-                accessory: .disclosureIndicator,
-                uuid: self.walletRowUUID.uuidString)
-            )
-          } else if !created, let index = walletRowIndex {
-            copyOfSections.remove(at: index)
-          }
+      var copyOfSections = self.sections
+      if let featureSectionIndex = self.sections.firstIndex(where: {
+        $0.uuid == self.featureSectionUUID.uuidString
+      }) {
+        let walletRowIndex = copyOfSections[featureSectionIndex].rows.firstIndex(where: {
+          $0.uuid == self.walletRowUUID.uuidString
+        })
+        if walletRowIndex == nil {
+          settingsStore.addKeyringServiceObserver(self)
+          copyOfSections[featureSectionIndex].rows.append(
+            Row(
+              text: Strings.Wallet.web3,
+              selection: { [unowned self] in
+                let walletSettingsView = WalletSettingsView(
+                  settingsStore: settingsStore,
+                  networkStore: cryptoStore.networkStore,
+                  keyringStore: keyringStore
+                )
+                let vc = UIHostingController(rootView: walletSettingsView)
+                self.navigationController?.pushViewController(vc, animated: true)
+              },
+              image: UIImage(named: "menu-crypto", in: .module, compatibleWith: nil)!.template,
+              accessory: .disclosureIndicator,
+              uuid: self.walletRowUUID.uuidString)
+          )
+        } else if let index = walletRowIndex {
+          copyOfSections.remove(at: index)
         }
-        self.dataSource.sections = copyOfSections
       }
+      self.dataSource.sections = copyOfSections
     } else {
       self.dataSource.sections = sections
     }

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -59,7 +59,7 @@ struct AccountsHeaderView: View {
             }
         )
         NavigationLink(
-          destination: WalletSettingsView(
+          destination: Web3SettingsView(
             settingsStore: settingsStore,
             networkStore: networkStore,
             keyringStore: keyringStore)

--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -58,7 +58,7 @@ struct CryptoPagesView: View {
     })
     .background(
       NavigationLink(
-        destination: WalletSettingsView(
+        destination: Web3SettingsView(
           settingsStore: cryptoStore.settingsStore,
           networkStore: cryptoStore.networkStore,
           keyringStore: keyringStore

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -185,7 +185,7 @@ public struct CryptoView: View {
               }
             case .settings:
               NavigationView {
-                WalletSettingsView(
+                Web3SettingsView(
                   settingsStore: store.settingsStore,
                   networkStore: store.networkStore,
                   keyringStore: keyringStore

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -16,6 +16,8 @@ public class SettingsStore: ObservableObject {
       keyringService.setAutoLockMinutes(autoLockInterval.value) { _ in }
     }
   }
+  
+  @Published var isDefaultKeyringCreated: Bool = false
 
   /// If we should attempt to unlock via biometrics (Face ID / Touch ID)
   var isBiometricsUnlockEnabled: Bool {
@@ -59,6 +61,10 @@ public class SettingsStore: ObservableObject {
     walletService.defaultBaseCurrency { [self] currencyCode in
       self.currencyCode = CurrencyCode(code: currencyCode)
     }
+    
+    keyringService.keyringInfo(BraveWallet.DefaultKeyringId) { [self] keyringInfo in
+      self.isDefaultKeyringCreated = keyringInfo.isKeyringCreated
+    }
   }
 
   func reset() {
@@ -73,12 +79,6 @@ public class SettingsStore: ObservableObject {
 
   func resetTransaction() {
     txService.reset()
-  }
-
-  public func isDefaultKeyringCreated(_ completion: @escaping (Bool) -> Void) {
-    keyringService.keyringInfo(BraveWallet.DefaultKeyringId) { keyring in
-      completion(keyring.isKeyringCreated)
-    }
   }
 
   public func addKeyringServiceObserver(_ observer: BraveWalletKeyringServiceObserver) {
@@ -109,6 +109,9 @@ extension SettingsStore: BraveWalletKeyringServiceObserver {
   }
   
   public func keyringReset() {
+    keyringService.keyringInfo(BraveWallet.DefaultKeyringId) { [self] keyringInfo in
+      self.isDefaultKeyringCreated = keyringInfo.isKeyringCreated
+    }
   }
   
   public func locked() {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -356,7 +356,7 @@ enum TransactionParser {
       let fromValue = "\(amount)"
       var fromValueFormatted = ""
       var fromFiat = "$0.00"
-      if let token = fromToken  {
+      if let token = fromToken {
         fromValueFormatted = formatter.decimalString(for: fromValue, radix: .decimal, decimals: Int(token.decimals))?.trimmingTrailingZeros ?? ""
         if token.isNft {
           fromFiat = "" // don't show fiat for NFTs

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -13,11 +13,15 @@ public struct WalletSettingsView: View {
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
+  @ObservedObject var enableIPFS = Preferences.Wallet.enableIPFS
+  @ObservedObject var enableSNSDomainName = Preferences.Wallet.resolveSNSDomainNames
 
   @State private var isShowingResetWalletAlert = false
   @State private var isShowingResetTransactionAlert = false
   /// If we are showing the modal so the user can enter their password to enable unlock via biometrics.
   @State private var isShowingBiometricsPasswordEntry = false
+  
+  private var domainOptions: [Preferences.Wallet.Web3DomainOption] = [.ask, .enable, .disable]
 
   public init(
     settingsStore: SettingsStore,
@@ -82,9 +86,9 @@ public struct WalletSettingsView: View {
             isOn: Binding(get: { settingsStore.isBiometricsUnlockEnabled },
                           set: { toggledBiometricsUnlock($0) })
           )
-            .foregroundColor(Color(.braveLabel))
-            .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-            .listRowBackground(Color(.secondaryBraveGroupedBackground))
+          .foregroundColor(Color(.braveLabel))
+          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
       Section(
@@ -138,12 +142,31 @@ public struct WalletSettingsView: View {
           Text(Strings.Wallet.settingsResetButtonTitle)
             .foregroundColor(.red)
         } // iOS 15: .role(.destructive)
+      }
+      Section(header: Text(Strings.Wallet.web3IPFSHeader)) {
+        Toggle(Strings.Wallet.web3IPFSTitle, isOn: .constant(false))
+          .foregroundColor(Color(.braveLabel))
+          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      }
+      Section(header: Text(Strings.Wallet.web3DomainOptionsHeader)) {
+        Picker(selection: $enableSNSDomainName.value) {
+          ForEach(Preferences.Wallet.Web3DomainOption.allCases) { option in
+            Text(option.name)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .tag(option)
+          }
+        } label: {
+          Text(Strings.Wallet.web3DomainOptionsTitle)
+            .foregroundColor(Color(.braveLabel))
+            .padding(.vertical, 4)
+        }
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
     .listStyle(InsetGroupedListStyle())
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
-    .navigationTitle(Strings.Wallet.braveWallet)
+    .navigationTitle(Strings.Wallet.web3)
     .navigationBarTitleDisplayMode(.inline)
     .background(
       Color.clear

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -13,7 +13,6 @@ public struct WalletSettingsView: View {
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore
   @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
-  @ObservedObject var enableIPFS = Preferences.Wallet.enableIPFS
   @ObservedObject var enableSNSDomainName = Preferences.Wallet.resolveSNSDomainNames
 
   @State private var isShowingResetWalletAlert = false
@@ -142,12 +141,6 @@ public struct WalletSettingsView: View {
           Text(Strings.Wallet.settingsResetButtonTitle)
             .foregroundColor(.red)
         } // iOS 15: .role(.destructive)
-      }
-      Section(header: Text(Strings.Wallet.web3IPFSHeader)) {
-        Toggle(Strings.Wallet.web3IPFSTitle, isOn: .constant(false))
-          .foregroundColor(Color(.braveLabel))
-          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       Section(header: Text(Strings.Wallet.web3DomainOptionsHeader)) {
         Picker(selection: $enableSNSDomainName.value) {

--- a/Sources/BraveWallet/Settings/WalletSettingsView.swift
+++ b/Sources/BraveWallet/Settings/WalletSettingsView.swift
@@ -7,140 +7,43 @@ import SwiftUI
 import Strings
 import BraveUI
 import BraveShared
+import BraveCore
 
-public struct WalletSettingsView: View {
-  @ObservedObject var settingsStore: SettingsStore
-  @ObservedObject var networkStore: NetworkStore
-  @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
+public struct Web3SettingsView: View {
+  var settingsStore: SettingsStore?
+  var networkStore: NetworkStore?
+  var keyringStore: KeyringStore?
+  
   @ObservedObject var enableSNSDomainName = Preferences.Wallet.resolveSNSDomainNames
-
+  
   @State private var isShowingResetWalletAlert = false
   @State private var isShowingResetTransactionAlert = false
   /// If we are showing the modal so the user can enter their password to enable unlock via biometrics.
   @State private var isShowingBiometricsPasswordEntry = false
   
   private var domainOptions: [Preferences.Wallet.Web3DomainOption] = [.ask, .enable, .disable]
-
+  
   public init(
-    settingsStore: SettingsStore,
-    networkStore: NetworkStore,
-    keyringStore: KeyringStore
+    settingsStore: SettingsStore? = nil,
+    networkStore: NetworkStore? = nil,
+    keyringStore: KeyringStore? = nil
   ) {
     self.settingsStore = settingsStore
     self.networkStore = networkStore
     self.keyringStore = keyringStore
   }
-
-  private var autoLockIntervals: [AutoLockInterval] {
-    var all = AutoLockInterval.allOptions
-    if !all.contains(settingsStore.autoLockInterval) {
-      // Ensure that the users selected interval always appears as an option even if
-      // we remove it from `allOptions`
-      all.append(settingsStore.autoLockInterval)
-    }
-    return all.sorted(by: { $0.value < $1.value })
-  }
-
+  
   public var body: some View {
     List {
-      Section(
-        footer: Text(Strings.Wallet.autoLockFooter)
-          .foregroundColor(Color(.secondaryBraveLabel))
-      ) {
-        Picker(selection: $settingsStore.autoLockInterval) {
-          ForEach(autoLockIntervals) { interval in
-            Text(interval.label)
-              .foregroundColor(Color(.secondaryBraveLabel))
-              .tag(interval)
-          }
-        } label: {
-          Text(Strings.Wallet.autoLockTitle)
-            .foregroundColor(Color(.braveLabel))
-            .padding(.vertical, 4)
-        }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
-      }
-      Section {
-        Picker(selection: $settingsStore.currencyCode) {
-          ForEach(CurrencyCode.allCurrencyCodes) { currencyCode in
-            Text(currencyCode.code)
-              .foregroundColor(Color(.secondaryBraveLabel))
-              .tag(currencyCode)
-          }
-        } label: {
-          Text(Strings.Wallet.settingsDefaultBaseCurrencyTitle)
-            .foregroundColor(Color(.braveLabel))
-            .padding(.vertical, 4)
-        }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
-      }
-      if settingsStore.isBiometricsAvailable, keyringStore.defaultKeyring.isKeyringCreated {
-        Section(
-          footer: Text(Strings.Wallet.settingsEnableBiometricsFooter)
-            .foregroundColor(Color(.secondaryBraveLabel))
-        ) {
-          Toggle(
-            Strings.Wallet.settingsEnableBiometricsTitle,
-            isOn: Binding(get: { settingsStore.isBiometricsUnlockEnabled },
-                          set: { toggledBiometricsUnlock($0) })
-          )
-          .foregroundColor(Color(.braveLabel))
-          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        }
-      }
-      Section(
-        footer: Text(Strings.Wallet.networkFooter)
-          .foregroundColor(Color(.secondaryBraveLabel))
-      ) {
-        NavigationLink(destination: CustomNetworkListView(networkStore: networkStore)) {
-          Text(Strings.Wallet.settingsNetworkButtonTitle)
-            .foregroundColor(Color(.braveLabel))
-        }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
-      }
-      Section(
-        header: Text(Strings.Wallet.web3PreferencesSectionTitle)
-          .foregroundColor(Color(.secondaryBraveLabel))
-      ) {
-        Group {
-          ForEach(Array(WalletConstants.supportedCoinTypes)) { coin in
-            NavigationLink(
-              destination:
-                DappsSettings(
-                  coin: coin,
-                  siteConnectionStore: settingsStore.manageSiteConnectionsStore(keyringStore: keyringStore)
-                )
-                .onDisappear {
-                  settingsStore.closeManageSiteConnectionStore()
-                }
-            ) {
-              Text(coin.localizedTitle)
-                .foregroundColor(Color(.braveLabel))
-            }
-          }
-          Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
-            .foregroundColor(Color(.braveLabel))
-            .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
-        }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
-      }
-      Section(
-        footer: Text(Strings.Wallet.settingsResetTransactionFooter)
-          .foregroundColor(Color(.secondaryBraveLabel))
-      ) {
-        Button(action: { isShowingResetTransactionAlert = true }) {
-          Text(Strings.Wallet.settingsResetTransactionTitle)
-            .foregroundColor(Color(.braveBlurpleTint))
-        }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
-      }
-      Section {
-        Button(action: { isShowingResetWalletAlert = true }) {
-          Text(Strings.Wallet.settingsResetButtonTitle)
-            .foregroundColor(.red)
-        } // iOS 15: .role(.destructive)
+      if let settingsStore, let networkStore, let keyringStore, settingsStore.isDefaultKeyringCreated {
+        WalletSettingsView(
+          settingsStore: settingsStore,
+          networkStore: networkStore,
+          keyringStore: keyringStore,
+          isShowingResetWalletAlert: $isShowingResetWalletAlert,
+          isShowingResetTransactionAlert: $isShowingResetTransactionAlert,
+          isShowingBiometricsPasswordEntry: $isShowingBiometricsPasswordEntry
+        )
       }
       Section(header: Text(Strings.Wallet.web3DomainOptionsHeader)) {
         Picker(selection: $enableSNSDomainName.value) {
@@ -170,7 +73,7 @@ public struct WalletSettingsView: View {
             primaryButton: .destructive(
               Text(Strings.Wallet.settingsResetTransactionAlertButtonTitle),
               action: {
-                settingsStore.resetTransaction()
+                settingsStore?.resetTransaction()
               }),
             secondaryButton: .cancel(Text(Strings.cancelButtonTitle))
           )
@@ -185,7 +88,7 @@ public struct WalletSettingsView: View {
             primaryButton: .destructive(
               Text(Strings.Wallet.settingsResetWalletAlertButtonTitle),
               action: {
-                settingsStore.reset()
+                settingsStore?.reset()
               }),
             secondaryButton: .cancel(Text(Strings.no))
           )
@@ -194,9 +97,133 @@ public struct WalletSettingsView: View {
     .background(
       Color.clear
         .sheet(isPresented: $isShowingBiometricsPasswordEntry) {
-          BiometricsPasscodeEntryView(keyringStore: keyringStore)
+          if let keyringStore {
+            BiometricsPasscodeEntryView(keyringStore: keyringStore)
+          }
         }
     )
+  }
+}
+
+struct WalletSettingsView: View {
+  @ObservedObject var settingsStore: SettingsStore
+  @ObservedObject var networkStore: NetworkStore
+  @ObservedObject var keyringStore: KeyringStore
+  @ObservedObject var displayDappsNotifications = Preferences.Wallet.displayWeb3Notifications
+  
+  @Binding var isShowingResetWalletAlert: Bool
+  @Binding var isShowingResetTransactionAlert: Bool
+  @Binding var isShowingBiometricsPasswordEntry: Bool
+
+  private var autoLockIntervals: [AutoLockInterval] {
+    var all = AutoLockInterval.allOptions
+    if !all.contains(settingsStore.autoLockInterval) {
+      // Ensure that the users selected interval always appears as an option even if
+      // we remove it from `allOptions`
+      all.append(settingsStore.autoLockInterval)
+    }
+    return all.sorted(by: { $0.value < $1.value })
+  }
+
+  var body: some View {
+    Section(
+      footer: Text(Strings.Wallet.autoLockFooter)
+        .foregroundColor(Color(.secondaryBraveLabel))
+    ) {
+      Picker(selection: $settingsStore.autoLockInterval) {
+        ForEach(autoLockIntervals) { interval in
+          Text(interval.label)
+            .foregroundColor(Color(.secondaryBraveLabel))
+            .tag(interval)
+        }
+      } label: {
+        Text(Strings.Wallet.autoLockTitle)
+          .foregroundColor(Color(.braveLabel))
+          .padding(.vertical, 4)
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    Section {
+      Picker(selection: $settingsStore.currencyCode) {
+        ForEach(CurrencyCode.allCurrencyCodes) { currencyCode in
+          Text(currencyCode.code)
+            .foregroundColor(Color(.secondaryBraveLabel))
+            .tag(currencyCode)
+        }
+      } label: {
+        Text(Strings.Wallet.settingsDefaultBaseCurrencyTitle)
+          .foregroundColor(Color(.braveLabel))
+          .padding(.vertical, 4)
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    if settingsStore.isBiometricsAvailable, keyringStore.defaultKeyring.isKeyringCreated {
+      Section(
+        footer: Text(Strings.Wallet.settingsEnableBiometricsFooter)
+          .foregroundColor(Color(.secondaryBraveLabel))
+      ) {
+        Toggle(
+          Strings.Wallet.settingsEnableBiometricsTitle,
+          isOn: Binding(get: { settingsStore.isBiometricsUnlockEnabled },
+                        set: { toggledBiometricsUnlock($0) })
+        )
+        .foregroundColor(Color(.braveLabel))
+        .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      }
+    }
+    Section(
+      footer: Text(Strings.Wallet.networkFooter)
+        .foregroundColor(Color(.secondaryBraveLabel))
+    ) {
+      NavigationLink(destination: CustomNetworkListView(networkStore: networkStore)) {
+        Text(Strings.Wallet.settingsNetworkButtonTitle)
+          .foregroundColor(Color(.braveLabel))
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    Section(
+      header: Text(Strings.Wallet.web3PreferencesSectionTitle)
+        .foregroundColor(Color(.secondaryBraveLabel))
+    ) {
+      Group {
+        ForEach(Array(WalletConstants.supportedCoinTypes)) { coin in
+          NavigationLink(
+            destination:
+              DappsSettings(
+                coin: coin,
+                siteConnectionStore: settingsStore.manageSiteConnectionsStore(keyringStore: keyringStore)
+              )
+              .onDisappear {
+                settingsStore.closeManageSiteConnectionStore()
+              }
+          ) {
+            Text(coin.localizedTitle)
+              .foregroundColor(Color(.braveLabel))
+          }
+        }
+        Toggle(Strings.Wallet.web3PreferencesDisplayWeb3Notifications, isOn: $displayDappsNotifications.value)
+          .foregroundColor(Color(.braveLabel))
+          .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    Section(
+      footer: Text(Strings.Wallet.settingsResetTransactionFooter)
+        .foregroundColor(Color(.secondaryBraveLabel))
+    ) {
+      Button(action: { isShowingResetTransactionAlert = true }) {
+        Text(Strings.Wallet.settingsResetTransactionTitle)
+          .foregroundColor(Color(.braveBlurpleTint))
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    Section {
+      Button(action: { isShowingResetWalletAlert = true }) {
+        Text(Strings.Wallet.settingsResetButtonTitle)
+          .foregroundColor(.red)
+      } // iOS 15: .role(.destructive)
+    }
   }
   
   private func toggledBiometricsUnlock(_ enabled: Bool) {
@@ -215,7 +242,10 @@ struct WalletSettingsView_Previews: PreviewProvider {
       WalletSettingsView(
         settingsStore: .previewStore,
         networkStore: .previewStore,
-        keyringStore: .previewStore
+        keyringStore: .previewStore,
+        isShowingResetWalletAlert: .constant(false),
+        isShowingResetTransactionAlert: .constant(false),
+        isShowingBiometricsPasswordEntry: .constant(false)
       )
     }
   }

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -21,7 +21,7 @@ public struct Web3SettingsView: View {
   /// If we are showing the modal so the user can enter their password to enable unlock via biometrics.
   @State private var isShowingBiometricsPasswordEntry = false
   
-  private var domainOptions: [Preferences.Wallet.Web3DomainOption] = [.ask, .enable, .disable]
+  private var domainOptions: [Preferences.Wallet.Web3DomainOption] = Preferences.Wallet.Web3DomainOption.allCases
   
   public init(
     settingsStore: SettingsStore? = nil,
@@ -45,19 +45,21 @@ public struct Web3SettingsView: View {
           isShowingBiometricsPasswordEntry: $isShowingBiometricsPasswordEntry
         )
       }
-      Section(header: Text(Strings.Wallet.web3DomainOptionsHeader)) {
-        Picker(selection: $enableSNSDomainName.value) {
-          ForEach(Preferences.Wallet.Web3DomainOption.allCases) { option in
-            Text(option.name)
-              .foregroundColor(Color(.secondaryBraveLabel))
-              .tag(option)
+      if WalletFeatureFlags.SNSDomainResolverEnabled {
+        Section(header: Text(Strings.Wallet.web3DomainOptionsHeader)) {
+          Picker(selection: $enableSNSDomainName.value) {
+            ForEach(Preferences.Wallet.Web3DomainOption.allCases) { option in
+              Text(option.name)
+                .foregroundColor(Color(.secondaryBraveLabel))
+                .tag(option)
+            }
+          } label: {
+            Text(Strings.Wallet.web3DomainOptionsTitle)
+              .foregroundColor(Color(.braveLabel))
+              .padding(.vertical, 4)
           }
-        } label: {
-          Text(Strings.Wallet.web3DomainOptionsTitle)
-            .foregroundColor(Color(.braveLabel))
-            .padding(.vertical, 4)
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
     .listStyle(InsetGroupedListStyle())
@@ -105,7 +107,7 @@ public struct Web3SettingsView: View {
   }
 }
 
-struct WalletSettingsView: View {
+private struct WalletSettingsView: View {
   @ObservedObject var settingsStore: SettingsStore
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var keyringStore: KeyringStore

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -92,3 +92,7 @@ struct WalletConstants {
   /// The link for for users to learn more about sign transactions
   static let signTransactionRiskLink: URL = URL(string: "https://support.brave.com/hc/en-us/articles/4409513799693")!
 }
+
+struct WalletFeatureFlags {
+  static let SNSDomainResolverEnabled: Bool = false
+}

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -63,5 +63,31 @@ extension Preferences {
         return
       }
     }
+    
+    /// The option to enable IPFS
+    public static let enableIPFS = Option<Bool>(key: "web3.enable-ipfs", default: false)
+    
+    public enum Web3DomainOption: Int, Identifiable, CaseIterable {
+      case ask
+      case enable
+      case disable
+      
+      public var id: Int {
+        rawValue
+      }
+      
+      public var name: String {
+        switch self {
+        case .ask:
+          return Strings.Wallet.web3DomainOptionAsk
+        case .enable:
+          return Strings.Wallet.web3DomainOptionEnabled
+        case .disable:
+          return Strings.Wallet.web3DomainOptionDisabled
+        }
+      }
+    }
+    
+    public static let resolveSNSDomainNames = Option<Int>(key: "web3.resolve-sns-domain-names", default: Web3DomainOption.ask.rawValue)
   }
 }

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -64,9 +64,6 @@ extension Preferences {
       }
     }
     
-    /// The option to enable IPFS
-    public static let enableIPFS = Option<Bool>(key: "web3.enable-ipfs", default: false)
-    
     public enum Web3DomainOption: Int, Identifiable, CaseIterable {
       case ask
       case enable

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3478,7 +3478,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .module,
       value: "Disabled",
-      comment: "One of the options for Brave to handle Solana Name Service domain name. 'Enabled' means Brave will disable resolving SNS domain name."
+      comment: "One of the options for Brave to handle Solana Name Service domain name. 'Disabled' means Brave will disable resolving SNS domain name."
     )
     public static let web3DomainOptionsTitle = NSLocalizedString(
       "wallet.web3DomainOptionsTitle",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3464,27 +3464,27 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .module,
       value: "Ask",
-      comment: "One of the option for Brave to handle Solana Name Service domain name. 'Ask' means Brave will ask user first before enable or disable resolving SNS domain name."
+      comment: "One of the options for Brave to handle Solana Name Service domain name. 'Ask' means Brave will ask user first before enable or disable resolving SNS domain name."
     )
     public static let web3DomainOptionEnabled = NSLocalizedString(
       "wallet.web3DomainOptionEnabled",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Enabled",
-      comment: "One of the option for Brave to handle Solana Name Service domain name. 'Enabled' means Brave will enable resolving SNS domain name."
+      comment: "One of the options for Brave to handle Solana Name Service domain name. 'Enabled' means Brave will enable resolving SNS domain name."
     )
     public static let web3DomainOptionDisabled = NSLocalizedString(
       "wallet.web3DomainOptionDisabled",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Disabled",
-      comment: "One of the option for Brave to handle Solana Name Service domain name. 'Enabled' means Brave will disable resolving SNS domain name."
+      comment: "One of the options for Brave to handle Solana Name Service domain name. 'Enabled' means Brave will disable resolving SNS domain name."
     )
     public static let web3DomainOptionsTitle = NSLocalizedString(
       "wallet.web3DomainOptionsTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Resolve Solana Name Service (SNS) domain names",
+      value: "Resolve Solana Name Service (SNS) Domain Names",
       comment: "The title for the options to resolve Solana Name service domain names."
     )
     public static let web3DomainOptionsHeader = NSLocalizedString(

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3494,19 +3494,5 @@ extension Strings {
       value: "Web3 Domains",
       comment: "The header for the options to resolve Solana Name service domain names."
     )
-    public static let web3IPFSTitle = NSLocalizedString(
-      "wallet.web3IPFSTitle",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Enable IPFS",
-      comment: "The title for the options to enable IPFS."
-    )
-    public static let web3IPFSHeader = NSLocalizedString(
-      "wallet.web3IPFSTitle",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Enable IPFS",
-      comment: "The title for the options to enable IPFS."
-    )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -22,6 +22,13 @@ extension Strings {
       value: "Wallet",
       comment: "The title shown on the menu to access Brave Wallet"
     )
+    public static let web3 = NSLocalizedString(
+      "wallet.web3",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Web3",
+      comment: "The title shown on the settings menu to Web3 settings."
+    )
     public static let otherWalletActionsAccessibilityTitle = NSLocalizedString(
       "wallet.otherWalletActionsAccessibilityTitle",
       tableName: "BraveWallet",
@@ -712,7 +719,7 @@ extension Strings {
       "wallet.settingsResetButtonTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Reset",
+      value: "Reset Brave Wallet",
       comment: "The title of a button that will reset the wallet. As in to erase the users wallet from the device"
     )
     public static let settingsResetWalletAlertTitle = NSLocalizedString(
@@ -3451,6 +3458,55 @@ extension Strings {
       bundle: .module,
       value: "on %@",
       comment: "The description displayed below the name of the token being swapped from and to. Tthe '%@' will be the token's network name."
+    )
+    public static let web3DomainOptionAsk = NSLocalizedString(
+      "wallet.web3DomainOptionAsk",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Ask",
+      comment: "One of the option for Brave to handle Solana Name Service domain name. 'Ask' means Brave will ask user first before enable or disable resolving SNS domain name."
+    )
+    public static let web3DomainOptionEnabled = NSLocalizedString(
+      "wallet.web3DomainOptionEnabled",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enabled",
+      comment: "One of the option for Brave to handle Solana Name Service domain name. 'Enabled' means Brave will enable resolving SNS domain name."
+    )
+    public static let web3DomainOptionDisabled = NSLocalizedString(
+      "wallet.web3DomainOptionDisabled",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Disabled",
+      comment: "One of the option for Brave to handle Solana Name Service domain name. 'Enabled' means Brave will disable resolving SNS domain name."
+    )
+    public static let web3DomainOptionsTitle = NSLocalizedString(
+      "wallet.web3DomainOptionsTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Resolve Solana Name Service (SNS) domain names",
+      comment: "The title for the options to resolve Solana Name service domain names."
+    )
+    public static let web3DomainOptionsHeader = NSLocalizedString(
+      "wallet.web3DomainOptionsHeader",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Web3 Domains",
+      comment: "The header for the options to resolve Solana Name service domain names."
+    )
+    public static let web3IPFSTitle = NSLocalizedString(
+      "wallet.web3IPFSTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enable IPFS",
+      comment: "The title for the options to enable IPFS."
+    )
+    public static let web3IPFSHeader = NSLocalizedString(
+      "wallet.web3IPFSTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enable IPFS",
+      comment: "The title for the options to enable IPFS."
     )
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Rename Wallet settings as Web3 settings
Introduce a new toggle for SNS domain resolver. 
Wallet related settings options will be hidden if there is no wallet set up. However, SNS domain settings will be under Web3 regardless of wallet creation. 
Note: IPFS settings option is in [PR](https://github.com/brave/brave-ios/pull/6757).  

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6719

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
![Simulator Screen Shot - iPhone Xʀ - 2023-01-26 at 22 41 32](https://user-images.githubusercontent.com/1187676/215005032-56845515-5936-4407-bc2f-202464bc161e.png) | ![Simulator Screen Shot - iPhone Xʀ - 2023-01-26 at 22 41 30](https://user-images.githubusercontent.com/1187676/215005042-62eea2f6-668d-4bc3-92e3-17206ee4dfb6.png) | ![Simulator Screen Shot - iPhone Xʀ - 2023-01-26 at 22 41 05](https://user-images.githubusercontent.com/1187676/215005048-57a28b17-32ec-4f6e-9692-b9c133de7264.png)
--|--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
