### PR TITLE
No Bug: Fix Wallet leak in Portfolio, Asset Details on iOS 16+

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -12,6 +12,7 @@ import Strings
 import BraveShared
 import BraveUI
 import Introspect
+import Shared
 
 struct AssetDetailView: View {
   @ObservedObject var assetDetailStore: AssetDetailStore
@@ -25,7 +26,7 @@ struct AssetDetailView: View {
   
   @Environment(\.sizeCategory) private var sizeCategory
   /// Reference to the collection view used to back the `List` on iOS 16+
-  @State private var collectionView: UICollectionView?
+  @State private var collectionViewRef: WeakRef<UICollectionView>?
 
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
@@ -152,12 +153,12 @@ struct AssetDetailView: View {
     }
     .onChange(of: sizeCategory) { _ in
       // Fix broken header when text size changes on iOS 16+
-      collectionView?.collectionViewLayout.invalidateLayout()
+      self.collectionViewRef?.value?.collectionViewLayout.invalidateLayout()
     }
     .introspect(
       selector: TargetViewSelector.ancestorOrSiblingContaining
     ) { (collectionView: UICollectionView) in
-      self.collectionView = collectionView
+      self.collectionViewRef = .init(collectionView)
     }
     .background(
       Color.clear

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -11,6 +11,7 @@ import Introspect
 import Strings
 import DesignSystem
 import BraveUI
+import Shared
 
 struct PortfolioView: View {
   var cryptoStore: CryptoStore
@@ -27,7 +28,7 @@ struct PortfolioView: View {
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
   /// Reference to the collection view used to back the `List` on iOS 16+
-  @State private var collectionView: UICollectionView?
+  @State private var collectionViewRef: WeakRef<UICollectionView>?
 
   private var isShowingBackupBanner: Bool {
     !keyringStore.defaultKeyring.isBackedUp && !dismissedBackupBannerThisSession
@@ -272,12 +273,12 @@ struct PortfolioView: View {
     }
     .onChange(of: sizeCategory) { _ in
       // Fix broken header when text size changes on iOS 16+
-      collectionView?.collectionViewLayout.invalidateLayout()
+      self.collectionViewRef?.value?.collectionViewLayout.invalidateLayout()
     }
     .introspect(
       selector: TargetViewSelector.ancestorOrSiblingContaining
     ) { (collectionView: UICollectionView) in
-      self.collectionView = collectionView
+      self.collectionViewRef = .init(collectionView)
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- `PortfolioStore` and `AssetDetailStore` are leaking on iOS 16+. We are holding a reference to the collection view to invalidate the layout when size changes, however this reference needs stored weakly or it causes `PortfolioStore` to leak. Using `WeakRef` helper resolves the leak.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. On iOS 16 on `development`, open wallet & unlock it and then dismiss wallet.
2. Observe `PortfolioStore` still exists in memory graph. Alternatively can add a log in `deinit` for `PortfolioStore`.
3. Checkout this PR branch `wallet/fix-leak`
4. Open wallet & unlock it and then dismiss wallet
5. Verify `PortfolioStore` is no longer in memory graph / `deinit` is executed.
6. Open Portfolio and verify https://github.com/brave/brave-ios/issues/6304 by changing text size; confirm graph/header lays out as expected


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
