### PR TITLE
Fix #6474: Only show reader mode bar for active tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -33,6 +33,7 @@ extension BrowserViewController: ReaderModeScriptHandlerDelegate {
   }
 
   func readerMode(_ readerMode: ReaderModeScriptHandler, didDisplayReaderizedContentForTab tab: Tab) {
+    if tabManager.selectedTab !== tab { return }
     showReaderModeBar(animated: true)
     tab.showContent(true)
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6474 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
