### PR TITLE
Fix #7014: Keep BraveSkusManager alive to finish credential setup.

### DIFF
--- a/Sources/Brave/BraveSkus/BraveSkusManager.swift
+++ b/Sources/Brave/BraveSkus/BraveSkusManager.swift
@@ -92,7 +92,7 @@ public class BraveSkusManager {
   }
   
   func credentialSummary(for domain: String, resultJSON: @escaping (Any?) -> Void) {
-    sku.credentialSummary(domain) { [weak self] completion in
+    sku.credentialSummary(domain) { [self] completion in
       do {
         Logger.module.debug("skus credentialSummary")
         
@@ -110,7 +110,10 @@ public class BraveSkusManager {
         case .valid:
           if Preferences.VPN.skusCredential.value == nil {
             Logger.module.debug("The credential does NOT exists, calling prepareCredentialsPresentation")
-            self?.prepareCredentialsPresentation(for: domain, path: "*", resultCredential: nil)
+            self.prepareCredentialsPresentation(for: domain, path: "*") { _ in
+              // Keep the skus manager alive until preparing credential presentation finishes.
+              _ = self
+            }
           } else {
             Logger.module.debug("The credential exists, NOT calling prepareCredentialsPresentation")
           }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7014 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Have a build with this fix installed
2. On a desktop device, purchase Brave VPN from https://account.brave.com
3. On the iOS device, visit https://account.brave.com and login
4. Visit Plans tab
5. Find your VPN product and click `Refresh Brave VPN`
6. It should load VPN on your iOS device- VPN should work
7. Wait a day or two
8. Try to use VPN on the device. Specifically, choose a different server and connect (so that it gets new credentials)
9. This should work great. If the fix does NOT work, you'll be kicked over to In-App-Purchase (for App Store)


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
