### PR TITLE
Fix #6892: Display domain info for signature requests

### DIFF
--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -536,11 +536,16 @@ struct TransactionConfirmationView: View {
 /// so we have to fallback to UIKit for this
 struct StaticTextView: UIViewRepresentable {
   var text: String
+  var attributedText: NSAttributedString?
   var isMonospaced: Bool = true
 
   func makeUIView(context: Context) -> UITextView {
     let textView = UITextView()
-    textView.text = text
+    if let attributedText {
+      textView.attributedText = attributedText
+    } else {
+      textView.text = text
+    }
     textView.isEditable = false
     textView.backgroundColor = .tertiaryBraveGroupedBackground
     textView.font = {
@@ -556,7 +561,11 @@ struct StaticTextView: UIViewRepresentable {
     return textView
   }
   func updateUIView(_ uiView: UITextView, context: Context) {
-    uiView.text = text
+    if let attributedText {
+      uiView.attributedText = attributedText
+    } else {
+      uiView.text = text
+    }
   }
 }
 

--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -37,6 +37,7 @@ struct SignatureRequestView: View {
     keyringStore.allAccounts.first(where: { $0.address == currentRequest.address }) ?? keyringStore.selectedAccount
   }
   
+  /// Request display text, used as fallback.
   private var requestDisplayText: String {
     if currentRequest.domain.isEmpty {
       return requestMessage
@@ -48,6 +49,29 @@ struct SignatureRequestView: View {
     \(Strings.Wallet.signatureRequestMessageTitle):
     \(requestMessage)
     """
+  }
+  
+  /// Formatted request display text. Will display with bold `Domain` / `Message` headers if domain is non-empty.
+  private var requestDisplayAttributedText: NSAttributedString? {
+    let metrics = UIFontMetrics(forTextStyle: .body)
+    let desc = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
+    let regularFont = metrics.scaledFont(for: UIFont.systemFont(ofSize: desc.pointSize, weight: .regular))
+    if currentRequest.domain.isEmpty {
+      // if we don't show domain, we don't need the full title
+      return NSAttributedString(string: requestMessage, attributes: [.font: regularFont])
+    }
+    let boldFont = metrics.scaledFont(for: UIFont.systemFont(ofSize: desc.pointSize, weight: .bold))
+    
+    let domainTitle = NSAttributedString(string: "\(Strings.Wallet.signatureRequestDomainTitle):\n", attributes: [.font: boldFont])
+    let domain = NSAttributedString(string: requestDomain, attributes: [.font: regularFont])
+    let messageTitle = NSAttributedString(string: "\n\(Strings.Wallet.signatureRequestMessageTitle):\n", attributes: [.font: boldFont])
+    let message = NSAttributedString(string: requestMessage, attributes: [.font: regularFont])
+    
+    let attrString = NSMutableAttributedString(attributedString: domainTitle)
+    attrString.append(domain)
+    attrString.append(messageTitle)
+    attrString.append(message)
+    return attrString
   }
   
   private var requestDomain: String {
@@ -185,7 +209,7 @@ struct SignatureRequestView: View {
           }
         }
         .padding(.vertical, 32)
-        StaticTextView(text: requestDisplayText, isMonospaced: false)
+        StaticTextView(text: requestDisplayText, attributedText: requestDisplayAttributedText, isMonospaced: false)
           .frame(maxWidth: .infinity)
           .frame(height: staticTextViewHeight)
           .background(Color(.tertiaryBraveGroupedBackground))

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2402,6 +2402,20 @@ extension Strings {
       value: "Your signature is being requested",
       comment: "A subtitle of the view shown over a dapps website that requests the user sign a message."
     )
+    public static let signatureRequestDomainTitle = NSLocalizedString(
+      "wallet.signatureRequestDomainTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Domain",
+      comment: "A title displayed inside the text view in Signature Request View above the request's domain information."
+    )
+    public static let signatureRequestMessageTitle = NSLocalizedString(
+      "wallet.signatureRequestMessageTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Message",
+      comment: "A title displayed inside the text view in Signature Request View above the request's message."
+    )
     public static let sign = NSLocalizedString(
       "wallet.sign",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Display domain info for Signature Requests when domain is non-empty (EIP712).
- Add attributed string support to `StaticTextView`, display `Domain` / `Message` headers in bold.

This pull request fixes #6892

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Follow 'how to test' section in https://bravesoftware.slack.com/archives/C023VS4HJ6Q/p1675122385242399?thread_ts=1675122269.673589&cid=C023VS4HJ6Q. Verify 'Domain' info is shown.

If you have ability to build w/ Xcode: verify no regressions with https://github.com/brave/brave-ios/pull/6300. Code reviewers, please +1 in approval if you tested this.

## Screenshots:

https://user-images.githubusercontent.com/5314553/217655758-1f0aa402-3249-45bd-8891-25cba4e37f67.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
