### PR TITLE
Fix #5636: Invalidate NTP layout when sections change to fix News layout

### DIFF
--- a/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Client/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -279,6 +279,7 @@ class NewTabPageViewController: UIViewController {
           UIView.performWithoutAnimation {
             self?.collectionView.reloadSections(IndexSet(integer: index))
           }
+          self?.collectionView.collectionViewLayout.invalidateLayout()
         }
       }
     }


### PR DESCRIPTION
On first launches default favourites are added async which cause FRCs to fire after NTP is already laid out, which trigger `sectionDidChange`. When this happens we were reloading the changed sections without animation but this would sometimes cause layout issues with sections not reloaded like Brave News.

## Summary of Changes

This pull request fixes #5636 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
