### PR TITLE
Fix #6995, Fix #6996: Fix Favicons blurry from Desktop and Monogram capitalization

### DIFF
--- a/Sources/Favicon/Favicon.swift
+++ b/Sources/Favicon/Favicon.swift
@@ -50,6 +50,11 @@ public class Favicon: Codable {
     try container.encode(isMonogramImage, forKey: .isMonogramImage)
     try container.encode(backgroundColor.rgba, forKey: .backgroundColor)
   }
+  
+  @MainActor
+  public static func renderImage(_ image: UIImage, backgroundColor: UIColor?, shouldScale: Bool) async -> Favicon {
+    await UIImage.renderFavicon(image, backgroundColor: backgroundColor, shouldScale: shouldScale)
+  }
 
   private enum CodingKeys: CodingKey {
     case image

--- a/Sources/Favicon/UIImage+FaviconRenderer.swift
+++ b/Sources/Favicon/UIImage+FaviconRenderer.swift
@@ -167,7 +167,7 @@ extension UIImage {
     let text = (monogramString ?? FaviconUtils.monogramLetter(
         for: url,
         fallbackCharacter: nil
-      )) as NSString
+    )).uppercased() as NSString
 
     let padding = 28.0
     let finalImage = await drawOnImageContext(size: imageSize) { context, rect in


### PR DESCRIPTION
Fix favicon caching so website visits override cached icons.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add documentation to Favicons rendering.
- Fix favicon blurry when syncing with Desktop.
- Fix favicon updates when visiting a website.
- Fix monogram icons to always be capitalized.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6995, #6996

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Fresh install
2. Turn on sync bookmarks and history on Desktop.
3. Join sync chain on iOS, and turn on bookmarks and history sync on Mobile.
4. Wait until History and Bookmarks sync successfully.
5. Notice icons are blurry.
6. Close tabs on NTP until icons update (or restart app).
7. NTP icons are blurry.
8. Visit website on NTP.
9. Icons should now be HD!
10. Visit History and Bookmarks, icons should be HD!


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
