### PR TITLE
No bug: fix empty wallet settings coming from wallet panel view

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -93,6 +93,9 @@ public class KeyringStore: ObservableObject {
   }
   /// All available `KeyringInfo` for all supported coin type
   @Published var allKeyrings: [BraveWallet.KeyringInfo] = []
+  /// Indicates if default keyring has been created. This value used for display wallet related settings if default
+  /// keyring has been created
+  @Published var isDefaultKeyringCreated: Bool = false
   /// All `AccountInfo` for all available keyrings
   var allAccounts: [BraveWallet.AccountInfo] {
     allKeyrings.flatMap(\.accountInfos)
@@ -154,6 +157,7 @@ public class KeyringStore: ObservableObject {
       self.defaultAccounts = await keyringService.defaultAccounts(for: WalletConstants.supportedCoinTypes)
       if let defaultKeyring = allKeyrings.first(where: { $0.id == BraveWallet.DefaultKeyringId }) {
         self.defaultKeyring = defaultKeyring
+        self.isDefaultKeyringCreated = defaultKeyring.isKeyringCreated
       }
       self.allKeyrings = allKeyrings
       if let selectedAccountKeyring = allKeyrings.first(where: { $0.coin == selectedCoin }) {

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -16,8 +16,6 @@ public class SettingsStore: ObservableObject {
       keyringService.setAutoLockMinutes(autoLockInterval.value) { _ in }
     }
   }
-  
-  @Published var isDefaultKeyringCreated: Bool = false
 
   /// If we should attempt to unlock via biometrics (Face ID / Touch ID)
   var isBiometricsUnlockEnabled: Bool {
@@ -60,10 +58,6 @@ public class SettingsStore: ObservableObject {
     walletService.add(self)
     walletService.defaultBaseCurrency { [self] currencyCode in
       self.currencyCode = CurrencyCode(code: currencyCode)
-    }
-    
-    keyringService.keyringInfo(BraveWallet.DefaultKeyringId) { [self] keyringInfo in
-      self.isDefaultKeyringCreated = keyringInfo.isKeyringCreated
     }
   }
 
@@ -109,9 +103,6 @@ extension SettingsStore: BraveWalletKeyringServiceObserver {
   }
   
   public func keyringReset() {
-    keyringService.keyringInfo(BraveWallet.DefaultKeyringId) { [self] keyringInfo in
-      self.isDefaultKeyringCreated = keyringInfo.isKeyringCreated
-    }
   }
   
   public func locked() {

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -40,7 +40,7 @@ public struct Web3SettingsView: View {
   
   public var body: some View {
     List {
-      if let settingsStore, let networkStore, let keyringStore, settingsStore.isDefaultKeyringCreated {
+      if let settingsStore = settingsStore, let networkStore = networkStore, let keyringStore = keyringStore, keyringStore.isDefaultKeyringCreated {
         WalletSettingsView(
           settingsStore: settingsStore,
           networkStore: networkStore,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
move `isDefaultKeyringCreated` to `KeyringStore`

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. connect brave wallet to a dapp
2. open wallet panel from the wallet icon from the url bar
3. click the `...` button on the top right
4. click `settings`
5. observe the wallet settings screen appear with all the settings options


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
