### PR TITLE
Fix #6997: Only load urls via QR code that are http/https

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2280,7 +2280,7 @@ public class BrowserViewController: UIViewController {
       let qrCodeController = RecentSearchQRCodeScannerController { [weak self] string in
         guard let self = self else { return }
 
-        if let url = URIFixup.getURL(string) {
+        if let url = URIFixup.getURL(string), url.isWebPage(includeDataURIs: false) {
           self.didScanQRCodeWithURL(url)
         } else {
           self.didScanQRCodeWithText(string)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6997 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
