### PR TITLE
Fix #6811: Always show buy/send/swap in pan modal

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuySendSwapView.swift
@@ -18,13 +18,9 @@ struct BuySendSwapView: View {
   ) {
     self.networkStore = networkStore
     self.action = action
-    if !WalletConstants.supportedTestNetworkChainIds.contains(networkStore.selectedChainId) {
-      self.destinations.append(BuySendSwapDestination(kind: .buy))
-    }
+    self.destinations.append(BuySendSwapDestination(kind: .buy))
     self.destinations.append(BuySendSwapDestination(kind: .send))
-    if networkStore.isSwapSupported {
-      self.destinations.append(BuySendSwapDestination(kind: .swap))
-    }
+    self.destinations.append(BuySendSwapDestination(kind: .swap))
   }
 
   var body: some View {


### PR DESCRIPTION
## Summary of Changes
- Always show buy/send/swap in the pan modal regardless of the current network after multichain changes that removed the network picker from Portfolio

This pull request fixes #6811

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
precondition: Enable test networks in Wallet/Web3 Settings -> Custom Networks
1. Switch to Solana network (Either via dapp panel, or via in Send token view)
2. Navigate to Portfolio and tap buy/send/swap button
3. Verify Swap is visible (previously hidden for Solana)
4. Tap Swap and verify unsupported network error shown for Swap, confirm ability to change networks to supported network
5. Change network to any pre-loaded test network (ex. Goerli)
6. Navigate to Portfolio and tap buy/send/swap button
7. Verify Buy is visible (previously hidden for test networks)
4. Tap Buy and verify unsupported network error shown for Buy, confirm ability to change networks to supported network


## Screenshots:

before fix:

https://user-images.githubusercontent.com/5314553/218523205-3772a7be-2322-4944-82dc-7002cd2e88c4.mov

after fix:

https://user-images.githubusercontent.com/5314553/218523235-fd687fe6-447e-460c-84c6-abbacf21448e.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
