### PR TITLE
Fix #6954: Balance of ERC721 when 2 added with different token identifiers

### DIFF
--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -225,7 +225,7 @@ extension BraveWallet.BlockchainToken {
   
   /// The id to map with the return balance from RPCService
   var assetBalanceId: String {
-    contractAddress + symbol + chainId
+    contractAddress + symbol + chainId + tokenId
   }
   
   var isAuroraSupportedToken: Bool {


### PR DESCRIPTION
## Summary of Changes
- Include `tokenId` in our `assetBalanceId: String` helper for mapping tokens to their fetched balances. Previously we did not include `tokenId`, so the balance of one of the two tokens would be displayed for both.
    - `assetBalanceId` is only used to map the token to their balance, unlike `assetRatioId` which is given to core APIs for CoinGecko.

This pull request fixes #6954

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
pre-requisite: Own 1 ERC721 NFT that belongs to a collection with an NFT you don't own. Same contract address, symbol and chain but different token id.
1. Add 2 ERC721 NFTs with same contract address, symbol and chain but different token ids (you must have a different balance for the two NFTs)
    e.g. [NFT1](https://testnets.opensea.io/assets/goerli/0xef6cdea5845c5ce10a533bd20fdfe9b174ab1687/9) and [NFT2](https://testnets.opensea.io/assets/goerli/0xef6cdea5845c5ce10a533bd20fdfe9b174ab1687/4)
2. Verify balance is displayed correctly for both NFTs


## Screenshots:

before | after
--|--
![6954 - before](https://user-images.githubusercontent.com/5314553/220447214-9b18c063-fe54-4fa7-bff8-2d9f4e7f0c75.png) | ![6954 - fixed](https://user-images.githubusercontent.com/5314553/220447228-b6eab1be-914e-44a1-bd25-98f858bae7f5.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
