### PR TITLE
Fix #6956: Sign Message domain display in dark mode

### DIFF
--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -56,16 +56,21 @@ struct SignatureRequestView: View {
     let metrics = UIFontMetrics(forTextStyle: .body)
     let desc = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
     let regularFont = metrics.scaledFont(for: UIFont.systemFont(ofSize: desc.pointSize, weight: .regular))
+    let regularAttributes: [NSAttributedString.Key: Any] = [
+      .font: regularFont, .foregroundColor: UIColor.braveLabel]
     if currentRequest.domain.isEmpty {
-      // if we don't show domain, we don't need the full title
-      return NSAttributedString(string: requestMessage, attributes: [.font: regularFont])
+      // if we don't show domain, we don't need the titles so we
+      // can fallback to `requestDisplayText` string for perf reasons
+      return nil
     }
     let boldFont = metrics.scaledFont(for: UIFont.systemFont(ofSize: desc.pointSize, weight: .bold))
+    let boldAttributes: [NSAttributedString.Key: Any] = [
+      .font: boldFont, .foregroundColor: UIColor.braveLabel]
     
-    let domainTitle = NSAttributedString(string: "\(Strings.Wallet.signatureRequestDomainTitle):\n", attributes: [.font: boldFont])
-    let domain = NSAttributedString(string: requestDomain, attributes: [.font: regularFont])
-    let messageTitle = NSAttributedString(string: "\n\(Strings.Wallet.signatureRequestMessageTitle):\n", attributes: [.font: boldFont])
-    let message = NSAttributedString(string: requestMessage, attributes: [.font: regularFont])
+    let domainTitle = NSAttributedString(string: "\(Strings.Wallet.signatureRequestDomainTitle):\n", attributes: boldAttributes)
+    let domain = NSAttributedString(string: requestDomain, attributes: regularAttributes)
+    let messageTitle = NSAttributedString(string: "\n\(Strings.Wallet.signatureRequestMessageTitle):\n", attributes: boldAttributes)
+    let message = NSAttributedString(string: requestMessage, attributes: regularAttributes)
     
     let attrString = NSMutableAttributedString(attributedString: domainTitle)
     attrString.append(domain)


### PR DESCRIPTION
## Summary of Changes
- Switched to using NSAttributedString to bold titles, but missed applying foreground color for the text color.

This pull request fixes #6956

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Visit https://brandon-t.github.io/test-dapp-eip-712/ test site
2. Connect and tap `Sign` under `Sign Typed Data V4`
3. Change appearance to/from dark mode, verify text color updates and matches theme


## Screenshots:

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-16 at 09 15 38](https://user-images.githubusercontent.com/5314553/219389827-bd00014f-5c50-406b-9456-72f75e9aa52e.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-16 at 09 15 34](https://user-images.githubusercontent.com/5314553/219389829-f9879b3d-75ae-41cc-b25f-9ea8753b42cd.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
