### PR TITLE
Fix #6896: Solana QR Code scanning prefix

### DIFF
--- a/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
+++ b/Sources/BraveWallet/Crypto/Scanner/AddressQRCodeScannerView.swift
@@ -250,6 +250,8 @@ extension AddressQRCodeScannerViewController: AVCaptureMetadataOutputObjectsDele
       } else {
         isErrorPresented = true
       }
+    case .sol:
+      foundAddress(stringValue.strippedSOLAddress)
     default:
       foundAddress(stringValue)
     }

--- a/Sources/BraveWallet/Crypto/Stores/Address.swift
+++ b/Sources/BraveWallet/Crypto/Stores/Address.swift
@@ -57,6 +57,15 @@ extension String {
     return self
   }
   
+  /// Strip prefix if it exists, ex. 'solana:'
+  var strippedSOLAddress: String {
+    let prefixesToRemove = ["solana:", "Solana:"]
+    for prefix in prefixesToRemove where self.hasPrefix(prefix) {
+      return String(self.dropFirst(prefix.count))
+    }
+    return self
+  }
+
   /// Insert zero-width space every character inside this string
   var zwspOutput: String {
     return map {

--- a/Tests/BraveWalletTests/AddressTests.swift
+++ b/Tests/BraveWalletTests/AddressTests.swift
@@ -64,6 +64,21 @@ class AddressTests: XCTestCase {
     XCTAssertEqual(addressFalseWrongPrefix, addressFalseWrongPrefixStripped)
   }
   
+  func testStrippedSOLAddress() {
+    let address = "DpF8LrdYWH9jCsmjQfKz3cvWvRWQPS3xrdVLm8qUs2ZL"
+    XCTAssertEqual(address, address.strippedETHAddress)
+    
+    let addressSolanaPrefix = "solana:\(address)"
+    let addressSolanaPrefixStripped = addressSolanaPrefix.strippedSOLAddress
+    XCTAssertNotEqual(addressSolanaPrefix, addressSolanaPrefixStripped)
+    XCTAssertEqual(addressSolanaPrefixStripped, address)
+    
+    let addressSolanaPrefix2 = "Solana:\(address)"
+    let addressSolanaPrefix2Stripped = addressSolanaPrefix2.strippedSOLAddress
+    XCTAssertNotEqual(addressSolanaPrefix2, addressSolanaPrefix2Stripped)
+    XCTAssertEqual(addressSolanaPrefix2Stripped, address)
+  }
+
   func testZwspOutput() {
     let address = "0x1bBE4E6EF7294c99358377abAd15A6d9E98127A2"
     let zwspAddress = "0\u{200b}x\u{200b}1\u{200b}b\u{200b}B\u{200b}E\u{200b}4\u{200b}E\u{200b}6\u{200b}E\u{200b}F\u{200b}7\u{200b}2\u{200b}9\u{200b}4\u{200b}c\u{200b}9\u{200b}9\u{200b}3\u{200b}5\u{200b}8\u{200b}3\u{200b}7\u{200b}7\u{200b}a\u{200b}b\u{200b}A\u{200b}d\u{200b}1\u{200b}5\u{200b}A\u{200b}6\u{200b}d\u{200b}9\u{200b}E\u{200b}9\u{200b}8\u{200b}1\u{200b}2\u{200b}7\u{200b}A\u{200b}2\u{200b}"


### PR DESCRIPTION
## Summary of Changes
- Remove `solana:` / `Solana:` prefix when scanning a wallet QR code for Solana
- Unable to reproduce 'invalid data' error, please flag it! If there are other known prefixes please flag as well, we can't search for hex prefix like ethereum scanning does.

This pull request fixes #6896

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Send and change network to Solana if not already selected
2. Tap the QR code icon in the send address
3. Scan the [Solana QR code from Slack](https://bravesoftware.slack.com/archives/C02S9LFEXU4/p1675727132010679?thread_ts=1675449869.032959&cid=C02S9LFEXU4)
4. Verify `solana:` prefix is not shown, address does not display as invalid SOL address.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
