### PR TITLE
Fix #6982: Auto-complete adding known custom assets

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -109,21 +109,20 @@ struct AddCustomAssetView: View {
         ) {
           TextField(Strings.Wallet.enterAddress, text: $addressInput)
             .onChange(of: addressInput) { newValue in
-              if !newValue.isEmpty, newValue.isETHAddress {
-                userAssetStore.tokenInfo(by: newValue) { token in
-                  if let token = token {
-                    if nameInput.isEmpty {
-                      nameInput = token.name
-                    }
-                    if symbolInput.isEmpty {
-                      symbolInput = token.symbol
-                    }
-                    if !token.isErc721 {
-                      if decimalsInput.isEmpty {
-                        decimalsInput = "\(token.decimals)"
-                      }
-                    }
-                  }
+              guard !newValue.isEmpty else { return }
+              userAssetStore.tokenInfo(address: newValue) { token in
+                guard let token else { return }
+                if nameInput.isEmpty {
+                  nameInput = token.name
+                }
+                if symbolInput.isEmpty {
+                  symbolInput = token.symbol
+                }
+                if !token.isErc721, decimalsInput.isEmpty {
+                  decimalsInput = "\(token.decimals)"
+                }
+                if let network = networkStore.allChains.first(where: { $0.chainId == token.chainId }) {
+                  networkSelectionStore.networkSelectionInForm = network
                 }
               }
             }

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -118,7 +118,7 @@ struct AddCustomAssetView: View {
                 if symbolInput.isEmpty {
                   symbolInput = token.symbol
                 }
-                if !token.isErc721, decimalsInput.isEmpty {
+                if !token.isErc721, !token.isNft, decimalsInput.isEmpty {
                   decimalsInput = "\(token.decimals)"
                 }
                 if let network = networkStore.allChains.first(where: { $0.chainId == token.chainId }) {


### PR DESCRIPTION
## Summary of Changes
- Fix logic for auto-complete only working for Ethereum addresses, so Solana mint addresses were not checked against known assets.
- Set network of autocompleted token
- Fetching token info is currently only supported on Ethereum Mainnet, however you can add a Ethereum Mainnet asset while on any network with multichain updates so we should no longer check the selected network is ethereum mainnet.

This pull request fixes #6982

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Enter a custom Solana asset (in our blockchain registry) contract address:
    - ex. USDC mint address: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v `
    - ex. Wrapped BAT (Portal) mint address: `EPeUFDgHRxs9xxEPVaL6kfGQvCon7jmAWKVUHuux1Tpz`
2. Verify details auto-complete, asset can be added
3. Add a custom Ethereum asset in our blockchain registry
    - ex. Wrapped BTC contract address: `0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599`
4. Verify details auto-complete
5. Add a custom Ethereum asset not in our blockchain registry (requires network lookup)
    - ex. UNI contract address: `0x1f9840a85d5af5bf1d1762f925bdaddc4201f984`
6. Verify details auto-complete

Encountered https://github.com/brave/brave-ios/issues/6989 during development

## Screenshots:

https://user-images.githubusercontent.com/5314553/220682196-ae977b6c-7fb3-4a6c-a804-83a8b9bf625a.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
