### PR TITLE
Fix #6638: Re-land The Wallet Standard

### DIFF
--- a/Client/Frontend/Browser/UserScriptManager.swift
+++ b/Client/Frontend/Browser/UserScriptManager.swift
@@ -275,6 +275,20 @@ class UserScriptManager {
         }
       }
       
+      if let solanaProvider = tab.walletSolProvider {
+        solanaProvider.isSolanaKeyringCreated { isSolanaKeyringCreated in
+          guard isSolanaKeyringCreated, // don't inject if Solana keyring is not created.
+                let walletStandardScript = tab.walletSolProviderScripts[.walletStandard]
+          else { return }
+          let wkScript = WKUserScript.create(
+            source: walletStandardScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true,
+            in: SolanaProviderScriptHandler.scriptSandbox)
+          scriptController.addUserScript(wkScript)
+        }
+      }
+      
       // TODO: Refactor this and get rid of the `UserScriptType`
       // Inject Custom scripts
       for userScriptType in customScripts.sorted(by: { $0.order < $1.order }) {


### PR DESCRIPTION
## Summary of Changes
- Cherry picked the commit from the [v1.47 release PR](https://github.com/brave/brave-ios/pull/6852) with the wallet standard script updates now available in v1.48 after latest [BraveCore bump](https://github.com/brave/brave-ios/pull/6864).

This pull request fixes #6638

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
First verify The Wallet Standard is not injected if no Solana keyring is created:
1. Launch Brave with no wallet setup. 
2. Navigate to https://solana-labs.github.io/wallet-adapter/example/
3. Verify 'Brave Wallet' is not displayed in 'Select Wallet' drop down
    - This can be used as confirmation it is not injected (assuming it shows in step 5).
4. Setup or restore your wallet
5. Navigate to https://solana-labs.github.io/wallet-adapter/example/ in a new tab (new webview needed to inject wallet standard script)
6. Should be able to choose Brave Wallet.
7. After choosing it, click Airdrop and switch to dev net
8. Test `SignTransaction`, `SignMessage` and `SendTransaction`
9. <img width="473" alt="Screen Shot 2022-12-19 at 14 55 55" src="https://user-images.githubusercontent.com/11330831/208542623-80285f2d-43b8-4b80-bb5e-8ffa1087a2a3.png"> should be greyed out until we support versioned transaction.


## Screenshots:

https://user-images.githubusercontent.com/5314553/213776407-b4f78e2a-a190-4ce3-aeaa-cd28a1c9622e.mp4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
