### PR TITLE
Added .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brave/ios


### PR DESCRIPTION
To prevent any approval from being sufficient to merge to a release branch, I'd suggest adding a [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) with at least a catch-all pattern (already added), though ideally there should be more entries.

Please push more changes to this branch, as you see fit and merge when ready.