### PR TITLE
Fix #6171: Don't shift switches on shields view when text gets too long

### DIFF
--- a/Sources/Brave/Frontend/Shields/AdvancedShieldsView.swift
+++ b/Sources/Brave/Frontend/Shields/AdvancedShieldsView.swift
@@ -110,6 +110,7 @@ extension AdvancedShieldsView {
       toggleSwitch.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
 
       toggleSwitch.setContentHuggingPriority(.required, for: .horizontal)
+      toggleSwitch.setContentCompressionResistancePriority(.required, for: .horizontal)
 
       snp.makeConstraints {
         $0.height.greaterThanOrEqualTo(toggleSwitch)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6171

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![Simulator Screenshot - iPhone 14 Pro - 2023-02-21 at 16 30 44](https://user-images.githubusercontent.com/529104/220463316-357f4258-2823-425f-93d5-47a2c786ac51.png)

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
