### PR TITLE
Fix #6626: Adjust wallet settings menu

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -97,11 +97,11 @@ struct CryptoPagesView: View {
             Label(Strings.Wallet.lock, braveSystemImage: "brave.lock")
               .imageScale(.medium)  // Menu inside nav bar implicitly gets large
           }
-          Divider()
           Button(action: { isShowingSettings = true }) {
             Label(Strings.Wallet.settings, braveSystemImage: "brave.gear")
               .imageScale(.medium)  // Menu inside nav bar implicitly gets large
           }
+          Divider()
           Button(action: { openWalletURL?(WalletConstants.braveWalletSupportURL) }) {
             Label(Strings.Wallet.helpCenter, braveSystemImage: "brave.info.circle")
           }

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -328,10 +328,10 @@ struct WalletPanelView: View {
       Button(action: { keyringStore.lock() }) {
         Label(Strings.Wallet.lock, braveSystemImage: "brave.lock")
       }
-      Divider()
       Button(action: { presentWalletWithContext(.settings) }) {
         Label(Strings.Wallet.settings, braveSystemImage: "brave.gear")
       }
+      Divider()
       Button(action: { openWalletURL?(WalletConstants.braveWalletSupportURL) }) {
         Label(Strings.Wallet.helpCenter, braveSystemImage: "brave.info.circle")
       }


### PR DESCRIPTION
## Summary of Changes
- Change divider position to match designs

This pull request fixes #6626

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open a dapp site, open wallet panel and tap `...` button. Verify divider shown directly above Help Center.
2. Open main wallet and tap `...` button. Verify divider shown directly above Help Center.


## Screenshots:


![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 09 23 42](https://user-images.githubusercontent.com/5314553/218766372-6410bc8d-ab2b-4694-b5fe-e65edae12056.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 09 23 48](https://user-images.githubusercontent.com/5314553/218766378-cba5b7b8-e9c8-4ee4-a71d-210adf5f7041.png)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
