### PR TITLE
Fix #6626: Add Help Center link in Wallet context menus

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -19,6 +19,8 @@ struct CryptoPagesView: View {
   @State private var isShowingSearch: Bool = false
   @State private var fetchedPendingRequestsThisSession: Bool = false
 
+  @Environment(\.openWalletURLAction) private var openWalletURL
+
   var body: some View {
     _CryptoPagesView(
       keyringStore: keyringStore,
@@ -99,6 +101,9 @@ struct CryptoPagesView: View {
           Button(action: { isShowingSettings = true }) {
             Label(Strings.Wallet.settings, braveSystemImage: "brave.gear")
               .imageScale(.medium)  // Menu inside nav bar implicitly gets large
+          }
+          Button(action: { openWalletURL?(WalletConstants.braveWalletSupportURL) }) {
+            Label(Strings.Wallet.helpCenter, braveSystemImage: "brave.info.circle")
           }
         } label: {
           Label(Strings.Wallet.otherWalletActionsAccessibilityTitle, systemImage: "ellipsis.circle")

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -25,6 +25,7 @@ public struct WalletPanelContainerView: View {
   var origin: URLOrigin
   var presentWalletWithContext: ((PresentingContext) -> Void)?
   var presentBuySendSwap: (() -> Void)?
+  var openWalletURLAction: ((URL) -> Void)?
   /// An invisible `UIView` background lives in SwiftUI for UIKit API to reference later
   var buySendSwapBackground: InvisibleUIView = .init()
   
@@ -151,6 +152,11 @@ public struct WalletPanelContainerView: View {
         presentWalletWithContext?(.panelUnlockOrSetup)
       }
     }
+    .environment(
+      \.openWalletURLAction,
+      .init(action: { [openWalletURLAction] url in
+        openWalletURLAction?(url)
+      }))
   }
 }
 
@@ -166,6 +172,7 @@ struct WalletPanelView: View {
   var presentBuySendSwap: () -> Void
   var buySendSwapBackground: InvisibleUIView
   
+  @Environment(\.openWalletURLAction) private var openWalletURL
   @Environment(\.pixelLength) private var pixelLength
   @Environment(\.sizeCategory) private var sizeCategory
   @ScaledMetric private var blockieSize = 54
@@ -324,6 +331,9 @@ struct WalletPanelView: View {
       Divider()
       Button(action: { presentWalletWithContext(.settings) }) {
         Label(Strings.Wallet.settings, braveSystemImage: "brave.gear")
+      }
+      Button(action: { openWalletURL?(WalletConstants.braveWalletSupportURL) }) {
+        Label(Strings.Wallet.helpCenter, braveSystemImage: "brave.info.circle")
       }
     } label: {
       Image(systemName: "ellipsis")

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -18,6 +18,9 @@ struct WalletConstants {
   
   /// The origin used for transactions/requests from Brave Wallet.
   static let braveWalletOrigin: URLOrigin = .init(url: URL(string: "chrome://wallet")!)
+  
+  /// The url to Brave Help Center for Wallet.
+  static let braveWalletSupportURL = URL(string: "https://support.brave.com/hc/en-us/categories/360001059151-Brave-Wallet")!
 
   /// The currently supported test networks.
   static let supportedTestNetworkChainIds = [

--- a/Sources/BraveWallet/WalletPanelHostingController.swift
+++ b/Sources/BraveWallet/WalletPanelHostingController.swift
@@ -35,6 +35,11 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
       guard let self = self else { return }
       self.delegate?.walletPanel(self, presentWalletWithContext: context, walletStore: walletStore)
     }
+    rootView.openWalletURLAction = { [unowned self] url in
+      (presentingViewController ?? self).dismiss(animated: true) {
+        self.delegate?.openWalletURL(url)
+      }
+    }
     rootView.presentBuySendSwap = { [weak self] in
       guard let self = self, let store = walletStore.cryptoStore else { return }
       let controller = FixedHeightHostingPanModalController(

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1674,6 +1674,13 @@ extension Strings {
       value: "Settings",
       comment: "The title of the settings option inside the menu when user clicks the three dots button beside assets search button."
     )
+    public static let helpCenter = NSLocalizedString(
+      "wallet.helpCenter",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Help Center",
+      comment: "The title of the Help Center option inside the menu when user clicks the three dots button beside assets search button or on wallet panel."
+    )
     public static let swapDexAggrigatorNote = NSLocalizedString(
       "wallet.swapDexAggrigatorNote",
       tableName: "BraveWallet",

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/brave.info.circle.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/brave.info.circle.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "brave.info.circle.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/brave.info.circle.symbolset/brave.info.circle.svg
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/brave.info.circle.symbolset/brave.info.circle.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Apple Native CoreSVG 175.5-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="3300" height="2200">
+ <!--glyph: "", point size: 100.0, font version: "18.0d12e2", template writer version: "101"-->
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 856.422 322)">Thin</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1153.13 322)">Light</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1746.56 322)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2043.27 322)">Semibold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2339.98 322)">Bold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2636.69 322)">Heavy</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <g transform="matrix(1 0 0 1 263 1933)">
+   <path d="M9.24805 0.830078C13.5547 0.830078 17.1387-2.74414 17.1387-7.05078C17.1387-11.3574 13.5449-14.9316 9.23828-14.9316C4.94141-14.9316 1.36719-11.3574 1.36719-7.05078C1.36719-2.74414 4.95117 0.830078 9.24805 0.830078ZM9.24805-0.654297C5.70312-0.654297 2.87109-3.49609 2.87109-7.05078C2.87109-10.6055 5.69336-13.4473 9.23828-13.4473C12.793-13.4473 15.6445-10.6055 15.6445-7.05078C15.6445-3.49609 12.8027-0.654297 9.24805-0.654297ZM5.6543-7.05078C5.6543-6.62109 5.95703-6.32812 6.40625-6.32812L8.50586-6.32812L8.50586-4.20898C8.50586-3.76953 8.79883-3.4668 9.22852-3.4668C9.67773-3.4668 9.9707-3.76953 9.9707-4.20898L9.9707-6.32812L12.0898-6.32812C12.5293-6.32812 12.832-6.62109 12.832-7.05078C12.832-7.49023 12.5293-7.79297 12.0898-7.79297L9.9707-7.79297L9.9707-9.90234C9.9707-10.3516 9.67773-10.6543 9.22852-10.6543C8.79883-10.6543 8.50586-10.3516 8.50586-9.90234L8.50586-7.79297L6.40625-7.79297C5.95703-7.79297 5.6543-7.49023 5.6543-7.05078Z"/>
+  </g>
+  <g transform="matrix(1 0 0 1 281.867 1933)">
+   <path d="M11.709 2.91016C17.1582 2.91016 21.6699-1.61133 21.6699-7.05078C21.6699-12.5 17.1484-17.0117 11.6992-17.0117C6.25977-17.0117 1.74805-12.5 1.74805-7.05078C1.74805-1.61133 6.26953 2.91016 11.709 2.91016ZM11.709 1.25C7.09961 1.25 3.41797-2.44141 3.41797-7.05078C3.41797-11.6602 7.08984-15.3516 11.6992-15.3516C16.3086-15.3516 20.0098-11.6602 20.0098-7.05078C20.0098-2.44141 16.3184 1.25 11.709 1.25ZM7.17773-7.05078C7.17773-6.57227 7.50977-6.25 8.00781-6.25L10.8789-6.25L10.8789-3.36914C10.8789-2.88086 11.2109-2.53906 11.6895-2.53906C12.1777-2.53906 12.5195-2.87109 12.5195-3.36914L12.5195-6.25L15.4004-6.25C15.8887-6.25 16.2305-6.57227 16.2305-7.05078C16.2305-7.53906 15.8887-7.88086 15.4004-7.88086L12.5195-7.88086L12.5195-10.752C12.5195-11.25 12.1777-11.5918 11.6895-11.5918C11.2109-11.5918 10.8789-11.25 10.8789-10.752L10.8789-7.88086L8.00781-7.88086C7.50977-7.88086 7.17773-7.53906 7.17773-7.05078Z"/>
+  </g>
+  <g transform="matrix(1 0 0 1 305.646 1933)">
+   <path d="M14.9707 5.66406C21.9336 5.66406 27.6953-0.0976562 27.6953-7.05078C27.6953-14.0137 21.9238-19.7754 14.9609-19.7754C8.00781-19.7754 2.25586-14.0137 2.25586-7.05078C2.25586-0.0976562 8.01758 5.66406 14.9707 5.66406ZM14.9707 3.84766C8.93555 3.84766 4.08203-1.01562 4.08203-7.05078C4.08203-13.0957 8.92578-17.9492 14.9609-17.9492C21.0059-17.9492 25.8691-13.0957 25.8691-7.05078C25.8691-1.01562 21.0156 3.84766 14.9707 3.84766ZM9.19922-7.05078C9.19922-6.5332 9.57031-6.17188 10.1172-6.17188L14.0625-6.17188L14.0625-2.2168C14.0625-1.67969 14.4336-1.29883 14.9512-1.29883C15.4883-1.29883 15.8594-1.66992 15.8594-2.2168L15.8594-6.17188L19.8145-6.17188C20.3516-6.17188 20.7324-6.5332 20.7324-7.05078C20.7324-7.59766 20.3613-7.96875 19.8145-7.96875L15.8594-7.96875L15.8594-11.9141C15.8594-12.4609 15.4883-12.8418 14.9512-12.8418C14.4336-12.8418 14.0625-12.4609 14.0625-11.9141L14.0625-7.96875L10.1172-7.96875C9.57031-7.96875 9.19922-7.59766 9.19922-7.05078Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 1953)">Design Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1971)">Symbols are supported in up to nine weights and three scales.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1989)">For optimal layout with text and other symbols, vertically align</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 2007)">symbols with the adjacent text.</text>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="776" x2="776" y1="1919" y2="1933"/>
+  <g transform="matrix(1 0 0 1 776 1933)">
+   <path d="M3.31055 0.15625C3.82812 0.15625 4.08203-0.0390625 4.26758-0.585938L5.52734-4.0332L11.2891-4.0332L12.5488-0.585938C12.7344-0.0390625 12.9883 0.15625 13.4961 0.15625C14.0137 0.15625 14.3457-0.15625 14.3457-0.644531C14.3457-0.810547 14.3164-0.966797 14.2383-1.17188L9.6582-13.3691C9.43359-13.9648 9.0332-14.2676 8.4082-14.2676C7.80273-14.2676 7.39258-13.9746 7.17773-13.3789L2.59766-1.16211C2.51953-0.957031 2.49023-0.800781 2.49023-0.634766C2.49023-0.146484 2.80273 0.15625 3.31055 0.15625ZM6.00586-5.51758L8.37891-12.0898L8.42773-12.0898L10.8008-5.51758Z"/>
+  </g>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="793.197" x2="793.197" y1="1919" y2="1933"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 776 1953)">Margins</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1971)">Leading and trailing margins on the left and right side of each symbol</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1989)">can be adjusted by modifying the x-location of the margin guidelines.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2007)">Modifications are automatically applied proportionally to all</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2025)">scales and weights.</text>
+  <g transform="matrix(1 0 0 1 1289 1933)">
+   <path d="M2.8418 1.86523L4.54102 3.57422C5.40039 4.44336 6.38672 4.38477 7.31445 3.35938L18.0078-8.42773L17.041-9.4043L6.42578 2.27539C6.07422 2.67578 5.74219 2.77344 5.27344 2.30469L4.10156 1.14258C3.63281 0.683594 3.74023 0.341797 4.14062-0.0195312L15.6152-10.8203L14.6387-11.7871L3.04688-0.898438C2.06055 0.0195312 1.98242 0.996094 2.8418 1.86523ZM9.25781-16.3281C8.83789-15.918 8.80859-15.3418 9.04297-14.9512C9.27734-14.5898 9.73633-14.3555 10.3809-14.5215C11.8457-14.8633 13.3691-14.9219 14.7949-13.9844L14.209-12.5293C13.8672-11.6992 14.043-11.1133 14.5801-10.5664L16.875-8.25195C17.3633-7.76367 17.7734-7.74414 18.3398-7.8418L19.4043-8.03711L20.0684-7.36328L20.0293-6.80664C19.9902-6.30859 20.1172-5.92773 20.6055-5.44922L21.3672-4.70703C21.8457-4.22852 22.4609-4.19922 22.9297-4.66797L25.8398-7.58789C26.3086-8.05664 26.2891-8.65234 25.8105-9.13086L25.0391-9.89258C24.5605-10.3711 24.1895-10.5273 23.7109-10.4883L23.1348-10.4395L22.4902-11.0742L22.7344-12.1973C22.8613-12.7637 22.7051-13.2031 22.1191-13.7891L19.9219-15.9766C16.582-19.2969 12.1484-19.2188 9.25781-16.3281ZM10.752-15.957C13.1836-17.7344 16.4746-17.4316 18.7012-15.2051L21.1328-12.793C21.3672-12.5586 21.4062-12.373 21.3379-12.0312L21.0156-10.5469L22.5195-9.0625L23.5059-9.12109C23.7598-9.13086 23.8379-9.11133 24.0332-8.91602L24.6094-8.33984L22.168-5.89844L21.5918-6.47461C21.3965-6.66992 21.3672-6.74805 21.377-7.01172L21.4453-7.98828L19.9512-9.47266L18.4277-9.21875C18.1055-9.15039 17.959-9.17969 17.7148-9.41406L15.7129-11.416C15.459-11.6504 15.4297-11.8164 15.5859-12.1875L16.4648-14.2773C14.9023-15.7324 12.8711-16.3574 10.8398-15.7617C10.6836-15.7227 10.625-15.8496 10.752-15.957Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 1289 1953)">Exporting</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1971)">Symbols should be outlined when exporting to ensure the</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1989)">design is preserved when submitting to Xcode.</text>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.2.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 12 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from brave.info.circle</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="left-margin" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1389.32" x2="1389.32" y1="1030.79" y2="1150.12"/>
+  <line id="right-margin" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1510.37" x2="1510.37" y1="1030.79" y2="1150.12"/>
+ </g>
+ <g id="Symbols">
+  <g id="Regular-L" transform="matrix(1 0 0 1 1374.74 1556)">
+   <path d="M75.5121-99.9244C111.18-99.9244 140.095-71.0095 140.095-35.3411C140.095 0.326984 111.18 29.2422 75.5121 29.2422C39.8437 29.2422 10.9288 0.326984 10.9288-35.3411C10.9288-71.0095 39.8437-99.9244 75.5121-99.9244ZM75.5121-89.9885C45.3312-89.9885 20.8647-65.5221 20.8647-35.3411C20.8647-5.16002 45.3312 19.3061 75.5121 19.3061C105.693 19.3061 130.159-5.16002 130.159-35.3411C130.159-65.5221 105.693-89.9885 75.5121-89.9885ZM75.5121-45.2772C78.2556-45.2772 80.4799-43.053 80.4799-40.3088L80.4799-9.01112C80.4799-6.26697 78.2556-4.04272 75.5121-4.04272C72.7686-4.04272 70.5444-6.26697 70.5444-9.01112L70.5444-40.3088C70.5444-43.053 72.7686-45.2772 75.5121-45.2772ZM75.5121-67.6328C79.4356-67.6328 82.6163-64.4521 82.6163-60.5286C82.6163-56.605 79.4356-53.4244 75.5121-53.4244C71.5887-53.4244 68.408-56.605 68.408-60.5286C68.408-64.4521 71.5887-67.6328 75.5121-67.6328Z"/>
+  </g>
+  <g id="Regular-M" transform="matrix(1 0 0 1 1389.32 1126)">
+   <path d="M60.9288-85.6582C88.5428-85.6582 110.929-63.2725 110.929-35.6582C110.929-8.0442 88.5428 14.3418 60.9288 14.3418C33.3146 14.3418 10.9288-8.0442 10.9288-35.6582C10.9288-63.2725 33.3146-85.6582 60.9288-85.6582ZM60.9288-77.9659C37.5629-77.9659 18.6211-59.0241 18.6211-35.6582C18.6211-12.2922 37.5629 6.6493 60.9288 6.6493C84.2948 6.6493 103.236-12.2922 103.236-35.6582C103.236-59.0241 84.2948-77.9659 60.9288-77.9659ZM60.9288-43.3507C63.0528-43.3507 64.7748-41.6287 64.7748-39.5042L64.7748-15.2737C64.7748-13.1492 63.0528-11.4272 60.9288-11.4272C58.8048-11.4272 57.0828-13.1492 57.0828-15.2737L57.0828-39.5042C57.0828-41.6287 58.8048-43.3507 60.9288-43.3507ZM60.9288-60.6582C63.9663-60.6582 66.4288-58.1958 66.4288-55.1582C66.4288-52.1206 63.9663-49.6582 60.9288-49.6582C57.8913-49.6582 55.4288-52.1206 55.4288-55.1582C55.4288-58.1958 57.8913-60.6582 60.9288-60.6582Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1400.15 696)">
+   <path d="M50.0955-74.1667C71.7264-74.1667 89.2621-56.6312 89.2621-35C89.2621-13.369 71.7264 4.16667 50.0955 4.16667C28.4643 4.16667 10.9288-13.369 10.9288-35C10.9288-56.6312 28.4643-74.1667 50.0955-74.1667ZM50.0955-68.141C31.7922-68.141 16.9544-53.3033 16.9544-35C16.9544-16.6966 31.7922-1.85913 50.0955-1.85913C68.3988-1.85913 83.2363-16.6966 83.2363-35C83.2363-53.3033 68.3988-68.141 50.0955-68.141ZM50.0955-41.0258C51.7593-41.0258 53.1082-39.6769 53.1082-38.0127L53.1082-19.0321C53.1082-17.368 51.7593-16.0191 50.0955-16.0191C48.4317-16.0191 47.0828-17.368 47.0828-19.0321L47.0828-38.0127C47.0828-39.6769 48.4317-41.0258 50.0955-41.0258ZM50.0955-54.5833C52.4748-54.5833 54.4038-52.6544 54.4038-50.275C54.4038-47.8955 52.4748-45.9667 50.0955-45.9667C47.7161-45.9667 45.7871-47.8955 45.7871-50.275C45.7871-52.6544 47.7161-54.5833 50.0955-54.5833Z"/>
+  </g>
+ </g>
+</svg>


### PR DESCRIPTION
## Summary of Changes
- Adds a 'Help Center' button to the wallet panel and main wallet `...` context menu.
- Add `openWalletURLAction` to `WalletPanelView`

This pull request fixes #6626

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open main wallet and unlock
2. Tap `...` button in top right
3. Verify 'Help Center' row is displayed
4. Tap the row/button, verify help center for wallet is opened
5. Visit a Dapp site
6. Tap wallet icon in URL bar
7. Tap `...` button in top right
8. Verify 'Help Center' row is displayed
9. Tap the row/button, verify help center for wallet is opened

## Screenshots:

![Help Center wallet](https://user-images.githubusercontent.com/5314553/217916046-b6dec573-74b6-49ed-a938-88a0062eb0a9.png) | ![Help Center panel](https://user-images.githubusercontent.com/5314553/217916054-7c1f5770-d017-4ce4-84ca-efb22a74b424.png)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
