### PR TITLE
Fix #6712: unsupported provider is showing for some tokens.

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyProviderSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyProviderSelectionView.swift
@@ -5,6 +5,8 @@
 
 import SwiftUI
 import DesignSystem
+import BraveCore
+import OrderedCollections
 
 struct BuyProviderSelectionView: View {
   @ObservedObject var buyTokenStore: BuyTokenStore
@@ -15,6 +17,16 @@ struct BuyProviderSelectionView: View {
   @ScaledMetric private var iconSize = 40.0
   private let maxIconSize: CGFloat = 80.0
   
+  private var supportedProviders: OrderedSet<BraveWallet.OnRampProvider> {
+    return OrderedSet(buyTokenStore.orderedSupportedBuyOptions
+      .filter { provider in
+        guard let tokens = buyTokenStore.buyTokens[provider],
+              let selectedBuyToken = buyTokenStore.selectedBuyToken
+        else { return false }
+        return tokens.includes(selectedBuyToken)
+      })
+  }
+  
   var body: some View {
     List {
       Section(
@@ -22,7 +34,7 @@ struct BuyProviderSelectionView: View {
           title: Text(Strings.Wallet.providerSelectionSectionHeader)
         )
       ) {
-        ForEach(buyTokenStore.orderedSupportedBuyOptions) { provider in
+        ForEach(supportedProviders) { provider in
           VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 12) {
               Image(provider.iconName, bundle: .module)

--- a/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
@@ -90,6 +90,7 @@ public class BuyTokenStore: ObservableObject {
     self.prefilledToken = nil
   }
 
+  @MainActor
   func fetchBuyUrl(
     provider: BraveWallet.OnRampProvider,
     account: BraveWallet.AccountInfo
@@ -167,17 +168,6 @@ public class BuyTokenStore: ObservableObject {
     selectedNetwork = await rpcService.network(coin)
     await validatePrefilledToken(on: selectedNetwork) // selectedNetwork may change
     await fetchBuyTokens(network: selectedNetwork)
-  
-    // exclude all buy options that its available buy tokens list does not include the
-    // `selectedBuyToken`
-    orderedSupportedBuyOptions = OrderedSet(orderedSupportedBuyOptions
-      .filter { [weak self] provider in
-      guard let self = self,
-            let tokens = self.buyTokens[provider],
-            let selectedBuyToken = self.selectedBuyToken
-      else { return false }
-      return tokens.includes(selectedBuyToken)
-    })
     
     // check if current selected network supports buy
     if WalletConstants.supportedTestNetworkChainIds.contains(selectedNetwork.chainId) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
make sure after user selects a token to buy it shows the supported providers. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6712

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the ticket #6712


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
