### PR TITLE
Ref #6863 - Bump Brave-Core to 1.48.154

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
+++ b/Client/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
@@ -74,10 +74,10 @@ extension TabTrayController: UITableViewDataSource, UITableViewDelegate {
     
     var deviceTypeImage: UIImage?
     
-    switch sectionDetails.deviceType {
+    switch sectionDetails.deviceFormFactor {
     case .phone, .tablet:
       deviceTypeImage = UIImage(braveSystemNamed: "brave.tablet.and.phone")
-    case .win, .linux, .mac:
+    case .desktop:
       deviceTypeImage = UIImage(braveSystemNamed: "brave.laptop")
     default:
       deviceTypeImage = UIImage(braveSystemNamed: "brave.laptop.and.phone")

--- a/Sources/BraveWallet/Extensions/SwapServiceExtension.swift
+++ b/Sources/BraveWallet/Extensions/SwapServiceExtension.swift
@@ -9,7 +9,7 @@ import BraveCore
 extension BraveWalletSwapService {
   /// Helper function to determine if we support swaping for a given chainId & coin type
   /// Swap may be supported by `swapService` prior to being supported on iOS.
-  func isiOSSwapSupported(chainId: String, coin: BraveWallet.CoinType) async -> Bool {
+  @MainActor func isiOSSwapSupported(chainId: String, coin: BraveWallet.CoinType) async -> Bool {
     if coin == .eth {
       return await isSwapSupported(chainId)
     } else {

--- a/Tests/ClientTests/SearchTests.swift
+++ b/Tests/ClientTests/SearchTests.swift
@@ -116,7 +116,7 @@ class SearchTests: XCTestCase {
     checkValidURL("https://www.Ǎ-.com", afterFixup: "https://www.xn----dta.com/")
     checkValidURL("http://www.googlé.com", afterFixup: "http://www.xn--googl-fsa.com/")
     checkValidURL("http://asĸ.com", afterFixup: "http://xn--as-3pa.com/")
-    checkValidURL("http://dießner.de", afterFixup: "http://diessner.de/")
+    checkValidURL("http://dießner.de", afterFixup: "http://xn--diener-dta.de/")
     checkValidURL("http://16კ.com", afterFixup: "http://xn--16-1ik.com/")
     checkValidURL("http://www.pаypal.com", afterFixup: "http://www.xn--pypal-4ve.com/")
     checkValidURL("http://аpple.com", afterFixup: "http://xn--pple-43d.com/")

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.48.141/brave-core-ios-1.48.141.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.48.154/brave-core-ios-1.48.154.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.48.141",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.48.141/brave-core-ios-1.48.141.tgz",
-      "integrity": "sha512-qqcvZecPs6fmZSZZCbYu41oh6PCAogIy4q4oLQ2hemoqkcyqJCXZNRGIICXTJOMMnied8/z8r+C4XaL91WUyhw==",
+      "version": "1.48.154",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.48.154/brave-core-ios-1.48.154.tgz",
+      "integrity": "sha512-9OJIDytrViHcWQ3+wJDLM4/NO8ezhIVN95cNv1buebtrfwzNxQkQUlnO7Tpn8pj62rnPMZGYI/Q04ENBze7SCA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.48.141/brave-core-ios-1.48.141.tgz",
-      "integrity": "sha512-qqcvZecPs6fmZSZZCbYu41oh6PCAogIy4q4oLQ2hemoqkcyqJCXZNRGIICXTJOMMnied8/z8r+C4XaL91WUyhw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.48.154/brave-core-ios-1.48.154.tgz",
+      "integrity": "sha512-9OJIDytrViHcWQ3+wJDLM4/NO8ezhIVN95cNv1buebtrfwzNxQkQUlnO7Tpn8pj62rnPMZGYI/Q04ENBze7SCA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.48.141/brave-core-ios-1.48.141.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.48.154/brave-core-ios-1.48.154.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
Update BraveCore to v1.48.154 and sync + crash change

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request reference #6863

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
