### PR TITLE
Fix #6873: Back button to NTP is not active/tappable

### DIFF
--- a/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
+++ b/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
@@ -77,22 +77,9 @@ public class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
   }
 
   public func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
-    guard var url = urlSchemeTask.request.url else {
+    guard let url = urlSchemeTask.request.url else {
       urlSchemeTask.didFailWithError(InternalPageSchemeHandlerError.badURL)
       return
-    }
-    
-    // Home URL contains "/" - "about" - "home"
-    // None of the path components should be removed
-    var isAboutHomeUrl = false
-    if let internalURL = InternalURL(url) {
-      isAboutHomeUrl = internalURL.isAboutHomeURL
-    }
-    
-    if !isAboutHomeUrl {
-      while url.pathComponents.count > 2 {
-        url = url.deletingLastPathComponent()
-      }
     }
       
     let path = url.path.starts(with: "/") ? String(url.path.dropFirst()) : url.path

--- a/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
+++ b/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
@@ -6,6 +6,7 @@
 import Foundation
 import WebKit
 import Shared
+import BraveShared
 
 enum InternalPageSchemeHandlerError: Error {
   case badURL
@@ -80,11 +81,20 @@ public class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
       urlSchemeTask.didFailWithError(InternalPageSchemeHandlerError.badURL)
       return
     }
-
-    while url.pathComponents.count > 2 {
-      url = url.deletingLastPathComponent()
+    
+    // Home URL contains "/" - "about" - "home"
+    // None of the path components should be removed
+    var isAboutHomeUrl = false
+    if let internalURL = InternalURL(url) {
+      isAboutHomeUrl = internalURL.isAboutHomeURL
     }
     
+    if !isAboutHomeUrl {
+      while url.pathComponents.count > 2 {
+        url = url.deletingLastPathComponent()
+      }
+    }
+      
     let path = url.path.starts(with: "/") ? String(url.path.dropFirst()) : url.path
 
     // For non-main doc URL, try load it as a resource


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Home URL path component should not be altered and home path component should not removed NTP

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6873

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Remove all Tabs
- Enable Brave News
- Click an article on Brave News
- Check back navigation is proper

## Screenshots:



https://user-images.githubusercontent.com/6643505/216686511-ea9bbef0-17cc-458e-8980-d12e49dbab74.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
