### PR TITLE
No bug: Decoded Solana instruction copy fix

### DIFF
--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3316,7 +3316,7 @@ extension Strings {
       "wallet.solanaInstructionAccounts",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Program Id",
+      value: "Accounts",
       comment: "The label displayed beside the Accounts for an instruction type we don't support decoding. Ex. \"Accounts: <solana_public_key>\""
     )
     public static let solanaInstructionData = NSLocalizedString(


### PR DESCRIPTION
## Summary of Changes
- Caught a typo in localization for copy in decoded Solana instructions when investigating some work with desktop using core Solana instruction decoding on front-end

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open `jup.ag` and create a Solana swap transaction
2. In the details pane, verify `Accounts:` is displayed below the `Program Id:`


## Screenshots:

before | after
--|--
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-17 at 11 40 51](https://user-images.githubusercontent.com/5314553/219713267-78e6bff5-8c8c-4f3d-84b7-ae460341df4b.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-17 at 11 39 30](https://user-images.githubusercontent.com/5314553/219713264-adf0d5eb-0f1b-4d75-a9fb-3109d9ab90b5.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
