### PR TITLE
Fix #6993: Open buy crypto from provider crash

### DIFF
--- a/Sources/BraveWallet/WalletHostingViewController.swift
+++ b/Sources/BraveWallet/WalletHostingViewController.swift
@@ -72,7 +72,7 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
       self.dismiss(animated: true)
     }
     rootView.openWalletURLAction = { [unowned self] url in
-      (presentingViewController ?? self).dismiss(animated: true) {
+      (self.presentingViewController ?? self).dismiss(animated: true) { [self] in
         self.delegate?.openWalletURL(url)
       }
     }

--- a/Sources/BraveWallet/WalletPanelHostingController.swift
+++ b/Sources/BraveWallet/WalletPanelHostingController.swift
@@ -36,7 +36,7 @@ public class WalletPanelHostingController: UIHostingController<WalletPanelContai
       self.delegate?.walletPanel(self, presentWalletWithContext: context, walletStore: walletStore)
     }
     rootView.openWalletURLAction = { [unowned self] url in
-      (presentingViewController ?? self).dismiss(animated: true) {
+      (self.presentingViewController ?? self).dismiss(animated: true) { [self] in
         self.delegate?.openWalletURL(url)
       }
     }


### PR DESCRIPTION
## Summary of Changes
- Suspect crash occurred by `self` being released prior to dismissal completion block executing.
- Hold string reference to `self` in the completion block so it is not released prior to executing this block

This pull request fixes #6993

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
From both the Wallet Panel (in browser dapp) and from Native wallet, open multiple buy crypto from provider tabs for different tokens and providers, verify no crashes.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
