### PR TITLE
Fix #6787: Start Brave News onboarding animation after a small delay

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -182,7 +182,12 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
 
   func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
     if indexPath.item == 0, let cell = cell as? FeedCardCell<BraveNewsOptInView> {
-      cell.content.graphicAnimationView.play()
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        // Seems like there is a CoreGraphics glitch somewhere here after we create a new tab it starts
+        // playing too quickly before the tab tray animation is done, so it doesn't play... possibly a Lottie
+        // bug
+        cell.content.graphicAnimationView.play()
+      }
     }
     if let card = dataSource.state.cards?[safe: indexPath.item] {
       if !viewedCards.contains(card) && collectionView.contentOffset.y > 0 {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6787 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
