### PR TITLE
Fix #4998: Fix auto-play playing without obeying the preference

### DIFF
--- a/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Client/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -287,8 +287,13 @@ class PlaylistListViewController: UIViewController {
       lastPlayedItemTime = initialItem != nil ? initialItemOffset : Preferences.Playlist.lastPlayedItemTime.value
     }
     
-    autoPlayEnabled = initialItem != nil ? true : loadingState != .loading ? Preferences.Playlist.firstLoadAutoPlay.value : false
-    if !autoPlayEnabled {
+    // Auto-play is based on loading state and preference only
+    autoPlayEnabled = loadingState != .loading ? Preferences.Playlist.firstLoadAutoPlay.value : false
+    
+    // Should load determines if the player should load the item, but does not "auto-play" it!
+    let shouldLoad = initialItem != nil ? true : autoPlayEnabled
+    
+    if !shouldLoad {
       delegate?.showStaticImage(image: nil)
       delegate?.stopPlaying()
       return


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Loads the video but does NOT auto-play it, if the preference is off when playing from a web-page.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4998

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Turn Auto-Play OFF
2. Visit Youtube.com
3. Add a video to playlist
4. On the popup menu, tap on "Open Playlist" (OR the icon from the URL bar)
5. Confirm the video is NOT auto-played.

-- 
1. Turn Auto-Play ON
2. Visit Youtube.com
3. Add a video to playlist
4. On the popup menu, tap on "Open Playlist" (OR the icon from the URL bar)
5. Confirm the video is auto-played.

--
1. Turn Auto-Play OFF
2. Visit Youtube.com
3. Add a video to playlist
4. Close the tab OR visit a new page OR open a different tab
5. Confirm the video is NOT auto-played.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
