### PR TITLE
Use nft gateway in the wallet page

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2655,7 +2655,7 @@ extension BrowserViewController: TabDelegate {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
     // If we have an open `WalletStore`, use that so we can assign the pending request if the wallet is open,
     // which allows us to store the new `PendingRequest` triggering a modal presentation for that request.
-    guard let cryptoStore = self.walletStore?.cryptoStore ?? CryptoStore.from(privateMode: privateMode) else {
+    guard let cryptoStore = self.walletStore?.cryptoStore ?? CryptoStore.from(ipfsApi: braveCore.ipfsAPI, privateMode: privateMode) else {
       return false
     }
     if await cryptoStore.isPendingRequestAvailable() {
@@ -2996,7 +2996,7 @@ extension BrowserViewController: PreferencesObserver {
       WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.eth])
       WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.eth])
       let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-      if let cryptoStore = CryptoStore.from(privateMode: privateMode) {
+      if let cryptoStore = CryptoStore.from(ipfsApi: braveCore.ipfsAPI, privateMode: privateMode) {
         cryptoStore.rejectAllPendingWebpageRequests()
       }
       updateURLBarWalletButton()
@@ -3007,7 +3007,7 @@ extension BrowserViewController: PreferencesObserver {
       WalletProviderPermissionRequestsManager.shared.cancelAllPendingRequests(for: [.sol])
       WalletProviderAccountCreationRequestManager.shared.cancelAllPendingRequests(coins: [.sol])
       let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-      if let cryptoStore = CryptoStore.from(privateMode: privateMode) {
+      if let cryptoStore = CryptoStore.from(ipfsApi: braveCore.ipfsAPI, privateMode: privateMode) {
         cryptoStore.rejectAllPendingWebpageRequests()
       }
       updateURLBarWalletButton()

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -153,7 +153,7 @@ extension BrowserViewController {
           )
         }
         
-        let cryptoStore = CryptoStore.from(privateMode: isPrivateMode)
+        let cryptoStore = CryptoStore.from(ipfsApi: braveCore.ipfsAPI, privateMode: isPrivateMode)
 
         let vc = SettingsViewController(
           profile: self.profile,

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -16,7 +16,7 @@ import Growth
 
 extension WalletStore {
   /// Creates a WalletStore based on whether or not the user is in Private Mode
-  static func from(privateMode: Bool) -> WalletStore? {
+  static func from(ipfsApi: IpfsAPI?, privateMode: Bool) -> WalletStore? {
     guard
       let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode),
       let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: privateMode),
@@ -39,14 +39,15 @@ extension WalletStore {
       blockchainRegistry: BraveWalletAPI.blockchainRegistry,
       txService: txService,
       ethTxManagerProxy: ethTxManagerProxy,
-      solTxManagerProxy: solTxManagerProxy
+      solTxManagerProxy: solTxManagerProxy,
+      ipfsApi: ipfsApi
     )
   }
 }
 
 extension CryptoStore {
   /// Creates a CryptoStore based on whether or not the user is in Private Mode
-  static func from(privateMode: Bool) -> CryptoStore? {
+  static func from(ipfsApi: IpfsAPI?, privateMode: Bool) -> CryptoStore? {
     guard
       let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode),
       let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: privateMode),
@@ -69,7 +70,8 @@ extension CryptoStore {
       blockchainRegistry: BraveWalletAPI.blockchainRegistry,
       txService: txService,
       ethTxManagerProxy: ethTxManagerProxy,
-      solTxManagerProxy: solTxManagerProxy
+      solTxManagerProxy: solTxManagerProxy,
+      ipfsApi: ipfsApi
     )
   }
 }
@@ -79,7 +81,7 @@ extension BrowserViewController {
   /// when the pending request is updated so we can update the wallet url bar button.
   func newWalletStore() -> WalletStore? {
     let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-    guard let walletStore = WalletStore.from(privateMode: privateMode) else {
+    guard let walletStore = WalletStore.from(ipfsApi: braveCore.ipfsAPI, privateMode: privateMode) else {
       Logger.module.error("Failed to load wallet. One or more services were unavailable")
       return nil
     }
@@ -208,7 +210,7 @@ extension Tab: BraveWalletProviderDelegate {
         }
       }
       
-      guard WalletStore.from(privateMode: isPrivate) != nil else {
+      guard WalletStore.from(ipfsApi: nil, privateMode: isPrivate) != nil else {
         completion(.internal, nil)
         return
       }

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -90,6 +90,7 @@ public class CryptoStore: ObservableObject {
   private let txService: BraveWalletTxService
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+  private let ipfsApi: IpfsAPI?
   
   public init(
     keyringService: BraveWalletKeyringService,
@@ -100,7 +101,8 @@ public class CryptoStore: ObservableObject {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     txService: BraveWalletTxService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
-    solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
+    ipfsApi: IpfsAPI?
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService
@@ -111,6 +113,7 @@ public class CryptoStore: ObservableObject {
     self.txService = txService
     self.ethTxManagerProxy = ethTxManagerProxy
     self.solTxManagerProxy = solTxManagerProxy
+    self.ipfsApi = ipfsApi
     
     self.networkStore = .init(
       keyringService: keyringService,
@@ -123,7 +126,8 @@ public class CryptoStore: ObservableObject {
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
-      blockchainRegistry: blockchainRegistry
+      blockchainRegistry: blockchainRegistry,
+      ipfsApi: ipfsApi
     )
     
     self.keyringService.add(self)
@@ -160,7 +164,8 @@ public class CryptoStore: ObservableObject {
       blockchainRegistry: blockchainRegistry,
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: prefilledToken
+      prefilledToken: prefilledToken,
+      ipfsApi: self.ipfsApi
     )
     sendTokenStore = store
     return store
@@ -280,6 +285,7 @@ public class CryptoStore: ObservableObject {
     }
     let store = NFTDetailStore(
       rpcService: rpcService,
+      ipfsApi: ipfsApi,
       nft: nft,
       nftMetadata: nftMetadata
     )

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -100,7 +100,8 @@ public class PortfolioStore: ObservableObject {
     blockchainRegistry: self.blockchainRegistry,
     rpcService: self.rpcService,
     keyringService: self.keyringService,
-    assetRatioService: self.assetRatioService
+    assetRatioService: self.assetRatioService,
+    ipfsApi: self.ipfsApi
   )
   
   let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
@@ -121,19 +122,22 @@ public class PortfolioStore: ObservableObject {
   private let walletService: BraveWalletBraveWalletService
   private let assetRatioService: BraveWalletAssetRatioService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
+  private let ipfsApi: IpfsAPI?
 
   public init(
     keyringService: BraveWalletKeyringService,
     rpcService: BraveWalletJsonRpcService,
     walletService: BraveWalletBraveWalletService,
     assetRatioService: BraveWalletAssetRatioService,
-    blockchainRegistry: BraveWalletBlockchainRegistry
+    blockchainRegistry: BraveWalletBlockchainRegistry,
+    ipfsApi: IpfsAPI?
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService
     self.walletService = walletService
     self.assetRatioService = assetRatioService
     self.blockchainRegistry = blockchainRegistry
+    self.ipfsApi = ipfsApi
 
     self.rpcService.add(self)
     self.keyringService.add(self)

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -114,6 +114,7 @@ public class SendTokenStore: ObservableObject {
   private var sendAmountUpdatedTimer: Timer?
   private var prefilledToken: BraveWallet.BlockchainToken?
   private var metadataCache: [String: NFTMetadata] = [:]
+  private let ipfsApi: IpfsAPI?
 
   public init(
     keyringService: BraveWalletKeyringService,
@@ -123,7 +124,8 @@ public class SendTokenStore: ObservableObject {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
-    prefilledToken: BraveWallet.BlockchainToken?
+    prefilledToken: BraveWallet.BlockchainToken?,
+    ipfsApi: IpfsAPI?
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService
@@ -133,6 +135,7 @@ public class SendTokenStore: ObservableObject {
     self.ethTxManagerProxy = ethTxManagerProxy
     self.solTxManagerProxy = solTxManagerProxy
     self.prefilledToken = prefilledToken
+    self.ipfsApi = ipfsApi
 
     self.keyringService.add(self)
     self.rpcService.add(self)
@@ -206,7 +209,7 @@ public class SendTokenStore: ObservableObject {
       )
   
       if (selectedSendToken.isErc721 || selectedSendToken.isNft), metadataCache[selectedSendToken.id] == nil {
-        metadataCache[selectedSendToken.id] = await rpcService.fetchNFTMetadata(for: selectedSendToken)
+        metadataCache[selectedSendToken.id] = await rpcService.fetchNFTMetadata(for: selectedSendToken, ipfsApi: self.ipfsApi)
       }
       guard !Task.isCancelled else { return }
       self.selectedSendTokenBalance = balance

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -29,6 +29,7 @@ public class AssetStore: ObservableObject, Equatable {
 
   private let walletService: BraveWalletBraveWalletService
   private let rpcService: BraveWalletJsonRpcService
+  private let ipfsApi: IpfsAPI?
   private(set) var isCustomToken: Bool
 
   init(
@@ -36,6 +37,7 @@ public class AssetStore: ObservableObject, Equatable {
     rpcService: BraveWalletJsonRpcService,
     network: BraveWallet.NetworkInfo,
     token: BraveWallet.BlockchainToken,
+    ipfsApi: IpfsAPI?,
     isCustomToken: Bool,
     isVisible: Bool
   ) {
@@ -43,6 +45,7 @@ public class AssetStore: ObservableObject, Equatable {
     self.rpcService = rpcService
     self.network = network
     self.token = token
+    self.ipfsApi = ipfsApi
     self.isCustomToken = isCustomToken
     self.isVisible = isVisible
   }
@@ -52,7 +55,7 @@ public class AssetStore: ObservableObject, Equatable {
   }
   
   @MainActor func fetchERC721Metadata() async -> NFTMetadata? {
-    return await rpcService.fetchNFTMetadata(for: token)
+    return await rpcService.fetchNFTMetadata(for: token, ipfsApi: self.ipfsApi)
   }
 }
 
@@ -65,6 +68,7 @@ public class UserAssetsStore: ObservableObject {
   private let rpcService: BraveWalletJsonRpcService
   private let keyringService: BraveWalletKeyringService
   private let assetRatioService: BraveWalletAssetRatioService
+  private let ipfsApi: IpfsAPI?
   private var allTokens: [BraveWallet.BlockchainToken] = []
   private var timer: Timer?
 
@@ -73,13 +77,15 @@ public class UserAssetsStore: ObservableObject {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     rpcService: BraveWalletJsonRpcService,
     keyringService: BraveWalletKeyringService,
-    assetRatioService: BraveWalletAssetRatioService
+    assetRatioService: BraveWalletAssetRatioService,
+    ipfsApi: IpfsAPI?
   ) {
     self.walletService = walletService
     self.blockchainRegistry = blockchainRegistry
     self.rpcService = rpcService
     self.keyringService = keyringService
     self.assetRatioService = assetRatioService
+    self.ipfsApi = ipfsApi
     self.keyringService.add(self)
   }
   
@@ -131,6 +137,7 @@ public class UserAssetsStore: ObservableObject {
             rpcService: rpcService,
             network: assetsForNetwork.network,
             token: token,
+            ipfsApi: self.ipfsApi,
             isCustomToken: isCustomToken,
             isVisible: visibleIds.contains(where: { $0 == (token.id + token.chainId) })
           )

--- a/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -29,7 +29,8 @@ public class WalletStore {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     txService: BraveWalletTxService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
-    solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
+    ipfsApi: IpfsAPI?
   ) {
     self.keyringStore = .init(keyringService: keyringService, walletService: walletService, rpcService: rpcService)
     self.setUp(
@@ -41,7 +42,8 @@ public class WalletStore {
       blockchainRegistry: blockchainRegistry,
       txService: txService,
       ethTxManagerProxy: ethTxManagerProxy,
-      solTxManagerProxy: solTxManagerProxy
+      solTxManagerProxy: solTxManagerProxy,
+      ipfsApi: ipfsApi
     )
   }
 
@@ -54,7 +56,8 @@ public class WalletStore {
     blockchainRegistry: BraveWalletBlockchainRegistry,
     txService: BraveWalletTxService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
-    solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
+    ipfsApi: IpfsAPI?
   ) {
     self.cancellable = self.keyringStore.$defaultKeyring
       .map(\.isKeyringCreated)
@@ -73,7 +76,8 @@ public class WalletStore {
             blockchainRegistry: blockchainRegistry,
             txService: txService,
             ethTxManagerProxy: ethTxManagerProxy,
-            solTxManagerProxy: solTxManagerProxy
+            solTxManagerProxy: solTxManagerProxy,
+            ipfsApi: ipfsApi
           )
           self.onPendingRequestCancellable = self.cryptoStore?.$pendingRequest
             .removeDuplicates()

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -278,7 +278,7 @@ extension BraveWalletJsonRpcService {
   }
   
   /// Returns a nullable NFT metadata
-  @MainActor func fetchNFTMetadata(for token: BraveWallet.BlockchainToken) async -> NFTMetadata? {
+  @MainActor func fetchNFTMetadata(for token: BraveWallet.BlockchainToken, ipfsApi: IpfsAPI?) async -> NFTMetadata? {
     var metaDataString = ""
     if token.isErc721 {
       let (_, metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
@@ -296,7 +296,8 @@ extension BraveWalletJsonRpcService {
     }
     if let data = metaDataString.data(using: .utf8),
        let result = try? JSONDecoder().decode(NFTMetadata.self, from: data) {
-      return result
+      let r =  result.httpfyIpfsUrl(ipfsApi: ipfsApi)
+      return r
     }
     return nil
   }
@@ -325,6 +326,7 @@ extension BraveWalletJsonRpcService {
           
           if let data = metaDataString.data(using: .utf8),
              let result = try? JSONDecoder().decode(NFTMetadata.self, from: data) {
+
             return [token.id: result]
           }
           return [:]

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -296,8 +296,7 @@ extension BraveWalletJsonRpcService {
     }
     if let data = metaDataString.data(using: .utf8),
        let result = try? JSONDecoder().decode(NFTMetadata.self, from: data) {
-      let r =  result.httpfyIpfsUrl(ipfsApi: ipfsApi)
-      return r
+      return result.httpfyIpfsUrl(ipfsApi: ipfsApi)
     }
     return nil
   }

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -20,7 +20,8 @@ extension WalletStore {
       blockchainRegistry: MockBlockchainRegistry(),
       txService: MockTxService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
-      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy
+      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
+      ipfsApi: nil
     )
   }
 }
@@ -36,7 +37,8 @@ extension CryptoStore {
       blockchainRegistry: MockBlockchainRegistry(),
       txService: MockTxService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
-      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy
+      solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
+      ipfsApi: nil
     )
   }
 }
@@ -108,7 +110,8 @@ extension SendTokenStore {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
-      prefilledToken: .previewToken
+      prefilledToken: .previewToken,
+      ipfsApi: nil
     )
   }
 }
@@ -151,7 +154,8 @@ extension UserAssetsStore {
       blockchainRegistry: MockBlockchainRegistry(),
       rpcService: MockJsonRpcService(),
       keyringService: MockKeyringService(),
-      assetRatioService: MockAssetRatioService()
+      assetRatioService: MockAssetRatioService(),
+      ipfsApi: nil
     )
   }
 }

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -161,7 +161,8 @@ class PortfolioStoreTests: XCTestCase {
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
-      blockchainRegistry: BraveWallet.TestBlockchainRegistry()
+      blockchainRegistry: BraveWallet.TestBlockchainRegistry(),
+      ipfsApi: nil
     )
     // test that `update()` will assign new value to `userVisibleAssets` publisher
     let userVisibleAssetsException = expectation(description: "update-userVisibleAssets")

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -81,7 +81,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     XCTAssertNil(store.selectedSendToken)
 
@@ -93,7 +94,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .previewToken
+      prefilledToken: .previewToken,
+      ipfsApi: nil
     )
     let sendTokenExpectation = expectation(description: "update-sendTokenExpectation")
     store.$selectedSendToken
@@ -138,7 +140,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .mockSolToken
+      prefilledToken: .mockSolToken,
+      ipfsApi: nil
     )
     let sendTokenExpectation = expectation(description: "update-sendTokenExpectation")
     store.$selectedSendToken
@@ -172,7 +175,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     let selectedSendTokenExpectation = expectation(description: "update-selectedSendToken")
     XCTAssertNil(store.selectedSendToken)  // Initial state
@@ -215,7 +219,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .previewToken
+      prefilledToken: .previewToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .previewToken
     let ex = expectation(description: "send-eth-eip1559-transaction")
@@ -239,7 +244,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .previewToken
+      prefilledToken: .previewToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .previewToken
     let ex = expectation(description: "send-eth-transaction")
@@ -263,7 +269,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     let token: BraveWallet.BlockchainToken = .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, isNft: false, symbol: batSymbol, decimals: 18, visible: true, tokenId: "", coingeckoId: "", chainId: "", coin: .eth)
     store.selectedSendToken = token
@@ -289,7 +296,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .previewToken
+      prefilledToken: .previewToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .previewToken
     let ex = expectation(description: "send-bat-transaction")
@@ -317,7 +325,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .mockERC721NFTToken
+      prefilledToken: .mockERC721NFTToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .mockERC721NFTToken
     let ex = expectation(description: "send-NFT-transaction")
@@ -366,7 +375,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .previewToken
+      prefilledToken: .previewToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .previewToken
     let fetchSelectedTokenBalanceEx = expectation(description: "fetchSelectedTokenBalance")
@@ -417,7 +427,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: BraveWallet.NetworkInfo.mockSolana.nativeToken
+      prefilledToken: BraveWallet.NetworkInfo.mockSolana.nativeToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = BraveWallet.NetworkInfo.mockSolana.nativeToken
     let ex = expectation(description: "send-sol-transaction")
@@ -454,7 +465,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .mockSpdToken
+      prefilledToken: .mockSpdToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .mockSpdToken
     let ex = expectation(description: "send-sol-transaction")
@@ -494,7 +506,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .mockSolToken
+      prefilledToken: .mockSolToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .mockSolToken
     let ex = expectation(description: "send-sol-transaction")
@@ -535,7 +548,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: .mockSpdToken
+      prefilledToken: .mockSpdToken,
+      ipfsApi: nil
     )
     store.selectedSendToken = .mockSpdToken
     let ex = expectation(description: "send-spl-transaction")
@@ -567,7 +581,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     
     let selectedSendNFTMetadataERC721Exception = expectation(description: "sendTokenStore-selectedSendTokenERC721MetadataException")
@@ -609,7 +624,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     
     let selectedSendNFTMetadataSolNFTException = expectation(description: "sendTokenStore-selectedSendNFTMetadataSolNFTException")
@@ -652,7 +668,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: BraveWallet.TestEthTxManagerProxy(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy(),
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
@@ -692,7 +709,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: BraveWallet.TestEthTxManagerProxy(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy(),
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
@@ -741,7 +759,8 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: BraveWallet.TestEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil
+      prefilledToken: nil,
+      ipfsApi: nil
     )
     store.selectedSendToken = .mockSolToken
     

--- a/Tests/BraveWalletTests/UserAssetsStoreTests.swift
+++ b/Tests/BraveWalletTests/UserAssetsStoreTests.swift
@@ -61,7 +61,8 @@ class UserAssetsStoreTests: XCTestCase {
       blockchainRegistry: blockchainRegistry,
       rpcService: rpcService,
       keyringService: keyringService,
-      assetRatioService: assetRatioService
+      assetRatioService: assetRatioService,
+      ipfsApi: nil
     )
     
     let assetStoresException = expectation(description: "userAssetsStore-assetStores")
@@ -112,7 +113,8 @@ class UserAssetsStoreTests: XCTestCase {
       blockchainRegistry: blockchainRegistry,
       rpcService: rpcService,
       keyringService: keyringService,
-      assetRatioService: assetRatioService
+      assetRatioService: assetRatioService,
+      ipfsApi: nil
     )
     
     let assetStoresException = expectation(description: "userAssetsStore-assetStores")


### PR DESCRIPTION
Resolves https://github.com/brave/brave-ios/issues/6999

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
1. Verify NFT Gateway url value in `Settings -> Web3 -> Customize NFT Gateway`
2. Open wallet and add an NFT with IPFS image
    - ex. [Invisible Friends](https://opensea.io/assets/ethereum/0x59468516a8259058bad1ca5f8f4bff190d30e066/3965)
3. Use a proxy to verify NFT image is downloaded from NFT Gateway url in settings


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
