### PR TITLE
Fix #6883: Update Swap transactions to use async/await

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -407,7 +407,8 @@ struct SwapCryptoView: View {
           WalletLoadingButton(
             isLoading: swapTokensStore.isMakingTx,
             action: {
-              swapTokensStore.prepareSwap { success in
+              Task { @MainActor in
+                let success = await swapTokensStore.createSwapTransaction()
                 if success {
                   appRatingRequest?()
                 }

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -15,7 +15,7 @@ import BraveCore
 class MockJsonRpcService: BraveWalletJsonRpcService {
   
   private var chainId: String = BraveWallet.MainnetChainId
-  private var networks: [BraveWallet.NetworkInfo] = [.mockMainnet, .mockGoerli, .mockSepolia, .mockPolygon]
+  private var networks: [BraveWallet.NetworkInfo] = [.mockMainnet, .mockGoerli, .mockSepolia, .mockPolygon, .mockCelo]
   private var networkURL: URL?
   private var observers: NSHashTable<BraveWalletJsonRpcServiceObserver> = .weakObjects()
   
@@ -220,6 +220,19 @@ extension BraveWallet.NetworkInfo {
     decimals: 18,
     coin: .eth,
     isEip1559: true
+  )
+  static let mockCelo: BraveWallet.NetworkInfo = .init(
+    chainId: BraveWallet.CeloMainnetChainId,
+    chainName: "Celo Mainnet",
+    blockExplorerUrls: [""],
+    iconUrls: [],
+    activeRpcEndpointIndex: 0,
+    rpcEndpoints: [URL(string: "https://rpc.mockchain.com")!],
+    symbol: "CELO",
+    symbolName: "CELO",
+    decimals: 18,
+    coin: .eth,
+    isEip1559: false
   )
   static let mockSolana: BraveWallet.NetworkInfo = .init(
     chainId: BraveWallet.SolanaMainnet,


### PR DESCRIPTION
## Summary of Changes
- Refactor swap transaction store to use async/await for fetching price quote, creating swap transaction. 
- Logic should not be changed, just moved apis to async/await wrappers
    - `fetchPriceQuote` split into `fetchEthPriceQuote` for upcoming Solana Swap
- Resolved/fix all `SwapTokenStoreTests`. Previous tests were not verifying transaction was created, and not creating EIP 1559 transactions.
- Added fetch price quote tests when user edits sell amount and buy amount (from / to values)

This pull request fixes #6883

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create some swap transactions and verify pieces working as expected
    - Logic should not change, just moved apis to async/await wrappers
2. Verify ERC 20 approve transaction can still be created as expected
3. Verify errors display correctly, ex. insufficient liquidity for a token


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
