### PR TITLE
No bug: Fix regression dismissing buy/send/swap

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -20,7 +20,7 @@ enum PendingRequest: Equatable {
 extension PendingRequest: Identifiable {
   var id: String {
     switch self {
-    case .transactions: return "transactions"
+    case let .transactions(transactions): return "transactions-\(transactions.map(\.id))"
     case let .addChain(request): return "addChain-\(request.networkInfo.chainId)"
     case let .switchChain(chainRequest): return "switchChain-\(chainRequest.chainId)"
     case let .addSuggestedToken(tokenRequest): return "addSuggestedToken-\(tokenRequest.token.id)"


### PR DESCRIPTION
## Summary of Changes
- Regressed with changes in https://github.com/brave/brave-ios/pull/6878 (new bug to v1.48).
- Because all transactions used an id of `transactions`, regardless of the number of transactions, we were failing to detect a new transaction being created when previously dismissing a pending transaction.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create a send transaction
2. Swipe down to dismiss the transaction confirmation without cancelling / confirming it
3. Create a second send transaction
4. Verify send view is dismissed when tapping 'send' and both transactions are now shown in transaction confirmation


## Screenshots:

Bug:

https://user-images.githubusercontent.com/5314553/217852173-92e3f1a9-6b2d-4dfc-a0bc-1c7a9c90d212.mov

Fixed:

https://user-images.githubusercontent.com/5314553/217852218-c2b3e2d3-8968-4af5-a13f-ec4ff57f5cb3.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
