### PR TITLE
Fix #6888: Fixes __firefox__ overrides to not override themselves

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/__firefox__.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/__firefox__.js
@@ -164,12 +164,6 @@ if (!window.__firefox__) {
         
         // Override all of the functions in the overrides array
         let descriptor = $Object.getOwnPropertyDescriptor(value, name);
-        
-        // Do not secure our already secured property override
-        if (descriptor && descriptor.value === property) {
-          continue;
-        }
-        
         if (!descriptor || descriptor.configurable) {
           $Object.defineProperty(value, name, {
             enumerable: false,

--- a/Sources/Brave/Frontend/UserContent/UserScripts/__firefox__.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/__firefox__.js
@@ -136,7 +136,11 @@ if (!window.__firefox__) {
             // on custom objects we don't own. We secure it,
             // but not freeze it.
             // The object may want to change it or override it, etc.
-            secureToString(value[name]);
+            // Do not secure our already secured toString override,
+            // if the custom override happens to be the same
+            if (value[name] !== toString) {
+              secureToString(value[name]);
+            }
             continue;
           }
           
@@ -149,13 +153,23 @@ if (!window.__firefox__) {
             // on custom objects we don't own. We secure it,
             // but not freeze it.
             // The object may want to change it or override it, etc.
-            secureToString(value[name]);
+            // Do not secure our already secured toString override,
+            // if the custom override happens to be the same
+            if (descriptor.value !== toString) {
+              secureToString(descriptor.value);
+            }
             continue;
           }
         }
         
         // Override all of the functions in the overrides array
         let descriptor = $Object.getOwnPropertyDescriptor(value, name);
+        
+        // Do not secure our already secured property override
+        if (descriptor && descriptor.value === property) {
+          continue;
+        }
+        
         if (!descriptor || descriptor.configurable) {
           $Object.defineProperty(value, name, {
             enumerable: false,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes __firefox__ overrides to not override themselves
- Recursive overriding can cause issues on `twitch` which overrides `XMLHttpRequest.prototype.send` and tries to do its own security on top of our own.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6888

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit twitch.tv
2. Refresh the page
3. Twitch should NOT freeze! The page should refresh and load just fine.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
