### PR TITLE
No Bug: Make web view auth challenge delegate method `nonisolated`

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -485,7 +485,7 @@ extension BrowserViewController: WKNavigationDelegate {
     return .allow
   }
 
-  public func webView(_ webView: WKWebView, respondTo challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+  nonisolated public func webView(_ webView: WKWebView, respondTo challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
 
     // If this is a certificate challenge, see if the certificate has previously been
     // accepted by the user.
@@ -527,12 +527,12 @@ extension BrowserViewController: WKNavigationDelegate {
                                       code: Int(errorCode),
                                       userInfo: ["_kCFStreamErrorCodeKey": Int(errorCode)])
         
-        let error = NSError(domain: kCFErrorDomainCFNetwork as String,
-                            code: Int(errorCode),
-                            userInfo: [NSURLErrorFailingURLErrorKey: webView.url as Any,
-                                       "NSErrorPeerCertificateChainKey": certificateChain,
-                                               NSUnderlyingErrorKey: underlyingError])
-          
+        let error = await NSError(domain: kCFErrorDomainCFNetwork as String,
+                                  code: Int(errorCode),
+                                  userInfo: [NSURLErrorFailingURLErrorKey: webView.url as Any,
+                                             "NSErrorPeerCertificateChainKey": certificateChain,
+                                                     NSUnderlyingErrorKey: underlyingError])
+        
         await MainActor.run {
           // Handle the error later in `didFailProvisionalNavigation`
           self.tab(for: webView)?.sslPinningError = error


### PR DESCRIPTION
This method was meant to run off main, but BVC is main actor isolated so it has to be `nonisolated`

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
