### PR TITLE
Fix #6886: Refactor Certificate Evaluation to Async-Await

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -552,11 +552,6 @@ extension BrowserViewController: WKNavigationDelegate {
         return (.performDefaultHandling, nil)
       }
       
-      // If this is a request to our local web server, use our private credentials.
-      if challenge.protectionSpace.host == "localhost" && challenge.protectionSpace.port == Int(WebServer.sharedInstance.server.port) {
-        return (.useCredential, WebServer.sharedInstance.credentials)
-      }
-      
       // The challenge may come from a background tab, so ensure it's the one visible.
       tabManager.selectTab(tab)
       


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Make certificate evaluation off the main thread, and async-await
- Get rid of duplicate evaluation code

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6886

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- In the ticket


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
