### PR TITLE
Fix #7009: Fixes seeking from CarPlay (Bluetooth)

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -394,16 +394,6 @@ class PlaylistViewController: UIViewController {
       guard let self = self, !PlaylistCarplayManager.shared.isCarPlayAvailable else { return }
       self.onNextTrack(self.playerView, isUserInitiated: true)
     }.store(in: &playerStateObservers)
-    
-    player.publisher(for: .seekBackward).sink { [weak self] _ in
-      guard let self = self, !PlaylistCarplayManager.shared.isCarPlayAvailable else { return }
-      self.seekBackwards(self.playerView)
-    }.store(in: &playerStateObservers)
-    
-    player.publisher(for: .seekForward).sink { [weak self] _ in
-      guard let self = self, !PlaylistCarplayManager.shared.isCarPlayAvailable else { return }
-      self.seekForwards(self.playerView)
-    }.store(in: &playerStateObservers)
 
     player.publisher(for: .finishedPlaying).sink { [weak self] event in
       guard let self = self,

--- a/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -599,6 +599,26 @@ extension MediaPlayer {
       self.seekForwards()
       MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = Double(currentTime.seconds + event.interval)
     }.store(in: &notificationObservers)
+    
+    center.publisher(for: .seekBackwardCommand).sink { [weak self] event in
+      guard let self = self,
+        let event = event as? MPSkipIntervalCommandEvent
+      else { return }
+
+      let currentTime = self.player.currentTime()
+      self.seekBackwards()
+      MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = Double(currentTime.seconds - event.interval)
+    }.store(in: &notificationObservers)
+
+    center.publisher(for: .seekForwardCommand).sink { [weak self] event in
+      guard let self = self,
+        let event = event as? MPSkipIntervalCommandEvent
+      else { return }
+
+      let currentTime = self.player.currentTime()
+      self.seekForwards()
+      MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = Double(currentTime.seconds + event.interval)
+    }.store(in: &notificationObservers)
 
     center.publisher(for: .changePlaybackPositionCommand).sink { [weak self] event in
       guard let self = self,


### PR DESCRIPTION
## Summary of Changes
- Fixes seeking from CarPlay (Bluetooth), but ignore notification centre as it's recursive and has its own handler `skip` instead of `seek` (Apple reasons).
- This subtle difference can cause freezing if handled incorrectly.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7009

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Add video to playlist
2. Seek forwards and backwards
3. Should seek correctly 15s forwards and 15s backwards


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
