### PR TITLE
Fix #6949: Ensure the bookmark is valid before checking deletion status

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -528,8 +528,10 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     if isBookmarksBeingSearched {
       return true
     } else {
-      fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath)
-      return fetchedBookmarkItem?.canBeDeleted ?? false
+      if let fetchedBookmarkItem = bookmarksFRC?.object(at: indexPath), fetchedBookmarkItem.bookmarkNode.isValid {
+        return fetchedBookmarkItem.canBeDeleted
+      }
+      return false
     }
   }
 


### PR DESCRIPTION
There is slight difference in `UITableView` delegate calls while VoiceOver is enabled. The `tableView(_:canEditRowAt:)` seems to be called multiple times including directly after deleting a bookmark which ends up being before the Bookmarks FRC has a chance to update after the deletion

## Summary of Changes

This pull request fixes #6949 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).

## Test Plan

1. Prefix: Add a bookmark
2. Enable VoiceOver and visit bookmarks
3. Tap on a bookmark to highlight it. Siri will read out that there are actions available.
4. While its highlighted swipe down or up with one finger until you hear "Delete"
5. Double tap the screen

Verify item is deleted and doesn't crash