### PR TITLE
[release] Fix #6676, #6638: Bump BraveCore to v1.47.189, Re-land The Wallet Standard

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -275,6 +275,20 @@ class UserScriptManager {
         }
       }
       
+      if let solanaProvider = tab.walletSolProvider {
+        solanaProvider.isSolanaKeyringCreated { isSolanaKeyringCreated in
+          guard isSolanaKeyringCreated, // don't inject if Solana keyring is not created.
+                let walletStandardScript = tab.walletSolProviderScripts[.walletStandard]
+          else { return }
+          let wkScript = WKUserScript.create(
+            source: walletStandardScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true,
+            in: SolanaProviderScriptHandler.scriptSandbox)
+          scriptController.addUserScript(wkScript)
+        }
+      }
+      
       // TODO: Refactor this and get rid of the `UserScriptType`
       // Inject Custom scripts
       for userScriptType in customScripts.sorted(by: { $0.order < $1.order }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.186/brave-core-ios-1.47.186.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.189/brave-core-ios-1.47.189.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.47.186",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.47.186/brave-core-ios-1.47.186.tgz",
-      "integrity": "sha512-oujFpXokM5qyMUFgECYV4rXfcf/k7y/ezBDzVmFCMgrPZ+ByQCvahlok4qUaiJsUC4x0TOuhpnvPgJ+s4Opz0Q==",
+      "version": "1.47.189",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.47.189/brave-core-ios-1.47.189.tgz",
+      "integrity": "sha512-3BNEaSNFiyDHiOV5IpNcKzHQ9LoEZtEq3f5YY1Xa7UR9Am4MHWD5yLHLNXQf2bjjFhu9cicNZzvjOZqo9wQkoA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.47.186/brave-core-ios-1.47.186.tgz",
-      "integrity": "sha512-oujFpXokM5qyMUFgECYV4rXfcf/k7y/ezBDzVmFCMgrPZ+ByQCvahlok4qUaiJsUC4x0TOuhpnvPgJ+s4Opz0Q=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.47.189/brave-core-ios-1.47.189.tgz",
+      "integrity": "sha512-3BNEaSNFiyDHiOV5IpNcKzHQ9LoEZtEq3f5YY1Xa7UR9Am4MHWD5yLHLNXQf2bjjFhu9cicNZzvjOZqo9wQkoA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.186/brave-core-ios-1.47.186.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.47.189/brave-core-ios-1.47.189.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Bump BraveCore version to v1.47.189 to re-land The Wallet Standard support if a Solana keyring is created

This pull request fixes #6676,
#6638

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
First verify The Wallet Standard is not injected if no Solana keyring is created:
1. Launch Brave with no wallet setup. 
2. Navigate to https://solana-labs.github.io/wallet-adapter/example/
3. Verify 'Brave Wallet' is not displayed in 'Select Wallet' drop down
    - This can be used as confirmation it is not injected (assuming it shows in step 5).
4. Setup or restore your wallet
5. Navigate to https://solana-labs.github.io/wallet-adapter/example/ in a new tab (new webview needed to inject wallet standard script)
6. Should be able to choose Brave Wallet.
7. After choosing it, click Airdrop and switch to dev net
8. Test `SignTransaction`, `SignMessage` and `SendTransaction`
9. <img width="473" alt="Screen Shot 2022-12-19 at 14 55 55" src="https://user-images.githubusercontent.com/11330831/208542623-80285f2d-43b8-4b80-bb5e-8ffa1087a2a3.png"> should be greyed out until we support versioned transaction.


## Screenshots:

https://user-images.githubusercontent.com/5314553/213776407-b4f78e2a-a190-4ce3-aeaa-cd28a1c9622e.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
