### PR TITLE
Fix #6841: Make sure we don't leak S3 private data and cleanup resources

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -339,7 +339,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       UrpLog.log("Failed to initialize user referral program")
     }
 
-    DebouncingResourceDownloader.shared.startLoading()
 #if canImport(BraveTalk)
     BraveTalkJitsiCoordinator.sendAppLifetimeEvent(
       .didFinishLaunching(options: launchOptions ?? [:])

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -220,11 +220,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   func sceneWillEnterForeground(_ scene: UIScene) {
-    // The reason we need to call this method here instead of `applicationDidBecomeActive`
-    // is that this method is only invoked whenever the application is entering the foreground where as
-    // `applicationDidBecomeActive` will get called whenever the Touch ID authentication overlay disappears.
-    DebouncingResourceDownloader.shared.startLoading()
-
     if let scene = scene as? UIWindowScene {
       scene.browserViewController?.windowProtection = windowProtection
     }

--- a/Sources/Brave/WebFilters/BraveS3Resource.swift
+++ b/Sources/Brave/WebFilters/BraveS3Resource.swift
@@ -1,0 +1,85 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+
+enum BraveS3Resource: Hashable, DownloadResourceInterface {
+  /// Rules for debouncing links
+  case debounceRules
+  /// Generic iOS only content blocking behaviours used for the iOS content blocker
+  case genericContentBlockingBehaviors
+  /// Cosmetic filter rules
+  case generalCosmeticFilters
+  /// Adblock rules for a filter list
+  /// iOS only content blocking behaviours used for the iOS content blocker for a given filter list
+  case filterListContentBlockingBehaviors(uuid: String, componentId: String)
+  
+  /// The name of the info plist key that contains the service key
+  private static let servicesKeyName = "SERVICES_KEY"
+  /// The name of the header value that contains the service key
+  private static let servicesKeyHeaderValue = "BraveServiceKey"
+  /// The base s3 environment url that hosts the debouncing (and other) files.
+  /// Cannot be used as-is and must be combined with a path
+  private static var baseResourceURL: URL = {
+    if AppConstants.buildChannel.isPublic {
+      return URL(string: "https://adblock-data.s3.brave.com")!
+    } else {
+      return URL(string: "https://adblock-data-staging.s3.bravesoftware.com")!
+    }
+  }()
+  
+  /// The folder name under which this data should be saved under
+  var cacheFolderName: String {
+    switch self {
+    case .debounceRules:
+      return "debounce-data"
+    case .filterListContentBlockingBehaviors(_, let componentId):
+      return ["filter-lists", componentId].joined(separator: "/")
+    case .genericContentBlockingBehaviors:
+      return "abp-data"
+    case .generalCosmeticFilters:
+      return "cmf-data"
+    }
+  }
+  
+  /// Get the file name that is stored on the device
+  var cacheFileName: String {
+    switch self {
+    case .debounceRules:
+      return "ios-debouce.json"
+    case .filterListContentBlockingBehaviors(let uuid, _):
+      return "\(uuid)-latest.json"
+    case .genericContentBlockingBehaviors:
+      return "latest.json"
+    case .generalCosmeticFilters:
+      return "ios-cosmetic-filters.dat"
+    }
+  }
+  
+  /// Get the external path for the given filter list and this resource type
+  var externalURL: URL {
+    switch self {
+    case .debounceRules:
+      return Self.baseResourceURL.appendingPathComponent("/ios/debounce.json")
+    case .filterListContentBlockingBehaviors(let uuid, _):
+      return Self.baseResourceURL.appendingPathComponent("/ios/\(uuid)-latest.json")
+    case .genericContentBlockingBehaviors:
+      return Self.baseResourceURL.appendingPathComponent("/ios/latest.json")
+    case .generalCosmeticFilters:
+      return Self.baseResourceURL.appendingPathComponent("/ios/ios-cosmetic-filters.dat")
+    }
+  }
+  
+  var headers: [String: String] {
+    var headers = [String: String]()
+    
+    if let servicesKeyValue = Bundle.main.getPlistString(for: Self.servicesKeyName) {
+      headers[Self.servicesKeyHeaderValue] = servicesKeyValue
+    }
+    
+    return headers
+  }
+}

--- a/Sources/Brave/WebFilters/FilterListCustomURLDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListCustomURLDownloader.swift
@@ -22,7 +22,7 @@ actor FilterListCustomURLDownloader: ObservableObject {
     }
     
     var headers: [String: String] {
-      return [:]
+      return ["Accept": "text/plain"]
     }
   }
   

--- a/Sources/Brave/WebFilters/FilterListInterface.swift
+++ b/Sources/Brave/WebFilters/FilterListInterface.swift
@@ -11,7 +11,7 @@ protocol FilterListInterface {
 }
 
 extension FilterListInterface {
-  @MainActor func makeResource(componentId: String) -> ResourceDownloader.Resource {
+  @MainActor func makeResource(componentId: String) -> BraveS3Resource {
     return .filterListContentBlockingBehaviors(
       uuid: uuid, componentId: componentId
     )

--- a/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
@@ -107,11 +107,11 @@ public class FilterListResourceDownloader: ObservableObject {
   /// Manager that handles updates to filter list settings in core data
   private let settingsManager: FilterListSettingsManager
   /// The resource downloader that downloads our resources
-  private let resourceDownloader: ResourceDownloader
+  private let resourceDownloader: ResourceDownloader<BraveS3Resource>
   /// The filter list subscription
   private var filterListSubscription: AnyCancellable?
   /// Fetch content blocking tasks per filter list
-  private var fetchTasks: [ResourceDownloader.Resource: Task<Void, Error>]
+  private var fetchTasks: [BraveS3Resource: Task<Void, Error>]
   /// Ad block service tasks per filter list UUID
   private var adBlockServiceTasks: [String: Task<Void, Error>]
   /// A marker that says if fetching has started
@@ -359,7 +359,7 @@ public class FilterListResourceDownloader: ObservableObject {
   
   /// Start fetching the resource for the given filter list
   private func startFetchingGenericContentBlockingBehaviors(for filterList: FilterList) {
-    let resource = ResourceDownloader.Resource.filterListContentBlockingBehaviors(
+    let resource = BraveS3Resource.filterListContentBlockingBehaviors(
       uuid: filterList.entry.uuid,
       componentId: filterList.entry.componentId
     )
@@ -388,12 +388,12 @@ public class FilterListResourceDownloader: ObservableObject {
   }
   
   /// Cancel all fetching tasks for the given resource
-  private func stopFetching(resource: ResourceDownloader.Resource) {
+  private func stopFetching(resource: BraveS3Resource) {
     fetchTasks[resource]?.cancel()
     fetchTasks.removeValue(forKey: resource)
   }
   
-  private func handle(downloadResult: ResourceDownloaderStream.DownloadResult, for filterList: FilterListInterface) async {
+  private func handle(downloadResult: ResourceDownloaderStream<BraveS3Resource>.DownloadResult, for filterList: FilterListInterface) async {
     do {
       if !downloadResult.isModified {
         // if the file is not modified first we need to see if we already have a cached value loaded

--- a/Sources/Brave/WebFilters/ResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/ResourceDownloader.swift
@@ -98,10 +98,12 @@ actor ResourceDownloader<Resource: DownloadResourceInterface>: Sendable {
         throw DownloadResultError.noData
       }
       
-      return .downloaded(networkResource, Date())
+      let date = try Self.creationDate(for: resource)
+      return .downloaded(networkResource, date ?? Date())
     } catch let error as NetworkManagerError {
       if error == .fileNotModified, let fileURL = Self.downloadedFileURL(for: resource) {
-        return .notModified(fileURL, Date())
+        let date = try Self.creationDate(for: resource)
+        return .notModified(fileURL, date ?? Date())
       } else {
         throw error
       }

--- a/Sources/Brave/WebFilters/ResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/ResourceDownloader.swift
@@ -217,7 +217,7 @@ actor ResourceDownloader<Resource: DownloadResourceInterface>: Sendable {
   }
   
   /// Removes all the data for the given `Resource`
-  private static func removeCacheFolder(for resource: Resource) throws {
+  static func removeCacheFolder(for resource: Resource) throws {
     guard
       let folderURL = self.createdCacheFolderURL(for: resource)
     else {

--- a/Sources/Brave/WebFilters/ResourceDownloaderStream.swift
+++ b/Sources/Brave/WebFilters/ResourceDownloaderStream.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// An endless sequence iterator for the given resource
-struct ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProtocol {
+struct ResourceDownloaderStream<Resource: DownloadResourceInterface>: Sendable, AsyncSequence, AsyncIteratorProtocol {
   /// An object representing the download
   struct DownloadResult: Equatable {
     let date: Date
@@ -15,12 +15,12 @@ struct ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProtocol 
   }
   
   typealias Element = Result<DownloadResult, Error>
-  private let resource: ResourceDownloader.Resource
-  private let resourceDownloader: ResourceDownloader
+  private let resource: Resource
+  private let resourceDownloader: ResourceDownloader<Resource>
   private let fetchInterval: TimeInterval
   private var firstLoad = true
   
-  init(resource: ResourceDownloader.Resource, resourceDownloader: ResourceDownloader, fetchInterval: TimeInterval) {
+  init(resource: Resource, resourceDownloader: ResourceDownloader<Resource>, fetchInterval: TimeInterval) {
     self.resource = resource
     self.resourceDownloader = resourceDownloader
     self.fetchInterval = fetchInterval
@@ -75,7 +75,7 @@ struct ResourceDownloaderStream: Sendable, AsyncSequence, AsyncIteratorProtocol 
     return self
   }
   
-  static func downloadResult(for resource: ResourceDownloader.Resource) throws -> DownloadResult? {
+  static func downloadResult(for resource: Resource) throws -> DownloadResult? {
     guard let fileURL = ResourceDownloader.downloadedFileURL(for: resource) else { return nil }
     guard let creationDate = try ResourceDownloader.creationDate(for: resource) else { return nil }
     return DownloadResult(date: creationDate, fileURL: fileURL, isModified: false)

--- a/Sources/Data/models/Domain.swift
+++ b/Sources/Data/models/Domain.swift
@@ -36,6 +36,10 @@ public final class Domain: NSManagedObject, CRUD {
     return URLComponents(string: url ?? "")
   }
   
+  @MainActor public var areAllSheildsOff: Bool {
+    return shield_allOff == 1
+  }
+  
   private static let containsEthereumPermissionsPredicate = NSPredicate(format: "wallet_permittedAccounts != nil && wallet_permittedAccounts != ''")
   private static let containsSolanaPermissionsPredicate = NSPredicate(format: "wallet_solanaPermittedAcccounts != nil && wallet_solanaPermittedAcccounts != ''")
   

--- a/Tests/ClientTests/Web Filters/NetworkManager+Tests.swift
+++ b/Tests/ClientTests/Web Filters/NetworkManager+Tests.swift
@@ -9,7 +9,7 @@ import BraveCore
 
 extension NetworkManager {
   private struct ResourceNotFoundError: Error {}
-  static func makeNetworkManager(for resources: [ResourceDownloader.Resource], statusCode: Int = 200, etag: String? = nil) -> NetworkManager {
+  static func makeNetworkManager(for resources: [BraveS3Resource], statusCode: Int = 200, etag: String? = nil) -> NetworkManager {
     let session = BaseMockNetworkSession { url in
       guard let resource = resources.first(where: { resource in
         url.absoluteURL == resource.externalURL
@@ -32,7 +32,7 @@ extension NetworkManager {
     return NetworkManager(session: session)
   }
   
-  static func mockData(for resource: ResourceDownloader.Resource) async throws -> Data {
+  static func mockData(for resource: BraveS3Resource) async throws -> Data {
     try await Task<Data, Error>.detached(priority: .background) {
       switch resource {
       case .debounceRules:

--- a/Tests/ClientTests/Web Filters/ResourceDownloaderStreamTests.swift
+++ b/Tests/ClientTests/Web Filters/ResourceDownloaderStreamTests.swift
@@ -11,8 +11,8 @@ class ResourceDownloaderStreamTests: XCTestCase {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resources")
     expectation.expectedFulfillmentCount = 2
-    let resource = ResourceDownloader.Resource.debounceRules
-    let downloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.debounceRules
+    let downloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 200
     ))
     
@@ -33,8 +33,8 @@ class ResourceDownloaderStreamTests: XCTestCase {
   func testSequenceWithErrorDownload() throws {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resources")
-    let resource = ResourceDownloader.Resource.debounceRules
-    let downloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.debounceRules
+    let downloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 404
     ))
     
@@ -52,7 +52,7 @@ class ResourceDownloaderStreamTests: XCTestCase {
     task.cancel()
   }
   
-  @MainActor private func ensureSuccessResult(result: Result<ResourceDownloaderStream.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
+  @MainActor private func ensureSuccessResult(result: Result<ResourceDownloaderStream<BraveS3Resource>.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
     // Then
     switch result {
     case .success:
@@ -62,7 +62,7 @@ class ResourceDownloaderStreamTests: XCTestCase {
     }
   }
   
-  @MainActor private func ensureErrorResult(result: Result<ResourceDownloaderStream.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
+  @MainActor private func ensureErrorResult(result: Result<ResourceDownloaderStream<BraveS3Resource>.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
     // Then
     switch result {
     case .success:

--- a/Tests/ClientTests/Web Filters/ResourceDownloaderTests.swift
+++ b/Tests/ClientTests/Web Filters/ResourceDownloaderTests.swift
@@ -10,11 +10,11 @@ class ResourceDownloaderTests: XCTestCase {
   func testSuccessfulResourceDownload() throws {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resources")
-    let resource = ResourceDownloader.Resource.debounceRules
-    let firstDownloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.debounceRules
+    let firstDownloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 200, etag: "123"
     ))
-    let secondDownloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let secondDownloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 304, etag: "123"
     ))
     
@@ -62,8 +62,8 @@ class ResourceDownloaderTests: XCTestCase {
   func testFailedResourceDownload() throws {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resource")
-    let resource = ResourceDownloader.Resource.debounceRules
-    let downloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.debounceRules
+    let downloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 404
     ))
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This PR cleans up a few things and ensures that we don't leak the S3 Private key to sites that are not S3.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6841 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Same as found here: https://github.com/brave/brave-ios/pull/6857

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
