### PR TITLE
Fix #5727: Fix Wallet JS async-await and replyHandler order

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -636,10 +636,12 @@ extension BrowserViewController: WKNavigationDelegate {
           isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing
         )
       }
-      tab.updateEthereumProperties()
+      
       Task {
+        await tab.updateEthereumProperties()
         await tab.updateSolanaProperties()
       }
+      
       tab.reportPageLoad(to: rewards, redirectionURLs: tab.redirectURLs)
       tab.redirectURLs = []
       if webView.url?.isLocal == false {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -99,13 +99,16 @@ class EthereumProviderScriptHandler: TabContentScript {
       firstAllowedAccount: String,
       updateJSProperties: Bool
     ) {
-      if reject {
-        replyHandler(nil, formedResponse.jsonString)
-      } else {
-        replyHandler(formedResponse.jsonObject, nil)
-      }
-      if updateJSProperties {
-        tab.updateEthereumProperties()
+      Task {
+        if updateJSProperties {
+          await tab.updateEthereumProperties()
+        }
+        
+        if reject {
+          replyHandler(nil, formedResponse.jsonString)
+        } else {
+          replyHandler(formedResponse.jsonObject, nil)
+        }
       }
     }
     


### PR DESCRIPTION


<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Make Ethereum functions properly async and execute the JS update properties before the `replyHandler`.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5727

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit `https://poap.fun/`
2. Connect wallet.
3. Should show wallet `address` in the top navigation bar.


## Screenshots:
![image](https://user-images.githubusercontent.com/1530031/221923517-bb3add59-5a09-4b13-bde8-2dc28a30a283.png)

![image](https://user-images.githubusercontent.com/1530031/221923572-847a2c34-e306-49ed-9596-60173dfa99bf.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
