### PR TITLE
Fix #6860: Changing network auto closes the buy screen and shows pending tx

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -67,6 +67,15 @@ public class CryptoStore: ObservableObject {
     didSet {
       if pendingRequest == nil {
         isPresentingPendingRequest = false
+        return
+      }
+      // Verify a new request is available
+      guard pendingRequest != oldValue, pendingRequest != nil else { return }
+      // If we set these before the send or swap screens disappear for some reason it may crash
+      // within the SwiftUI runtime or fail to dismiss. Delaying it to give time for the
+      // animation to complete fixes it.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        self.isPresentingPendingRequest = true
       }
     }
   }
@@ -303,13 +312,7 @@ public class CryptoStore: ObservableObject {
         // Dismiss any buy send swap open to show the newPendingRequest
         self.buySendSwapDestination = nil
       }
-      // If we set these before the send or swap screens disappear for some reason it may crash
-      // within the SwiftUI runtime or fail to dismiss. Delaying it to give time for the
-      // animation to complete fixes it.
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-        self.pendingRequest = newPendingRequest
-        self.isPresentingPendingRequest = self.pendingRequest != nil
-      }
+      self.pendingRequest = newPendingRequest
     }
   }
 

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -63,7 +63,13 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
-  @Published private(set) var pendingRequest: PendingRequest?
+  @Published private(set) var pendingRequest: PendingRequest? {
+    didSet {
+      if pendingRequest == nil {
+        isPresentingPendingRequest = false
+      }
+    }
+  }
   
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -285,10 +291,6 @@ public class CryptoStore: ObservableObject {
       let pendingTransactions = await fetchPendingTransactions()
       var newPendingRequest: PendingRequest?
       if !pendingTransactions.isEmpty {
-        if self.buySendSwapDestination != nil {
-          // Dismiss any buy send swap open to show the unapproved transactions
-          self.buySendSwapDestination = nil
-        }
         newPendingRequest = .transactions(pendingTransactions)
       } else { // no pending transactions, check for webpage requests
         newPendingRequest = await fetchPendingWebpageRequest()
@@ -296,13 +298,16 @@ public class CryptoStore: ObservableObject {
       // Verify this new `newPendingRequest` isn't the same as the current
       // `pendingRequest` because re-assigning the same request could cause
       // present of a previously dismissed / ignored pending request (#6750).
-      if newPendingRequest?.id != self.pendingRequest?.id {
-        self.pendingRequest = newPendingRequest
+      guard newPendingRequest?.id != self.pendingRequest?.id else { return }
+      if self.buySendSwapDestination != nil && newPendingRequest != nil {
+        // Dismiss any buy send swap open to show the newPendingRequest
+        self.buySendSwapDestination = nil
       }
       // If we set these before the send or swap screens disappear for some reason it may crash
       // within the SwiftUI runtime or fail to dismiss. Delaying it to give time for the
       // animation to complete fixes it.
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        self.pendingRequest = newPendingRequest
         self.isPresentingPendingRequest = self.pendingRequest != nil
       }
     }
@@ -445,7 +450,12 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
 
 extension CryptoStore: BraveWalletJsonRpcServiceObserver {
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType) {
-    prepare()
+    // if user had just changed networks, there is a potential race condition
+    // blocking presenting pendingRequest here, as Network Selection might still be on screen
+    // by delaying here instead of at present we only delay after chain changes (#6750)
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      self?.prepare()
+    }
   }
   
   public func onAddEthereumChainRequestCompleted(_ chainId: String, error: String) {

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -483,11 +483,7 @@ struct WalletPanelView: View {
     )
     .onChange(of: cryptoStore.pendingRequest) { newValue in
       if newValue != nil {
-        // if user had just changed networks, there is a potential race condition
-        // blocking present here, as Network Selection might still be on screen
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-          presentWalletWithContext(.pendingRequests)
-        }
+        presentWalletWithContext(.pendingRequests)
       }
     }
     .onChange(of: tabDappStore.solConnectedAddresses) { newValue in


### PR DESCRIPTION
## Summary of Changes
- Fix changing network on buy screen with a pending transaction available will dismiss buy screen
- Fix related issue where buy/send/swap and pending transaction cannot be opened
- Improve fix of #6750 by only delaying present after network change.

This pull request fixes #6860

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

### Flow 1: #6860 (changing from Solana to Sepolia with pending tx on Goerli):
1. Have a pending transaction on Goerli Test Network (Goerli must be the last selected Ethereum network).
2. Have a Solana Mainnet selected (you may have to close wallet after selecting Solana Mainnet to 'reset' wallet state). This network should appear in buy/send/swap (not Goerli, which is selected for Eth coin type).
3. Re-open Wallet if not open
4. Dismiss the pending transaction on Goerli Test Network (don't reject / confirm).
5. Open Buy token view.
6. Change network from Solana to Sepolia Test Network (not the EVM you have pending tx on in step 1).
7. Verify buy token view is not dismissed

_note: Goerli can be replaced with any EVM network, Solana Mainnet can be replaced with any Solana network, and Seolia can be replaced with any EVM (must differ from other EVM network)._

### Flow 2: unable to present bug (changing from Solana to Goerli with pending tx on Goerli):
1. Have a pending transaction on Goerli Test Network
2. Have a Solana Mainnet selected (you may have to close wallet after selecting Solana Mainnet to 'reset' state)
3. Re-open Wallet if not open
4. Dismiss the pending transaction on Goerli Test Network (don't reject / confirm).
5. Open Buy token view.
6. Change network from Solana Mainnet to Goerli Test Network.
7. Verify buy/send/swap is not dismiss. Verify you can swipe to dismiss buy/send/swap and open the pending transaction and/or re-open buy/send/swap


### Verify no regression on #6750 
1. Create a Solana Sign Transaction
2. Swipe down to dismiss the transaction approval screen
3. Change network to Ethereum, transaction approval screen shows up
4. Dismiss the screen and change to Polygon
5. Verify Solana transaction approval screen does not present automatically


## Screenshots:

### Flow 1: Fix #6860 (changing from Solana to Sepolia with pending tx on Goerli):

https://user-images.githubusercontent.com/5314553/216720713-24389175-831a-4a2a-b391-9061824d652b.mov

_Video is demonstrating that buy/send/swap is not automatically closed when changing networks on buy/send/swap_

### Flow 2: Fix unable to present bug (changing from Solana to Goerli with pending tx on Goerli):

https://user-images.githubusercontent.com/5314553/216720702-5f32deb1-4f10-45a7-a9cf-49249ab1263b.mov

_Video is demonstrating that buy/send/swap is not automatically closed when changing networks on buy/send/swap, and also demonstrating you can re-open the pending transaction and buy/send/swap after_


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
