### PR TITLE
No bug: New strings for transaction status UI.

### DIFF
--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1450,6 +1450,13 @@ extension Strings {
       value: "Error",
       comment: "A status that explains that the transaction failed due to some error"
     )
+    public static let transactionStatusSigned = NSLocalizedString(
+      "wallet.transactionStatusSigned",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Signed",
+      comment: "A status that explains that the transaction has been signed."
+    )
     public static let transactionStatusUnknown = NSLocalizedString(
       "wallet.transactionStatusUnknown",
       tableName: "BraveWallet",
@@ -3584,6 +3591,97 @@ extension Strings {
       bundle: .module,
       value: "Invalid url was provided. Gateway should be able to resolve IPFS resources.",
       comment: "Description of the wrong IPFS gateway alert"
+    )
+    public static let signedTransactionTitle = NSLocalizedString(
+      "wallet.signedTransactionTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction signed",
+      comment: "A title of transaction signed status view indicating this transaction has been signed."
+    )
+    public static let submittedTransactionTitle = NSLocalizedString(
+      "wallet.submittedTransactionTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction submitted",
+      comment: "A title of transaction signed status view indicating this transaction has been submitted to the network."
+    )
+    public static let confirmedTransactionTitle = NSLocalizedString(
+      "wallet.confirmedTransactionTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction completed",
+      comment: "A title of transaction confirmed status view indicating this transaction has been included in a block."
+    )
+    public static let failedTransactionTitle = NSLocalizedString(
+      "wallet.failedTransactionTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction failed",
+      comment: "A title of transaction failed status view indicating this transaction has not been included in a block."
+    )
+    public static let signedTransactionDescription = NSLocalizedString(
+      "wallet.signedTransactionDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction has been signed and will be sent to network by dapps and awaits confirmation.",
+      comment: "A description explains signed transaction will be sent to network by dapps and awaits confirmation."
+    )
+    public static let submittedTransactionDescription = NSLocalizedString(
+      "wallet.submittedTransactionDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction has been successfully sent to the network and awaits confirmation.",
+      comment: "A description explains submitted transaction has been sent to the netwokr and awaits confirmation."
+    )
+    public static let confirmedTransactionDescription = NSLocalizedString(
+      "wallet.confirmedTransactionDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction has been successfully included in a block. To avoid the risk of double spending, we recommend waiting for block confirmations.",
+      comment: "A description explains confirmed transaction has been included in a block."
+    )
+    public static let failedTransactionDescription = NSLocalizedString(
+      "wallet.failedTransactionDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction was failed due to a large price movement. Increase slippage tolerance to succeed at a larger price movement.",
+      comment: "A description explains transaction is failed."
+    )
+    public static let confirmedTransactionReceiptButtonTitle = NSLocalizedString(
+      "wallet.confirmedTransactionReceiptButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Receipt",
+      comment: "A title of a button which can open a confirmed transaction details screen."
+    )
+    public static let confirmedTransactionCloseButtonTitle = NSLocalizedString(
+      "wallet.confirmedTransactionCloseButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Close",
+      comment: "A title of a button which will close this transaction status view."
+    )
+    public static let failedTransactionViewErrorButtonTitle = NSLocalizedString(
+      "wallet.failedTransactionViewErrorButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "View Error",
+      comment: "A title of a button which will a new view to display the error."
+    )
+    public static let failedTransactionErrorViewTitle = NSLocalizedString(
+      "wallet.failedTransactionErrorViewTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Error message",
+      comment: "A title of the view that will display the error message."
+    )
+    public static let failedTransactionErrorViewDescription = NSLocalizedString(
+      "wallet.failedTransactionErrorViewDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Please save the error message for future reference.",
+      comment: "A title of the view that will display the error message."
     )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3681,7 +3681,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .module,
       value: "Please save the error message for future reference.",
-      comment: "A title of the view that will display the error message."
+      comment: "A description of the view that will display the error message."
     )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3596,28 +3596,28 @@ extension Strings {
       "wallet.signedTransactionTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Transaction signed",
+      value: "Transaction Signed",
       comment: "A title of transaction signed status view indicating this transaction has been signed."
     )
     public static let submittedTransactionTitle = NSLocalizedString(
       "wallet.submittedTransactionTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Transaction submitted",
+      value: "Transaction Submitted",
       comment: "A title of transaction signed status view indicating this transaction has been submitted to the network."
     )
     public static let confirmedTransactionTitle = NSLocalizedString(
       "wallet.confirmedTransactionTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Transaction completed",
+      value: "Transaction Completed",
       comment: "A title of transaction confirmed status view indicating this transaction has been included in a block."
     )
     public static let failedTransactionTitle = NSLocalizedString(
       "wallet.failedTransactionTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Transaction failed",
+      value: "Transaction Failed",
       comment: "A title of transaction failed status view indicating this transaction has not been included in a block."
     )
     public static let signedTransactionDescription = NSLocalizedString(
@@ -3673,7 +3673,7 @@ extension Strings {
       "wallet.failedTransactionErrorViewTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Error message",
+      value: "Error Message",
       comment: "A title of the view that will display the error message."
     )
     public static let failedTransactionErrorViewDescription = NSLocalizedString(


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
A separated PR to include new strings we needed so we can order translation early. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
