### PR TITLE
Fix #6888: Do not override `toString`for XMLHTTPRequest

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RequestBlockingScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RequestBlockingScript.js
@@ -45,7 +45,7 @@ window.__firefox__.execute(function($) {
         return originalFetch.apply(this, arguments)
       }
     })
-  });
+  }, /*overrideToString=*/false);
   
   const originalOpen = XMLHttpRequest.prototype.open
   XMLHttpRequest.prototype.open = $(function() {
@@ -60,7 +60,7 @@ window.__firefox__.execute(function($) {
     // Store only primitive types not things like URL objects
     this._url = arguments[1]
     return originalOpen.apply(this, arguments)
-  });
+  }, /*overrideToString=*/false);
 
   const originalSend = XMLHttpRequest.prototype.send
   XMLHttpRequest.prototype.send = $(function () {
@@ -92,5 +92,5 @@ window.__firefox__.execute(function($) {
         originalSend.apply(this, arguments)
       }
     })
-  });
+  }, /*overrideToString=*/false);
 });

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RewardsReportingScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RewardsReportingScript.js
@@ -41,7 +41,7 @@ window.__firefox__.includeOnce("RewardsReporting", function($) {
         this.addEventListener('load', listener, true);
         this.addEventListener('error', listener, true);
         return originalOpen.apply(this, arguments);
-    });
+    }, /*overrideToString=*/false);
     
     XMLHttpRequest.prototype.send = $(function(body) {
         this._ref = null;
@@ -51,7 +51,7 @@ window.__firefox__.includeOnce("RewardsReporting", function($) {
             this._data = null;
         }
         return originalSend.apply(this, arguments);
-    });
+    }, /*overrideToString=*/false);
 
     window.fetch = $(function(resource, options) {
         const args = arguments
@@ -71,7 +71,7 @@ window.__firefox__.includeOnce("RewardsReporting", function($) {
               reject(error);
             })
         }));
-    });
+    }, /*overrideToString=*/false);
 
     navigator.sendBeacon = $(function(url, data) {
       sendMessage("POST", url, data);

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
@@ -78,7 +78,7 @@ window.__firefox__.execute(function($) {
       this._shouldTrack = arguments[2] !== undefined && !arguments[2]
       this._url = url;
       return originalOpen.apply(this, arguments);
-    });
+    }, /*overrideToString=*/false);
 
     xhrProto.send = $(function(body) {
       if (this._url === undefined || !this._shouldTrack) {
@@ -96,7 +96,7 @@ window.__firefox__.execute(function($) {
         this.addEventListener("error", this._tpErrorHandler);
       }
       return originalSend.apply(this, arguments);
-    });
+    }, /*overrideToString=*/false);
 
     // -------------------------------------------------
     // Detect when new sources get set on Image and send them to the host application


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1201

## Summary of Changes
- Twitch checks if `XMLHttpRequest.prototype.toString !== Object.toString` and will refuse to load the https://gql.twitch.tv/UUID_HERE/ANOTHER_UUID_HERE/fp script which also does its own toString override as well via `Symbol.toStringTagTag`.
- We cannot override Object.prototype.toString or Object.toString (aka Function.prototype.toString) because it is quite difficult to implement and dangerous when used on arrays. We should look into a way to do that cleanly though.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6888

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
